### PR TITLE
Keep-1336: Read only and duplicate not clearing when navigating back to hub page from public workflow

### DIFF
--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1544,6 +1544,8 @@ function WorkflowMenuComponent({
   // start custom KeeperHub code
   const pathname = usePathname();
   const isHubPage = pathname === "/hub";
+  const isWorkflowRoute =
+    pathname === "/workflows" || pathname.startsWith("/workflows/");
 
   // validate against route workflow id as the state can be out of date
   const { workflowId: routeWorkflowId } = useParams();
@@ -1646,7 +1648,7 @@ function WorkflowMenuComponent({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {workflowId && !state.isOwner && (
+      {isWorkflowRoute && workflowId && !state.isOwner && (
         <span className="text-muted-foreground text-xs uppercase lg:hidden">
           Read-only
         </span>
@@ -1705,7 +1707,7 @@ export const WorkflowToolbar = ({
             state={state}
             workflowId={effectiveWorkflowId}
           />
-          {effectiveWorkflowId && !state.isOwner && (
+          {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
             <span className="hidden text-muted-foreground text-xs uppercase lg:inline">
               Read-only
             </span>
@@ -1723,7 +1725,7 @@ export const WorkflowToolbar = ({
               />
             )}
             <div className="flex items-center gap-2">
-              {effectiveWorkflowId && !state.isOwner && (
+              {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
                 <DuplicateButton
                   isDuplicating={state.isDuplicating}
                   onDuplicate={actions.handleDuplicate}
@@ -1761,7 +1763,7 @@ export const WorkflowToolbar = ({
             state={state}
             workflowId={effectiveWorkflowId}
           />
-          {effectiveWorkflowId && !state.isOwner && (
+          {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
             <span className="hidden text-muted-foreground text-xs uppercase lg:inline">
               Read-only
             </span>
@@ -1779,7 +1781,7 @@ export const WorkflowToolbar = ({
             />
           )}
           <div className="flex items-center gap-2">
-            {effectiveWorkflowId && !state.isOwner && (
+            {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
               <DuplicateButton
                 isDuplicating={state.isDuplicating}
                 onDuplicate={actions.handleDuplicate}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -24,6 +24,7 @@ import { useParams, usePathname, useRouter } from "next/navigation";
 // end custom KeeperHub code
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import {
@@ -41,6 +42,7 @@ import { authClient, useSession } from "@/lib/auth-client";
 import { getCustomLogo } from "@/lib/extension-registry";
 import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
+import { cn } from "@/lib/utils";
 import {
   addNodeAtom,
   canRedoAtom,
@@ -1504,6 +1506,21 @@ function RunButtonGroup({
   // end custom keeperhub code //
 }
 
+// Read-only badge - pill with a live green accent on the toolbar
+function ReadOnlyBadge({ className }: { className?: string }) {
+  return (
+    <Badge
+      className={cn(
+        "border-keeperhub-green/60 bg-keeperhub-green/10 font-medium text-foreground/90 uppercase backdrop-blur-sm dark:border-keeperhub-green/50 dark:bg-transparent",
+        className
+      )}
+      variant="outline"
+    >
+      Preview
+    </Badge>
+  );
+}
+
 // Duplicate Button Component - placed next to Sign In for non-owners
 function DuplicateButton({
   isDuplicating,
@@ -1649,9 +1666,7 @@ function WorkflowMenuComponent({
         </DropdownMenu>
       </div>
       {isWorkflowRoute && workflowId && !state.isOwner && (
-        <span className="text-muted-foreground text-xs uppercase lg:hidden">
-          Read-only
-        </span>
+        <ReadOnlyBadge className="lg:hidden" />
       )}
     </div>
   );
@@ -1708,9 +1723,7 @@ export const WorkflowToolbar = ({
             workflowId={effectiveWorkflowId}
           />
           {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
-            <span className="hidden text-muted-foreground text-xs uppercase lg:inline">
-              Read-only
-            </span>
+            <ReadOnlyBadge className="hidden lg:inline-flex" />
           )}
         </div>
 
@@ -1764,9 +1777,7 @@ export const WorkflowToolbar = ({
             workflowId={effectiveWorkflowId}
           />
           {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
-            <span className="hidden text-muted-foreground text-xs uppercase lg:inline">
-              Read-only
-            </span>
+            <ReadOnlyBadge className="hidden lg:inline-flex" />
           )}
         </div>
       </Panel>


### PR DESCRIPTION
# Summary

This pull request updates current behavior of read-only badge and duplicate CTA button. Also renames the "Read-only" badge to "Preview"

# Visual badge update

|Dark mode|
|:--------------:|
|<img width="1914" height="1074" alt="image" src="https://github.com/user-attachments/assets/fe0a7a46-3c22-4de3-b0c3-a347bbe688ae" />|

|Light mode|
|:--------------:|
|<img width="1914" height="1074" alt="image" src="https://github.com/user-attachments/assets/a0f2cd1f-f725-426b-88c1-37fbaa5acc9b" />|