### PR TITLE
fix: Keep-1388 - Get database node working

### DIFF
--- a/app/api/integrations/[integrationId]/test/route.ts
+++ b/app/api/integrations/[integrationId]/test/route.ts
@@ -1,78 +1,18 @@
 import { NextResponse } from "next/server";
-import postgres from "postgres";
 // start custom keeperhub code //
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
-import {
-  buildDatabaseUrlFromConfig,
-  getDatabaseErrorMessage,
-  getPostgresConnectionOptions,
-} from "@/lib/db/connection-utils";
 import { getIntegration as getIntegrationFromDb } from "@/lib/db/integrations";
-import type { IntegrationType } from "@/lib/types/integration";
-import {
-  getCredentialMapping,
-  getIntegration as getPluginFromRegistry,
-} from "@/plugins";
+import { handleDatabaseTest, handlePluginTest } from "@/lib/db/test-connection";
+
 // end keeperhub code //
 
-export type TestConnectionResult = {
-  status: "success" | "error";
-  message: string;
-};
-
-async function handleDatabaseTest(
-  config: Record<string, unknown>
-): Promise<NextResponse> {
-  const url = buildDatabaseUrlFromConfig(
-    config as Parameters<typeof buildDatabaseUrlFromConfig>[0]
-  );
-  if (!url) {
-    return NextResponse.json({
-      status: "error",
-      message:
-        "Provide a connection string or connection details (host, username, password, database).",
-    });
-  }
-  const sslMode =
-    typeof config.sslMode === "string" ? config.sslMode : undefined;
-  const result = await testDatabaseConnection(url, sslMode);
-  return NextResponse.json(result);
-}
-
-async function handlePluginTest(
-  integrationType: string,
-  config: Record<string, unknown>
-): Promise<NextResponse> {
-  const plugin = getPluginFromRegistry(integrationType as IntegrationType);
-  if (!plugin) {
-    return NextResponse.json(
-      { error: "Invalid integration type" },
-      { status: 400 }
-    );
-  }
-  if (!plugin.testConfig) {
-    return NextResponse.json(
-      { error: "Integration does not support testing" },
-      { status: 400 }
-    );
-  }
-  const credentials = getCredentialMapping(plugin, config);
-  const testFn = await plugin.testConfig.getTestFunction();
-  const testResult = await testFn(credentials);
-  const result: TestConnectionResult = {
-    status: testResult.success ? "success" : "error",
-    message: testResult.success
-      ? "Connection successful"
-      : testResult.error || "Connection failed",
-  };
-  return NextResponse.json(result);
-}
+export type { TestConnectionResult } from "@/lib/db/test-connection";
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ integrationId: string }> }
-) {
+): Promise<NextResponse> {
   try {
     const session = await auth.api.getSession({
       headers: request.headers,
@@ -84,7 +24,7 @@ export async function POST(
 
     // start custom keeperhub code //
     const orgContext = await getOrgContext();
-    const organizationId = orgContext.organization?.id || null;
+    const organizationId = orgContext.organization?.id ?? null;
     // end keeperhub code //
 
     const { integrationId } = await params;
@@ -112,57 +52,21 @@ export async function POST(
     }
 
     if (integration.type === "database") {
-      return handleDatabaseTest(integration.config);
+      const result = await handleDatabaseTest(integration.config);
+      return NextResponse.json(result);
     }
 
-    return handlePluginTest(integration.type, integration.config);
+    const result = await handlePluginTest(integration.type, integration.config);
+    if (
+      result.message === "Invalid integration type" ||
+      result.message === "Integration does not support testing"
+    ) {
+      return NextResponse.json({ error: result.message }, { status: 400 });
+    }
+    return NextResponse.json(result);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to test connection";
     return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
-
-async function testDatabaseConnection(
-  databaseUrl?: string,
-  sslMode?: string
-): Promise<TestConnectionResult> {
-  let connection: postgres.Sql | null = null;
-
-  try {
-    if (!databaseUrl) {
-      return {
-        status: "error",
-        message: "Connection failed",
-      };
-    }
-
-    const { normalizedUrl, ssl } = getPostgresConnectionOptions(
-      databaseUrl,
-      sslMode
-    );
-
-    connection = postgres(normalizedUrl, {
-      max: 1,
-      idle_timeout: 5,
-      connect_timeout: 5,
-      ssl,
-    });
-
-    await connection`SELECT 1`;
-
-    return {
-      status: "success",
-      message: "Connection successful",
-    };
-  } catch (error) {
-    return {
-      status: "error",
-      message: getDatabaseErrorMessage(error),
-    };
-  } finally {
-    if (connection) {
-      await connection.end();
-    }
   }
 }

--- a/app/api/integrations/test/route.ts
+++ b/app/api/integrations/test/route.ts
@@ -1,86 +1,23 @@
 import { NextResponse } from "next/server";
-import postgres from "postgres";
 import { auth } from "@/lib/auth";
-import {
-  buildDatabaseUrlFromConfig,
-  getDatabaseErrorMessage,
-  getPostgresConnectionOptions,
-} from "@/lib/db/connection-utils";
+import { handleDatabaseTest, handlePluginTest } from "@/lib/db/test-connection";
 import type {
   IntegrationConfig,
   IntegrationType,
 } from "@/lib/types/integration";
-import {
-  getCredentialMapping,
-  getIntegration as getPluginFromRegistry,
-} from "@/plugins";
+
+export type { TestConnectionResult } from "@/lib/db/test-connection";
 
 export type TestConnectionRequest = {
   type: IntegrationType;
   config: IntegrationConfig;
 };
 
-export type TestConnectionResult = {
-  status: "success" | "error";
-  message: string;
-};
-
-async function handleDatabaseTest(
-  config: IntegrationConfig
-): Promise<NextResponse<TestConnectionResult>> {
-  const url = buildDatabaseUrlFromConfig(config);
-  if (!url) {
-    return NextResponse.json(
-      {
-        status: "error",
-        message:
-          "Provide a connection string or connection details (host, username, password, database).",
-      },
-      { status: 200 }
-    );
-  }
-  const sslMode =
-    typeof config.sslMode === "string" ? config.sslMode : undefined;
-  const result = await testDatabaseConnection(url, sslMode);
-  return NextResponse.json(result);
-}
-
-async function handlePluginTest(
-  type: IntegrationType,
-  config: IntegrationConfig
-): Promise<NextResponse<TestConnectionResult | { error: string }>> {
-  const plugin = getPluginFromRegistry(type);
-
-  if (!plugin) {
-    return NextResponse.json(
-      { error: "Invalid integration type" },
-      { status: 400 }
-    );
-  }
-  if (!plugin.testConfig) {
-    return NextResponse.json(
-      { error: "Integration does not support testing" },
-      { status: 400 }
-    );
-  }
-
-  const credentials = getCredentialMapping(plugin, config);
-  const testFn = await plugin.testConfig.getTestFunction();
-  const testResult = await testFn(credentials);
-  const result: TestConnectionResult = {
-    status: testResult.success ? "success" : "error",
-    message: testResult.success
-      ? "Connection successful"
-      : testResult.error || "Connection failed",
-  };
-  return NextResponse.json(result);
-}
-
 /**
  * POST /api/integrations/test
  * Test connection credentials without saving
  */
-export async function POST(request: Request) {
+export async function POST(request: Request): Promise<NextResponse> {
   try {
     const session = await auth.api.getSession({
       headers: request.headers,
@@ -100,50 +37,21 @@ export async function POST(request: Request) {
     }
 
     if (body.type === "database") {
-      return handleDatabaseTest(body.config);
+      const result = await handleDatabaseTest(body.config);
+      return NextResponse.json(result);
     }
 
-    return handlePluginTest(body.type, body.config);
+    const result = await handlePluginTest(body.type, body.config);
+    if (
+      result.message === "Invalid integration type" ||
+      result.message === "Integration does not support testing"
+    ) {
+      return NextResponse.json({ error: result.message }, { status: 400 });
+    }
+    return NextResponse.json(result);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to test connection";
     return NextResponse.json({ status: "error", message }, { status: 500 });
-  }
-}
-
-async function testDatabaseConnection(
-  databaseUrl: string,
-  sslMode?: string
-): Promise<TestConnectionResult> {
-  let connection: postgres.Sql | null = null;
-
-  try {
-    const { normalizedUrl, ssl } = getPostgresConnectionOptions(
-      databaseUrl,
-      sslMode
-    );
-
-    connection = postgres(normalizedUrl, {
-      max: 1,
-      idle_timeout: 5,
-      connect_timeout: 5,
-      ssl,
-    });
-
-    await connection`SELECT 1`;
-
-    return {
-      status: "success",
-      message: "Connection successful",
-    };
-  } catch (error) {
-    return {
-      status: "error",
-      message: getDatabaseErrorMessage(error),
-    };
-  } finally {
-    if (connection) {
-      await connection.end();
-    }
   }
 }

--- a/app/api/integrations/test/route.ts
+++ b/app/api/integrations/test/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import postgres from "postgres";
 import { auth } from "@/lib/auth";
+import {
+  buildDatabaseUrlFromConfig,
+  getDatabaseErrorMessage,
+  getPostgresConnectionOptions,
+} from "@/lib/db/connection-utils";
 import type {
   IntegrationConfig,
   IntegrationType,
@@ -19,6 +24,57 @@ export type TestConnectionResult = {
   status: "success" | "error";
   message: string;
 };
+
+async function handleDatabaseTest(
+  config: IntegrationConfig
+): Promise<NextResponse<TestConnectionResult>> {
+  const url = buildDatabaseUrlFromConfig(config);
+  if (!url) {
+    return NextResponse.json(
+      {
+        status: "error",
+        message:
+          "Provide a connection string or connection details (host, username, password, database).",
+      },
+      { status: 200 }
+    );
+  }
+  const sslMode =
+    typeof config.sslMode === "string" ? config.sslMode : undefined;
+  const result = await testDatabaseConnection(url, sslMode);
+  return NextResponse.json(result);
+}
+
+async function handlePluginTest(
+  type: IntegrationType,
+  config: IntegrationConfig
+): Promise<NextResponse<TestConnectionResult | { error: string }>> {
+  const plugin = getPluginFromRegistry(type);
+
+  if (!plugin) {
+    return NextResponse.json(
+      { error: "Invalid integration type" },
+      { status: 400 }
+    );
+  }
+  if (!plugin.testConfig) {
+    return NextResponse.json(
+      { error: "Integration does not support testing" },
+      { status: 400 }
+    );
+  }
+
+  const credentials = getCredentialMapping(plugin, config);
+  const testFn = await plugin.testConfig.getTestFunction();
+  const testResult = await testFn(credentials);
+  const result: TestConnectionResult = {
+    status: testResult.success ? "success" : "error",
+    message: testResult.success
+      ? "Connection successful"
+      : testResult.error || "Connection failed",
+  };
+  return NextResponse.json(result);
+}
 
 /**
  * POST /api/integrations/test
@@ -44,76 +100,34 @@ export async function POST(request: Request) {
     }
 
     if (body.type === "database") {
-      const url = body.config.url;
-      if (typeof url !== "string") {
-        return NextResponse.json(
-          { error: "Database URL must be a string" },
-          { status: 400 }
-        );
-      }
-      const result = await testDatabaseConnection(url);
-      return NextResponse.json(result);
+      return handleDatabaseTest(body.config);
     }
 
-    const plugin = getPluginFromRegistry(body.type);
-
-    if (!plugin) {
-      return NextResponse.json(
-        { error: "Invalid integration type" },
-        { status: 400 }
-      );
-    }
-
-    if (!plugin.testConfig) {
-      return NextResponse.json(
-        { error: "Integration does not support testing" },
-        { status: 400 }
-      );
-    }
-
-    const credentials = getCredentialMapping(plugin, body.config);
-
-    const testFn = await plugin.testConfig.getTestFunction();
-    const testResult = await testFn(credentials);
-
-    const result: TestConnectionResult = {
-      status: testResult.success ? "success" : "error",
-      message: testResult.success
-        ? "Connection successful"
-        : testResult.error || "Connection failed",
-    };
-
-    return NextResponse.json(result);
+    return handlePluginTest(body.type, body.config);
   } catch (error) {
-    console.error("Failed to test connection:", error);
-    return NextResponse.json(
-      {
-        status: "error",
-        message:
-          error instanceof Error ? error.message : "Failed to test connection",
-      },
-      { status: 500 }
-    );
+    const message =
+      error instanceof Error ? error.message : "Failed to test connection";
+    return NextResponse.json({ status: "error", message }, { status: 500 });
   }
 }
 
 async function testDatabaseConnection(
-  databaseUrl?: string
+  databaseUrl: string,
+  sslMode?: string
 ): Promise<TestConnectionResult> {
   let connection: postgres.Sql | null = null;
 
   try {
-    if (!databaseUrl) {
-      return {
-        status: "error",
-        message: "Connection failed",
-      };
-    }
+    const { normalizedUrl, ssl } = getPostgresConnectionOptions(
+      databaseUrl,
+      sslMode
+    );
 
-    connection = postgres(databaseUrl, {
+    connection = postgres(normalizedUrl, {
       max: 1,
       idle_timeout: 5,
       connect_timeout: 5,
+      ssl,
     });
 
     await connection`SELECT 1`;
@@ -122,10 +136,10 @@ async function testDatabaseConnection(
       status: "success",
       message: "Connection successful",
     };
-  } catch {
+  } catch (error) {
     return {
       status: "error",
-      message: "Connection failed",
+      message: getDatabaseErrorMessage(error),
     };
   } finally {
     if (connection) {

--- a/components/overlays/add-connection-overlay.tsx
+++ b/components/overlays/add-connection-overlay.tsx
@@ -351,13 +351,17 @@ export function ConfigureConnectionOverlay({
     }
   };
 
-  const hasValidDatabaseConfig = (config: Record<string, string>) => {
-    const { url, host, username, password, database } = config;
+  const hasValidDatabaseConfig = (cfg: Record<string, string>) => {
+    const { url, host, username, password, database } = cfg;
     const hasUrl = typeof url === "string" && url.trim() !== "";
     const hasParts =
-      typeof host === "string" && host.trim() !== "" &&
-      typeof username === "string" && username.trim() !== "" &&
-      typeof password === "string" && typeof database === "string" && database.trim() !== "";
+      typeof host === "string" &&
+      host.trim() !== "" &&
+      typeof username === "string" &&
+      username.trim() !== "" &&
+      typeof password === "string" &&
+      typeof database === "string" &&
+      database.trim() !== "";
     return hasUrl || hasParts;
   };
 

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -5,64 +5,216 @@
  */
 
 /**
- * Regex pattern for parsing PostgreSQL connection strings
- * Format: postgres[ql]://username:password@host:port/database
+ * Protocol prefix for PostgreSQL connection strings
  */
-const CONNECTION_STRING_REGEX = /^(postgres(?:ql)?:\/\/)([^:]+):([^@]+)@(.+)$/;
+const CONNECTION_STRING_PREFIX = /^(postgres(?:ql)?:\/\/)/;
 
-/**
- * Ensures that the database connection string has properly URL-encoded credentials.
- *
- * Passwords with special characters like +, /, = need to be percent-encoded when
- * used in connection strings. This function parses the connection string and
- * re-encodes the password component if needed.
- *
- * @param connectionString - PostgreSQL connection string
- * @returns Connection string with properly encoded credentials
- *
- * @example
- * ```ts
- * const url = "postgresql://user:pass+word@host:5432/db";
- * const safe = ensureEncodedConnectionString(url);
- * // Returns: "postgresql://user:pass%2Bword@host:5432/db"
- * ```
- */
-export function ensureEncodedConnectionString(
-  connectionString: string
-): string {
+function safeDecodeUriComponent(s: string): string {
   try {
-    // Try to parse as-is first (it might already be valid)
-    new URL(connectionString);
-    return connectionString;
+    return decodeURIComponent(s);
   } catch {
-    // If parsing fails, it's likely due to special characters in the password
-    // Parse and re-encode the connection string manually
-    const match = connectionString.match(CONNECTION_STRING_REGEX);
-
-    if (!match) {
-      // Can't parse the format, return as-is and let the caller handle the error
-      return connectionString;
-    }
-
-    const [, protocol, username, password, hostAndDb] = match;
-
-    // URL-encode the password component
-    const encodedPassword = encodeURIComponent(password);
-
-    // Reconstruct the connection string
-    return `${protocol}${username}:${encodedPassword}@${hostAndDb}`;
+    return s;
   }
 }
 
 /**
- * Gets the database connection string from environment with proper encoding.
+ * Ensures that the database connection string has properly URL-encoded credentials.
+ * Uses the last @ as the separator between userinfo and host so that passwords
+ * containing @ or : are parsed correctly. Decodes then re-encodes to avoid
+ * double-encoding when the URL already contains encoded credentials.
  *
- * @param fallback - Fallback connection string if DATABASE_URL is not set
+ * @param connectionString - PostgreSQL connection string
+ * @returns Connection string with properly encoded credentials
+ */
+export function ensureEncodedConnectionString(
+  connectionString: string
+): string {
+  const prefixMatch = connectionString.match(CONNECTION_STRING_PREFIX);
+  if (!prefixMatch) {
+    return connectionString;
+  }
+  const protocol = prefixMatch[1];
+  const rest = connectionString.slice(protocol.length);
+  const lastAt = rest.lastIndexOf("@");
+  if (lastAt === -1) {
+    return connectionString;
+  }
+  const userinfo = rest.slice(0, lastAt);
+  const hostAndDb = rest.slice(lastAt + 1);
+  const firstColon = userinfo.indexOf(":");
+  const rawUsername =
+    firstColon === -1 ? userinfo : userinfo.slice(0, firstColon);
+  const rawPassword = firstColon === -1 ? "" : userinfo.slice(firstColon + 1);
+  const username = safeDecodeUriComponent(rawUsername);
+  const password = safeDecodeUriComponent(rawPassword);
+  return `${protocol}${encodeURIComponent(username)}:${encodeURIComponent(password)}@${hostAndDb}`;
+}
+
+/**
+ * Returns a safe, user-facing message for database connection errors.
+ * Avoids leaking credentials or internal details.
+ */
+export function getDatabaseErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return "Unknown database error";
+  }
+
+  const errorMessage = error.message;
+
+  if (errorMessage.includes("ECONNREFUSED")) {
+    return "Connection refused. Please check your database URL and ensure the database is running.";
+  }
+  if (errorMessage.includes("ENOTFOUND")) {
+    return "Database host not found. Please check your database URL.";
+  }
+  if (errorMessage.includes("ENETUNREACH")) {
+    return "Network unreachable. The database host may resolve to an IPv6 address; try using an IPv4 address or a hostname that resolves to IPv4.";
+  }
+  if (errorMessage.includes("authentication failed")) {
+    return "Authentication failed. Please check your database credentials.";
+  }
+  if (errorMessage.includes("does not exist")) {
+    return `Database error: ${errorMessage}`;
+  }
+
+  return errorMessage;
+}
+
+export type DatabaseConnectionConfig = {
+  url?: string;
+  host?: string;
+  port?: string;
+  username?: string;
+  password?: string;
+  database?: string;
+};
+
+/**
+ * Builds a single PostgreSQL connection URL from integration config.
+ * Prefers building from separate fields (host, username, password, database) when all are present; otherwise uses config.url.
+ *
+ * @param config - Integration config with optional url or host/port/username/password/database
+ * @returns Connection string or null if config is insufficient
+ */
+export function buildDatabaseUrlFromConfig(
+  config: DatabaseConnectionConfig
+): string | null {
+  const hasParts =
+    typeof config.host === "string" &&
+    config.host.trim() !== "" &&
+    typeof config.username === "string" &&
+    config.username.trim() !== "" &&
+    typeof config.password === "string" &&
+    typeof config.database === "string" &&
+    config.database.trim() !== "";
+
+  if (hasParts) {
+    const host = config.host?.trim() ?? "";
+    const port = (config.port?.trim() || "5432").trim() || "5432";
+    const username = config.username?.trim() ?? "";
+    const password = config.password ?? "";
+    const database = config.database?.trim() ?? "";
+    const encoded = `${encodeURIComponent(username)}:${encodeURIComponent(password)}`;
+    return `postgresql://${encoded}@${host}:${port}/${database}`;
+  }
+
+  if (typeof config.url === "string" && config.url.trim() !== "") {
+    return ensureEncodedConnectionString(config.url.trim());
+  }
+
+  return null;
+}
+
+/**
+ * Gets the database connection string from environment with proper encoding.
+ * Production should set DATABASE_URL; fallback is for development only.
+ *
+ * @param fallback - Optional fallback when DATABASE_URL is not set (e.g. dev)
  * @returns Properly encoded connection string
  */
-export function getDatabaseUrl(
-  fallback = "postgres://localhost:5432/workflow"
-): string {
-  const connectionString = process.env.DATABASE_URL || fallback;
+export function getDatabaseUrl(fallback?: string): string {
+  const connectionString =
+    (process.env.DATABASE_URL || fallback) ??
+    "postgres://localhost:5432/workflow";
   return ensureEncodedConnectionString(connectionString);
+}
+
+export type PostgresSslOption =
+  | "require"
+  | "prefer"
+  | "allow"
+  | "verify-full"
+  | false;
+
+function sslModeToOption(mode: string): PostgresSslOption {
+  const m = mode.toLowerCase();
+  if (m === "disable" || m === "false") {
+    return false;
+  }
+  if (m === "require") {
+    return "require";
+  }
+  if (m === "prefer") {
+    return "prefer";
+  }
+  if (m === "allow") {
+    return "allow";
+  }
+  if (m === "verify-full") {
+    return "verify-full";
+  }
+  return false;
+}
+
+/**
+ * Returns normalized connection URL and ssl option for postgres.js client.
+ * Use for Database Query step and test connection API.
+ *
+ * @param url - Raw PostgreSQL connection string (postgres:// or postgresql://)
+ * @param sslMode - User choice: 'require' | 'prefer' | 'allow' | 'verify-full' | 'disable' | 'auto' (default). When 'auto', uses URL sslmode/ssl if present, else SSL for remote hosts.
+ */
+export function getPostgresConnectionOptions(
+  url: string,
+  sslMode?: string
+): { normalizedUrl: string; ssl: PostgresSslOption } {
+  const normalizedUrl = ensureEncodedConnectionString(url);
+
+  if (
+    sslMode === "require" ||
+    sslMode === "prefer" ||
+    sslMode === "allow" ||
+    sslMode === "verify-full"
+  ) {
+    return { normalizedUrl, ssl: sslModeToOption(sslMode) };
+  }
+  if (sslMode === "disable") {
+    return { normalizedUrl, ssl: false };
+  }
+
+  // 'auto' or missing: respect sslmode/ssl from URL if present
+  try {
+    const parsed = new URL(normalizedUrl);
+    const urlSsl =
+      parsed.searchParams.get("sslmode") ?? parsed.searchParams.get("ssl");
+    if (urlSsl !== null && urlSsl !== "") {
+      return { normalizedUrl, ssl: sslModeToOption(urlSsl) };
+    }
+  } catch {
+    // fall through to hostname heuristic
+  }
+
+  // No URL ssl param: enable SSL for remote hosts (production); disable for local/dev hostnames
+  let hostname: string;
+  try {
+    const parsed = new URL(normalizedUrl);
+    hostname = parsed.hostname ?? "";
+  } catch {
+    hostname = "";
+  }
+  const isLocalDev =
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "";
+  return {
+    normalizedUrl,
+    ssl: isLocalDev ? false : "require",
+  };
 }

--- a/lib/db/test-connection.ts
+++ b/lib/db/test-connection.ts
@@ -1,0 +1,92 @@
+import postgres from "postgres";
+import {
+  buildDatabaseUrlFromConfig,
+  type DatabaseConnectionConfig,
+  getDatabaseErrorMessage,
+  getPostgresConnectionOptions,
+} from "@/lib/db/connection-utils";
+import type { IntegrationType } from "@/lib/types/integration";
+import {
+  getCredentialMapping,
+  getIntegration as getPluginFromRegistry,
+} from "@/plugins";
+
+export type TestConnectionResult = {
+  status: "success" | "error";
+  message: string;
+};
+
+export async function testDatabaseConnection(
+  databaseUrl: string,
+  sslMode?: string
+): Promise<TestConnectionResult> {
+  let connection: postgres.Sql | null = null;
+
+  try {
+    const { normalizedUrl, ssl } = getPostgresConnectionOptions(
+      databaseUrl,
+      sslMode
+    );
+
+    connection = postgres(normalizedUrl, {
+      max: 1,
+      idle_timeout: 5,
+      connect_timeout: 5,
+      ssl,
+    });
+
+    await connection`SELECT 1`;
+
+    return {
+      status: "success",
+      message: "Connection successful",
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      message: getDatabaseErrorMessage(error),
+    };
+  } finally {
+    if (connection) {
+      await connection.end();
+    }
+  }
+}
+
+export async function handleDatabaseTest(
+  config: Record<string, unknown>
+): Promise<TestConnectionResult> {
+  const url = buildDatabaseUrlFromConfig(config as DatabaseConnectionConfig);
+  if (!url) {
+    return {
+      status: "error",
+      message:
+        "Provide a connection string or connection details (host, username, password, database).",
+    };
+  }
+  const sslMode =
+    typeof config.sslMode === "string" ? config.sslMode : undefined;
+  return await testDatabaseConnection(url, sslMode);
+}
+
+export async function handlePluginTest(
+  type: IntegrationType | string,
+  config: Record<string, unknown>
+): Promise<TestConnectionResult> {
+  const plugin = getPluginFromRegistry(type as IntegrationType);
+  if (!plugin) {
+    return { status: "error", message: "Invalid integration type" };
+  }
+  if (!plugin.testConfig) {
+    return { status: "error", message: "Integration does not support testing" };
+  }
+  const credentials = getCredentialMapping(plugin, config);
+  const testFn = await plugin.testConfig.getTestFunction();
+  const testResult = await testFn(credentials);
+  return {
+    status: testResult.success ? "success" : "error",
+    message: testResult.success
+      ? "Connection successful"
+      : testResult.error || "Connection failed",
+  };
+}


### PR DESCRIPTION
# Summary

Refactor integration and database connection code: production-focused copy (no localhost in DB UI), clearer logic, and fewer race conditions. Removes console logging, adds guards against double-submit, stabilizes callbacks, and ensures DB client cleanup.

# Details

- **Database (production focus):** Connection utils JSDoc and add/edit overlays now say “remote hosts” instead of “non-localhost.” Host placeholder set to `e.g. db.example.com or your-provider.supabase.co`; SSL option label and help text updated accordingly.
- **Cleanup:** Removed `console.log` from credential-fetcher and `console.error` from integration test API routes. Fixed keeperhub comment block in action-config; anonymous-user fetch uses a `cancelled` flag in effect cleanup to avoid setState after unmount.
- **Race conditions:** Add/edit overlays guard `handleSave`, `handleTest`, and (edit) `handleDelete` with early return when already in progress; delete uses `finally` to clear loading state. Integration-selector wraps `handleNewIntegrationCreated` and `handleIntegrationChange` in `useCallback` with stable deps. Database-query step closes the Postgres client in a `finally` block.
- **Lint:** Early returns use block form; unused catch param renamed to `_error`; “save anyway” and test flow extracted into helpers to satisfy complexity rules; `runConnectionTest` returns a promise without `async`.