### PR TITLE
Add feedback service env vars to prod deployment

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -190,6 +190,13 @@ env:
     type: parameterStore
     name: hub-service-api-key
     parameter_name: /eks/maker-prod/keeperhub-hub/keeperhub-api-key
+  FEEDBACK_SERVICE_URL:
+    type: kv
+    value: "http://keeperhub-feedback-common.keeperhub:3001/api/feedback"
+  FEEDBACK_API_KEY:
+    type: parameterStore
+    name: feedback-api-key
+    parameter_name: /eks/maker-prod/keeperhub-feedback/feedback-api-key
 
 externalSecrets:
   clusterSecretStoreName: maker-prod


### PR DESCRIPTION
## Summary
- Add FEEDBACK_SERVICE_URL and FEEDBACK_API_KEY env vars to prod keeperhub deployment
- Uses keeperhub-feedback-common service URL

## Test plan
- Deploy to prod and verify feedback submission works