### PR TITLE
feat: automated release and docs sync GHA workflows

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: docs-sync


### PR DESCRIPTION
## Summary

- Adds automated release workflow triggered by PRs merged to `prod` with `release:*` title prefixes
- Adds docs-sync workflow that uses Claude Code Action to keep `/docs/` in sync with code changes after each release
- Adds PR title enforcement check for conventional commit format
- Fixes OIDC permission issue (`id-token: write`) required by `claude-code-action@v1`

## Test plan

- [ ] Verify docs-sync workflow succeeds on next release (no more OIDC token error)
- [ ] Verify release workflow creates GitHub releases from prod merges
- [ ] Verify PR title check runs on new PRs