### PR TITLE
Fix duplicate ExternalSecret names for OAuth client IDs

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -150,7 +150,7 @@ env:
     parameter_name: /eks/maker-prod/keeperhub/github-client-secret
   NEXT_PUBLIC_GITHUB_CLIENT_ID:
     type: parameterStore
-    name: github-client-id
+    name: next-public-github-client-id
     parameter_name: /eks/maker-prod/keeperhub/github-client-id
   GOOGLE_CLIENT_ID:
     type: parameterStore
@@ -162,7 +162,7 @@ env:
     parameter_name: /eks/maker-prod/keeperhub/google-client-secret
   NEXT_PUBLIC_GOOGLE_CLIENT_ID:
     type: parameterStore
-    name: google-client-id
+    name: next-public-google-client-id
     parameter_name: /eks/maker-prod/keeperhub/google-client-id
   OPENAI_API_KEY:
     type: parameterStore

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -141,7 +141,7 @@ env:
     parameter_name: /eks/maker-staging/keeperhub/github-client-secret
   NEXT_PUBLIC_GITHUB_CLIENT_ID:
     type: parameterStore
-    name: github-client-id
+    name: next-public-github-client-id
     parameter_name: /eks/maker-staging/keeperhub/github-client-id
   GOOGLE_CLIENT_ID:
     type: parameterStore
@@ -153,7 +153,7 @@ env:
     parameter_name: /eks/maker-staging/keeperhub/google-client-secret
   NEXT_PUBLIC_GOOGLE_CLIENT_ID:
     type: parameterStore
-    name: google-client-id
+    name: next-public-google-client-id
     parameter_name: /eks/maker-staging/keeperhub/google-client-id
   OPENAI_API_KEY:
     type: parameterStore


### PR DESCRIPTION
## Summary
- Fix Helm deployment failure caused by duplicate ExternalSecret resources
- `NEXT_PUBLIC_GITHUB_CLIENT_ID` and `NEXT_PUBLIC_GOOGLE_CLIENT_ID` now use unique `name` fields
- Both still reference the same SSM parameters, so values remain unchanged

## Root Cause
The Helm chart's `externalSecret.yaml` template creates one ExternalSecret per `parameterStore` env var using the `name` field. When multiple env vars shared the same `name` (e.g., both `GITHUB_CLIENT_ID` and `NEXT_PUBLIC_GITHUB_CLIENT_ID` used `name: github-client-id`), duplicate ExternalSecret resources were generated, causing the upgrade to fail.

## Test plan
- [ ] Deploy to staging and verify the deployment succeeds
- [ ] Verify OAuth login works with GitHub and Google