### PR TITLE
fix(metrics): remove hashmod relabeling from db-metrics ServiceMonitor

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -89,15 +89,6 @@ serviceMonitors:
       path: /api/metrics/db
       interval: 30s
       scrapeTimeout: 10s
-      relabelings:
-        # Scrape only 1 of 2 pods for DB metrics (identical across pods)
-        - sourceLabels: [__address__]
-          modulus: 2
-          targetLabel: __tmp_hash
-          action: hashmod
-        - sourceLabels: [__tmp_hash]
-          regex: "0"
-          action: keep
 
 resources:
   limits:


### PR DESCRIPTION
Checked all possible solutions to keep /api/metrics/db single-scrape. 
Hashmod can’t guarantee it because pod IPs change on every rollout, so there's alway a chance get all targets dropped. Another way is switching the workload to a StatefulSet would give a stable keeperhub-prod-0 pod, but that’s a Helm change against the intuitive. 
Setting up a dedicated one-replica Deployment Service for DB metrics would also work but feels like overkill. 

The most practical choice at this stage is to delete the relabel and scrape both pods. 
The dashboards panel and alerts removed duplicates with max/sum.
The gauges are low-cardinality metrics so no big impact on grafana storage.
also high availability achieved during rollouts to avoid interruption.