### PR TITLE
chore: KEEP-1315 Add Claude Code configuration and skills

### DIFF
--- a/.claude/hooks/pre-commit-checks.sh
+++ b/.claude/hooks/pre-commit-checks.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Pre-commit hook for Claude Code
+# Runs lint and type-check before git commit commands
+# Saves output to .claude/*.txt for Claude to read without re-running
+# Exit code 2 blocks the commit, exit code 0 allows it
+
+set -e
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract the command being run
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only process git commit commands
+if ! echo "$COMMAND" | grep -q "git commit"; then
+    exit 0
+fi
+
+# Get the project directory
+PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // empty')
+if [ -z "$PROJECT_DIR" ]; then
+    PROJECT_DIR="$CLAUDE_PROJECT_DIR"
+fi
+
+cd "$PROJECT_DIR"
+
+# Ensure .claude directory exists
+mkdir -p .claude
+
+echo "Running pre-commit checks..." >&2
+
+# Run lint check and save output
+echo "Checking lint (pnpm check)..." >&2
+LINT_OUTPUT=$(pnpm check 2>&1) || true
+echo "$LINT_OUTPUT" > .claude/lint-output.txt
+echo "Lint output saved to .claude/lint-output.txt" >&2
+
+if echo "$LINT_OUTPUT" | grep -q "error\|Error"; then
+    echo "" >&2
+    echo "COMMIT BLOCKED: Lint check failed." >&2
+    echo "Read .claude/lint-output.txt for errors, or run 'pnpm fix' to auto-fix." >&2
+    exit 2
+fi
+
+# Run type check and save output
+echo "Checking types (pnpm type-check)..." >&2
+TYPE_OUTPUT=$(pnpm type-check 2>&1) || true
+echo "$TYPE_OUTPUT" > .claude/typecheck-output.txt
+echo "Type check output saved to .claude/typecheck-output.txt" >&2
+
+if echo "$TYPE_OUTPUT" | grep -q "error TS"; then
+    echo "" >&2
+    echo "COMMIT BLOCKED: Type check failed." >&2
+    echo "Read .claude/typecheck-output.txt for errors." >&2
+    exit 2
+fi
+
+echo "All pre-commit checks passed." >&2
+exit 0

