### PR TITLE
To Prod: KEEP-1240 Nonce Manager Dedicated Connections

### DIFF
--- a/scripts/reset-password.ts
+++ b/scripts/reset-password.ts
@@ -3,11 +3,27 @@
  * Usage: DATABASE_URL="..." npx tsx scripts/reset-password.ts <email> <new-password>
  */
 
-import { scryptAsync } from "@noble/hashes/scrypt.js";
-import { bytesToHex } from "@noble/hashes/utils.js";
+import { randomBytes, type ScryptOptions, scrypt } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { db } from "../lib/db";
 import { accounts, users } from "../lib/db/schema";
+
+function scryptAsync(
+  password: string,
+  salt: string,
+  keylen: number,
+  options: ScryptOptions
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, keylen, options, (err, derivedKey) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(derivedKey);
+      }
+    });
+  });
+}
 
 // Better-auth compatible password hashing (matches their implementation exactly)
 const config = {
@@ -17,16 +33,26 @@ const config = {
   dkLen: 64,
 };
 
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 async function hashPassword(password: string): Promise<string> {
-  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+  const saltBytes = randomBytes(16);
   const salt = bytesToHex(saltBytes);
-  const key = await scryptAsync(password.normalize("NFKC"), salt, {
-    N: config.N,
-    p: config.p,
-    r: config.r,
-    dkLen: config.dkLen,
-    maxmem: 128 * config.N * config.r * 2,
-  });
+  const key = await scryptAsync(
+    password.normalize("NFKC"),
+    salt,
+    config.dkLen,
+    {
+      N: config.N,
+      p: config.p,
+      r: config.r,
+      maxmem: 128 * config.N * config.r * 2,
+    }
+  );
   return `${salt}:${bytesToHex(key)}`;
 }
 


### PR DESCRIPTION
## Summary
- Cherry-picks PR #173 changes onto prod
- Fixes the squash merge conflict issue from PR #174

## Changes (from PR #173)
- Nonce manager now uses dedicated connections for advisory locks
- Fixes "Failed to acquire nonce lock after 50 attempts" error
- Updated reset-password script to use Node.js crypto
- Added e2e tests for dedicated connection behavior

## Files Changed
- `keeperhub/lib/web3/nonce-manager.ts`
- `scripts/reset-password.ts`
- `tests/e2e/nonce-manager.test.ts`
- `tests/unit/nonce-manager.test.ts`