### PR TITLE
refactor: Keep-1415 Diamond proxy feedback

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -15,6 +15,7 @@ import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 // start custom keeperhub code //
 import { SaveAddressBookmark } from "@/keeperhub/components/address-book/save-address-bookmark";
+import { computeSelector } from "@/keeperhub/lib/abi-utils";
 import { parseAddressBookSelection } from "@/keeperhub/lib/address-book-selection";
 import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
 // end keeperhub code //
@@ -204,10 +205,15 @@ function AbiFunctionSelectField({
               `${input.type} ${input.name}`
           )
           .join(", ");
+        // start custom keeperhub code //
+        const inputTypes = inputs.map((input: { type: string }) => input.type);
+        const selector = computeSelector(func.name, inputTypes);
+        // end keeperhub code //
         return {
           name: func.name,
           label: `${func.name}(${params})`,
           stateMutability: func.stateMutability || "nonpayable",
+          selector,
         };
       });
     } catch {
@@ -234,7 +240,14 @@ function AbiFunctionSelectField({
         {functions.map((func) => (
           <SelectItem key={func.label} value={func.name}>
             <div className="flex flex-col items-start">
-              <span>{func.label}</span>
+              {/* start custom keeperhub code // */}
+              <span>
+                {func.label}{" "}
+                <code className="text-muted-foreground text-xs">
+                  ({func.selector})
+                </code>
+              </span>
+              {/* end keeperhub code // */}
               <span className="text-muted-foreground text-xs">
                 {func.stateMutability}
               </span>

--- a/keeperhub/components/workflow/config/abi-event-select-field.tsx
+++ b/keeperhub/components/workflow/config/abi-event-select-field.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { computeSelector } from "@/keeperhub/lib/abi-utils";
 import type { ActionConfigFieldBase } from "@/plugins";
 
 type FieldProps = {
@@ -52,9 +53,14 @@ export function AbiEventSelectField({
               return `${input.type}${indexed} ${input.name || "unnamed"}`;
             })
             .join(", ");
+          const inputTypes = inputs.map(
+            (input: { type: string }) => input.type
+          );
+          const selector = computeSelector(event.name, inputTypes);
           return {
             name: event.name,
             label: `${event.name}(${params})`,
+            selector,
           };
         });
     } catch {
@@ -81,7 +87,12 @@ export function AbiEventSelectField({
         {events.map((event) => (
           <SelectItem key={event.name} value={event.name}>
             <div className="flex flex-col items-start">
-              <span>{event.label}</span>
+              <span>
+                {event.label}{" "}
+                <code className="text-muted-foreground text-xs">
+                  ({event.selector})
+                </code>
+              </span>
             </div>
           </SelectItem>
         ))}

--- a/keeperhub/components/workflow/config/abi-event-select-field.tsx
+++ b/keeperhub/components/workflow/config/abi-event-select-field.tsx
@@ -9,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { computeSelector } from "@/keeperhub/lib/abi-utils";
 import type { ActionConfigFieldBase } from "@/plugins";
 
 type FieldProps = {
@@ -53,14 +52,9 @@ export function AbiEventSelectField({
               return `${input.type}${indexed} ${input.name || "unnamed"}`;
             })
             .join(", ");
-          const inputTypes = inputs.map(
-            (input: { type: string }) => input.type
-          );
-          const selector = computeSelector(event.name, inputTypes);
           return {
             name: event.name,
             label: `${event.name}(${params})`,
-            selector,
           };
         });
     } catch {
@@ -87,12 +81,7 @@ export function AbiEventSelectField({
         {events.map((event) => (
           <SelectItem key={event.name} value={event.name}>
             <div className="flex flex-col items-start">
-              <span>
-                {event.label}{" "}
-                <code className="text-muted-foreground text-xs">
-                  ({event.selector})
-                </code>
-              </span>
+              <span>{event.label}</span>
             </div>
           </SelectItem>
         ))}

--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -815,7 +815,7 @@ export function AbiWithAutoFetchField({
 
   const handleManualToggle = (checked: boolean) => {
     setUseManualAbi(checked);
-    onUpdateConfig?.("useManualAbi", checked);
+    onUpdateConfig?.("useManualAbi", String(checked));
     setError(null);
     if (checked) {
       onChange("");

--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -445,6 +445,7 @@ type AbiWithAutoFetchProps = FieldProps & {
   contractInteractionType?: "read" | "write";
   networkField?: string;
   config: Record<string, unknown>;
+  onUpdateConfig?: (key: string, value: unknown) => void;
 };
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ABI field handles proxy, diamond, and read/write-as-proxy states with toggles
@@ -457,8 +458,11 @@ export function AbiWithAutoFetchField({
   contractInteractionType,
   networkField = "network",
   config,
+  onUpdateConfig,
 }: AbiWithAutoFetchProps) {
-  const [useManualAbi, setUseManualAbi] = useState(false);
+  const [useManualAbi, setUseManualAbi] = useState(
+    () => String(config.useManualAbi) === "true"
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isProxy, setIsProxy] = useState(false);
@@ -805,7 +809,13 @@ export function AbiWithAutoFetchField({
 
   const handleManualToggle = (checked: boolean) => {
     setUseManualAbi(checked);
+    onUpdateConfig?.("useManualAbi", checked);
     setError(null);
+    if (checked) {
+      onChange("");
+      resetProxyState();
+      lastFetchedRef.current = null;
+    }
   };
 
   return (
@@ -851,7 +861,7 @@ export function AbiWithAutoFetchField({
         </div>
       )}
 
-      {isDiamond && diamondFacets && (
+      {isDiamond && diamondFacets && !useManualAbi && (
         <DiamondContractAlert
           chains={chains}
           facets={diamondFacets}
@@ -888,7 +898,7 @@ export function AbiWithAutoFetchField({
         }}
         placeholder={
           useManualAbi
-            ? "Paste contract ABI JSON here"
+            ? "Paste your ABI here"
             : "Click 'Fetch ABI from Etherscan' or enable 'Use manual ABI' to enter manually"
         }
         rows={4}

--- a/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/keeperhub/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -329,7 +329,13 @@ function DiamondContractAlert({
             Using combined ABI from all facets (Diamond Proxy).
           </p>
         )}
-        <DiamondFacetsList chains={chains} facets={facets} network={network} />
+        {useDiamondAbi && (
+          <DiamondFacetsList
+            chains={chains}
+            facets={facets}
+            network={network}
+          />
+        )}
         {warning && (
           <p className="mt-2 text-amber-700 text-sm dark:text-amber-300">
             {warning}

--- a/keeperhub/lib/abi-utils.ts
+++ b/keeperhub/lib/abi-utils.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 
 /**
- * Compute the 4-byte function/event selector from a name and its input types.
+ * Compute the 4-byte function selector from a name and its input types.
  * Returns a hex string like "0xcdffacc6".
  */
 export function computeSelector(name: string, inputTypes: string[]): string {

--- a/keeperhub/lib/abi-utils.ts
+++ b/keeperhub/lib/abi-utils.ts
@@ -1,0 +1,10 @@
+import { ethers } from "ethers";
+
+/**
+ * Compute the 4-byte function/event selector from a name and its input types.
+ * Returns a hex string like "0xcdffacc6".
+ */
+export function computeSelector(name: string, inputTypes: string[]): string {
+  const signature = `${name}(${inputTypes.join(",")})`;
+  return ethers.id(signature).slice(0, 10);
+}

--- a/keeperhub/lib/extensions.tsx
+++ b/keeperhub/lib/extensions.tsx
@@ -52,6 +52,7 @@ registerFieldRenderer(
           field={field}
           networkField={networkField}
           onChange={(val: unknown) => onUpdateConfig(field.key, val)}
+          onUpdateConfig={onUpdateConfig}
           value={value}
         />
       </div>

--- a/tests/unit/abi-utils.test.ts
+++ b/tests/unit/abi-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { computeSelector } from "@/keeperhub/lib/abi-utils";
+
+describe("computeSelector", () => {
+  it("returns correct 4-byte selector for transfer(address,uint256)", () => {
+    expect(computeSelector("transfer", ["address", "uint256"])).toBe(
+      "0xa9059cbb"
+    );
+  });
+
+  it("returns correct 4-byte selector for approve(address,uint256)", () => {
+    expect(computeSelector("approve", ["address", "uint256"])).toBe(
+      "0x095ea7b3"
+    );
+  });
+
+  it("returns correct 4-byte selector for balanceOf(address)", () => {
+    expect(computeSelector("balanceOf", ["address"])).toBe("0x70a08231");
+  });
+
+  it("returns correct selector for no-arg function", () => {
+    expect(computeSelector("totalSupply", [])).toBe("0x18160ddd");
+  });
+
+  it("returns a 10-character hex string (0x + 8 hex digits)", () => {
+    const result = computeSelector("foo", ["uint256"]);
+    expect(result).toMatch(/^0x[\da-f]{8}$/);
+  });
+});

--- a/tests/unit/abi-utils.test.ts
+++ b/tests/unit/abi-utils.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { computeSelector } from "@/keeperhub/lib/abi-utils";
 
+const SELECTOR_PATTERN = /^0x[\da-f]{8}$/;
+
 describe("computeSelector", () => {
   it("returns correct 4-byte selector for transfer(address,uint256)", () => {
     expect(computeSelector("transfer", ["address", "uint256"])).toBe(
@@ -25,6 +27,6 @@ describe("computeSelector", () => {
 
   it("returns a 10-character hex string (0x + 8 hex digits)", () => {
     const result = computeSelector("foo", ["uint256"]);
-    expect(result).toMatch(/^0x[\da-f]{8}$/);
+    expect(result).toMatch(SELECTOR_PATTERN);
   });
 });


### PR DESCRIPTION
## Summary

Improve diamond proxy contract UX: persist manual ABI toggle state, fix stale config updates, and display 4-byte function selectors in ABI dropdowns.

## Details

- Fix stale closure in `handleUpdateConfig` by introducing `pendingConfigRef` so multiple synchronous config updates within the same event don't overwrite each other
- Persist the "Use manual ABI" checkbox in node config so it survives navigation between nodes
- Clear ABI, reset proxy/diamond state, and hide diamond alerts when manual ABI is toggled on
- Hide diamond facets list when "Read/Write as Proxy" is selected
- Display 4-byte function selectors (e.g. `0xa9059cbb`) next to function names in ABI dropdowns (functions only, not events)
- Add `computeSelector` utility in `keeperhub/lib/abi-utils.ts` with unit tests
- Store `useManualAbi` as a string for consistency with all other node config values