### PR TITLE
KEEP-1353: Refetch organizations after modal action confirmation

### DIFF
--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -645,6 +645,7 @@ export function ManageOrgsModal({
         }
       }
 
+      refetchOrganizations();
       router.refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "An error occurred");


### PR DESCRIPTION
# Summary

After user confirmation and a successful request to leave an organization, a refetch is triggered to remove the organization from both places: the Organizations dropdown and the modal.