### PR TITLE
fix: KEEP-1298 non-existing workflows and disable actions like delete

### DIFF
--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -1,21 +1,23 @@
 "use client";
 
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { ChevronLeft, ChevronRight, LayoutTemplate, Plus } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
 import { NodeConfigPanel } from "@/components/workflow/node-config-panel";
 import { useIsMobile } from "@/hooks/use-mobile";
 // start custom keeperhub code //
+import { FeaturedOverlay } from "@/keeperhub/components/overlays/featured-overlay";
 import {
   getPendingClaim,
   useClaimWorkflow,
 } from "@/keeperhub/lib/hooks/use-claim-workflow";
 // end keeperhub code //
 import { api } from "@/lib/api-client";
+import { authClient, useSession } from "@/lib/auth-client";
 import {
   integrationsAtom,
   integrationsLoadedAtom,
@@ -113,6 +115,7 @@ function checkNodeIntegration(
 const WorkflowEditor = ({ params }: WorkflowPageProps) => {
   const { workflowId } = use(params);
   const searchParams = useSearchParams();
+  const router = useRouter();
   const isMobile = useIsMobile();
   const [isGenerating, setIsGenerating] = useAtom(isGeneratingAtom);
   const [_isSaving, setIsSaving] = useAtom(isSavingAtom);
@@ -151,6 +154,16 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
   const setGlobalIntegrations = useSetAtom(integrationsAtom);
   const setIntegrationsLoaded = useSetAtom(integrationsLoadedAtom);
   const integrationsVersion = useAtomValue(integrationsVersionAtom);
+  const { open: openOverlay } = useOverlay();
+  const { data: session } = useSession();
+
+  // Helper to create anonymous session if needed
+  const ensureSession = useCallback(async () => {
+    if (!session) {
+      await authClient.signIn.anonymous();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }, [session]);
 
   // Panel width state for resizing
   const [panelWidth, setPanelWidth] = useState(30); // default percentage
@@ -707,9 +720,50 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
             <p className="mb-6 text-muted-foreground">
               The workflow you're looking for doesn't exist or has been deleted.
             </p>
-            <Button asChild>
-              <Link href="/">New Workflow</Link>
-            </Button>
+            <div className="flex justify-center gap-3">
+              <Button
+                className="gap-2"
+                onClick={async () => {
+                  try {
+                    await ensureSession();
+                    const triggerNode = {
+                      id: `trigger-${Date.now()}`,
+                      type: "trigger" as const,
+                      position: { x: 400, y: 200 },
+                      data: {
+                        label: "",
+                        type: "trigger" as const,
+                        config: { triggerType: "Manual" },
+                        status: "idle" as const,
+                      },
+                    };
+                    const newWorkflow = await api.workflow.create({
+                      name: "Untitled Workflow",
+                      description: "",
+                      nodes: [triggerNode],
+                      edges: [],
+                    });
+                    router.replace(`/workflows/${newWorkflow.id}`);
+                  } catch (error) {
+                    console.error("Failed to create workflow:", error);
+                    toast.error("Failed to create workflow. Please try again.");
+                  }
+                }}
+              >
+                <Plus className="size-4" />
+                Start building
+              </Button>
+              <Button
+                className="gap-2"
+                onClick={() =>
+                  openOverlay(FeaturedOverlay, {}, { size: "full" })
+                }
+                variant="outline"
+              >
+                <LayoutTemplate className="size-4" />
+                Explore Workflows
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { use, useCallback, useEffect, useRef, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { NodeConfigPanel } from "@/components/workflow/node-config-panel";
@@ -117,6 +117,12 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
   const [isGenerating, setIsGenerating] = useAtom(isGeneratingAtom);
   const [_isSaving, setIsSaving] = useAtom(isSavingAtom);
   const [nodes] = useAtom(nodesAtom);
+
+  // Check if workflow has a trigger node - panels only show when trigger exists
+  const hasTriggerNode = useMemo(
+    () => nodes.some((node) => node.data.type === "trigger"),
+    [nodes]
+  );
   const [edges] = useAtom(edgesAtom);
   const [currentWorkflowId] = useAtom(currentWorkflowIdAtom);
   const [selectedExecutionId] = useAtom(selectedExecutionIdAtom);
@@ -398,6 +404,7 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
 
   // start custom keeperhub code //
   const { claimPending } = useClaimWorkflow(workflowId, loadExistingWorkflow);
+
   // end keeperhub code //
 
   // Track if we've already auto-fixed integrations for this workflow+version
@@ -707,8 +714,8 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
         </div>
       )}
 
-      {/* Expand button when panel is collapsed */}
-      {!isMobile && panelCollapsed && (
+      {/* Expand button when panel is collapsed - only show if trigger exists */}
+      {!isMobile && hasTriggerNode && panelCollapsed && (
         <button
           className="pointer-events-auto absolute top-1/2 right-0 z-20 flex size-6 -translate-y-1/2 items-center justify-center rounded-l-full border border-r-0 bg-background shadow-sm transition-colors hover:bg-muted"
           onClick={() => {
@@ -722,8 +729,8 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
         </button>
       )}
 
-      {/* Right panel overlay (desktop only) */}
-      {!isMobile && (
+      {/* Right panel overlay (desktop only) - only show if trigger exists */}
+      {!isMobile && hasTriggerNode && (
         <div
           className="pointer-events-auto absolute top-[60px] right-0 bottom-0 z-20 border-l bg-background transition-transform duration-300 ease-out"
           style={{
@@ -767,8 +774,8 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
         </div>
       )}
 
-      {/* Mobile: NodeConfigPanel renders the overlay trigger button */}
-      {isMobile && <NodeConfigPanel />}
+      {/* Mobile: NodeConfigPanel renders the overlay trigger button - only show if trigger exists */}
+      {isMobile && hasTriggerNode && <NodeConfigPanel />}
     </div>
   );
 };

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -52,6 +52,7 @@ import {
   showClearDialogAtom,
   showDeleteDialogAtom,
   updateNodeDataAtom,
+  workflowNotFoundAtom,
 } from "@/lib/workflow-store";
 import { findActionById } from "@/plugins";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
@@ -163,6 +164,7 @@ export const PanelInner = () => {
     currentWorkflowDescriptionAtom
   );
   const isOwner = useAtomValue(isWorkflowOwnerAtom);
+  const workflowNotFound = useAtomValue(workflowNotFoundAtom);
   const updateNodeData = useSetAtom(updateNodeDataAtom);
   const deleteNode = useSetAtom(deleteNodeAtom);
   const deleteEdge = useSetAtom(deleteEdgeAtom);
@@ -712,6 +714,7 @@ export const PanelInner = () => {
                 <div className="flex items-center gap-2 pt-4">
                   <Button
                     className="text-muted-foreground"
+                    disabled={workflowNotFound}
                     onClick={() => setShowClearDialog(true)}
                     size="sm"
                     variant="ghost"
@@ -721,6 +724,7 @@ export const PanelInner = () => {
                   </Button>
                   <Button
                     className="text-muted-foreground"
+                    disabled={workflowNotFound}
                     onClick={() => {
                       setShowDeleteDialog(true);
                     }}
@@ -752,6 +756,7 @@ export const PanelInner = () => {
                 </Button>
                 <Button
                   className="text-muted-foreground"
+                  disabled={workflowNotFound}
                   onClick={() => setShowDeleteRunsAlert(true)}
                   size="sm"
                   variant="ghost"

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -995,6 +995,12 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       return;
     }
 
+    // When enabling, check if user is logged in
+    if (!session?.user) {
+      toast.error("Please login to activate your workflow");
+      return;
+    }
+
     // When enabling, validate first
     if (
       validateAndProceed(() => updateWorkflowEnabled(true), "Enable Anyway")


### PR DESCRIPTION
- Add redirect to /workflows when workflowNotFound is true
- Remove the 'Workflow Not Found' overlay (redirect handles this)
- Hide right panel (NodeConfigPanel) when workflow doesn't exist
- Disable Clear, Delete, and Clear All buttons when workflowNotFound
- Ground prevention: buttons are disabled even if panel hiding is removed