### PR TITLE
fix: add API key pre-flight check for docs-sync

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,11 +1,10 @@
 name: Docs Sync
 
 on:
-  # TODO: restore after debugging
-  # workflow_run:
-  #   workflows: ['Release']
-  #   types: [completed]
-  #   branches: [prod]
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+    branches: [prod]
 
   workflow_dispatch:
     inputs:
@@ -168,22 +167,33 @@ jobs:
             echo "release_tag=${{ steps.manual_changes.outputs.release_tag }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install Claude Code
+      - name: Validate Anthropic API key
         if: steps.tag.outputs.release_tag != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.18
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d '{"model":"claude-sonnet-4-5-20250929","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}')
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "API key is valid and has sufficient credits."
+          else
+            echo "::error::Anthropic API pre-flight check failed (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi
 
       - name: Run Claude Code docs sync
         if: steps.tag.outputs.release_tag != ''
         id: claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_MODEL: claude-sonnet-4-5-20250929
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          path_to_claude_code_executable: /home/runner/.local/bin/claude
-          show_full_output: "true"
           base_branch: staging
           branch_prefix: claude/docs-sync-
           prompt: |
@@ -274,7 +284,10 @@ jobs:
                automatically create a pull request from your commits. Use a commit message
                format like: "docs: sync documentation with ${{ steps.tag.outputs.release_tag }}"
                and include a summary of what was updated and why in the commit body.
-          claude_args: --max-turns 30 --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*)"
+          claude_args: |
+            --model claude-sonnet-4-5-20250929
+            --max-turns 30
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*)"
 
       - name: Notify Discord on completion
         if: always() && steps.tag.outputs.release_tag != ''


### PR DESCRIPTION
## Summary

- Adds a pre-flight API validation step that catches auth/credit issues with a clear error message before running claude-code-action
- Reverts unnecessary AJV workarounds (custom CLI install, custom executable path, show_full_output) -- the root cause was depleted API credits, not an SDK bug
- Restores workflow_run trigger and original claude_args format

## Test plan

- [ ] Verify pre-flight check passes when API key has credits
- [ ] Verify pre-flight check fails with clear message when credits are low