### PR TITLE
fix: Always rebuild migrator image and update web3 action label

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -29,20 +29,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Detect changed paths
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            migrator:
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'Dockerfile'
-              - 'lib/db/**'
-              - 'keeperhub/db/**'
-              - 'drizzle/**'
-              - 'drizzle.config.ts'
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -82,7 +68,7 @@ jobs:
 
       - name: Build, tag, and push migrator image to ECR
         id: build-migrator
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && (steps.changes.outputs.migrator == 'true' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ !contains(github.event.head_commit.message, '[skip build]') }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -96,14 +82,6 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator,mode=max
-
-      # Re-tag existing images when builds are skipped (creates new tag pointing to -latest)
-      - name: Re-tag migrator image if build skipped
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') && steps.changes.outputs.migrator != 'true' && github.event_name != 'workflow_dispatch' }}
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-${{ steps.vars.outputs.sha_short }} \
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-latest
 
       - name: Replace variables in the Helm values file
         id: replace-vars

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -25,7 +25,7 @@ const web3Plugin: IntegrationPlugin = {
   actions: [
     {
       slug: "check-balance",
-      label: "Get Native Balance",
+      label: "Get Native Token Balance",
       description: "Get native token balance (ETH, MATIC, etc.) of any address",
       category: "Web3",
       stepFunction: "checkBalanceStep",


### PR DESCRIPTION
## Summary
- Always rebuild migrator image on deploy to prevent migration drift when schema changes are merged via merge commits
- Remove paths-filter conditional that was causing migrator to skip rebuilds when db changes were in merged commits
- Update "Get Native Balance" label to "Get Native Token Balance" for clarity

## Context
The `dorny/paths-filter` action only compares the HEAD commit, not the full merge diff. This caused the migrator image to be skipped when schema changes (like `address_book_entry` table) were merged via merge commits, resulting in production missing database migrations.

## Test plan
- [ ] Verify migrator image is built on every deploy (unless `[skip build]` in commit message)
- [ ] Verify web3 action label displays correctly in UI