### PR TITLE
fix: KEEP-1448 switch deploy migrations from db:push to db:migrate

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -61,7 +61,7 @@ deployment:
           export WORKFLOW_POSTGRES_URL=$(node scripts/encode-pg-url.mjs)
           pnpm exec workflow-postgres-setup
           echo "Running database migrations..."
-          pnpm db:push
+          pnpm db:migrate
           echo "Seeding chains..."
           pnpm db:seed
           echo "Migrations and seeding completed successfully"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -61,7 +61,7 @@ deployment:
           export WORKFLOW_POSTGRES_URL=$(node scripts/encode-pg-url.mjs)
           pnpm exec workflow-postgres-setup
           echo "Running database migrations..."
-          pnpm db:push
+          pnpm db:migrate
           echo "Seeding chains..."
           pnpm db:seed
           echo "Migrations and seeding completed successfully"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -62,7 +62,7 @@ deployment:
           export WORKFLOW_POSTGRES_URL=$(node scripts/encode-pg-url.mjs)
           pnpm exec workflow-postgres-setup
           echo "Running database migrations..."
-          pnpm db:push
+          pnpm db:migrate
           echo "Seeding chains..."
           pnpm db:seed
           echo "Migrations and seeding completed successfully"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,7 +284,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: pnpm db:push
+    command: pnpm db:migrate
     profiles:
       - migrator
 

--- a/drizzle/0003_parched_wendell_rand.sql
+++ b/drizzle/0003_parched_wendell_rand.sql
@@ -3,16 +3,3 @@ CREATE TABLE "beta_access_requests" (
 	"email" text NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL
 );
---> statement-breakpoint
-CREATE TABLE "para_wallets" (
-	"id" text PRIMARY KEY NOT NULL,
-	"user_id" text NOT NULL,
-	"email" text NOT NULL,
-	"wallet_id" text NOT NULL,
-	"wallet_address" text NOT NULL,
-	"user_share" text NOT NULL,
-	"created_at" timestamp DEFAULT now() NOT NULL,
-	CONSTRAINT "para_wallets_user_id_unique" UNIQUE("user_id")
-);
---> statement-breakpoint
-ALTER TABLE "para_wallets" ADD CONSTRAINT "para_wallets_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0019_broken_abomination.sql
+++ b/drizzle/0019_broken_abomination.sql
@@ -32,5 +32,5 @@ CREATE INDEX "idx_tags_org" ON "tags" USING btree ("organization_id");--> statem
 CREATE INDEX "idx_workflow_public_tags_workflow" ON "workflow_public_tags" USING btree ("workflow_id");--> statement-breakpoint
 CREATE INDEX "idx_workflow_public_tags_tag" ON "workflow_public_tags" USING btree ("public_tag_id");--> statement-breakpoint
 ALTER TABLE "workflows" ADD CONSTRAINT "workflows_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "workflows" DROP COLUMN "category";--> statement-breakpoint
-ALTER TABLE "workflows" DROP COLUMN "protocol";
+ALTER TABLE "workflows" DROP COLUMN IF EXISTS "category";--> statement-breakpoint
+ALTER TABLE "workflows" DROP COLUMN IF EXISTS "protocol";


### PR DESCRIPTION
## Summary

- Switch all deploy configs (staging, prod, PR environments) from `pnpm db:push` to `pnpm db:migrate`
- Fix broken migration files that prevented `db:migrate` from running

## Problem

Discovered during KEEP-1399 (PR #322, PR #331) that `drizzle-kit push --force` hangs in non-interactive init containers when it encounters ambiguous schema changes (e.g. "is this column created or renamed?"). The `--force` flag only auto-accepts data-loss operations, not create/rename prompts.

`db:push` has been used since the first deployment and worked until now because all previous schema changes were unambiguous. KEEP-1399 added `tag_id` to a table that had `category` and `protocol` columns of the same type, triggering the interactive prompt.

See:
- PR #322 — original KEEP-1399 merge that exposed the issue
- PR #331 — migration file + SSL fixes

## Changes

**Deploy configs** (`deploy/keeperhub/staging/values.yaml`, `deploy/keeperhub/prod/values.yaml`, `deploy/pr-environment/values.template.yaml`, `docker-compose.yml`):
- `pnpm db:push` -> `pnpm db:migrate`

**Migration fixes**:
- `drizzle/0003`: Remove duplicate `CREATE TABLE para_wallets` (already created in 0002)
- `drizzle/0019`: Use `DROP COLUMN IF EXISTS` for `category`/`protocol` (only exist on staging via db:push, not in migration history)

## Tested

- All 20 migrations (0000-0019) apply cleanly on a fresh database
- `tag_id` column created with FK to `tags` table
- `category`/`protocol` drops are safe on both fresh and existing databases

## Staging/Prod migration note

Since staging and prod have always used `db:push`, they have no `__drizzle_migrations` tracking table. Before merging, the tracking table needs to be bootstrapped with migrations 0000-0018 marked as applied, so `db:migrate` only runs 0019.

## Test plan

- [ ] PR environment deploys successfully with `db:migrate`
- [ ] Verify `tags` table and `tag_id` column exist
- [ ] Bootstrap `__drizzle_migrations` on staging before merge
- [ ] Staging deploys successfully after merge