### PR TITLE
feat: add automated release and docs sync GHA workflows

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,290 @@
+name: Docs Sync
+
+on:
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+    branches: [prod]
+
+  workflow_dispatch:
+    inputs:
+      days_back:
+        description: 'Number of days to look back for code changes'
+        required: false
+        default: '30'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: docs-sync
+  cancel-in-progress: true
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 75
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect changes from release
+        if: github.event_name == 'workflow_run'
+        id: release_changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggered by Release workflow completion."
+
+          # Get the two most recent release tags
+          RELEASE_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          PREV_TAG=$(gh release list --limit 2 --json tagName --jq '.[1].tagName')
+
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "No release tag found. Skipping."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Latest release: $RELEASE_TAG"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found. Scanning all files in release tag."
+            CHANGED_FILES=$(git ls-tree -r --name-only "$RELEASE_TAG" -- \
+              'keeperhub/plugins/' \
+              'keeperhub/api/' \
+              'keeperhub/lib/' \
+              'lib/' \
+              'plugins/' \
+              'app/api/' \
+              | grep -E '\.(ts|tsx|js|jsx)$' \
+              | grep -vE '\.(test|spec|stories)\.' \
+              | head -100 \
+              || true)
+          else
+            echo "Previous release: $PREV_TAG"
+            CHANGED_FILES=$(git diff --name-only "$PREV_TAG".."$RELEASE_TAG" -- \
+              'keeperhub/plugins/' \
+              'keeperhub/api/' \
+              'keeperhub/lib/' \
+              'lib/' \
+              'plugins/' \
+              'app/api/' \
+              | grep -E '\.(ts|tsx|js|jsx)$' \
+              | grep -vE '\.(test|spec|stories)\.' \
+              | head -100 \
+              || true)
+          fi
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No relevant code changes detected between tags."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
+            echo "Found $FILE_COUNT changed files."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+            # Save file list to output using heredoc
+            echo "changed_files<<CHANGED_FILES_EOF" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+            echo "CHANGED_FILES_EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect changes from manual trigger
+        if: github.event_name == 'workflow_dispatch'
+        id: manual_changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DAYS_BACK="${{ github.event.inputs.days_back }}"
+
+          # Validate that days_back is a positive integer
+          if ! echo "$DAYS_BACK" | grep -qE '^[0-9]+$' || [ "$DAYS_BACK" -lt 1 ] || [ "$DAYS_BACK" -gt 365 ]; then
+            echo "Invalid days_back value: $DAYS_BACK. Must be a number between 1 and 365."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Manual trigger: scanning changes from the last $DAYS_BACK days."
+
+          # Try to get the latest release tag for labeling
+          RELEASE_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "manual-sync")
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+          CHANGED_FILES=$(git log --since="${DAYS_BACK} days ago" --name-only --pretty=format: -- \
+            'keeperhub/plugins/' \
+            'keeperhub/api/' \
+            'keeperhub/lib/' \
+            'lib/' \
+            'plugins/' \
+            'app/api/' \
+            | sort -u \
+            | grep -E '\.(ts|tsx|js|jsx)$' \
+            | grep -vE '\.(test|spec|stories)\.' \
+            | head -100 \
+            || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No relevant code changes in the last $DAYS_BACK days."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
+            echo "Found $FILE_COUNT changed files."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+            echo "changed_files<<CHANGED_FILES_EOF" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+            echo "CHANGED_FILES_EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if no changes
+        if: >-
+          (github.event_name == 'workflow_run' && steps.release_changes.outputs.has_changes != 'true') ||
+          (github.event_name == 'workflow_dispatch' && steps.manual_changes.outputs.has_changes != 'true')
+        run: |
+          echo "No relevant code changes detected. Skipping docs sync."
+
+      - name: Set release tag
+        if: >-
+          (github.event_name == 'workflow_run' && steps.release_changes.outputs.has_changes == 'true') ||
+          (github.event_name == 'workflow_dispatch' && steps.manual_changes.outputs.has_changes == 'true')
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "release_tag=${{ steps.release_changes.outputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_tag=${{ steps.manual_changes.outputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude Code docs sync
+        if: steps.tag.outputs.release_tag != ''
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          base_branch: staging
+          branch_prefix: claude/docs-sync-
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            RELEASE TAG: ${{ steps.tag.outputs.release_tag }}
+
+            CHANGED FILES:
+            ${{ github.event_name == 'workflow_run' && steps.release_changes.outputs.changed_files || steps.manual_changes.outputs.changed_files }}
+
+            ---
+
+            You are a documentation maintenance agent for KeeperHub, a blockchain automation
+            platform. A new release has been published and the code files listed above have
+            changed. Your job is to ensure the documentation in `/docs/` stays accurate and
+            in sync with the codebase.
+
+            ## Documentation Infrastructure
+
+            - Documentation lives in the `/docs/` directory at the repository root.
+            - The docs site uses Nextra 4 (a Next.js-based docs framework). Content is plain
+              Markdown with YAML frontmatter.
+            - Navigation is controlled by `_meta.json` files in each directory. The root
+              `_meta.json` at `/docs/_meta.json` defines the top-level sections. Each
+              subdirectory has its own `_meta.json` for page ordering within that section.
+            - There are approximately 33 documentation pages organized across these sections:
+              intro, getting-started, keepers, workflows, keeper-runs, notifications,
+              wallet-management, users-teams-orgs, practices, api, FAQ.
+            - Two sections are hidden from navigation: `api` and `plans-features`.
+
+            ## Documentation Style Rules
+
+            Follow these rules strictly when editing or creating documentation:
+
+            - Every page starts with YAML frontmatter containing `title` and `description`.
+            - Use one `# H1` heading per page matching the frontmatter title.
+            - Use `## H2` for major sections, `### H3` for subsections.
+            - Write in a professional, instructive tone. Use second person ("you") for
+              instructions and third person for feature descriptions.
+            - Use short paragraphs, bullet lists, and tables. Use bold for emphasis and key
+              terms.
+            - Do NOT use emojis anywhere in the documentation. This is strictly enforced.
+            - Use code blocks for configuration examples, API responses, addresses, and code
+              snippets.
+            - File and directory naming convention is kebab-case.
+
+            ## Your Task
+
+            1. Read each changed file listed above to understand what was modified.
+               Focus on: API endpoint changes, plugin interface changes, configuration
+               changes, new features, removed features, changed function signatures.
+
+            2. For each meaningful change, search the `/docs/` directory for related
+               documentation pages. Check:
+               - Are code examples in the docs still correct?
+               - Are API signatures, types, and endpoints still accurate?
+               - Are plugin configuration options still complete and correct?
+               - Are instructions and procedures still valid?
+
+            3. Fix ONLY what is broken or inaccurate:
+               - Update incorrect code examples to match the current code.
+               - Fix wrong API signatures, types, and endpoint paths.
+               - Update outdated configuration examples.
+               - Add minimal documentation for significant new features that have absolutely
+                 no existing documentation coverage. Only do this for user-facing features.
+               - If a plugin gained new configuration options, add them to the relevant
+                 docs table or list.
+
+            4. Do NOT do any of the following:
+               - Do NOT rewrite working documentation for style or tone improvements.
+               - Do NOT add changelog or release notes entries.
+               - Do NOT reorganize existing documentation structure or navigation.
+               - Do NOT add sections about internal implementation details.
+               - Do NOT modify documentation that is already accurate.
+               - Do NOT create documentation for test utilities, internal helpers, or
+                 non-user-facing code.
+
+            5. If you create any new documentation pages:
+               - Use kebab-case filenames.
+               - Add the page to the appropriate `_meta.json` file.
+               - Include proper YAML frontmatter with title and description.
+               - Match the writing style and depth of existing pages in that section.
+
+            6. If after analyzing all changes you determine that no documentation updates
+               are needed (the docs are already accurate), report that finding and do not
+               create a PR. Simply state: "Documentation is up to date. No changes needed."
+
+            7. If you do make changes, commit them to the branch. The CI system will
+               automatically create a pull request from your commits. Use a commit message
+               format like: "docs: sync documentation with ${{ steps.tag.outputs.release_tag }}"
+               and include a summary of what was updated and why in the commit body.
+          claude_args: |
+            --model claude-sonnet-4-5-20250929
+            --max-turns 30
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*)"
+
+      - name: Notify Discord on completion
+        if: always() && steps.tag.outputs.release_tag != ''
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          RELEASE_TAG="${{ steps.tag.outputs.release_tag }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ "${{ steps.claude.outcome }}" = "success" ]; then
+            MESSAGE="**Docs Sync Completed** for \`$RELEASE_TAG\`\n\nClaude analyzed code changes and processed documentation updates.\nWorkflow run: $RUN_URL"
+          elif [ "${{ steps.claude.outcome }}" = "skipped" ]; then
+            MESSAGE="**Docs Sync Skipped** for \`$RELEASE_TAG\`\n\nNo relevant code changes detected.\nWorkflow run: $RUN_URL"
+          else
+            MESSAGE="**Docs Sync Failed** for \`$RELEASE_TAG\`\n\nPlease check the workflow logs: $RUN_URL"
+          fi
+
+          curl -s -H "Content-Type: application/json" \
+            -d "{\"username\": \"KeeperHub Docs Bot\", \"content\": \"$MESSAGE\"}" \
+            "$DISCORD_WEBHOOK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,309 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - prod
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get previous release tag
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tags found. This will be the first release."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "first_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Previous tag: $PREV_TAG"
+            echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+            echo "first_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Discover merged PRs since last release
+        id: discover_prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREV_TAG="${{ steps.prev_tag.outputs.tag }}"
+          FIRST_RELEASE="${{ steps.prev_tag.outputs.first_release }}"
+
+          if [ "$FIRST_RELEASE" = "true" ]; then
+            # No previous tag: get all merged PRs to prod
+            PR_JSON=$(gh pr list \
+              --state merged \
+              --base prod \
+              --json number,title,author,url,body \
+              --limit 200)
+          else
+            # Get the date of the previous tag commit
+            SINCE=$(git log -1 --format=%aI "$PREV_TAG")
+            echo "Finding PRs merged after: $SINCE"
+
+            PR_JSON=$(gh pr list \
+              --state merged \
+              --base prod \
+              --json number,title,author,url,mergedAt,body \
+              --limit 200 \
+              --jq "[.[] | select(.mergedAt > \"$SINCE\")]")
+          fi
+
+          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+          echo "Found $PR_COUNT merged PR(s) since last release."
+
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "has_prs=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_prs=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Save PR JSON for subsequent steps
+          echo "PR_JSON<<PRJSONEOF" >> "$GITHUB_ENV"
+          echo "$PR_JSON" >> "$GITHUB_ENV"
+          echo "PRJSONEOF" >> "$GITHUB_ENV"
+
+      - name: Skip release if no PRs found
+        if: steps.discover_prs.outputs.has_prs == 'false'
+        run: |
+          echo "No merged PRs found since last release. Skipping release creation."
+
+      - name: Determine version bump and classify PRs
+        if: steps.discover_prs.outputs.has_prs == 'true'
+        id: version
+        run: |
+          PREV_TAG="${{ steps.prev_tag.outputs.tag }}"
+          FIRST_RELEASE="${{ steps.prev_tag.outputs.first_release }}"
+
+          HAS_BREAKING=false
+          HAS_FEAT=false
+
+          BREAKING_PRS=""
+          FEAT_PRS=""
+          FIX_PRS=""
+          OTHER_PRS=""
+
+          # Process each PR
+          while IFS= read -r pr_line; do
+            NUMBER=$(echo "$pr_line" | jq -r '.number')
+            TITLE=$(echo "$pr_line" | jq -r '.title')
+            AUTHOR=$(echo "$pr_line" | jq -r '.author.login')
+            URL=$(echo "$pr_line" | jq -r '.url')
+            BODY=$(echo "$pr_line" | jq -r '.body // ""')
+
+            # Clean the title: remove leading/trailing whitespace
+            TITLE=$(printf '%s' "$TITLE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+            # Strip the prefix from the title for display
+            DISPLAY_TITLE=$(printf '%s' "$TITLE" | sed -E 's/^(feat|fix|bug|breaking|chore|docs|refactor|test|ci|build|perf|style)(\([^)]*\))?[!]?:[[:space:]]*//')
+
+            # If stripping produced empty string, use original title
+            if [ -z "$DISPLAY_TITLE" ]; then
+              DISPLAY_TITLE="$TITLE"
+            fi
+
+            # Build the entry line
+            ENTRY="- ${DISPLAY_TITLE} ([#${NUMBER}](${URL})) @${AUTHOR}"
+
+            # Classify by prefix
+            # Check for breaking changes: prefix "breaking:" or "!" before colon or BREAKING CHANGE in body
+            if printf '%s' "$TITLE" | grep -qiE "^breaking(\([^)]*\))?:"; then
+              HAS_BREAKING=true
+              BREAKING_PRS="${BREAKING_PRS}${ENTRY}"$'\n'
+            elif printf '%s' "$TITLE" | grep -qiE "^[a-z]+(\([^)]*\))?!:"; then
+              HAS_BREAKING=true
+              BREAKING_PRS="${BREAKING_PRS}${ENTRY}"$'\n'
+            elif printf '%s' "$BODY" | grep -q "BREAKING CHANGE"; then
+              HAS_BREAKING=true
+              BREAKING_PRS="${BREAKING_PRS}${ENTRY}"$'\n'
+            elif printf '%s' "$TITLE" | grep -qiE "^feat(\([^)]*\))?:"; then
+              HAS_FEAT=true
+              FEAT_PRS="${FEAT_PRS}${ENTRY}"$'\n'
+            elif printf '%s' "$TITLE" | grep -qiE "^(fix|bug)(\([^)]*\))?:"; then
+              FIX_PRS="${FIX_PRS}${ENTRY}"$'\n'
+            else
+              OTHER_PRS="${OTHER_PRS}${ENTRY}"$'\n'
+            fi
+          done < <(echo "$PR_JSON" | jq -c '.[]')
+
+          # Determine bump type
+          if [ "$HAS_BREAKING" = true ]; then
+            BUMP="major"
+          elif [ "$HAS_FEAT" = true ]; then
+            BUMP="minor"
+          else
+            BUMP="patch"
+          fi
+
+          echo "Version bump: $BUMP"
+
+          # Calculate new version
+          if [ "$FIRST_RELEASE" = "true" ]; then
+            # No previous tags: start at v0.1.0
+            NEW_TAG="v0.1.0"
+          else
+            VERSION="${PREV_TAG#v}"
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+            case "$BUMP" in
+              major)
+                MAJOR=$((MAJOR + 1))
+                MINOR=0
+                PATCH=0
+                ;;
+              minor)
+                MINOR=$((MINOR + 1))
+                PATCH=0
+                ;;
+              patch)
+                PATCH=$((PATCH + 1))
+                ;;
+            esac
+
+            NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          fi
+
+          echo "New tag: $NEW_TAG"
+
+          # Check if tag already exists
+          if git tag -l "$NEW_TAG" | grep -q "$NEW_TAG"; then
+            echo "Tag $NEW_TAG already exists. Aborting."
+            exit 1
+          fi
+
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+
+          # Build release notes
+          REPO_URL="https://github.com/${{ github.repository }}"
+          NOTES="## What's Changed"$'\n'
+
+          if [ -n "$BREAKING_PRS" ]; then
+            NOTES="${NOTES}"$'\n'"### Breaking Changes"$'\n'
+            NOTES="${NOTES}${BREAKING_PRS}"
+          fi
+
+          if [ -n "$FEAT_PRS" ]; then
+            NOTES="${NOTES}"$'\n'"### Features"$'\n'
+            NOTES="${NOTES}${FEAT_PRS}"
+          fi
+
+          if [ -n "$FIX_PRS" ]; then
+            NOTES="${NOTES}"$'\n'"### Bug Fixes"$'\n'
+            NOTES="${NOTES}${FIX_PRS}"
+          fi
+
+          if [ -n "$OTHER_PRS" ]; then
+            NOTES="${NOTES}"$'\n'"### Other Changes"$'\n'
+            NOTES="${NOTES}${OTHER_PRS}"
+          fi
+
+          if [ "$FIRST_RELEASE" = "true" ]; then
+            NOTES="${NOTES}"$'\n'"**Full Changelog**: ${REPO_URL}/commits/${NEW_TAG}"
+          else
+            NOTES="${NOTES}"$'\n'"**Full Changelog**: ${REPO_URL}/compare/${PREV_TAG}...${NEW_TAG}"
+          fi
+
+          # Save notes to a file for gh release create
+          echo "$NOTES" > /tmp/release-notes.md
+
+          echo "Release notes written to /tmp/release-notes.md"
+
+      - name: Create GitHub Release
+        if: steps.discover_prs.outputs.has_prs == 'true'
+        id: create_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          REPO_URL="https://github.com/${{ github.repository }}"
+
+          gh release create "$NEW_TAG" \
+            --title "$NEW_TAG" \
+            --notes-file /tmp/release-notes.md \
+            --target "${{ github.sha }}"
+
+          RELEASE_URL="${REPO_URL}/releases/tag/${NEW_TAG}"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          echo "Release created: $RELEASE_URL"
+
+      - name: Notify Discord
+        if: steps.discover_prs.outputs.has_prs == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          RELEASE_URL="${{ steps.create_release.outputs.release_url }}"
+          BUMP="${{ steps.version.outputs.bump }}"
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+          # Read release notes and truncate for Discord embed description limit (4096 chars).
+          NOTES=$(cat /tmp/release-notes.md)
+          MAX_DESC_LENGTH=3800
+          if [ ${#NOTES} -gt $MAX_DESC_LENGTH ]; then
+            NOTES="${NOTES:0:$MAX_DESC_LENGTH}"$'\n\n'"... [See full release notes](${RELEASE_URL})"
+          fi
+
+          # Build the Discord JSON payload using jq for safe JSON escaping.
+          # jq handles all special characters (quotes, newlines, backslashes) automatically.
+          jq -n \
+            --arg title "${NEW_TAG} Released" \
+            --arg url "$RELEASE_URL" \
+            --arg desc "$NOTES" \
+            --arg footer "KeeperHub Release | ${BUMP} bump" \
+            --arg ts "$TIMESTAMP" \
+            '{
+              username: "KeeperHub Release Bot",
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 5763719,
+                footer: { text: $footer },
+                timestamp: $ts
+              }]
+            }' > /tmp/discord-payload.json
+
+          # Send to Discord
+          HTTP_STATUS=$(curl -s -o /tmp/discord-response.txt -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/discord-payload.json \
+            "$DISCORD_WEBHOOK")
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "Discord notification sent successfully (HTTP $HTTP_STATUS)."
+          else
+            echo "Discord notification failed (HTTP $HTTP_STATUS)."
+            cat /tmp/discord-response.txt
+            echo ""
+            echo "Release was created successfully. Discord notification failure is non-blocking."
+          fi
+
+      - name: Notify Discord on release failure
+        if: failure() && steps.discover_prs.outputs.has_prs == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d "{\"username\": \"KeeperHub Release Bot\", \"content\": \"Release workflow failed. Please check the GitHub Actions logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            "$DISCORD_WEBHOOK"

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ tailwindcss-*.log
 # Claude lint output cache (read instead of re-running commands)
 .claude/lint-output.txt
 .claude/typecheck-output.txt
