### PR TITLE
fix: KEEP-1225 improve CHAIN_RPC_CONFIG error logging and add db:seed to prod

### DIFF
--- a/deploy/prod/values.yaml
+++ b/deploy/prod/values.yaml
@@ -52,7 +52,9 @@ deployment:
         - |
           echo "Running database migrations..."
           pnpm db:push
-          echo "Migrations completed successfully"
+          echo "Seeding chains..."
+          pnpm db:seed
+          echo "Migrations and seeding completed successfully"
       env: *shared_env
 
 serviceAccount:

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -67,6 +67,15 @@ export type GetRpcUrlOptions = {
 };
 
 /**
+ * Result type for parseRpcConfig with error details
+ */
+export type ParseRpcConfigResult = {
+  config: RpcConfig;
+  error?: string;
+  rawValue?: string;
+};
+
+/**
  * Parse JSON config from environment variable
  *
  * @param envValue - The CHAIN_RPC_CONFIG environment variable value
@@ -77,6 +86,31 @@ export function parseRpcConfig(envValue: string | undefined): RpcConfig {
     return JSON.parse(envValue || "{}");
   } catch {
     return {};
+  }
+}
+
+/**
+ * Parse JSON config with detailed error information for debugging
+ *
+ * @param envValue - The CHAIN_RPC_CONFIG environment variable value
+ * @returns Object containing parsed config and any error details
+ */
+export function parseRpcConfigWithDetails(
+  envValue: string | undefined
+): ParseRpcConfigResult {
+  if (!envValue) {
+    return { config: {} };
+  }
+
+  try {
+    const config = JSON.parse(envValue);
+    return { config };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    // Truncate raw value for logging (may contain sensitive URLs)
+    const rawValue =
+      envValue.length > 100 ? `${envValue.slice(0, 100)}...` : envValue;
+    return { config: {}, error, rawValue };
   }
 }
 

--- a/scripts/seed-chains.ts
+++ b/scripts/seed-chains.ts
@@ -24,16 +24,29 @@ import {
   getConfigValue,
   getWssUrl,
   PUBLIC_RPCS,
-  parseRpcConfig,
+  parseRpcConfigWithDetails,
 } from "../lib/rpc/rpc-config";
 
 // Parse JSON config from environment (if available)
 const rpcConfig = (() => {
-  const config = parseRpcConfig(process.env.CHAIN_RPC_CONFIG);
-  if (process.env.CHAIN_RPC_CONFIG && Object.keys(config).length === 0) {
+  const envValue = process.env.CHAIN_RPC_CONFIG;
+  const result = parseRpcConfigWithDetails(envValue);
+
+  if (envValue && Object.keys(result.config).length === 0) {
     console.warn("Failed to parse CHAIN_RPC_CONFIG, using individual env vars");
+    if (result.error) {
+      console.warn(`  Parse error: ${result.error}`);
+    }
+    if (result.rawValue) {
+      console.warn(`  Raw value (truncated): ${result.rawValue}`);
+    }
+    console.warn(`  Value length: ${envValue.length} characters`);
+    console.warn(
+      `  First char code: ${envValue.charCodeAt(0)} (expected 123 for '{')`
+    );
   }
-  return config;
+
+  return result.config;
 })();
 
 // Create resolver function for this script


### PR DESCRIPTION
- Add parseRpcConfigWithDetails() to show parse errors, raw value preview, and char codes
- Update seed-chains.ts to log detailed debug info when JSON parsing fails
- Add pnpm db:seed to prod init container to match staging