### PR TITLE
KEEP-1255: Give Organization's Owners the ability to rename it

### DIFF
--- a/app/api/organizations/[organizationId]/route.ts
+++ b/app/api/organizations/[organizationId]/route.ts
@@ -1,0 +1,7 @@
+/**
+ * KeeperHub Organization API Route
+ *
+ * This is a thin wrapper that re-exports the actual implementation
+ * from the keeperhub directory to maintain clean separation.
+ */
+export { PATCH } from "@/keeperhub/api/organizations/[organizationId]/route";

--- a/keeperhub/api/organizations/[organizationId]/route.ts
+++ b/keeperhub/api/organizations/[organizationId]/route.ts
@@ -1,0 +1,84 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { member, organization } from "@/lib/db/schema";
+
+interface UpdateOrganizationNameRequest {
+  name?: string;
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json()) as UpdateOrganizationNameRequest;
+    const nextName =
+      typeof body.name === "string" ? body.name.trim() : undefined;
+
+    if (!nextName) {
+      return NextResponse.json(
+        { error: "Organization name is required" },
+        { status: 400 }
+      );
+    }
+
+    if (nextName.length > 120) {
+      return NextResponse.json(
+        { error: "Organization name is too long" },
+        { status: 400 }
+      );
+    }
+
+    const ownerMembership = await db
+      .select({ id: member.id })
+      .from(member)
+      .where(
+        and(
+          eq(member.organizationId, organizationId),
+          eq(member.userId, session.user.id),
+          eq(member.role, "owner")
+        )
+      )
+      .limit(1);
+
+    if (ownerMembership.length === 0) {
+      return NextResponse.json(
+        { error: "Only organization owners can update the organization" },
+        { status: 403 }
+      );
+    }
+
+    const [updated] = await db
+      .update(organization)
+      .set({ name: nextName })
+      .where(eq(organization.id, organizationId))
+      .returning({ id: organization.id, name: organization.name });
+
+    if (!updated) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ organization: updated }, { status: 200 });
+  } catch (error) {
+    console.error("Failed to update organization:", error);
+    return NextResponse.json(
+      { error: "Failed to update organization" },
+      { status: 500 }
+    );
+  }
+}

--- a/keeperhub/api/organizations/[organizationId]/route.ts
+++ b/keeperhub/api/organizations/[organizationId]/route.ts
@@ -4,9 +4,9 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { member, organization } from "@/lib/db/schema";
 
