### PR TITLE
Tech 6029 high cardinality metrics

### DIFF
--- a/keeperhub/lib/metrics/METRICS_REFERENCE.md
+++ b/keeperhub/lib/metrics/METRICS_REFERENCE.md
@@ -53,9 +53,9 @@ Histogram metrics tracking duration/response times.
 |-------------|-------------|--------|--------|--------|
 | `workflow.execution.duration_ms` | Total workflow execution time | `le` (bucket) | P95 < 2000ms | DB |
 | `workflow.step.duration_ms` | Individual step execution time | `le` (bucket) | P95 < 500ms | DB |
-| `api.webhook.latency_ms` | Webhook trigger response time | `workflow_id`, `execution_id`, `status`, `status_code` | P95 < 50ms | API |
-| `api.status.latency_ms` | Status polling response time | `execution_id`, `status`, `status_code`, `execution_status` | P95 < 30ms | API |
-| `plugin.action.duration_ms` | Plugin action execution time | `plugin_name`, `action_name`, `execution_id`, `status` | P95 < 1000ms | API |
+| `api.webhook.latency_ms` | Webhook trigger response time | `status_code`, `status` | P95 < 50ms | API |
+| `api.status.latency_ms` | Status polling response time | `status_code`, `status`, `execution_status` | P95 < 30ms | API |
+| `plugin.action.duration_ms` | Plugin action execution time | `plugin_name`, `action_name`, `status` | P95 < 1000ms | API |
 | `ai.generation.duration_ms` | AI workflow generation time | `status` | P95 < 5000ms | API |
 
 ---

--- a/keeperhub/lib/metrics/METRICS_REFERENCE.md
+++ b/keeperhub/lib/metrics/METRICS_REFERENCE.md
@@ -110,6 +110,7 @@ Gauge metrics tracking user and organization statistics.
 | `user.with_workflows` | Users who have created at least one workflow | - | DB |
 | `user.with_integrations` | Users who have configured at least one integration | - | DB |
 | `user.active.daily` | Daily active users (24h) | - | DB |
+| `user.info` | Info gauge with one series per user | `email`, `name`, `verified` | DB |
 
 ### Organization Metrics
 
@@ -120,6 +121,7 @@ Gauge metrics tracking user and organization statistics.
 | `org.members_by_role` | Organization members by role | `role` | DB |
 | `org.invitations.pending` | Pending organization invitations | - | DB |
 | `org.with_workflows` | Organizations with at least one workflow | - | DB |
+| `org.info` | Info gauge with one series per org | `org_name`, `slug` | DB |
 
 ### Workflow Definition Metrics
 
@@ -176,6 +178,11 @@ Gauge metrics tracking user and organization statistics.
 | `role` | Organization member role | `owner`, `admin`, `member` |
 | `visibility` | Workflow visibility | `public`, `private` |
 | `type` | Integration type | `discord`, `sendgrid`, `web3` |
+| `email` | User email address (info gauge) | `user@example.com` |
+| `name` | User display name (info gauge) | `John Doe` |
+| `verified` | User email verified status (info gauge) | `true`, `false` |
+| `org_name` | Organization name (info gauge) | `Acme Corp` |
+| `slug` | Organization slug (info gauge) | `acme-corp` |
 
 ---
 
@@ -184,7 +191,7 @@ Gauge metrics tracking user and organization statistics.
 | Category | File | Functions |
 |----------|------|-----------|
 | Core | `keeperhub/lib/metrics/index.ts` | `getMetricsCollector()`, `createTimer()`, `withMetrics()` |
