### PR TITLE
docs: sync documentation with v0.1.0

### DIFF
--- a/docs/api/_meta.json
+++ b/docs/api/_meta.json
@@ -6,6 +6,7 @@
   "integrations": "Integrations",
   "chains": "Chains",
   "user": "User",
+  "organizations": "Organizations",
   "api-keys": "API Keys",
   "errors": "Errors"
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -54,7 +54,8 @@ API requests are subject to rate limiting. Current limits:
 | [Executions](/api/executions) | Monitor workflow execution status and logs |
 | [Integrations](/api/integrations) | Manage notification and service integrations |
 | [Chains](/api/chains) | List supported blockchain networks |
-| [User](/api/user) | User profile and preferences |
+| [User](/api/user) | User profile, preferences, and address book |
+| [Organizations](/api/organizations) | Organization membership management |
 | [API Keys](/api/api-keys) | Manage API keys for programmatic access |
 
 ## SDKs

--- a/docs/api/organizations.md
+++ b/docs/api/organizations.md
@@ -1,0 +1,26 @@
+---
+title: "Organizations API"
+description: "KeeperHub Organizations API - manage organization membership."
+---
+
+# Organizations API
+
+Manage organization membership programmatically.
+
+## Leave Organization
+
+```http
+POST /api/organizations/{organizationId}/leave
+```
+
+Remove yourself from an organization. If you are the sole owner, you must transfer ownership by providing `newOwnerMemberId` in the request body. The new owner must be an accepted member of the organization.
+
+### Request Body
+
+```json
+{
+  "newOwnerMemberId": "member_456"
+}
+```
+
+The `newOwnerMemberId` field is only required when you are the last remaining owner.

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -122,3 +122,110 @@ DELETE /api/user/rpc-preferences/{chainId}
 ```
 
 Reverts to default RPC endpoints for the chain.
+
+## Change Password
+
+```http
+POST /api/user/password
+```
+
+Change the password for a credential-based account. Requires the current password and a new password (minimum 8 characters). Not available for OAuth-only accounts.
+
+### Request Body
+
+```json
+{
+  "currentPassword": "old-password",
+  "newPassword": "new-password"
+}
+```
+
+## Forgot Password
+
+```http
+POST /api/user/forgot-password
+```
+
+Handles password reset via OTP. Supports two actions controlled by the `action` field in the request body.
+
+**Request OTP** (default when `action` is omitted or set to `"request"`):
+
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+**Reset password** (`action: "reset"`):
+
+```json
+{
+  "action": "reset",
+  "email": "user@example.com",
+  "otp": "123456",
+  "newPassword": "new-password"
+}
+```
+
+The OTP expires after 5 minutes. OAuth-only accounts receive a notification email instead of a reset code.
+
+## Deactivate Account
+
+```http
+POST /api/user/delete
+```
+
+Soft-deletes the authenticated user account. Requires a confirmation string in the request body. Invalidates all active sessions on success. Not available for anonymous users.
+
+### Request Body
+
+```json
+{
+  "confirmation": "DEACTIVATE"
+}
+```
+
+## Address Book
+
+Manage saved Ethereum addresses scoped to the active organization. All address book endpoints require an active organization context.
+
+### List Address Book Entries
+
+```http
+GET /api/address-book
+```
+
+Returns all address book entries for the active organization, ordered by creation date (newest first).
+
+### Create Address Book Entry
+
+```http
+POST /api/address-book
+```
+
+#### Request Body
+
+```json
+{
+  "label": "Treasury Wallet",
+  "address": "0x..."
+}
+```
+
+The address must be a valid Ethereum address.
+
+### Update Address Book Entry
+
+```http
+PATCH /api/address-book/{entryId}
+```
+
+Update the label or address of an existing entry. Both fields are optional.
+
+### Delete Address Book Entry
+
+```http
+DELETE /api/address-book/{entryId}
+```
+
+Removes the entry from the organization address book.

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -133,3 +133,36 @@ GET /api/workflows/{workflowId}/code
 ```
 
 Generate SDK code for the workflow.
