### PR TITLE
fix: KEEP-1330 Fix function args not saving on blur

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -263,27 +263,47 @@ function AbiFunctionArgsField({
     }
   }, [abiValue, functionValue]);
 
-  // Parse current value (JSON array) into individual arg values
-  const argValues = React.useMemo(() => {
-    if (!value || value.trim() === "") {
+  // Parse prop value into array
+  const parsePropValue = React.useCallback((val: string): unknown[] => {
+    if (!val || val.trim() === "") {
       return [];
     }
     try {
-      const parsed = JSON.parse(value);
+      const parsed = JSON.parse(val);
       return Array.isArray(parsed) ? parsed : [];
     } catch {
       return [];
     }
-  }, [value]);
+  }, []);
 
-  // Handle individual arg change
+  // Use local state to manage arg values - this prevents race conditions on blur
+  const [localArgValues, setLocalArgValues] = React.useState<unknown[]>(() =>
+    parsePropValue(value)
+  );
+
+  // Track the last function to detect when user selects a different function
+  const lastFunctionRef = React.useRef(functionValue);
+
+  // Sync from prop only when function changes (user selected different function)
+  React.useEffect(() => {
+    if (functionValue !== lastFunctionRef.current) {
+      // Function changed - reset to prop value (which should be empty for new function)
+      setLocalArgValues(parsePropValue(value));
+      lastFunctionRef.current = functionValue;
+    }
+  }, [functionValue, value, parsePropValue]);
+
+  // Handle individual arg change - update local state and propagate to parent
   const handleArgChange = (index: number, newValue: string) => {
-    const newArgs = [...argValues];
+    const newArgs = [...localArgValues];
     // Ensure array is long enough
     while (newArgs.length <= index) {
       newArgs.push("");
     }
     newArgs[index] = newValue;
+    // Update local state
+    setLocalArgValues(newArgs);
+    // Propagate to parent (outside of setState to avoid render-phase updates)
     onChange(JSON.stringify(newArgs));
   };
 
@@ -311,7 +331,7 @@ function AbiFunctionArgsField({
               id={`${field.key}-${index}`}
               onChange={(val) => handleArgChange(index, val as string)}
               placeholder={`Enter ${input.type} value or {{NodeName.value}}`}
-              value={(argValues[index] as string) || ""}
+              value={(localArgValues[index] as string) || ""}
             />
           </div>
         )


### PR DESCRIPTION
## Summary

Fix Write Contract function argument values not persisting when user clicks away from the input field.

## Changes

- Use local state in `AbiFunctionArgsField` to manage argument values instead of deriving from props via `useMemo`
- Local state updates immediately on user input, preventing race condition on blur
- State only resets from props when a different function is selected
- Moved `onChange` call outside setState to avoid React render-phase update warnings

## Test Plan

- [x] Add a Write Contract action
- [x] Select a function with parameters
- [x] Type values in the argument fields
- [x] Click away - values should persist
- [x] Select a different function - args should reset
- [x] No console errors about setState during render

## Jira

[KEEP-1330](https://techops-services.atlassian.net/browse/KEEP-1330)

---
Generated with Claude Code

[KEEP-1330]: https://techopsservices.atlassian.net/browse/KEEP-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