### PR TITLE
fix: KEEP-1284 Throw error for empty/missing condition data

### DIFF
--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -375,7 +375,7 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
   };
 
   // Generate full workflow code
-  const workflowCode = (() => {
+  const { workflowCode, workflowValidationErrors } = (() => {
     const baseName = currentWorkflowName
       .replace(NON_ALPHANUMERIC_REGEX, "")
       .split(WORD_SPLIT_REGEX)
@@ -386,8 +386,10 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
       )
       .join("");
     const functionName = `${baseName}Workflow`;
-    const { code } = generateWorkflowCode(nodes, edges, { functionName });
-    return code;
+    const { code, validationErrors } = generateWorkflowCode(nodes, edges, {
+      functionName,
+    });
+    return { workflowCode: code, workflowValidationErrors: validationErrors };
   })();
 
   // Handle copy workflow code
@@ -543,6 +545,19 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
                   Copy
                 </Button>
               </div>
+              {workflowValidationErrors &&
+                workflowValidationErrors.length > 0 && (
+                  <div className="border-amber-500/30 border-b bg-amber-500/10 px-3 py-2">
+                    <p className="font-medium text-amber-600 text-xs dark:text-amber-400">
+                      Workflow has configuration issues:
+                    </p>
+                    <ul className="mt-1 list-inside list-disc text-amber-600/80 text-xs dark:text-amber-400/80">
+                      {workflowValidationErrors.map((error) => (
+                        <li key={error}>{error}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               <div className="h-[400px]">
                 <CodeEditor
                   defaultLanguage="typescript"

--- a/lib/steps/condition.ts
+++ b/lib/steps/condition.ts
@@ -11,20 +11,33 @@ export type ConditionInput = StepInput & {
   expression?: string;
   /** Resolved values of template variables for logging (e.g., { "Label.field": "actual_value" }) */
   values?: Record<string, unknown>;
+  /** KEEP-1284: Error from condition evaluation - if set, the step will throw */
+  _evaluationError?: string;
 };
 
 type ConditionResult = {
   condition: boolean;
 };
 
-function evaluateCondition(input: ConditionInput): ConditionResult {
+type ConditionErrorResult = {
+  success: false;
+  error: string;
+};
+
+function evaluateCondition(
+  input: ConditionInput
+): ConditionResult | ConditionErrorResult {
+  // KEEP-1284: Return error result so step is properly logged as failed
+  if (input._evaluationError) {
+    return { success: false, error: input._evaluationError };
+  }
   return { condition: input.condition };
 }
 
 // biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
 export async function conditionStep(
   input: ConditionInput
-): Promise<ConditionResult> {
+): Promise<ConditionResult | ConditionErrorResult> {
   "use step";
   return withStepLogging(input, () =>
     Promise.resolve(evaluateCondition(input))

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -71,8 +71,9 @@ export type WorkflowExecutionInput = {
 /**
  * Helper to replace template variables in conditions
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: KEEP-1284 validation requires checking multiple error conditions
 function replaceTemplateVariable(
-  match: string,
+  _match: string,
   nodeId: string,
   rest: string,
   outputs: NodeOutputs,
@@ -82,9 +83,11 @@ function replaceTemplateVariable(
   const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
   const output = outputs[sanitizedNodeId];
 
+  // KEEP-1284: Throw error when referenced node output doesn't exist
   if (!output) {
-    console.log("[Condition] Output not found for node:", sanitizedNodeId);
-    return match;
+    throw new Error(
+      `Condition references node "${nodeId}" but no output was found. The referenced node may not have executed or produced output.`
+    );
   }
 
   const dotIndex = rest.indexOf(".");
@@ -93,7 +96,10 @@ function replaceTemplateVariable(
   if (dotIndex === -1) {
     value = output.data;
   } else if (output.data === null || output.data === undefined) {
-    value = undefined;
+    // KEEP-1284: Throw error when node data is null/undefined
+    throw new Error(
+      `Condition references "${rest}" but the node output data is ${output.data === null ? "null" : "undefined"}. Ensure the referenced node produces valid output.`
+    );
   } else {
     const fieldPath = rest.substring(dotIndex + 1);
     const fields = fieldPath.split(".");
@@ -102,16 +108,21 @@ function replaceTemplateVariable(
 
     for (const field of fields) {
       if (current && typeof current === "object") {
+        // KEEP-1284: Check if field exists before accessing
+        if (!(field in current)) {
+          throw new Error(
+            `Condition references field "${fieldPath}" but "${field}" does not exist on the data. Available fields: ${Object.keys(current).join(", ") || "(none)"}`
+          );
+        }
         current = current[field];
       } else {
-        console.log("[Condition] Field access failed:", fieldPath);
-        value = undefined;
-        break;
+        // KEEP-1284: Throw error when field access fails
+        throw new Error(
+          `Condition references field "${fieldPath}" but it could not be resolved. Check that the field path is correct.`
+        );
       }
     }
-    if (value === undefined && current !== undefined) {
-      value = current;
-    }
+    value = current;
   }
 
   const varName = `__v${varCounter.value}`;
@@ -132,11 +143,20 @@ type ConditionEvalResult = {
  * Security: Expressions are validated before evaluation to prevent code injection.
  * Only comparison operators, logical operators, and whitelisted methods are allowed.
  */
-function evaluateConditionExpression(
+// Exported for testing - KEEP-1284
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: KEEP-1284 validation requires comprehensive error checking
+export function evaluateConditionExpression(
   conditionExpression: unknown,
   outputs: NodeOutputs
 ): ConditionEvalResult {
   console.log("[Condition] Original expression:", conditionExpression);
+
+  // KEEP-1284: Throw error when condition is not configured
+  if (conditionExpression === undefined || conditionExpression === null) {
+    throw new Error(
+      "Condition node has no expression configured. Please add a condition expression."
+    );
+  }
 
   if (typeof conditionExpression === "boolean") {
     return { result: conditionExpression, resolvedValues: {} };
@@ -144,11 +164,12 @@ function evaluateConditionExpression(
 
   if (typeof conditionExpression === "string") {
     // Pre-validate the expression before any processing
+    // KEEP-1284: Throw error when condition is empty/invalid instead of silently returning false
     const preValidation = preValidateConditionExpression(conditionExpression);
     if (!preValidation.valid) {
-      console.error("[Condition] Pre-validation failed:", preValidation.error);
-      console.error("[Condition] Expression was:", conditionExpression);
-      return { result: false, resolvedValues: {} };
+      throw new Error(
+        `Condition expression is invalid: ${preValidation.error}. Expression: "${conditionExpression}"`
+      );
     }
 
     try {
@@ -176,15 +197,12 @@ function evaluateConditionExpression(
       );
 
       // Validate the transformed expression before evaluation
+      // KEEP-1284: Throw error when validation fails instead of silently returning false
       const validation = validateConditionExpression(transformedExpression);
       if (!validation.valid) {
-        console.error("[Condition] Validation failed:", validation.error);
-        console.error("[Condition] Original expression:", conditionExpression);
-        console.error(
-          "[Condition] Transformed expression:",
-          transformedExpression
+        throw new Error(
+          `Condition expression validation failed: ${validation.error}. Original: "${conditionExpression}"`
         );
-        return { result: false, resolvedValues };
       }
 
       const varNames = Object.keys(evalContext);
@@ -199,13 +217,26 @@ function evaluateConditionExpression(
       const result = evalFunc(...varValues);
       return { result: Boolean(result), resolvedValues };
     } catch (error) {
+      // KEEP-1284: Re-throw errors about missing data - these should not be silently swallowed
+      if (
+        error instanceof Error &&
+        error.message.includes("Condition references")
+      ) {
+        throw error;
+      }
+      // Other errors (syntax errors, etc.) should still fail loudly
       console.error("[Condition] Failed to evaluate condition:", error);
       console.error("[Condition] Expression was:", conditionExpression);
-      return { result: false, resolvedValues: {} };
+      throw new Error(
+        `Failed to evaluate condition expression: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
-  return { result: Boolean(conditionExpression), resolvedValues: {} };
+  // KEEP-1284: Throw error for unexpected expression types (number, object, etc.)
+  throw new Error(
+    `Condition expression must be a string or boolean, got ${typeof conditionExpression}`
+  );
 }
 
 /**

--- a/tests/unit/workflow-codegen-condition.test.ts
+++ b/tests/unit/workflow-codegen-condition.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock server-only to allow importing workflow-executor in tests
+vi.mock("server-only", () => ({}));
+
+import { generateWorkflowCode } from "@/lib/workflow-codegen";
+import { evaluateConditionExpression } from "@/lib/workflow-executor.workflow";
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow-store";
+
+// Top-level regex patterns for test assertions
+const CONDITION_NOT_CONFIGURED_REGEX = /has no condition expression configured/;
+const NODE_NOT_FOUND_REGEX = /Condition references node.*no output was found/i;
+const FIELD_NOT_EXIST_REGEX = /does not exist on the data/i;
+const COULD_NOT_RESOLVE_NULL_REGEX = /could not resolve|null/i;
+const COULD_NOT_RESOLVE_UNDEFINED_REGEX = /could not resolve|undefined/i;
+
+/**
+ * Tests for KEEP-1284: Conditional will pass when no values are given to it
+ *
+ * Verifies that condition nodes with empty/unconfigured expressions
+ * throw an error during code generation instead of silently defaulting to true.
+ */
+
+// Helper to create a minimal trigger node
+function createTriggerNode(id: string): WorkflowNode {
+  return {
+    id,
+    type: "trigger",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "Manual Trigger",
+      type: "trigger",
+      config: { triggerType: "manual" },
+    },
+  };
+}
+
+// Helper to create a condition node (conditions are actions with actionType: "Condition")
+function createConditionNode(
+  id: string,
+  condition: string | undefined
+): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 100 },
+    data: {
+      label: "Test Condition",
+      type: "action",
+      config: { actionType: "Condition", condition },
+    },
+  };
+}
+
+// Helper to create an action node
+function createActionNode(id: string): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 200 },
+    data: {
+      label: "Test Action",
+      type: "action",
+      config: { actionType: "Send Webhook" },
+    },
+  };
+}
+
+// Helper to create edges
+function createEdge(
+  source: string,
+  target: string,
+  sourceHandle?: string
+): WorkflowEdge {
+  return {
+    id: `${source}-${target}`,
+    source,
+    target,
+    sourceHandle,
+  };
+}
+
+describe("workflow-codegen condition validation", () => {
+  describe("KEEP-1284: empty condition expression handling", () => {
+    it("should return validation error when condition expression is undefined", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        createConditionNode("condition-1", undefined),
+        createActionNode("action-1"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "action-1", "true"),
+      ];
+
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result.validationErrors).toBeDefined();
+      expect(result.validationErrors?.length).toBeGreaterThan(0);
+      expect(result.validationErrors?.[0]).toMatch(
+        CONDITION_NOT_CONFIGURED_REGEX
+      );
+    });
+
+    it("should return validation error when condition expression is empty string", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        createConditionNode("condition-1", ""),
+        createActionNode("action-1"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "action-1", "true"),
+      ];
+
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result.validationErrors).toBeDefined();
+      expect(result.validationErrors?.length).toBeGreaterThan(0);
+      expect(result.validationErrors?.[0]).toMatch(
+        CONDITION_NOT_CONFIGURED_REGEX
+      );
+    });
+
+    it("should include node label in validation error message", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        {
+          id: "condition-1",
+          type: "action",
+          position: { x: 0, y: 100 },
+          data: {
+            label: "My Custom Condition",
+            type: "action",
+            config: { actionType: "Condition", condition: undefined },
+          },
+        },
+        createActionNode("action-1"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "action-1", "true"),
+      ];
+
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result.validationErrors).toBeDefined();
+      expect(result.validationErrors?.[0]).toContain("My Custom Condition");
+    });
+
+    it("should succeed when condition expression is valid", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        createConditionNode("condition-1", "true === true"),
+        createActionNode("action-1"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "action-1", "true"),
+      ];
+
+      // Should not throw
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result).toBeDefined();
+      expect(result.code).toContain("if (true === true)");
+    });
+
+    it("should succeed with template variable condition", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        createConditionNode(
+          "condition-1",
+          "{{@trigger-1:Manual Trigger.value}} > 100"
+        ),
+        createActionNode("action-1"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "action-1", "true"),
+      ];
+
+      // Should not throw
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result).toBeDefined();
+      expect(result.code).toContain("> 100");
+    });
+  });
+
+  describe("condition with both true and false branches", () => {
+    it("should return validation error for empty condition with both branches", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        createConditionNode("condition-1", undefined),
+        createActionNode("action-true"),
+        createActionNode("action-false"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "action-true", "true"),
+        createEdge("condition-1", "action-false", "false"),
+      ];
+
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result.validationErrors).toBeDefined();
+      expect(result.validationErrors?.[0]).toMatch(
+        CONDITION_NOT_CONFIGURED_REGEX
+      );
+    });
+  });
+
+  describe("nested conditions", () => {
+    it("should return validation error for empty nested condition", () => {
+      const nodes: WorkflowNode[] = [
+        createTriggerNode("trigger-1"),
+        createConditionNode("condition-1", "true"),
+        createConditionNode("condition-2", undefined),
+        createActionNode("action-1"),
+      ];
+
+      const edges: WorkflowEdge[] = [
+        createEdge("trigger-1", "condition-1"),
+        createEdge("condition-1", "condition-2", "true"),
+        createEdge("condition-2", "action-1", "true"),
+      ];
+
+      const result = generateWorkflowCode(nodes, edges);
+      expect(result.validationErrors).toBeDefined();
+      expect(result.validationErrors?.[0]).toMatch(
+        CONDITION_NOT_CONFIGURED_REGEX
+      );
+    });
+  });
+});
+
+/**
+ * Runtime condition evaluation tests
+ *
+ * Tests for KEEP-1284: Conditions should throw error when referenced data is missing
+ * instead of silently evaluating to false.
+ */
+describe("runtime condition evaluation", () => {
+  describe("KEEP-1284: missing data should throw error", () => {
+    it("should throw error when referenced node output does not exist", () => {
+      const expression = "{{@nonExistentNode:Label.value}} > 100";
+      const outputs = {}; // No outputs available
+
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+        NODE_NOT_FOUND_REGEX
+      );
+    });
+
+    it("should throw error when referenced field is undefined", () => {
+      const expression = "{{@node1:Label.missingField}} > 100";
+      const outputs = {
+        node1: { label: "Label", data: { existingField: 42 } },
+      };
+
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+        FIELD_NOT_EXIST_REGEX
+      );
+    });
+
+    it("should throw error when node data is null", () => {
+      const expression = "{{@node1:Label.value}} > 100";
+      const outputs = {
+        node1: { label: "Label", data: null },
+      };
+
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+        COULD_NOT_RESOLVE_NULL_REGEX
+      );
+    });
+
+    it("should throw error when node data is undefined", () => {
+      const expression = "{{@node1:Label.value}} > 100";
+      const outputs = {
+        node1: { label: "Label", data: undefined },
+      };
+
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+        COULD_NOT_RESOLVE_UNDEFINED_REGEX
+      );
+    });
+
+    it("should succeed when all referenced data exists", () => {
+      const expression = "{{@node1:Label.value}} > 100";
+      const outputs = {
+        node1: { label: "Label", data: { value: 150 } },
+      };
+
+      const result = evaluateConditionExpression(expression, outputs);
+      expect(result.result).toBe(true);
+      expect(result.resolvedValues).toHaveProperty("Label.value", 150);
+    });
+
+    it("should succeed when comparing to zero (falsy but valid)", () => {
+      const expression = "{{@node1:Label.count}} === 0";
+      const outputs = {
+        node1: { label: "Label", data: { count: 0 } },
+      };
+
+      const result = evaluateConditionExpression(expression, outputs);
+      expect(result.result).toBe(true);
+    });
+
+    it("should succeed when comparing to empty string (falsy but valid)", () => {
+      const expression = "{{@node1:Label.name}} === ''";
+      const outputs = {
+        node1: { label: "Label", data: { name: "" } },
+      };
+
+      const result = evaluateConditionExpression(expression, outputs);
+      expect(result.result).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Throws error during code generation when condition expression is empty/undefined
- Throws error at runtime when condition references missing node outputs
- Throws error when referenced data field does not exist
- Throws error when node data is null or undefined
- Allows falsy values (0, "") that explicitly exist

## Test plan

- [x] Unit tests added for all error scenarios (14 tests)
- [x] Manual test: Create workflow with empty condition, verify error on save
- [x] Manual test: Create workflow where condition references non-existent node output, verify runtime error