### PR TITLE
fix: KEEP-869 Use shared RPC config for token seeding

### DIFF
--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -37,6 +37,139 @@ export const PUBLIC_RPCS = {
 } as const;
 
 /**
+ * Chain configuration mapping - single source of truth for chain ID to config key mapping
+ */
+export type ChainConfigEntry = {
+  jsonKey: string;
+  envKey: string;
+  fallbackEnvKey: string;
+  publicDefault: string;
+};
+
+export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
+  // Ethereum Mainnet
+  1: {
+    jsonKey: "eth-mainnet",
+    envKey: "CHAIN_ETH_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_ETH_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.ETH_MAINNET,
+  },
+  // Sepolia Testnet
+  11155111: {
+    jsonKey: "sepolia",
+    envKey: "CHAIN_SEPOLIA_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_SEPOLIA_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.SEPOLIA,
+  },
+  // Base Mainnet
+  8453: {
+    jsonKey: "base-mainnet",
+    envKey: "CHAIN_BASE_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_BASE_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.BASE_MAINNET,
+  },
+  // Base Sepolia
+  84532: {
+    jsonKey: "base-sepolia",
+    envKey: "CHAIN_BASE_SEPOLIA_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_BASE_SEPOLIA_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.BASE_SEPOLIA,
+  },
+  // Tempo Testnet
+  42429: {
+    jsonKey: "tempo-testnet",
+    envKey: "CHAIN_TEMPO_TESTNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_TEMPO_TESTNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.TEMPO_TESTNET,
+  },
+  // Tempo Mainnet
+  42420: {
+    jsonKey: "tempo-mainnet",
+    envKey: "CHAIN_TEMPO_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_TEMPO_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.TEMPO_MAINNET,
+  },
+  // Solana Mainnet
+  101: {
+    jsonKey: "solana-mainnet",
+    envKey: "CHAIN_SOLANA_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_SOLANA_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.SOLANA_MAINNET,
+  },
+  // Solana Devnet
+  103: {
+    jsonKey: "solana-devnet",
+    envKey: "CHAIN_SOLANA_DEVNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_SOLANA_DEVNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.SOLANA_DEVNET,
+  },
+};
+
+/**
+ * Lazy-initialized RPC config singleton
+ * Parses CHAIN_RPC_CONFIG from environment once on first access
+ */
+let _rpcConfigSingleton: RpcConfig = {};
+
+function getRpcConfigSingleton(): RpcConfig {
+  if (Object.keys(_rpcConfigSingleton).length === 0) {
+    const envValue = process.env.CHAIN_RPC_CONFIG;
+    const result = parseRpcConfigWithDetails(envValue);
+
+    if (envValue && Object.keys(result.config).length === 0) {
+      console.warn(
+        "[rpc-config] Failed to parse CHAIN_RPC_CONFIG, using public RPC defaults"
+      );
+      if (result.error) {
+        console.warn(`  Parse error: ${result.error}`);
+      }
+    }
+
+    _rpcConfigSingleton = result.config;
+  }
+  return _rpcConfigSingleton;
+}
+
+/**
+ * Get RPC URL by chain ID - simple convenience function for scripts
+ *
+ * Uses CHAIN_RPC_CONFIG from environment if available, falls back to public RPCs.
+ *
+ * @param chainId - The chain ID (e.g., 1 for Ethereum mainnet)
+ * @param type - "primary" or "fallback"
+ * @returns The resolved RPC URL
+ * @throws Error if chain ID is not configured
+ */
+export function getRpcUrlByChainId(
+  chainId: number,
+  type: "primary" | "fallback" = "primary"
+): string {
+  const config = CHAIN_CONFIG[chainId];
+  if (!config) {
+    throw new Error(`No RPC configuration for chain ID ${chainId}`);
+  }
+
+  const rpcConfig = getRpcConfigSingleton();
+  const envKey = type === "primary" ? config.envKey : config.fallbackEnvKey;
+
+  return getRpcUrl({
+    rpcConfig,
+    jsonKey: config.jsonKey,
+    envValue: process.env[envKey],
+    publicDefault: config.publicDefault,
+    type,
+  });
+}
+
+/**
+ * Get the chain config entry for a chain ID
+ * Useful when you need access to the jsonKey or env var names
+ */
+export function getChainConfig(chainId: number): ChainConfigEntry | undefined {
+  return CHAIN_CONFIG[chainId];
+}
+
+/**
  * Type for RPC configuration entry
  */
 export type RpcConfigEntry = {

--- a/scripts/seed-chains.ts
+++ b/scripts/seed-chains.ts
@@ -20,14 +20,14 @@ import {
   type NewExplorerConfig,
 } from "../lib/db/schema";
 import {
-  createRpcUrlResolver,
+  CHAIN_CONFIG,
   getConfigValue,
+  getRpcUrlByChainId,
   getWssUrl,
-  PUBLIC_RPCS,
   parseRpcConfigWithDetails,
 } from "../lib/rpc/rpc-config";
 
-// Parse JSON config from environment (if available)
+// Parse JSON config from environment (if available) - used for WSS URLs and config values
 const rpcConfig = (() => {
   const envValue = process.env.CHAIN_RPC_CONFIG;
   const result = parseRpcConfigWithDetails(envValue);
@@ -49,11 +49,8 @@ const rpcConfig = (() => {
   return result.config;
 })();
 
-// Create resolver function for this script
-const getRpcUrl = createRpcUrlResolver(rpcConfig);
-
 // Helper to get config value with rpcConfig pre-bound
-const getChainConfig = <T>(
+const getChainConfigValue = <T>(
   jsonKey: string,
   field: "chainId" | "symbol" | "isEnabled" | "isTestnet",
   defaultValue: T
@@ -61,245 +58,165 @@ const getChainConfig = <T>(
 
 const DEFAULT_CHAINS: NewChain[] = [
   {
-    chainId: getChainConfig("eth-mainnet", "chainId", 1),
+    chainId: getChainConfigValue("eth-mainnet", "chainId", 1),
     name: "Ethereum Mainnet",
-    symbol: getChainConfig("eth-mainnet", "symbol", "ETH"),
+    symbol: getChainConfigValue("eth-mainnet", "symbol", "ETH"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrl(
-      "eth-mainnet",
-      "CHAIN_ETH_MAINNET_PRIMARY_RPC",
-      PUBLIC_RPCS.ETH_MAINNET,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "eth-mainnet",
-      "CHAIN_ETH_MAINNET_FALLBACK_RPC",
-      PUBLIC_RPCS.ETH_MAINNET,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(1, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(1, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "eth-mainnet",
+      jsonKey: CHAIN_CONFIG[1].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "eth-mainnet",
+      jsonKey: CHAIN_CONFIG[1].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("eth-mainnet", "isTestnet", false),
-    isEnabled: getChainConfig("eth-mainnet", "isEnabled", true),
+    isTestnet: getChainConfigValue("eth-mainnet", "isTestnet", false),
+    isEnabled: getChainConfigValue("eth-mainnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfig("sepolia", "chainId", 11_155_111),
+    chainId: getChainConfigValue("sepolia", "chainId", 11_155_111),
     name: "Sepolia Testnet",
-    symbol: getChainConfig("sepolia", "symbol", "ETH"),
+    symbol: getChainConfigValue("sepolia", "symbol", "ETH"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrl(
-      "sepolia",
-      "CHAIN_SEPOLIA_PRIMARY_RPC",
-      PUBLIC_RPCS.SEPOLIA,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "sepolia",
-      "CHAIN_SEPOLIA_FALLBACK_RPC",
-      PUBLIC_RPCS.SEPOLIA,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(11_155_111, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(11_155_111, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "sepolia",
+      jsonKey: CHAIN_CONFIG[11_155_111].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "sepolia",
+      jsonKey: CHAIN_CONFIG[11_155_111].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("sepolia", "isTestnet", true),
-    isEnabled: getChainConfig("sepolia", "isEnabled", true),
+    isTestnet: getChainConfigValue("sepolia", "isTestnet", true),
+    isEnabled: getChainConfigValue("sepolia", "isEnabled", true),
   },
   {
-    chainId: getChainConfig("base-mainnet", "chainId", 8453),
+    chainId: getChainConfigValue("base-mainnet", "chainId", 8453),
     name: "Base",
-    symbol: getChainConfig("base-mainnet", "symbol", "BASE"),
+    symbol: getChainConfigValue("base-mainnet", "symbol", "BASE"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrl(
-      "base-mainnet",
-      "CHAIN_BASE_MAINNET_PRIMARY_RPC",
-      PUBLIC_RPCS.BASE_MAINNET,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "base-mainnet",
-      "CHAIN_BASE_MAINNET_FALLBACK_RPC",
-      PUBLIC_RPCS.BASE_MAINNET,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(8453, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(8453, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "base-mainnet",
+      jsonKey: CHAIN_CONFIG[8453].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "base-mainnet",
+      jsonKey: CHAIN_CONFIG[8453].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("base-mainnet", "isTestnet", false),
-    isEnabled: getChainConfig("base-mainnet", "isEnabled", true),
+    isTestnet: getChainConfigValue("base-mainnet", "isTestnet", false),
+    isEnabled: getChainConfigValue("base-mainnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfig("base-sepolia", "chainId", 84_532),
+    chainId: getChainConfigValue("base-sepolia", "chainId", 84_532),
     name: "Base Sepolia",
-    symbol: getChainConfig("base-sepolia", "symbol", "BASE"),
+    symbol: getChainConfigValue("base-sepolia", "symbol", "BASE"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrl(
-      "base-sepolia",
-      "CHAIN_BASE_SEPOLIA_PRIMARY_RPC",
-      PUBLIC_RPCS.BASE_SEPOLIA,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "base-sepolia",
-      "CHAIN_BASE_SEPOLIA_FALLBACK_RPC",
-      PUBLIC_RPCS.BASE_SEPOLIA,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(84_532, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(84_532, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "base-sepolia",
+      jsonKey: CHAIN_CONFIG[84_532].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "base-sepolia",
+      jsonKey: CHAIN_CONFIG[84_532].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("base-sepolia", "isTestnet", true),
-    isEnabled: getChainConfig("base-sepolia", "isEnabled", true),
+    isTestnet: getChainConfigValue("base-sepolia", "isTestnet", true),
+    isEnabled: getChainConfigValue("base-sepolia", "isEnabled", true),
   },
   {
-    chainId: getChainConfig("tempo-testnet", "chainId", 42_429),
+    chainId: getChainConfigValue("tempo-testnet", "chainId", 42_429),
     name: "Tempo Testnet",
-    symbol: getChainConfig("tempo-testnet", "symbol", "TEMPO"),
+    symbol: getChainConfigValue("tempo-testnet", "symbol", "TEMPO"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrl(
-      "tempo-testnet",
-      "CHAIN_TEMPO_TESTNET_PRIMARY_RPC",
-      PUBLIC_RPCS.TEMPO_TESTNET,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "tempo-testnet",
-      "CHAIN_TEMPO_TESTNET_FALLBACK_RPC",
-      PUBLIC_RPCS.TEMPO_TESTNET,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(42_429, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(42_429, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "tempo-testnet",
+      jsonKey: CHAIN_CONFIG[42_429].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "tempo-testnet",
+      jsonKey: CHAIN_CONFIG[42_429].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("tempo-testnet", "isTestnet", true),
-    isEnabled: getChainConfig("tempo-testnet", "isEnabled", true),
+    isTestnet: getChainConfigValue("tempo-testnet", "isTestnet", true),
+    isEnabled: getChainConfigValue("tempo-testnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfig("tempo-mainnet", "chainId", 42_420),
+    chainId: getChainConfigValue("tempo-mainnet", "chainId", 42_420),
     name: "Tempo",
-    symbol: getChainConfig("tempo-mainnet", "symbol", "TEMPO"),
+    symbol: getChainConfigValue("tempo-mainnet", "symbol", "TEMPO"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrl(
-      "tempo-mainnet",
-      "CHAIN_TEMPO_MAINNET_PRIMARY_RPC",
-      PUBLIC_RPCS.TEMPO_MAINNET,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "tempo-mainnet",
-      "CHAIN_TEMPO_MAINNET_FALLBACK_RPC",
-      PUBLIC_RPCS.TEMPO_MAINNET,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(42_420, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(42_420, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "tempo-mainnet",
+      jsonKey: CHAIN_CONFIG[42_420].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "tempo-mainnet",
+      jsonKey: CHAIN_CONFIG[42_420].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("tempo-mainnet", "isTestnet", false),
-    isEnabled: getChainConfig("tempo-mainnet", "isEnabled", false),
+    isTestnet: getChainConfigValue("tempo-mainnet", "isTestnet", false),
+    isEnabled: getChainConfigValue("tempo-mainnet", "isEnabled", false),
   },
   // Solana chains (non-EVM - uses SolanaProviderManager)
   {
-    chainId: getChainConfig("solana-mainnet", "chainId", 101),
+    chainId: getChainConfigValue("solana-mainnet", "chainId", 101),
     name: "Solana",
-    symbol: getChainConfig("solana-mainnet", "symbol", "SOL"),
+    symbol: getChainConfigValue("solana-mainnet", "symbol", "SOL"),
     chainType: "solana",
-    defaultPrimaryRpc: getRpcUrl(
-      "solana-mainnet",
-      "CHAIN_SOLANA_MAINNET_PRIMARY_RPC",
-      PUBLIC_RPCS.SOLANA_MAINNET,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "solana-mainnet",
-      "CHAIN_SOLANA_MAINNET_FALLBACK_RPC",
-      PUBLIC_RPCS.SOLANA_MAINNET,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(101, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(101, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "solana-mainnet",
+      jsonKey: CHAIN_CONFIG[101].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "solana-mainnet",
+      jsonKey: CHAIN_CONFIG[101].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("solana-mainnet", "isTestnet", false),
-    isEnabled: getChainConfig("solana-mainnet", "isEnabled", true),
+    isTestnet: getChainConfigValue("solana-mainnet", "isTestnet", false),
+    isEnabled: getChainConfigValue("solana-mainnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfig("solana-devnet", "chainId", 103),
+    chainId: getChainConfigValue("solana-devnet", "chainId", 103),
     name: "Solana Devnet",
-    symbol: getChainConfig("solana-devnet", "symbol", "SOL"),
+    symbol: getChainConfigValue("solana-devnet", "symbol", "SOL"),
     chainType: "solana",
-    defaultPrimaryRpc: getRpcUrl(
-      "solana-devnet",
-      "CHAIN_SOLANA_DEVNET_PRIMARY_RPC",
-      PUBLIC_RPCS.SOLANA_DEVNET,
-      "primary"
-    ),
-    defaultFallbackRpc: getRpcUrl(
-      "solana-devnet",
-      "CHAIN_SOLANA_DEVNET_FALLBACK_RPC",
-      PUBLIC_RPCS.SOLANA_DEVNET,
-      "fallback"
-    ),
+    defaultPrimaryRpc: getRpcUrlByChainId(103, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(103, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: "solana-devnet",
+      jsonKey: CHAIN_CONFIG[103].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: "solana-devnet",
+      jsonKey: CHAIN_CONFIG[103].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfig("solana-devnet", "isTestnet", true),
-    isEnabled: getChainConfig("solana-devnet", "isEnabled", true),
+    isTestnet: getChainConfigValue("solana-devnet", "isTestnet", true),
+    isEnabled: getChainConfigValue("solana-devnet", "isEnabled", true),
   },
 ];
 

--- a/scripts/seed-tokens.ts
+++ b/scripts/seed-tokens.ts
@@ -5,6 +5,11 @@
  * for each supported chain. Token metadata (symbol, name, decimals) is fetched
  * directly from the blockchain to ensure accuracy.
  *
+ * RPC URL resolution priority:
+ *   1. CHAIN_RPC_CONFIG JSON (for Helm/AWS Parameter Store)
+ *   2. Individual env vars (CHAIN_ETH_MAINNET_PRIMARY_RPC, etc.)
+ *   3. Public RPC defaults (no API keys required)
+ *
  * Run with: pnpm tsx scripts/seed-tokens.ts
  */
 
@@ -15,20 +20,13 @@ import { ethers } from "ethers";
 import postgres from "postgres";
 import { supportedTokens } from "../keeperhub/db/schema-extensions";
 import { ERC20_ABI } from "../lib/contracts";
+import { getRpcUrlByChainId } from "../lib/rpc/rpc-config";
 
 // Token logo URLs (using popular token list sources)
 const LOGOS = {
   USDC: "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
   USDT: "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
   USDS: "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdC035D45d973E3EC169d2276DDab16f1e407384F/logo.png",
-};
-
-// RPC URLs for each chain (using public endpoints for seeding)
-const RPC_URLS: Record<number, string> = {
-  1: "https://eth.llamarpc.com",
-  11155111: "https://ethereum-sepolia-rpc.publicnode.com",
-  8453: "https://base.llamarpc.com",
-  84532: "https://base-sepolia-rpc.publicnode.com",
 };
 
 /**
@@ -120,15 +118,13 @@ const TOKEN_CONFIGS: TokenConfig[] = [
 
 /**
  * Fetch token metadata from the blockchain
+ * Uses CHAIN_RPC_CONFIG for RPC URLs (same as seed-chains.ts)
  */
 async function fetchTokenMetadata(
   chainId: number,
   tokenAddress: string
 ): Promise<{ symbol: string; name: string; decimals: number }> {
-  const rpcUrl = RPC_URLS[chainId];
-  if (!rpcUrl) {
-    throw new Error(`No RPC URL configured for chain ${chainId}`);
-  }
+  const rpcUrl = getRpcUrlByChainId(chainId, "primary");
 
   const provider = new ethers.JsonRpcProvider(rpcUrl);
   const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);


### PR DESCRIPTION
## Summary
- Add `CHAIN_CONFIG` mapping and `getRpcUrlByChainId()` to `rpc-config.ts` as single source of truth
- Update `seed-chains.ts` to use shared config
- Update `seed-tokens.ts` to use `CHAIN_RPC_CONFIG` instead of hardcoded public RPCs

## Problem
Token seeding was failing in staging because `seed-tokens.ts` used hardcoded public RPCs (llamarpc.com, publicnode.com) that were being rate-limited or blocked, while `seed-chains.ts` properly used `CHAIN_RPC_CONFIG` from AWS Parameter Store.

## Solution
Both seed scripts now use the same RPC resolution priority:
1. `CHAIN_RPC_CONFIG` JSON (from AWS Parameter Store)
2. Individual env vars (fallback)
3. Public RPC defaults (last resort)

## Test plan
- [x] Verified locally with `pnpm db:seed` - both chains and tokens seed successfully