+
+.planning
+.prompts


### PR DESCRIPTION
## Summary

- **release.yml**: Automatically creates GitHub Releases on merge to `prod` with semantic versioning (v1.2.3), categorized PR notes (features/fixes/chores), and Discord notifications. Zero external action dependencies -- uses `gh` CLI + bash only.
- **docs-sync.yml**: Triggers after each release to detect code changes and sync documentation using `claude-code-action@v1`. Creates PRs targeting `staging` with doc updates. Also supports manual `workflow_dispatch`.
- Adds `.prompts` and `.planning` to `.gitignore`.

## Details

### release.yml
- Triggers on push to `prod`
- Parses PR title prefixes (`feat:`, `fix:`, `breaking:`) for semver bumps
- Groups PRs by category (Features, Bug Fixes, Other Changes) with PR links and author attribution
- Posts rich Discord embed via webhook
- Handles edge cases: first release (v0.1.0), no PRs, long changelogs, duplicate tags

### docs-sync.yml
- Primary trigger: `workflow_run` after Release workflow succeeds
- Secondary trigger: `workflow_dispatch` with configurable `days_back`
- Uses `claude-code-action@v1` with Nextra-aware inner prompt
- Claude analyzes changed code files and fixes only broken/outdated docs
- PRs target `staging` with `claude/docs-sync-` branch prefix

## Secrets Required
- `DISCORD_RELEASE_WEBHOOK_URL` - For release Discord notifications
- `ANTHROPIC_API_KEY` - For Claude Code Action in docs-sync

## Test plan
- [ ] Verify release.yml YAML syntax passes CI
- [ ] Verify docs-sync.yml YAML syntax passes CI
- [ ] After merge to staging, test docs-sync via `workflow_dispatch` in Actions UI
- [ ] After merge to prod, verify release is created at /releases
- [ ] Verify Discord notification is received
- [ ] Verify docs-sync triggers automatically after release