### PR TITLE
fix: KEEP-1240 Nonce manager dedicated connections for advisory locks

### DIFF
--- a/scripts/reset-password.ts
+++ b/scripts/reset-password.ts
@@ -3,11 +3,27 @@
  * Usage: DATABASE_URL="..." npx tsx scripts/reset-password.ts <email> <new-password>
  */
 
-import { scryptAsync } from "@noble/hashes/scrypt.js";
-import { bytesToHex } from "@noble/hashes/utils.js";
+import { randomBytes, type ScryptOptions, scrypt } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { db } from "../lib/db";
 import { accounts, users } from "../lib/db/schema";
+
+function scryptAsync(
+  password: string,
+  salt: string,
+  keylen: number,
+  options: ScryptOptions
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, keylen, options, (err, derivedKey) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(derivedKey);
+      }
+    });
+  });
+}
 
 // Better-auth compatible password hashing (matches their implementation exactly)
 const config = {
@@ -17,16 +33,26 @@ const config = {
   dkLen: 64,
 };
 
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 async function hashPassword(password: string): Promise<string> {
-  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+  const saltBytes = randomBytes(16);
   const salt = bytesToHex(saltBytes);
-  const key = await scryptAsync(password.normalize("NFKC"), salt, {
-    N: config.N,
-    p: config.p,
-    r: config.r,
-    dkLen: config.dkLen,
-    maxmem: 128 * config.N * config.r * 2,
-  });
+  const key = await scryptAsync(
+    password.normalize("NFKC"),
+    salt,
+    config.dkLen,
+    {
+      N: config.N,
+      p: config.p,
+      r: config.r,
+      maxmem: 128 * config.N * config.r * 2,
+    }
+  );
   return `${salt}:${bytesToHex(key)}`;
 }
 


### PR DESCRIPTION
## Summary

Fixes "Failed to acquire nonce lock after 50 attempts" error caused by PostgreSQL advisory locks being tied to pooled connections. When processes crashed, the connection returned to the pool still holding the lock, causing subsequent processes to fail.

## Changes

- **Nonce Manager**: Each NonceSession now uses a dedicated connection (not from pool)
  - When session ends or crashes, connection closes and PostgreSQL auto-releases the lock
  - Eliminates stale locks from crashed processes
  - Added e2e tests for dedicated connection behavior and lock cleanup
  
- **Reset Password Script**: Replaced `@noble/hashes` with Node.js built-in `crypto` module
  - Fixes TypeScript module resolution errors

## Test Plan

- [x] Unit tests pass (19 tests)
- [x] E2E tests pass (18 tests including new dedicated connection tests)
- [x] `pnpm check` passes
- [x] `pnpm type-check` passes
- [x] Tested reset-password script with real database

## Jira

[KEEP-1240](https://techops-services.atlassian.net/browse/KEEP-1240)

---
Generated with Claude Code

[KEEP-1240]: https://techopsservices.atlassian.net/browse/KEEP-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