### PR TITLE
fix(docs-site): remove unused notFound import

### DIFF
--- a/docs-site/app/[[...mdxPath]]/page.tsx
+++ b/docs-site/app/[[...mdxPath]]/page.tsx
@@ -1,5 +1,4 @@
 import { generateStaticParamsFor, importPage } from "nextra/pages";
-import { notFound } from "next/navigation";
 import { useMDXComponents } from "../../mdx-components";
 
 export const generateStaticParams = generateStaticParamsFor("mdxPath");


### PR DESCRIPTION
## Summary
- Remove unused `notFound` import that was causing lint failure

## Context
Follow-up to PR #159 which added `dynamicParams = false`. The `notFound` import was added but not used since `dynamicParams = false` handles 404s automatically.