### PR TITLE
Add keeperhub directory to migrator Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
 COPY --from=builder /app/lib ./lib
+COPY --from=builder /app/keeperhub ./keeperhub
 COPY --from=builder /app/package.json ./package.json
 
 # This stage can be used to run migrations


### PR DESCRIPTION
## Problem

The db-migration init pod fails with:

```
Error: Cannot find module '../../keeperhub/db/schema-extensions'
```

The `migrator` stage in the Dockerfile wasn't copying the `keeperhub/` directory which contains `schema-extensions.ts`.

## Fix

**`Dockerfile`**
```diff
  COPY --from=builder /app/lib ./lib
+ COPY --from=builder /app/keeperhub ./keeperhub
  COPY --from=builder /app/package.json ./package.json
```

## Test Plan

- [ ] Deploy to staging and verify db-migration pod succeeds