### PR TITLE
Add SENDGRID_API_KEY to scheduler service

### DIFF
--- a/deploy/scheduler/prod/values.yaml
+++ b/deploy/scheduler/prod/values.yaml
@@ -73,6 +73,10 @@ env:
     type: parameterStore
     name: integration-encryption-key
     parameter_name: /eks/maker-prod/keeperhub/integration-encryption-key
+  SENDGRID_API_KEY:
+    type: parameterStore
+    name: sendgrid-api-key
+    parameter_name: /eks/maker-prod/keeperhub/sendgrid-api-key
 
 externalSecrets:
   clusterSecretStoreName: maker-prod

--- a/deploy/scheduler/staging/values.yaml
+++ b/deploy/scheduler/staging/values.yaml
@@ -79,6 +79,10 @@ env:
     type: parameterStore
     name: integration-encryption-key
     parameter_name: /eks/maker-staging/keeperhub/integration-encryption-key
+  SENDGRID_API_KEY:
+    type: parameterStore
+    name: sendgrid-api-key
+    parameter_name: /eks/maker-staging/keeper-app/sendgrid-api-key
 
 externalSecrets:
   clusterSecretStoreName: maker-staging


### PR DESCRIPTION
## Summary
- Add SENDGRID_API_KEY environment variable to scheduler service deployments
- Uses same SSM parameter paths as main keeperhub app
- Staging: `/eks/maker-staging/keeper-app/sendgrid-api-key`
- Prod: `/eks/maker-prod/keeperhub/sendgrid-api-key`

## Test plan
- [ ] Deploy to staging and verify scheduler pod has SENDGRID_API_KEY env var