### PR TITLE
feat(phase-2): scheduler internal API endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test-e2e:
 	DATABASE_URL="postgresql://local:local@localhost:5433/keeperhub" \
 	AWS_ENDPOINT_URL="http://localhost:4566" \
 	SQS_QUEUE_URL="http://localhost:4566/000000000000/keeperhub-workflow-queue" \
-	KEEPERHUB_URL="https://workflow.keeperhub.local" \
+	KEEPERHUB_API_URL="https://workflow.keeperhub.local" \
 	pnpm test -- --run tests/e2e/; \
 	kill $$PF_PID_DB 2>/dev/null || true; \
 	kill $$PF_PID_SQS 2>/dev/null || true

--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -1,3 +1,4 @@
+// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -25,7 +26,7 @@ export async function PATCH(
   const validStatuses: ExecutionStatus[] = ["running", "success", "error"];
 
   // Validate status
-  if (!status || !validStatuses.includes(status)) {
+  if (!(status && validStatuses.includes(status))) {
     return NextResponse.json(
       { error: "status must be 'running', 'success', or 'error'" },
       { status: 400 }
@@ -65,3 +66,4 @@ export async function PATCH(
 
   return NextResponse.json({ success: true });
 }
+// end keeperhub code //

--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -1,0 +1,67 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ executionId: string }> }
+) {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error || "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { executionId } = await context.params;
+  const body = await request.json();
+  const { status, error } = body;
+
+  type ExecutionStatus = "running" | "success" | "error";
+  const validStatuses: ExecutionStatus[] = ["running", "success", "error"];
+
+  // Validate status
+  if (!status || !validStatuses.includes(status)) {
+    return NextResponse.json(
+      { error: "status must be 'running', 'success', or 'error'" },
+      { status: 400 }
+    );
+  }
+
+  const typedStatus = status as ExecutionStatus;
+
+  // Check execution exists
+  const existing = await db.query.workflowExecutions.findFirst({
+    where: eq(workflowExecutions.id, executionId),
+    columns: { id: true },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Execution not found" }, { status: 404 });
+  }
+
+  // Build update payload
+  const updateData: {
+    status: ExecutionStatus;
+    error?: string | null;
+    completedAt?: Date;
+  } = { status: typedStatus };
+
+  if (status === "error") {
+    updateData.error = error || "Unknown error";
+    updateData.completedAt = new Date();
+  } else if (status === "success") {
+    updateData.completedAt = new Date();
+  }
+
+  await db
+    .update(workflowExecutions)
+    .set(updateData)
+    .where(eq(workflowExecutions.id, executionId));
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -1,3 +1,4 @@
+// start custom keeperhub code //
 import { NextResponse } from "next/server";
 
 import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
@@ -17,7 +18,7 @@ export async function POST(request: Request) {
   const { workflowId, userId, input } = body;
 
   // Validate required fields
-  if (!workflowId || !userId) {
+  if (!(workflowId && userId)) {
     return NextResponse.json(
       { error: "workflowId and userId are required" },
       { status: 400 }
@@ -36,3 +37,4 @@ export async function POST(request: Request) {
 
   return NextResponse.json({ executionId: execution.id }, { status: 201 });
 }
+// end keeperhub code //

--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+
+export async function POST(request: Request) {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error || "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const body = await request.json();
+  const { workflowId, userId, input } = body;
+
+  // Validate required fields
+  if (!workflowId || !userId) {
+    return NextResponse.json(
+      { error: "workflowId and userId are required" },
+      { status: 400 }
+    );
+  }
+
+  const [execution] = await db
+    .insert(workflowExecutions)
+    .values({
+      workflowId,
+      userId,
+      status: "running",
+      input: input || {},
+    })
+    .returning({ id: workflowExecutions.id });
+
+  return NextResponse.json({ executionId: execution.id }, { status: 201 });
+}

--- a/app/api/internal/schedules/[scheduleId]/route.ts
+++ b/app/api/internal/schedules/[scheduleId]/route.ts
@@ -1,0 +1,102 @@
+import { CronExpressionParser } from "cron-parser";
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflowSchedules } from "@/lib/db/schema";
+
+type RouteContext = {
+  params: Promise<{ scheduleId: string }>;
+};
+
+function computeNextRunTime(
+  cronExpression: string,
+  timezone: string
+): Date | null {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, {
+      currentDate: new Date(),
+      tz: timezone,
+    });
+    return interval.next().toDate();
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error || "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { scheduleId } = await context.params;
+
+  const schedule = await db.query.workflowSchedules.findFirst({
+    where: eq(workflowSchedules.id, scheduleId),
+  });
+
+  if (!schedule) {
+    return NextResponse.json({ error: "Schedule not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ schedule });
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error || "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { scheduleId } = await context.params;
+
+  const body = await request.json();
+  const { status, error } = body as { status?: string; error?: string };
+
+  if (status !== "success" && status !== "error") {
+    return NextResponse.json(
+      { error: "Invalid status. Must be 'success' or 'error'" },
+      { status: 400 }
+    );
+  }
+
+  const schedule = await db.query.workflowSchedules.findFirst({
+    where: eq(workflowSchedules.id, scheduleId),
+  });
+
+  if (!schedule) {
+    return NextResponse.json({ error: "Schedule not found" }, { status: 404 });
+  }
+
+  const nextRunAt = computeNextRunTime(
+    schedule.cronExpression,
+    schedule.timezone
+  );
+
+  const runCount =
+    status === "success"
+      ? String(Number(schedule.runCount || "0") + 1)
+      : schedule.runCount;
+
+  await db
+    .update(workflowSchedules)
+    .set({
+      lastRunAt: new Date(),
+      lastStatus: status,
+      lastError: status === "error" ? error : null,
+      nextRunAt,
+      runCount,
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowSchedules.id, scheduleId));
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/internal/schedules/[scheduleId]/route.ts
+++ b/app/api/internal/schedules/[scheduleId]/route.ts
@@ -1,3 +1,4 @@
+// start custom keeperhub code //
 import { CronExpressionParser } from "cron-parser";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -100,3 +101,4 @@ export async function PATCH(request: Request, context: RouteContext) {
 
   return NextResponse.json({ success: true });
 }
+// end keeperhub code //

--- a/app/api/internal/schedules/route.ts
+++ b/app/api/internal/schedules/route.ts
@@ -1,0 +1,31 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflows, workflowSchedules } from "@/lib/db/schema";
+
+export async function GET(request: Request) {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error || "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const schedules = await db
+    .select({
+      id: workflowSchedules.id,
+      workflowId: workflowSchedules.workflowId,
+      cronExpression: workflowSchedules.cronExpression,
+      timezone: workflowSchedules.timezone,
+    })
+    .from(workflowSchedules)
+    .innerJoin(workflows, eq(workflowSchedules.workflowId, workflows.id))
+    .where(
+      and(eq(workflowSchedules.enabled, true), eq(workflows.enabled, true))
+    );
+
+  return NextResponse.json({ schedules });
+}

--- a/app/api/internal/schedules/route.ts
+++ b/app/api/internal/schedules/route.ts
@@ -1,9 +1,10 @@
+// start custom keeperhub code //
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
 import { db } from "@/lib/db";
-import { workflows, workflowSchedules } from "@/lib/db/schema";
+import { workflowSchedules, workflows } from "@/lib/db/schema";
 
 export async function GET(request: Request) {
   const auth = authenticateInternalService(request);
@@ -29,3 +30,4 @@ export async function GET(request: Request) {
 
   return NextResponse.json({ schedules });
 }
+// end keeperhub code //

--- a/app/api/internal/workflows/[workflowId]/route.ts
+++ b/app/api/internal/workflows/[workflowId]/route.ts
@@ -1,0 +1,38 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflows } from "@/lib/db/schema";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ workflowId: string }> }
+) {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error || "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { workflowId } = await context.params;
+
+  const workflow = await db.query.workflows.findFirst({
+    where: eq(workflows.id, workflowId),
+    columns: {
+      id: true,
+      enabled: true,
+      userId: true,
+      nodes: true,
+      edges: true,
+    },
+  });
+
+  if (!workflow) {
+    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ workflow });
+}

--- a/app/api/internal/workflows/[workflowId]/route.ts
+++ b/app/api/internal/workflows/[workflowId]/route.ts
@@ -1,3 +1,4 @@
+// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -36,3 +37,4 @@ export async function GET(
 
   return NextResponse.json({ workflow });
 }
+// end keeperhub code //

--- a/deploy/local/schedule-trigger.yaml
+++ b/deploy/local/schedule-trigger.yaml
@@ -28,7 +28,8 @@ data:
   AWS_ACCESS_KEY_ID: "test"
   AWS_SECRET_ACCESS_KEY: "test"
   SQS_QUEUE_URL: "http://localstack:4566/000000000000/keeperhub-workflow-queue"
-  KEEPERHUB_URL: "http://keeperhub-common:3000"
+  KEEPERHUB_API_URL: "http://keeperhub-common:3000"
+  KEEPERHUB_API_KEY: "local-scheduler-key-for-dev"
   DATABASE_URL: "postgresql://local:local@postgresql:5432/keeperhub"
   # Job spawner settings
   RUNNER_IMAGE: "keeperhub-runner:latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,17 +173,20 @@ services:
     restart: unless-stopped
     working_dir: /app
     environment:
-      <<: *env_db_connection
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
       AWS_ENDPOINT_URL: http://localstack:4566
       SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
+      KEEPERHUB_API_URL: http://keeperhub:3000
+      KEEPERHUB_API_KEY: local-scheduler-key-for-dev
     depends_on:
       db:
         condition: service_healthy
       localstack:
         condition: service_healthy
+      app-dev:
+        condition: service_started
     # Run dispatcher every minute using a simple loop
     # (Docker doesn't have native cron, so we simulate it)
     command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,8 +217,8 @@ services:
       AWS_SECRET_ACCESS_KEY: test
       AWS_ENDPOINT_URL: http://localstack:4566
       SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
-      KEEPERHUB_URL: http://keeperhub:3000
-      SCHEDULER_SERVICE_API_KEY: local-scheduler-key-for-dev
+      KEEPERHUB_API_URL: http://keeperhub:3000
+      KEEPERHUB_API_KEY: local-scheduler-key-for-dev
     depends_on:
       db:
         condition: service_healthy

--- a/scripts/schedule-dispatcher.ts
+++ b/scripts/schedule-dispatcher.ts
@@ -8,8 +8,8 @@
  *   npx tsx scripts/schedule-dispatcher.ts
  *
  * Environment variables:
- *   KEEPERHUB_URL - KeeperHub API URL (default: http://localhost:3000)
- *   SCHEDULER_SERVICE_API_KEY - Service API key for authentication
+ *   KEEPERHUB_API_URL - KeeperHub API URL (default: http://localhost:3000)
+ *   KEEPERHUB_API_KEY - Service API key for authentication
  *   AWS_ENDPOINT_URL - LocalStack endpoint (default: http://localhost:4566)
  *   SQS_QUEUE_URL - SQS queue URL (default: LocalStack queue)
  */
@@ -37,8 +37,8 @@ const QUEUE_URL =
   process.env.SQS_QUEUE_URL ||
   "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/keeperhub-workflow-queue";
 
-const KEEPERHUB_URL = process.env.KEEPERHUB_URL || "http://localhost:3000";
-const SERVICE_API_KEY = process.env.SCHEDULER_SERVICE_API_KEY || "";
+const KEEPERHUB_URL = process.env.KEEPERHUB_API_URL || "http://localhost:3000";
+const SERVICE_API_KEY = process.env.KEEPERHUB_API_KEY || "";
 
 type Schedule = {
   id: string;

--- a/scripts/schedule-dispatcher.ts
+++ b/scripts/schedule-dispatcher.ts
@@ -66,7 +66,9 @@ async function fetchSchedules(): Promise<Schedule[]> {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch schedules: ${response.status} ${await response.text()}`);
+    throw new Error(
+      `Failed to fetch schedules: ${response.status} ${await response.text()}`
+    );
   }
 
   const data = await response.json();

--- a/scripts/schedule-dispatcher.ts
+++ b/scripts/schedule-dispatcher.ts
@@ -8,23 +8,14 @@
  *   npx tsx scripts/schedule-dispatcher.ts
  *
  * Environment variables:
- *   DATABASE_URL - PostgreSQL connection string
+ *   KEEPERHUB_URL - KeeperHub API URL (default: http://localhost:3000)
+ *   SCHEDULER_SERVICE_API_KEY - Service API key for authentication
  *   AWS_ENDPOINT_URL - LocalStack endpoint (default: http://localhost:4566)
  *   SQS_QUEUE_URL - SQS queue URL (default: LocalStack queue)
  */
 
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { CronExpressionParser } from "cron-parser";
-import { and, eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/postgres-js";
-import postgres from "postgres";
-import { getDatabaseUrl } from "../lib/db/connection-utils";
-import { workflowSchedules, workflows } from "../lib/db/schema";
-
-// Database connection
-const connectionString = getDatabaseUrl();
-const queryClient = postgres(connectionString);
-const db = drizzle(queryClient, { schema: { workflowSchedules, workflows } });
 
 // SQS client - only use custom endpoint/credentials for local development
 const sqsConfig: ConstructorParameters<typeof SQSClient>[0] = {
@@ -46,12 +37,41 @@ const QUEUE_URL =
   process.env.SQS_QUEUE_URL ||
   "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/keeperhub-workflow-queue";
 
+const KEEPERHUB_URL = process.env.KEEPERHUB_URL || "http://localhost:3000";
+const SERVICE_API_KEY = process.env.SCHEDULER_SERVICE_API_KEY || "";
+
+type Schedule = {
+  id: string;
+  workflowId: string;
+  cronExpression: string;
+  timezone: string;
+};
+
 type ScheduleMessage = {
   workflowId: string;
   scheduleId: string;
   triggerTime: string;
   triggerType: "schedule";
 };
+
+/**
+ * Fetch enabled schedules from KeeperHub API
+ */
+async function fetchSchedules(): Promise<Schedule[]> {
+  const response = await fetch(`${KEEPERHUB_URL}/api/internal/schedules`, {
+    method: "GET",
+    headers: {
+      "X-Service-Key": SERVICE_API_KEY,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch schedules: ${response.status} ${await response.text()}`);
+  }
+
+  const data = await response.json();
+  return data.schedules;
+}
 
 /**
  * Check if a cron expression should trigger at the given time
@@ -116,19 +136,8 @@ async function dispatch(): Promise<{
     `[${runId}] Starting dispatch run at ${new Date().toISOString()}`
   );
 
-  // Query all enabled schedules for enabled workflows
-  const schedules = await db
-    .select({
-      id: workflowSchedules.id,
-      workflowId: workflowSchedules.workflowId,
-      cronExpression: workflowSchedules.cronExpression,
-      timezone: workflowSchedules.timezone,
-    })
-    .from(workflowSchedules)
-    .innerJoin(workflows, eq(workflowSchedules.workflowId, workflows.id))
-    .where(
-      and(eq(workflowSchedules.enabled, true), eq(workflows.enabled, true))
-    );
+  // Fetch all enabled schedules via API
+  const schedules = await fetchSchedules();
 
   console.log(`[${runId}] Found ${schedules.length} enabled schedules`);
 
@@ -184,13 +193,9 @@ async function main() {
   try {
     const result = await dispatch();
 
-    // Close database connection
-    await queryClient.end();
-
     process.exit(result.errors > 0 ? 1 : 0);
   } catch (error) {
     console.error("Fatal error:", error);
-    await queryClient.end();
     process.exit(1);
   }
 }

--- a/scripts/schedule-executor.ts
+++ b/scripts/schedule-executor.ts
@@ -89,7 +89,9 @@ async function apiRequest<T>(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`API ${options.method || "GET"} ${path} failed: ${response.status} ${text}`);
+    throw new Error(
+      `API ${options.method || "GET"} ${path} failed: ${response.status} ${text}`
+    );
   }
 
   return response.json();
@@ -98,7 +100,9 @@ async function apiRequest<T>(
 // Fetch workflow by ID
 async function fetchWorkflow(workflowId: string): Promise<Workflow | null> {
   try {
-    const result = await apiRequest<{ workflow: Workflow }>(`/api/internal/workflows/${workflowId}`);
+    const result = await apiRequest<{ workflow: Workflow }>(
+      `/api/internal/workflows/${workflowId}`
+    );
     return result.workflow;
   } catch (error) {
     if (error instanceof Error && error.message.includes("404")) {
@@ -111,7 +115,9 @@ async function fetchWorkflow(workflowId: string): Promise<Workflow | null> {
 // Fetch schedule by ID
 async function fetchSchedule(scheduleId: string): Promise<Schedule | null> {
   try {
-    const result = await apiRequest<{ schedule: Schedule }>(`/api/internal/schedules/${scheduleId}`);
+    const result = await apiRequest<{ schedule: Schedule }>(
+      `/api/internal/schedules/${scheduleId}`
+    );
     return result.schedule;
   } catch (error) {
     if (error instanceof Error && error.message.includes("404")) {
@@ -217,15 +223,11 @@ async function processScheduledWorkflow(
   }
 
   // Create execution record
-  const executionId = await createExecution(
-    workflowId,
-    workflow.userId,
-    {
-      triggerType: "schedule",
-      scheduleId,
-      triggerTime,
-    }
-  );
+  const executionId = await createExecution(workflowId, workflow.userId, {
+    triggerType: "schedule",
+    scheduleId,
+    triggerTime,
+  });
 
   console.log(`[Executor] Created execution ${executionId}`);
 

--- a/scripts/schedule-executor.ts
+++ b/scripts/schedule-executor.ts
@@ -20,7 +20,6 @@ import {
   ReceiveMessageCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { CronExpressionParser } from "cron-parser";
 
 // SQS client - only use custom endpoint/credentials for local development
 const sqsConfig: ConstructorParameters<typeof SQSClient>[0] = {
@@ -165,24 +164,6 @@ async function updateScheduleStatus(
     method: "PATCH",
     body: JSON.stringify({ status, error }),
   });
-}
-
-/**
- * Compute next run time for a cron expression
- */
-function computeNextRunTime(
-  cronExpression: string,
-  timezone: string
-): Date | null {
-  try {
-    const interval = CronExpressionParser.parse(cronExpression, {
-      currentDate: new Date(),
-      tz: timezone,
-    });
-    return interval.next().toDate();
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -361,12 +342,12 @@ async function listen(): Promise<void> {
 }
 
 // Handle graceful shutdown
-process.on("SIGINT", async () => {
+process.on("SIGINT", () => {
   console.log("\n[Executor] Shutting down...");
   process.exit(0);
 });
 
-process.on("SIGTERM", async () => {
+process.on("SIGTERM", () => {
   console.log("\n[Executor] Shutting down...");
   process.exit(0);
 });

--- a/scripts/schedule-executor.ts
+++ b/scripts/schedule-executor.ts
@@ -8,10 +8,10 @@
  *   npx tsx scripts/schedule-executor.ts
  *
  * Environment variables:
- *   DATABASE_URL - PostgreSQL connection string
  *   AWS_ENDPOINT_URL - LocalStack endpoint (default: http://localhost:4566)
  *   SQS_QUEUE_URL - SQS queue URL (default: LocalStack queue)
- *   KEEPERHUB_URL - KeeperHub API URL (default: http://localhost:3000)
+ *   KEEPERHUB_API_URL - KeeperHub API URL (default: http://localhost:3000)
+ *   KEEPERHUB_API_KEY - Service API key for authentication
  */
 
 import {
@@ -41,8 +41,8 @@ const QUEUE_URL =
   process.env.SQS_QUEUE_URL ||
   "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/keeperhub-workflow-queue";
 
-const KEEPERHUB_URL = process.env.KEEPERHUB_URL || "http://localhost:3000";
-const SERVICE_API_KEY = process.env.SCHEDULER_SERVICE_API_KEY || "";
+const KEEPERHUB_URL = process.env.KEEPERHUB_API_URL || "http://localhost:3000";
+const SERVICE_API_KEY = process.env.KEEPERHUB_API_KEY || "";
 
 const VISIBILITY_TIMEOUT = 300; // 5 minutes
 const WAIT_TIME_SECONDS = 20; // Long polling


### PR DESCRIPTION
## Summary

Adds internal HTTP API endpoints for scheduler service extraction. These endpoints allow the scheduler services (dispatcher and executor) to operate via HTTP instead of direct database access.

## Endpoints Added

- `GET /api/internal/schedules` - List enabled schedules with enabled workflows
- `GET /api/internal/schedules/:id` - Get schedule details by ID
- `PATCH /api/internal/schedules/:id` - Update schedule status after execution
- `GET /api/internal/workflows/:id` - Get workflow details by ID
- `POST /api/internal/executions` - Create execution record
- `PATCH /api/internal/executions/:id` - Update execution status

## Refactored Scripts

- `schedule-dispatcher.ts` - Now uses HTTP API instead of direct database
- `schedule-executor.ts` - Now uses HTTP APIs for all 5 database operations

## Authentication

All endpoints authenticate via `X-Service-Key` header using `authenticateInternalService()` from `keeperhub/lib/internal-service-auth.ts`.

## Requirements

SAPI-01, SAPI-02, SAPI-03, SAPI-04, SAPI-05, SAPI-06

## Test Plan

- [ ] Verify lint passes
- [ ] Verify local scheduler dispatcher runs with HTTP APIs
- [ ] Verify local scheduler executor runs with HTTP APIs