### PR TITLE
Fix: re-tag images when builds are skipped

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -145,6 +145,28 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
           cache-to: type=inline
 
+      # Re-tag existing images when builds are skipped (creates new tag pointing to -latest)
+      - name: Re-tag migrator image if build skipped
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.migrator != 'true' && github.event_name != 'workflow_dispatch' }}
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-${{ steps.vars.outputs.sha_short }} \
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-latest
+
+      - name: Re-tag scheduler image if build skipped
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.scheduler != 'true' && github.event_name != 'workflow_dispatch' }}
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-${{ steps.vars.outputs.sha_short }} \
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
+
+      - name: Re-tag workflow-runner image if build skipped
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.workflow-runner != 'true' && github.event_name != 'workflow_dispatch' }}
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }} \
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-latest
+
       - name: Replace variables in the Helm values file
         id: replace-vars
         if: ${{ !contains(github.event.head_commit.message , '[skip deploy]') }}


### PR DESCRIPTION
## Problem

After PR #69, when path filters skip building images (migrator/scheduler/workflow-runner), the deployment still references `image-${IMAGE_TAG}` which doesn't exist, causing deployment failures.

## Solution

When a build is skipped due to path filters, re-tag the existing `-latest` image with the current commit hash using `docker buildx imagetools create`. This:

- Creates the expected tag without rebuilding
- Points to the most recent actual build of that image
- Is fast (just creates a tag pointer, no layer uploads)

## How it works

```
Build skipped → Re-tag step runs → scheduler-abc123 points to same image as scheduler-latest → Deploy succeeds
```

## Test Plan

- [ ] Push a frontend-only change
- [ ] Verify scheduler/migrator/workflow-runner builds are skipped
- [ ] Verify re-tag steps run successfully
- [ ] Verify deployment succeeds with the new tags