### PR TITLE
Refactor deployment workflows and rename job-spawner to scheduler

### DIFF
--- a/.github/workflows/deploy-job-spawner.yaml
+++ b/.github/workflows/deploy-job-spawner.yaml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'deploy/job-spawner/**'
       - 'scripts/job-spawner.ts'
+      - 'scripts/schedule-*.ts'
+      - 'scripts/workflow-runner.ts'
+      - 'lib/**'
+      - 'plugins/**'
+      - 'keeperhub/**'
       - '.github/workflows/deploy-job-spawner.yaml'
   workflow_run:
     workflows: ["deploy-keeperhub"]
@@ -40,6 +45,30 @@ jobs:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            scheduler:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'Dockerfile'
+              - 'scripts/schedule-*.ts'
+              - 'scripts/job-spawner.ts'
+              - 'lib/**'
+              - 'keeperhub/**'
+              - 'tsconfig.json'
+            workflow-runner:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'Dockerfile'
+              - 'scripts/workflow-runner.ts'
+              - 'lib/**'
+              - 'plugins/**'
+              - 'keeperhub/**'
+              - 'tsconfig.json'
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -51,11 +80,63 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up Docker Buildx
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') }}
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract commit hash
         id: vars
         shell: bash
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build, tag, and push scheduler image to ECR
+        id: build-scheduler
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && (steps.changes.outputs.scheduler == 'true' || github.event_name == 'workflow_dispatch') }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: scheduler
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-${{ steps.vars.outputs.sha_short }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
+          cache-to: type=inline
+
+      - name: Build, tag, and push workflow-runner image to ECR
+        id: build-workflow-runner
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && (steps.changes.outputs.workflow-runner == 'true' || github.event_name == 'workflow_dispatch') }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: workflow-runner
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-latest
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
+          cache-to: type=inline
+
+      # Re-tag existing images when builds are skipped (creates new tag pointing to -latest)
+      - name: Re-tag scheduler image if build skipped
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.scheduler != 'true' && github.event_name != 'workflow_dispatch' }}
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-${{ steps.vars.outputs.sha_short }} \
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
+
+      - name: Re-tag workflow-runner image if build skipped
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.workflow-runner != 'true' && github.event_name != 'workflow_dispatch' }}
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }} \
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-latest
 
       - name: Replace variables in the Helm values file
         env:

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -42,24 +42,6 @@ jobs:
               - 'keeperhub/db/**'
               - 'drizzle/**'
               - 'drizzle.config.ts'
-            scheduler:
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'Dockerfile'
-              - 'scripts/schedule-*.ts'
-              - 'scripts/job-spawner.ts'
-              - 'lib/**'
-              - 'keeperhub/**'
-              - 'tsconfig.json'
-            workflow-runner:
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'Dockerfile'
-              - 'scripts/workflow-runner.ts'
-              - 'lib/**'
-              - 'plugins/**'
-              - 'keeperhub/**'
-              - 'tsconfig.json'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -114,39 +96,6 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
           cache-to: type=inline
 
-      - name: Build, tag, and push scheduler image to ECR
-        id: build-scheduler
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && (steps.changes.outputs.scheduler == 'true' || github.event_name == 'workflow_dispatch') }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          target: scheduler
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-${{ steps.vars.outputs.sha_short }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
-          cache-from: |
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
-          cache-to: type=inline
-
-      - name: Build, tag, and push workflow-runner image to ECR
-        id: build-workflow-runner
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && (steps.changes.outputs.workflow-runner == 'true' || github.event_name == 'workflow_dispatch') }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          target: workflow-runner
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-latest
-          cache-from: |
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
-
       # Re-tag existing images when builds are skipped (creates new tag pointing to -latest)
       - name: Re-tag migrator image if build skipped
         if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.migrator != 'true' && github.event_name != 'workflow_dispatch' }}
@@ -154,20 +103,6 @@ jobs:
           docker buildx imagetools create \
             --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-${{ steps.vars.outputs.sha_short }} \
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-latest
-
-      - name: Re-tag scheduler image if build skipped
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.scheduler != 'true' && github.event_name != 'workflow_dispatch' }}
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-${{ steps.vars.outputs.sha_short }} \
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
-
-      - name: Re-tag workflow-runner image if build skipped
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.workflow-runner != 'true' && github.event_name != 'workflow_dispatch' }}
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }} \
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-latest
 
       - name: Replace variables in the Helm values file
         id: replace-vars

--- a/.github/workflows/deploy-sc-event-tracker.yaml
+++ b/.github/workflows/deploy-sc-event-tracker.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ github.ref == 'refs/heads/prod' && secrets.AWS_ACCESS_KEY_ID || secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ github.ref == 'refs/heads/prod' && secrets.AWS_SECRET_ACCESS_KEY || secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR

