### PR TITLE
fix: KEEP-1303 & KEEP-1310 Prevent adding duplicate default tokens to org wallet & Stablecoin UI Rebuff

### DIFF
--- a/keeperhub/components/overlays/wallet-overlay.tsx
+++ b/keeperhub/components/overlays/wallet-overlay.tsx
@@ -62,20 +62,6 @@ const MAINNET_CHAIN_ID = 1;
 // Balance Display Components
 // ============================================================================
 
-function TokenBalanceDisplay({ token }: { token: TokenBalance }) {
-  if (token.loading) {
-    return <div className="text-muted-foreground text-xs">Loading...</div>;
-  }
-  if (token.error) {
-    return <div className="text-destructive text-xs">{token.error}</div>;
-  }
-  return (
-    <div className="text-muted-foreground text-xs">
-      {token.balance} {token.symbol}
-    </div>
-  );
-}
-
 function ChainBalanceDisplay({ balance }: { balance: ChainBalance }) {
   if (balance.loading) {
     return <div className="mt-1 text-muted-foreground text-xs">Loading...</div>;
@@ -90,23 +76,46 @@ function ChainBalanceDisplay({ balance }: { balance: ChainBalance }) {
   );
 }
 
-// Stablecoin item with individual withdraw button
-function StablecoinWithWithdraw({
+// Token item with withdraw and optional delete button
+function TokenItemWithActions({
   token,
   isAdmin,
+  isCustom,
+  customExplorerUrl,
+  onDelete,
   onWithdraw,
 }: {
-  token: SupportedTokenBalance;
+  token: SupportedTokenBalance | TokenBalance;
   isAdmin: boolean;
+  isCustom?: boolean;
+  customExplorerUrl?: string | null;
+  onDelete?: (tokenId: string, symbol: string) => void;
   onWithdraw: (chainId: number, tokenAddress: string) => void;
 }) {
-  const isUnavailable = token.available === false;
+  // Type guard to check if it's a SupportedTokenBalance (has logoUrl)
+  const isSupportedToken = (
+    t: SupportedTokenBalance | TokenBalance
+  ): t is SupportedTokenBalance => "logoUrl" in t;
+
+  const supportedToken = isSupportedToken(token) ? token : null;
+  const customToken = isSupportedToken(token) ? null : token;
+
+  const isUnavailable = supportedToken?.available === false;
   const numBalance = Number.parseFloat(token.balance);
   const hasBalance = Number.isFinite(numBalance) && numBalance > 0;
 
+  // Both types now have tokenAddress
+  const tokenAddress =
+    supportedToken?.tokenAddress || customToken?.tokenAddress;
+
+  // Explorer URL: use supported token's URL or custom explorer URL for custom tokens
+  const explorerUrl = supportedToken?.explorerUrl || customExplorerUrl;
+
   const copyTokenAddress = () => {
-    navigator.clipboard.writeText(token.tokenAddress);
-    toast.success("Token address copied");
+    if (tokenAddress) {
+      navigator.clipboard.writeText(tokenAddress);
+      toast.success("Token address copied");
+    }
   };
 
   const renderBalance = () => {
@@ -126,17 +135,24 @@ function StablecoinWithWithdraw({
     <div
       className={`flex items-center gap-2 py-1.5 ${isUnavailable ? "opacity-50" : ""}`}
     >
-      {token.logoUrl && (
+      {/* Logo: supported tokens show logo, custom tokens show $ */}
+      {supportedToken?.logoUrl && (
         <Image
           alt={token.symbol}
           className={`h-4 w-4 rounded-full ${isUnavailable ? "grayscale" : ""}`}
           height={16}
-          src={token.logoUrl}
+          src={supportedToken.logoUrl}
           width={16}
         />
       )}
+      {!supportedToken?.logoUrl && (
+        <div className="flex h-4 w-4 items-center justify-center rounded-full bg-muted font-medium text-[10px]">
+          $
+        </div>
+      )}
       <span className="font-medium text-xs">{token.symbol}</span>
-      {!isUnavailable && (
+      {/* Copy + explorer link for all tokens with addresses */}
+      {!isUnavailable && tokenAddress && (
         <div className="flex items-center gap-1">
           <button
             className="text-muted-foreground hover:text-foreground"
@@ -146,10 +162,10 @@ function StablecoinWithWithdraw({
           >
             <Copy className="h-3 w-3" />
           </button>
-          {token.explorerUrl && (
+          {explorerUrl && (
             <a
               className="text-muted-foreground hover:text-foreground"
-              href={token.explorerUrl}
+              href={explorerUrl}
               rel="noopener noreferrer"
               target="_blank"
               title="View on explorer"
@@ -159,25 +175,58 @@ function StablecoinWithWithdraw({
           )}
         </div>
       )}
-      <span className="ml-auto text-muted-foreground text-xs">
-        {renderBalance()}
-      </span>
-      {isAdmin && hasBalance && !token.loading && !isUnavailable && (
+      {/* Delete button for custom tokens - before balance */}
+      {isAdmin && isCustom && customToken && onDelete && (
         <Button
-          className="h-6 px-2 text-xs"
-          onClick={() => onWithdraw(token.chainId, token.tokenAddress)}
-          size="sm"
+          className="ml-auto h-6 w-6"
+          onClick={() => onDelete(customToken.tokenId, customToken.symbol)}
+          size="icon"
+          title="Remove token"
           variant="ghost"
         >
-          <SendHorizontal className="h-3 w-3" />
+          <Trash2 className="h-3 w-3 text-muted-foreground" />
         </Button>
       )}
+      {/* Balance */}
+      <span
+        className={`text-muted-foreground text-xs ${isAdmin && isCustom ? "" : "ml-auto"}`}
+      >
+        {renderBalance()}
+      </span>
+      {/* Withdraw button for tokens with balance */}
+      {isAdmin &&
+        hasBalance &&
+        !token.loading &&
+        !isUnavailable &&
+        tokenAddress && (
+          <Button
+            className="h-6 px-2 text-xs"
+            onClick={() => onWithdraw(token.chainId, tokenAddress)}
+            size="sm"
+            variant="ghost"
+          >
+            <SendHorizontal className="h-3 w-3" />
+          </Button>
+        )}
     </div>
   );
 }
 
+// Helper to build explorer URL for a token address
+function buildTokenExplorerUrl(
+  chain: ChainData | undefined,
+  tokenAddress: string
+): string | null {
+  if (!chain?.explorerUrl) {
+    return null;
+  }
+  const path = chain.explorerAddressPath || "/address/{address}";
+  return `${chain.explorerUrl}${path.replace("{address}", tokenAddress)}`;
+}
+
 function ChainBalanceItem({
   balance,
+  chain,
   isAdmin,
   onRemoveToken,
   onWithdraw,
@@ -185,13 +234,14 @@ function ChainBalanceItem({
   tokenBalances,
 }: {
   balance: ChainBalance;
+  chain: ChainData | undefined;
   isAdmin: boolean;
   onRemoveToken: (tokenId: string, symbol: string) => void;
   onWithdraw: (chainId: number, tokenAddress?: string) => void;
   supportedTokenBalances: SupportedTokenBalance[];
   tokenBalances: TokenBalance[];
 }) {
-  const chainTokens = tokenBalances.filter(
+  const chainCustomTokens = tokenBalances.filter(
     (t) => t.chainId === balance.chainId
   );
 
@@ -239,13 +289,72 @@ function ChainBalanceItem({
   const nativeBalance = Number.parseFloat(balance.balance);
   const hasNativeBalance = Number.isFinite(nativeBalance) && nativeBalance > 0;
 
-  // For TEMPO, show stablecoins only (no native balance display)
+  // Determine section label based on whether there are custom tokens
+  const tokenSectionLabel =
+    chainCustomTokens.length > 0 ? "Tokens" : "Stablecoins";
+
+  // For TEMPO, show tokens only (no native balance display)
   if (isTempo) {
     return (
-      <div className="space-y-2">
-        <div className="rounded-lg border bg-muted/50 p-3">
-          <div className="mb-2 flex items-center gap-1">
-            <span className="font-medium text-sm">TEMPO</span>
+      <div className="rounded-lg border bg-muted/50 p-3">
+        <div className="mb-2 flex items-center gap-1">
+          <span className="font-medium text-sm">TEMPO</span>
+          {balance.explorerUrl && (
+            <a
+              className="text-muted-foreground hover:text-foreground"
+              href={balance.explorerUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+        <div className="mb-1 font-medium text-muted-foreground text-xs">
+          {tokenSectionLabel}
+        </div>
+        {chainSupportedTokens.length > 0 || chainCustomTokens.length > 0 ? (
+          <div className="divide-y rounded border bg-background/50 px-2">
+            {/* Supported tokens (stablecoins) */}
+            {chainSupportedTokens.map((token) => (
+              <TokenItemWithActions
+                isAdmin={isAdmin}
+                key={`supported-${token.chainId}-${token.tokenAddress}`}
+                onWithdraw={onWithdraw}
+                token={token}
+              />
+            ))}
+            {/* Custom tokens integrated in the same list */}
+            {chainCustomTokens.map((token) => (
+              <TokenItemWithActions
+                customExplorerUrl={buildTokenExplorerUrl(
+                  chain,
+                  token.tokenAddress
+                )}
+                isAdmin={isAdmin}
+                isCustom
+                key={`custom-${token.tokenId}`}
+                onDelete={onRemoveToken}
+                onWithdraw={onWithdraw}
+                token={token}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="text-muted-foreground text-xs">Loading tokens...</div>
+        )}
+      </div>
+    );
+  }
+
+  // Non-TEMPO chains: show native balance and tokens in same card
+  return (
+    <div className="rounded-lg border bg-muted/50 p-3">
+      {/* Chain header with native balance */}
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-1">
+            <span className="font-medium text-sm">{balance.name}</span>
             {balance.explorerUrl && (
               <a
                 className="text-muted-foreground hover:text-foreground"
@@ -257,139 +366,52 @@ function ChainBalanceItem({
               </a>
             )}
           </div>
-          <div className="mb-1 font-medium text-muted-foreground text-xs">
-            Stablecoins
-          </div>
-          {chainSupportedTokens.length > 0 ? (
-            <div className="divide-y rounded border bg-background/50 px-2">
-              {chainSupportedTokens.map((token) => (
-                <StablecoinWithWithdraw
-                  isAdmin={isAdmin}
-                  key={`${token.chainId}-${token.tokenAddress}`}
-                  onWithdraw={onWithdraw}
-                  token={token}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="text-muted-foreground text-xs">
-              Loading stablecoins...
-            </div>
-          )}
+          <ChainBalanceDisplay balance={balance} />
         </div>
-        {/* Custom Tracked Tokens for TEMPO */}
-        {chainTokens.length > 0 && (
-          <div className="ml-4 space-y-1">
-            <div className="font-medium text-muted-foreground text-xs">
-              Tracked Tokens
-            </div>
-            {chainTokens.map((token) => (
-              <div
-                className="flex items-center justify-between rounded border bg-background p-2"
-                key={token.tokenId}
-              >
-                <div className="flex-1">
-                  <div className="font-medium text-xs">{token.symbol}</div>
-                  <TokenBalanceDisplay token={token} />
-                </div>
-                {isAdmin && (
-                  <Button
-                    className="h-6 w-6"
-                    onClick={() => onRemoveToken(token.tokenId, token.symbol)}
-                    size="icon"
-                    variant="ghost"
-                  >
-                    <Trash2 className="h-3 w-3 text-muted-foreground" />
-                  </Button>
+        {isAdmin && hasNativeBalance && (
+          <Button
+            className="h-7 px-2 text-xs"
+            onClick={() => onWithdraw(balance.chainId)}
+            size="sm"
+            variant="ghost"
+          >
+            <SendHorizontal className="h-3 w-3" />
+            Withdraw
+          </Button>
+        )}
+      </div>
+      {/* Tokens section (stablecoins + custom tokens combined) */}
+      {(chainSupportedTokens.length > 0 || chainCustomTokens.length > 0) && (
+        <div className="mt-3">
+          <div className="mb-1 font-medium text-muted-foreground text-xs">
+            {tokenSectionLabel}
+          </div>
+          <div className="divide-y rounded border bg-background/50 px-2">
+            {/* Supported tokens (stablecoins) */}
+            {chainSupportedTokens.map((token) => (
+              <TokenItemWithActions
+                isAdmin={isAdmin}
+                key={`supported-${token.chainId}-${token.tokenAddress}`}
+                onWithdraw={onWithdraw}
+                token={token}
+              />
+            ))}
+            {/* Custom tokens integrated in the same list */}
+            {chainCustomTokens.map((token) => (
+              <TokenItemWithActions
+                customExplorerUrl={buildTokenExplorerUrl(
+                  chain,
+                  token.tokenAddress
                 )}
-              </div>
+                isAdmin={isAdmin}
+                isCustom
+                key={`custom-${token.tokenId}`}
+                onDelete={onRemoveToken}
+                onWithdraw={onWithdraw}
+                token={token}
+              />
             ))}
           </div>
-        )}
-      </div>
-    );
-  }
-
-  // Non-TEMPO chains: show native balance and stablecoins in same card
-  return (
-    <div className="space-y-2">
-      <div className="rounded-lg border bg-muted/50 p-3">
-        {/* Chain header with native balance */}
-        <div className="flex items-center justify-between">
-          <div className="flex-1">
-            <div className="flex items-center gap-1">
-              <span className="font-medium text-sm">{balance.name}</span>
-              {balance.explorerUrl && (
-                <a
-                  className="text-muted-foreground hover:text-foreground"
-                  href={balance.explorerUrl}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                </a>
-              )}
-            </div>
-            <ChainBalanceDisplay balance={balance} />
-          </div>
-          {isAdmin && hasNativeBalance && (
-            <Button
-              className="h-7 px-2 text-xs"
-              onClick={() => onWithdraw(balance.chainId)}
-              size="sm"
-              variant="ghost"
-            >
-              <SendHorizontal className="h-3 w-3" />
-              Withdraw
-            </Button>
-          )}
-        </div>
-        {/* Stablecoins inside same card */}
-        {chainSupportedTokens.length > 0 && (
-          <div className="mt-3">
-            <div className="mb-1 font-medium text-muted-foreground text-xs">
-              Stablecoins
-            </div>
-            <div className="divide-y rounded border bg-background/50 px-2">
-              {chainSupportedTokens.map((token) => (
-                <StablecoinWithWithdraw
-                  isAdmin={isAdmin}
-                  key={`${token.chainId}-${token.tokenAddress}`}
-                  onWithdraw={onWithdraw}
-                  token={token}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-      {/* Custom Tracked Tokens (outside main card) */}
-      {chainTokens.length > 0 && (
-        <div className="ml-4 space-y-1">
-          <div className="font-medium text-muted-foreground text-xs">
-            Tracked Tokens
-          </div>
-          {chainTokens.map((token) => (
-            <div
-              className="flex items-center justify-between rounded border bg-background p-2"
-              key={token.tokenId}
-            >
-              <div className="flex-1">
-                <div className="font-medium text-xs">{token.symbol}</div>
-                <TokenBalanceDisplay token={token} />
-              </div>
-              {isAdmin && (
-                <Button
-                  className="h-6 w-6"
-                  onClick={() => onRemoveToken(token.tokenId, token.symbol)}
-                  size="icon"
-                  variant="ghost"
-                >
-                  <Trash2 className="h-3 w-3 text-muted-foreground" />
-                </Button>
-              )}
-            </div>
-          ))}
         </div>
       )}
     </div>
@@ -653,6 +675,7 @@ function BalanceListSection({
           {filteredBalances.map((balance) => (
             <ChainBalanceItem
               balance={balance}
+              chain={chains.find((c) => c.chainId === balance.chainId)}
               isAdmin={isAdmin}
               key={balance.chainId}
               onRemoveToken={onRemoveToken}
@@ -1066,7 +1089,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
       }
 
       toast.success(`Removed ${symbol} from tracked tokens`);
-      setTokens((prev) => prev.filter((t) => t.id !== tokenId));
+      await loadWallet(); // Refresh to show updated token list
     } catch (error) {
       console.error("Failed to remove token:", error);
       toast.error(

--- a/keeperhub/components/overlays/wallet-overlay.tsx
+++ b/keeperhub/components/overlays/wallet-overlay.tsx
@@ -104,6 +104,11 @@ function StablecoinWithWithdraw({
   const numBalance = Number.parseFloat(token.balance);
   const hasBalance = Number.isFinite(numBalance) && numBalance > 0;
 
+  const copyTokenAddress = () => {
+    navigator.clipboard.writeText(token.tokenAddress);
+    toast.success("Token address copied");
+  };
+
   const renderBalance = () => {
     if (isUnavailable) {
       return <span className="italic">Not available</span>;
@@ -131,6 +136,29 @@ function StablecoinWithWithdraw({
         />
       )}
       <span className="font-medium text-xs">{token.symbol}</span>
+      {!isUnavailable && (
+        <div className="flex items-center gap-1">
+          <button
+            className="text-muted-foreground hover:text-foreground"
+            onClick={copyTokenAddress}
+            title="Copy token address"
+            type="button"
+          >
+            <Copy className="h-3 w-3" />
+          </button>
+          {token.explorerUrl && (
+            <a
+              className="text-muted-foreground hover:text-foreground"
+              href={token.explorerUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+              title="View on explorer"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      )}
       <span className="ml-auto text-muted-foreground text-xs">
         {renderBalance()}
       </span>

--- a/keeperhub/components/workflow/config/token-select-field.tsx
+++ b/keeperhub/components/workflow/config/token-select-field.tsx
@@ -323,9 +323,7 @@ export function TokenSelectField({
                       width={16}
                     />
                   )}
-                  <span>
-                    {token.symbol} - {token.name}
-                  </span>
+                  <span>{token.symbol}</span>
                   {isSelected && <span className="text-primary">✓</span>}
                 </div>
               </SelectItem>
@@ -355,7 +353,7 @@ export function TokenSelectField({
                       />
                     )}
                     <span className="text-muted-foreground">
-                      {token.symbol} - {token.name}
+                      {token.symbol}
                     </span>
                   </div>
                 </SelectItem>

--- a/keeperhub/components/workflow/config/token-select-field.tsx
+++ b/keeperhub/components/workflow/config/token-select-field.tsx
@@ -209,6 +209,10 @@ export function TokenSelectField({
         </div>
       );
     }
+    // Separate available and unavailable tokens
+    const availableTokens = tokens.filter((t) => t.available !== false);
+    const unavailableTokens = tokens.filter((t) => t.available === false);
+
     return (
       <Select
         disabled={disabled}
@@ -219,7 +223,7 @@ export function TokenSelectField({
           <SelectValue placeholder="Select a token..." />
         </SelectTrigger>
         <SelectContent>
-          {tokens.map((token) => {
+          {availableTokens.map((token) => {
             const isSelected = currentValue.supportedTokenId === token.id;
             return (
               <SelectItem key={token.id} value={token.id}>
@@ -241,6 +245,37 @@ export function TokenSelectField({
               </SelectItem>
             );
           })}
+          {unavailableTokens.length > 0 && (
+            <>
+              <div className="my-1 border-t" />
+              <div className="px-2 py-1.5 text-muted-foreground text-xs">
+                Not available on this chain
+              </div>
+              {unavailableTokens.map((token) => (
+                <SelectItem
+                  className="opacity-50"
+                  disabled
+                  key={token.id}
+                  value={token.id}
+                >
+                  <div className="flex items-center gap-2">
+                    {token.logoUrl && (
+                      <Image
+                        alt={token.symbol}
+                        className="h-4 w-4 rounded-full grayscale"
+                        height={16}
+                        src={token.logoUrl}
+                        width={16}
+                      />
+                    )}
+                    <span className="text-muted-foreground">
+                      {token.symbol} - {token.name}
+                    </span>
+                  </div>
+                </SelectItem>
+              ))}
+            </>
+          )}
         </SelectContent>
       </Select>
     );

--- a/keeperhub/components/workflow/config/token-select-field.tsx
+++ b/keeperhub/components/workflow/config/token-select-field.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Loader2, Plus } from "lucide-react";
+import { Copy, ExternalLink, Loader2, Plus } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -179,6 +180,91 @@ export function TokenSelectField({
 
   const isCustomMode = currentValue.mode === "custom";
 
+  // Get the currently selected token for display
+  const selectedSupportedToken = currentValue.supportedTokenId
+    ? tokens.find((t) => t.id === currentValue.supportedTokenId)
+    : null;
+
+  // Copy token address to clipboard
+  const copyTokenAddress = (address: string) => {
+    navigator.clipboard.writeText(address);
+    toast.success("Token address copied");
+  };
+
+  // Render selected token info with copy + explorer icons
+  const renderSelectedTokenInfo = () => {
+    // For supported tokens mode
+    if (!isCustomMode && selectedSupportedToken) {
+      return (
+        <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm">
+          {selectedSupportedToken.logoUrl && (
+            <Image
+              alt={selectedSupportedToken.symbol}
+              className="h-4 w-4 rounded-full"
+              height={16}
+              src={selectedSupportedToken.logoUrl}
+              width={16}
+            />
+          )}
+          <span className="font-medium">{selectedSupportedToken.symbol}</span>
+          <span className="truncate font-mono text-muted-foreground text-xs">
+            {selectedSupportedToken.tokenAddress.slice(0, 10)}...
+            {selectedSupportedToken.tokenAddress.slice(-8)}
+          </span>
+          <div className="ml-auto flex items-center gap-1">
+            <button
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={() =>
+                copyTokenAddress(selectedSupportedToken.tokenAddress)
+              }
+              title="Copy token address"
+              type="button"
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </button>
+            {selectedSupportedToken.explorerUrl && (
+              <a
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                href={selectedSupportedToken.explorerUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+                title="View on explorer"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // For custom token mode
+    if (isCustomMode && currentValue.customToken) {
+      const customToken = currentValue.customToken;
+      return (
+        <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm">
+          <span className="font-medium">{customToken.symbol}</span>
+          <span className="truncate font-mono text-muted-foreground text-xs">
+            {customToken.address.slice(0, 10)}...
+            {customToken.address.slice(-8)}
+          </span>
+          <div className="ml-auto flex items-center gap-1">
+            <button
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={() => copyTokenAddress(customToken.address)}
+              title="Copy token address"
+              type="button"
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
   // Render supported tokens section based on state
   const renderSupportedTokensSection = () => {
     if (!networkValue) {
@@ -303,7 +389,10 @@ export function TokenSelectField({
 
       {/* Supported Tokens Single-Select */}
       {!isCustomMode && (
-        <div className="space-y-2">{renderSupportedTokensSection()}</div>
+        <div className="space-y-2">
+          {renderSupportedTokensSection()}
+          {renderSelectedTokenInfo()}
+        </div>
       )}
 
       {/* Custom Token Address Input */}
@@ -350,6 +439,7 @@ export function TokenSelectField({
               Select a network first to add custom tokens
             </p>
           )}
+          {renderSelectedTokenInfo()}
         </div>
       )}
     </div>

--- a/keeperhub/lib/wallet/fetch-balances.ts
+++ b/keeperhub/lib/wallet/fetch-balances.ts
@@ -179,6 +179,7 @@ export async function fetchTokenBalance(
       return {
         tokenId: token.id,
         chainId: token.chainId,
+        tokenAddress: token.tokenAddress,
         symbol: token.symbol,
         name: token.name,
         balance: "0.000000",
@@ -191,6 +192,7 @@ export async function fetchTokenBalance(
     return {
       tokenId: token.id,
       chainId: token.chainId,
+      tokenAddress: token.tokenAddress,
       symbol: token.symbol,
       name: token.name,
       balance: formatWeiToBalance(balanceWei, token.decimals),
@@ -201,6 +203,7 @@ export async function fetchTokenBalance(
     return {
       tokenId: token.id,
       chainId: token.chainId,
+      tokenAddress: token.tokenAddress,
       symbol: token.symbol,
       name: token.name,
       balance: "0",
@@ -235,6 +238,7 @@ export function fetchAllTokenBalances(
       return Promise.resolve({
         tokenId: token.id,
         chainId: token.chainId,
+        tokenAddress: token.tokenAddress,
         symbol: token.symbol,
         name: token.name,
         balance: "0",

--- a/keeperhub/lib/wallet/fetch-balances.ts
+++ b/keeperhub/lib/wallet/fetch-balances.ts
@@ -300,6 +300,11 @@ export function fetchSupportedTokenBalance(
         throw new Error(result.error.message || "RPC error");
       }
 
+      const tokenExplorerUrl = buildExplorerAddressUrl(
+        chain,
+        token.tokenAddress
+      );
+
       if (!result.result || result.result === "0x") {
         return {
           chainId: token.chainId,
@@ -309,6 +314,7 @@ export function fetchSupportedTokenBalance(
           logoUrl: token.logoUrl,
           balance: "0.000000",
           loading: false,
+          explorerUrl: tokenExplorerUrl,
         };
       }
 
@@ -322,6 +328,7 @@ export function fetchSupportedTokenBalance(
         logoUrl: token.logoUrl,
         balance: formatWeiToBalance(balanceWei, token.decimals),
         loading: false,
+        explorerUrl: tokenExplorerUrl,
       };
     } catch (error) {
       // Retry on network errors
@@ -345,6 +352,7 @@ export function fetchSupportedTokenBalance(
         balance: "0",
         loading: false,
         error: error instanceof Error ? error.message : "Failed to fetch",
+        explorerUrl: buildExplorerAddressUrl(chain, token.tokenAddress),
       };
     }
   };

--- a/keeperhub/lib/wallet/types.ts
+++ b/keeperhub/lib/wallet/types.ts
@@ -57,6 +57,8 @@ export type SupportedToken = {
   logoUrl: string | null;
   /** Whether this token is available on the requested chain. Undefined means available. */
   available?: boolean;
+  /** Explorer URL for the token contract */
+  explorerUrl?: string | null;
 };
 
 /**
@@ -109,6 +111,8 @@ export type SupportedTokenBalance = {
   error?: string;
   /** Whether this token is available on the chain. Undefined means available. */
   available?: boolean;
+  /** Explorer URL for the token contract */
+  explorerUrl?: string | null;
 };
 
 // ============================================================================

--- a/keeperhub/lib/wallet/types.ts
+++ b/keeperhub/lib/wallet/types.ts
@@ -90,6 +90,7 @@ export type TokenData = {
 export type TokenBalance = {
   tokenId: string;
   chainId: number;
+  tokenAddress: string;
   symbol: string;
   name: string;
   balance: string;

--- a/keeperhub/lib/wallet/types.ts
+++ b/keeperhub/lib/wallet/types.ts
@@ -40,6 +40,12 @@ export type ChainBalance = {
 /**
  * Supported token from the system-wide supported_tokens table.
  * These are pre-configured tokens (primarily stablecoins) available on each chain.
+ *
+ * When fetching tokens for a specific chain, the API returns all mainnet tokens
+ * as a "master list" with availability info for the requested chain:
+ * - `available: true` - Token has an official contract on this chain
+ * - `available: false` - Token exists on mainnet but not on this chain
+ * - `tokenAddress` - The chain-specific contract address (only when available)
  */
 export type SupportedToken = {
   id: string;
@@ -49,6 +55,8 @@ export type SupportedToken = {
   name: string;
   decimals: number;
   logoUrl: string | null;
+  /** Whether this token is available on the requested chain. Undefined means available. */
+  available?: boolean;
 };
 
 /**

--- a/keeperhub/lib/wallet/types.ts
+++ b/keeperhub/lib/wallet/types.ts
@@ -107,6 +107,8 @@ export type SupportedTokenBalance = {
   balance: string;
   loading: boolean;
   error?: string;
+  /** Whether this token is available on the chain. Undefined means available. */
+  available?: boolean;
 };
 
 // ============================================================================

--- a/keeperhub/lib/wallet/use-wallet-balances.ts
+++ b/keeperhub/lib/wallet/use-wallet-balances.ts
@@ -59,6 +59,7 @@ export function useWalletBalances(): UseWalletBalancesReturn {
           tokens.map((token) => ({
             tokenId: token.id,
             chainId: token.chainId,
+            tokenAddress: token.tokenAddress,
             symbol: token.symbol,
             name: token.name,
             balance: "0",

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -148,8 +148,9 @@ const web3Plugin: IntegrationPlugin = {
     },
     {
       slug: "transfer-funds",
-      label: "Transfer Funds",
-      description: "Transfer ETH from your wallet to a recipient address",
+      label: "Transfer Native Token",
+      description:
+        "Transfer native tokens (ETH, MATIC, etc.) from your wallet to a recipient address",
       category: "Web3",
       stepFunction: "transferFundsStep",
       stepImportPath: "transfer-funds",
@@ -196,9 +197,8 @@ const web3Plugin: IntegrationPlugin = {
     },
     {
       slug: "transfer-token",
-      label: "Transfer Token",
-      description:
-        "Transfer ERC20 tokens from your wallet to a recipient address",
+      label: "Transfer ERC20 Token",
+      description: "Transfer ERC20 tokens on your desired EVM chain",
       category: "Web3",
       stepFunction: "transferTokenStep",
       stepImportPath: "transfer-token",

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -21,8 +21,8 @@ const web3Plugin: IntegrationPlugin = {
   actions: [
     {
       slug: "check-balance",
-      label: "Check Balance",
-      description: "Check ETH balance of any address (wallet or contract)",
+      label: "Get Native Balance",
+      description: "Get native token balance (ETH, MATIC, etc.) of any address",
       category: "Web3",
       stepFunction: "checkBalanceStep",
       stepImportPath: "check-balance",
@@ -69,8 +69,8 @@ const web3Plugin: IntegrationPlugin = {
     },
     {
       slug: "check-token-balance",
-      label: "Check Token Balance",
-      description: "Check ERC20 token balance of any address",
+      label: "Get ERC20 Token Balance",
+      description: "Get ERC20 token balance of any address",
       category: "Web3",
       stepFunction: "checkTokenBalanceStep",
       stepImportPath: "check-token-balance",

--- a/scripts/seed-tokens.ts
+++ b/scripts/seed-tokens.ts
@@ -103,7 +103,13 @@ const TOKEN_CONFIGS: TokenConfig[] = [
     isStablecoin: true,
     sortOrder: 2,
   },
-  // Note: USDS not yet deployed on Base
+  {
+    chainId: 8453,
+    tokenAddress: "0x820c137fa70c8691f0e44dc420a5e53c168921dc", // USDS (Sky/MakerDAO)
+    logoUrl: LOGOS.USDS,
+    isStablecoin: true,
+    sortOrder: 3,
+  },
 
   // ==========================================================================
   // Base Sepolia (chainId: 84532)


### PR DESCRIPTION
## Summary
- Fixed validation when adding new tokens to org wallet - now checks both `organizationTokens` AND `supportedTokens` tables to prevent duplicates
- Added USDS to Base Mainnet supported tokens (was missing)
- Implemented "master list" feature: shows all mainnet tokens as reference list across all chains, with unavailable tokens clearly marked as "Not available on this chain"
- Updated wallet overlay to show unavailable tokens with visual distinction
- Added copy icon and explorer link to token selections in wallet overlay and token select field
- Custom tokens now appear in the same list as stablecoins (not separate section)
- Custom tokens show $ icon, copy button, explorer link, and delete button
- Auto-refresh after token removal to show updated list

## Test plan
- [x] Verify that adding a supported token (USDC, USDT, USDS) to org wallet shows "Token (SYMBOL) is already being tracked" error
- [x] Verify USDS appears in supported tokens for Base Mainnet
- [x] Verify token dropdown shows all mainnet tokens with unavailable ones marked as "Not available on this chain"
- [x] Verify wallet overlay shows unavailable tokens greyed out
- [x] Verify copy icon copies token address to clipboard with toast feedback
- [x] Verify explorer link opens correct block explorer for the token
- [x] Verify custom tokens appear in the same list as stablecoins with delete button
- [x] Verify removing a custom token auto-refreshes the list