### PR TITLE
Keep-1307: Run button shouldn't change size when clicked

### DIFF
--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1457,7 +1457,7 @@ function RunButtonGroup({
 
   const button = (
     <Button
-      className="bg-keeperhub-green min-w-20 hover:bg-keeperhub-green-dark disabled:opacity-70 disabled:[&>svg]:text-muted-foreground"
+      className="min-w-20 bg-keeperhub-green hover:bg-keeperhub-green-dark disabled:opacity-70 disabled:[&>svg]:text-muted-foreground"
       disabled={disabled}
       onClick={() => actions.handleExecute()}
       title="Run Workflow"

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1457,7 +1457,7 @@ function RunButtonGroup({
 
   const button = (
     <Button
-      className="bg-keeperhub-green hover:bg-keeperhub-green-dark disabled:opacity-70 disabled:[&>svg]:text-muted-foreground"
+      className="bg-keeperhub-green min-w-20 hover:bg-keeperhub-green-dark disabled:opacity-70 disabled:[&>svg]:text-muted-foreground"
       disabled={disabled}
       onClick={() => actions.handleExecute()}
       title="Run Workflow"


### PR DESCRIPTION
# Summary:

Adds a min width for button to prevent sizes updates during workflow runs.

# Evidence

|Record|
|:--------:|
|[Screencast from 2026-01-27 11-35-03.webm](https://github.com/user-attachments/assets/0a44fa71-e74f-4b66-b890-543fa7731c2b)|

