### PR TITLE
fix: KEEP-1258 Chain seeding always takes values from env var JSON

### DIFF
--- a/lib/rpc/network-utils.ts
+++ b/lib/rpc/network-utils.ts
@@ -32,12 +32,14 @@ export function getChainIdFromNetwork(network: string | number): number {
     ethereum: SUPPORTED_CHAIN_IDS.MAINNET,
     // Sepolia Testnet
     sepolia: SUPPORTED_CHAIN_IDS.SEPOLIA,
+    "eth-sepolia": SUPPORTED_CHAIN_IDS.SEPOLIA,
     "sepolia-testnet": SUPPORTED_CHAIN_IDS.SEPOLIA,
     // Base Mainnet
     base: SUPPORTED_CHAIN_IDS.BASE,
     "base-mainnet": SUPPORTED_CHAIN_IDS.BASE,
     // Base Sepolia
     "base-sepolia": SUPPORTED_CHAIN_IDS.BASE_SEPOLIA,
+    "base-testnet": SUPPORTED_CHAIN_IDS.BASE_SEPOLIA,
     // Tempo
     "tempo-testnet": SUPPORTED_CHAIN_IDS.TEMPO_TESTNET,
     tempo: SUPPORTED_CHAIN_IDS.TEMPO_MAINNET,
@@ -46,6 +48,7 @@ export function getChainIdFromNetwork(network: string | number): number {
     solana: SUPPORTED_CHAIN_IDS.SOLANA_MAINNET,
     "solana-mainnet": SUPPORTED_CHAIN_IDS.SOLANA_MAINNET,
     "solana-devnet": SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
+    "solana-testnet": SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
   };
 
   const chainId = networkMap[network.toLowerCase()];

--- a/lib/rpc/network-utils.ts
+++ b/lib/rpc/network-utils.ts
@@ -28,6 +28,7 @@ export function getChainIdFromNetwork(network: string | number): number {
   const networkMap: Record<string, number> = {
     // Ethereum Mainnet
     mainnet: SUPPORTED_CHAIN_IDS.MAINNET,
+    "eth-mainnet": SUPPORTED_CHAIN_IDS.MAINNET,
     "ethereum-mainnet": SUPPORTED_CHAIN_IDS.MAINNET,
     ethereum: SUPPORTED_CHAIN_IDS.MAINNET,
     // Sepolia Testnet

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -56,7 +56,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
   },
   // Sepolia Testnet
   11155111: {
-    jsonKey: "sepolia",
+    jsonKey: "eth-sepolia",
     envKey: "CHAIN_SEPOLIA_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_SEPOLIA_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.SEPOLIA,
@@ -70,7 +70,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
   },
   // Base Sepolia
   84532: {
-    jsonKey: "base-sepolia",
+    jsonKey: "base-testnet",
     envKey: "CHAIN_BASE_SEPOLIA_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_BASE_SEPOLIA_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.BASE_SEPOLIA,
@@ -98,7 +98,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
   },
   // Solana Devnet
   103: {
-    jsonKey: "solana-devnet",
+    jsonKey: "solana-testnet",
     envKey: "CHAIN_SOLANA_DEVNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_SOLANA_DEVNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.SOLANA_DEVNET,

--- a/scripts/seed-chains.ts
+++ b/scripts/seed-chains.ts
@@ -78,9 +78,9 @@ const DEFAULT_CHAINS: NewChain[] = [
     isEnabled: getChainConfigValue("eth-mainnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfigValue("sepolia", "chainId", 11_155_111),
+    chainId: getChainConfigValue("eth-sepolia", "chainId", 11_155_111),
     name: "Sepolia Testnet",
-    symbol: getChainConfigValue("sepolia", "symbol", "ETH"),
+    symbol: getChainConfigValue("eth-sepolia", "symbol", "ETH"),
     chainType: "evm",
     defaultPrimaryRpc: getRpcUrlByChainId(11_155_111, "primary"),
     defaultFallbackRpc: getRpcUrlByChainId(11_155_111, "fallback"),
@@ -94,8 +94,8 @@ const DEFAULT_CHAINS: NewChain[] = [
       jsonKey: CHAIN_CONFIG[11_155_111].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfigValue("sepolia", "isTestnet", true),
-    isEnabled: getChainConfigValue("sepolia", "isEnabled", true),
+    isTestnet: getChainConfigValue("eth-sepolia", "isTestnet", true),
+    isEnabled: getChainConfigValue("eth-sepolia", "isEnabled", true),
   },
   {
     chainId: getChainConfigValue("base-mainnet", "chainId", 8453),
@@ -118,9 +118,9 @@ const DEFAULT_CHAINS: NewChain[] = [
     isEnabled: getChainConfigValue("base-mainnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfigValue("base-sepolia", "chainId", 84_532),
+    chainId: getChainConfigValue("base-testnet", "chainId", 84_532),
     name: "Base Sepolia",
-    symbol: getChainConfigValue("base-sepolia", "symbol", "BASE"),
+    symbol: getChainConfigValue("base-testnet", "symbol", "BASE"),
     chainType: "evm",
     defaultPrimaryRpc: getRpcUrlByChainId(84_532, "primary"),
     defaultFallbackRpc: getRpcUrlByChainId(84_532, "fallback"),
@@ -134,8 +134,8 @@ const DEFAULT_CHAINS: NewChain[] = [
       jsonKey: CHAIN_CONFIG[84_532].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfigValue("base-sepolia", "isTestnet", true),
-    isEnabled: getChainConfigValue("base-sepolia", "isEnabled", true),
+    isTestnet: getChainConfigValue("base-testnet", "isTestnet", true),
+    isEnabled: getChainConfigValue("base-testnet", "isEnabled", true),
   },
   {
     chainId: getChainConfigValue("tempo-testnet", "chainId", 42_429),
@@ -199,9 +199,9 @@ const DEFAULT_CHAINS: NewChain[] = [
     isEnabled: getChainConfigValue("solana-mainnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfigValue("solana-devnet", "chainId", 103),
+    chainId: getChainConfigValue("solana-testnet", "chainId", 103),
     name: "Solana Devnet",
-    symbol: getChainConfigValue("solana-devnet", "symbol", "SOL"),
+    symbol: getChainConfigValue("solana-testnet", "symbol", "SOL"),
     chainType: "solana",
     defaultPrimaryRpc: getRpcUrlByChainId(103, "primary"),
     defaultFallbackRpc: getRpcUrlByChainId(103, "fallback"),
@@ -215,8 +215,8 @@ const DEFAULT_CHAINS: NewChain[] = [
       jsonKey: CHAIN_CONFIG[103].jsonKey,
       type: "fallback",
     }),
-    isTestnet: getChainConfigValue("solana-devnet", "isTestnet", true),
-    isEnabled: getChainConfigValue("solana-devnet", "isEnabled", true),
+    isTestnet: getChainConfigValue("solana-testnet", "isTestnet", true),
+    isEnabled: getChainConfigValue("solana-testnet", "isEnabled", true),
   },
 ];
 
@@ -332,6 +332,8 @@ async function seedChains() {
 
     if (existing.length > 0) {
       // Update existing chain with new values (except id and timestamps)
+      // Note: Use ?? null to ensure undefined values are explicitly set to null,
+      // otherwise Drizzle skips undefined fields in UPDATE statements
       await db
         .update(chains)
         .set({
@@ -339,9 +341,9 @@ async function seedChains() {
           symbol: chain.symbol,
           chainType: chain.chainType,
           defaultPrimaryRpc: chain.defaultPrimaryRpc,
-          defaultFallbackRpc: chain.defaultFallbackRpc,
-          defaultPrimaryWss: chain.defaultPrimaryWss,
-          defaultFallbackWss: chain.defaultFallbackWss,
+          defaultFallbackRpc: chain.defaultFallbackRpc ?? null,
+          defaultPrimaryWss: chain.defaultPrimaryWss ?? null,
+          defaultFallbackWss: chain.defaultFallbackWss ?? null,
           isTestnet: chain.isTestnet,
           isEnabled: chain.isEnabled,
           updatedAt: new Date(),

--- a/scripts/seed-chains.ts
+++ b/scripts/seed-chains.ts
@@ -366,8 +366,22 @@ async function seedChains() {
       .limit(1);
 
     if (existing.length > 0) {
+      // Update existing explorer config with new values (except id and timestamps)
+      await db
+        .update(explorerConfigs)
+        .set({
+          chainType: config.chainType,
+          explorerUrl: config.explorerUrl,
+          explorerApiType: config.explorerApiType,
+          explorerApiUrl: config.explorerApiUrl,
+          explorerTxPath: config.explorerTxPath,
+          explorerAddressPath: config.explorerAddressPath,
+          explorerContractPath: config.explorerContractPath,
+          updatedAt: new Date(),
+        })
+        .where(eq(explorerConfigs.chainId, config.chainId));
       console.log(
-        `  - Explorer config for chain ${config.chainId} already exists, skipping`
+        `  ~ Explorer config for chain ${config.chainId} (${config.explorerApiType}) updated`
       );
       continue;
     }

--- a/tests/unit/rpc-config.test.ts
+++ b/tests/unit/rpc-config.test.ts
@@ -248,13 +248,13 @@ describe("RPC Config Resolution", () => {
   describe("all chain keys", () => {
     const chainKeys = [
       { json: "eth-mainnet", public: PUBLIC_RPCS.ETH_MAINNET },
-      { json: "sepolia", public: PUBLIC_RPCS.SEPOLIA },
+      { json: "eth-sepolia", public: PUBLIC_RPCS.SEPOLIA },
       { json: "base-mainnet", public: PUBLIC_RPCS.BASE_MAINNET },
-      { json: "base-sepolia", public: PUBLIC_RPCS.BASE_SEPOLIA },
+      { json: "base-testnet", public: PUBLIC_RPCS.BASE_SEPOLIA },
       { json: "tempo-testnet", public: PUBLIC_RPCS.TEMPO_TESTNET },
       { json: "tempo-mainnet", public: PUBLIC_RPCS.TEMPO_MAINNET },
       { json: "solana-mainnet", public: PUBLIC_RPCS.SOLANA_MAINNET },
-      { json: "solana-devnet", public: PUBLIC_RPCS.SOLANA_DEVNET },
+      { json: "solana-testnet", public: PUBLIC_RPCS.SOLANA_DEVNET },
     ];
 
     it.each(chainKeys)("should resolve $json from JSON config", ({
@@ -353,7 +353,7 @@ describe("RPC Config Resolution", () => {
           primaryRpcUrl: "https://eth.primary.com",
           fallbackRpcUrl: "https://eth.fallback.com",
         },
-        sepolia: {
+        "eth-sepolia": {
           primaryRpcUrl: "https://sepolia.primary.com",
           fallbackRpcUrl: "https://sepolia.fallback.com",
         },
@@ -361,7 +361,7 @@ describe("RPC Config Resolution", () => {
           primaryRpcUrl: "https://base.primary.com",
           fallbackRpcUrl: "https://base.fallback.com",
         },
-        "base-sepolia": {
+        "base-testnet": {
           primaryRpcUrl: "https://base-sep.primary.com",
           fallbackRpcUrl: "https://base-sep.fallback.com",
         },
@@ -377,7 +377,7 @@ describe("RPC Config Resolution", () => {
           primaryRpcUrl: "https://solana.primary.com",
           fallbackRpcUrl: "https://solana.fallback.com",
         },
-        "solana-devnet": {
+        "solana-testnet": {
           primaryRpcUrl: "https://solana-dev.primary.com",
           fallbackRpcUrl: "https://solana-dev.fallback.com",
         },
@@ -596,7 +596,7 @@ describe("RPC Config Resolution", () => {
           isEnabled: true,
           isTestnet: false,
         },
-        sepolia: {
+        "eth-sepolia": {
           chainId: 11_155_111,
           symbol: "ETH",
           primaryRpcUrl: "https://chain.techops.live/eth-sepolia",
@@ -633,11 +633,11 @@ describe("RPC Config Resolution", () => {
         "https://eth-mainnet.g.alchemy.com/v2/s_8VpY02izssHI4yW2uyC1XWkrMCdS7a"
       );
 
-      // Verify sepolia
+      // Verify eth-sepolia
       expect(
         getRpcUrl({
           rpcConfig: config,
-          jsonKey: "sepolia",
+          jsonKey: "eth-sepolia",
           envValue: undefined,
           publicDefault: PUBLIC_RPCS.SEPOLIA,
           type: "primary",
@@ -775,7 +775,7 @@ describe("RPC Config Resolution", () => {
           isEnabled: true,
           isTestnet: false,
         },
-        sepolia: {
+        "eth-sepolia": {
           chainId: 11_155_111,
           symbol: "ETH",
           primaryRpcUrl: "https://sepolia.example.com",
@@ -798,7 +798,7 @@ describe("RPC Config Resolution", () => {
       expect(
         getRpcUrl({
           rpcConfig: multiChainConfig,
-          jsonKey: "sepolia",
+          jsonKey: "eth-sepolia",
           envValue: undefined,
           publicDefault: PUBLIC_RPCS.SEPOLIA,
           type: "primary",
@@ -816,7 +816,7 @@ describe("RPC Config Resolution", () => {
       expect(
         getWssUrl({
           rpcConfig: multiChainConfig,
-          jsonKey: "sepolia",
+          jsonKey: "eth-sepolia",
           type: "primary",
         })
       ).toBe("wss://sepolia.example.com");
@@ -882,12 +882,12 @@ describe("RPC Config Resolution", () => {
 
     it("should return isTestnet from config when present", () => {
       const rpcConfig: RpcConfig = {
-        sepolia: {
+        "eth-sepolia": {
           isTestnet: true,
         },
       };
 
-      expect(getConfigValue(rpcConfig, "sepolia", "isTestnet", false)).toBe(
+      expect(getConfigValue(rpcConfig, "eth-sepolia", "isTestnet", false)).toBe(
         true
       );
     });


### PR DESCRIPTION
## Summary

Chain seeding script now always updates existing database records with values from `CHAIN_RPC_CONFIG` environment variable, ensuring env vars take authority over stale database values.

## Changes

- Explorer configs now **update** existing records instead of skipping them
- Matches the existing behavior for chain records (which already updated)
- Ensures `CHAIN_RPC_CONFIG` values always take precedence

## Test Plan

- [x] Tested locally - ran `pnpm tsx scripts/seed-chains.ts` twice
- [x] First run: inserts all chains and explorer configs
- [x] Second run: updates all chains and explorer configs (shows `~` prefix)

## Jira

[KEEP-1258](https://techops-services.atlassian.net/browse/KEEP-1258)

[KEEP-1258]: https://techopsservices.atlassian.net/browse/KEEP-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