### PR TITLE
Fix db-migration: add keeperhub dir to migrator stage and use relative imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
 COPY --from=builder /app/lib ./lib
+COPY --from=builder /app/keeperhub ./keeperhub
 COPY --from=builder /app/package.json ./package.json
 
 # This stage can be used to run migrations


### PR DESCRIPTION
## Problem

The db-migration init pod was failing with:

```
Error: Cannot find module '@/keeperhub/db/schema-extensions'
```

Two issues:

1. **Path alias resolution**: `drizzle-kit` runs outside Next.js bundler and doesn't understand `@/` path aliases
2. **Missing directory in Docker**: The `migrator` stage wasn't copying the `keeperhub/` directory

## Fix

### 1. Use relative imports in schema files

**`lib/db/schema.ts`**
```diff
- } from "@/keeperhub/db/schema-extensions";
+ } from "../../keeperhub/db/schema-extensions";
```

**`keeperhub/db/schema-extensions.ts`**
```diff
- import { users } from "@/lib/db/schema";
- import { generateId } from "@/lib/utils/id";
+ import { users } from "../../lib/db/schema";
+ import { generateId } from "../../lib/utils/id";
```

### 2. Add keeperhub directory to migrator Docker stage

**`Dockerfile`**
```diff
  COPY --from=builder /app/lib ./lib
+ COPY --from=builder /app/keeperhub ./keeperhub
  COPY --from=builder /app/package.json ./package.json
```

## Test Plan

- [x] Verified `drizzle-kit check` passes locally
- [x] Verified `drizzle-kit generate` successfully reads all 12 tables
- [ ] Deploy to staging and verify db-migration pod succeeds