-interface UpdateOrganizationNameRequest {
+type UpdateOrganizationNameRequest = {
   name?: string;
-}
+};
 
 export async function PATCH(
   request: Request,

--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -954,7 +954,7 @@ export function ManageOrgsModal({
                           </>
                         )}
                         {isManagedOrgActive && (
-                          <span className="rounded-full bg-green-100 min-w-11 px-2 py-0.5 text-green-700 text-xs">
+                          <span className="min-w-11 rounded-full bg-green-100 px-2 py-0.5 text-green-700 text-xs">
                             Active
                           </span>
                         )}

--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -2,8 +2,10 @@
 
 import {
   ArrowLeft,
+  Check,
   LogOut,
   Mail,
+  Pencil,
   Plus,
   Settings,
   Trash2,
@@ -11,7 +13,7 @@ import {
   X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   AlertDialog,
@@ -47,6 +49,8 @@ import {
   useOrganization,
   useOrganizations,
 } from "@/keeperhub/lib/hooks/use-organization";
+import { refetchOrganizations } from "@/keeperhub/lib/refetch-organizations";
+import { api } from "@/lib/api-client";
 import { authClient } from "@/lib/auth-client";
 
 // Helper function to get status color based on invitation status
@@ -239,7 +243,7 @@ export function ManageOrgsModal({
   const [managedOrgId, setManagedOrgId] = useState<string | null>(null);
 
   const { organization, switchOrganization } = useOrganization();
-  const { organizations, refetch: refetchOrganizations } = useOrganizations();
+  const { organizations } = useOrganizations();
   const { isOwner: isActiveOrgOwner, isAdmin: isActiveOrgAdmin } =
     useActiveMember();
   const router = useRouter();
@@ -249,6 +253,7 @@ export function ManageOrgsModal({
   const managedOrg = managedOrgId
     ? organizations.find((org) => org.id === managedOrgId)
     : null;
+  const managedOrgName = managedOrg?.name ?? "";
 
   // Determine if the managed org is the active session org
   const isManagedOrgActive = managedOrgId === organization?.id;
@@ -258,6 +263,11 @@ export function ManageOrgsModal({
   const [orgSlug, setOrgSlug] = useState("");
   const [orgSlugManuallyEdited, setOrgSlugManuallyEdited] = useState(false);
   const [createLoading, setCreateLoading] = useState(false);
+
+  // Organization name editing state (managed org detail view)
+  const [isEditingOrgName, setIsEditingOrgName] = useState(false);
+  const [editingOrgName, setEditingOrgName] = useState("");
+  const [updatingOrgName, setUpdatingOrgName] = useState(false);
 
   // Invite state
   const [inviteEmail, setInviteEmail] = useState("");
@@ -421,6 +431,27 @@ export function ManageOrgsModal({
       fetchMembers();
     }
   }, [open, managedOrgId, fetchSentInvitations, fetchMembers]);
+
+  // Keep edit input in sync when switching orgs / name updates
+  const lastManagedOrgIdForNameEditRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (lastManagedOrgIdForNameEditRef.current !== managedOrgId) {
+      lastManagedOrgIdForNameEditRef.current = managedOrgId;
+      setIsEditingOrgName(false);
+    }
+
+    if (!managedOrgId) {
+      setEditingOrgName("");
+      return;
+    }
+
+    if (isEditingOrgName) {
+      return;
+    }
+
+    setEditingOrgName(managedOrgName);
+  }, [managedOrgId, managedOrgName, isEditingOrgName]);
 
   // Reset managed org when modal closes
   useEffect(() => {
@@ -653,6 +684,37 @@ export function ManageOrgsModal({
     }
   };
 
+  const handleUpdateOrgName = async () => {
+    if (!(managedOrgId && managedOrg)) {
+      return;
+    }
+
+    const nextName = editingOrgName.trim();
+
+    if (!nextName) {
+      toast.error("Organization name is required");
+      return;
+    }
+
+    if (nextName === managedOrg.name) {
+      setIsEditingOrgName(false);
+      return;
+    }
+
+    setUpdatingOrgName(true);
+    try {
+      await api.organization.updateName(managedOrgId, { name: nextName });
+      toast.success("Organization name updated");
+      setIsEditingOrgName(false);
+      refetchOrganizations();
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to update name");
+    } finally {
+      setUpdatingOrgName(false);
+    }
+  };
+
   return (
     <>
       <Dialog onOpenChange={setOpen} open={open}>
@@ -826,11 +888,73 @@ export function ManageOrgsModal({
                   <div className="space-y-4 rounded-lg border p-4">
                     <div>
                       <div className="flex items-center gap-2">
-                        <h3 className="font-semibold text-lg">
-                          {managedOrg.name}
-                        </h3>
+                        {isEditingOrgName ? (
+                          <>
+                            <Input
+                              aria-label="Organization name"
+                              className="h-8 max-w-xs"
+                              disabled={updatingOrgName}
+                              onChange={(e) =>
+                                setEditingOrgName(e.target.value)
+                              }
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  handleUpdateOrgName();
+                                }
+                                if (e.key === "Escape") {
+                                  setIsEditingOrgName(false);
+                                  setEditingOrgName(managedOrg.name);
+                                }
+                              }}
+                              value={editingOrgName}
+                            />
+                            <Button
+                              aria-label="Save organization name"
+                              disabled={
+                                updatingOrgName || !editingOrgName.trim()
+                              }
+                              onClick={handleUpdateOrgName}
+                              size="icon"
+                              variant="ghost"
+                            >
+                              <Check className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              aria-label="Cancel editing organization name"
+                              disabled={updatingOrgName}
+                              onClick={() => {
+                                setIsEditingOrgName(false);
+                                setEditingOrgName(managedOrg.name);
+                              }}
+                              size="icon"
+                              variant="ghost"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <h3 className="font-semibold text-lg">
+                              {managedOrg.name}
+                            </h3>
+                            {isOwner && (
+                              <Button
+                                aria-label="Edit organization name"
+                                disabled={updatingOrgName}
+                                onClick={() => {
+                                  setIsEditingOrgName(true);
+                                  setEditingOrgName(managedOrg.name);
+                                }}
+                                size="icon"
+                                variant="ghost"
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </>
+                        )}
                         {isManagedOrgActive && (
-                          <span className="rounded-full bg-green-100 px-2 py-0.5 text-green-700 text-xs">
+                          <span className="rounded-full bg-green-100 min-w-11 px-2 py-0.5 text-green-700 text-xs">
                             Active
                           </span>
                         )}

--- a/keeperhub/components/organization/org-switcher.tsx
+++ b/keeperhub/components/organization/org-switcher.tsx
@@ -77,7 +77,7 @@ export function OrgSwitcher() {
                     }}
                   >
                     <Check
-                      className={`mr-2 h-4 w-4 ${
+                      className={`mr-1 h-4 w-4 ${
                         organization.id === org.id ? "opacity-100" : "opacity-0"
                       }`}
                     />

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -336,6 +336,11 @@ export type IntegrationWithConfig = Integration & {
   config: IntegrationConfig;
 };
 
+export type Organization = {
+  id: string;
+  name: string;
+};
+
 // AI Gateway types
 export type AiGatewayStatusResponse = {
   enabled: boolean;
@@ -416,6 +421,18 @@ export const integrationApi = {
       "/api/integrations/test",
       {
         method: "POST",
+        body: JSON.stringify(data),
+      }
+    ),
+};
+
+// Organization API
+export const organizationApi = {
+  updateName: (organizationId: string, data: { name: string }) =>
+    apiCall<{ organization: Organization }>(
+      `/api/organizations/${organizationId}`,
+      {
+        method: "PATCH",
         body: JSON.stringify(data),
       }
     ),
@@ -690,6 +707,7 @@ export const api = {
   ai: aiApi,
   aiGateway: aiGatewayApi,
   integration: integrationApi,
+  organization: organizationApi,
   user: userApi,
   workflow: workflowApi,
 };


### PR DESCRIPTION
# Summary:

This pull request introduces the ability to update default organization names for owners.

# Details:

- Introduced a new API route for updating organization names with proper authorization checks.
  - `[ PATCH ] - /api/organizations/:id`
- Implemented organization name editing in the ManageOrgsModal component, including input handling and API integration.
- Enhanced organization switching UI with improved styling and functionality.
- Updated API client to include organization update method.