### PR TITLE
KEEP-1391: Update MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,16 +1,21 @@
 {
   "mcpServers": {
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
     "keeperhub": {
       "command": "docker",
       "args": [
         "run",
         "-i",
         "--rm",
+        "--pull=always",
         "-e",
         "KEEPERHUB_API_KEY",
         "-e",
         "KEEPERHUB_API_URL=https://app.keeperhub.com",
-        "ghcr.io/techops-services/keeperhub-mcp"
+        "ghcr.io/techops-services/keeperhub-mcp:latest"
       ]
     },
     "terraform": {


### PR DESCRIPTION
## Jira
[KEEP-1391](https://techopsservices.atlassian.net/browse/KEEP-1391)

## Changes
- Add Atlassian MCP for Jira integration
- Ensure keeperhub-mcp always pulls latest image

[KEEP-1391]: https://techopsservices.atlassian.net/browse/KEEP-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