### PR TITLE
KEEP-1309: Enhance delete workflow logic to check for executions before deletion

### DIFF
--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -215,7 +215,8 @@ export const PanelInner = () => {
     const openCannotDeleteWarning = () => {
       openOverlay(ConfirmOverlay, {
         title: "Cannot delete workflow",
-        message: `This workflow has run history. Run history may contain sensitive data you want to save before deleting. Delete all executions from the Runs tab first, then you can delete the workflow.`,
+        message:
+          "This workflow has run history. Run history may contain sensitive data you want to save before deleting. Delete all executions from the Runs tab first, then you can delete the workflow.",
         confirmLabel: "View runs",
         cancelLabel: "Cancel",
         destructive: false,


### PR DESCRIPTION
# Summary:

This pull request introduces a flow update.

Users are now informed that, before deleting a workflow, they must first delete all its executions. Once the executions are removed, the workflow can be deleted.