### PR TITLE
chore: ignore .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ tailwindcss-*.log
 
 # Subdirectory node_modules
 */node_modules/*
+
+# Worktrees (local only)
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore`
- Worktrees are local to each machine and should not be tracked

## Test plan
- N/A - gitignore change only