### PR TITLE
Update common helm chart to v0.2.1

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -156,7 +156,7 @@ jobs:
           timeout: 5m0s
           name: ${{ env.SERVICE_NAME }}
           chart-repository: https://techops-services.github.io/helm-charts
-          version: 0.0.33
+          version: 0.2.1
           atomic: true
 
       - name: Deploying Job Spawner to Kubernetes with Helm
@@ -171,5 +171,5 @@ jobs:
           timeout: 5m0s
           name: keeperhub-job-spawner
           chart-repository: https://techops-services.github.io/helm-charts
-          version: 0.0.33
+          version: 0.2.1
           atomic: true


### PR DESCRIPTION
## Summary

Updates the `techops-services/common` helm chart from `0.0.33` to `0.2.1`.

## Why

v0.2.1 includes a fix for `serviceAccountName` not being set when `serviceAccount.create=false`. This was causing the job-spawner pod to use the `default` service account instead of `keeperhub-prod`.

See: https://github.com/techops-services/helm-charts/pull/64

## Changes

- Updated chart version in both helm deployments (main app + job-spawner)

## Test Plan

- [x] Merge helm-charts PR first
- [ ] Deploy and verify job-spawner uses correct service account