### PR TITLE
Keep-1339: Incorrect messaging for the abi

### DIFF
--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -497,7 +497,7 @@ export function AbiWithAutoFetchField({
             if (isLoading) {
               return "Fetching ABI from Etherscan...";
             }
-            return "ABI will be fetched automatically, or click the button above to fetch manually";
+            return "Click the button above to fetch the ABI from Etherscan";
           })()}
         </p>
       )}


### PR DESCRIPTION
# Summary

The auto-fetch functionality is disabled momentarily, so the incorrect message is updated.