-| DB Metrics | `keeperhub/lib/metrics/db-metrics.ts` | `getWorkflowStatsFromDb()`, `getStepStatsFromDb()`, `getDailyActiveUsersFromDb()`, `getUserStatsFromDb()`, `getOrgStatsFromDb()`, `getWorkflowDefinitionStatsFromDb()`, `getScheduleStatsFromDb()`, `getIntegrationStatsFromDb()`, `getInfraStatsFromDb()` |
+| DB Metrics | `keeperhub/lib/metrics/db-metrics.ts` | `getWorkflowStatsFromDb()`, `getStepStatsFromDb()`, `getDailyActiveUsersFromDb()`, `getUserStatsFromDb()`, `getOrgStatsFromDb()`, `getWorkflowDefinitionStatsFromDb()`, `getScheduleStatsFromDb()`, `getIntegrationStatsFromDb()`, `getInfraStatsFromDb()`, `getUserListFromDb()`, `getOrgListFromDb()` |
 | API | `keeperhub/lib/metrics/instrumentation/api.ts` | `recordWebhookMetrics()`, `recordStatusPollMetrics()` |
 | Plugin | `keeperhub/lib/metrics/instrumentation/plugin.ts` | `withPluginMetrics()` |
 
@@ -214,10 +221,10 @@ The following tables are queried:
 - `workflow_executions` - execution counts by status, duration histogram
 - `workflow_execution_logs` - step counts by type/status, step duration histogram
 - `sessions` - daily active users (distinct users with sessions updated in 24h)
-- `users` - total, verified, anonymous user counts
+- `users` - total, verified, anonymous user counts; individual user info (email, name, verified)
 - `workflows` - users/orgs with workflows
 - `integrations` - users with integrations
-- `organization` - total organization count
+- `organization` - total organization count; individual org info (name, slug)
 - `member` - member counts by role
 - `invitation` - pending invitation counts
 - `workflow_schedules` - schedule counts, enabled status, last run status
@@ -264,11 +271,13 @@ Prometheus metrics are prefixed with `keeperhub_` and use snake_case:
 | `user.anonymous` | `keeperhub_user_anonymous_total` | gauge |
 | `user.with_workflows` | `keeperhub_user_with_workflows_total` | gauge |
 | `user.with_integrations` | `keeperhub_user_with_integrations_total` | gauge |
+| `user.info` | `keeperhub_user_info` | gauge |
 | `org.total` | `keeperhub_org_total` | gauge |
 | `org.members.total` | `keeperhub_org_members_total` | gauge |
 | `org.members_by_role` | `keeperhub_org_members_by_role` | gauge |
 | `org.invitations.pending` | `keeperhub_org_invitations_pending` | gauge |
 | `org.with_workflows` | `keeperhub_org_with_workflows_total` | gauge |
+| `org.info` | `keeperhub_org_info` | gauge |
 | `workflow.total` | `keeperhub_workflow_total` | gauge |
 | `workflow.by_visibility` | `keeperhub_workflow_by_visibility` | gauge |
 | `workflow.anonymous` | `keeperhub_workflow_anonymous_total` | gauge |

--- a/keeperhub/lib/metrics/collectors/prometheus.ts
+++ b/keeperhub/lib/metrics/collectors/prometheus.ts
@@ -29,8 +29,8 @@ const _WORKFLOW_LABELS = [
 ];
 const _STEP_LABELS = ["execution_id", "step_type", "status"];
 const _API_LABELS = ["endpoint", "status_code", "status"];
-const WEBHOOK_LABELS = ["workflow_id", "status_code", "status", "execution_id"];
-const PLUGIN_LABELS = ["plugin_name", "action_name", "execution_id", "status"];
+const WEBHOOK_LABELS = ["status_code", "status"];
+const PLUGIN_LABELS = ["plugin_name", "action_name", "status"];
 const _ERROR_LABELS = ["error_type", "plugin_name", "action_name", "service"];
 const DB_LABELS = ["query_type", "threshold"];
 const POOL_LABELS = ["active", "max"];
@@ -163,7 +163,7 @@ const webhookLatency = getOrCreateHistogram(
 const statusLatency = getOrCreateHistogram(
   "keeperhub_api_status_latency_ms",
   "Status polling response time in milliseconds",
-  ["execution_id", "status_code", "status", "execution_status"],
+  ["status_code", "status", "execution_status"],
   [5, 10, 25, 50, 100]
 );
 

--- a/keeperhub/lib/metrics/db-metrics.ts
+++ b/keeperhub/lib/metrics/db-metrics.ts
@@ -445,6 +445,58 @@ export async function getOrgStatsFromDb(): Promise<OrgStats> {
   }
 }
 
