### PR TITLE
Keep-1358: Display checksummed addresses

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -16,6 +16,7 @@ import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 // start custom keeperhub code //
 import { SaveAddressBookmark } from "@/keeperhub/components/address-book/save-address-bookmark";
 import { parseAddressBookSelection } from "@/keeperhub/lib/address-book-selection";
+import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
 // end keeperhub code //
 import { getCustomFieldRenderer } from "@/lib/extension-registry";
 import {
@@ -51,13 +52,17 @@ function TemplateInputField({
     field.key === "address" ||
     field.key.toLowerCase().endsWith("address");
 
+  const displayValue = isAddressField
+    ? toChecksumAddress(value ?? "")
+    : (value ?? "");
+
   const input = (
     <TemplateBadgeInput
       disabled={disabled}
       id={field.key}
       onChange={onChange}
       placeholder={field.placeholder}
-      value={value}
+      value={displayValue}
     />
   );
 

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -264,8 +264,8 @@ function JsonWithLinks({ data }: { data: unknown }) {
 
           // Ethereum addresses (40 hex) or tx hashes (64 hex): copy + optional link icons
           if (ETH_HEX_REGEX.test(innerValue)) {
-            const isAddress = innerValue.length === 42;
-            const displayValue = isAddress
+            const looksLikeAddress = innerValue.length === 42;
+            const displayValue = looksLikeAddress
               ? toChecksumAddress(innerValue)
               : innerValue;
             const explorerUrl = linkMap.get(innerValue);

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -15,6 +15,7 @@ import {
 import Image from "next/image";
 import type { JSX } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
 import { api } from "@/lib/api-client";
 import {
   OUTPUT_DISPLAY_CONFIGS,
@@ -263,16 +264,20 @@ function JsonWithLinks({ data }: { data: unknown }) {
 
           // Ethereum addresses (40 hex) or tx hashes (64 hex): copy + optional link icons
           if (ETH_HEX_REGEX.test(innerValue)) {
+            const isAddress = innerValue.length === 42;
+            const displayValue = isAddress
+              ? toChecksumAddress(innerValue)
+              : innerValue;
             const explorerUrl = linkMap.get(innerValue);
             // Truncate: 0x + first 6 hex chars + ... + last 6 hex chars
-            const truncated = `${innerValue.slice(0, 8)}...${innerValue.slice(-6)}`;
+            const truncated = `${displayValue.slice(0, 8)}...${displayValue.slice(-6)}`;
             return (
               <span
                 className="inline-flex items-center"
                 key={`h-${innerValue}`}
               >
                 {`"${truncated}"`}
-                <InlineCopyButton text={innerValue} />
+                <InlineCopyButton text={displayValue} />
                 {explorerUrl && (
                   <a
                     className="ml-1 inline-flex align-middle text-muted-foreground hover:text-foreground"

--- a/keeperhub/api/address-book/[entryId]/route.ts
+++ b/keeperhub/api/address-book/[entryId]/route.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { normalizeAddressForStorage } from "@/keeperhub/lib/address-utils";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
@@ -106,7 +107,7 @@ function buildUpdateObject(body: { label?: string; address?: string }) {
       };
     }
 
-    updates.address = address;
+    updates.address = normalizeAddressForStorage(address);
   }
 
   return { updates };

--- a/keeperhub/api/address-book/route.ts
+++ b/keeperhub/api/address-book/route.ts
@@ -2,6 +2,7 @@ import { desc, eq, inArray } from "drizzle-orm";
 import { ethers } from "ethers";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { normalizeAddressForStorage } from "@/keeperhub/lib/address-utils";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
@@ -132,13 +133,13 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create new entry
+    // Create new entry (store lowercase for consistency)
     const [newEntry] = await db
       .insert(addressBookEntry)
       .values({
         organizationId: activeOrgId,
         label,
-        address,
+        address: normalizeAddressForStorage(address),
         createdBy: session.user.id,
       })
       .returning({

--- a/keeperhub/api/user/wallet/route.ts
+++ b/keeperhub/api/user/wallet/route.ts
@@ -2,7 +2,10 @@ import { Environment, Para as ParaServer } from "@getpara/server-sdk";
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
-import { normalizeAddressForStorage, truncateAddress } from "@/keeperhub/lib/address-utils";
+import {
+  normalizeAddressForStorage,
+  truncateAddress,
+} from "@/keeperhub/lib/address-utils";
 import { apiError } from "@/keeperhub/lib/api-error";
 import { encryptUserShare } from "@/keeperhub/lib/encryption";
 import {

--- a/keeperhub/api/user/wallet/route.ts
+++ b/keeperhub/api/user/wallet/route.ts
@@ -2,6 +2,7 @@ import { Environment, Para as ParaServer } from "@getpara/server-sdk";
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { normalizeAddressForStorage, truncateAddress } from "@/keeperhub/lib/address-utils";
 import { apiError } from "@/keeperhub/lib/api-error";
 import { encryptUserShare } from "@/keeperhub/lib/encryption";
 import {
@@ -185,22 +186,24 @@ async function storeWalletAndIntegration(options: {
   const { userId, organizationId, email, walletId, walletAddress, userShare } =
     options;
 
-  // Store wallet in para_wallets table
+  const normalizedWalletAddress = normalizeAddressForStorage(walletAddress);
+
+  // Store wallet in para_wallets table (lowercase for consistency)
   await db.insert(paraWallets).values({
     userId,
     organizationId,
     email,
     walletId,
-    walletAddress,
+    walletAddress: normalizedWalletAddress,
     userShare: encryptUserShare(userShare),
   });
 
   console.log(
-    `[Para] ✓ Wallet created for organization ${organizationId}: ${walletAddress}`
+    `[Para] ✓ Wallet created for organization ${organizationId}: ${normalizedWalletAddress}`
   );
 
   // Create Web3 integration record with truncated address as name
-  const truncatedAddress = `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`;
+  const truncatedAddress = truncateAddress(normalizedWalletAddress);
 
   await createIntegration({
     userId,
@@ -212,7 +215,11 @@ async function storeWalletAndIntegration(options: {
 
   console.log(`[Para] ✓ Web3 integration created: ${truncatedAddress}`);
 
-  return { walletAddress, walletId, truncatedAddress };
+  return {
+    walletAddress: normalizedWalletAddress,
+    walletId,
+    truncatedAddress,
+  };
 }
 
 export async function GET(request: Request) {
@@ -306,8 +313,8 @@ export async function POST(request: Request) {
     const walletId = wallet.id as string;
     const walletAddress = wallet.address as string;
 
-    // 5. Store wallet and create integration
-    await storeWalletAndIntegration({
+    // 5. Store wallet and create integration (returns normalized lowercase address)
+    const { walletAddress: storedAddress } = await storeWalletAndIntegration({
       userId: user.id,
       organizationId,
       email: walletEmail,
@@ -316,11 +323,11 @@ export async function POST(request: Request) {
       userShare,
     });
 
-    // 6. Return success
+    // 6. Return success (return stored lowercase address for consistency)
     return NextResponse.json({
       success: true,
       wallet: {
-        address: walletAddress,
+        address: storedAddress,
         walletId,
         email: walletEmail,
         organizationId,

--- a/keeperhub/api/user/wallet/tokens/route.ts
+++ b/keeperhub/api/user/wallet/tokens/route.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { normalizeAddressForStorage } from "@/keeperhub/lib/address-utils";
 import { apiError } from "@/keeperhub/lib/api-error";
 import { organizationHasWallet } from "@/keeperhub/lib/para/wallet-helpers";
 import { auth } from "@/lib/auth";
@@ -130,6 +131,8 @@ export async function POST(request: Request) {
       );
     }
 
+    const normalizedTokenAddress = normalizeAddressForStorage(tokenAddress);
+
     // Check if token is already tracked by the organization
     const existing = await db
       .select()
@@ -138,7 +141,7 @@ export async function POST(request: Request) {
         and(
           eq(organizationTokens.organizationId, activeOrgId),
           eq(organizationTokens.chainId, chainId),
-          eq(organizationTokens.tokenAddress, tokenAddress.toLowerCase())
+          eq(organizationTokens.tokenAddress, normalizedTokenAddress)
         )
       )
       .limit(1);
@@ -157,7 +160,7 @@ export async function POST(request: Request) {
       .where(
         and(
           eq(supportedTokens.chainId, chainId),
-          eq(supportedTokens.tokenAddress, tokenAddress.toLowerCase())
+          eq(supportedTokens.tokenAddress, normalizedTokenAddress)
         )
       )
       .limit(1);
@@ -199,7 +202,7 @@ export async function POST(request: Request) {
       .values({
         organizationId: activeOrgId,
         chainId,
-        tokenAddress: tokenAddress.toLowerCase(),
+        tokenAddress: normalizedTokenAddress,
         symbol,
         name,
         decimals,

--- a/keeperhub/api/validate-token/route.ts
+++ b/keeperhub/api/validate-token/route.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import { NextResponse } from "next/server";
+import { normalizeAddressForStorage } from "@/keeperhub/lib/address-utils";
 import { ERC20_ABI } from "@/lib/contracts";
 import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
 
@@ -65,7 +66,7 @@ export async function GET(request: Request) {
     return NextResponse.json({
       valid: true,
       token: {
-        address: address.toLowerCase(),
+        address: normalizeAddressForStorage(address),
         symbol,
         name,
         decimals: Number(decimals),

--- a/keeperhub/components/address-book/address-book-row.tsx
+++ b/keeperhub/components/address-book/address-book-row.tsx
@@ -5,7 +5,10 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TableCell, TableRow } from "@/components/ui/table";
-import { truncateAddress } from "@/keeperhub/lib/address-utils";
+import {
+  toChecksumAddress,
+  truncateAddress,
+} from "@/keeperhub/lib/address-utils";
 import type { AddressBookEntry } from "@/lib/api-client";
 
 type AddressBookRowProps = {
@@ -36,7 +39,7 @@ export function AddressBookRow({
             {truncateAddress(entry.address, 12)}
           </code>
           <Button
-            onClick={() => copyToClipboard(entry.address)}
+            onClick={() => copyToClipboard(toChecksumAddress(entry.address))}
             size="sm"
             variant="ghost"
           >

--- a/keeperhub/components/address-book/save-address-bookmark.tsx
+++ b/keeperhub/components/address-book/save-address-bookmark.tsx
@@ -11,6 +11,7 @@ import {
   ADDRESS_BOOK_SELECTION_KEY,
   parseAddressBookSelection,
 } from "@/keeperhub/lib/address-book-selection";
+import { normalizeAddressForStorage } from "@/keeperhub/lib/address-utils";
 import { addressBookApi, api } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
 import {
@@ -127,10 +128,12 @@ export function SaveAddressBookmark({
 
   useEffect(() => {
     const childValue = children.props.value;
-    if (childValue !== undefined) {
-      setCurrentAddress(childValue);
-    } else if (addressProp !== undefined) {
-      setCurrentAddress(addressProp);
+    const raw = childValue !== undefined ? childValue : addressProp;
+    if (raw !== undefined) {
+      const stored = ethers.isAddress(raw)
+        ? normalizeAddressForStorage(raw)
+        : raw;
+      setCurrentAddress(stored);
     }
   }, [children.props.value, addressProp]);
 
@@ -149,8 +152,11 @@ export function SaveAddressBookmark({
 
   const childWithInterception = React.cloneElement(children, {
     onChange: (value: string) => {
-      setCurrentAddress(value);
-      children.props.onChange?.(value);
+      const stored = ethers.isAddress(value)
+        ? normalizeAddressForStorage(value)
+        : value;
+      setCurrentAddress(stored);
+      children.props.onChange?.(stored);
     },
     onFocus: (e: React.FocusEvent) => {
       if (!isTemporalAccount) {
@@ -188,8 +194,11 @@ export function SaveAddressBookmark({
   }, [isTemporalAccount, scheduleClosePopoverIfBlurred]);
 
   const handleAddressSelect = (selectedAddress: string, bookmarkId: string) => {
-    children.props.onChange?.(selectedAddress);
-    setCurrentAddress(selectedAddress);
+    const stored = ethers.isAddress(selectedAddress)
+      ? normalizeAddressForStorage(selectedAddress)
+      : selectedAddress;
+    children.props.onChange?.(stored);
+    setCurrentAddress(stored);
     setIsInputFocused(false);
     setOptimisticBookmarkId(bookmarkId);
 

--- a/keeperhub/components/overlays/address-book-overlay.tsx
+++ b/keeperhub/components/overlays/address-book-overlay.tsx
@@ -26,6 +26,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { AddressBookRow } from "@/keeperhub/components/address-book/address-book-row";
+import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
 import { useDebounce } from "@/keeperhub/lib/hooks/use-debounce";
 import { usePagination } from "@/keeperhub/lib/hooks/use-pagination";
 import type { AddressBookEntry } from "@/lib/api-client";
@@ -51,9 +52,15 @@ export function AddAddressOverlay({
 }: AddAddressOverlayProps) {
   const { pop } = useOverlay();
   const [newLabel, setNewLabel] = useState(entry?.label ?? "");
-  const [newAddress, setNewAddress] = useState(
-    entry?.address ?? initialAddress ?? ""
-  );
+  const [newAddress, setNewAddress] = useState(() => {
+    if (entry) {
+      return toChecksumAddress(entry.address);
+    }
+    if (initialAddress) {
+      return toChecksumAddress(initialAddress);
+    }
+    return "";
+  });
   const [saving, setSaving] = useState(false);
 
   const isEditing = !!entry;

--- a/keeperhub/components/overlays/wallet-overlay.tsx
+++ b/keeperhub/components/overlays/wallet-overlay.tsx
@@ -24,6 +24,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  toChecksumAddress,
+  truncateAddress,
+} from "@/keeperhub/lib/address-utils";
 import { useActiveMember } from "@/keeperhub/lib/hooks/use-organization";
 import { fetchAllSupportedTokenBalances } from "@/keeperhub/lib/wallet/fetch-balances";
 import type {
@@ -42,17 +46,6 @@ import { type WithdrawableAsset, WithdrawModal } from "./withdraw-modal";
 type WalletOverlayProps = {
   overlayId: string;
 };
-
-// ============================================================================
-// Utility Functions
-// ============================================================================
-
-function truncateAddress(address: string): string {
-  if (address.length <= 13) {
-    return address;
-  }
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
 
 // TEMPO testnet uses stablecoins for gas, so we display stablecoins only (no native token)
 const TEMPO_CHAIN_ID = 42_429;
@@ -828,7 +821,7 @@ function AccountDetailsSection({
   };
 
   const copyAddress = () => {
-    navigator.clipboard.writeText(walletAddress);
+    navigator.clipboard.writeText(toChecksumAddress(walletAddress));
     toast.success("Address copied to clipboard");
   };
 

--- a/keeperhub/components/overlays/withdraw-modal.tsx
+++ b/keeperhub/components/overlays/withdraw-modal.tsx
@@ -17,6 +17,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SaveAddressBookmark } from "@/keeperhub/components/address-book/save-address-bookmark";
+import {
+  toChecksumAddress,
+  truncateAddress,
+} from "@/keeperhub/lib/address-utils";
 
 export type WithdrawableAsset = {
   type: "native" | "token";
@@ -138,7 +142,7 @@ export function WithdrawModal({
             {amount} {selectedAsset?.symbol} sent
           </p>
           <p className="mb-4 text-muted-foreground text-sm">
-            To: {recipient.slice(0, 6)}...{recipient.slice(-4)}
+            To: {truncateAddress(recipient)}
           </p>
         </div>
       </Overlay>
@@ -262,7 +266,7 @@ export function WithdrawModal({
             <Input
               onChange={(e) => setRecipient(e.target.value)}
               placeholder="0x..."
-              value={recipient}
+              value={toChecksumAddress(recipient)}
             />
           </SaveAddressBookmark>
           {recipient && !ethers.isAddress(recipient) && (

--- a/keeperhub/components/settings/web3-wallet-section.tsx
+++ b/keeperhub/components/settings/web3-wallet-section.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
 import { useSession } from "@/lib/auth-client";
 import { integrationsVersionAtom } from "@/lib/integrations-store";
 
@@ -185,7 +186,7 @@ export function Web3WalletSection({
                   Wallet Address
                 </div>
                 <code className="break-all font-mono text-xs">
-                  {walletAddress}
+                  {walletAddress ? toChecksumAddress(walletAddress) : null}
                 </code>
               </div>
               {showDelete && (

--- a/keeperhub/components/workflow/config/token-select-field.tsx
+++ b/keeperhub/components/workflow/config/token-select-field.tsx
@@ -196,6 +196,9 @@ export function TokenSelectField({
   const renderSelectedTokenInfo = () => {
     // For supported tokens mode
     if (!isCustomMode && selectedSupportedToken) {
+      const displayAddress = toChecksumAddress(
+        selectedSupportedToken.tokenAddress
+      );
       return (
         <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm">
           {selectedSupportedToken.logoUrl && (
@@ -209,12 +212,7 @@ export function TokenSelectField({
           )}
           <span className="font-medium">{selectedSupportedToken.symbol}</span>
           <span className="truncate font-mono text-muted-foreground text-xs">
-            {toChecksumAddress(selectedSupportedToken.tokenAddress).slice(
-              0,
-              10
-            )}
-            ...
-            {toChecksumAddress(selectedSupportedToken.tokenAddress).slice(-8)}
+            {displayAddress.slice(0, 10)}...{displayAddress.slice(-8)}
           </span>
           <div className="ml-auto flex items-center gap-1">
             <button
@@ -246,12 +244,12 @@ export function TokenSelectField({
     // For custom token mode
     if (isCustomMode && currentValue.customToken) {
       const customToken = currentValue.customToken;
+      const displayAddress = toChecksumAddress(customToken.address);
       return (
         <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm">
           <span className="font-medium">{customToken.symbol}</span>
           <span className="truncate font-mono text-muted-foreground text-xs">
-            {toChecksumAddress(customToken.address).slice(0, 10)}...
-            {toChecksumAddress(customToken.address).slice(-8)}
+            {displayAddress.slice(0, 10)}...{displayAddress.slice(-8)}
           </span>
           <div className="ml-auto flex items-center gap-1">
             <button

--- a/keeperhub/components/workflow/config/token-select-field.tsx
+++ b/keeperhub/components/workflow/config/token-select-field.tsx
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
 import type {
   CustomToken,
   SupportedToken,
@@ -185,9 +186,9 @@ export function TokenSelectField({
     ? tokens.find((t) => t.id === currentValue.supportedTokenId)
     : null;
 
-  // Copy token address to clipboard
+  // Copy token address to clipboard (checksummed for user safety)
   const copyTokenAddress = (address: string) => {
-    navigator.clipboard.writeText(address);
+    navigator.clipboard.writeText(toChecksumAddress(address));
     toast.success("Token address copied");
   };
 
@@ -208,8 +209,12 @@ export function TokenSelectField({
           )}
           <span className="font-medium">{selectedSupportedToken.symbol}</span>
           <span className="truncate font-mono text-muted-foreground text-xs">
-            {selectedSupportedToken.tokenAddress.slice(0, 10)}...
-            {selectedSupportedToken.tokenAddress.slice(-8)}
+            {toChecksumAddress(selectedSupportedToken.tokenAddress).slice(
+              0,
+              10
+            )}
+            ...
+            {toChecksumAddress(selectedSupportedToken.tokenAddress).slice(-8)}
           </span>
           <div className="ml-auto flex items-center gap-1">
             <button
@@ -245,8 +250,8 @@ export function TokenSelectField({
         <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm">
           <span className="font-medium">{customToken.symbol}</span>
           <span className="truncate font-mono text-muted-foreground text-xs">
-            {customToken.address.slice(0, 10)}...
-            {customToken.address.slice(-8)}
+            {toChecksumAddress(customToken.address).slice(0, 10)}...
+            {toChecksumAddress(customToken.address).slice(-8)}
           </span>
           <div className="ml-auto flex items-center gap-1">
             <button

--- a/keeperhub/lib/address-utils.ts
+++ b/keeperhub/lib/address-utils.ts
@@ -1,6 +1,37 @@
 /**
+ * EVM address utilities for KeeperHub.
+ *
+ * Convention: store lowercase (consistent, easy to compare/index), display
+ * checksummed (EIP-55; user safety, professional appearance), accept both on
+ * input (normalize with getAddress from ethers).
+ */
+
+import { ethers } from "ethers";
+
+/**
+ * Returns the EIP-55 checksummed form of an EVM address.
+ * If the address is invalid or corrupt, returns it unchanged so UI never crashes.
+ */
+export function toChecksumAddress(address: string): string {
+  try {
+    return ethers.getAddress(address);
+  } catch {
+    return address;
+  }
+}
+
+/**
+ * Normalizes an EVM address for storage: validates and returns lowercase.
+ * Call only after validation (e.g. ethers.isAddress(address)).
+ */
+export function normalizeAddressForStorage(address: string): string {
+  return ethers.getAddress(address).toLowerCase();
+}
+
+/**
  * Truncates an Ethereum address for display purposes.
- * If the address is shorter than or equal to the maxLength, returns it unchanged.
+ * Uses EIP-55 checksummed form before slicing so truncated display is always checksummed.
+ * If the address is shorter than or equal to the maxLength, returns it unchanged (checksummed).
  * Otherwise, returns a truncated version showing the first 6 characters and last 4 characters.
  *
  * @param address - The Ethereum address to truncate
@@ -8,8 +39,9 @@
  * @returns The truncated address in the format "0x1234...5678" or the original address if it's short enough
  */
 export function truncateAddress(address: string, maxLength = 10): string {
-  if (address.length <= maxLength) {
-    return address;
+  const checksummed = toChecksumAddress(address);
+  if (checksummed.length <= maxLength) {
+    return checksummed;
   }
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  return `${checksummed.slice(0, 6)}...${checksummed.slice(-4)}`;
 }

--- a/tests/unit/address-utils.test.ts
+++ b/tests/unit/address-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeAddressForStorage,
+  toChecksumAddress,
+  truncateAddress,
+} from "@/keeperhub/lib/address-utils";
+
+describe("address-utils", () => {
+  const lowercaseAddress = "0xae36bc35098e24bbaed3dee86ec4653eb88a71a9";
+  const checksummedAddress = "0xae36bc35098E24bbaeD3deE86EC4653Eb88A71a9";
+
+  describe("toChecksumAddress", () => {
+    it("returns EIP-55 checksummed form for valid lowercase address", () => {
+      expect(toChecksumAddress(lowercaseAddress)).toBe(checksummedAddress);
+    });
+
+    it("returns unchanged for valid checksummed address", () => {
+      expect(toChecksumAddress(checksummedAddress)).toBe(checksummedAddress);
+    });
+
+    it("returns passthrough for invalid address (no throw)", () => {
+      const invalid = "0xinvalid";
+      expect(toChecksumAddress(invalid)).toBe(invalid);
+    });
+
+    it("returns passthrough for empty string", () => {
+      expect(toChecksumAddress("")).toBe("");
+    });
+
+    it("returns passthrough for too-short hex", () => {
+      const short = "0x1234";
+      expect(toChecksumAddress(short)).toBe(short);
+    });
+  });
+
+  describe("normalizeAddressForStorage", () => {
+    it("returns lowercase for valid lowercase address", () => {
+      expect(normalizeAddressForStorage(lowercaseAddress)).toBe(
+        lowercaseAddress
+      );
+    });
+
+    it("returns lowercase for valid checksummed address", () => {
+      expect(normalizeAddressForStorage(checksummedAddress)).toBe(
+        lowercaseAddress
+      );
+    });
+
+    it("throws for invalid address", () => {
+      expect(() => normalizeAddressForStorage("0xinvalid")).toThrow();
+    });
+  });
+
+  describe("truncateAddress", () => {
+    it("returns checksummed address when length <= maxLength", () => {
+      const short = "0x1234";
+      expect(truncateAddress(short, 10)).toBe(short);
+      expect(truncateAddress(lowercaseAddress, 50)).toBe(checksummedAddress);
+    });
+
+    it("returns truncated checksummed format for long address", () => {
+      const result = truncateAddress(lowercaseAddress, 10);
+      expect(result).toBe("0xae36...71a9");
+      expect(result.startsWith("0x")).toBe(true);
+      expect(result).toContain("...");
+      expect(result.endsWith("71a9")).toBe(true);
+    });
+
+    it("uses default maxLength 10", () => {
+      const result = truncateAddress(lowercaseAddress);
+      expect(result).toBe("0xae36...71a9");
+    });
+
+    it("returns full checksummed when maxLength >= address length", () => {
+      const result = truncateAddress(lowercaseAddress, 50);
+      expect(result).toBe(checksummedAddress);
+    });
+
+    it("handles invalid address by passing through then truncating", () => {
+      const invalid = "0xnotavalidaddressbutlongenough";
+      expect(truncateAddress(invalid, 10)).toBe("0xnota...ough");
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Implements EIP-55 handling for EVM addresses: store in lowercase, show checksummed in the UI, and accept both formats on input. Adds shared address helpers, updates address book and Para wallet APIs to persist lowercase, and updates all address display/copy surfaces to use the checksummed form.

# Details

- **Address helpers** (`keeperhub/lib/address-utils.ts`): `toChecksumAddress` (EIP-55, safe for invalid input), `normalizeAddressForStorage` (lowercase for persistence), and `truncateAddress` (checksummed before truncation). Documented convention: store lowercase, display checksummed, accept both.

- **Backend storage**: Address book POST/PATCH normalize with `normalizeAddressForStorage` before insert/update. Para wallet creation normalizes `wallet_address` to lowercase in `storeWalletAndIntegration` and returns that value in the POST response. Organization tokens already used `tokenAddress.toLowerCase()`.

- **UI display and copy**: Address book (row, select popover, overlay edit/initial), workflow config address fields (action-config-renderer), workflow run hex output (40-char addresses), wallet overlay, web3 wallet section, withdraw modal (recipient input and success “To” line), and token-select custom token display/copy now use checksummed addresses for display and clipboard.

- **SaveAddressBookmark**: Normalizes to lowercase in internal state and when calling parent `onChange` (typed, pasted, or selected-from-book). Display remains checksummed via parent-supplied value.

- **Withdraw modal**: Recipient input value and success “To” text use checksummed form; web3 wallet section shows wallet address checksummed.

- **Tests**: `tests/unit/address-utils.test.ts` added for `toChecksumAddress`, `normalizeAddressForStorage`, and `truncateAddress`.