### PR TITLE
feat(metrics): split Prometheus endpoints for DB and API scraping

### DIFF
--- a/app/api/metrics/api/route.ts
+++ b/app/api/metrics/api/route.ts
@@ -1,0 +1,6 @@
+/**
+ * API-Process Metrics API Route
+ *
+ * Re-exports from keeperhub directory.
+ */
+export { GET } from "@/keeperhub/api/metrics/api/route";

--- a/app/api/metrics/db/route.ts
+++ b/app/api/metrics/db/route.ts
@@ -1,0 +1,6 @@
+/**
+ * DB-Sourced Metrics API Route
+ *
+ * Re-exports from keeperhub directory.
+ */
+export { GET } from "@/keeperhub/api/metrics/db/route";

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -79,11 +79,25 @@ podAnnotations:
 serviceMonitors:
   enabled: true
   monitors:
-    - name: metrics
+    - name: api-metrics
       port: http
-      path: /api/metrics
+      path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
+    - name: db-metrics
+      port: http
+      path: /api/metrics/db
+      interval: 30s
+      scrapeTimeout: 10s
+      relabelings:
+        # Scrape only 1 of 2 pods for DB metrics (identical across pods)
+        - sourceLabels: [__address__]
+          modulus: 2
+          targetLabel: __tmp_hash
+          action: hashmod
+        - sourceLabels: [__tmp_hash]
+          regex: "0"
+          action: keep
 
 resources:
   limits:

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -79,9 +79,14 @@ podAnnotations:
 serviceMonitors:
   enabled: true
   monitors:
-    - name: metrics
+    - name: api-metrics
       port: http
-      path: /api/metrics
+      path: /api/metrics/api
+      interval: 30s
+      scrapeTimeout: 10s
+    - name: db-metrics
+      port: http
+      path: /api/metrics/db
       interval: 30s
       scrapeTimeout: 10s
 

--- a/keeperhub/api/metrics/api/route.ts
+++ b/keeperhub/api/metrics/api/route.ts
@@ -1,0 +1,37 @@
+/**
+ * API-Process Metrics Endpoint
+ *
+ * Exposes only in-memory API-process metrics (histograms, counters).
+ * These are per-pod and should be scraped from all pods.
+ */
+
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  if (process.env.METRICS_COLLECTOR !== "prometheus") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  try {
+    const { getApiProcessMetrics, getPrometheusContentType } = await import(
+      "@/keeperhub/lib/metrics/prometheus-api"
+    );
+
+    const metrics = await getApiProcessMetrics();
+    const contentType = getPrometheusContentType();
+
+    return new NextResponse(metrics, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    });
+  } catch (error) {
+    console.error("[Metrics] Failed to get API metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to collect metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/keeperhub/api/metrics/db/route.ts
+++ b/keeperhub/api/metrics/db/route.ts
@@ -1,0 +1,38 @@
+/**
+ * DB-Sourced Metrics Endpoint
+ *
+ * Exposes only database-sourced gauge metrics. These are identical across pods,
+ * so only one pod needs to be scraped for these metrics.
+ */
+
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  if (process.env.METRICS_COLLECTOR !== "prometheus") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  try {
+    const { getDbMetrics, getPrometheusContentType, updateDbMetrics } =
+      await import("@/keeperhub/lib/metrics/prometheus-api");
+
+    await updateDbMetrics();
+
+    const metrics = await getDbMetrics();
+    const contentType = getPrometheusContentType();
+
+    return new NextResponse(metrics, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    });
+  } catch (error) {
+    console.error("[Metrics] Failed to get DB metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to collect metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/keeperhub/lib/metrics/prometheus-api.ts
+++ b/keeperhub/lib/metrics/prometheus-api.ts
@@ -14,5 +14,7 @@ export {
   prometheusMetricsCollector,
   // start custom keeperhub code //
   updateDbMetrics,
+  getDbMetrics,
+  getApiProcessMetrics,
   // end keeperhub code //
 } from "./collectors/prometheus";

--- a/keeperhub/lib/metrics/prometheus-api.ts
+++ b/keeperhub/lib/metrics/prometheus-api.ts
@@ -9,12 +9,14 @@
 import "server-only";
 
 export {
+  // start custom keeperhub code //
+  getApiProcessMetrics,
+  getDbMetrics,
+  // end keeperhub code //
   getPrometheusContentType,
   getPrometheusMetrics,
   prometheusMetricsCollector,
   // start custom keeperhub code //
   updateDbMetrics,
-  getDbMetrics,
-  getApiProcessMetrics,
   // end keeperhub code //
 } from "./collectors/prometheus";


### PR DESCRIPTION
Split metrics into two paths: /api/metrics/api keeps the fast, per-pod counters while /api/metrics/db serves the slow, database-driven gauges.
Helm now scrapes the API path on every pod but only one pod for the DB path, so we’re no longer collecting duplicate snapshots.
2 other solutions abandoned:
Drop pod and instance label to dedupe metrics, but timestamp from 2 pods is identical.
build another aggregation layer. It's kind of overkill.