--- a/.github/workflows/deploy-sc-event-worker.yaml
+++ b/.github/workflows/deploy-sc-event-worker.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ github.ref == 'refs/heads/prod' && secrets.AWS_ACCESS_KEY_ID || secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ github.ref == 'refs/heads/prod' && secrets.AWS_SECRET_ACCESS_KEY || secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR

--- a/.github/workflows/deploy-scheduler.yaml
+++ b/.github/workflows/deploy-scheduler.yaml
@@ -4,14 +4,14 @@ on:
       - staging
       - prod
     paths:
-      - 'deploy/job-spawner/**'
+      - 'deploy/scheduler/**'
       - 'scripts/job-spawner.ts'
       - 'scripts/schedule-*.ts'
       - 'scripts/workflow-runner.ts'
       - 'lib/**'
       - 'plugins/**'
       - 'keeperhub/**'
-      - '.github/workflows/deploy-job-spawner.yaml'
+      - '.github/workflows/deploy-scheduler.yaml'
   workflow_run:
     workflows: ["deploy-keeperhub"]
     types:
@@ -21,21 +21,21 @@ on:
       - prod
   workflow_dispatch:
 
-name: deploy-job-spawner
+name: deploy-scheduler
 
 jobs:
-  deploy-job-spawner:
+  deploy-scheduler:
     # Skip if triggered by workflow_run and the workflow failed
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     environment: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
     runs-on: ubuntu-latest
     env:
       ENV_NAME: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
-      HELM_FILE: deploy/job-spawner/${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}/values.yaml
+      HELM_FILE: deploy/scheduler/${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}/values.yaml
       REGION: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'us-east-1' || 'us-east-2' }}
       CLUSTER_NAME: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'maker-prod' || 'maker-staging' }}
       NAMESPACE: keeperhub
-      SERVICE_NAME: keeperhub-job-spawner
+      SERVICE_NAME: keeperhub-scheduler
       AWS_ECR_NAME: keeperhub-${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'prod') || github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
 
     steps:
@@ -152,7 +152,7 @@ jobs:
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}
 
-      - name: Deploying Job Spawner to Kubernetes with Helm
+      - name: Deploying Scheduler to Kubernetes with Helm
         id: deploy
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
         with:

--- a/deploy/scheduler/prod/values.yaml
+++ b/deploy/scheduler/prod/values.yaml
@@ -1,31 +1,28 @@
-# Job Spawner Deployment - Staging
+# Scheduler Deployment - Production
 # Polls SQS for scheduled workflow triggers and creates K8s Jobs to execute them
 #
-# This is a long-running deployment that:
-# 1. Receives messages from SQS (sent by schedule-dispatcher)
-# 2. Creates workflow execution records in the database
-# 3. Spawns K8s Jobs to run the actual workflows
+# NOTE: Production deployment not yet enabled - this is a placeholder
+# Update SQS_QUEUE_URL and parameter paths when ready
 
 replicaCount: 1
 
 service:
-  enabled: false  # No service needed - this is a background worker
+  enabled: false
 
 ingress:
   enabled: false
 
 image:
-  repository: ${ECR_REGISTRY}/keeperhub-staging
+  repository: ${ECR_REGISTRY}/keeperhub-prod
   tag: scheduler-${IMAGE_TAG}
   pullPolicy: Always
 
 deployment:
   enabled: true
 
-# Use the same service account as main app (has K8s job creation permissions)
 serviceAccount:
   create: false
-  name: keeperhub-staging
+  name: keeperhub-prod
 
 podAnnotations:
   reloader.stakater.com/auto: "true"
@@ -42,26 +39,24 @@ command: ["/bin/sh"]
 args:
   - "-c"
   - |
-    echo "$(date) - [JobSpawner] Starting..."
+    echo "$(date) - [Scheduler] Starting..."
     tsx scripts/job-spawner.ts
 
 env:
-  # Database connection
   DATABASE_URL:
     type: parameterStore
     name: db-url
-    parameter_name: /eks/maker-staging/keeperhub/db-url
-  # AWS/SQS configuration (no endpoint for real AWS)
+    parameter_name: /eks/maker-prod/keeperhub/db-url
   AWS_REGION:
     type: kv
-    value: "us-east-2"
+    value: "us-east-1"
+  # TODO: Create production SQS queue
   SQS_QUEUE_URL:
     type: kv
-    value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
-  # K8s Job configuration
+    value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
   RUNNER_IMAGE:
     type: kv
-    value: "${ECR_REGISTRY}/keeperhub-staging:workflow-runner-${IMAGE_TAG}"
+    value: "${ECR_REGISTRY}/keeperhub-prod:workflow-runner-${IMAGE_TAG}"
   IMAGE_PULL_POLICY:
     type: kv
     value: "Always"
@@ -74,16 +69,14 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
-  # For workflow runner jobs - passed to created K8s Jobs
   INTEGRATION_ENCRYPTION_KEY:
     type: parameterStore
     name: integration-encryption-key
-    parameter_name: /eks/maker-staging/keeperhub/integration-encryption-key
+    parameter_name: /eks/maker-prod/keeperhub/integration-encryption-key
 
 externalSecrets:
-  clusterSecretStoreName: maker-staging
+  clusterSecretStoreName: maker-prod
 
-# Exec probe to check if the node process is running
 livenessProbe:
   exec:
     command:

--- a/deploy/scheduler/staging/values.yaml
+++ b/deploy/scheduler/staging/values.yaml
@@ -1,28 +1,31 @@
-# Job Spawner Deployment - Production
+# Scheduler Deployment - Staging
 # Polls SQS for scheduled workflow triggers and creates K8s Jobs to execute them
 #
-# NOTE: Production deployment not yet enabled - this is a placeholder
-# Update SQS_QUEUE_URL and parameter paths when ready
+# This is a long-running deployment that:
+# 1. Receives messages from SQS (sent by schedule-dispatcher)
+# 2. Creates workflow execution records in the database
+# 3. Spawns K8s Jobs to run the actual workflows
 
 replicaCount: 1
 
 service:
-  enabled: false
+  enabled: false  # No service needed - this is a background worker
 
 ingress:
   enabled: false
 
 image:
-  repository: ${ECR_REGISTRY}/keeperhub-prod
+  repository: ${ECR_REGISTRY}/keeperhub-staging
   tag: scheduler-${IMAGE_TAG}
   pullPolicy: Always
 
 deployment:
   enabled: true
 
+# Use the same service account as main app (has K8s job creation permissions)
 serviceAccount:
   create: false
-  name: keeperhub-prod
+  name: keeperhub-staging
 
 podAnnotations:
   reloader.stakater.com/auto: "true"
@@ -39,24 +42,26 @@ command: ["/bin/sh"]
 args:
   - "-c"
   - |
-    echo "$(date) - [JobSpawner] Starting..."
+    echo "$(date) - [Scheduler] Starting..."
     tsx scripts/job-spawner.ts
 
 env:
+  # Database connection
   DATABASE_URL:
     type: parameterStore
     name: db-url
-    parameter_name: /eks/maker-prod/keeperhub/db-url
+    parameter_name: /eks/maker-staging/keeperhub/db-url
+  # AWS/SQS configuration (no endpoint for real AWS)
   AWS_REGION:
     type: kv
-    value: "us-east-1"
-  # TODO: Create production SQS queue
+    value: "us-east-2"
   SQS_QUEUE_URL:
     type: kv
-    value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
+    value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
+  # K8s Job configuration
   RUNNER_IMAGE:
     type: kv
-    value: "${ECR_REGISTRY}/keeperhub-prod:workflow-runner-${IMAGE_TAG}"
+    value: "${ECR_REGISTRY}/keeperhub-staging:workflow-runner-${IMAGE_TAG}"
   IMAGE_PULL_POLICY:
     type: kv
     value: "Always"
@@ -69,14 +74,16 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
+  # For workflow runner jobs - passed to created K8s Jobs
   INTEGRATION_ENCRYPTION_KEY:
     type: parameterStore
     name: integration-encryption-key
-    parameter_name: /eks/maker-prod/keeperhub/integration-encryption-key
+    parameter_name: /eks/maker-staging/keeperhub/integration-encryption-key
 
 externalSecrets:
-  clusterSecretStoreName: maker-prod
+  clusterSecretStoreName: maker-staging
 
+# Exec probe to check if the node process is running
 livenessProbe:
   exec:
     command:


### PR DESCRIPTION
## Summary
- Standardize AWS credentials in sc-event-tracker and sc-event-worker workflows (use simple `secrets.AWS_ACCESS_KEY_ID` pattern)
- Move scheduler and workflow-runner Docker builds from deploy-keeperhub to deploy-scheduler workflow
- Rename job-spawner to scheduler across all files:
  - `deploy-job-spawner.yaml` → `deploy-scheduler.yaml`
  - `deploy/job-spawner/` → `deploy/scheduler/`
  - SERVICE_NAME: `keeperhub-job-spawner` → `keeperhub-scheduler`

## Changes

**deploy-keeperhub.yaml:**
- Now only builds: app, migrator
- Removed scheduler and workflow-runner build steps

**deploy-scheduler.yaml (renamed from deploy-job-spawner.yaml):**
- Builds scheduler and workflow-runner images
- Triggers on relevant path changes (`lib/**`, `plugins/**`, `keeperhub/**`, `scripts/`)
- Triggers after deploy-keeperhub completes

**deploy-sc-event-tracker.yaml & deploy-sc-event-worker.yaml:**
- Standardized AWS credentials pattern

## Test plan
- [ ] Verify deploy-keeperhub builds app and migrator images
- [ ] Verify deploy-scheduler builds scheduler and workflow-runner images
- [ ] Verify deploy-scheduler triggers after deploy-keeperhub completes
- [ ] Verify sc-event-tracker and sc-event-worker deploy correctly