+
+## Claim Workflow
+
+```http
+POST /api/workflows/{workflowId}/claim
+```
+
+Claim an anonymous workflow into the authenticated user's organization. Only the original creator of the anonymous workflow can claim it.
+
+## Workflow Taxonomy
+
+```http
+GET /api/workflows/taxonomy
+```
+
+Returns distinct categories and protocols from all public workflows. Useful for building filter UIs.
+
+### Response
+
+```json
+{
+  "categories": ["defi", "nft"],
+  "protocols": ["uniswap", "aave"]
+}
+```
+
+## Update Featured Status (Internal)
+
+```http
+POST /api/hub/featured
+```
+
+Mark a workflow as featured in the hub. Requires internal service authentication (`hub` service). Accepts optional `category`, `protocol`, and `featuredOrder` fields alongside the `workflowId`.

--- a/docs/keepers/configuration.md
+++ b/docs/keepers/configuration.md
@@ -79,7 +79,7 @@ No additional configuration needed. Click the Run button to execute.
 | Function * | Read function to call (auto-populated from ABI) |
 | Parameters | Function input parameters |
 
-KeeperHub automatically fetches the contract ABI from block explorers.
+KeeperHub automatically fetches the contract ABI from block explorers. For proxy contracts, it detects the proxy pattern and fetches the implementation ABI automatically. Supported proxy standards include EIP-1967, EIP-1822 (UUPS), OpenZeppelin Transparent Proxy, EIP-1167 (minimal proxy), and Gnosis Safe. For EIP-2535 Diamond contracts, KeeperHub queries the Diamond Loupe interface to discover all facets and combines their ABIs into a single unified interface.
 
 ### Write Contract
 

--- a/docs/users-teams-orgs/organizations.md
+++ b/docs/users-teams-orgs/organizations.md
@@ -58,6 +58,16 @@ Workflows created within an organization are automatically shared with all membe
 - All members can view run history
 - All members can enable or disable workflows
 
+## Leaving an Organization
+
+Members can leave an organization at any time:
+
+1. Open the Manage Organizations modal
+2. Select the organization you want to leave
+3. Click **Leave Organization**
+
+If you are the sole owner, you must transfer ownership to another accepted member before leaving. Select a member to promote to owner during the leave process.
+
 ## Current Limitations
 
 ### No Role-Based Access

--- a/docs/users-teams-orgs/users.md
+++ b/docs/users-teams-orgs/users.md
@@ -31,7 +31,23 @@ Access your account settings to:
 - Update display name
 - Change email address
 - Manage authentication methods
+- Change your password
 - View wallet information
+- Deactivate your account
+
+## Password Management
+
+### Changing Your Password
+
+You can change your password from account settings. Enter your current password, then provide and confirm a new password. Passwords must be at least 8 characters. You will be signed out after changing your password and must sign in again.
+
+### Forgot Password
+
+If you forget your password, use the forgot password flow from the sign-in page. Enter your email address and a one-time verification code (OTP) will be sent to you. The code expires after 5 minutes. Enter the code along with your new password to complete the reset.
+
+### OAuth Users
+
+If you signed up with a social provider (Google, GitHub, or Vercel), your password is managed by that provider. The change password option will direct you to your provider's account settings. If you attempt a password reset, you will receive an email indicating which provider manages your account.
 
 ## Personal Workflows
 
@@ -66,4 +82,7 @@ See [API Authentication](/docs/api/authentication) for details.
 
 - Your workflows and run data are private to you and your organizations
 - Para wallet private keys are never exposed
-- Account deletion removes all associated data
+
+### Account Deactivation
+
+You can deactivate your account from account settings. To confirm, you must type **DEACTIVATE** in the confirmation dialog. Deactivation is a soft delete -- your data is preserved, but you will be signed out and unable to sign in. All active sessions are invalidated immediately. To reactivate a deactivated account, contact an administrator.

--- a/docs/wallet-management/_meta.json
+++ b/docs/wallet-management/_meta.json
@@ -1,4 +1,5 @@
 {
   "para": "Para Integration",
-  "gas": "Gas Management"
+  "gas": "Gas Management",
+  "address-book": "Address Book"
 }