+export type UserListEntry = {
+  email: string;
+  name: string;
+  verified: boolean;
+};
+
+export async function getUserListFromDb(): Promise<UserListEntry[]> {
+  try {
+    const result = await db
+      .select({
+        email: users.email,
+        name: users.name,
+        verified: users.emailVerified,
+      })
+      .from(users)
+      .where(eq(users.isAnonymous, false));
+
+    return result.map((row) => ({
+      email: row.email ?? "unknown",
+      name: row.name ?? "unknown",
+      verified: row.verified,
+    }));
+  } catch (error) {
+    console.error("[Metrics] Failed to query user list from DB:", error);
+    return [];
+  }
+}
+
+export type OrgListEntry = {
+  name: string;
+  slug: string;
+};
+
+export async function getOrgListFromDb(): Promise<OrgListEntry[]> {
+  try {
+    const result = await db
+      .select({
+        name: organization.name,
+        slug: organization.slug,
+      })
+      .from(organization);
+
+    return result.map((row) => ({
+      name: row.name,
+      slug: row.slug,
+    }));
+  } catch (error) {
+    console.error("[Metrics] Failed to query org list from DB:", error);
+    return [];
+  }
+}
+
 export type WorkflowDefinitionStats = {
   total: number;
   public: number;

--- a/keeperhub/lib/metrics/instrumentation/api.ts
+++ b/keeperhub/lib/metrics/instrumentation/api.ts
@@ -20,11 +20,8 @@ export function recordWebhookMetrics(options: {
   const success = options.statusCode < 400;
 
   const labels: Record<string, string> = {
-    [LabelKeys.WORKFLOW_ID]: options.workflowId,
     [LabelKeys.STATUS_CODE]: String(options.statusCode),
     [LabelKeys.STATUS]: success ? "success" : "failure",
-    // Always include execution_id - Prometheus histogram requires this label
-    [LabelKeys.EXECUTION_ID]: options.executionId ?? "unknown",
   };
 
   metrics.recordLatency(
@@ -57,10 +54,8 @@ export function recordStatusPollMetrics(options: {
   const metrics = getMetricsCollector();
 
   metrics.recordLatency(MetricNames.API_STATUS_LATENCY, options.durationMs, {
-    [LabelKeys.EXECUTION_ID]: options.executionId,
     [LabelKeys.STATUS_CODE]: String(options.statusCode),
     [LabelKeys.STATUS]: options.statusCode < 400 ? "success" : "failure",
-    // Always include execution_status - Prometheus histogram requires this label
     execution_status: options.executionStatus ?? "unknown",
   });
 }

--- a/keeperhub/lib/metrics/instrumentation/plugin.ts
+++ b/keeperhub/lib/metrics/instrumentation/plugin.ts
@@ -38,9 +38,6 @@ export function recordPluginMetrics(options: {
     [LabelKeys.ACTION_NAME]: options.actionName,
     [LabelKeys.STATUS]: options.success ? "success" : "failure",
   };
-  if (options.executionId) {
-    labels[LabelKeys.EXECUTION_ID] = options.executionId;
-  }
 
   // Record plugin action duration
   metrics.recordLatency(
@@ -86,13 +83,10 @@ export async function withPluginMetrics<T>(
     [LabelKeys.ACTION_NAME]: context.actionName,
   };
 
-  // Extended labels for latency/error metrics (includes execution_id)
+  // Labels for latency/error metrics
   const labels: Record<string, string> = {
     ...invocationLabels,
   };
-  if (context.executionId) {
-    labels[LabelKeys.EXECUTION_ID] = context.executionId;
-  }
 
   // Increment invocation counter (only uses plugin_name, action_name)
   metrics.incrementCounter(


### PR DESCRIPTION
Get rid of high-cardinality labels (execution_id, workflow_id) from histograms that were creating unbounded series per execution. 
Add user and org info gauges with email/name labels so we can drill down to individual entities in Grafana. Fine at current scale.
