### PR TITLE
Keep-1366: Organization owners should be able to leave an organization without deleting it

### DIFF
--- a/app/api/organizations/[organizationId]/leave/route.ts
+++ b/app/api/organizations/[organizationId]/leave/route.ts
@@ -1,0 +1,8 @@
+/**
+ * KeeperHub Organization API Route
+ *
+ * This is a thin wrapper that re-exports the actual implementation
+ * from the keeperhub directory to maintain clean separation.
+ */
+
+export { POST } from "@/keeperhub/api/organizations/[organizationId]/leave/route";

--- a/keeperhub/api/organizations/[organizationId]/leave/route.ts
+++ b/keeperhub/api/organizations/[organizationId]/leave/route.ts
@@ -1,0 +1,161 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { member, sessions } from "@/lib/db/schema";
+
+type LeaveRequestBody = {
+  /**
+   * Required when caller is the sole owner: member id to promote to owner.
+   * Must be an accepted member (row in member table), not a pending invitation.
+   */
+  newOwnerMemberId?: string;
+};
+
+/**
+ * POST /api/organizations/:organizationId/leave
+ *
+ * Leave the organization. When the caller is the sole owner, newOwnerMemberId
+ * must be provided and must refer to an accepted member (in member table).
+ * Ownership is transferred and membership removed in a single transaction.
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json()) as LeaveRequestBody;
+    const newOwnerMemberId =
+      typeof body.newOwnerMemberId === "string"
+        ? body.newOwnerMemberId.trim()
+        : "";
+
+    const sessionToken = session.session?.token;
+    if (!sessionToken) {
+      return NextResponse.json(
+        { error: "Session token not found" },
+        { status: 401 }
+      );
+    }
+
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: transaction steps are linear validation + updates
+    await db.transaction(async (tx) => {
+      const [currentMember] = await tx
+        .select({ id: member.id, role: member.role })
+        .from(member)
+        .where(
+          and(
+            eq(member.organizationId, organizationId),
+            eq(member.userId, session.user.id)
+          )
+        )
+        .limit(1);
+
+      if (!currentMember) {
+        throw new Error("NOT_MEMBER");
+      }
+
+      const ownerCount = await tx
+        .select({ id: member.id })
+        .from(member)
+        .where(
+          and(
+            eq(member.organizationId, organizationId),
+            eq(member.role, "owner")
+          )
+        );
+
+      const isOnlyOwner =
+        currentMember.role === "owner" && ownerCount.length === 1;
+
+      if (isOnlyOwner) {
+        if (!newOwnerMemberId) {
+          throw new Error("NEW_OWNER_REQUIRED");
+        }
+
+        const [newOwner] = await tx
+          .select({ id: member.id })
+          .from(member)
+          .where(
+            and(
+              eq(member.id, newOwnerMemberId),
+              eq(member.organizationId, organizationId)
+            )
+          )
+          .limit(1);
+
+        // newOwner must exist in member table => accepted member (not pending invite)
+        if (!newOwner) {
+          throw new Error("NEW_OWNER_NOT_ACCEPTED_MEMBER");
+        }
+
+        if (newOwner.id === currentMember.id) {
+          throw new Error("NEW_OWNER_SAME_AS_CURRENT");
+        }
+
+        await tx
+          .update(member)
+          .set({ role: "owner" })
+          .where(eq(member.id, newOwnerMemberId));
+      }
+
+      await tx.delete(member).where(eq(member.id, currentMember.id));
+
+      if (session.session?.activeOrganizationId === organizationId) {
+        await tx
+          .update(sessions)
+          .set({ activeOrganizationId: null })
+          .where(eq(sessions.token, sessionToken));
+      }
+    });
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    if (message === "NOT_MEMBER") {
+      return NextResponse.json(
+        { error: "You are not a member of this organization" },
+        { status: 403 }
+      );
+    }
+    if (message === "NEW_OWNER_REQUIRED") {
+      return NextResponse.json(
+        {
+          error:
+            "You must assign a new owner before leaving. Provide newOwnerMemberId.",
+        },
+        { status: 400 }
+      );
+    }
+    if (message === "NEW_OWNER_NOT_ACCEPTED_MEMBER") {
+      return NextResponse.json(
+        {
+          error:
+            "Selected user is not an accepted member of this organization. Only members who have accepted their invitation can be assigned as owner.",
+        },
+        { status: 400 }
+      );
+    }
+    if (message === "NEW_OWNER_SAME_AS_CURRENT") {
+      return NextResponse.json(
+        { error: "Cannot assign yourself as the new owner" },
+        { status: 400 }
+      );
+    }
+    console.error("Leave organization failed:", err);
+    return NextResponse.json(
+      { error: "Failed to leave organization" },
+      { status: 500 }
+    );
+  }
+}

--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -870,29 +870,28 @@ export function ManageOrgsModal({
       return;
     }
 
-    const { error } = await authClient.organization.leave({
-      organizationId: managedOrg.id,
-    });
+    try {
+      await api.organization.leave(managedOrg.id, {});
 
-    if (error) {
-      toast.error(error.message || "Failed to leave organization");
-      return;
-    }
+      toast.success(`Left ${managedOrg.name}`);
+      setShowLeaveDialog(false);
+      setShowAssignOwnerDialog(false);
+      setManagedOrgId(null);
 
-    toast.success(`Left ${managedOrg.name}`);
-    setShowLeaveDialog(false);
-    setShowAssignOwnerDialog(false);
-    setManagedOrgId(null);
-
-    if (isManagedOrgActive) {
-      const otherOrg = organizations.find((org) => org.id !== managedOrg.id);
-      if (otherOrg) {
-        await switchOrganization(otherOrg.id);
+      if (isManagedOrgActive) {
+        const otherOrg = organizations.find((org) => org.id !== managedOrg.id);
+        if (otherOrg) {
+          await switchOrganization(otherOrg.id);
+        }
       }
-    }
 
-    refetchOrganizations();
-    router.refresh();
+      refetchOrganizations();
+      router.refresh();
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : "Failed to leave organization";
+      toast.error(message);
+    }
   }, [
     managedOrg,
     isManagedOrgActive,

--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -865,7 +865,7 @@ export function ManageOrgsModal({
     }
   };
 
-  const performLeaveOrg = useCallback(async () => {
+  const handleLeaveOrg = useCallback(async () => {
     if (!managedOrg) {
       return;
     }
@@ -901,10 +901,6 @@ export function ManageOrgsModal({
     switchOrganization,
     router,
   ]);
-
-  const handleLeaveOrg = useCallback(async () => {
-    await performLeaveOrg();
-  }, [performLeaveOrg]);
 
   const handleLeaveClick = useCallback(() => {
     if (!isOwner) {

--- a/keeperhub/components/organization/manage-orgs-modal.tsx
+++ b/keeperhub/components/organization/manage-orgs-modal.tsx
@@ -55,6 +55,7 @@ import {
   useOrganizations,
 } from "@/keeperhub/lib/hooks/use-organization";
 import { refetchOrganizations } from "@/keeperhub/lib/refetch-organizations";
+import type { MemberRole } from "@/keeperhub/lib/types/organization";
 import { ApiError, api } from "@/lib/api-client";
 import { authClient } from "@/lib/auth-client";
 
@@ -72,8 +73,6 @@ function getStatusBadgeClasses(status: string): string {
       return "bg-muted text-muted-foreground";
   }
 }
-
-type Role = "member" | "admin" | "owner";
 
 // Helper to check invitation status before cancelling
 type InvitationCheckResult = {
@@ -209,7 +208,7 @@ type MembersListContentProps = {
     status: string;
   }[];
   canInvite: boolean;
-  currentUserRole?: Role;
+  currentUserRole?: MemberRole;
   cancellingInvite: string | null;
   onCancelInvitation: (invitationId: string) => void;
   removingMember: string | null;
@@ -423,7 +422,7 @@ export function ManageOrgsModal({
 
   // Invite state
   const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<Role>("member");
+  const [inviteRole, setInviteRole] = useState<MemberRole>("member");
   const [inviteLoading, setInviteLoading] = useState(false);
   const [inviteId, setInviteId] = useState<string | null>(null);
 
@@ -474,7 +473,7 @@ export function ManageOrgsModal({
 
   // Compute user's role in the managed org from fetched members
   const currentUserMember = members.find((m) => m.userId === session?.user?.id);
-  const managedOrgRole = currentUserMember?.role as Role | undefined;
+  const managedOrgRole = currentUserMember?.role as MemberRole | undefined;
   const isOwner = isManagedOrgActive
     ? isActiveOrgOwner
     : managedOrgRole === "owner";
@@ -1292,7 +1291,9 @@ export function ManageOrgsModal({
                             value={inviteEmail}
                           />
                           <Select
-                            onValueChange={(v) => setInviteRole(v as Role)}
+                            onValueChange={(v) =>
+                              setInviteRole(v as MemberRole)
+                            }
                             value={inviteRole}
                           >
                             <SelectTrigger className="w-[130px]">

--- a/keeperhub/lib/types/organization.ts
+++ b/keeperhub/lib/types/organization.ts
@@ -1,0 +1,5 @@
+/**
+ * Member role in an organization.
+ * Matches the `role` column in the `member` table.
+ */
+export type MemberRole = "member" | "admin" | "owner";

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -436,6 +436,13 @@ export const organizationApi = {
         body: JSON.stringify(data),
       }
     ),
