### PR TITLE
KEEP-1287 - Fixing DB migrations errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,12 @@
 {
+  "permissions": {
+    "allow": ["Bash(pnpm check:*)", "Bash(pnpm install)"]
+  },
+  "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "terraform",
     "mcp-obsidian",
     "chrome-devtools",
     "memory"
-  ],
-  "enableAllProjectMcpServers": true
+  ]
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,19 @@
 {
   "permissions": {
-    "allow": ["Bash(pnpm check:*)", "Bash(pnpm install)"]
+    "allow": [
+      "Bash(pnpm check:*)",
+      "Bash(pnpm install)",
+      "Bash(git push:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh run list:*)",
+      "Bash(aws-vault exec maker-main -- kubectl get pods:*)",
+      "Bash(aws-vault exec maker-main -- kubectl logs:*)",
+      "Bash(aws-vault exec maker-main -- kubectl describe pod:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(aws-vault exec maker-main -- kubectl get:*)"
+    ]
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,5 +4,6 @@
     "mcp-obsidian",
     "chrome-devtools",
     "memory"
-  ]
+  ],
+  "enableAllProjectMcpServers": true
 }

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -94,7 +94,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-latest
           cache-from: |
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator,mode=max
 
       # Re-tag existing images when builds are skipped (creates new tag pointing to -latest)
       - name: Re-tag migrator image if build skipped

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Deploy LocalStack
         run: |
-          envsubst < deploy/pr-environment/localstack.template.yaml | kubectl apply -f -
+          envsubst '$PR_NUMBER' < deploy/pr-environment/localstack.template.yaml | kubectl apply -f -
 
       - name: Wait for LocalStack to be ready
         run: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -105,7 +105,7 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:app-${{ steps.vars.outputs.sha_short }}
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app,mode=max
 
       - name: Build and push migrator image
         if: steps.check-images.outputs.migrator-exists != 'true'
