### PR TITLE
fix: KEEP-1261 Allow web3 chain selection without wallet, state sync components related to web3 connection, auth flow and web3 wallet creation flow

### DIFF
--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -605,6 +605,11 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
     setError("");
     setLoading(true);
 
+    // start custom keeperhub code //
+    // Capture claim context BEFORE verification (while still anonymous)
+    const claimContext = await getClaimContext();
+    // end keeperhub code //
+
     try {
       const response = await authClient.emailOtp.verifyEmail({
         email: verifyEmail,
@@ -639,6 +644,11 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
           return;
         }
       }
+
+      // start custom keeperhub code //
+      // Store claim context after successful sign-in
+      storeClaimIfNeeded(claimContext);
+      // end keeperhub code //
 
       // Refresh session
       await authClient.getSession();

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -26,7 +26,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { integrationRequiresCredentials } from "@/keeperhub/lib/integration-helpers";
+import { actionRequiresCredentials } from "@/keeperhub/lib/integration-helpers";
 // end keeperhub
 import { aiGatewayStatusAtom } from "@/lib/ai-gateway/state";
 import { validateConditionExpressionUI } from "@/lib/condition-validator";
@@ -446,10 +446,10 @@ export function ActionConfig({
   }, [actionType]);
 
   // start keeperhub
-  // Check if integration requires credentials (some like web3 don't)
+  // Check if action requires credentials (some like web3 read-only actions don't)
   const requiresCredentials = useMemo(
-    () => integrationRequiresCredentials(integrationType),
-    [integrationType]
+    () => actionRequiresCredentials(actionType),
+    [actionType]
   );
   // end keeperhub
 

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -523,17 +523,24 @@ function ExecutionLogEntry({
                 </span>
                 {explorerLink && (
                   <>
-                    <button
-                      className="text-muted-foreground hover:text-foreground"
+                    <span
+                      className="cursor-pointer text-muted-foreground hover:text-foreground"
                       onClick={async (e) => {
                         e.stopPropagation();
                         await navigator.clipboard.writeText(explorerLink);
                       }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.stopPropagation();
+                          navigator.clipboard.writeText(explorerLink);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
                       title="Copy link"
-                      type="button"
                     >
                       <Copy className="h-3 w-3" />
-                    </button>
+                    </span>
                     <a
                       className="text-muted-foreground hover:text-foreground"
                       href={explorerLink}

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -523,6 +523,7 @@ function ExecutionLogEntry({
                 </span>
                 {explorerLink && (
                   <>
+                    {/* biome-ignore lint/a11y/useSemanticElements: Using span with role=button to avoid nested button hydration error */}
                     <span
                       className="cursor-pointer text-muted-foreground hover:text-foreground"
                       onClick={async (e) => {

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -68,6 +68,8 @@ export const UserMenu = () => {
 
   const handleLogout = async () => {
     await signOut();
+    // Full page refresh to clear all React/jotai state
+    window.location.href = "/";
   };
 
   // OAuth users can't edit their profile

--- a/keeperhub/components/overlays/wallet-overlay.tsx
+++ b/keeperhub/components/overlays/wallet-overlay.tsx
@@ -1208,9 +1208,13 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     [walletData?.walletAddress, buildWithdrawableAssets, findAssetIndex, push]
   );
 
+  // Re-fetch wallet when session changes (e.g., user signs in)
+  const sessionUserId = session?.user?.id;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionUserId is intentionally included to trigger re-fetch on sign-in
   useEffect(() => {
     loadWallet();
-  }, [loadWallet]);
+  }, [loadWallet, sessionUserId]);
 
   const description = walletData?.hasWallet
     ? "View your organization's wallet address and balances across different chains"

--- a/keeperhub/lib/extensions.tsx
+++ b/keeperhub/lib/extensions.tsx
@@ -154,7 +154,13 @@ registerFieldRenderer(
  * Web3 Wallet Integration
  * Shows the wallet creation/management UI instead of a standard form
  */
-registerIntegrationFormHandler("web3", () => <Web3WalletSection />);
+registerIntegrationFormHandler("web3", ({ onSuccess, closeAll }) => (
+  <Web3WalletSection
+    closeAll={closeAll}
+    onSuccess={onSuccess}
+    showDelete={false}
+  />
+));
 
 /**
  * SendGrid Email Integration

--- a/keeperhub/lib/integration-helpers.ts
+++ b/keeperhub/lib/integration-helpers.ts
@@ -4,7 +4,7 @@
  */
 
 import type { IntegrationType } from "@/lib/types/integration";
-import { getIntegration } from "@/plugins";
+import { findActionById, getIntegration } from "@/plugins";
 
 /**
  * Check if an integration type requires credentials
@@ -18,5 +18,32 @@ export function integrationRequiresCredentials(
   }
 
   const plugin = getIntegration(integrationType as IntegrationType);
+  return plugin?.requiresCredentials !== false;
+}
+
+/**
+ * Check if a specific action requires credentials
+ * Checks action-level requiresCredentials first, then falls back to plugin-level
+ * This allows plugins with mixed read/write actions (e.g., web3) to have per-action control
+ */
+export function actionRequiresCredentials(
+  actionId: string | undefined
+): boolean {
+  if (!actionId) {
+    return false;
+  }
+
+  const action = findActionById(actionId);
+  if (!action) {
+    return false;
+  }
+
+  // Check action-level first
+  if (action.requiresCredentials !== undefined) {
+    return action.requiresCredentials;
+  }
+
+  // Fall back to plugin-level
+  const plugin = getIntegration(action.integration);
   return plugin?.requiresCredentials !== false;
 }

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -12,6 +12,10 @@ const web3Plugin: IntegrationPlugin = {
   // Web3 uses Para wallet - one wallet per user
   singleConnection: true,
 
+  // Read-only actions (check balance, read contract) don't require a wallet
+  // Write actions will check for wallet at execution time
+  requiresCredentials: false,
+
   // No form fields - wallet creation is handled by the custom form handler
   formFields: [],
 

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -160,6 +160,7 @@ const web3Plugin: IntegrationPlugin = {
       description:
         "Transfer native tokens (ETH, MATIC, etc.) from your wallet to a recipient address",
       category: "Web3",
+      requiresCredentials: true,
       stepFunction: "transferFundsStep",
       stepImportPath: "transfer-funds",
       outputFields: [
@@ -208,6 +209,7 @@ const web3Plugin: IntegrationPlugin = {
       label: "Transfer ERC20 Token",
       description: "Transfer ERC20 tokens on your desired EVM chain",
       category: "Web3",
+      requiresCredentials: true,
       stepFunction: "transferTokenStep",
       stepImportPath: "transfer-token",
       outputFields: [
@@ -344,6 +346,7 @@ const web3Plugin: IntegrationPlugin = {
       label: "Write Contract",
       description: "Write data to a smart contract (state-changing functions)",
       category: "Web3",
+      requiresCredentials: true,
       stepFunction: "writeContractStep",
       stepImportPath: "write-contract",
       outputFields: [

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -126,11 +126,14 @@ const plugins = [
   emailOTP({
     async sendVerificationOTP({ email, otp, type }) {
       console.log(`[Auth] Sending OTP to ${email} for ${type}`);
-      await sendVerificationOTP({
+      const success = await sendVerificationOTP({
         email,
         otp,
         type,
       });
+      if (!success) {
+        throw new Error("Failed to send verification email");
+      }
     },
     otpLength: 6,
     expiresIn: 300, // 5 minutes

--- a/lib/extension-registry.ts
+++ b/lib/extension-registry.ts
@@ -62,6 +62,10 @@ type IntegrationFormContext = {
   isEditMode: boolean;
   config: Record<string, unknown>;
   updateConfig: (key: string, value: string) => void;
+  // start keeperhub - callbacks for closing overlay after success
+  onSuccess?: (integrationId: string) => void;
+  closeAll?: () => void;
+  // end keeperhub
 };
 
 type CustomIntegrationFormHandler = (

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -157,6 +157,11 @@ export type PluginAction = {
   // Output display configuration (how to render output in workflow runs panel)
   outputConfig?: OutputDisplayConfig;
 
+  // Whether this specific action requires credentials/integration setup
+  // Overrides the plugin-level requiresCredentials if set
+  // Useful for plugins with mixed read/write actions (e.g., web3)
+  requiresCredentials?: boolean;
+
   // Code generation template (the actual template string, not a path)
   // Optional - if not provided, will fall back to auto-generated template
   // from steps that export _exportCore


### PR DESCRIPTION
## Summary

Allow users to configure web3 nodes (select chains, enter addresses) without having a wallet connected. This enables anonymous users and users without wallets to explore and set up web3 workflows. Also includes auth flow improvements and wallet creation UX fixes.

## User Story

1. Anonymous user creates a workflow
2. Adds web3 nodes - can select chains without wallet for read-only actions (Get Balance, Read Contract)
3. Adds a Transfer node - prompted to create account and wallet
4. Signs in via auth dialog
5. Creates web3 wallet - wallet is auto-selected, overlay closes
6. All component state stays in sync throughout
7. Signs out - redirected to home page (not back to anonymous workflow)

## Changes

### Web3 Per-Action Credentials
- Add per-action `requiresCredentials` support in plugin registry
- Web3 read actions (Get Balance, Read Contract) no longer require wallet connection
- Web3 write actions (Transfer Funds, Transfer Token, Write Contract) require wallet
- Chain selection works for all users regardless of wallet status

### Web3 Wallet Dialog Improvements
- Show "Sign In" button for anonymous users in Add Web3 dialog
- Sync integrations state after wallet create/delete (auto-selects new wallet)
- Hide delete button in Add/Edit Web3 overlays
- Pass callbacks through extension registry for proper overlay closing

### Auth Flow Fixes
- Fix silent email OTP failures - now throws error and shows toast
- Add toast.error() for all OTP sending failures in auth dialog

### Sign Out Flow
- Redirect to home with full page refresh on sign out (clears React/jotai state)
- Delete anonymous workflow when duplicating to org account (prevents redirect to old workflow)

### Bug Fixes
- Fix nested button hydration error in workflow-runs.tsx

## Test Plan

- [x] Anonymous user can create workflow and add nodes
- [x] Chain selection works without wallet for read-only web3 actions
- [x] Transfer node shows wallet connection requirement
- [x] Anonymous user sees "Sign In" button in Add Web3 dialog
- [x] After sign in, can create wallet
- [x] Wallet creation closes overlay and auto-selects new wallet
- [x] All component state stays in sync
- [x] Sign out redirects to home page (not old anonymous workflow)

## Jira

[KEEP-1261](https://techops-services.atlassian.net/browse/KEEP-1261)

[KEEP-1261]: https://techopsservices.atlassian.net/browse/KEEP-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