### PR TITLE
perf: KEEP-1257 Reduce scheduler Docker image from 1.85GB to 267MB

### DIFF
--- a/.github/workflows/deploy-scheduler.yaml
+++ b/.github/workflows/deploy-scheduler.yaml
@@ -5,6 +5,8 @@ on:
       - prod
     paths:
       - 'deploy/scheduler/**'
+      - 'scheduler/**'
+      - 'Dockerfile'
       - 'scripts/job-spawner.ts'
       - 'scripts/schedule-*.ts'
       - 'scripts/workflow-runner.ts'
@@ -54,6 +56,7 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'Dockerfile'
+              - 'scheduler/**'
               - 'scripts/schedule-*.ts'
               - 'scripts/job-spawner.ts'
               - 'lib/**'

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "keeperhub-scheduler",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal dependencies for scheduler scripts (schedule-dispatcher, job-spawner)",
+  "dependencies": {
+    "@aws-sdk/client-sqs": "^3.948.0",
+    "@kubernetes/client-node": "^1.4.0",
+    "cron-parser": "^5.4.0",
+    "drizzle-orm": "^0.44.7",
+    "nanoid": "^5.1.6",
+    "postgres": "^3.4.7"
+  }
+}


### PR DESCRIPTION
## Summary

Reduces the scheduler Docker image size by **85%** (1.85GB → 267MB) by using a separate minimal dependency set instead of copying the full node_modules.

## Changes

- Added `scheduler/package.json` with only 6 required dependencies:
  - `@aws-sdk/client-sqs`
  - `@kubernetes/client-node`
  - `cron-parser`
  - `drizzle-orm`
  - `nanoid`
  - `postgres`
- Added `scheduler-deps` Docker stage that installs only scheduler dependencies
- Updated `scheduler` stage to use slim deps instead of full node_modules
- Updated GitHub workflow path filters to trigger rebuilds on `scheduler/**` changes

## Test Plan

- [x] Built scheduler image locally: `docker build --target scheduler -t keeperhub-scheduler:slim .`
- [x] Verified image size: 267MB (down from 1.85GB)
- [x] Tested scheduler scripts run correctly in slim image
- [x] Verified docker-compose compatibility
- [x] Verified Helm values compatibility

## Jira

[KEEP-1257](https://techops-services.atlassian.net/browse/KEEP-1257)

[KEEP-1257]: https://techopsservices.atlassian.net/browse/KEEP-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