### PR TITLE
Tech 5915 metrics implementation

### DIFF
--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -329,6 +329,11 @@ export async function POST(request: Request) {
     });
 
     if (!session?.user) {
+      // start custom keeperhub code //
+      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
+        status: "failure",
+      });
+      // end keeperhub code //
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -336,6 +341,11 @@ export async function POST(request: Request) {
     const { prompt, existingWorkflow } = body;
 
     if (!prompt) {
+      // start custom keeperhub code //
+      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
+        status: "failure",
+      });
+      // end keeperhub code //
       return NextResponse.json(
         { error: "Prompt is required" },
         { status: 400 }
@@ -352,6 +362,11 @@ export async function POST(request: Request) {
     );
 
     if (!modelResult.success) {
+      // start custom keeperhub code //
+      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
+        status: "failure",
+      });
+      // end keeperhub code //
       return NextResponse.json({ error: modelResult.error }, { status: 500 });
     }
 

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -29,6 +29,13 @@ export async function GET(
     });
 
     if (!session?.user) {
+      // start custom keeperhub code //
+      recordStatusPollMetrics({
+        executionId,
+        durationMs: timer(),
+        statusCode: 401,
+      });
+      // end keeperhub code //
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -41,6 +48,13 @@ export async function GET(
     });
 
     if (!execution) {
+      // start custom keeperhub code //
+      recordStatusPollMetrics({
+        executionId,
+        durationMs: timer(),
+        statusCode: 404,
+      });
+      // end keeperhub code //
       return NextResponse.json(
         { error: "Execution not found" },
         { status: 404 }
@@ -57,6 +71,11 @@ export async function GET(
       orgContext.organization?.id === execution.workflow.organizationId;
 
     if (!(isOwner || isSameOrg)) {
+      recordStatusPollMetrics({
+        executionId,
+        durationMs: timer(),
+        statusCode: 403,
+      });
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     // end keeperhub code //

--- a/keeperhub/lib/metrics/collectors/prometheus.ts
+++ b/keeperhub/lib/metrics/collectors/prometheus.ts
@@ -40,7 +40,7 @@ const WORKFLOW_LABELS = [
   "status",
 ];
 const STEP_LABELS = ["execution_id", "step_type", "status"];
-const API_LABELS = ["endpoint", "status_code", "status"];
+const _API_LABELS = ["endpoint", "status_code", "status"];
 const WEBHOOK_LABELS = ["workflow_id", "status_code", "status", "execution_id"];
 const PLUGIN_LABELS = ["plugin_name", "action_name", "execution_id", "status"];
 const _ERROR_LABELS = ["error_type", "plugin_name", "action_name", "service"];

--- a/keeperhub/lib/metrics/collectors/prometheus.ts
+++ b/keeperhub/lib/metrics/collectors/prometheus.ts
@@ -41,6 +41,7 @@ const WORKFLOW_LABELS = [
 ];
 const STEP_LABELS = ["execution_id", "step_type", "status"];
 const API_LABELS = ["endpoint", "status_code", "status"];
+const WEBHOOK_LABELS = ["workflow_id", "status_code", "status", "execution_id"];
 const PLUGIN_LABELS = ["plugin_name", "action_name", "execution_id", "status"];
 const _ERROR_LABELS = ["error_type", "plugin_name", "action_name", "service"];
 const DB_LABELS = ["query_type", "threshold"];
@@ -110,14 +111,14 @@ const stepDuration = getOrCreateHistogram(
 const webhookLatency = getOrCreateHistogram(
   "keeperhub_api_webhook_latency_ms",
   "Webhook trigger response time in milliseconds",
-  API_LABELS,
+  WEBHOOK_LABELS,
   [10, 25, 50, 100, 250, 500]
 );
 
 const statusLatency = getOrCreateHistogram(
   "keeperhub_api_status_latency_ms",
   "Status polling response time in milliseconds",
-  ["execution_id", "status"],
+  ["execution_id", "status_code", "status", "execution_status"],
   [5, 10, 25, 50, 100]
 );
 

--- a/keeperhub/lib/metrics/instrumentation/api.ts
+++ b/keeperhub/lib/metrics/instrumentation/api.ts
@@ -109,10 +109,9 @@ export function recordWebhookMetrics(options: {
     [LabelKeys.WORKFLOW_ID]: options.workflowId,
     [LabelKeys.STATUS_CODE]: String(options.statusCode),
     [LabelKeys.STATUS]: success ? "success" : "failure",
+    // Always include execution_id - Prometheus histogram requires this label
+    [LabelKeys.EXECUTION_ID]: options.executionId ?? "unknown",
   };
-  if (options.executionId) {
-    labels[LabelKeys.EXECUTION_ID] = options.executionId;
-  }
 
   metrics.recordLatency(
     MetricNames.API_WEBHOOK_LATENCY,
@@ -147,8 +146,7 @@ export function recordStatusPollMetrics(options: {
     [LabelKeys.EXECUTION_ID]: options.executionId,
     [LabelKeys.STATUS_CODE]: String(options.statusCode),
     [LabelKeys.STATUS]: options.statusCode < 400 ? "success" : "failure",
-    ...(options.executionStatus && {
-      execution_status: options.executionStatus,
-    }),
+    // Always include execution_status - Prometheus histogram requires this label
+    execution_status: options.executionStatus ?? "unknown",
   });
 }

--- a/tests/unit/api-metrics.test.ts
+++ b/tests/unit/api-metrics.test.ts
@@ -191,7 +191,7 @@ describe("API Metrics Instrumentation", () => {
       );
     });
 
-    it("should handle missing executionId", () => {
+    it("should use 'unknown' for missing executionId", () => {
       recordWebhookMetrics({
         workflowId: "wf_123",
         durationMs: 30,
@@ -200,7 +200,7 @@ describe("API Metrics Instrumentation", () => {
 
       const labels = (mockCollector.recordLatency as ReturnType<typeof vi.fn>)
         .mock.calls[0][2];
-      expect(labels.execution_id).toBeUndefined();
+      expect(labels.execution_id).toBe("unknown");
     });
   });
 
@@ -243,7 +243,7 @@ describe("API Metrics Instrumentation", () => {
       );
     });
 
-    it("should handle missing executionStatus", () => {
+    it("should use 'unknown' for missing executionStatus", () => {
       recordStatusPollMetrics({
         executionId: "exec_123",
         durationMs: 20,
@@ -252,7 +252,7 @@ describe("API Metrics Instrumentation", () => {
 
       const labels = (mockCollector.recordLatency as ReturnType<typeof vi.fn>)
         .mock.calls[0][2];
-      expect(labels.execution_status).toBeUndefined();
+      expect(labels.execution_status).toBe("unknown");
     });
   });
 });


### PR DESCRIPTION
This PR fixes Prometheus metrics not appearing in /api/metrics and ensures complete instrumentation coverage for all API routes.

**Root Cause**

The metrics collector singleton wasn't persisting across Next.js module bundles. Each bundle got its own instance, so API routes recorded metrics to one collector while /api/metrics read from another (empty) one.

**Fixes**

  1. Singleton persistence (781aada)
  - Changed metricsCollectorInstance from module-level let to globalThis
  - Ensures single collector instance shared across all Next.js bundles

  2. Required Prometheus labels (7fdce45, c85677d)
  - execution_id and execution_status are now always included with "unknown" fallback
  - Prevents prom-client from throwing "Missing label" errors in error paths

  3. Complete exit path coverage (f371d56)
  - Added metrics recording for all early returns (4xx/5xx responses)
  - Previously, validation errors (401, 403, 404, 400) bypassed metrics entirely