+
+  /** Leave organization. When sole owner, pass newOwnerMemberId for atomic transfer + leave. */
+  leave: (organizationId: string, body: { newOwnerMemberId?: string }) =>
+    apiCall<{ success: true }>(`/api/organizations/${organizationId}/leave`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 };
 
 // Address Book API


### PR DESCRIPTION
# Summary

Owners can transfer ownership to another member and leave an organization without deleting it. Role changes are enforced by permission (admins cannot assign owner). Leaving as the sole owner requires selecting an accepted member as the new owner; that transfer and the leave are done in a single transactional API.

# Details

- **Role assignation in Manage Orgs:** Members list in the manage-orgs modal has a role dropdown (Member / Admin / Owner). Only owners can set another member to Owner; admins can set Member or Admin only. Admins cannot change an existing owner’s role (no dropdown on owner rows).
- **Leave as owner:** Owners see both “Leave Organization” and “Delete Organization.” If the owner is the only owner, Leave opens an “Assign new owner” dialog: they must pick an accepted member (from the current members list). If there are no other members, Leave is disabled with a tooltip; Delete remains available.
- **Validation (client and backend):** The chosen new owner must be an accepted member (in the `member` table). Client: dropdown is built only from `members` (listMembers); before submit we check the selected id is in that list. Backend: in the leave route we require the given `newOwnerMemberId` to exist in `member` for the org and return a clear error if not.
- **Transactional leave endpoint:** `POST /api/organizations/:organizationId/leave` with optional body `{ newOwnerMemberId }`. When the caller is the sole owner, `newOwnerMemberId` is required. In one DB transaction we: promote the selected member to owner, delete the caller’s membership, and clear `activeOrganizationId` on the session when applicable. This avoids partial failure (e.g. transfer succeeds but leave fails).
- **Invite as owner:** Owners can invite with role “Owner” from the invite dropdown in the same modal.
