### PR TITLE
fix: KEEP-1447 remove submodule checkout from deploy workflow

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary
- Removed `submodules: recursive` from deploy-keeperhub.yaml checkout step
- Dev-only submodules (keeperhub-events, keeperhub-scheduler) don't exist as remote repos, causing CI checkout to fail with "Repository not found"

## Test plan
- [x] Merge to staging and verify deploy workflow passes the Checkout step
- [x] Verify Docker build completes without submodule dependencies