### PR TITLE
Remove debug and tracing logs from staging

### DIFF
--- a/deploy/staging/values.yaml
+++ b/deploy/staging/values.yaml
@@ -66,13 +66,9 @@ resources:
 
 env:
   <<: *shared_env
-  # Debug logging for observability in staging
-  DEBUG:
-    type: kv
-    value: "*"
   LOG_LEVEL:
     type: kv
-    value: "debug"
+    value: "info"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps"


### PR DESCRIPTION
Removes verbose debug logging from staging environment:

- Removed DEBUG=* environment variable
- Changed LOG_LEVEL from 'debug' to 'info'
- Kept NODE_OPTIONS with source maps for error tracking

This reduces log verbosity while maintaining useful error information.