### PR TITLE
chore: remove default Node.js metrics from Prometheus output

### DIFF
--- a/keeperhub/lib/metrics/METRICS_REFERENCE.md
+++ b/keeperhub/lib/metrics/METRICS_REFERENCE.md
@@ -291,20 +291,6 @@ Prometheus metrics are prefixed with `keeperhub_` and use snake_case:
 | `plugin.action.errors` | `keeperhub_plugin_action_errors_total` | counter |
 | `api.errors.total` | `keeperhub_api_errors_total` | counter |
 
-### Default Node.js Metrics
-
-When Prometheus collector is enabled, default Node.js metrics are also collected:
-- `keeperhub_nodejs_heap_size_total_bytes`
-- `keeperhub_nodejs_heap_size_used_bytes`
-- `keeperhub_nodejs_external_memory_bytes`
-- `keeperhub_nodejs_active_handles_total`
-- `keeperhub_nodejs_active_requests_total`
-- `keeperhub_nodejs_eventloop_lag_seconds`
-- `keeperhub_process_cpu_*`
-- `keeperhub_process_resident_memory_bytes`
-
----
-
 ## Structured Log Format (Console Collector)
 
 When using console collector, metrics are emitted as structured JSON (CloudWatch/Datadog compatible):

--- a/keeperhub/lib/metrics/collectors/prometheus.ts
+++ b/keeperhub/lib/metrics/collectors/prometheus.ts
@@ -7,13 +7,7 @@
 
 import "server-only";
 
-import {
-  Counter,
-  collectDefaultMetrics,
-  Gauge,
-  Histogram,
-  Registry,
-} from "prom-client";
+import { Counter, Gauge, Histogram, Registry } from "prom-client";
 import type { ErrorContext, MetricLabels, MetricsCollector } from "../types";
 
 // Use global singleton to prevent duplicate registration during hot reload
@@ -25,12 +19,6 @@ const globalForProm = globalThis as unknown as {
 // Create a dedicated registry for application metrics (singleton)
 const registry = globalForProm.prometheusRegistry ?? new Registry();
 globalForProm.prometheusRegistry = registry;
-
-// Collect default Node.js metrics (memory, CPU, event loop, etc.)
-// Only register if not already registered (handles hot reload)
-if (!registry.getSingleMetric("keeperhub_process_cpu_seconds_total")) {
-  collectDefaultMetrics({ register: registry, prefix: "keeperhub_" });
-}
 
 // Pre-defined label names for each metric
 const _WORKFLOW_LABELS = [


### PR DESCRIPTION
Get rid of the default Node.js metrics