### PR TITLE
fix: Keep-1426 Hide secrets values from database node output

### DIFF
--- a/app/api/integrations/[integrationId]/route.ts
+++ b/app/api/integrations/[integrationId]/route.ts
@@ -112,12 +112,29 @@ export async function PUT(
 
     const body: UpdateIntegrationRequest = await request.json();
 
+    // start custom keeperhub code //
+    // Fetch existing integration so updateIntegration can merge database
+    // secrets without an extra DB round-trip.
+    const existing =
+      body.config !== undefined
+        ? await getIntegration(integrationId, session.user.id, organizationId)
+        : null;
+
+    if (body.config !== undefined && !existing) {
+      return NextResponse.json(
+        { error: "Integration not found" },
+        { status: 404 }
+      );
+    }
+    // end keeperhub code //
+
     const integration = await updateIntegration(
       integrationId,
       session.user.id,
       body,
       // start custom keeperhub code //
-      organizationId
+      organizationId,
+      existing
       // end keeperhub code //
     );
 

--- a/app/api/integrations/[integrationId]/route.ts
+++ b/app/api/integrations/[integrationId]/route.ts
@@ -5,6 +5,7 @@ import { auth } from "@/lib/auth";
 import {
   deleteIntegration,
   getIntegration,
+  stripDatabaseSecrets,
   updateIntegration,
 } from "@/lib/db/integrations";
 import type { IntegrationConfig } from "@/lib/types/integration";
@@ -62,14 +63,16 @@ export async function GET(
       );
     }
 
+    // start custom keeperhub code //
     const response: GetIntegrationResponse = {
       id: integration.id,
       name: integration.name,
       type: integration.type,
-      config: integration.config,
+      config: stripDatabaseSecrets(integration.config, integration.type),
       createdAt: integration.createdAt.toISOString(),
       updatedAt: integration.updatedAt.toISOString(),
     };
+    // end keeperhub code //
 
     return NextResponse.json(response);
   } catch (error) {
@@ -125,14 +128,16 @@ export async function PUT(
       );
     }
 
+    // start custom keeperhub code //
     const response: GetIntegrationResponse = {
       id: integration.id,
       name: integration.name,
       type: integration.type,
-      config: integration.config,
+      config: stripDatabaseSecrets(integration.config, integration.type),
       createdAt: integration.createdAt.toISOString(),
       updatedAt: integration.updatedAt.toISOString(),
     };
