### PR TITLE
Keep-1345: Automatically fetch abi and toggle code view with a button

### DIFF
--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -12,6 +12,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 import type { ActionConfigFieldBase } from "@/plugins";
 
+const AUTO_FETCH_DEBOUNCE_MS = 600;
+
 function DiamondUnsupportedAlert() {
   return (
     <Alert className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950">
@@ -365,8 +367,6 @@ export function AbiWithAutoFetchField({
   // stored performAbiFetch in a ref to avoid stale function references
   performAbiFetchRef.current = performAbiFetch;
   useEffect(() => {
-    const TIMEOUT_BEFORE_FETCH_DELAY = 600;
-
     if (!(isValidAddress && network) || useManualAbi) {
       return;
     }
@@ -390,7 +390,7 @@ export function AbiWithAutoFetchField({
           setError(message);
         });
       }
-    }, TIMEOUT_BEFORE_FETCH_DELAY);
+    }, AUTO_FETCH_DEBOUNCE_MS);
     return () => {
       clearTimeout(timeoutId);
     };

--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -384,12 +384,20 @@ export function AbiWithAutoFetchField({
       if (currentTargetRef.current) {
         lastFetchedRef.current = { ...currentTargetRef.current };
       }
+      const fetchTarget = { contractAddress, network };
       const fn = performAbiFetchRef.current;
       if (fn) {
         fn().catch((err: unknown) => {
-          const message =
-            err instanceof Error ? err.message : "Failed to fetch ABI";
-          setError(message);
+          // Only set error if the target hasn't changed since fetch started
+          const current = currentTargetRef.current;
+          if (
+            current?.contractAddress === fetchTarget.contractAddress &&
+            current?.network === fetchTarget.network
+          ) {
+            const message =
+              err instanceof Error ? err.message : "Failed to fetch ABI";
+            setError(message);
+          }
         });
       }
     }, AUTO_FETCH_DEBOUNCE_MS);

--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -361,8 +361,10 @@ export function AbiWithAutoFetchField({
     await performAbiFetch();
   }, [isValidAddress, network, performAbiFetch]);
 
-  // Auto-fetch ABI when contract address or network changes (debounced, once per pair)
-  // stored performAbiFetch in a ref to avoid stale function references
+  // Auto-fetch ABI when contract address or network changes (debounced, once per pair).
+  // performAbiFetch is stored in a ref and accessed via performAbiFetchRef.current inside
+  // the effect. This avoids adding performAbiFetch to the dependency array, which would
+  // cause the effect to re-run on every render and defeat the debounce logic.
   performAbiFetchRef.current = performAbiFetch;
   useEffect(() => {
     if (!(isValidAddress && network) || useManualAbi) {

--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -191,12 +191,10 @@ export function AbiWithAutoFetchField({
     contractAddress: string;
     network: string;
   } | null>(null);
-  const currentTargetRef = useRef<{ contractAddress: string; network: string }>(
-    {
-      contractAddress: "",
-      network: "",
-    }
-  );
+  const currentTargetRef = useRef<{
+    contractAddress: string;
+    network: string;
+  } | null>(null);
   const performAbiFetchRef = useRef<(() => Promise<void>) | null>(null);
 
   const abiToString = useCallback((abi: string | null): string | null => {
@@ -381,7 +379,9 @@ export function AbiWithAutoFetchField({
       return;
     }
     const timeoutId = setTimeout(() => {
-      lastFetchedRef.current = { ...currentTargetRef.current };
+      if (currentTargetRef.current) {
+        lastFetchedRef.current = { ...currentTargetRef.current };
+      }
       const fn = performAbiFetchRef.current;
       if (fn) {
         fn().catch((err: unknown) => {


### PR DESCRIPTION
# Summary

ABI field now auto-fetches when contract address or network changes, and the API checks that the address has contract code before fetching.

# Details:

- **API:** Validates address has bytecode (rejects EOA); normalizes address with `toChecksumAddress`.
- **UI:** Debounced (600ms) auto-fetch when address/network change; refs avoid re-fetch loops; errors shown on failure; manual fetch button unchanged.