### PR TITLE
fix: add missing KEEPERHUB_API_URL/KEY to dispatcher cronjob

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -220,36 +220,21 @@ cronjob:
         repository: ${ECR_REGISTRY}/keeperhub-prod
         tag: scheduler-${IMAGE_TAG}
       env:
+        # KeeperHub internal API (for fetching schedules via HTTP)
+        KEEPERHUB_API_URL:
+          type: kv
+          value: "http://keeperhub-common:3000"
+        KEEPERHUB_API_KEY:
+          type: parameterStore
+          name: scheduler-service-api-key
+          parameter_name: /eks/maker-prod/keeperhub-scheduler/keeperhub-api-key
+        # AWS/SQS configuration
         AWS_REGION:
           type: kv
           value: "us-east-1"
         SQS_QUEUE_URL:
           type: kv
           value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
-        RUNNER_IMAGE:
-          type: kv
-          value: "${ECR_REGISTRY}/keeperhub-prod:workflow-runner-${IMAGE_TAG}"
-        K8S_NAMESPACE:
-          type: kv
-          value: "keeperhub"
-        JOB_TTL_SECONDS:
-          type: kv
-          value: "3600"
-        JOB_ACTIVE_DEADLINE:
-          type: kv
-          value: "300"
-        DATABASE_URL:
-          type: parameterStore
-          name: db-url
-          parameter_name: /eks/maker-prod/keeperhub/db-url
-        CHAIN_RPC_CONFIG:
-          type: parameterStore
-          name: chain-rpc-config
-          parameter_name: /eks/maker-prod/keeperhub/chain-rpc-config
-        SCHEDULER_SERVICE_API_KEY:
-          type: parameterStore
-          name: scheduler-service-api-key
-          parameter_name: /eks/maker-prod/keeperhub-scheduler/keeperhub-api-key
       schedule: "* * * * *"
       command: ["/bin/sh"]
       args:

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -224,36 +224,21 @@ cronjob:
         repository: ${ECR_REGISTRY}/keeperhub-staging
         tag: scheduler-${IMAGE_TAG}
       env:
+        # KeeperHub internal API (for fetching schedules via HTTP)
+        KEEPERHUB_API_URL:
+          type: kv
+          value: "http://keeperhub-common:3000"
+        KEEPERHUB_API_KEY:
+          type: parameterStore
+          name: scheduler-service-api-key
+          parameter_name: /eks/maker-staging/keeperhub-scheduler/keeperhub-api-key
+        # AWS/SQS configuration
         AWS_REGION:
           type: kv
           value: "us-east-2"
         SQS_QUEUE_URL:
           type: kv
           value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
-        RUNNER_IMAGE:
-          type: kv
-          value: "${ECR_REGISTRY}/keeperhub-staging:workflow-runner-${IMAGE_TAG}"
-        K8S_NAMESPACE:
-          type: kv
-          value: "keeperhub"
-        JOB_TTL_SECONDS:
-          type: kv
-          value: "3600"
-        JOB_ACTIVE_DEADLINE:
-          type: kv
-          value: "300"
-        DATABASE_URL:
-          type: parameterStore
-          name: db-url
-          parameter_name: /eks/maker-staging/keeperhub/db-url
-        CHAIN_RPC_CONFIG:
-          type: parameterStore
-          name: chain-rpc-config
-          parameter_name: /eks/maker-staging/keeperhub/chain-rpc-config
-        SCHEDULER_SERVICE_API_KEY:
-          type: parameterStore
-          name: scheduler-service-api-key
-          parameter_name: /eks/maker-staging/keeperhub-scheduler/keeperhub-api-key
       schedule: "* * * * *"
       command: ["/bin/sh"]
       args:

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -220,38 +220,24 @@ cronjob:
         repository: ${ECR_REGISTRY}/keeperhub-staging
         tag: scheduler-${IMAGE_TAG}
       env:
+        # KeeperHub internal API (for fetching schedules via HTTP)
+        KEEPERHUB_API_URL:
+          type: kv
+          value: "http://keeperhub-pr-${PR_NUMBER}-common.pr-${PR_NUMBER}.svc.cluster.local:3000"
+        KEEPERHUB_API_KEY:
+          type: parameterStore
+          name: scheduler-service-api-key
+          parameter_name: /eks/maker-staging/keeperhub-scheduler/keeperhub-api-key
+        # AWS/SQS configuration
         AWS_REGION:
           type: kv
           value: "us-east-1"
-        AWS_ENDPOINT:
+        AWS_ENDPOINT_URL:
           type: kv
           value: "http://localstack.pr-${PR_NUMBER}.svc.cluster.local:4566"
         SQS_QUEUE_URL:
           type: kv
           value: "http://localstack.pr-${PR_NUMBER}.svc.cluster.local:4566/000000000000/keeperhub-workflow-queue"
-        RUNNER_IMAGE:
-          type: kv
-          value: "${ECR_REGISTRY}/keeperhub-staging:workflow-runner-${IMAGE_TAG}"
-        K8S_NAMESPACE:
-          type: kv
-          value: "pr-${PR_NUMBER}"
-        JOB_TTL_SECONDS:
-          type: kv
-          value: "3600"
-        JOB_ACTIVE_DEADLINE:
-          type: kv
-          value: "300"
-        DATABASE_URL:
-          type: kv
-          value: "postgresql://keeperhub:${DB_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.pr-${PR_NUMBER}.svc.cluster.local:5432/keeperhub"
-        CHAIN_RPC_CONFIG:
-          type: parameterStore
-          name: chain-rpc-config
-          parameter_name: /eks/maker-staging/keeperhub/chain-rpc-config
-        SCHEDULER_SERVICE_API_KEY:
-          type: parameterStore
-          name: scheduler-service-api-key
-          parameter_name: /eks/maker-staging/keeperhub-scheduler/keeperhub-api-key
       schedule: "* * * * *"
       command: ["/bin/sh"]
       args:


### PR DESCRIPTION
## Summary

Fixes the dispatcher `ECONNREFUSED` error by adding the missing environment variables to the cronjob configs.

PR #196 changed the dispatcher script to use HTTP APIs instead of direct database access, but the deployment configs weren't updated.

## Changes

- Add `KEEPERHUB_API_URL` pointing to internal keeperhub service
- Add `KEEPERHUB_API_KEY` for service authentication  
- Remove unused `DATABASE_URL`, `CHAIN_RPC_CONFIG` (no longer needed)
- Remove `RUNNER_IMAGE`, `K8S_NAMESPACE`, `JOB_*` vars (executor-only, not dispatcher)
- Fix `AWS_ENDPOINT` -> `AWS_ENDPOINT_URL` in PR environment

## Error Fixed

```
Fatal error: TypeError: fetch failed
  [cause]: AggregateError [ECONNREFUSED]
```

The dispatcher was defaulting to `localhost:3000` because `KEEPERHUB_API_URL` wasn't set.

## Test Plan

- [ ] Verify dispatcher pod starts without ECONNREFUSED
- [ ] Verify dispatcher can fetch schedules from KeeperHub API