+    // end keeperhub code //
 
     return NextResponse.json(response);
   } catch (error) {

--- a/app/api/integrations/[integrationId]/test/route.ts
+++ b/app/api/integrations/[integrationId]/test/route.ts
@@ -61,10 +61,17 @@ export async function POST(
     // server can test with updated non-secret fields (e.g. host) without
     // the client needing to send the password.
     let body: { configOverrides?: IntegrationConfig } = {};
-    try {
-      body = await request.json();
-    } catch {
-      // No body or invalid JSON is fine - test with stored config only
+    const contentType = request.headers.get("content-type") ?? "";
+    const hasBody = contentType.includes("application/json");
+    if (hasBody) {
+      try {
+        body = await request.json();
+      } catch {
+        return NextResponse.json(
+          { error: "Invalid JSON in request body" },
+          { status: 400 }
+        );
+      }
     }
 
     const testConfig =

--- a/components/overlays/edit-connection-overlay.tsx
+++ b/components/overlays/edit-connection-overlay.tsx
@@ -254,10 +254,12 @@ export function EditConnectionOverlay({
     }
     return result;
   };
+  // end keeperhub code //
 
   const doSave = async () => {
     try {
       setSaving(true);
+      // start custom keeperhub code //
       const nonEmptyConfig = getNonEmptyConfig();
       const hasNewConfig = Object.keys(nonEmptyConfig).length > 0;
       await api.integration.update(integration.id, {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -410,14 +410,23 @@ export const integrationApi = {
       method: "DELETE",
     }),
 
-  // Test existing integration connection
-  testConnection: (integrationId: string) =>
+  // start custom keeperhub code //
+  // Test existing integration connection, optionally with config overrides
+  // that are merged server-side with stored secrets before testing
+  testConnection: (
+    integrationId: string,
+    configOverrides?: IntegrationConfig
+  ) =>
     apiCall<{ status: "success" | "error"; message: string }>(
       `/api/integrations/${integrationId}/test`,
       {
         method: "POST",
+        ...(configOverrides
+          ? { body: JSON.stringify({ configOverrides }) }
+          : {}),
       }
     ),
+  // end keeperhub code //
 
   // Test credentials without saving
   testCredentials: (data: {

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -305,7 +305,8 @@ export async function updateIntegration(
     config?: IntegrationConfig;
   },
   // start custom keeperhub code //
-  organizationId?: string | null
+  organizationId?: string | null,
+  existingIntegration?: DecryptedIntegration | null
   // end keeperhub code //
 ): Promise<DecryptedIntegration | null> {
   const updateData: Partial<NewIntegration> = {
@@ -318,14 +319,9 @@ export async function updateIntegration(
 
   // start custom keeperhub code //
   if (updates.config !== undefined) {
-    const existing = await getIntegration(
-      integrationId,
-      userId,
-      organizationId
-    );
-    if (existing?.type === "database") {
+    if (existingIntegration?.type === "database") {
       updateData.config = encryptConfig(
-        mergeDatabaseConfig(existing.config, updates.config)
+        mergeDatabaseConfig(existingIntegration.config, updates.config)
       );
     } else {
       updateData.config = encryptConfig(updates.config);

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -99,6 +99,52 @@ function decryptConfig(encryptedConfig: string): Record<string, unknown> {
   }
 }
 
+// start custom keeperhub code //
+const DB_SECRET_KEYS = new Set(["password", "url"]);
+
+/**
+ * Strip secret fields from a database integration config before sending to clients.
+ * For non-database integrations, returns the config unchanged.
+ */
+export function stripDatabaseSecrets(
+  config: IntegrationConfig,
+  integrationType: string
+): IntegrationConfig {
+  if (integrationType !== "database") {
+    return config;
+  }
+
+  const stripped: IntegrationConfig = {};
+  for (const key of Object.keys(config)) {
+    if (!DB_SECRET_KEYS.has(key)) {
+      stripped[key] = config[key];
+    }
+  }
+  return stripped;
+}
+
+/**
+ * Merge incoming config with existing config, preserving secret fields
+ * that were not provided (empty or missing) in the update.
+ */
+function mergeDatabaseConfig(
+  existingConfig: IntegrationConfig,
+  incomingConfig: IntegrationConfig
+): IntegrationConfig {
+  const merged: IntegrationConfig = { ...existingConfig };
+  for (const [key, value] of Object.entries(incomingConfig)) {
+    if (DB_SECRET_KEYS.has(key)) {
+      if (value !== undefined && value !== "") {
+        merged[key] = value;
+      }
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+// end keeperhub code //
+
 export type DecryptedIntegration = {
   id: string;
   userId: string;
@@ -270,9 +316,22 @@ export async function updateIntegration(
     updateData.name = updates.name;
   }
 
+  // start custom keeperhub code //
   if (updates.config !== undefined) {
-    updateData.config = encryptConfig(updates.config);
+    const existing = await getIntegration(
+      integrationId,
+      userId,
+      organizationId
+    );
+    if (existing?.type === "database") {
+      updateData.config = encryptConfig(
+        mergeDatabaseConfig(existing.config, updates.config)
+      );
+    } else {
+      updateData.config = encryptConfig(updates.config);
+    }
   }
+  // end keeperhub code //
 
   // start custom keeperhub code //
   const conditions = organizationId

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -127,7 +127,7 @@ export function stripDatabaseSecrets(
  * Merge incoming config with existing config, preserving secret fields
  * that were not provided (empty or missing) in the update.
  */
-function mergeDatabaseConfig(
+export function mergeDatabaseConfig(
   existingConfig: IntegrationConfig,
   incomingConfig: IntegrationConfig
 ): IntegrationConfig {

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -108,7 +108,7 @@ const DB_SECRET_KEYS = new Set(["password", "url"]);
  */
 export function stripDatabaseSecrets(
   config: IntegrationConfig,
-  integrationType: string
+  integrationType: IntegrationType
 ): IntegrationConfig {
   if (integrationType !== "database") {
     return config;

--- a/tests/unit/database-secrets.test.ts
+++ b/tests/unit/database-secrets.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  mergeDatabaseConfig,
+  stripDatabaseSecrets,
+} from "@/lib/db/integrations";
+
+describe("stripDatabaseSecrets", () => {
+  it("strips password and url from database integrations", () => {
+    const config = {
+      host: "db.example.com",
+      port: "5432",
+      username: "postgres",
+      password: "secret123",
+      database: "mydb",
+      url: "postgresql://postgres:secret123@db.example.com:5432/mydb",
+    };
+
+    const result = stripDatabaseSecrets(config, "database");
+
+    expect(result).toEqual({
+      host: "db.example.com",
+      port: "5432",
+      username: "postgres",
+      database: "mydb",
+    });
+    expect(result).not.toHaveProperty("password");
+    expect(result).not.toHaveProperty("url");
+  });
+
+  it("returns config unchanged for non-database integrations", () => {
+    const config = {
+      apiKey: "sk-123",
+      webhookUrl: "https://example.com/hook",
+    };
+
+    const result = stripDatabaseSecrets(config, "discord");
+
+    expect(result).toBe(config);
+  });
+
+  it("handles empty config", () => {
+    const result = stripDatabaseSecrets({}, "database");
+    expect(result).toEqual({});
+  });
+
+  it("preserves non-secret database fields when secrets are present", () => {
+    const config = {
+      host: "localhost",
+      password: "pass",
+      sslMode: "require",
+    };
+
+    const result = stripDatabaseSecrets(config, "database");
+
+    expect(result).toEqual({
+      host: "localhost",
+      sslMode: "require",
+    });
+  });
+});
+
+describe("mergeDatabaseConfig", () => {
+  it("preserves existing secrets when incoming values are empty", () => {
+    const existing = {
+      host: "db.example.com",
+      password: "existing-pass",
+      url: "postgresql://user:existing-pass@db.example.com/mydb",
+    };
+    const incoming = {
+      host: "new-host.com",
+      password: "",
+      url: "",
+    };
+
+    const result = mergeDatabaseConfig(existing, incoming);
+
+    expect(result.host).toBe("new-host.com");
+    expect(result.password).toBe("existing-pass");
+    expect(result.url).toBe(
+      "postgresql://user:existing-pass@db.example.com/mydb"
+    );
+  });
+
+  it("preserves existing secrets when incoming values are undefined", () => {
+    const existing = {
+      host: "db.example.com",
+      password: "existing-pass",
+    };
+    const incoming = {
+      host: "new-host.com",
+      password: undefined,
+    };
+
+    const result = mergeDatabaseConfig(existing, incoming);
+
+    expect(result.host).toBe("new-host.com");
+    expect(result.password).toBe("existing-pass");
+  });
+
+  it("overwrites secrets when incoming values are non-empty", () => {
+    const existing = {
+      host: "db.example.com",
+      password: "old-pass",
+    };
+    const incoming = {
+      password: "new-pass",
+    };
+
+    const result = mergeDatabaseConfig(existing, incoming);
+
+    expect(result.host).toBe("db.example.com");
+    expect(result.password).toBe("new-pass");
+  });
+
+  it("overwrites non-secret fields unconditionally", () => {
+    const existing = {
+      host: "old-host.com",
+      port: "5432",
+      password: "pass",
+    };
+    const incoming = {
+      host: "",
+      port: "5433",
+    };
+
+    const result = mergeDatabaseConfig(existing, incoming);
+
+    expect(result.host).toBe("");
+    expect(result.port).toBe("5433");
+    expect(result.password).toBe("pass");
+  });
+
+  it("handles empty incoming config", () => {
+    const existing = {
+      host: "db.example.com",
+      password: "pass",
+    };
+
+    const result = mergeDatabaseConfig(existing, {});
+
+    expect(result).toEqual(existing);
+  });
+
+  it("does not mutate existing config", () => {
+    const existing = { host: "old", password: "pass" };
+    const existingCopy = { ...existing };
+
+    mergeDatabaseConfig(existing, { host: "new" });
+
+    expect(existing).toEqual(existingCopy);
+  });
+});


### PR DESCRIPTION
# Summary

Hide database secrets (password, connection URL) from API responses and enforce server-side connection testing on every save.

# Details

- `GET` and `PUT` on `/api/integrations/[id]` now strip `password` and `url` from database integration responses before returning to the client
- `PUT` merges incoming config with stored secrets server-side, so omitted secret fields are preserved rather than wiped
- Test endpoint accepts optional `configOverrides` in the request body, merging them with stored secrets before testing
- Edit overlay always runs a server-side connection test on save for database integrations, even when only non-secret fields (host, port) change
- No changes to other integration types (Discord, SendGrid, etc.)
