### PR TITLE
fix(docs-site): return 404 for non-existent routes

### DIFF
--- a/docs-site/app/[[...mdxPath]]/page.tsx
+++ b/docs-site/app/[[...mdxPath]]/page.tsx
@@ -1,12 +1,19 @@
 import { generateStaticParamsFor, importPage } from "nextra/pages";
+import { notFound } from "next/navigation";
 import { useMDXComponents } from "../../mdx-components";
 
 export const generateStaticParams = generateStaticParamsFor("mdxPath");
 
+export const dynamicParams = false;
+
 export async function generateMetadata(props: PageProps) {
   const params = await props.params;
-  const { metadata } = await importPage(params.mdxPath);
-  return metadata;
+  try {
+    const { metadata } = await importPage(params.mdxPath);
+    return metadata;
+  } catch {
+    return { title: "Not Found" };
+  }
 }
 
 type PageProps = {


### PR DESCRIPTION
## Summary
- Add `dynamicParams = false` to prevent dynamic route rendering for non-existent paths
- Add try/catch around metadata generation for safety

## Problem
Bots and users accessing non-existent routes (e.g., `/.env`, `/js/*.js`, `/admin/roles/3`) caused `MODULE_NOT_FOUND` errors because Nextra tried to dynamically import MDX files that don't exist.

## Solution
Setting `dynamicParams = false` tells Next.js to return a proper 404 for any routes not pre-generated by `generateStaticParams`.

## Test plan
- [x] Build passes locally
- [ ] Verify 404 returned for non-existent routes after deployment
- [ ] Confirm error logs no longer show MODULE_NOT_FOUND spam