### PR TITLE
feat: KEEP-1304 Add line-clamp to node descriptions

### DIFF
--- a/components/workflow/nodes/action-node.tsx
+++ b/components/workflow/nodes/action-node.tsx
@@ -381,7 +381,7 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
         <div className="flex flex-col items-center gap-1 text-center">
           <NodeTitle className="text-base">{displayTitle}</NodeTitle>
           {displayDescription && (
-            <NodeDescription className="text-xs">
+            <NodeDescription className="line-clamp-2 text-xs">
               {displayDescription}
             </NodeDescription>
           )}

--- a/components/workflow/nodes/trigger-node.tsx
+++ b/components/workflow/nodes/trigger-node.tsx
@@ -71,7 +71,7 @@ export const TriggerNode = memo(({ data, selected }: TriggerNodeProps) => {
         <div className="flex flex-col items-center gap-1 text-center">
           <NodeTitle className="text-base">{displayTitle}</NodeTitle>
           {displayDescription && (
-            <NodeDescription className="text-xs">
+            <NodeDescription className="line-clamp-2 text-xs">
               {displayDescription}
             </NodeDescription>
           )}


### PR DESCRIPTION
## Summary

Limits step description text to 2 lines on workflow nodes to prevent UI breakage from long text.

## Changes

- Added `line-clamp-2` class to `NodeDescription` in `action-node.tsx`
- Added `line-clamp-2` class to `NodeDescription` in `trigger-node.tsx`

## Test Plan

- [x] Tested locally
- [ ] Verified on staging

## Jira

[KEEP-1304](https://techops-services.atlassian.net/browse/KEEP-1304)


[KEEP-1304]: https://techopsservices.atlassian.net/browse/KEEP-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