### PR TITLE
fix: Fix workflow OG node icons and labels

### DIFF
--- a/keeperhub/api/og/generate-og.tsx
+++ b/keeperhub/api/og/generate-og.tsx
@@ -175,6 +175,16 @@ function getNodeIcon(label: string): string {
   return match?.icon ?? ICON_PLAY;
 }
 
+function getNodeLabel(node: WorkflowNode): string {
+  if (node.data.label) {
+    return node.data.label;
+  }
+  if (node.data.type === "trigger") {
+    return node.data.config?.triggerType ?? "Manual";
+  }
+  return node.data.config?.actionType ?? "Action";
+}
+
 const DOTS = generateDots(OG_WIDTH, OG_HEIGHT, DOT_SPACING);
 
 // ---------------------------------------------------------------------------
@@ -466,7 +476,11 @@ export function generateHubOGImage(): Promise<ImageResponse> {
 type WorkflowNode = {
   id: string;
   position: { x: number; y: number };
-  data: { type: "trigger" | "action" | "add"; label?: string };
+  data: {
+    type: "trigger" | "action" | "add";
+    label?: string;
+    config?: { triggerType?: string; actionType?: string };
+  };
 };
 
 type WorkflowEdge = {
@@ -606,7 +620,7 @@ function prepareRenderData(workflowData: {
     ns,
     title: workflowData.name,
     description: workflowData.description,
-    triggerLabel: triggerNode?.data.label,
+    triggerLabel: triggerNode ? getNodeLabel(triggerNode) : undefined,
     actionCount: nodes.filter((n) => n.data.type === "action").length,
     category: workflowData.category,
     protocol: workflowData.protocol,
@@ -673,7 +687,7 @@ function renderWorkflowOG(data: OGRenderData): Promise<ImageResponse> {
         );
         const nodeSquare = Math.max(ns * 0.7, 110);
         const isTrigger = node.data.type === "trigger";
-        const label = node.data.label ?? "";
+        const label = getNodeLabel(node);
         const iconSize = Math.max(nodeSquare * 0.32, 30);
 
         return (


### PR DESCRIPTION
## Summary

- Workflow OG images now show correct node icons and labels instead of generic play triangles with no text
- Added `getNodeLabel()` that falls back to `config.triggerType` / `config.actionType` when `data.label` is empty, matching the UI behavior
- Expanded `WorkflowNode` type to include `config` field

## Changes

- `keeperhub/api/og/generate-og.tsx`: Added `getNodeLabel()` function, expanded `WorkflowNode` type, updated node rendering and footer trigger label

## Test plan

- [ ] Workflow OG with unconfigured nodes shows "Manual" + play icon for trigger, "Action" + zap icon for action node
- [ ] Workflow OG with configured nodes shows correct labels and matched icons (e.g., "Schedule" + clock icon)
- [ ] Workflow OG with custom labels still uses the custom label
- [ ] Default and hub OG routes unaffected