### PR TITLE
Fix drizzle-kit path alias resolution for db migrations

### DIFF
--- a/keeperhub/db/schema-extensions.ts
+++ b/keeperhub/db/schema-extensions.ts
@@ -9,8 +9,9 @@
  */
 
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
-import { users } from "@/lib/db/schema";
-import { generateId } from "@/lib/utils/id";
+// Note: Using relative paths instead of @/ aliases for drizzle-kit compatibility
+import { users } from "../../lib/db/schema";
+import { generateId } from "../../lib/utils/id";
 
 /**
  * Para Wallets table

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -166,11 +166,12 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
 
 // KeeperHub: Para Wallets table (imported from KeeperHub schema extensions)
 // biome-ignore lint/performance/noBarrelFile: Intentional re-export for schema extensions
+// Note: Using relative path instead of @/ alias for drizzle-kit compatibility
 export {
   type NewParaWallet,
   type ParaWallet,
   paraWallets,
-} from "@/keeperhub/db/schema-extensions";
+} from "../../keeperhub/db/schema-extensions";
 
 // API Keys table for webhook authentication
 export const apiKeys = pgTable("api_keys", {


### PR DESCRIPTION
## Problem

The db-migration init pod was failing with the error:

```
Error: Cannot find module '@/keeperhub/db/schema-extensions'
Require stack:
- /app/lib/db/schema.ts
- /app/node_modules/.pnpm/drizzle-kit@0.31.6/node_modules/drizzle-kit/bin.cjs
```

`drizzle-kit` runs outside of Next.js's bundler context and doesn't understand the `@/` path aliases from `tsconfig.json`. When the migration pod ran `drizzle-kit push`, it couldn't resolve `@/keeperhub/db/schema-extensions`.

## Fix

Changed path aliases to relative imports in two files:

**`lib/db/schema.ts`**
```diff
- } from "@/keeperhub/db/schema-extensions";
+ } from "../../keeperhub/db/schema-extensions";
```

**`keeperhub/db/schema-extensions.ts`**
```diff
- import { users } from "@/lib/db/schema";
- import { generateId } from "@/lib/utils/id";
+ import { users } from "../../lib/db/schema";
+ import { generateId } from "../../lib/utils/id";
```

## Test Plan

- [x] Verified `drizzle-kit check` passes locally
- [x] Verified `drizzle-kit generate` successfully reads all 12 tables
- [ ] Deploy to staging and verify db-migration pod succeeds