@@ -117,8 +117,10 @@ jobs:
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-${{ steps.vars.outputs.sha_short }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator,mode=max
 
       - name: Build and push scheduler image
         if: steps.check-images.outputs.scheduler-exists != 'true'
@@ -130,8 +132,10 @@ jobs:
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-${{ steps.vars.outputs.sha_short }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-scheduler
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-scheduler,mode=max
 
       - name: Build and push workflow-runner image
         if: steps.check-images.outputs.workflow-runner-exists != 'true'
@@ -143,8 +147,10 @@ jobs:
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-workflow-runner
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-workflow-runner,mode=max
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/deploy-scheduler.yaml
+++ b/.github/workflows/deploy-scheduler.yaml
@@ -97,8 +97,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
           cache-from: |
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:scheduler-latest
-          cache-to: type=inline
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-scheduler
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-scheduler,mode=max
 
       - name: Build, tag, and push workflow-runner image to ECR
         id: build-workflow-runner
@@ -114,7 +114,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:workflow-runner-latest
           cache-from: |
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=inline
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-workflow-runner
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-workflow-runner,mode=max
 
       # Re-tag existing images when builds are skipped (creates new tag pointing to -latest)
       - name: Re-tag scheduler image if build skipped

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN npm install -g pnpm
 COPY package.json pnpm-lock.yaml* ./
 COPY .npmrc* ./
 
-# Install dependencies
-RUN pnpm install --frozen-lockfile
+# Install dependencies with cache mount for faster rebuilds
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 # Stage 2: Source (dependencies + source files, no build)
 FROM node:25-alpine AS source
@@ -64,8 +65,9 @@ RUN npm install -g pnpm
 # Copy scheduler-specific package.json with minimal dependencies
 COPY scheduler/package.json ./
 
-# Install only scheduler dependencies (production only)
-RUN pnpm install --prod
+# Install only scheduler dependencies (production only) with cache mount
+RUN --mount=type=cache,id=pnpm-scheduler,target=/root/.local/share/pnpm/store \
+    pnpm install --prod
 
 # Stage 2.7b: Scheduler stage (for schedule dispatcher and job spawner)
 FROM node:25-alpine AS scheduler

--- a/deploy/pr-environment/localstack.template.yaml
+++ b/deploy/pr-environment/localstack.template.yaml
@@ -117,17 +117,17 @@ spec:
               max_attempts=30
               attempt=0
 
-              while [ $$attempt -lt $$max_attempts ]; do
+              while [ $attempt -lt $max_attempts ]; do
                 if curl -sf http://localstack:4566/_localstack/health > /dev/null 2>&1; then
                   echo "LocalStack is ready!"
                   break
                 fi
-                echo "Attempt $$((attempt + 1))/$$max_attempts: LocalStack not ready yet..."
+                echo "Attempt $((attempt + 1))/$max_attempts: LocalStack not ready yet..."
                 sleep 2
-                attempt=$$((attempt + 1))
+                attempt=$((attempt + 1))
               done
 
-              if [ $$attempt -eq $$max_attempts ]; then
+              if [ $attempt -eq $max_attempts ]; then
                 echo "LocalStack failed to become ready"
                 exit 1
               fi

--- a/deploy/pr-environment/localstack.template.yaml
+++ b/deploy/pr-environment/localstack.template.yaml
@@ -117,17 +117,17 @@ spec:
               max_attempts=30
               attempt=0
 
-              while [ $attempt -lt $max_attempts ]; do
+              while [ $$attempt -lt $$max_attempts ]; do
                 if curl -sf http://localstack:4566/_localstack/health > /dev/null 2>&1; then
                   echo "LocalStack is ready!"
                   break
                 fi
-                echo "Attempt $((attempt + 1))/$max_attempts: LocalStack not ready yet..."
+                echo "Attempt $$((attempt + 1))/$$max_attempts: LocalStack not ready yet..."
                 sleep 2
-                attempt=$((attempt + 1))
+                attempt=$$((attempt + 1))
               done
 
-              if [ $attempt -eq $max_attempts ]; then
+              if [ $$attempt -eq $$max_attempts ]; then
                 echo "LocalStack failed to become ready"
                 exit 1
               fi

--- a/deploy/pr-environment/localstack.template.yaml
+++ b/deploy/pr-environment/localstack.template.yaml
@@ -1,5 +1,20 @@
 # LocalStack for SQS in PR environment
 # Variables to be replaced: ${PR_NUMBER}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: localstack-init
+  namespace: pr-${PR_NUMBER}
+data:
+  init-sqs.sh: |
+    #!/bin/bash
+    echo "Creating SQS queue..."
+    awslocal sqs create-queue \
+      --queue-name keeperhub-workflow-queue \
+      --attributes VisibilityTimeout=300
+    echo "SQS queue created successfully"
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,6 +54,9 @@ spec:
               value: "test"
             - name: AWS_DEFAULT_REGION
               value: "us-east-1"
+          volumeMounts:
+            - name: init-scripts
+              mountPath: /etc/localstack/init/ready.d
           resources:
             requests:
               memory: "256Mi"
@@ -68,6 +86,11 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: localstack-init
+            defaultMode: 0755
 
 ---
 apiVersion: v1
@@ -88,69 +111,3 @@ spec:
       name: edge
   type: ClusterIP
 
----
-# Init job to create SQS queue
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: create-sqs-queue
-  namespace: pr-${PR_NUMBER}
-  labels:
-    app: localstack-init
-    pr: pr-${PR_NUMBER}
-spec:
-  template:
-    metadata:
-      labels:
-        app: localstack-init
-        pr: pr-${PR_NUMBER}
-    spec:
-      restartPolicy: OnFailure
-      containers:
-        - name: aws-cli
-          image: amazon/aws-cli:latest
-          command:
-            - /bin/sh
-            - -c
-            - |
-              echo "Waiting for LocalStack to be ready..."
-              max_attempts=30
-              attempt=0
-
-              while [ $attempt -lt $max_attempts ]; do
-                if curl -sf http://localstack:4566/_localstack/health > /dev/null 2>&1; then
-                  echo "LocalStack is ready!"
-                  break
-                fi
-                echo "Attempt $((attempt + 1))/$max_attempts: LocalStack not ready yet..."
-                sleep 2
-                attempt=$((attempt + 1))
-              done
-
-              if [ $attempt -eq $max_attempts ]; then
-                echo "LocalStack failed to become ready"
-                exit 1
-              fi
-
-              echo "Creating SQS queue..."
-              aws --endpoint-url=http://localstack:4566 sqs create-queue \
-                --queue-name keeperhub-workflow-queue \
-                --region us-east-1 \
-                --attributes VisibilityTimeout=300
-
-              echo "SQS queue created successfully"
-          env:
-            - name: AWS_ACCESS_KEY_ID
-              value: "test"
-            - name: AWS_SECRET_ACCESS_KEY
-              value: "test"
-            - name: AWS_DEFAULT_REGION
-              value: "us-east-1"
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "10m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
-  backoffLimit: 5

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,11 +3,48 @@ import type { Config } from "drizzle-kit";
 
 config();
 
+/**
+ * Regex pattern for parsing PostgreSQL connection strings
+ */
+const CONNECTION_STRING_REGEX = /^(postgres(?:ql)?:\/\/)([^:]+):([^@]+)@(.+)$/;
+
+/**
+ * Ensures that the database connection string has properly URL-encoded credentials.
+ * Inline implementation for drizzle-kit config compatibility.
+ */
+function ensureEncodedConnectionString(connectionString: string): string {
+  try {
+    // Try to parse as-is first (it might already be valid)
+    new URL(connectionString);
+    return connectionString;
+  } catch {
+    // If parsing fails, it's likely due to special characters in the password
+    const match = connectionString.match(CONNECTION_STRING_REGEX);
+
+    if (!match) {
+      // Can't parse the format, return as-is and let the caller handle the error
+      return connectionString;
+    }
+
+    const [, protocol, username, password, hostAndDb] = match;
+
+    // URL-encode the password component
+    const encodedPassword = encodeURIComponent(password);
+
+    // Reconstruct the connection string
+    return `${protocol}${username}:${encodedPassword}@${hostAndDb}`;
+  }
+}
+
+const rawDatabaseUrl =
+  process.env.DATABASE_URL || "postgres://localhost:5432/workflow";
+const databaseUrl = ensureEncodedConnectionString(rawDatabaseUrl);
+
 export default {
   schema: "./lib/db/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL || "postgres://localhost:5432/workflow",
+    url: databaseUrl,
   },
 } satisfies Config;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -330,31 +330,28 @@ export const userRpcPreferences = pgTable(
 export const chains = pgTable(
   "chains",
   {
-    id: text().primaryKey().notNull(),
+    id: text("id").primaryKey().notNull(),
     chainId: integer("chain_id").notNull(),
-    name: text().notNull(),
-    symbol: text().notNull(),
+    name: text("name").notNull(),
+    symbol: text("symbol").notNull(),
+    chainType: text("chain_type").default("evm").notNull(),
     defaultPrimaryRpc: text("default_primary_rpc").notNull(),
     defaultFallbackRpc: text("default_fallback_rpc"),
+    defaultPrimaryWss: text("default_primary_wss"),
+    defaultFallbackWss: text("default_fallback_wss"),
     isTestnet: boolean("is_testnet").default(false),
     isEnabled: boolean("is_enabled").default(true),
+    // KEEP-1240: Chain-specific gas configuration
+    gasConfig: jsonb("gas_config").default({}),
     createdAt: timestamp("created_at", { mode: "string" })
       .defaultNow()
       .notNull(),
     updatedAt: timestamp("updated_at", { mode: "string" })
       .defaultNow()
       .notNull(),
-    defaultPrimaryWss: text("default_primary_wss"),
-    defaultFallbackWss: text("default_fallback_wss"),
-    chainType: text("chain_type").default("evm").notNull(),
-    // KEEP-1240: Chain-specific gas configuration
-    gasConfig: jsonb("gas_config").default({}),
   },
   (table) => [
-    index("idx_chains_chain_id").using(
-      "btree",
-      table.chainId.asc().nullsLast().op("int4_ops")
-    ),
+    index("idx_chains_chain_id").on(table.chainId),
     unique("chains_chain_id_unique").on(table.chainId),
   ]
 );
@@ -362,7 +359,7 @@ export const chains = pgTable(
 export const explorerConfigs = pgTable(
   "explorer_configs",
   {
-    id: text().primaryKey().notNull(),
+    id: text("id").primaryKey().notNull(),
     chainId: integer("chain_id").notNull(),
     chainType: text("chain_type").default("evm").notNull(),
     explorerUrl: text("explorer_url"),
@@ -381,15 +378,12 @@ export const explorerConfigs = pgTable(
       .notNull(),
   },
   (table) => [
-    index("idx_explorer_configs_chain_id").using(
-      "btree",
-      table.chainId.asc().nullsLast().op("int4_ops")
-    ),
+    index("idx_explorer_configs_chain_id").on(table.chainId),
     foreignKey({
       columns: [table.chainId],
       foreignColumns: [chains.chainId],
-      name: "explorer_configs_chain_id_fkey",
+      name: "explorer_configs_chain_id_chains_chain_id_fk",
     }).onDelete("cascade"),
-    unique("explorer_configs_chain_id_key").on(table.chainId),
+    unique("explorer_configs_chain_id_unique").on(table.chainId),
   ]
 );

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Database connection utilities
+ *
+ * Handles URL encoding of database credentials with special characters
+ */
+
+/**
+ * Regex pattern for parsing PostgreSQL connection strings
+ * Format: postgres[ql]://username:password@host:port/database
+ */
+const CONNECTION_STRING_REGEX = /^(postgres(?:ql)?:\/\/)([^:]+):([^@]+)@(.+)$/;
+
+/**
+ * Ensures that the database connection string has properly URL-encoded credentials.
+ *
+ * Passwords with special characters like +, /, = need to be percent-encoded when
+ * used in connection strings. This function parses the connection string and
+ * re-encodes the password component if needed.
+ *
+ * @param connectionString - PostgreSQL connection string
+ * @returns Connection string with properly encoded credentials
+ *
+ * @example
+ * ```ts
+ * const url = "postgresql://user:pass+word@host:5432/db";
+ * const safe = ensureEncodedConnectionString(url);
+ * // Returns: "postgresql://user:pass%2Bword@host:5432/db"
+ * ```
+ */
+export function ensureEncodedConnectionString(
+  connectionString: string
+): string {
+  try {
+    // Try to parse as-is first (it might already be valid)
+    new URL(connectionString);
+    return connectionString;
+  } catch {
+    // If parsing fails, it's likely due to special characters in the password
+    // Parse and re-encode the connection string manually
+    const match = connectionString.match(CONNECTION_STRING_REGEX);
+
+    if (!match) {
+      // Can't parse the format, return as-is and let the caller handle the error
+      return connectionString;
+    }
+
+    const [, protocol, username, password, hostAndDb] = match;
+
+    // URL-encode the password component
+    const encodedPassword = encodeURIComponent(password);
+
+    // Reconstruct the connection string
+    return `${protocol}${username}:${encodedPassword}@${hostAndDb}`;
+  }
+}
+
+/**
+ * Gets the database connection string from environment with proper encoding.
+ *
+ * @param fallback - Fallback connection string if DATABASE_URL is not set
+ * @returns Properly encoded connection string
+ */
+export function getDatabaseUrl(
+  fallback = "postgres://localhost:5432/workflow"
+): string {
+  const connectionString = process.env.DATABASE_URL || fallback;
+  return ensureEncodedConnectionString(connectionString);
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,6 +1,7 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { getDatabaseUrl } from "./connection-utils";
 import {
   accounts,
   apiKeys,
@@ -54,8 +55,7 @@ const schema = {
   userRpcPreferencesRelations,
 };
 
-const connectionString =
-  process.env.DATABASE_URL || "postgres://localhost:5432/workflow";
+const connectionString = getDatabaseUrl();
 
 // For migrations
 export const migrationClient = postgres(connectionString, { max: 1 });

--- a/scripts/schedule-dispatcher.ts
+++ b/scripts/schedule-dispatcher.ts
@@ -18,11 +18,11 @@ import { CronExpressionParser } from "cron-parser";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { getDatabaseUrl } from "../lib/db/connection-utils";
 import { workflowSchedules, workflows } from "../lib/db/schema";
 
 // Database connection
-const connectionString =
-  process.env.DATABASE_URL || "postgres://localhost:5432/workflow";
+const connectionString = getDatabaseUrl();
 const queryClient = postgres(connectionString);
 const db = drizzle(queryClient, { schema: { workflowSchedules, workflows } });
 

--- a/scripts/schedule-executor.ts
+++ b/scripts/schedule-executor.ts
@@ -24,6 +24,7 @@ import { CronExpressionParser } from "cron-parser";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { getDatabaseUrl } from "../lib/db/connection-utils";
 import {
   workflowExecutions,
   workflowSchedules,
@@ -32,8 +33,7 @@ import {
 import { generateId } from "../lib/utils/id";
 
 // Database connection
-const connectionString =
-  process.env.DATABASE_URL || "postgres://localhost:5432/workflow";
+const connectionString = getDatabaseUrl();
 const queryClient = postgres(connectionString);
 const db = drizzle(queryClient, {
   schema: { workflows, workflowExecutions, workflowSchedules },

--- a/scripts/seed-chains.ts
+++ b/scripts/seed-chains.ts
@@ -222,7 +222,10 @@ const DEFAULT_CHAINS: NewChain[] = [
 
 // Explorer configuration template for each chain (KEEP-1154)
 // Note: chainIds are resolved dynamically from DEFAULT_CHAINS to ensure consistency
-const EXPLORER_CONFIG_TEMPLATES: Record<number, Omit<NewExplorerConfig, "chainId">> = {
+const EXPLORER_CONFIG_TEMPLATES: Record<
+  number,
+  Omit<NewExplorerConfig, "chainId">
+> = {
   // Ethereum Mainnet - Etherscan
   1: {
     chainType: "evm",
@@ -234,7 +237,7 @@ const EXPLORER_CONFIG_TEMPLATES: Record<number, Omit<NewExplorerConfig, "chainId
     explorerContractPath: "/address/{address}#code",
   },
   // Sepolia Testnet - Etherscan (uses unified V2 API with chainid param)
-  11_155_111: {
+  11155111: {
     chainType: "evm",
     explorerUrl: "https://sepolia.etherscan.io",
     explorerApiType: "etherscan",
@@ -254,7 +257,7 @@ const EXPLORER_CONFIG_TEMPLATES: Record<number, Omit<NewExplorerConfig, "chainId
     explorerContractPath: "/address/{address}#code",
   },
   // Base Sepolia - Etherscan
-  84_532: {
+  84532: {
     chainType: "evm",
     explorerUrl: "https://sepolia.basescan.org",
     explorerApiType: "etherscan",
@@ -264,7 +267,7 @@ const EXPLORER_CONFIG_TEMPLATES: Record<number, Omit<NewExplorerConfig, "chainId
     explorerContractPath: "/address/{address}#code",
   },
   // Tempo Testnet - Blockscout
-  42_429: {
+  42429: {
     chainType: "evm",
     explorerUrl: "https://explorer.testnet.tempo.xyz",
     explorerApiType: "blockscout",
@@ -274,7 +277,7 @@ const EXPLORER_CONFIG_TEMPLATES: Record<number, Omit<NewExplorerConfig, "chainId
     explorerContractPath: "/address/{address}?tab=contract",
   },
   // Tempo Mainnet - Blockscout
-  42_420: {
+  42420: {
     chainType: "evm",
     explorerUrl: "https://explorer.tempo.xyz",
     explorerApiType: "blockscout",
@@ -356,11 +359,11 @@ async function seedChains() {
   const chainToDefaultIdMap: Record<string, number> = {
     "Ethereum Mainnet": 1,
     "Sepolia Testnet": 11_155_111,
-    "Base": 8453,
+    Base: 8453,
     "Base Sepolia": 84_532,
     "Tempo Testnet": 42_429,
-    "Tempo": 42_420,
-    "Solana": 101,
+    Tempo: 42_420,
+    Solana: 101,
     "Solana Devnet": 103,
   };
 
@@ -368,7 +371,7 @@ async function seedChains() {
     // Look up the default chainId using the chain name
     const defaultChainId = chainToDefaultIdMap[chain.name];
 
-    if (!defaultChainId || !EXPLORER_CONFIG_TEMPLATES[defaultChainId]) {
+    if (!(defaultChainId && EXPLORER_CONFIG_TEMPLATES[defaultChainId])) {
       console.warn(
         `  ! No explorer config template for chain ${chain.name} (${chain.chainId}), skipping`
       );

--- a/scripts/seed-chains.ts
+++ b/scripts/seed-chains.ts
@@ -13,6 +13,7 @@ import "dotenv/config";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { getDatabaseUrl } from "../lib/db/connection-utils";
 import {
   chains,
   explorerConfigs,
@@ -309,8 +310,7 @@ const EXPLORER_CONFIG_TEMPLATES: Record<
 };
 
 async function seedChains() {
-  const connectionString =
-    process.env.DATABASE_URL || "postgres://localhost:5432/workflow";
+  const connectionString = getDatabaseUrl();
 
   console.log("Connecting to database...");
   const client = postgres(connectionString, { max: 1 });

--- a/scripts/seed-tokens.ts
+++ b/scripts/seed-tokens.ts
@@ -20,6 +20,7 @@ import { ethers } from "ethers";
 import postgres from "postgres";
 import { supportedTokens } from "../keeperhub/db/schema-extensions";
 import { ERC20_ABI } from "../lib/contracts";
+import { getDatabaseUrl } from "../lib/db/connection-utils";
 import { getRpcUrlByChainId } from "../lib/rpc/rpc-config";
 
 // Token logo URLs (using popular token list sources)
@@ -175,8 +176,7 @@ async function fetchTokenMetadata(
 }
 
 async function seedTokens() {
-  const connectionString =
-    process.env.DATABASE_URL || "postgres://localhost:5432/workflow";
+  const connectionString = getDatabaseUrl();
 
   console.log("Connecting to database...");
   const client = postgres(connectionString, { max: 1 });


### PR DESCRIPTION
While bootstrapping the enthronement from scratch (say, PR one) we have next errors in DB migration container
```
Running database migrations...

> ai-workflow-builder-template@0.1.0 db:push /app
> drizzle-kit push --force

No config path provided, using default 'drizzle.config.ts'
Reading config file '/app/drizzle.config.ts'
[dotenv@17.2.3] injecting env (0) from .env -- tip: ⚙️  override existing env vars with { override: true }
Using 'postgres' driver for database querying
[⣷] Pulling schema from database...
[⣯] Pulling schema from database...
[⣟] Pulling schema from database...
[⡿] Pulling schema from database...
[⢿] Pulling schema from database...
[⣻] Pulling schema from database...
[⣽] Pulling schema from database...
[✓] Pulling schema from database...
PostgresError: column "id" is in a primary key
    at ErrorResponse (file:///app/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/src/connection.js:794:26)
    at handle (file:///app/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/src/connection.js:480:6)
    at Socket.data (file:///app/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/src/connection.js:315:9)
    at Socket.emit (node:events:508:20)
    at addChunk (node:internal/streams/readable:564:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:515:3)
    at Readable.push (node:internal/streams/readable:395:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
  severity_local: 'ERROR',
  severity: 'ERROR',
  code: '42P16',
  file: 'tablecmds.c',
  line: '14146',
  routine: 'dropconstraint_internal'
}
Seeding chains...

> ai-workflow-builder-template@0.1.0 db:seed /app
> tsx scripts/seed-chains.ts && tsx scripts/seed-tokens.ts

Connecting to database...
Seeding 8 chains...
  ~ Ethereum Mainnet (1) updated
  ~ Sepolia Testnet (11155111) updated
  ~ Base (8453) updated
  ~ Base Sepolia (84532) updated
  ~ Tempo Testnet (42429) updated
  ~ Tempo (0) updated
  ~ Solana (101) updated
  ~ Solana Devnet (103) updated

Seeding 8 explorer configs...
  - Explorer config for chain 1 already exists, skipping
  - Explorer config for chain 11155111 already exists, skipping
  - Explorer config for chain 8453 already exists, skipping
  - Explorer config for chain 84532 already exists, skipping
  - Explorer config for chain 42429 already exists, skipping
Error seeding chains: DrizzleQueryError: Failed query: insert into "explorer_configs" ("id", "chain_id", "chain_type", "explorer_url", "explorer_api_type", "explorer_api_url", "explorer_tx_path", "explorer_address_path", "explorer_contract_path", "created_at", "updated_at") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, default, default)
params: iypb0uc422ajl23x60nbt,42420,evm,https://explorer.tempo.xyz,blockscout,https://explorer.tempo.xyz/api,/tx/{hash},/address/{address},/address/{address}?tab=contract
    at PostgresJsPreparedQuery.queryWithCache (/app/node_modules/.pnpm/drizzle-orm@0.44.7_@opentelemetry+api@1.9.0_@types+pg@8.15.6_kysely@0.28.8_postgres@3.4.7/node_modules/src/pg-core/session.ts:73:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async seedChains (/app/scripts/seed-chains.ts:375:5) {
  query: 'insert into "explorer_configs" ("id", "chain_id", "chain_type", "explorer_url", "explorer_api_type", "explorer_api_url", "explorer_tx_path", "explorer_address_path", "explorer_contract_path", "created_at", "updated_at") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, default, default)',
  params: [
    'iypb0uc422ajl23x60nbt',
    42420,
    'evm',
    'https://explorer.tempo.xyz',
    'blockscout',
    'https://explorer.tempo.xyz/api',
    '/tx/{hash}',
    '/address/{address}',
    '/address/{address}?tab=contract'
  ],
  cause: PostgresError: insert or update on table "explorer_configs" violates foreign key constraint "explorer_configs_chain_id_chains_chain_id_fk"
      at ErrorResponse (/app/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/cjs/src/connection.js:794:26)
      at handle (/app/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/cjs/src/connection.js:480:6)
      at Socket.data (/app/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/cjs/src/connection.js:315:9)
      at Socket.emit (node:events:508:20)
      at addChunk (node:internal/streams/readable:564:12)
      at readableAddChunkPushByteMode (node:internal/streams/readable:515:3)
      at Readable.push (node:internal/streams/readable:395:5)
      at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
    severity_local: 'ERROR',
    severity: 'ERROR',
    code: '23503',
    detail: 'Key (chain_id)=(42420) is not present in table "chains".',
    schema_name: 'public',
    table_name: 'explorer_configs',
    constraint_name: 'explorer_configs_chain_id_chains_chain_id_fk',
    file: 'ri_triggers.c',
    line: '2772',
    routine: 'ri_ReportViolation'
  }
}
 ELIFECYCLE  Command failed with exit code 1.
Migrations and seeding completed successfully
stream closed EOF for pr-164/keeperhub-pr-164-common-84b9f85f48-zqg4f (db-migration)

```