--- a/docs/wallet-management/address-book.md
+++ b/docs/wallet-management/address-book.md
@@ -1,0 +1,46 @@
+---
+title: "Address Book"
+description: "Save and manage frequently used blockchain addresses for quick reuse across workflows in KeeperHub."
+---
+
+# Address Book
+
+The address book lets you save and label blockchain addresses that your organization uses frequently. Saved addresses are available across all workflows, so you do not need to copy and paste the same addresses repeatedly.
+
+Address book entries are **organization-scoped** -- every member of your organization can view and use them.
+
+## Adding an Address
+
+There are two ways to save an address:
+
+**From the address book page**: Click **Add Address**, enter a label (for example, "Treasury Wallet") and a valid Ethereum address, then click **Save**.
+
+**From a workflow node field**: When you enter a valid address into any address-type field in the workflow builder, a **Save** button appears next to the input. Click it to open the save form with the address pre-filled. Provide a label and confirm.
+
+Both methods validate the address format before saving. Invalid addresses are rejected with an error message.
+
+## Editing an Address
+
+Click the **Edit** icon next to any entry in the address book table. You can update the label, the address, or both. The address is re-validated on save.
+
+## Removing an Address
+
+Click the **Delete** icon next to any entry. The entry is removed immediately. Removing an address book entry does not alter workflow nodes that already reference that address -- the address value remains in the node configuration.
+
+## Checksummed Address Display
+
+All addresses are stored in lowercase for consistency and displayed in **EIP-55 checksummed format**. This means mixed-case characters serve as a built-in integrity check, helping you verify that an address has not been corrupted.
+
+When you copy an address from the address book, the checksummed form is copied to your clipboard.
+
+## Using Addresses in Workflow Nodes
+
+When you focus an address-type input field in the workflow builder, a **popover** appears showing your saved addresses. You can search by label or address, then select an entry to populate the field.
+
+The selected bookmark is persisted in the node configuration. If you open the workflow later, the field retains its association with the address book entry.
+
+## Block Explorer Links
+
+KeeperHub generates block explorer links for addresses and transaction hashes based on the selected network. Clicking an address or transaction hash link opens the relevant page on the network's block explorer (for example, Etherscan for Ethereum Mainnet).
+
+Explorer URL construction uses the chain's configured `explorerUrl` and `explorerAddressPath`, so links work automatically for any supported network.

--- a/docs/workflows/creating.md
+++ b/docs/workflows/creating.md
@@ -132,6 +132,18 @@ The **Ask AI...** input at the bottom of the canvas lets you describe your autom
 - "Every hour, check if a contract's totalSupply changed and email me"
 - "When someone sends ETH to my wallet, log it to Slack"
 
+## Importing from the Hub
+
+The **Hub** lists workflow templates shared by the community. To use a template:
+
+1. Browse the Hub from the main navigation
+2. Select a workflow template
+3. Click **Duplicate** to copy it into your workspace
+
+The copy is created with a unique name (e.g., "My Workflow (Copy)") and set to private visibility. Node configurations are preserved, but integration credentials are removed so you can assign your own connections.
+
+You can also duplicate any public workflow you are viewing by clicking the **Duplicate** button in the toolbar.
+
 ## Workflow States
 
 | State | Description |


### PR DESCRIPTION
## Summary
- Add password management and account deactivation to user docs
- Create address book documentation page and API endpoints
- Document EIP-2535 diamond proxy support in keeper configuration
- Add leave organization flow to org docs and new organizations API page
- Document workflow duplication and Hub import in workflow creation guide
- Add hub/featured, taxonomy, and claim endpoints to workflow API reference

## Files changed
- `docs/users-teams-orgs/users.md` - Password management, account deactivation
- `docs/wallet-management/address-book.md` - New page
- `docs/wallet-management/_meta.json` - Added address-book entry
- `docs/keepers/configuration.md` - EIP-2535 proxy support note
- `docs/users-teams-orgs/organizations.md` - Leave organization section
- `docs/workflows/creating.md` - Duplicate workflows, Hub import
- `docs/api/user.md` - Password, forgot password, deactivate, address book endpoints
- `docs/api/workflows.md` - Claim, taxonomy, featured endpoints
- `docs/api/organizations.md` - New page with leave endpoint
- `docs/api/index.md` - Updated endpoint table
- `docs/api/_meta.json` - Added organizations entry