### PR TITLE
fix: KEEP-1435 set explicit sslmode=verify-full for pg-boss connections

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -73,7 +73,12 @@ export async function register() {
       const rawUrl =
         process.env.WORKFLOW_POSTGRES_URL || process.env.DATABASE_URL;
       if (rawUrl) {
-        process.env.WORKFLOW_POSTGRES_URL = encodePostgresPassword(rawUrl);
+        const { ensureExplicitSslMode } = await import(
+          "@/lib/db/connection-utils"
+        );
+        process.env.WORKFLOW_POSTGRES_URL = ensureExplicitSslMode(
+          encodePostgresPassword(rawUrl)
+        );
       }
 
       const { getWorld } = await import("workflow/runtime");


### PR DESCRIPTION
## Summary
- Adds `ensureExplicitSslMode()` utility to `lib/db/connection-utils.ts` that replaces deprecated SSL mode aliases (`require`, `prefer`, `verify-ca`) with explicit `verify-full` for remote hosts
- Applies it to the Postgres World (pg-boss) connection URL in `instrumentation.ts`
- Suppresses `pg-connection-string` deprecation warning ahead of pg v9.0.0 where these modes will adopt weaker libpq semantics
- No behavioral change — these modes are already treated as `verify-full` today

## Test plan
- [ ] Verify staging deploys without SSL deprecation warning in logs
- [ ] Confirm Postgres World initializes successfully ("Postgres World initialized" log present)
- [x] Verify local dev (`localhost`) connections are unaffected (no sslmode appended)