### PR TITLE
feat: KEEP-1356 Allow Org Owners/Admin to remove members

### DIFF
--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -52,6 +52,7 @@ import {
 import { refetchOrganizations } from "@/keeperhub/lib/refetch-organizations";
 import { api } from "@/lib/api-client";
 import { authClient } from "@/lib/auth-client";
+import { MembersList } from "./members-list";
 
 // Helper function to get status color based on invitation status
 function getStatusColor(status: string): string {
@@ -308,9 +309,11 @@ export function ManageOrgsModal({
     id: string;
     userId: string;
     role: string;
+    createdAt?: Date;
     user: {
       name?: string;
       email?: string;
+      image?: string;
     };
   };
   const [members, setMembers] = useState<Member[]>([]);
@@ -994,23 +997,20 @@ export function ManageOrgsModal({
                         <h4 className="font-medium text-muted-foreground text-sm">
                           Members
                         </h4>
-                        <div className="space-y-2">
-                          {members.map((member, index) => (
-                            <div
-                              className="flex items-center justify-between rounded-lg border p-3"
-                              key={member.id || `member-${index}`}
-                            >
-                              <div className="min-w-0 flex-1">
-                                <p className="truncate font-medium text-sm">
-                                  {member.user?.email || "Unknown"}
-                                </p>
-                                <p className="text-muted-foreground text-xs">
-                                  {member.role}
-                                </p>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
+                        <MembersList
+                          canManage={isAdmin}
+                          members={members.map((m) => ({
+                            id: m.id,
+                            user: {
+                              name: m.user?.name ?? m.user?.email ?? "Unknown",
+                              email: m.user?.email ?? "",
+                              image: m.user?.image,
+                            },
+                            role: m.role,
+                            createdAt: m.createdAt ?? new Date(),
+                          }))}
+                          onUpdate={fetchMembers}
+                        />
                       </div>
                     )}
 

--- a/keeperhub/components/organization/members-list.tsx
+++ b/keeperhub/components/organization/members-list.tsx
@@ -47,10 +47,19 @@ type Member = {
 type MembersListProps = {
   members: Member[];
   onUpdate: () => void;
+  /** Override admin status (for managing non-active orgs) */
+  canManage?: boolean;
 };
 
-export function MembersList({ members, onUpdate }: MembersListProps) {
-  const { isAdmin, member: currentMember } = useActiveMember();
+export function MembersList({
+  members,
+  onUpdate,
+  canManage,
+}: MembersListProps) {
+  const { isAdmin: isActiveOrgAdmin, member: currentMember } =
+    useActiveMember();
+  // Use prop if provided, otherwise fall back to hook result
+  const isAdmin = canManage ?? isActiveOrgAdmin;
   const [updating, setUpdating] = useState<string | null>(null);
 
   const handleRoleChange = async (memberId: string, newRole: string) => {


### PR DESCRIPTION
## Summary

- Refactored `ManageOrgsModal` to use the shared `MembersList` component instead of inline member rendering
- Added `canManage` prop to `MembersList` to allow admin controls when viewing organizations where the user is an owner/admin (not just the active organization)

## Changes

- `manage-orgs-modal.tsx`: Replace inline member list with `MembersList` component, passing `canManage={isAdmin}`
- `members-list.tsx`: Add optional `canManage` prop that overrides the `useActiveMember()` hook result

## Test Plan

- [x] Tested locally
- [x] Org owners can see and use member management controls (role change, remove) in the manage orgs modal
- [x] Non-admin users cannot see management controls

## Jira

[KEEP-1356](https://techops-services.atlassian.net/browse/KEEP-1356)

[KEEP-1356]: https://techopsservices.atlassian.net/browse/KEEP-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