### PR TITLE
feat: KEEP-869 Fix balance precision and add TEMPO pathUSD display

### DIFF
--- a/keeperhub/components/overlays/withdraw-modal.tsx
+++ b/keeperhub/components/overlays/withdraw-modal.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/select";
 
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
-const UNLIMITED_BALANCE = "∞";
 
 export type WithdrawableAsset = {
   type: "native" | "token";
@@ -62,12 +61,10 @@ export function WithdrawModal({
   const isValidAddress = (address: string) => ADDRESS_REGEX.test(address);
 
   const handleMaxClick = () => {
-    if (selectedAsset && !isUnlimitedBalance(selectedAsset.balance)) {
+    if (selectedAsset) {
       setAmount(selectedAsset.balance);
     }
   };
-
-  const isUnlimitedBalance = (balance: string) => balance === UNLIMITED_BALANCE;
 
   const validateWithdrawal = (): string | null => {
     if (!selectedAsset) {
@@ -76,11 +73,7 @@ export function WithdrawModal({
     if (!amount || Number.parseFloat(amount) <= 0) {
       return "Please enter a valid amount";
     }
-    // Skip balance check for unlimited (testnet mock) balances
-    if (
-      !isUnlimitedBalance(selectedAsset.balance) &&
-      Number.parseFloat(amount) > Number.parseFloat(selectedAsset.balance)
-    ) {
+    if (Number.parseFloat(amount) > Number.parseFloat(selectedAsset.balance)) {
       return "Insufficient balance";
     }
     if (!isValidAddress(recipient)) {
@@ -200,9 +193,8 @@ export function WithdrawModal({
           disabled:
             !(amount && recipient && isValidAddress(recipient)) ||
             Number.parseFloat(amount) <= 0 ||
-            (!isUnlimitedBalance(selectedAsset?.balance || "0") &&
-              Number.parseFloat(amount) >
-                Number.parseFloat(selectedAsset?.balance || "0")),
+            Number.parseFloat(amount) >
+              Number.parseFloat(selectedAsset?.balance || "0"),
         },
       ]}
       overlayId={overlayId}

--- a/keeperhub/components/overlays/withdraw-modal.tsx
+++ b/keeperhub/components/overlays/withdraw-modal.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const UNLIMITED_BALANCE = "∞";
 
 export type WithdrawableAsset = {
   type: "native" | "token";
@@ -61,10 +62,12 @@ export function WithdrawModal({
   const isValidAddress = (address: string) => ADDRESS_REGEX.test(address);
 
   const handleMaxClick = () => {
-    if (selectedAsset) {
+    if (selectedAsset && !isUnlimitedBalance(selectedAsset.balance)) {
       setAmount(selectedAsset.balance);
     }
   };
+
+  const isUnlimitedBalance = (balance: string) => balance === UNLIMITED_BALANCE;
 
   const validateWithdrawal = (): string | null => {
     if (!selectedAsset) {
@@ -73,7 +76,11 @@ export function WithdrawModal({
     if (!amount || Number.parseFloat(amount) <= 0) {
       return "Please enter a valid amount";
     }
-    if (Number.parseFloat(amount) > Number.parseFloat(selectedAsset.balance)) {
+    // Skip balance check for unlimited (testnet mock) balances
+    if (
+      !isUnlimitedBalance(selectedAsset.balance) &&
+      Number.parseFloat(amount) > Number.parseFloat(selectedAsset.balance)
+    ) {
       return "Insufficient balance";
     }
     if (!isValidAddress(recipient)) {
@@ -193,8 +200,9 @@ export function WithdrawModal({
           disabled:
             !(amount && recipient && isValidAddress(recipient)) ||
             Number.parseFloat(amount) <= 0 ||
-            Number.parseFloat(amount) >
-              Number.parseFloat(selectedAsset?.balance || "0"),
+            (!isUnlimitedBalance(selectedAsset?.balance || "0") &&
+              Number.parseFloat(amount) >
+                Number.parseFloat(selectedAsset?.balance || "0")),
         },
       ]}
       overlayId={overlayId}

--- a/keeperhub/lib/wallet/fetch-balances.ts
+++ b/keeperhub/lib/wallet/fetch-balances.ts
@@ -12,6 +12,67 @@ import type {
 } from "./types";
 
 /**
+ * Maximum balance threshold (1 trillion tokens) - balances above this are considered
+ * testnet mock balances and displayed as "unlimited"
+ */
+const MAX_DISPLAY_BALANCE = BigInt("1000000000000"); // 1 trillion
+const BIGINT_ZERO = BigInt(0);
+const BIGINT_ONE = BigInt(1);
+const BIGINT_FIVE = BigInt(5);
+const BIGINT_TEN = BigInt(10);
+
+/**
+ * Format a BigInt wei value to a decimal string with proper precision.
+ * Handles arbitrarily large values without JavaScript Number precision loss.
+ *
+ * @param weiValue - The balance in wei as BigInt
+ * @param decimals - Number of decimals (18 for ETH, varies for tokens)
+ * @param displayDecimals - Number of decimal places to show in output (default 6)
+ * @returns Formatted balance string, or "∞" for testnet mock balances
+ */
+export function formatWeiToBalance(
+  weiValue: bigint,
+  decimals: number,
+  displayDecimals = 6
+): string {
+  // Handle zero case
+  if (weiValue === BIGINT_ZERO) {
+    return `0.${"0".repeat(displayDecimals)}`;
+  }
+
+  const divisor = BIGINT_TEN ** BigInt(decimals);
+  const wholePart = weiValue / divisor;
+
+  // Check for testnet mock balances (unrealistically large values)
+  if (wholePart > MAX_DISPLAY_BALANCE) {
+    return "∞";
+  }
+
+  // Calculate fractional part with extra precision for rounding
+  const remainder = weiValue % divisor;
+  const scaleFactor = BIGINT_TEN ** BigInt(displayDecimals + 1); // +1 for rounding digit
+  const scaledFraction = (remainder * scaleFactor) / divisor;
+
+  // Round the last digit
+  const roundedFraction = (scaledFraction + BIGINT_FIVE) / BIGINT_TEN;
+
+  // Handle carry from rounding
+  const maxFraction = BIGINT_TEN ** BigInt(displayDecimals);
+  let finalWhole = wholePart;
+  let finalFraction = roundedFraction;
+
+  if (finalFraction >= maxFraction) {
+    finalWhole += BIGINT_ONE;
+    finalFraction = BIGINT_ZERO;
+  }
+
+  // Format the fractional part with leading zeros
+  const fractionStr = finalFraction.toString().padStart(displayDecimals, "0");
+
+  return `${finalWhole}.${fractionStr}`;
+}
+
+/**
  * Build explorer address URL for a chain
  */
 function buildExplorerAddressUrl(
@@ -50,13 +111,12 @@ export async function fetchNativeBalance(
     }
 
     const balanceWei = BigInt(result.result);
-    const balanceEth = Number(balanceWei) / 1e18;
 
     return {
       chainId: chain.chainId,
       name: chain.name,
       symbol: chain.symbol,
-      balance: balanceEth.toFixed(6),
+      balance: formatWeiToBalance(balanceWei, 18),
       loading: false,
       isTestnet: chain.isTestnet,
       explorerUrl: buildExplorerAddressUrl(chain, address),
@@ -127,14 +187,13 @@ export async function fetchTokenBalance(
     }
 
     const balanceWei = BigInt(result.result);
-    const balance = Number(balanceWei) / 10 ** token.decimals;
 
     return {
       tokenId: token.id,
       chainId: token.chainId,
       symbol: token.symbol,
       name: token.name,
-      balance: balance.toFixed(6),
+      balance: formatWeiToBalance(balanceWei, token.decimals),
       loading: false,
     };
   } catch (error) {
@@ -254,7 +313,6 @@ export function fetchSupportedTokenBalance(
       }
 
       const balanceWei = BigInt(result.result);
-      const balance = Number(balanceWei) / 10 ** token.decimals;
 
       return {
         chainId: token.chainId,
@@ -262,7 +320,7 @@ export function fetchSupportedTokenBalance(
         symbol: token.symbol,
         name: token.name,
         logoUrl: token.logoUrl,
-        balance: balance.toFixed(6),
+        balance: formatWeiToBalance(balanceWei, token.decimals),
         loading: false,
       };
     } catch (error) {

--- a/keeperhub/lib/wallet/fetch-balances.ts
+++ b/keeperhub/lib/wallet/fetch-balances.ts
@@ -13,7 +13,7 @@ import type {
 
 /**
  * Maximum balance threshold (1 trillion tokens) - balances above this are considered
- * testnet mock balances and displayed as "unlimited"
+ * testnet mock balances and treated as zero (not meaningful)
  */
 const MAX_DISPLAY_BALANCE = BigInt("1000000000000"); // 1 trillion
 const BIGINT_ZERO = BigInt(0);
@@ -28,7 +28,7 @@ const BIGINT_TEN = BigInt(10);
  * @param weiValue - The balance in wei as BigInt
  * @param decimals - Number of decimals (18 for ETH, varies for tokens)
  * @param displayDecimals - Number of decimal places to show in output (default 6)
- * @returns Formatted balance string, or "∞" for testnet mock balances
+ * @returns Formatted balance string, or "0.000000" for testnet mock balances
  */
 export function formatWeiToBalance(
   weiValue: bigint,
@@ -43,9 +43,9 @@ export function formatWeiToBalance(
   const divisor = BIGINT_TEN ** BigInt(decimals);
   const wholePart = weiValue / divisor;
 
-  // Check for testnet mock balances (unrealistically large values)
+  // Testnet mock balances (unrealistically large values) are not meaningful - show as zero
   if (wholePart > MAX_DISPLAY_BALANCE) {
-    return "∞";
+    return `0.${"0".repeat(displayDecimals)}`;
   }
 
   // Calculate fractional part with extra precision for rounding

--- a/scripts/seed-tokens.ts
+++ b/scripts/seed-tokens.ts
@@ -114,6 +114,38 @@ const TOKEN_CONFIGS: TokenConfig[] = [
     isStablecoin: true,
     sortOrder: 1,
   },
+
+  // ==========================================================================
+  // Tempo Testnet (chainId: 42429)
+  // ==========================================================================
+  {
+    chainId: 42_429,
+    tokenAddress: "0x20c0000000000000000000000000000000000000", // pathUSD
+    logoUrl: null, // Tempo testnet token
+    isStablecoin: true,
+    sortOrder: 1,
+  },
+  {
+    chainId: 42_429,
+    tokenAddress: "0x20c0000000000000000000000000000000000001", // AlphaUSD
+    logoUrl: null, // Tempo testnet token
+    isStablecoin: true,
+    sortOrder: 2,
+  },
+  {
+    chainId: 42_429,
+    tokenAddress: "0x20c0000000000000000000000000000000000002", // BetaUSD
+    logoUrl: null, // Tempo testnet token
+    isStablecoin: true,
+    sortOrder: 3,
+  },
+  {
+    chainId: 42_429,
+    tokenAddress: "0x20c0000000000000000000000000000000000003", // ThetaUSD
+    logoUrl: null, // Tempo testnet token
+    isStablecoin: true,
+    sortOrder: 4,
+  },
 ];
 
 /**

--- a/tests/unit/balance-formatting.test.ts
+++ b/tests/unit/balance-formatting.test.ts
@@ -143,25 +143,25 @@ describe("formatWeiToBalance", () => {
     });
   });
 
-  describe("Testnet mock balances (unlimited)", () => {
+  describe("Testnet mock balances (treated as zero)", () => {
     const DECIMALS = 18;
 
-    it("should return infinity for TEMPO testnet mock balance", () => {
+    it("should return zero for TEMPO testnet mock balance", () => {
       // This is the actual hex value returned by TEMPO testnet RPC for new accounts
       // 0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2
       const tempoMock = BigInt(
         "0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2"
       );
-      expect(formatWeiToBalance(tempoMock, DECIMALS)).toBe("∞");
+      expect(formatWeiToBalance(tempoMock, DECIMALS)).toBe("0.000000");
     });
 
-    it("should return infinity for balance exceeding 1 trillion tokens", () => {
+    it("should return zero for balance exceeding 1 trillion tokens", () => {
       // 1 trillion + 1 token in wei
       const overTrillion = BigInt("1000000000001000000000000000000");
-      expect(formatWeiToBalance(overTrillion, DECIMALS)).toBe("∞");
+      expect(formatWeiToBalance(overTrillion, DECIMALS)).toBe("0.000000");
     });
 
-    it("should NOT return infinity for exactly 1 trillion tokens", () => {
+    it("should NOT return zero for exactly 1 trillion tokens", () => {
       // Exactly 1 trillion tokens in wei
       const oneTrillion = BigInt("1000000000000000000000000000000");
       expect(formatWeiToBalance(oneTrillion, DECIMALS)).toBe(
@@ -169,7 +169,7 @@ describe("formatWeiToBalance", () => {
       );
     });
 
-    it("should NOT return infinity for 999 billion tokens", () => {
+    it("should NOT return zero for 999 billion tokens", () => {
       // 999 billion tokens in wei
       const underTrillion = BigInt("999000000000000000000000000000");
       expect(formatWeiToBalance(underTrillion, DECIMALS)).toBe(
@@ -177,12 +177,12 @@ describe("formatWeiToBalance", () => {
       );
     });
 
-    it("should handle repeating pattern mock values", () => {
+    it("should handle repeating pattern mock values as zero", () => {
       // Some testnets use repeating patterns like 42424242...
       const repeatingMock = BigInt(
         "424242424242424242424242424242424242424242424242"
       );
-      expect(formatWeiToBalance(repeatingMock, DECIMALS)).toBe("∞");
+      expect(formatWeiToBalance(repeatingMock, DECIMALS)).toBe("0.000000");
     });
   });
 
@@ -302,12 +302,12 @@ describe("formatWeiToBalance", () => {
         expect(formatWeiToBalance(faucetDrip, 6)).toBe("1000000.000000");
       });
 
-      it("should handle native TEMPO mock balance as unlimited", () => {
-        // The massive value TEMPO testnet returns
+      it("should treat native TEMPO mock balance as zero", () => {
+        // The massive value TEMPO testnet returns - treated as zero since it's meaningless
         const mockBalance = BigInt(
           "4242424242424242424242424242424242424242424242424242424242424242424242424242"
         );
-        expect(formatWeiToBalance(mockBalance, 18)).toBe("∞");
+        expect(formatWeiToBalance(mockBalance, 18)).toBe("0.000000");
       });
     });
 

--- a/tests/unit/balance-formatting.test.ts
+++ b/tests/unit/balance-formatting.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for balance formatting with BigInt precision
+ *
+ * Tests the formatWeiToBalance function which handles conversion of raw blockchain
+ * balance values (in smallest units) to human-readable decimal strings without
+ * JavaScript Number precision loss.
+ *
+ * EVM chains use different decimal precisions:
+ * - 18 decimals: ETH, MATIC, AVAX, TEMPO (native tokens)
+ * - 8 decimals: WBTC
+ * - 6 decimals: USDC, USDT, pathUSD
+ */
+
+import { describe, expect, it } from "vitest";
+import { formatWeiToBalance } from "../../keeperhub/lib/wallet/fetch-balances";
+
+describe("formatWeiToBalance", () => {
+  describe("18 decimals (ETH, MATIC, TEMPO native)", () => {
+    const DECIMALS = 18;
+
+    it("should format zero balance", () => {
+      expect(formatWeiToBalance(BigInt(0), DECIMALS)).toBe("0.000000");
+    });
+
+    it("should format 1 wei (smallest unit)", () => {
+      expect(formatWeiToBalance(BigInt(1), DECIMALS)).toBe("0.000000");
+    });
+
+    it("should format 1 gwei (1e9 wei)", () => {
+      const oneGwei = BigInt("1000000000");
+      expect(formatWeiToBalance(oneGwei, DECIMALS)).toBe("0.000000");
+    });
+
+    it("should format 1 ETH exactly", () => {
+      const oneEth = BigInt("1000000000000000000");
+      expect(formatWeiToBalance(oneEth, DECIMALS)).toBe("1.000000");
+    });
+
+    it("should format 0.5 ETH", () => {
+      const halfEth = BigInt("500000000000000000");
+      expect(formatWeiToBalance(halfEth, DECIMALS)).toBe("0.500000");
+    });
+
+    it("should format 1.5 ETH", () => {
+      const onePointFive = BigInt("1500000000000000000");
+      expect(formatWeiToBalance(onePointFive, DECIMALS)).toBe("1.500000");
+    });
+
+    it("should format 0.123456 ETH (6 decimal precision)", () => {
+      const amount = BigInt("123456000000000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("0.123456");
+    });
+
+    it("should format 0.000001 ETH (minimum displayable)", () => {
+      const microEth = BigInt("1000000000000");
+      expect(formatWeiToBalance(microEth, DECIMALS)).toBe("0.000001");
+    });
+
+    it("should format large balance (1000 ETH)", () => {
+      const thousandEth = BigInt("1000000000000000000000");
+      expect(formatWeiToBalance(thousandEth, DECIMALS)).toBe("1000.000000");
+    });
+
+    it("should format very large balance (1 million ETH)", () => {
+      const millionEth = BigInt("1000000000000000000000000");
+      expect(formatWeiToBalance(millionEth, DECIMALS)).toBe("1000000.000000");
+    });
+
+    it("should handle real RPC hex response (0x de0b6b3a7640000 = 1 ETH)", () => {
+      const fromHex = BigInt("0xde0b6b3a7640000");
+      expect(formatWeiToBalance(fromHex, DECIMALS)).toBe("1.000000");
+    });
+
+    it("should handle real RPC hex response (0.042 ETH)", () => {
+      const fromHex = BigInt("0x9536c708910000"); // 0.042 ETH
+      expect(formatWeiToBalance(fromHex, DECIMALS)).toBe("0.042000");
+    });
+  });
+
+  describe("6 decimals (USDC, USDT, pathUSD)", () => {
+    const DECIMALS = 6;
+
+    it("should format zero balance", () => {
+      expect(formatWeiToBalance(BigInt(0), DECIMALS)).toBe("0.000000");
+    });
+
+    it("should format 1 USDC exactly", () => {
+      const oneUsdc = BigInt("1000000");
+      expect(formatWeiToBalance(oneUsdc, DECIMALS)).toBe("1.000000");
+    });
+
+    it("should format 0.01 USDC (1 cent)", () => {
+      const oneCent = BigInt("10000");
+      expect(formatWeiToBalance(oneCent, DECIMALS)).toBe("0.010000");
+    });
+
+    it("should format 0.000001 USDC (smallest unit)", () => {
+      const smallest = BigInt("1");
+      expect(formatWeiToBalance(smallest, DECIMALS)).toBe("0.000001");
+    });
+
+    it("should format 100 USDC", () => {
+      const hundred = BigInt("100000000");
+      expect(formatWeiToBalance(hundred, DECIMALS)).toBe("100.000000");
+    });
+
+    it("should format 1000000 USDC (1 million)", () => {
+      const million = BigInt("1000000000000");
+      expect(formatWeiToBalance(million, DECIMALS)).toBe("1000000.000000");
+    });
+
+    it("should format 99.99 USDC", () => {
+      const amount = BigInt("99990000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("99.990000");
+    });
+  });
+
+  describe("8 decimals (WBTC)", () => {
+    const DECIMALS = 8;
+
+    it("should format zero balance", () => {
+      expect(formatWeiToBalance(BigInt(0), DECIMALS)).toBe("0.000000");
+    });
+
+    it("should format 1 WBTC exactly", () => {
+      const oneWbtc = BigInt("100000000");
+      expect(formatWeiToBalance(oneWbtc, DECIMALS)).toBe("1.000000");
+    });
+
+    it("should format 0.001 WBTC", () => {
+      const amount = BigInt("100000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("0.001000");
+    });
+
+    it("should format 0.00000001 WBTC (1 satoshi)", () => {
+      const oneSat = BigInt("1");
+      expect(formatWeiToBalance(oneSat, DECIMALS)).toBe("0.000000");
+    });
+
+    it("should format 21 WBTC (max supply reference)", () => {
+      const amount = BigInt("2100000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("21.000000");
+    });
+  });
+
+  describe("Testnet mock balances (unlimited)", () => {
+    const DECIMALS = 18;
+
+    it("should return infinity for TEMPO testnet mock balance", () => {
+      // This is the actual hex value returned by TEMPO testnet RPC for new accounts
+      // 0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2
+      const tempoMock = BigInt(
+        "0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2"
+      );
+      expect(formatWeiToBalance(tempoMock, DECIMALS)).toBe("∞");
+    });
+
+    it("should return infinity for balance exceeding 1 trillion tokens", () => {
+      // 1 trillion + 1 token in wei
+      const overTrillion = BigInt("1000000000001000000000000000000");
+      expect(formatWeiToBalance(overTrillion, DECIMALS)).toBe("∞");
+    });
+
+    it("should NOT return infinity for exactly 1 trillion tokens", () => {
+      // Exactly 1 trillion tokens in wei
+      const oneTrillion = BigInt("1000000000000000000000000000000");
+      expect(formatWeiToBalance(oneTrillion, DECIMALS)).toBe(
+        "1000000000000.000000"
+      );
+    });
+
+    it("should NOT return infinity for 999 billion tokens", () => {
+      // 999 billion tokens in wei
+      const underTrillion = BigInt("999000000000000000000000000000");
+      expect(formatWeiToBalance(underTrillion, DECIMALS)).toBe(
+        "999000000000.000000"
+      );
+    });
+
+    it("should handle repeating pattern mock values", () => {
+      // Some testnets use repeating patterns like 42424242...
+      const repeatingMock = BigInt(
+        "424242424242424242424242424242424242424242424242"
+      );
+      expect(formatWeiToBalance(repeatingMock, DECIMALS)).toBe("∞");
+    });
+  });
+
+  describe("Rounding behavior", () => {
+    const DECIMALS = 18;
+
+    it("should round up when 7th decimal >= 5", () => {
+      // 1.9999995 ETH should round to 2.000000
+      const amount = BigInt("1999999500000000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("2.000000");
+    });
+
+    it("should round down when 7th decimal < 5", () => {
+      // 1.9999994 ETH should round to 1.999999
+      const amount = BigInt("1999999400000000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("1.999999");
+    });
+
+    it("should handle rounding at exactly .5", () => {
+      // 0.0000005 should round to 0.000001
+      const amount = BigInt("500000000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("0.000001");
+    });
+
+    it("should handle carry from rounding (0.999999x -> 1.000000)", () => {
+      // 0.9999999 ETH should round to 1.000000
+      const amount = BigInt("999999950000000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("1.000000");
+    });
+
+    it("should handle carry with large whole part", () => {
+      // 999.9999995 should round to 1000.000000
+      const amount = BigInt("999999999500000000000");
+      expect(formatWeiToBalance(amount, DECIMALS)).toBe("1000.000000");
+    });
+  });
+
+  describe("Custom display decimals", () => {
+    const DECIMALS = 18;
+
+    it("should format with 2 decimal places", () => {
+      const amount = BigInt("1234567890000000000");
+      expect(formatWeiToBalance(amount, DECIMALS, 2)).toBe("1.23");
+    });
+
+    it("should format with 4 decimal places", () => {
+      const amount = BigInt("1234567890000000000");
+      expect(formatWeiToBalance(amount, DECIMALS, 4)).toBe("1.2346");
+    });
+
+    it("should format with 8 decimal places", () => {
+      const amount = BigInt("1234567890000000000");
+      expect(formatWeiToBalance(amount, DECIMALS, 8)).toBe("1.23456789");
+    });
+
+    it("should format zero with custom decimals", () => {
+      expect(formatWeiToBalance(BigInt(0), DECIMALS, 2)).toBe("0.00");
+      expect(formatWeiToBalance(BigInt(0), DECIMALS, 4)).toBe("0.0000");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle 0 decimals (whole number tokens)", () => {
+      const amount = BigInt("42");
+      expect(formatWeiToBalance(amount, 0)).toBe("42.000000");
+    });
+
+    it("should handle very high decimal tokens (24 decimals)", () => {
+      const amount = BigInt("1000000000000000000000000"); // 1 token with 24 decimals
+      expect(formatWeiToBalance(amount, 24)).toBe("1.000000");
+    });
+
+    it("should handle amount smaller than display precision", () => {
+      // 1 wei with 18 decimals = 0.000000000000000001, displays as 0.000000
+      const oneWei = BigInt(1);
+      expect(formatWeiToBalance(oneWei, 18)).toBe("0.000000");
+    });
+
+    it("should preserve leading zeros in fractional part", () => {
+      // 0.000123 ETH
+      const amount = BigInt("123000000000000");
+      expect(formatWeiToBalance(amount, 18)).toBe("0.000123");
+    });
+
+    it("should handle BigInt from hex string", () => {
+      // Common pattern when parsing RPC responses
+      const hexBalance = "0x4563918244f40000"; // 5 ETH
+      const amount = BigInt(hexBalance);
+      expect(formatWeiToBalance(amount, 18)).toBe("5.000000");
+    });
+  });
+
+  describe("Real-world chain scenarios", () => {
+    describe("Ethereum Mainnet", () => {
+      it("should format typical gas fee amount (0.002 ETH)", () => {
+        const gasFee = BigInt("2000000000000000");
+        expect(formatWeiToBalance(gasFee, 18)).toBe("0.002000");
+      });
+
+      it("should format typical staking amount (32 ETH)", () => {
+        const staking = BigInt("32000000000000000000");
+        expect(formatWeiToBalance(staking, 18)).toBe("32.000000");
+      });
+    });
+
+    describe("Base / Optimism (L2)", () => {
+      it("should format sub-cent gas fees (0.000042 ETH)", () => {
+        const l2Gas = BigInt("42000000000000");
+        expect(formatWeiToBalance(l2Gas, 18)).toBe("0.000042");
+      });
+    });
+
+    describe("TEMPO Testnet", () => {
+      it("should handle faucet drip amount (1M pathUSD)", () => {
+        // 1 million pathUSD with 6 decimals
+        const faucetDrip = BigInt("1000000000000");
+        expect(formatWeiToBalance(faucetDrip, 6)).toBe("1000000.000000");
+      });
+
+      it("should handle native TEMPO mock balance as unlimited", () => {
+        // The massive value TEMPO testnet returns
+        const mockBalance = BigInt(
+          "4242424242424242424242424242424242424242424242424242424242424242424242424242"
+        );
+        expect(formatWeiToBalance(mockBalance, 18)).toBe("∞");
+      });
+    });
+
+    describe("Stablecoin transfers", () => {
+      it("should format $1.50 USDC transfer", () => {
+        const amount = BigInt("1500000");
+        expect(formatWeiToBalance(amount, 6)).toBe("1.500000");
+      });
+
+      it("should format $1000.00 USDT transfer", () => {
+        const amount = BigInt("1000000000");
+        expect(formatWeiToBalance(amount, 6)).toBe("1000.000000");
+      });
+
+      it("should format dust amount (0.000001 USDC)", () => {
+        const dust = BigInt("1");
+        expect(formatWeiToBalance(dust, 6)).toBe("0.000001");
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Add BigInt-safe formatWeiToBalance to prevent precision loss on large values
- Show pathUSD as primary balance for TEMPO chain instead of native token
- Add TEMPO stablecoins (pathUSD, AlphaUSD, BetaUSD, ThetaUSD) to seed script
- Add comprehensive unit tests for balance formatting (51 tests)