### PR TITLE
Fix Configure workflow data directory for Kubernetes

### DIFF
--- a/deploy/staging/values.yaml
+++ b/deploy/staging/values.yaml
@@ -72,6 +72,9 @@ env:
   PARA_ENVIRONMENT:
     type: kv
     value: "beta"
+  WORKFLOW_EMBEDDED_DATA_DIR:
+    type: kv
+    value: "/tmp/workflow-data"
   NEXT_PUBLIC_API_URL:
     type: kv
     value: "http://localhost:3000"


### PR DESCRIPTION
  The Workflow SDK was attempting to write run state to `.workflow-data/runs/` which
   doesn't exist in our Kubernetes containers and cannot be created due to
  filesystem restrictions.

  ## Solution
  Configure the Workflow SDK to write to `/tmp/workflow-data` instead by setting the
   `WORKFLOW_EMBEDDED_DATA_DIR` environment variable in the staging deployment
  config.