### PR TITLE
feat: Keep-1423 Add built-in variables

### DIFF
--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -4,6 +4,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { BUILTIN_NODE_ID, BUILTIN_NODE_LABEL, BUILTIN_VARIABLE_FIELDS } from "@/keeperhub/lib/builtin-variables";
 import { api } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
 import {
@@ -495,36 +496,15 @@ export function TemplateAutocomplete({
 
   // start custom keeperhub code //
   // Built-in system variables (available to all nodes, evaluated at execution time)
-  // Constants inlined to avoid importing server-side module into "use client" component
-  {
-    const systemNodeId = "__system";
-    const systemLabel = "System";
-    const builtinFields = [
-      {
-        field: "unixTimestamp",
-        description:
-          "Current time as Unix timestamp in seconds (Solidity-compatible)",
-      },
-      {
-        field: "unixTimestampMs",
-        description: "Current time as Unix timestamp in milliseconds",
-      },
-      {
-        field: "isoTimestamp",
-        description: "Current time as ISO 8601 UTC string",
-      },
-    ];
-
-    for (const field of builtinFields) {
-      options.push({
-        type: "field",
-        nodeId: systemNodeId,
-        nodeName: systemLabel,
-        field: field.field,
-        description: field.description,
-        template: `{{@${systemNodeId}:${systemLabel}.${field.field}}}`,
-      });
-    }
+  for (const field of BUILTIN_VARIABLE_FIELDS) {
+    options.push({
+      type: "field",
+      nodeId: BUILTIN_NODE_ID,
+      nodeName: BUILTIN_NODE_LABEL,
+      field: field.field,
+      description: field.description,
+      template: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.${field.field}}}`,
+    });
   }
   // end keeperhub code //
 

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -493,6 +493,41 @@ export function TemplateAutocomplete({
     }
   }
 
+  // start custom keeperhub code //
+  // Built-in system variables (available to all nodes, evaluated at execution time)
+  // Constants inlined to avoid importing server-side module into "use client" component
+  {
+    const systemNodeId = "__system";
+    const systemLabel = "System";
+    const builtinFields = [
+      {
+        field: "unixTimestamp",
+        description:
+          "Current time as Unix timestamp in seconds (Solidity-compatible)",
+      },
+      {
+        field: "unixTimestampMs",
+        description: "Current time as Unix timestamp in milliseconds",
+      },
+      {
+        field: "isoTimestamp",
+        description: "Current time as ISO 8601 UTC string",
+      },
+    ];
+
+    for (const field of builtinFields) {
+      options.push({
+        type: "field",
+        nodeId: systemNodeId,
+        nodeName: systemLabel,
+        field: field.field,
+        description: field.description,
+        template: `{{@${systemNodeId}:${systemLabel}.${field.field}}}`,
+      });
+    }
+  }
+  // end keeperhub code //
+
   // Filter options based on search term
   const filteredOptions = filter
     ? options.filter(

--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -2,6 +2,7 @@
 
 import { useAtom } from "jotai";
 import { useEffect, useRef, useState } from "react";
+import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { findActionById } from "@/plugins";
@@ -23,8 +24,7 @@ function doesNodeExist(template: string, nodes: ReturnType<typeof useAtom<typeof
   
   const nodeId = match[1];
   // start custom keeperhub code //
-  // __system is a built-in pseudo-node for system variables
-  if (nodeId === "__system") return true;
+  if (nodeId === BUILTIN_NODE_ID) return true;
   // end keeperhub code //
   return nodes.some((n) => n.id === nodeId);
 }

--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -2,7 +2,9 @@
 
 import { useAtom } from "jotai";
 import { useEffect, useRef, useState } from "react";
-import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
+// start custom keeperhub code //
+import { doesNodeExist } from "@/keeperhub/lib/template-utils";
+// end keeperhub code //
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { findActionById } from "@/plugins";
@@ -15,18 +17,6 @@ export interface TemplateBadgeInputProps {
   disabled?: boolean;
   className?: string;
   id?: string;
-}
-
-// Helper to check if a template references an existing node
-function doesNodeExist(template: string, nodes: ReturnType<typeof useAtom<typeof nodesAtom>>[0]): boolean {
-  const match = template.match(/\{\{@([^:]+):([^}]+)\}\}/);
-  if (!match) return false;
-  
-  const nodeId = match[1];
-  // start custom keeperhub code //
-  if (nodeId === BUILTIN_NODE_ID) return true;
-  // end keeperhub code //
-  return nodes.some((n) => n.id === nodeId);
 }
 
 // Helper to get display text from template by looking up current node label

--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -3,11 +3,10 @@
 import { useAtom } from "jotai";
 import { useEffect, useRef, useState } from "react";
 // start custom keeperhub code //
-import { doesNodeExist } from "@/keeperhub/lib/template-utils";
+import { doesNodeExist, getDisplayTextForTemplate } from "@/keeperhub/lib/template-utils";
 // end keeperhub code //
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
-import { findActionById } from "@/plugins";
 import { TemplateAutocomplete } from "./template-autocomplete";
 
 export interface TemplateBadgeInputProps {
@@ -17,50 +16,6 @@ export interface TemplateBadgeInputProps {
   disabled?: boolean;
   className?: string;
   id?: string;
-}
-
-// Helper to get display text from template by looking up current node label
-function getDisplayTextForTemplate(template: string, nodes: ReturnType<typeof useAtom<typeof nodesAtom>>[0]): string {
-  // Extract nodeId and field from template: {{@nodeId:OldLabel.field}}
-  const match = template.match(/\{\{@([^:]+):([^}]+)\}\}/);
-  if (!match) return template;
-  
-  const nodeId = match[1];
-  const rest = match[2]; // e.g., "OldLabel.field" or "OldLabel"
-  
-  // Find the current node
-  const node = nodes.find((n) => n.id === nodeId);
-  if (!node) {
-    // Node not found, return as-is
-    return rest;
-  }
-  
-  // Get display label: custom label > human-readable action label > fallback
-  let displayLabel: string | undefined = node.data.label;
-  if (!displayLabel && node.data.type === "action") {
-    const actionType = node.data.config?.actionType as string | undefined;
-    if (actionType) {
-      const action = findActionById(actionType);
-      displayLabel = action?.label;
-    }
-  }
-  
-  const dotIndex = rest.indexOf(".");
-  
-  if (dotIndex === -1) {
-    // No field, just the node: {{@nodeId:Label}}
-    return displayLabel ?? rest;
-  }
-  
-  // Has field: {{@nodeId:Label.field}}
-  const field = rest.substring(dotIndex + 1);
-  
-  // If no display label, fall back to the original label from the template
-  if (!displayLabel) {
-    return rest;
-  }
-  
-  return `${displayLabel}.${field}`;
 }
 
 // start keeperhub custom code //

--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -22,6 +22,10 @@ function doesNodeExist(template: string, nodes: ReturnType<typeof useAtom<typeof
   if (!match) return false;
   
   const nodeId = match[1];
+  // start custom keeperhub code //
+  // __system is a built-in pseudo-node for system variables
+  if (nodeId === "__system") return true;
+  // end keeperhub code //
   return nodes.some((n) => n.id === nodeId);
 }
 

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -5,6 +5,7 @@ import { useAtom } from "jotai";
 import type { CSSProperties } from "react";
 // end keeperhub custom code //
 import { useEffect, useRef, useState } from "react";
+import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { findActionById } from "@/plugins";
@@ -31,8 +32,7 @@ function doesNodeExist(template: string, nodes: ReturnType<typeof useAtom<typeof
   
   const nodeId = match[1];
   // start custom keeperhub code //
-  // __system is a built-in pseudo-node for system variables
-  if (nodeId === "__system") return true;
+  if (nodeId === BUILTIN_NODE_ID) return true;
   // end keeperhub code //
   return nodes.some((n) => n.id === nodeId);
 }

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -5,7 +5,9 @@ import { useAtom } from "jotai";
 import type { CSSProperties } from "react";
 // end keeperhub custom code //
 import { useEffect, useRef, useState } from "react";
-import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
+// start custom keeperhub code //
+import { doesNodeExist } from "@/keeperhub/lib/template-utils";
+// end keeperhub code //
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { findActionById } from "@/plugins";
@@ -23,18 +25,6 @@ export interface TemplateBadgeTextareaProps {
   /** When set, limits visible height to this many rows and makes content scrollable */
   maxRows?: number;
   // end keeperhub custom code //
-}
-
-// Helper to check if a template references an existing node
-function doesNodeExist(template: string, nodes: ReturnType<typeof useAtom<typeof nodesAtom>>[0]): boolean {
-  const match = template.match(/\{\{@([^:]+):([^}]+)\}\}/);
-  if (!match) return false;
-  
-  const nodeId = match[1];
-  // start custom keeperhub code //
-  if (nodeId === BUILTIN_NODE_ID) return true;
-  // end keeperhub code //
-  return nodes.some((n) => n.id === nodeId);
 }
 
 // Helper to get display text from template by looking up current node label

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -6,11 +6,10 @@ import type { CSSProperties } from "react";
 // end keeperhub custom code //
 import { useEffect, useRef, useState } from "react";
 // start custom keeperhub code //
-import { doesNodeExist } from "@/keeperhub/lib/template-utils";
+import { doesNodeExist, getDisplayTextForTemplate } from "@/keeperhub/lib/template-utils";
 // end keeperhub code //
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
-import { findActionById } from "@/plugins";
 import { TemplateAutocomplete } from "./template-autocomplete";
 
 export interface TemplateBadgeTextareaProps {
@@ -25,50 +24,6 @@ export interface TemplateBadgeTextareaProps {
   /** When set, limits visible height to this many rows and makes content scrollable */
   maxRows?: number;
   // end keeperhub custom code //
-}
-
-// Helper to get display text from template by looking up current node label
-function getDisplayTextForTemplate(template: string, nodes: ReturnType<typeof useAtom<typeof nodesAtom>>[0]): string {
-  // Extract nodeId and field from template: {{@nodeId:OldLabel.field}}
-  const match = template.match(/\{\{@([^:]+):([^}]+)\}\}/);
-  if (!match) return template;
-  
-  const nodeId = match[1];
-  const rest = match[2]; // e.g., "OldLabel.field" or "OldLabel"
-  
-  // Find the current node
-  const node = nodes.find((n) => n.id === nodeId);
-  if (!node) {
-    // Node not found, return as-is
-    return rest;
-  }
-  
-  // Get display label: custom label > human-readable action label > fallback
-  let displayLabel: string | undefined = node.data.label;
-  if (!displayLabel && node.data.type === "action") {
-    const actionType = node.data.config?.actionType as string | undefined;
-    if (actionType) {
-      const action = findActionById(actionType);
-      displayLabel = action?.label;
-    }
-  }
-  
-  const dotIndex = rest.indexOf(".");
-  
-  if (dotIndex === -1) {
-    // No field, just the node: {{@nodeId:Label}}
-    return displayLabel ?? rest;
-  }
-  
-  // Has field: {{@nodeId:Label.field}}
-  const field = rest.substring(dotIndex + 1);
-  
-  // If no display label, fall back to the original label from the template
-  if (!displayLabel) {
-    return rest;
-  }
-  
-  return `${displayLabel}.${field}`;
 }
 
 // start keeperhub custom code //

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -30,6 +30,10 @@ function doesNodeExist(template: string, nodes: ReturnType<typeof useAtom<typeof
   if (!match) return false;
   
   const nodeId = match[1];
+  // start custom keeperhub code //
+  // __system is a built-in pseudo-node for system variables
+  if (nodeId === "__system") return true;
+  // end keeperhub code //
   return nodes.some((n) => n.id === nodeId);
 }
 

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -38,8 +38,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { OrgSwitcher } from "@/keeperhub/components/organization/org-switcher";
-// start custom keeperhub code //
 import { Switch } from "@/keeperhub/components/ui/switch";
+// start custom keeperhub code //
+import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
 import { api, type Project } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import { getCustomLogo } from "@/lib/extension-registry";
@@ -218,9 +219,8 @@ function getBrokenTemplateReferences(
 
     const allRefs = extractAllTemplateReferences(config);
     // start custom keeperhub code //
-    // __system is a built-in pseudo-node for system variables, not a real workflow node
     const brokenRefs = allRefs.filter(
-      (ref) => ref.nodeId !== "__system" && !nodeIds.has(ref.nodeId)
+      (ref) => ref.nodeId !== BUILTIN_NODE_ID && !nodeIds.has(ref.nodeId)
     );
     // end keeperhub code //
 

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -217,7 +217,12 @@ function getBrokenTemplateReferences(
     }
 
     const allRefs = extractAllTemplateReferences(config);
-    const brokenRefs = allRefs.filter((ref) => !nodeIds.has(ref.nodeId));
+    // start custom keeperhub code //
+    // __system is a built-in pseudo-node for system variables, not a real workflow node
+    const brokenRefs = allRefs.filter(
+      (ref) => ref.nodeId !== "__system" && !nodeIds.has(ref.nodeId)
+    );
+    // end keeperhub code //
 
     if (brokenRefs.length > 0) {
       // Get action for label lookups

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from "next/server";
 
 import "@/plugins";
 import "@/keeperhub/plugins";
+import {
+  BUILTIN_NODE_ID,
+  BUILTIN_NODE_LABEL,
+} from "@/keeperhub/lib/builtin-variables";
 
 import { db } from "@/lib/db";
 import { chains, explorerConfigs } from "@/lib/db/schema";
@@ -187,7 +191,7 @@ const TEMPLATE_SYNTAX = {
       description: "Reference 'price' from HTTP request response data",
     },
     {
-      template: "{{@__system:System.unixTimestamp}}",
+      template: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}}`,
       description:
         "Current Unix timestamp in seconds (built-in, evaluated at execution time)",
     },
@@ -441,27 +445,26 @@ export async function GET(request: Request) {
     // start custom keeperhub code //
     // Built-in system variables (evaluated at runtime)
     builtinVariables: {
-      description:
-        "Built-in variables evaluated at runtime. Reference using {{@__system:System.fieldName}} syntax.",
-      nodeId: "__system",
-      nodeLabel: "System",
+      description: `Built-in variables evaluated at runtime. Reference using {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.fieldName}} syntax.`,
+      nodeId: BUILTIN_NODE_ID,
+      nodeLabel: BUILTIN_NODE_LABEL,
       variables: {
         unixTimestamp: {
           type: "number",
           description:
             "Current Unix timestamp in seconds (Solidity-compatible, matches block.timestamp)",
-          example: "{{@__system:System.unixTimestamp}}",
+          example: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}}`,
         },
         unixTimestampMs: {
           type: "number",
           description:
             "Current Unix timestamp in milliseconds (JavaScript Date.now())",
-          example: "{{@__system:System.unixTimestampMs}}",
+          example: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestampMs}}`,
         },
         isoTimestamp: {
           type: "string",
           description: "Current time as ISO 8601 UTC string",
-          example: "{{@__system:System.isoTimestamp}}",
+          example: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.isoTimestamp}}`,
         },
       },
     },
@@ -521,7 +524,7 @@ export async function GET(request: Request) {
       "web3 read actions (check-balance, read-contract) don't require wallet integration",
       "web3 write actions (transfer-funds, write-contract) require wallet integration",
       "Use projectId to organize related workflows into a project (e.g., all Sky ESM workflows in one project)",
-      "Use {{@__system:System.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)",
+      `Use {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)`,
     ],
   };
 

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -186,6 +186,11 @@ const TEMPLATE_SYNTAX = {
       template: "{{@http-1:Fetch Price.data.price}}",
       description: "Reference 'price' from HTTP request response data",
     },
+    {
+      template: "{{@__system:System.unixTimestamp}}",
+      description:
+        "Current Unix timestamp in seconds (built-in, evaluated at execution time)",
+    },
   ],
   notes: [
     "nodeId is the unique identifier of the node (visible in node settings)",
@@ -433,6 +438,35 @@ export async function GET(request: Request) {
     // Template syntax documentation
     templateSyntax: TEMPLATE_SYNTAX,
 
+    // start custom keeperhub code //
+    // Built-in system variables (evaluated at runtime)
+    builtinVariables: {
+      description:
+        "Built-in variables evaluated at runtime. Reference using {{@__system:System.fieldName}} syntax.",
+      nodeId: "__system",
+      nodeLabel: "System",
+      variables: {
+        unixTimestamp: {
+          type: "number",
+          description:
+            "Current Unix timestamp in seconds (Solidity-compatible, matches block.timestamp)",
+          example: "{{@__system:System.unixTimestamp}}",
+        },
+        unixTimestampMs: {
+          type: "number",
+          description:
+            "Current Unix timestamp in milliseconds (JavaScript Date.now())",
+          example: "{{@__system:System.unixTimestampMs}}",
+        },
+        isoTimestamp: {
+          type: "string",
+          description: "Current time as ISO 8601 UTC string",
+          example: "{{@__system:System.isoTimestamp}}",
+        },
+      },
+    },
+    // end keeperhub code //
+
     // Workflow structure hints for AI
     workflowStructure: {
       nodeStructure: {
@@ -487,6 +521,7 @@ export async function GET(request: Request) {
       "web3 read actions (check-balance, read-contract) don't require wallet integration",
       "web3 write actions (transfer-funds, write-contract) require wallet integration",
       "Use projectId to organize related workflows into a project (e.g., all Sky ESM workflows in one project)",
+      "Use {{@__system:System.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)",
     ],
   };
 

--- a/keeperhub/lib/builtin-variables.ts
+++ b/keeperhub/lib/builtin-variables.ts
@@ -2,14 +2,33 @@
  * Built-in System Variables
  * Provides runtime-evaluated variables available in all workflow template fields.
  * These are injected as a pseudo-node with a reserved ID into the outputs map.
+ *
+ * NOTE: This module has zero dependencies so it can be safely imported in both
+ * server-side code and "use client" components.
  */
-import type { OutputField } from "@/plugins/registry";
 
 /** Reserved node ID for built-in system variables. Must not collide with user node IDs. */
 export const BUILTIN_NODE_ID = "__system";
 
 /** Display label shown in autocomplete UI and template syntax */
 export const BUILTIN_NODE_LABEL = "System";
+
+/** Static field definitions for autocomplete, badge validation, and MCP schemas */
+export const BUILTIN_VARIABLE_FIELDS = [
+  {
+    field: "unixTimestamp",
+    description:
+      "Current time as Unix timestamp in seconds (Solidity-compatible)",
+  },
+  {
+    field: "unixTimestampMs",
+    description: "Current time as Unix timestamp in milliseconds",
+  },
+  {
+    field: "isoTimestamp",
+    description: "Current time as ISO 8601 UTC string",
+  },
+] as const;
 
 /**
  * Returns current built-in variable values.
@@ -22,25 +41,4 @@ export function getBuiltinVariables(): Record<string, unknown> {
     unixTimestampMs: now,
     isoTimestamp: new Date(now).toISOString(),
   };
-}
-
-/**
- * Returns static field definitions for autocomplete and MCP schema documentation.
- */
-export function getBuiltinVariableDefinitions(): OutputField[] {
-  return [
-    {
-      field: "unixTimestamp",
-      description:
-        "Current time as Unix timestamp in seconds (Solidity-compatible)",
-    },
-    {
-      field: "unixTimestampMs",
-      description: "Current time as Unix timestamp in milliseconds",
-    },
-    {
-      field: "isoTimestamp",
-      description: "Current time as ISO 8601 UTC string",
-    },
-  ];
 }

--- a/keeperhub/lib/builtin-variables.ts
+++ b/keeperhub/lib/builtin-variables.ts
@@ -1,0 +1,46 @@
+/**
+ * Built-in System Variables
+ * Provides runtime-evaluated variables available in all workflow template fields.
+ * These are injected as a pseudo-node with a reserved ID into the outputs map.
+ */
+import type { OutputField } from "@/plugins/registry";
+
+/** Reserved node ID for built-in system variables. Must not collide with user node IDs. */
+export const BUILTIN_NODE_ID = "__system";
+
+/** Display label shown in autocomplete UI and template syntax */
+export const BUILTIN_NODE_LABEL = "System";
+
+/**
+ * Returns current built-in variable values.
+ * MUST be called at evaluation time (not cached) so timestamps are fresh.
+ */
+export function getBuiltinVariables(): Record<string, unknown> {
+  const now = Date.now();
+  return {
+    unixTimestamp: Math.floor(now / 1000),
+    unixTimestampMs: now,
+    isoTimestamp: new Date(now).toISOString(),
+  };
+}
+
+/**
+ * Returns static field definitions for autocomplete and MCP schema documentation.
+ */
+export function getBuiltinVariableDefinitions(): OutputField[] {
+  return [
+    {
+      field: "unixTimestamp",
+      description:
+        "Current time as Unix timestamp in seconds (Solidity-compatible)",
+    },
+    {
+      field: "unixTimestampMs",
+      description: "Current time as Unix timestamp in milliseconds",
+    },
+    {
+      field: "isoTimestamp",
+      description: "Current time as ISO 8601 UTC string",
+    },
+  ];
+}

--- a/keeperhub/lib/template-utils.ts
+++ b/keeperhub/lib/template-utils.ts
@@ -1,6 +1,17 @@
+import { findActionById } from "@/plugins";
 import { BUILTIN_NODE_ID } from "./builtin-variables";
 
 const TEMPLATE_REF_PATTERN = /\{\{@([^:]+):([^}]+)\}\}/;
+
+/** Minimal node shape needed by template helpers */
+export type TemplateNode = {
+  id: string;
+  data: {
+    label?: string;
+    type?: string;
+    config?: Record<string, unknown>;
+  };
+};
 
 /**
  * Checks whether a template reference like {{@nodeId:Label.field}}
@@ -21,4 +32,49 @@ export function doesNodeExist(
     return true;
   }
   return nodes.some((n) => n.id === nodeId);
+}
+
+/**
+ * Gets display text for a template badge by looking up the current node label.
+ * Resolves {{@nodeId:OldLabel.field}} to "CurrentLabel.field".
+ */
+export function getDisplayTextForTemplate(
+  template: string,
+  nodes: readonly TemplateNode[]
+): string {
+  const match = template.match(TEMPLATE_REF_PATTERN);
+  if (!match) {
+    return template;
+  }
+
+  const nodeId = match[1];
+  const rest = match[2];
+
+  const node = nodes.find((n) => n.id === nodeId);
+  if (!node) {
+    return rest;
+  }
+
+  let displayLabel: string | undefined = node.data.label;
+  if (!displayLabel && node.data.type === "action") {
+    const actionType = node.data.config?.actionType as string | undefined;
+    if (actionType) {
+      const action = findActionById(actionType);
+      displayLabel = action?.label;
+    }
+  }
+
+  const dotIndex = rest.indexOf(".");
+
+  if (dotIndex === -1) {
+    return displayLabel ?? rest;
+  }
+
+  const field = rest.substring(dotIndex + 1);
+
+  if (!displayLabel) {
+    return rest;
+  }
+
+  return `${displayLabel}.${field}`;
 }

--- a/keeperhub/lib/template-utils.ts
+++ b/keeperhub/lib/template-utils.ts
@@ -1,0 +1,24 @@
+import { BUILTIN_NODE_ID } from "./builtin-variables";
+
+const TEMPLATE_REF_PATTERN = /\{\{@([^:]+):([^}]+)\}\}/;
+
+/**
+ * Checks whether a template reference like {{@nodeId:Label.field}}
+ * points to a node that exists in the workflow (or is the built-in
+ * __system pseudo-node).
+ */
+export function doesNodeExist(
+  template: string,
+  nodes: ReadonlyArray<{ id: string }>
+): boolean {
+  const match = template.match(TEMPLATE_REF_PATTERN);
+  if (!match) {
+    return false;
+  }
+
+  const nodeId = match[1];
+  if (nodeId === BUILTIN_NODE_ID) {
+    return true;
+  }
+  return nodes.some((n) => n.id === nodeId);
+}

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -3,6 +3,12 @@
  * This executor captures step executions through the workflow SDK for better observability
  */
 
+// start custom keeperhub code //
+import {
+  BUILTIN_NODE_ID,
+  BUILTIN_NODE_LABEL,
+  getBuiltinVariables,
+} from "@/keeperhub/lib/builtin-variables";
 import {
   getMetricsCollector,
   LabelKeys,
@@ -12,7 +18,6 @@ import {
   decrementConcurrentExecutions,
   incrementConcurrentExecutions,
 } from "@/keeperhub/lib/metrics/instrumentation/saturation";
-// start custom keeperhub code //
 import {
   detectTriggerType,
   recordWorkflowComplete,
@@ -625,6 +630,15 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       );
       return;
     }
+
+    // start custom keeperhub code //
+    // Inject fresh built-in system variables for each node execution
+    const builtinSanitizedId = BUILTIN_NODE_ID.replace(/[^a-zA-Z0-9]/g, "_");
+    outputs[builtinSanitizedId] = {
+      label: BUILTIN_NODE_LABEL,
+      data: getBuiltinVariables(),
+    };
+    // end keeperhub code //
 
     try {
       let result: ExecutionResult;

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -632,7 +632,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
 
     // start custom keeperhub code //
-    // Inject fresh built-in system variables for each node execution
+    // Inject fresh built-in system variables before each node executes.
+    // Intentionally per-node (not per-workflow) so long-running sequential
+    // workflows get an up-to-date timestamp at each step.
     const builtinSanitizedId = BUILTIN_NODE_ID.replace(/[^a-zA-Z0-9]/g, "_");
     outputs[builtinSanitizedId] = {
       label: BUILTIN_NODE_LABEL,

--- a/tests/unit/builtin-variables.test.ts
+++ b/tests/unit/builtin-variables.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock server-only to allow importing workflow-executor in tests
+vi.mock("server-only", () => ({}));
+
+import {
+  BUILTIN_NODE_ID,
+  BUILTIN_NODE_LABEL,
+  getBuiltinVariableDefinitions,
+  getBuiltinVariables,
+} from "@/keeperhub/lib/builtin-variables";
+import { evaluateConditionExpression } from "@/lib/workflow-executor.workflow";
+
+describe("builtin-variables", () => {
+  describe("getBuiltinVariables", () => {
+    it("returns unixTimestamp as integer seconds", () => {
+      const vars = getBuiltinVariables();
+      expect(typeof vars.unixTimestamp).toBe("number");
+      expect(Number.isInteger(vars.unixTimestamp)).toBe(true);
+      const diff = Math.abs(
+        (vars.unixTimestamp as number) - Math.floor(Date.now() / 1000)
+      );
+      expect(diff).toBeLessThan(2);
+    });
+
+    it("returns unixTimestampMs as integer milliseconds", () => {
+      const vars = getBuiltinVariables();
+      expect(typeof vars.unixTimestampMs).toBe("number");
+      expect(Number.isInteger(vars.unixTimestampMs)).toBe(true);
+      const diff = Math.abs((vars.unixTimestampMs as number) - Date.now());
+      expect(diff).toBeLessThan(1000);
+    });
+
+    it("returns isoTimestamp as valid ISO string", () => {
+      const vars = getBuiltinVariables();
+      expect(typeof vars.isoTimestamp).toBe("string");
+      const parsed = new Date(vars.isoTimestamp as string);
+      expect(parsed.toISOString()).toBe(vars.isoTimestamp);
+    });
+
+    it("returns all three expected fields", () => {
+      const vars = getBuiltinVariables();
+      expect(Object.keys(vars)).toHaveLength(3);
+      expect(vars).toHaveProperty("unixTimestamp");
+      expect(vars).toHaveProperty("unixTimestampMs");
+      expect(vars).toHaveProperty("isoTimestamp");
+    });
+  });
+
+  describe("constants", () => {
+    it("BUILTIN_NODE_ID is __system", () => {
+      expect(BUILTIN_NODE_ID).toBe("__system");
+    });
+
+    it("BUILTIN_NODE_LABEL is System", () => {
+      expect(BUILTIN_NODE_LABEL).toBe("System");
+    });
+
+    it("sanitized BUILTIN_NODE_ID equals itself", () => {
+      const sanitized = BUILTIN_NODE_ID.replace(/[^a-zA-Z0-9]/g, "_");
+      expect(sanitized).toBe("__system");
+    });
+  });
+
+  describe("getBuiltinVariableDefinitions", () => {
+    it("returns definitions for all variables", () => {
+      const defs = getBuiltinVariableDefinitions();
+      expect(defs).toHaveLength(3);
+      const fields = defs.map((d) => d.field);
+      expect(fields).toContain("unixTimestamp");
+      expect(fields).toContain("unixTimestampMs");
+      expect(fields).toContain("isoTimestamp");
+    });
+
+    it("each definition has field and description", () => {
+      const defs = getBuiltinVariableDefinitions();
+      for (const def of defs) {
+        expect(def.field).toBeTruthy();
+        expect(def.description).toBeTruthy();
+      }
+    });
+  });
+});
+
+describe("condition evaluation with system variables", () => {
+  it("resolves __system variables in condition expressions", () => {
+    const outputs = {
+      __system: {
+        label: "System",
+        data: {
+          unixTimestamp: 1_700_000_000,
+          unixTimestampMs: 1_700_000_000_000,
+          isoTimestamp: "2023-11-14T22:13:20.000Z",
+        },
+      },
+      read_contract_1: {
+        label: "Read Contract",
+        data: { endTime: 1_600_000_000 },
+      },
+    };
+
+    const expression =
+      "{{@read_contract_1:Read Contract.endTime}} < {{@__system:System.unixTimestamp}}";
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(true);
+  });
+
+  it("returns false when contract timestamp is in the future", () => {
+    const outputs = {
+      __system: {
+        label: "System",
+        data: {
+          unixTimestamp: 1_700_000_000,
+          unixTimestampMs: 1_700_000_000_000,
+          isoTimestamp: "2023-11-14T22:13:20.000Z",
+        },
+      },
+      node1: {
+        label: "Read Contract",
+        data: { endTime: 1_800_000_000 },
+      },
+    };
+
+    const expression =
+      "{{@node1:Read Contract.endTime}} < {{@__system:System.unixTimestamp}}";
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(false);
+  });
+
+  it("compares contract timestamp against live system time", () => {
+    const futureTimestamp = Math.floor(Date.now() / 1000) + 86_400;
+    const outputs = {
+      __system: {
+        label: "System",
+        data: getBuiltinVariables(),
+      },
+      node1: {
+        label: "Read Contract",
+        data: { endTime: futureTimestamp },
+      },
+    };
+
+    const expression =
+      "{{@node1:Read Contract.endTime}} > {{@__system:System.unixTimestamp}}";
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(true);
+  });
+
+  it("works with unixTimestampMs", () => {
+    const outputs = {
+      __system: {
+        label: "System",
+        data: { unixTimestampMs: 1_700_000_000_000 },
+      },
+      node1: {
+        label: "API",
+        data: { timestamp: 1_600_000_000_000 },
+      },
+    };
+
+    const expression =
+      "{{@node1:API.timestamp}} < {{@__system:System.unixTimestampMs}}";
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(true);
+  });
+});

--- a/tests/unit/builtin-variables.test.ts
+++ b/tests/unit/builtin-variables.test.ts
@@ -6,7 +6,7 @@ vi.mock("server-only", () => ({}));
 import {
   BUILTIN_NODE_ID,
   BUILTIN_NODE_LABEL,
-  getBuiltinVariableDefinitions,
+  BUILTIN_VARIABLE_FIELDS,
   getBuiltinVariables,
 } from "@/keeperhub/lib/builtin-variables";
 import { evaluateConditionExpression } from "@/lib/workflow-executor.workflow";
@@ -62,19 +62,17 @@ describe("builtin-variables", () => {
     });
   });
 
-  describe("getBuiltinVariableDefinitions", () => {
-    it("returns definitions for all variables", () => {
-      const defs = getBuiltinVariableDefinitions();
-      expect(defs).toHaveLength(3);
-      const fields = defs.map((d) => d.field);
+  describe("BUILTIN_VARIABLE_FIELDS", () => {
+    it("contains definitions for all variables", () => {
+      expect(BUILTIN_VARIABLE_FIELDS).toHaveLength(3);
+      const fields = BUILTIN_VARIABLE_FIELDS.map((d) => d.field);
       expect(fields).toContain("unixTimestamp");
       expect(fields).toContain("unixTimestampMs");
       expect(fields).toContain("isoTimestamp");
     });
 
     it("each definition has field and description", () => {
-      const defs = getBuiltinVariableDefinitions();
-      for (const def of defs) {
+      for (const def of BUILTIN_VARIABLE_FIELDS) {
         expect(def.field).toBeTruthy();
         expect(def.description).toBeTruthy();
       }


### PR DESCRIPTION
# Summary

Add built-in system variables (`unixTimestamp`, `unixTimestampMs`, `isoTimestamp`) that are evaluated at execution time and available in Condition nodes and all template fields via `{{@__system:System.fieldName}}` syntax.

# Details

Smart contract read nodes return unix timestamps that need to be compared against the current time in Condition nodes (e.g., checking if an auction has expired). Previously there was no way to reference the current time at execution time.

This introduces a `__system` pseudo-node injected into the workflow outputs map before each node executes. It provides:

- `unixTimestamp` -- seconds since epoch (Solidity-compatible)
- `unixTimestampMs` -- milliseconds since epoch
- `isoTimestamp` -- ISO 8601 UTC string

Usage in a Condition expression:
```
{{@read-contract-1:Read Contract.endTime}} < {{@__system:System.unixTimestamp}}
```

Changes:
- New `keeperhub/lib/builtin-variables.ts` with constants and getter
- Inject into `outputs` in `executeNode()` so both Condition evaluation and config template resolution pick it up
- System variables appear in the `@` autocomplete dropdown for all nodes
- `__system` recognized as valid in badge rendering (blue, not red) and excluded from broken references validation
- MCP schemas endpoint documents the built-in variables for AI workflow generation
- 13 unit tests covering types, sanitization, and condition evaluation
