### PR TITLE
fix: KEEP-1253 Prevent anonymous users from activating workflows

### DIFF
--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -995,9 +995,14 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       return;
     }
 
-    // When enabling, check if user is logged in
-    if (!session?.user) {
-      toast.error("Please login to activate your workflow");
+    // When enabling, check if user is logged in (not anonymous)
+    const isAnonymous =
+      !session?.user ||
+      session.user.name === "Anonymous" ||
+      session.user.email?.startsWith("temp-");
+
+    if (isAnonymous) {
+      toast.error("Please sign in to activate your workflow");
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes the workflow activation check to properly detect anonymous users. Previously, the check only looked for a missing session, but anonymous users have a session with placeholder values.

## Changes

- Updated `useWorkflowActions` to detect anonymous users by checking for:
  - Missing session/user
  - User name being "Anonymous"
  - Email starting with "temp-"
- Changed error message from "Please login" to "Please sign in"

## Test Plan

- [x] Tested locally
- [x] Verified anonymous users cannot activate workflows
- [x] Verified logged-in users can still activate workflows

## Jira

[KEEP-1253](https://techops-services.atlassian.net/browse/KEEP-1253)

[KEEP-1253]: https://techopsservices.atlassian.net/browse/KEEP-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