### PR TITLE
fix: Fix OG image generation for production builds

### DIFF
--- a/keeperhub/api/og/generate-og.tsx
+++ b/keeperhub/api/og/generate-og.tsx
@@ -296,7 +296,7 @@ export function generateDefaultOGImage(): Promise<ImageResponse> {
           style={{
             display: "flex",
             fontSize: 72,
-            fontWeight: 600,
+            fontWeight: 400,
             color: "#ffffff",
             marginTop: 8,
           }}
@@ -320,7 +320,7 @@ export function generateDefaultOGImage(): Promise<ImageResponse> {
           top: 40,
           right: 56,
           display: "flex",
-          fontSize: 16,
+          fontSize: 24,
           color: "rgba(255,255,255,0.3)",
         }}
       >
@@ -856,7 +856,7 @@ function Header(): React.JSX.Element {
           style={{
             display: "flex",
             fontSize: 22,
-            fontWeight: 600,
+            fontWeight: 400,
             color: "rgba(255,255,255,0.85)",
           }}
         >
@@ -866,7 +866,7 @@ function Header(): React.JSX.Element {
       <div
         style={{
           display: "flex",
-          fontSize: 18,
+          fontSize: 24,
           color: "rgba(255,255,255,0.3)",
         }}
       >

--- a/next.config.ts
+++ b/next.config.ts
@@ -88,6 +88,7 @@ const nextConfig = {
       "./node_modules/undici/**/*",
       "./node_modules/xtend/**/*",
       "./node_modules/zod/**/*",
+      "./node_modules/next/dist/compiled/@vercel/og/**/*",
     ],
   },
   // end keeperhub code //


### PR DESCRIPTION
## Summary

- Fix `ERR_MODULE_NOT_FOUND` for `@vercel/og` in Next.js standalone production builds by adding the compiled OG package to `outputFileTracingIncludes`
- Adjust OG image styling: KeeperHub logo font weight to regular, increase `app.keeperhub.com` URL text size

## Changes

- `next.config.ts`: Add `./node_modules/next/dist/compiled/@vercel/og/**/*` to `outputFileTracingIncludes` so dynamic imports are included in standalone output
- `keeperhub/api/og/generate-og.tsx`: Logo font weight 600 → 400, URL font size → 24 across all templates

## Test plan

- [x] `pnpm build` succeeds
- [x] `.next/standalone/` contains `@vercel/og` files (index.node.js, resvg.wasm, yoga.wasm)
- [x] Local production server serves valid 1200x630 PNGs from `/api/og/default` and `/api/og/hub`
- [x] Docker container (Alpine Linux, matching K8s) serves valid PNGs
- [x] No `ERR_MODULE_NOT_FOUND` errors in server/container logs
- [x] Visual review of rendered OG images approved