### PR TITLE
feat: Keep-1432: Support template references in database SQL nodes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -246,6 +246,18 @@
 .add-step-button:hover + .add-step-connector line {
   stroke: var(--primary);
 }
+
+.sql-template-badge {
+  background-color: rgba(59, 130, 246, 0.1);
+  color: rgb(37, 99, 235) !important;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 3px;
+  padding: 1px 4px;
+}
+
+.dark .sql-template-badge {
+  color: rgb(96, 165, 250) !important;
+}
 /* end keeperhub code */
 
 /* Safe area support for mobile devices */

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -26,6 +26,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { SqlTemplateEditor } from "@/keeperhub/components/ui/sql-template-editor";
 // start keeperhub
 import { actionRequiresCredentials } from "@/keeperhub/lib/integration-helpers";
 // end keeperhub
@@ -67,29 +68,21 @@ function DatabaseQueryFields({
 }) {
   return (
     <>
+      {/* start custom keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="dbQuery">SQL Query</Label>
-        <div className="overflow-hidden rounded-md border">
-          <CodeEditor
-            defaultLanguage="sql"
-            height="150px"
-            onChange={(value) => onUpdateConfig("dbQuery", value || "")}
-            options={{
-              minimap: { enabled: false },
-              lineNumbers: "on",
-              scrollBeyondLastLine: false,
-              fontSize: 12,
-              readOnly: disabled,
-              wordWrap: "off",
-            }}
-            value={(config?.dbQuery as string) || ""}
-          />
-        </div>
+        <SqlTemplateEditor
+          disabled={disabled}
+          height="150px"
+          onChange={(v) => onUpdateConfig("dbQuery", v)}
+          value={(config?.dbQuery as string) || ""}
+        />
         <p className="text-muted-foreground text-xs">
           The selected database connection above will be used to execute this
-          query.
+          query. Use @ to insert values from previous nodes.
         </p>
       </div>
+      {/* end keeperhub code */}
       <div className="space-y-2">
         <Label>Schema (Optional)</Label>
         <SchemaBuilder

--- a/keeperhub/components/ui/sql-template-editor.tsx
+++ b/keeperhub/components/ui/sql-template-editor.tsx
@@ -567,6 +567,12 @@ export function SqlTemplateEditor({
         {
           triggerCharacters: ["@"],
           provideCompletionItems: (model, position) => {
+            // Only provide suggestions for our editor instance (the
+            // provider is registered at the language level, not per-editor)
+            if (model !== editorRef.current?.getModel()) {
+              return { suggestions: [] };
+            }
+
             const textUntilPosition = model.getValueInRange({
               startLineNumber: position.lineNumber,
               startColumn: 1,

--- a/keeperhub/components/ui/sql-template-editor.tsx
+++ b/keeperhub/components/ui/sql-template-editor.tsx
@@ -666,18 +666,6 @@ export function SqlTemplateEditor({
 
   return (
     <>
-      <style>{`
-        .sql-template-badge {
-          background-color: rgba(59, 130, 246, 0.1);
-          color: rgb(37, 99, 235) !important;
-          border: 1px solid rgba(59, 130, 246, 0.2);
-          border-radius: 3px;
-          padding: 1px 4px;
-        }
-        .dark .sql-template-badge {
-          color: rgb(96, 165, 250) !important;
-        }
-      `}</style>
       <div className="overflow-hidden rounded-md border">
         <CodeEditor
           defaultLanguage="sql"

--- a/keeperhub/components/ui/sql-template-editor.tsx
+++ b/keeperhub/components/ui/sql-template-editor.tsx
@@ -1,0 +1,670 @@
+"use client";
+
+import type { OnMount } from "@monaco-editor/react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { CodeEditor } from "@/components/ui/code-editor";
+import { getReadContractOutputFields } from "@/keeperhub/lib/action-output-fields";
+import { getTriggerOutputFields } from "@/keeperhub/lib/trigger-output-fields";
+import { api } from "@/lib/api-client";
+import { getAvailableFields, type NodeOutputs } from "@/lib/utils/template";
+import {
+  currentWorkflowIdAtom,
+  type ExecutionLogEntry,
+  edgesAtom,
+  executionLogsAtom,
+  lastExecutionLogsAtom,
+  nodesAtom,
+  selectedNodeAtom,
+  type WorkflowNode,
+  WorkflowTriggerEnum,
+} from "@/lib/workflow-store";
+import { findActionById } from "@/plugins";
+
+// ---------------------------------------------------------------------------
+// Helpers (same logic as template-autocomplete.tsx to keep upstream node
+// discovery and field extraction consistent)
+// ---------------------------------------------------------------------------
+
+type ExecutionLogsByNodeId = Record<string, ExecutionLogEntry>;
+
+function buildExecutionLogsMap(
+  logs: Array<{
+    nodeId: string;
+    nodeName: string;
+    nodeType: string;
+    status: "pending" | "running" | "success" | "error";
+    output?: unknown;
+  }>
+): ExecutionLogsByNodeId {
+  const map: ExecutionLogsByNodeId = {};
+  for (const log of logs) {
+    map[log.nodeId] = {
+      nodeId: log.nodeId,
+      nodeName: log.nodeName,
+      nodeType: log.nodeType,
+      status: log.status,
+      output: log.output,
+    };
+  }
+  return map;
+}
+
+function getNodeDisplayName(node: WorkflowNode): string {
+  if (node.data.label) {
+    return node.data.label;
+  }
+  if (node.data.type === "action") {
+    const actionType = node.data.config?.actionType as string | undefined;
+    if (actionType) {
+      const action = findActionById(actionType);
+      if (action?.label) {
+        return action.label;
+      }
+    }
+    return actionType || "HTTP Request";
+  }
+  if (node.data.type === "trigger") {
+    const triggerType = node.data.config?.triggerType as string | undefined;
+    return triggerType || "Manual";
+  }
+  return "Node";
+}
+
+type SchemaField = {
+  name: string;
+  type: "string" | "number" | "boolean" | "array" | "object";
+  itemType?: "string" | "number" | "boolean" | "object";
+  fields?: SchemaField[];
+  description?: string;
+};
+
+function schemaToFields(
+  schema: SchemaField[],
+  prefix = ""
+): Array<{ field: string; description: string }> {
+  const fields: Array<{ field: string; description: string }> = [];
+  for (const f of schema) {
+    const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
+    const typeLabel = f.type === "array" ? `${f.itemType}[]` : f.type;
+    fields.push({ field: fieldPath, description: f.description || typeLabel });
+    if (f.type === "object" && f.fields && f.fields.length > 0) {
+      fields.push(...schemaToFields(f.fields, fieldPath));
+    }
+    if (
+      f.type === "array" &&
+      f.itemType === "object" &&
+      f.fields &&
+      f.fields.length > 0
+    ) {
+      fields.push(...schemaToFields(f.fields, `${fieldPath}[0]`));
+    }
+  }
+  return fields;
+}
+
+type FieldEntry = { field: string; description: string };
+
+function isActionType(
+  actionType: string | undefined,
+  ...matches: string[]
+): boolean {
+  if (!actionType) {
+    return false;
+  }
+  return matches.some(
+    (m) =>
+      actionType === m ||
+      actionType.endsWith(`/${m.toLowerCase().replace(/\s+/g, "-")}`)
+  );
+}
+
+function tryParseSchemaFields(
+  raw: string | undefined,
+  prefix?: string
+): FieldEntry[] | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const schema = JSON.parse(raw) as SchemaField[];
+    if (schema.length > 0) {
+      return schemaToFields(schema, prefix);
+    }
+  } catch {
+    // invalid JSON, fall through
+  }
+  return null;
+}
+
+function getActionFields(node: WorkflowNode): FieldEntry[] | null {
+  const actionType = node.data.config?.actionType as string | undefined;
+
+  if (actionType === "HTTP Request") {
+    return [
+      { field: "data", description: "Response data" },
+      { field: "status", description: "HTTP status code" },
+    ];
+  }
+
+  if (actionType === "Database Query") {
+    const dbSchema = node.data.config?.dbSchema as string | undefined;
+    return (
+      tryParseSchemaFields(dbSchema) ?? [
+        { field: "rows", description: "Query result rows" },
+        { field: "count", description: "Number of rows" },
+      ]
+    );
+  }
+
+  if (isActionType(actionType, "Generate Text", "ai-gateway/generate-text")) {
+    const aiSchema = node.data.config?.aiSchema as string | undefined;
+    const aiFormat = node.data.config?.aiFormat as string | undefined;
+    if (aiFormat === "object") {
+      return (
+        tryParseSchemaFields(aiSchema, "object") ?? [
+          { field: "text", description: "Generated text" },
+        ]
+      );
+    }
+    return [{ field: "text", description: "Generated text" }];
+  }
+
+  if (isActionType(actionType, "Read Contract", "web3/read-contract")) {
+    const abi = node.data.config?.abi as string | undefined;
+    const abiFunction = node.data.config?.abiFunction as string | undefined;
+    const dynamicFields = getReadContractOutputFields(abi, abiFunction);
+    if (dynamicFields.length > 0) {
+      return dynamicFields;
+    }
+  }
+
+  if (actionType) {
+    const action = findActionById(actionType);
+    if (action?.outputFields && action.outputFields.length > 0) {
+      return action.outputFields;
+    }
+  }
+
+  return null;
+}
+
+function getTriggerFields(node: WorkflowNode): FieldEntry[] {
+  const triggerType = node.data.config?.triggerType as string | undefined;
+  const webhookSchema = node.data.config?.webhookSchema as string | undefined;
+  const config = node.data.config || {};
+
+  if (triggerType === WorkflowTriggerEnum.EVENT) {
+    const fields = getTriggerOutputFields(triggerType, config);
+    if (fields.length > 0) {
+      return fields;
+    }
+  }
+
+  if (triggerType === "Webhook") {
+    const parsed = tryParseSchemaFields(webhookSchema);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  if (triggerType) {
+    const fields = getTriggerOutputFields(triggerType, config);
+    if (fields.length > 0) {
+      return fields;
+    }
+  }
+
+  return [
+    { field: "triggered", description: "Trigger status" },
+    { field: "timestamp", description: "Trigger timestamp" },
+    { field: "input", description: "Input data" },
+  ];
+}
+
+function getCommonFields(node: WorkflowNode): FieldEntry[] {
+  if (node.data.type === "action") {
+    return (
+      getActionFields(node) ?? [{ field: "data", description: "Output data" }]
+    );
+  }
+  if (node.data.type === "trigger") {
+    return getTriggerFields(node);
+  }
+  return [{ field: "data", description: "Output data" }];
+}
+
+function sanitizeNodeId(nodeId: string): string {
+  return nodeId.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export type SqlTemplateEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  height?: string;
+};
+
+export function SqlTemplateEditor({
+  value,
+  onChange,
+  disabled,
+  height = "150px",
+}: SqlTemplateEditorProps) {
+  const [nodes] = useAtom(nodesAtom);
+  const [edges] = useAtom(edgesAtom);
+  const [selectedNodeId] = useAtom(selectedNodeAtom);
+  const executionLogs = useAtomValue(executionLogsAtom);
+  const currentWorkflowId = useAtomValue(currentWorkflowIdAtom);
+  const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
+  const setLastExecutionLogs = useSetAtom(lastExecutionLogsAtom);
+
+  // Refs for Monaco provider access to current React state
+  const nodesRef = useRef(nodes);
+  const edgesRef = useRef(edges);
+  const selectedNodeRef = useRef(selectedNodeId);
+  const executionLogsRef = useRef(executionLogs);
+  const lastExecutionLogsRef = useRef(lastExecutionLogs);
+  const currentWorkflowIdRef = useRef(currentWorkflowId);
+  const lastFetchWorkflowIdRef = useRef<string | null>(null);
+
+  // Template mapping: "Label.field" -> nodeId (for display <-> stored conversion)
+  const templateMapRef = useRef(new Map<string, string>());
+
+  // Keep refs in sync
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
+  useEffect(() => {
+    edgesRef.current = edges;
+  }, [edges]);
+  useEffect(() => {
+    selectedNodeRef.current = selectedNodeId;
+  }, [selectedNodeId]);
+  useEffect(() => {
+    executionLogsRef.current = executionLogs;
+  }, [executionLogs]);
+  useEffect(() => {
+    lastExecutionLogsRef.current = lastExecutionLogs;
+  }, [lastExecutionLogs]);
+  useEffect(() => {
+    currentWorkflowIdRef.current = currentWorkflowId;
+  }, [currentWorkflowId]);
+
+  // Editor + decoration refs
+  // biome-ignore lint/suspicious/noExplicitAny: Monaco editor types are complex and vary across versions
+  const editorRef = useRef<any>(null);
+  const decorationIdsRef = useRef<string[]>([]);
+
+  // Convert stored value -> display value.
+  // Display format: {{Label.field}} (user-friendly, no node IDs)
+  // Stored format: {{@nodeId:Label.field}} (used at runtime)
+  const displayValue = useMemo(
+    () => value.replace(/\{\{@[^:]+:([^}]+)\}\}/g, "{{$1}}"),
+    [value]
+  );
+
+  // Rebuild template map from stored value (kept separate from useMemo to
+  // avoid side effects in a pure computation)
+  useEffect(() => {
+    const map = new Map<string, string>();
+    const pattern = /\{\{@([^:]+):([^}]+)\}\}/g;
+    for (const match of value.matchAll(pattern)) {
+      map.set(match[2], match[1]);
+    }
+    templateMapRef.current = map;
+  }, [value]);
+
+  // Convert display value -> stored value using template map
+  const handleEditorChange = useCallback(
+    (newDisplay: string) => {
+      const stored = newDisplay.replace(
+        /\{\{([^@}][^}]*)\}\}/g,
+        (full: string, displayPart: string) => {
+          const nodeId = templateMapRef.current.get(displayPart);
+          return nodeId ? `{{@${nodeId}:${displayPart}}}` : full;
+        }
+      );
+      onChange(stored);
+    },
+    [onChange]
+  );
+
+  // Lazy-load last execution logs (same pattern as template-autocomplete.tsx)
+  useEffect(() => {
+    const alreadyHaveLogs = lastExecutionLogs.workflowId === currentWorkflowId;
+    const fetchAlreadyInProgress =
+      lastFetchWorkflowIdRef.current === currentWorkflowId;
+    if (!currentWorkflowId || alreadyHaveLogs || fetchAlreadyInProgress) {
+      return;
+    }
+
+    const workflowId = currentWorkflowId;
+    lastFetchWorkflowIdRef.current = workflowId;
+    let cancelled = false;
+
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: async fetch with cancellation guard mirrors template-autocomplete.tsx
+    const fetchLogs = async (): Promise<void> => {
+      try {
+        const executions = await api.workflow.getExecutions(workflowId);
+        if (cancelled) {
+          return;
+        }
+        const latest = executions[0];
+        if (!latest?.id) {
+          lastFetchWorkflowIdRef.current = null;
+          return;
+        }
+        const { logs } = await api.workflow.getExecutionLogs(latest.id);
+        if (cancelled) {
+          return;
+        }
+        const logsByNodeId = buildExecutionLogsMap(logs);
+        const isStillRelevant =
+          !cancelled && currentWorkflowIdRef.current === workflowId;
+        if (isStillRelevant) {
+          setLastExecutionLogs({ workflowId, logs: logsByNodeId });
+        }
+      } catch {
+        // non-blocking
+      } finally {
+        if (lastFetchWorkflowIdRef.current === workflowId) {
+          lastFetchWorkflowIdRef.current = null;
+        }
+      }
+    };
+
+    fetchLogs();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentWorkflowId, lastExecutionLogs.workflowId, setLastExecutionLogs]);
+
+  // Get upstream nodes for the currently selected node
+  function getUpstreamNodes(): WorkflowNode[] {
+    const nodeId = selectedNodeRef.current;
+    if (!nodeId) {
+      return [];
+    }
+    const allNodes = nodesRef.current;
+    const allEdges = edgesRef.current;
+    const visited = new Set<string>();
+    const upstream: string[] = [];
+    const traverse = (id: string): void => {
+      if (visited.has(id)) {
+        return;
+      }
+      visited.add(id);
+      for (const edge of allEdges) {
+        if (edge.target === id) {
+          upstream.push(edge.source);
+          traverse(edge.source);
+        }
+      }
+    };
+    traverse(nodeId);
+    return allNodes.filter((n) => upstream.includes(n.id));
+  }
+
+  type Suggestion = {
+    label: string;
+    insertText: string;
+    detail?: string;
+    nodeId: string;
+    field?: string;
+  };
+
+  // Resolve the best available output for a node (runtime > last-run > null)
+  function resolveNodeOutput(nodeId: string): unknown {
+    const runtimeOutput = executionLogsRef.current[nodeId]?.output;
+    if (runtimeOutput !== undefined && runtimeOutput !== null) {
+      return runtimeOutput;
+    }
+    const lastLogs =
+      lastExecutionLogsRef.current.workflowId === currentWorkflowIdRef.current
+        ? lastExecutionLogsRef.current.logs
+        : {};
+    const lastRunOutput = lastLogs[nodeId]?.output;
+    if (lastRunOutput !== undefined && lastRunOutput !== null) {
+      return lastRunOutput;
+    }
+    return null;
+  }
+
+  // Build suggestions from runtime/last-run output data.
+  // Uses display format for insertText and updates the template map.
+  function suggestionsFromOutput(
+    node: WorkflowNode,
+    nodeName: string,
+    output: unknown
+  ): Suggestion[] {
+    const sanitizedId = sanitizeNodeId(node.id);
+    const nodeOutputs: NodeOutputs = {
+      [sanitizedId]: { label: nodeName, data: output },
+    };
+    const runtimeFields = getAvailableFields(nodeOutputs);
+    const result: Suggestion[] = [];
+    for (const entry of runtimeFields) {
+      const fieldPath = entry.fieldPath || entry.field;
+      if (!fieldPath) {
+        continue;
+      }
+      const displayKey = `${nodeName}.${fieldPath}`;
+      templateMapRef.current.set(displayKey, node.id);
+      result.push({
+        label: displayKey,
+        insertText: `{{${displayKey}}}`,
+        nodeId: node.id,
+        field: fieldPath,
+      });
+    }
+    return result;
+  }
+
+  // Build suggestions from static field definitions.
+  // Uses display format for insertText and updates the template map.
+  function suggestionsFromStaticFields(
+    node: WorkflowNode,
+    nodeName: string
+  ): Suggestion[] {
+    const fields = getCommonFields(node);
+    const result: Suggestion[] = [];
+    for (const f of fields) {
+      const displayKey = `${nodeName}.${f.field}`;
+      templateMapRef.current.set(displayKey, node.id);
+      result.push({
+        label: displayKey,
+        insertText: `{{${displayKey}}}`,
+        detail: f.description,
+        nodeId: node.id,
+        field: f.field,
+      });
+    }
+    return result;
+  }
+
+  // Build completion suggestions from upstream nodes
+  function buildSuggestions(): Suggestion[] {
+    const upstreamNodes = getUpstreamNodes();
+    const suggestions: Suggestion[] = [];
+
+    for (const node of upstreamNodes) {
+      const nodeName = getNodeDisplayName(node);
+      const output = resolveNodeOutput(node.id);
+      const nodeSuggestions =
+        output !== null
+          ? suggestionsFromOutput(node, nodeName, output)
+          : suggestionsFromStaticFields(node, nodeName);
+      suggestions.push(...nodeSuggestions);
+    }
+
+    return suggestions;
+  }
+
+  // Update decorations for display-format template patterns {{...}}
+  const updateDecorations = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    const model = editor.getModel();
+    if (!model) {
+      return;
+    }
+
+    const text = model.getValue();
+    const templatePattern = /\{\{([^}]+)\}\}/g;
+    // biome-ignore lint/suspicious/noExplicitAny: Monaco decoration types vary across versions
+    const newDecorations: any[] = [];
+
+    for (const match of text.matchAll(templatePattern)) {
+      const start = model.getPositionAt(match.index);
+      const end = model.getPositionAt(match.index + match[0].length);
+      newDecorations.push({
+        range: {
+          startLineNumber: start.lineNumber,
+          startColumn: start.column,
+          endLineNumber: end.lineNumber,
+          endColumn: end.column,
+        },
+        options: {
+          inlineClassName: "sql-template-badge",
+          hoverMessage: { value: `Template: ${match[1]}` },
+        },
+      });
+    }
+
+    decorationIdsRef.current = editor.deltaDecorations(
+      decorationIdsRef.current,
+      newDecorations
+    );
+  }, []);
+
+  useEffect(() => {
+    updateDecorations();
+  }, [updateDecorations]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: buildSuggestions reads from refs to always get current state; adding it would cause Monaco to re-mount on every render
+  const handleMount: OnMount = useCallback(
+    (editor, monaco) => {
+      editorRef.current = editor;
+
+      // Initial decoration pass
+      updateDecorations();
+
+      // Update decorations on every content change
+      editor.onDidChangeModelContent(() => {
+        updateDecorations();
+      });
+
+      // Register completion provider for @ trigger
+      const disposable = monaco.languages.registerCompletionItemProvider(
+        "sql",
+        {
+          triggerCharacters: ["@"],
+          provideCompletionItems: (model, position) => {
+            const textUntilPosition = model.getValueInRange({
+              startLineNumber: position.lineNumber,
+              startColumn: 1,
+              endLineNumber: position.lineNumber,
+              endColumn: position.column,
+            });
+
+            // Find the last @ that is not inside a completed template
+            const atIndex = findActiveAtIndex(textUntilPosition);
+            if (atIndex === -1) {
+              return { suggestions: [] };
+            }
+
+            const range = {
+              startLineNumber: position.lineNumber,
+              startColumn: atIndex + 1, // 1-based
+              endLineNumber: position.lineNumber,
+              endColumn: position.column,
+            };
+
+            const items = buildSuggestions();
+            const suggestions = items.map((item) => ({
+              label: item.label,
+              kind: monaco.languages.CompletionItemKind.Variable,
+              insertText: item.insertText,
+              detail: item.detail || "",
+              range,
+              filterText: `@${item.label}`,
+              sortText: `0-${item.label}`,
+            }));
+
+            return { suggestions };
+          },
+        }
+      );
+
+      // Cleanup on unmount
+      editor.onDidDispose(() => {
+        disposable.dispose();
+      });
+    },
+    [updateDecorations]
+  );
+
+  return (
+    <>
+      <style>{`
+        .sql-template-badge {
+          background-color: rgba(59, 130, 246, 0.1);
+          color: rgb(37, 99, 235) !important;
+          border: 1px solid rgba(59, 130, 246, 0.2);
+          border-radius: 3px;
+          padding: 1px 4px;
+        }
+        .dark .sql-template-badge {
+          color: rgb(96, 165, 250) !important;
+        }
+      `}</style>
+      <div className="overflow-hidden rounded-md border">
+        <CodeEditor
+          defaultLanguage="sql"
+          height={height}
+          onChange={(v) => handleEditorChange(v || "")}
+          onMount={handleMount}
+          options={{
+            minimap: { enabled: false },
+            lineNumbers: "on",
+            scrollBeyondLastLine: false,
+            fontSize: 12,
+            readOnly: disabled,
+            wordWrap: "off",
+          }}
+          value={displayValue}
+        />
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Utility: find the position of an active "@" that is not inside a completed
+// template pattern ({{...}}).
+// ---------------------------------------------------------------------------
+function findActiveAtIndex(text: string): number {
+  const templatePattern = /\{\{[^}]+\}\}/g;
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (const m of text.matchAll(templatePattern)) {
+    ranges.push({ start: m.index, end: m.index + m[0].length });
+  }
+
+  // Walk backwards to find the last @ not inside any template
+  for (let i = text.length - 1; i >= 0; i--) {
+    if (text[i] === "@") {
+      const isInsideTemplate = ranges.some((r) => i >= r.start && i < r.end);
+      if (!isInsideTemplate) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}

--- a/lib/steps/database-query.ts
+++ b/lib/steps/database-query.ts
@@ -65,6 +65,11 @@ async function executeQuery(
       if (p === null || p === undefined) {
         return null;
       }
+      // Date and Uint8Array are natively supported by postgres.js
+      if (p instanceof Date || p instanceof Uint8Array) {
+        return p;
+      }
+      // Objects/arrays must be JSON-stringified for JSONB columns
       if (typeof p === "object") {
         return JSON.stringify(p);
       }
@@ -72,7 +77,7 @@ async function executeQuery(
     });
     return await client.unsafe(
       queryString,
-      serialized as postgres.SerializableParameter[]
+      serialized as postgres.ParameterOrJSON<never>[]
     );
   }
   // end keeperhub code //

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -803,7 +803,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // Store null output for disabled nodes so downstream templates don't fail
       const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
       outputs[sanitizedNodeId] = {
-        label: node.data.label || nodeId,
+        label: getNodeName(node),
         data: null,
       };
 
@@ -995,7 +995,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // Store outputs with sanitized nodeId for template variable lookup
       const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
       outputs[sanitizedNodeId] = {
-        label: node.data.label || nodeId,
+        label: getNodeName(node),
         data: result.data,
       };
 

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -765,11 +765,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     if (node.data.type === "action") {
       const actionType = node.data.config?.actionType as string;
       if (actionType) {
-        // Look up the human-readable label from the step registry
-        const label = getActionLabel(actionType);
-        if (label) {
-          return label;
-        }
+        // Look up the human-readable label from the step registry;
+        // fall back to actionType itself (system actions like "HTTP Request",
+        // "Database Query", "Condition" use their type name as the label)
+        return getActionLabel(actionType) ?? actionType;
       }
       return "Action";
     }

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -486,15 +486,12 @@ function replaceConfigTemplate(
     return "";
   }
 
-  const formatted = formatConfigValue(resolved);
-  console.log("[Template] Resolved:", {
-    type: typeof resolved,
-    isArray: Array.isArray(resolved),
-    formattedLength: formatted.length,
-    preview:
-      formatted.length > 100 ? `${formatted.slice(0, 100)}...` : formatted,
-  });
-  return formatted;
+  console.log(
+    "[Template] Resolved, type:",
+    typeof resolved,
+    Array.isArray(resolved) ? "array" : ""
+  );
+  return formatConfigValue(resolved);
 }
 
 /**
@@ -545,30 +542,16 @@ export function resolveDisplayTemplate(
     dotIndex === -1 ? displayRef : displayRef.substring(0, dotIndex);
   const fieldPath = dotIndex === -1 ? "" : displayRef.substring(dotIndex + 1);
 
-  console.log("[DB Template] Resolving display template:", {
-    displayRef,
-    label,
-    fieldPath: fieldPath || "(whole output)",
-    availableLabels: Object.values(outputs).map((e) => e.label),
-  });
-
   const entry = findOutputByLabel(label, outputs);
   if (!entry) {
-    console.log("[DB Template] No node found with label:", label);
     return null;
   }
 
   if (entry.data === null || entry.data === undefined) {
-    console.log("[DB Template] Found node by label but data is null/undefined");
     return null;
   }
 
-  const resolved = resolveFromOutputData(entry.data, fieldPath) ?? null;
-  console.log("[DB Template] Display template resolved:", {
-    type: typeof resolved,
-    isNull: resolved === null,
-  });
-  return resolved;
+  return resolveFromOutputData(entry.data, fieldPath) ?? null;
 }
 
 /**
@@ -586,12 +569,6 @@ export function extractTemplateParameters(
   query: string,
   outputs: NodeOutputs
 ): { parameterizedQuery: string; paramValues: unknown[] } {
-  console.log("[DB Template] Extracting parameters:", {
-    queryPreview: query.length > 200 ? `${query.slice(0, 200)}...` : query,
-    outputNodeCount: Object.keys(outputs).length,
-    outputLabels: Object.values(outputs).map((e) => e.label),
-  });
-
   const paramValues: unknown[] = [];
   let paramIndex = 0;
 
@@ -616,19 +593,6 @@ export function extractTemplateParameters(
       return `$${paramIndex}`;
     }
   );
-
-  console.log("[DB Template] Extraction complete:", {
-    paramCount: paramValues.length,
-    paramTypes: paramValues.map((v) => {
-      if (v === null) {
-        return "null";
-      }
-      if (Array.isArray(v)) {
-        return "array";
-      }
-      return typeof v;
-    }),
-  });
 
   return { parameterizedQuery: result, paramValues };
 }
@@ -670,37 +634,22 @@ export function resolveTemplateToRawValue(
     ? rest.substring(rest.indexOf(".") + 1).trim()
     : "";
 
-  console.log("[DB Template] Resolving stored template:", {
-    nodeId: trimmedNodeId,
-    sanitizedNodeId,
-    fieldPath: fieldPath || "(whole output)",
-    outputKeys: Object.keys(outputs),
-    foundOutput: !!output,
-  });
-
   const resolvedOutput = output ?? findOutputByLabelFallback(rest, outputs);
 
   if (!resolvedOutput) {
-    console.log("[DB Template] No output found for node:", trimmedNodeId);
     return null;
   }
 
   const data = resolvedOutput.data;
   if (data === null || data === undefined) {
-    console.log("[DB Template] Output data is null/undefined");
     return null;
   }
 
-  const resolved = resolveFromOutputData(data, fieldPath);
-  console.log("[DB Template] Stored template resolved:", {
-    type: typeof resolved,
-    isNull: resolved === null || resolved === undefined,
-  });
-  return resolved ?? null;
+  return resolveFromOutputData(data, fieldPath) ?? null;
 }
 
 /**
- * Attempt label-based fallback lookup, logging the result.
+ * Attempt label-based fallback lookup when node ID is not found in outputs.
  */
 function findOutputByLabelFallback(
   rest: string,
@@ -708,11 +657,7 @@ function findOutputByLabelFallback(
 ): { label: string; data: unknown } | undefined {
   const dotIndex = rest.indexOf(".");
   const label = dotIndex === -1 ? rest : rest.substring(0, dotIndex);
-  const result = findOutputByLabel(label, outputs);
-  if (result) {
-    console.log("[DB Template] Found node by label fallback:", label);
-  }
-  return result;
+  return findOutputByLabel(label, outputs);
 }
 // end keeperhub code //
 

--- a/tests/unit/db-template-params.test.ts
+++ b/tests/unit/db-template-params.test.ts
@@ -73,6 +73,33 @@ describe("DB template parameter extraction", () => {
       expect(parameterizedQuery).toBe("SELECT * FROM t WHERE name = $1");
     });
 
+    it("preserves leading quote when trailing quote is missing (asymmetric)", () => {
+      const outputs = makeOutputs();
+      const query =
+        "SELECT * FROM t WHERE name = '{{@abc_123:HTTP Request.data.total}}";
+      const { parameterizedQuery } = extractTemplateParameters(query, outputs);
+
+      expect(parameterizedQuery).toBe("SELECT * FROM t WHERE name = '$1");
+    });
+
+    it("preserves trailing quote when leading quote is missing (asymmetric)", () => {
+      const outputs = makeOutputs();
+      const query =
+        "SELECT * FROM t WHERE name = {{@abc_123:HTTP Request.data.total}}'";
+      const { parameterizedQuery } = extractTemplateParameters(query, outputs);
+
+      expect(parameterizedQuery).toBe("SELECT * FROM t WHERE name = $1'");
+    });
+
+    it("strips quotes on display-format templates symmetrically", () => {
+      const outputs = makeOutputs();
+      const query =
+        "SELECT * FROM t WHERE name = '{{HTTP Request.data.comments[0].body}}'";
+      const { parameterizedQuery } = extractTemplateParameters(query, outputs);
+
+      expect(parameterizedQuery).toBe("SELECT * FROM t WHERE name = $1");
+    });
+
     it("handles multiple templates in one query", () => {
       const outputs = makeOutputs();
       const query =

--- a/tests/unit/db-template-params.test.ts
+++ b/tests/unit/db-template-params.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  extractTemplateParameters,
+  resolveDisplayTemplate,
+  resolveTemplateToRawValue,
+} from "@/lib/workflow-executor.workflow";
+
+type NodeOutputs = Record<string, { label: string; data: unknown }>;
+
+const HTTP_STEP_OUTPUT = {
+  success: true,
+  data: {
+    skip: 0,
+    limit: 30,
+    total: 340,
+    comments: [
+      { id: 1, body: "Great work!", user: { id: 105, fullName: "Emma" } },
+      { id: 2, body: "Nice idea!", user: { id: 149, fullName: "Wyatt" } },
+    ],
+  },
+  status: 200,
+};
+
+function makeOutputs(
+  overrides?: Partial<Record<string, { label: string; data: unknown }>>
+): NodeOutputs {
+  return {
+    node_1: { label: "Trigger", data: { triggered: true, timestamp: 1 } },
+    abc_123: { label: "HTTP Request", data: HTTP_STEP_OUTPUT },
+    ...overrides,
+  };
+}
+
+describe("DB template parameter extraction", () => {
+  describe("extractTemplateParameters", () => {
+    it("extracts stored-format template and resolves value", () => {
+      const outputs = makeOutputs();
+      const query =
+        "INSERT INTO t(data) VALUES ({{@abc_123:HTTP Request.data.comments}}::jsonb)";
+      const { parameterizedQuery, paramValues } = extractTemplateParameters(
+        query,
+        outputs
+      );
+
+      expect(parameterizedQuery).toBe("INSERT INTO t(data) VALUES ($1::jsonb)");
+      expect(paramValues).toHaveLength(1);
+      expect(paramValues[0]).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("extracts display-format template and resolves value", () => {
+      const outputs = makeOutputs();
+      const query =
+        "INSERT INTO t(data) VALUES ({{HTTP Request.data.comments}}::jsonb)";
+      const { parameterizedQuery, paramValues } = extractTemplateParameters(
+        query,
+        outputs
+      );
+
+      expect(parameterizedQuery).toBe("INSERT INTO t(data) VALUES ($1::jsonb)");
+      expect(paramValues).toHaveLength(1);
+      expect(paramValues[0]).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("strips surrounding single quotes from templates", () => {
+      const outputs = makeOutputs();
+      const query =
+        "SELECT * FROM t WHERE name = '{{@abc_123:HTTP Request.data.comments[0].body}}'";
+      const { parameterizedQuery } = extractTemplateParameters(query, outputs);
+
+      expect(parameterizedQuery).toBe("SELECT * FROM t WHERE name = $1");
+    });
+
+    it("handles multiple templates in one query", () => {
+      const outputs = makeOutputs();
+      const query =
+        "INSERT INTO t(a, b) VALUES ({{@abc_123:HTTP Request.data.total}}, {{@node_1:Trigger.timestamp}})";
+      const { parameterizedQuery, paramValues } = extractTemplateParameters(
+        query,
+        outputs
+      );
+
+      expect(parameterizedQuery).toBe("INSERT INTO t(a, b) VALUES ($1, $2)");
+      expect(paramValues).toHaveLength(2);
+      expect(paramValues[0]).toBe(340);
+      expect(paramValues[1]).toBe(1);
+    });
+
+    it("preserves native types (arrays, numbers, strings)", () => {
+      const outputs = makeOutputs();
+      const query =
+        "INSERT INTO t(arr, num, txt) VALUES ({{@abc_123:HTTP Request.data.comments}}::jsonb, {{@abc_123:HTTP Request.data.total}}, {{@abc_123:HTTP Request.data.comments[0].body}})";
+      const { paramValues } = extractTemplateParameters(query, outputs);
+
+      expect(Array.isArray(paramValues[0])).toBe(true);
+      expect(typeof paramValues[1]).toBe("number");
+      expect(typeof paramValues[2]).toBe("string");
+    });
+
+    it("returns null for missing node reference", () => {
+      const outputs = makeOutputs();
+      const query = "SELECT {{@missing_node:Missing.field}}";
+      const { paramValues } = extractTemplateParameters(query, outputs);
+
+      expect(paramValues).toHaveLength(1);
+      expect(paramValues[0]).toBeNull();
+    });
+
+    it("returns empty paramValues when query has no templates", () => {
+      const outputs = makeOutputs();
+      const query = "SELECT * FROM t WHERE id = 1";
+      const { parameterizedQuery, paramValues } = extractTemplateParameters(
+        query,
+        outputs
+      );
+
+      expect(parameterizedQuery).toBe(query);
+      expect(paramValues).toHaveLength(0);
+    });
+  });
+
+  describe("resolveDisplayTemplate", () => {
+    it("resolves with exact label match", () => {
+      const outputs = makeOutputs();
+      const result = resolveDisplayTemplate(
+        "HTTP Request.data.comments",
+        outputs
+      );
+
+      expect(result).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("resolves with case-insensitive label match", () => {
+      const outputs = makeOutputs();
+      const result = resolveDisplayTemplate(
+        "http request.data.comments",
+        outputs
+      );
+
+      expect(result).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("resolves with mixed-case label", () => {
+      const outputs = makeOutputs();
+      const result = resolveDisplayTemplate(
+        "Http Request.data.comments",
+        outputs
+      );
+
+      expect(result).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("returns null when label not found", () => {
+      const outputs = makeOutputs();
+      const result = resolveDisplayTemplate("Unknown Node.data.field", outputs);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when data is null", () => {
+      const outputs: NodeOutputs = {
+        n1: { label: "Empty", data: null },
+      };
+      const result = resolveDisplayTemplate("Empty.field", outputs);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns whole output data when no field path", () => {
+      const outputs = makeOutputs();
+      const result = resolveDisplayTemplate("Trigger", outputs);
+
+      expect(result).toEqual({ triggered: true, timestamp: 1 });
+    });
+
+    it("resolves nested field paths", () => {
+      const outputs = makeOutputs();
+      const result = resolveDisplayTemplate(
+        "HTTP Request.data.comments[0].user.fullName",
+        outputs
+      );
+
+      expect(result).toBe("Emma");
+    });
+  });
+
+  describe("resolveTemplateToRawValue", () => {
+    it("resolves by sanitized node ID", () => {
+      const outputs = makeOutputs();
+      const result = resolveTemplateToRawValue(
+        "abc_123",
+        "HTTP Request.data.total",
+        outputs
+      );
+
+      expect(result).toBe(340);
+    });
+
+    it("resolves with node ID containing dashes (sanitization)", () => {
+      const outputs: NodeOutputs = {
+        abc_123: { label: "API", data: { value: 42 } },
+      };
+      const result = resolveTemplateToRawValue("abc-123", "API.value", outputs);
+
+      expect(result).toBe(42);
+    });
+
+    it("falls back to label matching when node ID not found", () => {
+      const outputs = makeOutputs();
+      const result = resolveTemplateToRawValue(
+        "stale_node_id",
+        "HTTP Request.data.comments",
+        outputs
+      );
+
+      expect(result).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("label fallback is case-insensitive", () => {
+      const outputs = makeOutputs();
+      const result = resolveTemplateToRawValue(
+        "wrong_id",
+        "http request.data.total",
+        outputs
+      );
+
+      expect(result).toBe(340);
+    });
+
+    it("returns null when neither ID nor label matches", () => {
+      const outputs = makeOutputs();
+      const result = resolveTemplateToRawValue(
+        "missing",
+        "Unknown.field",
+        outputs
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when output data is null", () => {
+      const outputs: NodeOutputs = {
+        n1: { label: "Empty", data: null },
+      };
+      const result = resolveTemplateToRawValue("n1", "Empty.field", outputs);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns whole output when no field path in rest", () => {
+      const outputs = makeOutputs();
+      const result = resolveTemplateToRawValue("node_1", "Trigger", outputs);
+
+      expect(result).toEqual({ triggered: true, timestamp: 1 });
+    });
+  });
+
+  describe("real-world reproduction: HTTP Request -> Database Query", () => {
+    it("resolves display-format comments template from HTTP output", () => {
+      const outputs = makeOutputs();
+      const query = `INSERT INTO test2(name, identifier, metadata)
+VALUES ('foo', now(), {{HTTP Request.data.comments}}::jsonb) RETURNING *;`;
+
+      const { parameterizedQuery, paramValues } = extractTemplateParameters(
+        query,
+        outputs
+      );
+
+      expect(parameterizedQuery).toBe(
+        `INSERT INTO test2(name, identifier, metadata)
+VALUES ('foo', now(), $1::jsonb) RETURNING *;`
+      );
+      expect(paramValues).toHaveLength(1);
+      expect(Array.isArray(paramValues[0])).toBe(true);
+      expect(paramValues[0]).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("resolves stored-format comments template from HTTP output", () => {
+      const outputs = makeOutputs();
+      const query = `INSERT INTO test2(name, identifier, metadata)
+VALUES ('foo', now(), {{@abc_123:HTTP Request.data.comments}}::jsonb) RETURNING *;`;
+
+      const { paramValues } = extractTemplateParameters(query, outputs);
+
+      expect(paramValues).toHaveLength(1);
+      expect(paramValues[0]).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+
+    it("resolves case-insensitive display-format (deployment fix)", () => {
+      const outputs: NodeOutputs = {
+        n1: { label: "http request", data: HTTP_STEP_OUTPUT },
+      };
+      const query =
+        "INSERT INTO t(data) VALUES ({{HTTP Request.data.comments}}::jsonb)";
+
+      const { paramValues } = extractTemplateParameters(query, outputs);
+
+      expect(paramValues).toHaveLength(1);
+      expect(paramValues[0]).toEqual(HTTP_STEP_OUTPUT.data.comments);
+    });
+  });
+});

--- a/tests/unit/serialize-sql-params.test.ts
+++ b/tests/unit/serialize-sql-params.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { serializeSqlParams } from "@/lib/steps/database-query";
+
+describe("serializeSqlParams", () => {
+  it("passes null through", () => {
+    expect(serializeSqlParams([null])).toEqual([null]);
+  });
+
+  it("converts undefined to null", () => {
+    expect(serializeSqlParams([undefined])).toEqual([null]);
+  });
+
+  it("passes strings through", () => {
+    expect(serializeSqlParams(["hello"])).toEqual(["hello"]);
+  });
+
+  it("passes numbers through", () => {
+    expect(serializeSqlParams([42, 3.14, 0])).toEqual([42, 3.14, 0]);
+  });
+
+  it("passes booleans through", () => {
+    expect(serializeSqlParams([true, false])).toEqual([true, false]);
+  });
+
+  it("passes Date instances through natively", () => {
+    const date = new Date("2026-01-15T12:00:00Z");
+    const result = serializeSqlParams([date]);
+    expect(result[0]).toBe(date);
+    expect(result[0]).toBeInstanceOf(Date);
+  });
+
+  it("passes Uint8Array instances through natively", () => {
+    const bytes = new Uint8Array([0x01, 0x02, 0x03]);
+    const result = serializeSqlParams([bytes]);
+    expect(result[0]).toBe(bytes);
+    expect(result[0]).toBeInstanceOf(Uint8Array);
+  });
+
+  it("JSON-stringifies plain objects for JSONB columns", () => {
+    const obj = { name: "Alice", age: 30 };
+    const result = serializeSqlParams([obj]);
+    expect(result[0]).toBe('{"name":"Alice","age":30}');
+  });
+
+  it("JSON-stringifies arrays for JSONB columns", () => {
+    const arr = [1, 2, 3];
+    const result = serializeSqlParams([arr]);
+    expect(result[0]).toBe("[1,2,3]");
+  });
+
+  it("JSON-stringifies nested objects", () => {
+    const nested = { users: [{ id: 1 }, { id: 2 }] };
+    const result = serializeSqlParams([nested]);
+    expect(result[0]).toBe('{"users":[{"id":1},{"id":2}]}');
+  });
+
+  it("handles mixed types in a single call", () => {
+    const date = new Date("2026-01-01T00:00:00Z");
+    const params = [null, "text", 42, true, date, { key: "val" }, [1, 2]];
+    const result = serializeSqlParams(params);
+
+    expect(result).toEqual([
+      null,
+      "text",
+      42,
+      true,
+      date,
+      '{"key":"val"}',
+      "[1,2]",
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(serializeSqlParams([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Summary

Add template reference support (`@` autocomplete) to the Database Query SQL editor and use parameterized queries at runtime to prevent SQL injection.

# Details

- New `SqlTemplateEditor` component replaces the plain CodeEditor for DB Query nodes. Supports `@` autocomplete to insert references from upstream nodes, with blue badge highlighting for template patterns.
- Templates are displayed as `{{Label.field}}` in the editor for readability but stored as `{{@nodeId:Label.field}}` for runtime resolution.
- At execution time, templates in SQL are converted to PostgreSQL `$1, $2, ...` placeholders and values are sent via the wire protocol (parameterized queries), preventing SQL injection from special characters like quotes.
- Handles JSONB objects, arrays, Date, Uint8Array, and null values in query parameters.
- Completion provider is scoped per editor instance to avoid conflicts if multiple SQL editors coexist.
- Backward compatible: plain SQL without templates still uses the existing `sql.raw()` path.
