### PR TITLE
Keep-1337: Logging out should redirect and close active workflow

### DIFF
--- a/keeperhub/lib/hooks/use-organization.ts
+++ b/keeperhub/lib/hooks/use-organization.ts
@@ -28,9 +28,9 @@ export function useOrganization() {
   );
 
   const switchOrganization = async (orgId: string) => {
-    // Reset workflow state using default store (safe in hook context)
-    getDefaultStore().set(resetWorkflowStateForOrgSwitchAtom);
     await authClient.organization.setActive({ organizationId: orgId });
+    // Reset workflow state only after org switch succeeds (safe in hook context)
+    getDefaultStore().set(resetWorkflowStateForOrgSwitchAtom);
     try {
       const list = await api.workflow.getAll();
       // Sort by createdAt descending to get the most recent workflow

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -466,6 +466,28 @@ export const clearWorkflowAtom = atom(null, (get, set) => {
   set(hasUnsavedChangesAtom, true);
 });
 
+// start custom keeperhub code //
+// Reset all workflow state for org switch (no history push; used by use-organization)
+export const resetWorkflowStateForOrgSwitchAtom = atom(null, (_get, set) => {
+  set(nodesAtom, []);
+  set(edgesAtom, []);
+  set(selectedNodeAtom, null);
+  set(selectedEdgeAtom, null);
+  set(currentWorkflowIdAtom, null);
+  set(currentWorkflowNameAtom, "");
+  set(currentWorkflowDescriptionAtom, "");
+  set(currentWorkflowVisibilityAtom, "private");
+  set(isWorkflowOwnerAtom, true);
+  set(isWorkflowEnabled, false);
+  set(workflowNotFoundAtom, false);
+  set(selectedExecutionIdAtom, null);
+  set(executionLogsAtom, {});
+  set(hasUnsavedChangesAtom, false);
+  set(historyAtom, []);
+  set(futureAtom, []);
+});
+// end custom keeperhub code //
+
 // Load workflow from database
 export const loadWorkflowAtom = atom(null, async (_get, set) => {
   try {


### PR DESCRIPTION
# Summary:

This pull request ensures that logged-out users no longer see the last workflows they were editing. It also adds an organization switcher dropdown.

When a user selects an organization from the dropdown, the corresponding workflows are loaded and the user is redirected to the most recently created one with a fallback redirect to `/`.