--- a/.claude/hooks/pre-edit-lint-context.sh
+++ b/.claude/hooks/pre-edit-lint-context.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Pre-Edit hook: Inject lint rules before Edit/Write operations
+# This makes lint rules salient in Claude's context before code changes
+
+set -e
+
+# Read JSON input
+INPUT=$(cat)
+
+# Extract file path being edited
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Only inject rules for TypeScript/JavaScript files
+case "$FILE_PATH" in
+    *.ts|*.tsx|*.js|*.jsx)
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+# Build lint context reminder
+LINT_CONTEXT="## Ultracite/Biome Lint Rules (apply to this edit)
+
+**Type Safety:**
+- Use explicit types for function parameters and return values
+- Prefer \`unknown\` over \`any\` - if you must use \`any\`, add a biome-ignore comment explaining why
+- Use const assertions (\`as const\`) for immutable values
+
+**Modern JS/TS:**
+- Use \`for...of\` loops, not \`.forEach()\` or indexed loops
+- Use optional chaining (\`?.\`) and nullish coalescing (\`??\`)
+- Use \`const\` by default, \`let\` only when reassignment needed
+- Use template literals over string concatenation
+- Use destructuring for object/array assignments
+
+**React/JSX:**
+- Use function components, not class components
+- Call hooks at top level only, never conditionally
+- Specify all dependencies in hook dependency arrays
+- Use \`key\` prop for elements in iterables (prefer unique IDs over indices)
+- Use semantic HTML elements (\`<button>\`, \`<nav>\`) not divs with roles
+
+**Next.js:**
+- Use Next.js \`<Image>\` component, not \`<img>\`
+- Use Server Components for async data fetching
+
+**Async:**
+- Always \`await\` promises in async functions
+- Use async/await over promise chains
+
+**Clean Code:**
+- Remove \`console.log\`, \`debugger\`, \`alert\` from production code
+- Add \`rel=\"noopener\"\` when using \`target=\"_blank\"\"
+- Prefer early returns to reduce nesting
+
+**Lint Ignores:**
+- Only use biome-ignore when absolutely necessary
+- Always specify the exact rule and add explanation
+- Example: \`// biome-ignore lint/suspicious/noExplicitAny: SDK types incomplete\`"
+
+# Output JSON with additionalContext
+cat << EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": $(echo "$LINT_CONTEXT" | jq -Rs .)
+  }
+}
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-checks.sh",
+            "timeout": 120
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-edit-lint-context.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,43 @@
 .DS_Store
 *.pem
 
+# OS files
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+*~
+
+# Editor/IDE
+.idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+*.swp
+*.swo
+*.swn
+*.sublime-workspace
+*.sublime-project
+.project
+.classpath
+.settings/
+
+# Backup files
+*.bak
+*.backup
+*.orig
+
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+
+# logs
+logs/
+*.log
+lerna-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*
@@ -50,6 +82,19 @@ next-env.d.ts
 .env*.local
 
 tmp/
+
+# cache
+.cache/
+*.cache
+
+# docker
+docker-compose.override.yml
+.docker/
+
+# database
+*.sqlite
+*.sqlite3
+*.db
 
 # generated files
 lib/types/integration.ts

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ tailwindcss-*.log
 
 # Worktrees (local only)
 .worktrees/
+
+# Claude lint output cache (read instead of re-running commands)
+.claude/lint-output.txt
+.claude/typecheck-output.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AI Workflow Builder Template (KeeperHub Fork)
 
-## 🚨 Important: AI Agents Code Policy
+## AI Agents Code Policy
 
 - **No Emojis**: Do not use emojis in any code, documentation, or README files
 - **No File Structure**: Do not include file/folder structure diagrams in README files
@@ -8,6 +8,90 @@
 - **No co-authored with Claude in PR descriptions and git commits**
 - **Do not git push or create Github PRs without user's confirmation**
 - **Do not leave code comments with summaries of user's prompt**
+
+## Code Quality: Lint and Type Checking
+
+**Before writing or editing any code**, review the lint configuration to write compliant code:
+
+1. **Check `biome.jsonc`** for project-specific lint rules and exclusions
+2. **Check `.cursor/rules/ultracite.mdc`** for detailed coding standards
+
+### Key Ultracite/Biome Rules
+
+- Use explicit types for function parameters and return values
+- Prefer `unknown` over `any`
+- Use `for...of` loops over `.forEach()` and indexed loops
+- Use optional chaining (`?.`) and nullish coalescing (`??`)
+- Use `const` by default, `let` only when reassignment is needed
+- Always `await` promises in async functions
+- Remove `console.log`, `debugger`, and `alert` from production code
+- Use Next.js `<Image>` component instead of `<img>` tags
+- Add `rel="noopener"` when using `target="_blank"`
+
+### Before Every Commit
+
+Run these checks and fix any issues before committing:
+
+```bash
+pnpm check      # Lint check (Ultracite/Biome)
+pnpm type-check # TypeScript validation
+pnpm fix        # Auto-fix lint issues (run if check fails)
+```
+
+If `pnpm check` or `pnpm type-check` fails, fix the issues before committing. Do not commit code with lint or type errors.
+
+### Lint Output Caching
+
+When lint/type-check commands run, their output is saved to gitignored files:
+
+- `.claude/lint-output.txt` - Output from `pnpm check`
+- `.claude/typecheck-output.txt` - Output from `pnpm type-check`
+
+**Workflow for fixing errors:**
+1. Run `pnpm check` or `pnpm type-check` once
+2. Read `.claude/lint-output.txt` or `.claude/typecheck-output.txt` for errors
+3. Fix the errors in code
+4. Re-run the check command only when you need fresh output
+
+**Do NOT** repeatedly run lint commands to check progress. Read the cached output file instead - this saves time and context.
+
+### Claude Hooks (Automatic Checks)
+
+This project has Claude Code hooks configured in `.claude/settings.json`:
+
+**Pre-Edit Lint Context** (`.claude/hooks/pre-edit-lint-context.sh`):
+- Fires before Edit/Write on .ts/.tsx/.js/.jsx files
+- Injects key Ultracite/Biome lint rules into context
+- **Rationale**: Higher upfront token cost, but saves overall context by writing correct code the first time instead of the expensive cycle of: write code → run lint → see errors → fix partially → re-run lint → repeat
+
+**Pre-Commit Checks** (`.claude/hooks/pre-commit-checks.sh`):
+- Detects `git commit` commands
+- Runs `pnpm check` (lint) and `pnpm type-check` (TypeScript)
+- Saves output to `.claude/*.txt` files for reading without re-running
+- Blocks the commit (exit code 2) if either fails
+
+### Lint Ignore Comments
+
+**Only use lint ignore comments when absolutely necessary.** Valid reasons:
+
+- Third-party library types are incorrect and cannot be fixed
+- Generated code that cannot be modified
+- Rare edge cases where the rule genuinely does not apply
+
+**Invalid reasons** (fix the code instead):
+
+- "It works fine"
+- "The rule is too strict"
+- "It's faster to ignore than fix"
+
+When you must use an ignore comment:
+1. Use the most specific ignore possible (target the exact rule, not all rules)
+2. Add a brief comment explaining why the ignore is necessary
+3. Example:
+   ```typescript
+   // biome-ignore lint/suspicious/noExplicitAny: third-party SDK types are incomplete
+   const result = externalLib.call() as any;
+   ```
 
 ## 🚨 CRITICAL: KeeperHub Custom Code Policy
 


### PR DESCRIPTION
## Summary

Add Claude Code hooks and configuration for lint-aware code generation in the keeperhub project.

## Changes

- **Pre-Edit Lint Context Hook**: Injects Ultracite/Biome lint rules into context before editing `.ts/.tsx/.js/.jsx` files
  - Higher upfront token cost, but saves overall context by writing correct code the first time
  - Avoids the expensive cycle of: write code → run lint → see errors → fix partially → re-run lint → repeat

- **Pre-Commit Checks Hook**: Runs `pnpm check` and `pnpm type-check` before commits, blocking if either fails

- **Lint Output Caching**: Saves command output to `.claude/lint-output.txt` and `.claude/typecheck-output.txt`
  - Read cached output to see errors without re-running commands
  - Saves time and context by avoiding repeated lint command execution

- **CLAUDE.md Updates**: Document hooks, output file workflow, and lint ignore comment policy

## Test Plan

- [x] Pre-edit hook injects lint context correctly
- [x] Pre-commit hook blocks commits with lint/type errors
- [x] Output files are created and readable

## Jira

[KEEP-1315](https://techops-services.atlassian.net/browse/KEEP-1315)

[KEEP-1315]: https://techopsservices.atlassian.net/browse/KEEP-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