### PR TITLE
fix: Rename event services for consistent K8s naming

### DIFF
--- a/.github/workflows/deploy-sc-event-tracker.yaml
+++ b/.github/workflows/deploy-sc-event-tracker.yaml
@@ -21,7 +21,7 @@ jobs:
       CLUSTER_NAME: ${{ github.ref == 'refs/heads/prod' && 'maker-prod' || 'maker-staging' }}
       ENVIRONMENT_TAG: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
       NAMESPACE: keeperhub
-      SERVICE_NAME: sc-event-tracker
+      SERVICE_NAME: keeperhub-events-tracker
       AWS_ECR_NAME: sc-event-tracker-${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
 
     steps:

--- a/.github/workflows/deploy-sc-event-worker.yaml
+++ b/.github/workflows/deploy-sc-event-worker.yaml
@@ -21,7 +21,7 @@ jobs:
       CLUSTER_NAME: ${{ github.ref == 'refs/heads/prod' && 'maker-prod' || 'maker-staging' }}
       ENVIRONMENT_TAG: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
       NAMESPACE: keeperhub
-      SERVICE_NAME: sc-event-worker
+      SERVICE_NAME: keeperhub-events-worker
       AWS_ECR_NAME: sc-event-worker-${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
 
     steps:

--- a/deploy/sc-event-tracker/prod/values.yaml
+++ b/deploy/sc-event-tracker/prod/values.yaml
@@ -42,10 +42,10 @@ env:
     value: "info"
   KEEPERHUB_API_URL:
     type: kv
-    value: "http://keeperhub-prod:3000"
+    value: "http://keeperhub-common:3000"
   WORKER_URL:
     type: kv
-    value: "http://sc-event-worker-prod:3010"
+    value: "http://keeperhub-events-worker-common:3010"
   REDIS_HOST:
     type: parameterStore
     name: redis-host

--- a/deploy/sc-event-tracker/staging/values.yaml
+++ b/deploy/sc-event-tracker/staging/values.yaml
@@ -42,10 +42,10 @@ env:
     value: "info"
   KEEPERHUB_API_URL:
     type: kv
-    value: "http://keeperhub-staging:3000"
+    value: "http://keeperhub-common:3000"
   WORKER_URL:
     type: kv
-    value: "http://sc-event-worker-staging:3010"
+    value: "http://keeperhub-events-worker-common:3010"
   REDIS_HOST:
     type: parameterStore
     name: redis-host

--- a/deploy/sc-event-worker/prod/values.yaml
+++ b/deploy/sc-event-worker/prod/values.yaml
@@ -46,7 +46,7 @@ env:
     parameter_name: /eks/maker-prod/keeperhub-events/worker-port
   KEEPERHUB_API_URL:
     type: kv
-    value: "http://keeperhub-prod:3000"
+    value: "http://keeperhub-common:3000"
   KEEPERHUB_API_KEY:
     type: parameterStore
     name: keeperhub-api-key

--- a/deploy/sc-event-worker/staging/values.yaml
+++ b/deploy/sc-event-worker/staging/values.yaml
@@ -46,7 +46,7 @@ env:
     parameter_name: /eks/maker-staging/keeperhub-events/worker-port
   KEEPERHUB_API_URL:
     type: kv
-    value: "http://keeperhub-staging:3000"
+    value: "http://keeperhub-common:3000"
   KEEPERHUB_API_KEY:
     type: parameterStore
     name: keeperhub-api-key


### PR DESCRIPTION
## Summary

- Rename SERVICE_NAME from `sc-event-tracker` to `keeperhub-events-tracker`
- Rename SERVICE_NAME from `sc-event-worker` to `keeperhub-events-worker`
- Fix WORKER_URL to use correct K8s service name (`keeperhub-events-worker-common`)
- Fix KEEPERHUB_API_URL to use correct K8s service name (`keeperhub-common`)

## Root Cause

The event tracker was failing with `ENOTFOUND sc-event-worker-staging` because:
- K8s services created by the common Helm chart are named `{release-name}-common`
- The WORKER_URL was pointing to `sc-event-worker-staging` (the `service.name` value, not the actual K8s service name)

## Post-Deploy Cleanup Required

After merging, the old Helm releases need to be manually uninstalled from K8s:
```bash
# Staging
helm uninstall sc-event-tracker -n keeperhub
helm uninstall sc-event-worker -n keeperhub

# Prod (after prod deploy)
helm uninstall sc-event-tracker -n keeperhub
helm uninstall sc-event-worker -n keeperhub
```

The new deployments will be created with names:
- `keeperhub-events-tracker-common`
- `keeperhub-events-worker-common`