### PR TITLE
feat: KEEP-1440 For Each/Collect loop iteration support

### DIFF
--- a/components/ai-elements/edge.tsx
+++ b/components/ai-elements/edge.tsx
@@ -43,14 +43,19 @@ const Temporary = ({
 
 const getHandleCoordsByPosition = (
   node: InternalNode<Node>,
-  handlePosition: Position
+  handlePosition: Position,
+  handleId?: string | null
 ) => {
   // Choose the handle type based on position - Left is for target, Right is for source
   const handleType = handlePosition === Position.Left ? "target" : "source";
 
-  const handle = node.internals.handleBounds?.[handleType]?.find(
-    (h) => h.position === handlePosition
-  );
+  // start custom keeperhub code //
+  // When a handle ID is provided (multi-handle nodes), find by ID; otherwise by position
+  const handles = node.internals.handleBounds?.[handleType];
+  const handle = handleId
+    ? handles?.find((h) => h.id === handleId)
+    : handles?.find((h) => h.position === handlePosition);
+  // end keeperhub code //
 
   if (!handle) {
     return [0, 0] as const;
@@ -85,14 +90,17 @@ const getHandleCoordsByPosition = (
   return [x, y] as const;
 };
 
+// start custom keeperhub code //
 const getEdgeParams = (
   source: InternalNode<Node>,
-  target: InternalNode<Node>
+  target: InternalNode<Node>,
+  sourceHandleId?: string | null,
+  targetHandleId?: string | null
 ) => {
   const sourcePos = Position.Right;
-  const [sx, sy] = getHandleCoordsByPosition(source, sourcePos);
+  const [sx, sy] = getHandleCoordsByPosition(source, sourcePos, sourceHandleId);
   const targetPos = Position.Left;
-  const [tx, ty] = getHandleCoordsByPosition(target, targetPos);
+  const [tx, ty] = getHandleCoordsByPosition(target, targetPos, targetHandleId);
 
   return {
     sx,
@@ -103,8 +111,9 @@ const getEdgeParams = (
     targetPos,
   };
 };
+// end keeperhub code //
 
-const Animated = ({ id, source, target, style, selected }: EdgeProps) => {
+const Animated = ({ id, source, target, sourceHandleId, targetHandleId, style, selected }: EdgeProps) => {
   const sourceNode = useInternalNode(source);
   const targetNode = useInternalNode(target);
 
@@ -114,7 +123,9 @@ const Animated = ({ id, source, target, style, selected }: EdgeProps) => {
 
   const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(
     sourceNode,
-    targetNode
+    targetNode,
+    sourceHandleId,
+    targetHandleId
   );
 
   const [edgePath] = getBezierPath({

--- a/components/ai-elements/node.tsx
+++ b/components/ai-elements/node.tsx
@@ -15,10 +15,21 @@ import { AnimatedBorder } from "@/components/ui/animated-border";
 import { AddStepButton } from "@/keeperhub/components/workflow/add-step-button";
 // end keeperhub code //
 
+// start custom keeperhub code //
+export type SourceHandleConfig = {
+  id: string;
+  label: string;
+  topPercent: number;
+};
+// end keeperhub code //
+
 export type NodeProps = ComponentProps<typeof Card> & {
   handles: {
     target: boolean;
     source: boolean;
+    // start custom keeperhub code //
+    sourceHandles?: SourceHandleConfig[];
+    // end keeperhub code //
   };
   status?: "idle" | "running" | "success" | "error";
   // start custom keeperhub code //
@@ -38,9 +49,47 @@ export const Node = ({ handles, className, status, nodeId, ...props }: NodeProps
   >
     {status === "running" && <AnimatedBorder />}
     {handles.target && <Handle position={Position.Left} type="target" />}
-    {handles.source && <Handle position={Position.Right} type="source" />}
     {/* start custom keeperhub code */}
-    {handles.source && nodeId && <AddStepButton sourceNodeId={nodeId} />}
+    {handles.sourceHandles ? (
+      <>
+        {handles.sourceHandles.map((h) => (
+          <Handle
+            id={h.id}
+            key={h.id}
+            position={Position.Right}
+            style={{ top: `${h.topPercent}%` }}
+            type="source"
+          />
+        ))}
+        {handles.sourceHandles.map((h) => (
+          <span
+            className="pointer-events-none absolute text-[10px] text-muted-foreground"
+            key={`label-${h.id}`}
+            style={{
+              right: 16,
+              top: `${h.topPercent}%`,
+              transform: "translateY(-50%)",
+            }}
+          >
+            {h.label}
+          </span>
+        ))}
+        {nodeId &&
+          handles.sourceHandles.map((h) => (
+            <AddStepButton
+              key={`btn-${h.id}`}
+              offsetTopPercent={h.topPercent}
+              sourceHandleId={h.id}
+              sourceNodeId={nodeId}
+            />
+          ))}
+      </>
+    ) : (
+      <>
+        {handles.source && <Handle position={Position.Right} type="source" />}
+        {handles.source && nodeId && <AddStepButton sourceNodeId={nodeId} />}
+      </>
+    )}
     {/* end keeperhub code */}
     {props.children}
   </Card>

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -298,6 +298,7 @@ const getCommonFields = (node: WorkflowNode) => {
   return [{ field: "data", description: "Output data" }];
 };
 
+// start custom keeperhub code //
 // Sanitize nodeId the same way as workflow executor for consistent lookup
 function sanitizeNodeId(nodeId: string): string {
   return nodeId.replace(/[^a-zA-Z0-9]/g, "_");

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -473,7 +473,8 @@ export function TemplateAutocomplete({
       const syntheticOutput = resolveForEachSyntheticOutput(
         node,
         executionLogs,
-        lastLogsForWorkflow
+        lastLogsForWorkflow,
+        upstreamNodes
       );
 
       if (syntheticOutput) {

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -379,6 +379,9 @@ function traverseDotPath(root: unknown, path: string): unknown {
   for (const part of path.split(".")) {
     if (data && typeof data === "object" && !Array.isArray(data)) {
       data = (data as Record<string, unknown>)[part];
+      if (data === undefined) {
+        return null;
+      }
     } else {
       return null;
     }

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -350,11 +350,40 @@ function resolveForEachSyntheticOutput(
     return null;
   }
 
+  // Apply mapExpression to transform currentItem, matching executor behavior
+  let currentItem: unknown = data[0];
+  const mapExpression = node.data.config?.mapExpression as string | undefined;
+  if (
+    mapExpression &&
+    currentItem &&
+    typeof currentItem === "object"
+  ) {
+    const mapped = traverseDotPath(currentItem, mapExpression);
+    if (mapped !== null) {
+      currentItem = mapped;
+    }
+  }
+
   return {
-    currentItem: data[0],
+    currentItem,
     index: 0,
     totalItems: data.length,
   };
+}
+
+/**
+ * Traverse a dot-path into a nested value, returning null on failure.
+ */
+function traverseDotPath(root: unknown, path: string): unknown {
+  let data: unknown = root;
+  for (const part of path.split(".")) {
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      data = (data as Record<string, unknown>)[part];
+    } else {
+      return null;
+    }
+  }
+  return data;
 }
 // end keeperhub code //
 

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -271,6 +271,7 @@ function ConditionFields({
 export function useArrayItemFields(arraySource: string | undefined): string[] {
   const executionLogs = useAtomValue(executionLogsAtom);
   const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
+  const nodes = useAtomValue(nodesAtom);
 
   return useMemo(() => {
     if (!arraySource) {
@@ -280,7 +281,8 @@ export function useArrayItemFields(arraySource: string | undefined): string[] {
     const first = resolveArraySourceElement(
       arraySource,
       executionLogs,
-      lastExecutionLogs.logs
+      lastExecutionLogs.logs,
+      nodes
     );
     if (!first) {
       return [];
@@ -289,7 +291,7 @@ export function useArrayItemFields(arraySource: string | undefined): string[] {
     const paths: string[] = [];
     extractObjectPaths(first, "", 0, paths);
     return paths;
-  }, [arraySource, executionLogs, lastExecutionLogs]);
+  }, [arraySource, executionLogs, lastExecutionLogs, nodes]);
 }
 // end keeperhub code //
 

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -324,13 +324,32 @@ function ForEachFields({
 // Collect fields component (informational only)
 function CollectFields() {
   return (
-    <div className="rounded-lg border bg-muted/30 p-3">
-      <p className="text-muted-foreground text-sm">
-        This node collects results from the preceding For Each loop. Downstream
-        nodes can reference <code className="text-xs">Collect.results</code> for
-        the collected array and <code className="text-xs">Collect.count</code>{" "}
-        for the number of iterations.
-      </p>
+    <div className="space-y-3">
+      <div className="rounded-lg border bg-muted/30 p-3">
+        <p className="text-muted-foreground text-sm">
+          Place this node after a For Each loop to gather iteration outputs into
+          a single array. The Collect node marks the end of the loop body --
+          nodes connected after Collect run once with the aggregated results.
+        </p>
+      </div>
+      <div className="space-y-2 rounded-lg border bg-muted/30 p-3">
+        <p className="font-medium text-sm">Available outputs</p>
+        <ul className="list-disc space-y-1 pl-4 text-muted-foreground text-sm">
+          <li>
+            <code className="text-xs">Collect.results</code> -- Array of
+            outputs, one entry per iteration (from the last body node before
+            Collect)
+          </li>
+          <li>
+            <code className="text-xs">Collect.count</code> -- Number of
+            completed iterations
+          </li>
+        </ul>
+        <p className="text-muted-foreground text-xs">
+          Without a Collect node, the loop runs as fire-and-forget with no
+          aggregated output.
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -268,7 +268,7 @@ function ConditionFields({
 /**
  * Extract dot-paths from the first element of the array referenced by arraySource.
  */
-function useArrayItemFields(arraySource: string | undefined): string[] {
+export function useArrayItemFields(arraySource: string | undefined): string[] {
   const executionLogs = useAtomValue(executionLogsAtom);
   const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
 
@@ -292,6 +292,9 @@ function useArrayItemFields(arraySource: string | undefined): string[] {
   }, [arraySource, executionLogs, lastExecutionLogs]);
 }
 // end keeperhub code //
+
+/** Sentinel value for the "Full element (no mapping)" select option. */
+const FULL_ELEMENT_VALUE = "__full__";
 
 // For Each fields component
 function ForEachFields({
@@ -330,15 +333,15 @@ function ForEachFields({
           <Select
             disabled={disabled}
             onValueChange={(value) =>
-              onUpdateConfig("mapExpression", value === "__full__" ? "" : value)
+              onUpdateConfig("mapExpression", value === FULL_ELEMENT_VALUE ? "" : value)
             }
-            value={(config?.mapExpression as string) || "__full__"}
+            value={(config?.mapExpression as string) || FULL_ELEMENT_VALUE}
           >
             <SelectTrigger id="mapExpression">
               <SelectValue placeholder="Full element" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="__full__">
+              <SelectItem value={FULL_ELEMENT_VALUE}>
                 Full element (no mapping)
               </SelectItem>
               <SelectSeparator />
@@ -524,6 +527,7 @@ function useCategoryData() {
       : SYSTEM_ACTIONS.filter((a) => a.id !== "Collect");
     // end keeperhub code //
 
+    // Build category map including System with both id and label
     const allCategories: Record<
       string,
       Array<{ id: string; label: string }>

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -295,6 +295,9 @@ function traverseFieldPath(root: unknown, fieldPath: string): unknown {
   for (const part of fieldPath.split(".")) {
     if (data && typeof data === "object" && !Array.isArray(data)) {
       data = (data as Record<string, unknown>)[part];
+      if (data === undefined) {
+        return null;
+      }
     } else {
       return null;
     }

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -8,6 +8,7 @@ import { AiGatewayConsentOverlay } from "@/components/overlays/ai-gateway-consen
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/code-editor";
+import { Input } from "@/components/ui/input";
 import { IntegrationIcon } from "@/components/ui/integration-icon";
 import { IntegrationSelector } from "@/components/ui/integration-selector";
 import { Label } from "@/components/ui/label";
@@ -249,6 +250,93 @@ function ConditionFields({
   );
 }
 
+// start custom keeperhub code //
+
+// For Each fields component
+function ForEachFields({
+  config,
+  onUpdateConfig,
+  disabled,
+}: {
+  config: Record<string, unknown>;
+  onUpdateConfig: (key: string, value: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="arraySource">Array Source</Label>
+        <TemplateBadgeInput
+          disabled={disabled}
+          id="arraySource"
+          onChange={(value) => onUpdateConfig("arraySource", value)}
+          placeholder="e.g., {{Database Query.rows}} or {{HTTP Request.data.items}}"
+          value={(config?.arraySource as string) || ""}
+        />
+        <p className="text-muted-foreground text-xs">
+          Reference an array from a previous node. Use @ to select a field.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="mapExpression">Map Expression (optional)</Label>
+        <Input
+          disabled={disabled}
+          id="mapExpression"
+          onChange={(e) => onUpdateConfig("mapExpression", e.target.value)}
+          placeholder="e.g., address or data.items[0].name"
+          value={(config?.mapExpression as string) || ""}
+        />
+        <p className="text-muted-foreground text-xs">
+          Dot-path to extract from each element. Leave empty to use the full
+          element.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="maxIterations">Max Items (optional)</Label>
+        <Input
+          disabled={disabled}
+          id="maxIterations"
+          min={1}
+          onChange={(e) => onUpdateConfig("maxIterations", e.target.value)}
+          placeholder="All"
+          type="number"
+          value={(config?.maxIterations as string) || ""}
+        />
+        <p className="text-muted-foreground text-xs">
+          Leave empty to process all items
+        </p>
+      </div>
+      <div className="rounded-lg border bg-muted/30 p-3">
+        <p className="text-muted-foreground text-sm">
+          Connect action nodes after this For Each to define the loop body.
+          Optionally end with a Collect node to aggregate results. Without
+          Collect, the loop runs as fire-and-forget. Inside the loop, use @ to
+          reference <code className="text-xs">For Each.currentItem</code> for
+          the current element and{" "}
+          <code className="text-xs">For Each.index</code> for the iteration
+          index.
+        </p>
+      </div>
+    </>
+  );
+}
+
+// Collect fields component (informational only)
+function CollectFields() {
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3">
+      <p className="text-muted-foreground text-sm">
+        This node collects results from the preceding For Each loop. Downstream
+        nodes can reference <code className="text-xs">Collect.results</code> for
+        the collected array and <code className="text-xs">Collect.count</code>{" "}
+        for the number of iterations.
+      </p>
+    </div>
+  );
+}
+
+// end keeperhub code //
+
 // System action fields wrapper - extracts conditional rendering to reduce complexity
 function SystemActionFields({
   actionType,
@@ -286,6 +374,18 @@ function SystemActionFields({
           onUpdateConfig={onUpdateConfig}
         />
       );
+    // start custom keeperhub code //
+    case "For Each":
+      return (
+        <ForEachFields
+          config={config}
+          disabled={disabled}
+          onUpdateConfig={onUpdateConfig}
+        />
+      );
+    case "Collect":
+      return <CollectFields />;
+    // end keeperhub code //
     default:
       return null;
   }
@@ -296,6 +396,10 @@ const SYSTEM_ACTIONS: Array<{ id: string; label: string }> = [
   { id: "HTTP Request", label: "HTTP Request" },
   { id: "Database Query", label: "Database Query" },
   { id: "Condition", label: "Condition" },
+  // start custom keeperhub code //
+  { id: "For Each", label: "For Each" },
+  { id: "Collect", label: "Collect" },
+  // end keeperhub code //
 ];
 
 const SYSTEM_ACTION_IDS = SYSTEM_ACTIONS.map((a) => a.id);

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -387,6 +387,48 @@ function ForEachFields({
           allowed.
         </p>
       </div>
+      {/* start custom keeperhub code */}
+      <div className="space-y-2">
+        <Label htmlFor="concurrency">Concurrency</Label>
+        <Select
+          disabled={disabled}
+          onValueChange={(value) => {
+            onUpdateConfig("concurrency", value);
+            if (value !== "custom") {
+              onUpdateConfig("concurrencyLimit", "");
+            }
+          }}
+          value={(config?.concurrency as string) || "sequential"}
+        >
+          <SelectTrigger id="concurrency">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="sequential">Sequential (one at a time)</SelectItem>
+            <SelectItem value="parallel">Parallel (all at once)</SelectItem>
+            <SelectItem value="custom">Custom limit</SelectItem>
+          </SelectContent>
+        </Select>
+        {(config?.concurrency as string) === "custom" && (
+          <Input
+            disabled={disabled}
+            id="concurrencyLimit"
+            min={2}
+            onChange={(e) => {
+              const raw = e.target.value.replace(/[^0-9]/g, "");
+              onUpdateConfig("concurrencyLimit", raw);
+            }}
+            placeholder="e.g., 5"
+            type="number"
+            value={(config?.concurrencyLimit as string) || ""}
+          />
+        )}
+        <p className="text-muted-foreground text-xs">
+          Sequential runs one iteration at a time. Parallel runs all at once.
+          Custom limit runs up to N iterations concurrently.
+        </p>
+      </div>
+      {/* end keeperhub code */}
       <div className="rounded-lg border bg-muted/30 p-3">
         <p className="text-muted-foreground text-sm">
           Connect action nodes after this For Each to define the loop body.

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -397,50 +397,65 @@ function ForEachFields({
           Reference an array from a previous node. Use @ to select a field.
         </p>
       </div>
+      {/* start custom keeperhub code */}
       <div className="space-y-2">
-        <Label htmlFor="mapExpression">Map Expression (optional)</Label>
-        <Input
-          disabled={disabled}
-          id="mapExpression"
-          onChange={(e) => onUpdateConfig("mapExpression", e.target.value)}
-          placeholder="e.g., address or data.items[0].name"
-          value={(config?.mapExpression as string) || ""}
-        />
-        {/* start custom keeperhub code */}
-        {itemFields.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {itemFields.map((field) => (
-              <button
-                className="rounded border bg-muted/50 px-1.5 py-0.5 font-mono text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
-                disabled={disabled}
-                key={field}
-                onClick={() => onUpdateConfig("mapExpression", field)}
-                type="button"
-              >
-                {field}
-              </button>
-            ))}
-          </div>
+        <Label htmlFor="mapExpression">Extract Field (optional)</Label>
+        {itemFields.length > 0 ? (
+          <Select
+            disabled={disabled}
+            onValueChange={(value) =>
+              onUpdateConfig("mapExpression", value === "__full__" ? "" : value)
+            }
+            value={(config?.mapExpression as string) || "__full__"}
+          >
+            <SelectTrigger id="mapExpression">
+              <SelectValue placeholder="Full element" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__full__">
+                Full element (no mapping)
+              </SelectItem>
+              <SelectSeparator />
+              {itemFields.map((field) => (
+                <SelectItem key={field} value={field}>
+                  <span className="font-mono text-xs">{field}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Input
+            disabled={disabled}
+            id="mapExpression"
+            onChange={(e) => onUpdateConfig("mapExpression", e.target.value)}
+            placeholder="e.g., address or data.name"
+            value={(config?.mapExpression as string) || ""}
+          />
         )}
-        {/* end keeperhub code */}
         <p className="text-muted-foreground text-xs">
-          Dot-path to extract from each element. Leave empty to use the full
-          element.
+          {itemFields.length > 0
+            ? "Pick a field to extract from each element, or keep full element."
+            : "Run the workflow once to see available fields, or type a dot-path manually."}
         </p>
       </div>
+      {/* end keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="maxIterations">Max Items (optional)</Label>
         <Input
           disabled={disabled}
           id="maxIterations"
-          min={1}
-          onChange={(e) => onUpdateConfig("maxIterations", e.target.value)}
+          min={0}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "");
+            onUpdateConfig("maxIterations", raw);
+          }}
           placeholder="All"
           type="number"
           value={(config?.maxIterations as string) || ""}
         />
         <p className="text-muted-foreground text-xs">
-          Leave empty to process all items
+          Leave empty or set to 0 to process all items. Negative values are not
+          allowed.
         </p>
       </div>
       <div className="rounded-lg border bg-muted/30 p-3">

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Zap,
 } from "lucide-react";
+import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,6 +30,9 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsTouch } from "@/hooks/use-touch";
 import { cn } from "@/lib/utils";
+// start custom keeperhub code //
+import { nodesAtom } from "@/lib/workflow-store";
+// end keeperhub code //
 import { getAllActions } from "@/plugins";
 
 type ActionType = {
@@ -77,10 +81,16 @@ const SYSTEM_ACTIONS: ActionType[] = [
 
 // Combine System actions with plugin actions
 function useAllActions(): ActionType[] {
+  // start custom keeperhub code //
+  const nodes = useAtomValue(nodesAtom);
+  const hasForEach = nodes.some(
+    (n) => n.data?.config?.actionType === "For Each"
+  );
+  // end keeperhub code //
+
   return useMemo(() => {
     const pluginActions = getAllActions();
 
-    // Map plugin actions to ActionType format
     const mappedPluginActions: ActionType[] = pluginActions.map((action) => ({
       id: action.id,
       label: action.label,
@@ -89,8 +99,14 @@ function useAllActions(): ActionType[] {
       integration: action.integration,
     }));
 
-    return [...SYSTEM_ACTIONS, ...mappedPluginActions];
-  }, []);
+    // start custom keeperhub code //
+    const systemActions = hasForEach
+      ? SYSTEM_ACTIONS
+      : SYSTEM_ACTIONS.filter((a) => a.id !== "Collect");
+    // end keeperhub code //
+
+    return [...systemActions, ...mappedPluginActions];
+  }, [hasForEach]);
 }
 
 type ActionGridProps = {

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -59,6 +59,20 @@ const SYSTEM_ACTIONS: ActionType[] = [
     description: "Branch based on a condition",
     category: "System",
   },
+  // start custom keeperhub code //
+  {
+    id: "For Each",
+    label: "For Each",
+    description: "Loop over an array from a previous step",
+    category: "System",
+  },
+  {
+    id: "Collect",
+    label: "Collect",
+    description: "Gather results from a For Each loop",
+    category: "System",
+  },
+  // end keeperhub code //
 ];
 
 // Combine System actions with plugin actions

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -329,8 +329,13 @@ export const PanelInner = () => {
     const isManualTrigger =
       selectedNode.data.type === "trigger" &&
       selectedNode.data.config?.triggerType === "Manual";
+    // start custom keeperhub code //
+    const isForEachOrCollect =
+      selectedNode.data.config?.actionType === "For Each" ||
+      selectedNode.data.config?.actionType === "Collect";
+    // end keeperhub code //
 
-    if (isConditionAction || isManualTrigger) {
+    if (isConditionAction || isManualTrigger || isForEachOrCollect) {
       setActiveTab("properties");
     }
   }, [selectedNode, activeTab, setActiveTab]);
@@ -999,7 +1004,11 @@ export const PanelInner = () => {
           </TabsTrigger>
           {(selectedNode.data.type !== "trigger" ||
             (selectedNode.data.config?.triggerType as string) !== "Manual") &&
-          selectedNode.data.config?.actionType !== "Condition" ? (
+          selectedNode.data.config?.actionType !== "Condition" &&
+          // start custom keeperhub code //
+          selectedNode.data.config?.actionType !== "For Each" &&
+          selectedNode.data.config?.actionType !== "Collect" ? (
+            // end keeperhub code //
             <TabsTrigger
               className="bg-transparent text-muted-foreground data-[state=active]:text-foreground data-[state=active]:shadow-none"
               value="code"

--- a/components/workflow/nodes/action-node.tsx
+++ b/components/workflow/nodes/action-node.tsx
@@ -9,6 +9,8 @@ import {
   Database,
   EyeOff,
   GitBranch,
+  ListEnd,
+  Repeat,
   XCircle,
   Zap,
 } from "lucide-react";
@@ -76,6 +78,10 @@ const SYSTEM_ACTION_LABELS: Record<string, string> = {
   "Database Query": "Database",
   Condition: "Condition",
   "Execute Code": "System",
+  // start custom keeperhub code //
+  "For Each": "Loop",
+  Collect: "Loop",
+  // end keeperhub code //
 };
 
 // Helper to get integration name from action type
@@ -137,6 +143,12 @@ const getProviderLogo = (actionType: string) => {
       return <Code className="size-12 text-green-300" strokeWidth={1.5} />;
     case "Condition":
       return <GitBranch className="size-12 text-pink-300" strokeWidth={1.5} />;
+    // start custom keeperhub code //
+    case "For Each":
+      return <Repeat className="size-12 text-purple-300" strokeWidth={1.5} />;
+    case "Collect":
+      return <ListEnd className="size-12 text-purple-300" strokeWidth={1.5} />;
+    // end keeperhub code //
     default:
       // Not a system action, continue to check plugin registry
       break;

--- a/components/workflow/nodes/action-node.tsx
+++ b/components/workflow/nodes/action-node.tsx
@@ -20,6 +20,7 @@ import {
   Node,
   NodeDescription,
   NodeTitle,
+  type SourceHandleConfig,
 } from "@/components/ai-elements/node";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
@@ -71,6 +72,13 @@ const getModelDisplayName = (modelId: string): string => {
   };
   return modelNames[modelId] || modelId;
 };
+
+// start custom keeperhub code //
+const FOR_EACH_SOURCE_HANDLES: SourceHandleConfig[] = [
+  { id: "done", label: "done", topPercent: 30 },
+  { id: "loop", label: "loop", topPercent: 70 },
+];
+// end keeperhub code //
 
 // System action labels (non-plugin actions)
 const SYSTEM_ACTION_LABELS: Record<string, string> = {
@@ -355,6 +363,13 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
   const aiModel = getAiModel();
   const isDisabled = data.enabled === false;
 
+  // start custom keeperhub code //
+  const isForEach = actionType === "For Each";
+  const handles = isForEach
+    ? { target: true, source: false, sourceHandles: FOR_EACH_SOURCE_HANDLES }
+    : { target: true, source: true };
+  // end keeperhub code //
+
   return (
     <Node
       className={cn(
@@ -363,7 +378,7 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
         isDisabled && "opacity-50"
       )}
       data-testid={`action-node-${id}`}
-      handles={{ target: true, source: true }}
+      handles={handles}
       nodeId={id}
       status={status}
     >

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -646,6 +646,7 @@ function IterationHeader({
 function ForEachLogGroup({
   forEachLog,
   iterations,
+  collectLog,
   expandedLogs,
   onToggleLog,
   getStatusIcon,
@@ -655,6 +656,7 @@ function ForEachLogGroup({
 }: {
   forEachLog: ExecutionLog;
   iterations: IterationGroup<ExecutionLog>[];
+  collectLog: ExecutionLog | null;
   expandedLogs: Set<string>;
   onToggleLog: (id: string) => void;
   getStatusIcon: (status: string) => JSX.Element;
@@ -685,12 +687,12 @@ function ForEachLogGroup({
         getStatusIcon={getStatusIcon}
         isExpanded={expandedLogs.has(forEachLog.id)}
         isFirst={isFirst}
-        isLast={isLast && iterations.length === 0}
+        isLast={isLast && iterations.length === 0 && collectLog === null}
         log={forEachLog}
         onToggle={() => onToggleLog(forEachLog.id)}
       />
 
-      {iterations.length > 0 && expandedLogs.has(forEachLog.id) && (
+      {expandedLogs.has(forEachLog.id) && (
         <div className="ml-6 border-border border-l pl-2">
           {iterations.map((iteration) => {
             const isIterExpanded = expandedIterations.has(
@@ -709,42 +711,36 @@ function ForEachLogGroup({
 
                 {isIterExpanded && (
                   <div className="ml-4">
-                    {groupLogsByIteration(iteration.logs).map(
-                      (subEntry, subIdx, subEntries) => {
-                        if (subEntry.type === FOR_EACH_GROUP_TYPE) {
-                          return (
-                            <ForEachLogGroup
-                              expandedLogs={expandedLogs}
-                              forEachLog={subEntry.forEachLog}
-                              getStatusDotClass={getStatusDotClass}
-                              getStatusIcon={getStatusIcon}
-                              isFirst={subIdx === 0}
-                              isLast={subIdx === subEntries.length - 1}
-                              iterations={subEntry.iterations}
-                              key={subEntry.forEachLog.id}
-                              onToggleLog={onToggleLog}
-                            />
-                          );
-                        }
-                        return (
-                          <ExecutionLogEntry
-                            getStatusDotClass={getStatusDotClass}
-                            getStatusIcon={getStatusIcon}
-                            isExpanded={expandedLogs.has(subEntry.log.id)}
-                            isFirst={subIdx === 0}
-                            isLast={subIdx === subEntries.length - 1}
-                            key={subEntry.log.id}
-                            log={subEntry.log}
-                            onToggle={() => onToggleLog(subEntry.log.id)}
-                          />
-                        );
-                      }
-                    )}
+                    {iteration.logs.map((iterLog, logIdx) => (
+                      <ExecutionLogEntry
+                        getStatusDotClass={getStatusDotClass}
+                        getStatusIcon={getStatusIcon}
+                        isExpanded={expandedLogs.has(iterLog.id)}
+                        isFirst={logIdx === 0}
+                        isLast={logIdx === iteration.logs.length - 1}
+                        key={iterLog.id}
+                        log={iterLog}
+                        onToggle={() => onToggleLog(iterLog.id)}
+                      />
+                    ))}
                   </div>
                 )}
               </div>
             );
           })}
+
+          {collectLog && (
+            <ExecutionLogEntry
+              getStatusDotClass={getStatusDotClass}
+              getStatusIcon={getStatusIcon}
+              isExpanded={expandedLogs.has(collectLog.id)}
+              isFirst={iterations.length === 0}
+              isLast={isLast}
+              key={collectLog.id}
+              log={collectLog}
+              onToggle={() => onToggleLog(collectLog.id)}
+            />
+          )}
         </div>
       )}
     </div>
@@ -1267,6 +1263,7 @@ export function WorkflowRuns({
                         if (entry.type === FOR_EACH_GROUP_TYPE) {
                           return (
                             <ForEachLogGroup
+                              collectLog={entry.collectLog}
                               expandedLogs={expandedLogs}
                               forEachLog={entry.forEachLog}
                               getStatusDotClass={getStatusDotClass}

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -684,20 +684,33 @@ function ForEachLogGroup({
     });
   }, []);
 
+  const hasContent = iterations.length > 0 || collectLog !== null;
+
   return (
-    <div>
+    <div className="relative">
+      {/* Continuous timeline line from For Each dot through expanded
+          iterations down to Collect (or the group bottom). Without this,
+          the line breaks because expanded content sits between two
+          ExecutionLogEntry siblings whose internal lines don't span
+          across intervening DOM nodes. */}
+      {hasContent && (!isLast || collectLog !== null) && (
+        <div
+          className="absolute w-px bg-border"
+          style={{ left: "9px", top: "calc(0.5rem + 1.25rem)", bottom: 0 }}
+        />
+      )}
       <ExecutionLogEntry
         getStatusDotClass={getStatusDotClass}
         getStatusIcon={getStatusIcon}
         isExpanded={expandedLogs.has(forEachLog.id)}
         isFirst={isFirst}
-        isLast={isLast && iterations.length === 0}
+        isLast={isLast && !hasContent}
         log={forEachLog}
         onToggle={() => onToggleLog(forEachLog.id)}
       />
 
       {expandedLogs.has(forEachLog.id) && (
-        <div className="ml-6 border-border border-l pl-2">
+        <div className="ml-6 pl-2">
           {iterations.map((iteration) => {
             const isIterExpanded = expandedIterations.has(
               iteration.iterationIndex
@@ -714,7 +727,7 @@ function ForEachLogGroup({
                 />
 
                 {isIterExpanded && (
-                  <div className="ml-4">
+                  <div className="ml-4 border-border border-l pl-2">
                     {groupLogsByIteration(iteration.logs, lookup).map(
                       (subEntry, subIdx, subEntries) => {
                         if (subEntry.type === FOR_EACH_GROUP_TYPE) {

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -690,7 +690,7 @@ function ForEachLogGroup({
         onToggle={() => onToggleLog(forEachLog.id)}
       />
 
-      {iterations.length > 0 && (
+      {iterations.length > 0 && expandedLogs.has(forEachLog.id) && (
         <div className="ml-6 border-border border-l pl-2">
           {iterations.map((iteration) => {
             const isIterExpanded = expandedIterations.has(
@@ -709,18 +709,37 @@ function ForEachLogGroup({
 
                 {isIterExpanded && (
                   <div className="ml-4">
-                    {iteration.logs.map((iterLog, logIdx) => (
-                      <ExecutionLogEntry
-                        getStatusDotClass={getStatusDotClass}
-                        getStatusIcon={getStatusIcon}
-                        isExpanded={expandedLogs.has(iterLog.id)}
-                        isFirst={logIdx === 0}
-                        isLast={logIdx === iteration.logs.length - 1}
-                        key={iterLog.id}
-                        log={iterLog}
-                        onToggle={() => onToggleLog(iterLog.id)}
-                      />
-                    ))}
+                    {groupLogsByIteration(iteration.logs).map(
+                      (subEntry, subIdx, subEntries) => {
+                        if (subEntry.type === FOR_EACH_GROUP_TYPE) {
+                          return (
+                            <ForEachLogGroup
+                              expandedLogs={expandedLogs}
+                              forEachLog={subEntry.forEachLog}
+                              getStatusDotClass={getStatusDotClass}
+                              getStatusIcon={getStatusIcon}
+                              isFirst={subIdx === 0}
+                              isLast={subIdx === subEntries.length - 1}
+                              iterations={subEntry.iterations}
+                              key={subEntry.forEachLog.id}
+                              onToggleLog={onToggleLog}
+                            />
+                          );
+                        }
+                        return (
+                          <ExecutionLogEntry
+                            getStatusDotClass={getStatusDotClass}
+                            getStatusIcon={getStatusIcon}
+                            isExpanded={expandedLogs.has(subEntry.log.id)}
+                            isFirst={subIdx === 0}
+                            isLast={subIdx === subEntries.length - 1}
+                            key={subEntry.log.id}
+                            log={subEntry.log}
+                            onToggle={() => onToggleLog(subEntry.log.id)}
+                          />
+                        );
+                      }
+                    )}
                   </div>
                 )}
               </div>

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -753,19 +753,19 @@ function ForEachLogGroup({
               </div>
             );
           })}
-
-          {collectLog && (
-            <ExecutionLogEntry
-              getStatusDotClass={getStatusDotClass}
-              getStatusIcon={getStatusIcon}
-              isExpanded={expandedLogs.has(collectLog.id)}
-              isFirst={false}
-              isLast={isLast}
-              log={collectLog}
-              onToggle={() => onToggleLog(collectLog.id)}
-            />
-          )}
         </div>
+      )}
+
+      {collectLog && (
+        <ExecutionLogEntry
+          getStatusDotClass={getStatusDotClass}
+          getStatusIcon={getStatusIcon}
+          isExpanded={expandedLogs.has(collectLog.id)}
+          isFirst={false}
+          isLast={isLast}
+          log={collectLog}
+          onToggle={() => onToggleLog(collectLog.id)}
+        />
       )}
     </div>
   );

--- a/drizzle/0003_parched_wendell_rand.sql
+++ b/drizzle/0003_parched_wendell_rand.sql
@@ -2,4 +2,15 @@ CREATE TABLE "beta_access_requests" (
 	"id" text PRIMARY KEY NOT NULL,
 	"email" text NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL
-);
+);--> statement-breakpoint
+CREATE TABLE "api_keys" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text,
+	"key_hash" text NOT NULL,
+	"key_prefix" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"last_used_at" timestamp
+);--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN "visibility" text DEFAULT 'private' NOT NULL;

--- a/drizzle/0014_dapper_ogun.sql
+++ b/drizzle/0014_dapper_ogun.sql
@@ -11,4 +11,6 @@ CREATE TABLE "address_book_entry" (
 ALTER TABLE "address_book_entry" ADD CONSTRAINT "address_book_entry_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "address_book_entry" ADD CONSTRAINT "address_book_entry_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "idx_address_book_org" ON "address_book_entry" USING btree ("organization_id");--> statement-breakpoint
-CREATE UNIQUE INDEX "idx_address_book_org_address" ON "address_book_entry" USING btree ("organization_id","address");
+CREATE UNIQUE INDEX "idx_address_book_org_address" ON "address_book_entry" USING btree ("organization_id","address");--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN "featured" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN "featured_order" integer DEFAULT 0;

--- a/drizzle/0020_silky_thunderbolt_ross.sql
+++ b/drizzle/0020_silky_thunderbolt_ross.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workflow_execution_logs" ADD COLUMN "iteration_index" integer;--> statement-breakpoint
+ALTER TABLE "workflow_execution_logs" ADD COLUMN "for_each_node_id" text;

--- a/drizzle/0021_backfill-missing-schema.sql
+++ b/drizzle/0021_backfill-missing-schema.sql
@@ -1,0 +1,20 @@
+-- Backfill schema items that were applied via db:push but never had migration SQL.
+-- Uses IF NOT EXISTS / DO blocks so this is safe on environments where they already exist.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'api_keys') THEN
+    CREATE TABLE "api_keys" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "name" text,
+      "key_hash" text NOT NULL,
+      "key_prefix" text NOT NULL,
+      "created_at" timestamp DEFAULT now() NOT NULL,
+      "last_used_at" timestamp
+    );
+    ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "visibility" text DEFAULT 'private' NOT NULL;--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "featured" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "featured_order" integer DEFAULT 0;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2762 @@
+{
+  "id": "3939ceb8-a681-4be4-8f8b-aa3f046ec3f7",
+  "prevId": "09d800e9-f842-4597-a593-9bc78d6d5717",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_book_entry": {
+      "name": "address_book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_address_book_org": {
+          "name": "idx_address_book_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_book_entry_organization_id_organization_id_fk": {
+          "name": "address_book_entry_organization_id_organization_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "address_book_entry_created_by_users_id_fk": {
+          "name": "address_book_entry_created_by_users_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beta_access_requests": {
+      "name": "beta_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "default_primary_rpc": {
+          "name": "default_primary_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_fallback_rpc": {
+          "name": "default_fallback_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_primary_wss": {
+          "name": "default_primary_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_wss": {
+          "name": "default_fallback_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "gas_config": {
+          "name": "gas_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chains_chain_id": {
+          "name": "idx_chains_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chains_chain_id_unique": {
+          "name": "chains_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explorer_configs": {
+      "name": "explorer_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "explorer_url": {
+          "name": "explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_type": {
+          "name": "explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_url": {
+          "name": "explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_tx_path": {
+          "name": "explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/tx/{hash}'"
+        },
+        "explorer_address_path": {
+          "name": "explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/address/{address}'"
+        },
+        "explorer_contract_path": {
+          "name": "explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_explorer_configs_chain_id": {
+          "name": "idx_explorer_configs_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "explorer_configs_chain_id_chains_chain_id_fk": {
+          "name": "explorer_configs_chain_id_chains_chain_id_fk",
+          "tableFrom": "explorer_configs",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "chain_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "explorer_configs_chain_id_unique": {
+          "name": "explorer_configs_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_managed": {
+          "name": "is_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_user_id_users_id_fk": {
+          "name": "integrations_user_id_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "integrations_organization_id_organization_id_fk": {
+          "name": "integrations_organization_id_organization_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_users_id_fk": {
+          "name": "invitation_inviter_id_users_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_users_id_fk": {
+          "name": "member_user_id_users_id_fk",
+          "tableFrom": "member",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_users_id_fk": {
+          "name": "organization_api_keys_created_by_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_api_keys_key_hash_unique": {
+          "name": "organization_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tokens": {
+      "name": "organization_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_tokens_org_chain": {
+          "name": "idx_org_tokens_org_chain",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tokens_organization_id_organization_id_fk": {
+          "name": "organization_tokens_organization_id_organization_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.para_wallets": {
+      "name": "para_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_share": {
+          "name": "user_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "para_wallets_user_id_users_id_fk": {
+          "name": "para_wallets_user_id_users_id_fk",
+          "tableFrom": "para_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "para_wallets_organization_id_organization_id_fk": {
+          "name": "para_wallets_organization_id_organization_id_fk",
+          "tableFrom": "para_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "para_wallets_organization_id_unique": {
+          "name": "para_wallets_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_transactions": {
+      "name": "pending_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_pending_tx_status": {
+          "name": "idx_pending_tx_status",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_tx_execution": {
+          "name": "idx_pending_tx_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_tx_wallet_chain_nonce": {
+          "name": "pending_tx_wallet_chain_nonce",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address",
+            "chain_id",
+            "nonce"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_org": {
+          "name": "idx_projects_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_tags": {
+      "name": "public_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "public_tags_name_unique": {
+          "name": "public_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "public_tags_slug_unique": {
+          "name": "public_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supported_tokens": {
+      "name": "supported_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stablecoin": {
+          "name": "is_stablecoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supported_tokens_chain": {
+          "name": "idx_supported_tokens_chain",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supported_tokens_chain_address": {
+          "name": "supported_tokens_chain_address",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id",
+            "token_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_org": {
+          "name": "idx_tags_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_organization_id_organization_id_fk": {
+          "name": "tags_organization_id_organization_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rpc_preferences": {
+      "name": "user_rpc_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_rpc_url": {
+          "name": "primary_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_rpc_url": {
+          "name": "fallback_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_wss_url": {
+          "name": "primary_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_wss_url": {
+          "name": "fallback_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_rpc_user_chain": {
+          "name": "idx_user_rpc_user_chain",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_rpc_user_id": {
+          "name": "idx_user_rpc_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_rpc_preferences_user_id_users_id_fk": {
+          "name": "user_rpc_preferences_user_id_users_id_fk",
+          "tableFrom": "user_rpc_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_locks": {
+      "name": "wallet_locks",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wallet_locks_wallet_address_chain_id_pk": {
+          "name": "wallet_locks_wallet_address_chain_id_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_logs": {
+      "name": "workflow_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_name": {
+          "name": "node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "iteration_index": {
+          "name": "iteration_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_each_node_id": {
+          "name": "for_each_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_execution_logs_execution_id_workflow_executions_id_fk": {
+          "name": "workflow_execution_logs_execution_id_workflow_executions_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "current_node_id": {
+          "name": "current_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_node_name": {
+          "name": "current_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_id": {
+          "name": "last_successful_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_name": {
+          "name": "last_successful_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_executions_workflow_id_workflows_id_fk": {
+          "name": "workflow_executions_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_user_id_users_id_fk": {
+          "name": "workflow_executions_user_id_users_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_public_tags": {
+      "name": "workflow_public_tags",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_tag_id": {
+          "name": "public_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workflow_public_tags_workflow": {
+          "name": "idx_workflow_public_tags_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_public_tags_tag": {
+          "name": "idx_workflow_public_tags_tag",
+          "columns": [
+            {
+              "expression": "public_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_public_tags_workflow_id_workflows_id_fk": {
+          "name": "workflow_public_tags_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_public_tags_public_tag_id_public_tags_id_fk": {
+          "name": "workflow_public_tags_public_tag_id_public_tags_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "public_tags",
+          "columnsFrom": [
+            "public_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_public_tags_workflow_id_public_tag_id_pk": {
+          "name": "workflow_public_tags_workflow_id_public_tag_id_pk",
+          "columns": [
+            "workflow_id",
+            "public_tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_schedules_enabled": {
+          "name": "idx_workflow_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_schedules_workflow": {
+          "name": "idx_workflow_schedules_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_workflow_id_workflows_id_fk": {
+          "name": "workflow_schedules_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_schedules_workflow_id_unique": {
+          "name": "workflow_schedules_workflow_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_order": {
+          "name": "featured_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_user_id_users_id_fk": {
+          "name": "workflows_user_id_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_organization_id_organization_id_fk": {
+          "name": "workflows_organization_id_organization_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_project_id_projects_id_fk": {
+          "name": "workflows_project_id_projects_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflows_tag_id_tags_id_fk": {
+          "name": "workflows_tag_id_tags_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_status": {
+      "name": "step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,2762 @@
+{
+  "id": "backfill-missing-schema-0021",
+  "prevId": "3939ceb8-a681-4be4-8f8b-aa3f046ec3f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_book_entry": {
+      "name": "address_book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_address_book_org": {
+          "name": "idx_address_book_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_book_entry_organization_id_organization_id_fk": {
+          "name": "address_book_entry_organization_id_organization_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "address_book_entry_created_by_users_id_fk": {
+          "name": "address_book_entry_created_by_users_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beta_access_requests": {
+      "name": "beta_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "default_primary_rpc": {
+          "name": "default_primary_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_fallback_rpc": {
+          "name": "default_fallback_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_primary_wss": {
+          "name": "default_primary_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_wss": {
+          "name": "default_fallback_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "gas_config": {
+          "name": "gas_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chains_chain_id": {
+          "name": "idx_chains_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chains_chain_id_unique": {
+          "name": "chains_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explorer_configs": {
+      "name": "explorer_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "explorer_url": {
+          "name": "explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_type": {
+          "name": "explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_url": {
+          "name": "explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_tx_path": {
+          "name": "explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/tx/{hash}'"
+        },
+        "explorer_address_path": {
+          "name": "explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/address/{address}'"
+        },
+        "explorer_contract_path": {
+          "name": "explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_explorer_configs_chain_id": {
+          "name": "idx_explorer_configs_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "explorer_configs_chain_id_chains_chain_id_fk": {
+          "name": "explorer_configs_chain_id_chains_chain_id_fk",
+          "tableFrom": "explorer_configs",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "chain_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "explorer_configs_chain_id_unique": {
+          "name": "explorer_configs_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_managed": {
+          "name": "is_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_user_id_users_id_fk": {
+          "name": "integrations_user_id_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "integrations_organization_id_organization_id_fk": {
+          "name": "integrations_organization_id_organization_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_users_id_fk": {
+          "name": "invitation_inviter_id_users_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_users_id_fk": {
+          "name": "member_user_id_users_id_fk",
+          "tableFrom": "member",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_users_id_fk": {
+          "name": "organization_api_keys_created_by_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_api_keys_key_hash_unique": {
+          "name": "organization_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tokens": {
+      "name": "organization_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_tokens_org_chain": {
+          "name": "idx_org_tokens_org_chain",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tokens_organization_id_organization_id_fk": {
+          "name": "organization_tokens_organization_id_organization_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.para_wallets": {
+      "name": "para_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_share": {
+          "name": "user_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "para_wallets_user_id_users_id_fk": {
+          "name": "para_wallets_user_id_users_id_fk",
+          "tableFrom": "para_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "para_wallets_organization_id_organization_id_fk": {
+          "name": "para_wallets_organization_id_organization_id_fk",
+          "tableFrom": "para_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "para_wallets_organization_id_unique": {
+          "name": "para_wallets_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_transactions": {
+      "name": "pending_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_pending_tx_status": {
+          "name": "idx_pending_tx_status",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_tx_execution": {
+          "name": "idx_pending_tx_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_tx_wallet_chain_nonce": {
+          "name": "pending_tx_wallet_chain_nonce",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address",
+            "chain_id",
+            "nonce"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_org": {
+          "name": "idx_projects_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_tags": {
+      "name": "public_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "public_tags_name_unique": {
+          "name": "public_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "public_tags_slug_unique": {
+          "name": "public_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supported_tokens": {
+      "name": "supported_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stablecoin": {
+          "name": "is_stablecoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supported_tokens_chain": {
+          "name": "idx_supported_tokens_chain",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supported_tokens_chain_address": {
+          "name": "supported_tokens_chain_address",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id",
+            "token_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_org": {
+          "name": "idx_tags_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_organization_id_organization_id_fk": {
+          "name": "tags_organization_id_organization_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rpc_preferences": {
+      "name": "user_rpc_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_rpc_url": {
+          "name": "primary_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_rpc_url": {
+          "name": "fallback_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_wss_url": {
+          "name": "primary_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_wss_url": {
+          "name": "fallback_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_rpc_user_chain": {
+          "name": "idx_user_rpc_user_chain",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_rpc_user_id": {
+          "name": "idx_user_rpc_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_rpc_preferences_user_id_users_id_fk": {
+          "name": "user_rpc_preferences_user_id_users_id_fk",
+          "tableFrom": "user_rpc_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_locks": {
+      "name": "wallet_locks",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wallet_locks_wallet_address_chain_id_pk": {
+          "name": "wallet_locks_wallet_address_chain_id_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_logs": {
+      "name": "workflow_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_name": {
+          "name": "node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "iteration_index": {
+          "name": "iteration_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_each_node_id": {
+          "name": "for_each_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_execution_logs_execution_id_workflow_executions_id_fk": {
+          "name": "workflow_execution_logs_execution_id_workflow_executions_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "current_node_id": {
+          "name": "current_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_node_name": {
+          "name": "current_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_id": {
+          "name": "last_successful_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_name": {
+          "name": "last_successful_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_executions_workflow_id_workflows_id_fk": {
+          "name": "workflow_executions_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_user_id_users_id_fk": {
+          "name": "workflow_executions_user_id_users_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_public_tags": {
+      "name": "workflow_public_tags",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_tag_id": {
+          "name": "public_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workflow_public_tags_workflow": {
+          "name": "idx_workflow_public_tags_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_public_tags_tag": {
+          "name": "idx_workflow_public_tags_tag",
+          "columns": [
+            {
+              "expression": "public_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_public_tags_workflow_id_workflows_id_fk": {
+          "name": "workflow_public_tags_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_public_tags_public_tag_id_public_tags_id_fk": {
+          "name": "workflow_public_tags_public_tag_id_public_tags_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "public_tags",
+          "columnsFrom": [
+            "public_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_public_tags_workflow_id_public_tag_id_pk": {
+          "name": "workflow_public_tags_workflow_id_public_tag_id_pk",
+          "columns": [
+            "workflow_id",
+            "public_tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_schedules_enabled": {
+          "name": "idx_workflow_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_schedules_workflow": {
+          "name": "idx_workflow_schedules_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_workflow_id_workflows_id_fk": {
+          "name": "workflow_schedules_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_schedules_workflow_id_unique": {
+          "name": "workflow_schedules_workflow_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_order": {
+          "name": "featured_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_user_id_users_id_fk": {
+          "name": "workflows_user_id_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_organization_id_organization_id_fk": {
+          "name": "workflows_organization_id_organization_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_project_id_projects_id_fk": {
+          "name": "workflows_project_id_projects_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflows_tag_id_tags_id_fk": {
+          "name": "workflows_tag_id_tags_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_status": {
+      "name": "step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1770999744018,
       "tag": "0020_silky_thunderbolt_ross",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1771293600000,
+      "tag": "0021_backfill-missing-schema",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1770953797688,
       "tag": "0019_broken_abomination",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1770999744018,
+      "tag": "0020_silky_thunderbolt_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -77,6 +77,47 @@ const SYSTEM_ACTIONS = {
       rowCount: "number - Number of rows returned",
     },
   },
+  "For Each": {
+    actionType: "For Each",
+    label: "For Each",
+    description:
+      "Loop over an array - executes connected body nodes once per element. Optionally pair with a downstream Collect node to aggregate results. Without Collect, the loop runs as fire-and-forget (side effects only).",
+    category: "System",
+    requiredFields: {
+      arraySource:
+        'string - Template reference to an array, e.g., "{{@db-query-1:Database Query.rows}}" or "{{@http-1:HTTP Request.data.items}}"',
+    },
+    optionalFields: {
+      maxIterations:
+        "number - Safety limit on iterations (default: processes entire array)",
+      mapExpression:
+        'string - Dot-path to extract from each element, e.g., "address" or "data.name". When set, the iteration output is transformed before being collected.',
+    },
+    outputFields: {
+      currentItem:
+        "unknown - Current array element (available inside loop body only via {{@forEachNodeId:For Each.currentItem}})",
+      index:
+        "number - Current zero-based iteration index (available inside loop body only)",
+      totalItems:
+        "number - Total number of items being iterated (available inside loop body only)",
+    },
+    behavior:
+      "LOOP - executes all downstream nodes once per array element. Optionally end with a Collect node to aggregate results. Without Collect, all downstream nodes run as fire-and-forget.",
+  },
+  Collect: {
+    actionType: "Collect",
+    label: "Collect",
+    description:
+      "Gathers results from a preceding For Each loop into an array. Place downstream of a For Each node to mark the end of the loop body and enable result aggregation.",
+    category: "System",
+    requiredFields: {},
+    optionalFields: {},
+    outputFields: {
+      results:
+        "array - Array of outputs from each iteration (one entry per element)",
+      count: "number - Number of iterations completed",
+    },
+  },
 } as const;
 
 // =============================================================================

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -92,6 +92,10 @@ const SYSTEM_ACTIONS = {
         "number - Safety limit on iterations (default: processes entire array)",
       mapExpression:
         'string - Dot-path to extract from each element, e.g., "address" or "data.name". When set, the iteration output is transformed before being collected.',
+      concurrency:
+        '"sequential" | "parallel" | "custom" - Execution mode for iterations (default: "sequential"). "parallel" runs all at once, "custom" uses concurrencyLimit.',
+      concurrencyLimit:
+        'number - Max concurrent iterations when concurrency is "custom" (min: 2)',
     },
     outputFields: {
       currentItem:

--- a/keeperhub/lib/for-each-concurrency.ts
+++ b/keeperhub/lib/for-each-concurrency.ts
@@ -1,0 +1,123 @@
+/**
+ * Concurrency orchestration for For Each iterations.
+ *
+ * Extracted from the workflow executor to enable isolated unit testing.
+ */
+
+export type ConcurrencyMode = "sequential" | "parallel" | "custom";
+
+export type IterationExecutor<T> = (item: T, index: number) => Promise<unknown>;
+
+export type ErrorHandler = (error: unknown) => Promise<string>;
+
+interface IterationFailure {
+  success: false;
+  error: string;
+}
+
+/**
+ * Run iterations over `items` with the specified concurrency strategy.
+ *
+ * - **sequential** (default): one at a time, in order.
+ * - **parallel**: all at once via `Promise.allSettled`.
+ * - **custom**: worker-pool with at most `concurrencyLimit` concurrent.
+ *
+ * Results are always returned in iteration order regardless of mode.
+ * Individual iteration failures are captured as `{ success: false, error }`,
+ * they never abort sibling iterations.
+ */
+export async function runIterations<T>(
+  items: T[],
+  execute: IterationExecutor<T>,
+  handleError: ErrorHandler,
+  mode: ConcurrencyMode = "sequential",
+  concurrencyLimit = 0
+): Promise<unknown[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  if (mode === "parallel") {
+    return await runParallel(items, execute, handleError);
+  }
+
+  if (mode === "custom" && concurrencyLimit > 1) {
+    return await runWorkerPool(items, execute, handleError, concurrencyLimit);
+  }
+
+  // Sequential (default, or custom with limit <= 1 falls back here)
+  return await runSequential(items, execute, handleError);
+}
+
+async function runSequential<T>(
+  items: T[],
+  execute: IterationExecutor<T>,
+  handleError: ErrorHandler
+): Promise<unknown[]> {
+  const results: unknown[] = [];
+  for (const [i, item] of items.entries()) {
+    try {
+      results.push(await execute(item, i));
+    } catch (error) {
+      const errorMessage = await handleError(error);
+      results.push({
+        success: false,
+        error: errorMessage,
+      } satisfies IterationFailure);
+    }
+  }
+  return results;
+}
+
+async function runParallel<T>(
+  items: T[],
+  execute: IterationExecutor<T>,
+  handleError: ErrorHandler
+): Promise<unknown[]> {
+  const settled = await Promise.allSettled(
+    items.map((item, i) => execute(item, i))
+  );
+  const results: unknown[] = [];
+  for (const entry of settled) {
+    if (entry.status === "fulfilled") {
+      results.push(entry.value);
+    } else {
+      const errorMessage = await handleError(entry.reason);
+      results.push({
+        success: false,
+        error: errorMessage,
+      } satisfies IterationFailure);
+    }
+  }
+  return results;
+}
+
+async function runWorkerPool<T>(
+  items: T[],
+  execute: IterationExecutor<T>,
+  handleError: ErrorHandler,
+  concurrencyLimit: number
+): Promise<unknown[]> {
+  const results: unknown[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const runWorker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      try {
+        results[i] = await execute(items[i], i);
+      } catch (error) {
+        const errorMessage = await handleError(error);
+        results[i] = {
+          success: false,
+          error: errorMessage,
+        } satisfies IterationFailure;
+      }
+    }
+  };
+
+  const workerCount = Math.min(concurrencyLimit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+  return results;
+}

--- a/keeperhub/lib/for-each-utils.ts
+++ b/keeperhub/lib/for-each-utils.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure helper functions for For Each loop features.
+ *
+ * Shared by:
+ *   - components/workflow/config/action-config.tsx (map expression dropdown)
+ *   - components/ui/template-autocomplete.tsx (synthetic output for autocomplete)
+ *   - tests/unit/action-config-helpers.test.ts
+ *   - tests/unit/template-autocomplete-foreach.test.ts
+ */
+
+/** Matches `{{@nodeId:Label.fieldPath}}` templates used by array sources. */
+export const ARRAY_SOURCE_RE = /^\{\{@([^:]+):([^.}]+)\.?([^}]*)\}\}$/;
+
+/**
+ * Traverse a dot-path into a nested value, returning null on failure.
+ * Returns null for missing keys, non-object intermediates, arrays, and
+ * null/undefined roots.
+ */
+export function traverseDotPath(root: unknown, path: string): unknown {
+  let data: unknown = root;
+  for (const part of path.split(".")) {
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      data = (data as Record<string, unknown>)[part];
+      if (data === undefined) {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+  return data;
+}
+
+/**
+ * Recursively extract dot-paths from an object up to a max depth of 3.
+ * Arrays are listed as keys but not recursed into.
+ */
+export function extractObjectPaths(
+  obj: Record<string, unknown>,
+  prefix: string,
+  depth: number,
+  paths: string[]
+): void {
+  if (depth > 3) {
+    return;
+  }
+  for (const key of Object.keys(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    paths.push(path);
+    const val = obj[key];
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      extractObjectPaths(
+        val as Record<string, unknown>,
+        path,
+        depth + 1,
+        paths
+      );
+    }
+  }
+}
+
+/**
+ * Resolve an array source template to the first element of the referenced
+ * array. Returns null when the template is invalid, the source node has no
+ * output, the resolved value is not an array, the array is empty, or the
+ * first element is not a plain object.
+ */
+export function resolveArraySourceElement(
+  arraySource: string,
+  executionLogs: Record<string, { output?: unknown }>,
+  lastLogs: Record<string, { output?: unknown }>
+): Record<string, unknown> | null {
+  const match = ARRAY_SOURCE_RE.exec(arraySource);
+  if (!match) {
+    return null;
+  }
+
+  const sourceNodeId = match[1];
+  const fieldPath = match[3] || "";
+
+  const sourceOutput =
+    executionLogs[sourceNodeId]?.output ?? lastLogs[sourceNodeId]?.output;
+  if (sourceOutput === undefined || sourceOutput === null) {
+    return null;
+  }
+
+  const data = fieldPath
+    ? traverseDotPath(sourceOutput, fieldPath)
+    : sourceOutput;
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+
+  const first = data[0];
+  if (!first || typeof first !== "object" || Array.isArray(first)) {
+    return null;
+  }
+
+  return first as Record<string, unknown>;
+}
+
+type ExecutionLogEntry = { output?: unknown };
+
+type ForEachNode = {
+  id: string;
+  data: {
+    config?: Record<string, unknown>;
+  };
+};
+
+/**
+ * For a For Each node, resolve the arraySource to build a synthetic output
+ * containing the first array element as `currentItem`. This enables
+ * getAvailableFields to enumerate nested object keys in autocomplete.
+ */
+export function resolveForEachSyntheticOutput(
+  node: ForEachNode,
+  executionLogs: Record<string, ExecutionLogEntry>,
+  lastLogs: Record<string, ExecutionLogEntry>
+): Record<string, unknown> | null {
+  const arraySource = node.data.config?.arraySource as string | undefined;
+  if (!arraySource) {
+    return null;
+  }
+
+  const match = ARRAY_SOURCE_RE.exec(arraySource);
+  if (!match) {
+    return null;
+  }
+
+  const sourceNodeId = match[1];
+  const fieldPath = match[3] || "";
+
+  const sourceOutput =
+    executionLogs[sourceNodeId]?.output ?? lastLogs[sourceNodeId]?.output;
+  if (sourceOutput === undefined || sourceOutput === null) {
+    return null;
+  }
+
+  const data = fieldPath
+    ? traverseDotPath(sourceOutput, fieldPath)
+    : sourceOutput;
+
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+
+  // Apply mapExpression to transform currentItem, matching executor behavior
+  let currentItem: unknown = data[0];
+  const mapExpression = node.data.config?.mapExpression as string | undefined;
+  if (mapExpression && currentItem && typeof currentItem === "object") {
+    const mapped = traverseDotPath(currentItem, mapExpression);
+    if (mapped !== null) {
+      currentItem = mapped;
+    }
+  }
+
+  return {
+    currentItem,
+    index: 0,
+    totalItems: data.length,
+  };
+}

--- a/keeperhub/lib/iteration-grouping.ts
+++ b/keeperhub/lib/iteration-grouping.ts
@@ -32,7 +32,64 @@ export type GroupedLogEntry<T extends IterationLogFields> =
       type: typeof FOR_EACH_GROUP_TYPE;
       forEachLog: T;
       iterations: IterationGroup<T>[];
+      collectLog: T | null;
     };
+
+/** Pre-built lookup maps for child and collect logs, keyed by forEachNodeId. */
+export type ChildLogsLookup<T extends IterationLogFields> = {
+  childLogs: Map<string, T[]>;
+  collectLogs: Map<string, T[]>;
+  /** For Each nodeId -> sorted invocation logs (multiple when nested). */
+  invocations: Map<string, T[]>;
+};
+
+const sortByStartedAt = <T extends IterationLogFields>(a: T, b: T): number =>
+  new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime();
+
+/**
+ * Build lookup maps from a flat log array. Call once on the full log set
+ * and pass the result to recursive `groupLogsByIteration` calls so nested
+ * For Each nodes can find their children.
+ */
+export function buildChildLogsLookup<T extends IterationLogFields>(
+  logs: T[]
+): ChildLogsLookup<T> {
+  const childLogs = new Map<string, T[]>();
+  const collectLogs = new Map<string, T[]>();
+  const invocations = new Map<string, T[]>();
+
+  for (const log of logs) {
+    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
+      const existing = childLogs.get(log.forEachNodeId) ?? [];
+      existing.push(log);
+      childLogs.set(log.forEachNodeId, existing);
+    } else if (
+      log.forEachNodeId !== null &&
+      log.iterationIndex === null &&
+      log.nodeType === "Collect"
+    ) {
+      const existing = collectLogs.get(log.forEachNodeId) ?? [];
+      existing.push(log);
+      collectLogs.set(log.forEachNodeId, existing);
+    }
+
+    if (log.nodeType === "For Each") {
+      const existing = invocations.get(log.nodeId) ?? [];
+      existing.push(log);
+      invocations.set(log.nodeId, existing);
+    }
+  }
+
+  // Sort invocations and collects by startedAt for time-window partitioning
+  for (const arr of invocations.values()) {
+    arr.sort(sortByStartedAt);
+  }
+  for (const arr of collectLogs.values()) {
+    arr.sort(sortByStartedAt);
+  }
+
+  return { childLogs, collectLogs, invocations };
+}
 
 /**
  * Group child logs by iteration index and sort them chronologically.
@@ -62,38 +119,91 @@ export function buildIterationGroups<T extends IterationLogFields>(
 /**
  * Transform a flat log array into grouped entries where For Each body
  * node logs are nested under their parent For Each node by iteration.
+ *
+ * Pass a pre-built `lookup` (from `buildChildLogsLookup`) when calling
+ * recursively on iteration sub-arrays so nested For Each nodes can find
+ * their children in the full log set.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: grouping logic requires nested conditionals for For Each / Collect classification
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: nested For Each + time-window partitioning requires branching
 export function groupLogsByIteration<T extends IterationLogFields>(
-  logs: T[]
+  logs: T[],
+  lookup?: ChildLogsLookup<T>
 ): GroupedLogEntry<T>[] {
-  const result: GroupedLogEntry<T>[] = [];
+  const {
+    childLogs: forEachChildLogs,
+    collectLogs: forEachCollectLogs,
+    invocations: forEachInvocations,
+  } = lookup ?? buildChildLogsLookup(logs);
 
-  // Collect logs that belong to a For Each loop body (iteration body logs)
-  const forEachChildLogs = new Map<string, T[]>();
+  // Track which node IDs are present in the current logs array so we only
+  // skip body logs whose parent For Each is in this array.  In recursive
+  // calls (iterating over an outer iteration's sub-logs), the parent For
+  // Each is NOT in the array, so nested For Each nodes won't be skipped.
+  const nodeIdsInLogs = new Set<string>();
   for (const log of logs) {
-    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
-      const existing = forEachChildLogs.get(log.forEachNodeId) ?? [];
-      existing.push(log);
-      forEachChildLogs.set(log.forEachNodeId, existing);
-    }
+    nodeIdsInLogs.add(log.nodeId);
   }
 
-  // Build grouped entries
+  const result: GroupedLogEntry<T>[] = [];
+
   for (const log of logs) {
-    // Skip iteration body logs -- they'll be attached to their For Each parent
-    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
+    // Skip iteration body logs whose parent For Each is in this logs array
+    if (
+      log.forEachNodeId !== null &&
+      log.iterationIndex !== null &&
+      nodeIdsInLogs.has(log.forEachNodeId)
+    ) {
+      continue;
+    }
+
+    // Skip Collect logs linked to a For Each -- they'll be attached to their group
+    if (
+      log.nodeType === "Collect" &&
+      log.forEachNodeId !== null &&
+      log.iterationIndex === null &&
+      forEachCollectLogs.has(log.forEachNodeId)
+    ) {
       continue;
     }
 
     // For Each parent with child logs: build iteration groups
     if (log.nodeType === "For Each" && forEachChildLogs.has(log.nodeId)) {
-      const childLogs = forEachChildLogs.get(log.nodeId) ?? [];
-      const iterations = buildIterationGroups(childLogs);
+      const allChildren = forEachChildLogs.get(log.nodeId) ?? [];
+      const invocs = forEachInvocations.get(log.nodeId) ?? [];
+      const allCollects = forEachCollectLogs.get(log.nodeId) ?? [];
+
+      let children: T[];
+      let collectLog: T | null;
+
+      if (invocs.length > 1) {
+        // Multi-invocation (nested For Each): filter by time window
+        const thisStart = new Date(log.startedAt).getTime();
+        const thisIdx = invocs.indexOf(log);
+        const nextStart =
+          thisIdx >= 0 && thisIdx < invocs.length - 1
+            ? new Date(invocs[thisIdx + 1].startedAt).getTime()
+            : Number.POSITIVE_INFINITY;
+
+        children = allChildren.filter((c) => {
+          const t = new Date(c.startedAt).getTime();
+          return t >= thisStart && t < nextStart;
+        });
+        collectLog =
+          allCollects.find((c) => {
+            const t = new Date(c.startedAt).getTime();
+            return t >= thisStart && t < nextStart;
+          }) ?? null;
+      } else {
+        children = allChildren;
+        collectLog = allCollects[0] ?? null;
+      }
+
+      const iterations = buildIterationGroups(children);
       result.push({
         type: FOR_EACH_GROUP_TYPE,
         forEachLog: log,
         iterations,
+        collectLog,
       });
     } else {
       result.push({ type: "standalone", log });

--- a/keeperhub/lib/iteration-grouping.ts
+++ b/keeperhub/lib/iteration-grouping.ts
@@ -9,6 +9,9 @@
  * upstream ExecutionLog) without this module redefining it.
  */
 
+/** Discriminant value for For Each group entries in grouped log output. */
+export const FOR_EACH_GROUP_TYPE = "for-each-group" as const;
+
 /** Minimal fields the grouping functions require from a log entry. */
 export type IterationLogFields = {
   nodeId: string;
@@ -26,7 +29,7 @@ export type IterationGroup<T extends IterationLogFields> = {
 export type GroupedLogEntry<T extends IterationLogFields> =
   | { type: "standalone"; log: T }
   | {
-      type: "for-each-group";
+      type: typeof FOR_EACH_GROUP_TYPE;
       forEachLog: T;
       iterations: IterationGroup<T>[];
     };
@@ -86,7 +89,7 @@ export function groupLogsByIteration<T extends IterationLogFields>(
     if (log.nodeType === "For Each" && forEachChildLogs.has(log.nodeId)) {
       const childLogs = forEachChildLogs.get(log.nodeId) ?? [];
       const iterations = buildIterationGroups(childLogs);
-      result.push({ type: "for-each-group", forEachLog: log, iterations });
+      result.push({ type: FOR_EACH_GROUP_TYPE, forEachLog: log, iterations });
     } else {
       result.push({ type: "standalone", log });
     }

--- a/keeperhub/lib/iteration-grouping.ts
+++ b/keeperhub/lib/iteration-grouping.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helper functions for grouping For Each execution logs by iteration.
+ *
+ * Shared by:
+ *   - components/workflow/workflow-runs.tsx (UI rendering)
+ *   - tests/unit/iteration-grouping.test.ts
+ *
+ * Uses a generic constraint so callers pass their own log type (e.g., the
+ * upstream ExecutionLog) without this module redefining it.
+ */
+
+/** Minimal fields the grouping functions require from a log entry. */
+export type IterationLogFields = {
+  nodeId: string;
+  nodeType: string;
+  startedAt: Date;
+  iterationIndex: number | null;
+  forEachNodeId: string | null;
+};
+
+export type IterationGroup<T extends IterationLogFields> = {
+  iterationIndex: number;
+  logs: T[];
+};
+
+export type GroupedLogEntry<T extends IterationLogFields> =
+  | { type: "standalone"; log: T }
+  | {
+      type: "for-each-group";
+      forEachLog: T;
+      iterations: IterationGroup<T>[];
+    };
+
+/**
+ * Group child logs by iteration index and sort them chronologically.
+ */
+export function buildIterationGroups<T extends IterationLogFields>(
+  childLogs: T[]
+): IterationGroup<T>[] {
+  const iterationMap = new Map<number, T[]>();
+  for (const child of childLogs) {
+    const idx = child.iterationIndex ?? 0;
+    const existing = iterationMap.get(idx) ?? [];
+    existing.push(child);
+    iterationMap.set(idx, existing);
+  }
+
+  return Array.from(iterationMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([index, iterLogs]) => ({
+      iterationIndex: index,
+      logs: iterLogs.sort(
+        (a, b) =>
+          new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+      ),
+    }));
+}
+
+/**
+ * Transform a flat log array into grouped entries where For Each body
+ * node logs are nested under their parent For Each node by iteration.
+ */
+export function groupLogsByIteration<T extends IterationLogFields>(
+  logs: T[]
+): GroupedLogEntry<T>[] {
+  const result: GroupedLogEntry<T>[] = [];
+
+  // Collect logs that belong to a For Each loop body
+  const forEachChildLogs = new Map<string, T[]>();
+  for (const log of logs) {
+    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
+      const existing = forEachChildLogs.get(log.forEachNodeId) ?? [];
+      existing.push(log);
+      forEachChildLogs.set(log.forEachNodeId, existing);
+    }
+  }
+
+  // Build grouped entries
+  for (const log of logs) {
+    // Skip loop body logs -- they'll be attached to their For Each parent
+    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
+      continue;
+    }
+
+    // For Each parent with child logs: build iteration groups
+    if (log.nodeType === "For Each" && forEachChildLogs.has(log.nodeId)) {
+      const childLogs = forEachChildLogs.get(log.nodeId) ?? [];
+      const iterations = buildIterationGroups(childLogs);
+      result.push({ type: "for-each-group", forEachLog: log, iterations });
+    } else {
+      result.push({ type: "standalone", log });
+    }
+  }
+
+  return result;
+}

--- a/keeperhub/lib/steps/__tests__/collect.test.ts
+++ b/keeperhub/lib/steps/__tests__/collect.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Mock step-handler to avoid database/logging dependencies
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+import { type CollectInput, collectStep } from "../collect";
+
+function makeInput(overrides: Partial<CollectInput> = {}): CollectInput {
+  return {
+    results: [{ data: "a" }, { data: "b" }],
+    count: 2,
+    ...overrides,
+  };
+}
+
+describe("collectStep", () => {
+  it("returns results and count unchanged", async () => {
+    const input = makeInput();
+    const result = await collectStep(input);
+    expect(result).toEqual({
+      results: [{ data: "a" }, { data: "b" }],
+      count: 2,
+    });
+  });
+
+  it("handles empty results array", async () => {
+    const result = await collectStep(makeInput({ results: [], count: 0 }));
+    expect(result.results).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it("preserves mixed success/error results", async () => {
+    const mixedResults = [
+      { success: true, data: 42 },
+      { success: false, error: "timeout" },
+      { success: true, data: 99 },
+    ];
+    const result = await collectStep(
+      makeInput({ results: mixedResults, count: 3 })
+    );
+    expect(result.results).toHaveLength(3);
+    expect(result.results[1]).toEqual({ success: false, error: "timeout" });
+  });
+
+  it("handles single result", async () => {
+    const result = await collectStep(
+      makeInput({ results: [{ value: "only" }], count: 1 })
+    );
+    expect(result.results).toHaveLength(1);
+    expect(result.count).toBe(1);
+  });
+
+  it("handles large result sets", async () => {
+    const results = Array.from({ length: 100 }, (_, i) => ({ index: i }));
+    const result = await collectStep(makeInput({ results, count: 100 }));
+    expect(result.results).toHaveLength(100);
+    expect(result.count).toBe(100);
+  });
+
+  it("preserves nested object structure in results", async () => {
+    const nestedResults = [
+      { data: { nested: { deep: "value" } } },
+      { data: { nested: { deep: "other" } } },
+    ];
+    const result = await collectStep(
+      makeInput({ results: nestedResults, count: 2 })
+    );
+    expect(result.results[0]).toEqual({
+      data: { nested: { deep: "value" } },
+    });
+  });
+
+  it("handles results with null and undefined values", async () => {
+    const results = [null, undefined, { data: "valid" }];
+    const result = await collectStep(makeInput({ results, count: 3 }));
+    expect(result.results).toEqual([null, undefined, { data: "valid" }]);
+    expect(result.count).toBe(3);
+  });
+
+  it("preserves primitive results", async () => {
+    const results = [1, "two", true, null];
+    const result = await collectStep(makeInput({ results, count: 4 }));
+    expect(result.results).toEqual([1, "two", true, null]);
+  });
+
+  it("count is independent of results array length", async () => {
+    const result = await collectStep(
+      makeInput({ results: [1, 2, 3], count: 10 })
+    );
+    expect(result.results).toHaveLength(3);
+    expect(result.count).toBe(10);
+  });
+
+  it("has maxRetries set to 0", () => {
+    expect(collectStep.maxRetries).toBe(0);
+  });
+});

--- a/keeperhub/lib/steps/__tests__/for-each.test.ts
+++ b/keeperhub/lib/steps/__tests__/for-each.test.ts
@@ -35,6 +35,40 @@ describe("forEachStep", () => {
     expect(result.arrayLength).toBe(20);
   });
 
+  it("handles zero arrayLength", async () => {
+    const result = await forEachStep(
+      makeInput({ arrayLength: 0, maxIterations: 10 })
+    );
+    expect(result.arrayLength).toBe(0);
+    expect(result.success).toBe(true);
+  });
+
+  it("handles zero maxIterations (process all)", async () => {
+    const result = await forEachStep(
+      makeInput({ arrayLength: 5, maxIterations: 0 })
+    );
+    expect(result.maxIterations).toBe(0);
+    expect(result.success).toBe(true);
+  });
+
+  it("handles large array length", async () => {
+    const result = await forEachStep(
+      makeInput({ arrayLength: 10_000, maxIterations: 100 })
+    );
+    expect(result.arrayLength).toBe(10_000);
+    expect(result.maxIterations).toBe(100);
+  });
+
+  it("returns consistent shape regardless of input values", async () => {
+    const result = await forEachStep(
+      makeInput({ arrayLength: 3, maxIterations: 1 })
+    );
+    expect(result).toHaveProperty("success");
+    expect(result).toHaveProperty("arrayLength");
+    expect(result).toHaveProperty("maxIterations");
+    expect(Object.keys(result)).toHaveLength(3);
+  });
+
   it("has maxRetries set to 0", () => {
     expect(forEachStep.maxRetries).toBe(0);
   });

--- a/keeperhub/lib/steps/__tests__/for-each.test.ts
+++ b/keeperhub/lib/steps/__tests__/for-each.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Mock step-handler to avoid database/logging dependencies
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+import { type ForEachInput, forEachStep } from "../for-each";
+
+function makeInput(overrides: Partial<ForEachInput> = {}): ForEachInput {
+  return {
+    arrayLength: 5,
+    maxIterations: 100,
+    ...overrides,
+  };
+}
+
+describe("forEachStep", () => {
+  it("returns success with input values echoed back", async () => {
+    const result = await forEachStep(makeInput());
+    expect(result).toEqual({
+      success: true,
+      arrayLength: 5,
+      maxIterations: 100,
+    });
+  });
+
+  it("reflects custom maxIterations and arrayLength", async () => {
+    const result = await forEachStep(
+      makeInput({ arrayLength: 20, maxIterations: 50 })
+    );
+    expect(result.maxIterations).toBe(50);
+    expect(result.arrayLength).toBe(20);
+  });
+
+  it("has maxRetries set to 0", () => {
+    expect(forEachStep.maxRetries).toBe(0);
+  });
+});

--- a/keeperhub/lib/steps/collect.ts
+++ b/keeperhub/lib/steps/collect.ts
@@ -1,0 +1,32 @@
+/**
+ * Executable step function for Collect action.
+ *
+ * Gathers results from a preceding For Each loop into an array.
+ * The executor populates the results before calling this step so that
+ * the execution is properly logged.
+ */
+import "server-only";
+
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+
+export type CollectInput = StepInput & {
+  results: unknown[];
+  count: number;
+};
+
+type CollectResult = {
+  results: unknown[];
+  count: number;
+};
+
+// biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
+export async function collectStep(input: CollectInput): Promise<CollectResult> {
+  "use step";
+  return withStepLogging(input, () =>
+    Promise.resolve({
+      results: input.results,
+      count: input.count,
+    })
+  );
+}
+collectStep.maxRetries = 0;

--- a/keeperhub/lib/steps/for-each.ts
+++ b/keeperhub/lib/steps/for-each.ts
@@ -1,0 +1,34 @@
+/**
+ * Executable step function for For Each (loop) action.
+ *
+ * This step logs the start of a For Each iteration cycle.
+ * The actual iteration logic lives in the workflow executor, not here,
+ * because the executor needs to orchestrate body-node execution per element.
+ */
+import "server-only";
+
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+
+export type ForEachInput = StepInput & {
+  arrayLength: number;
+  maxIterations: number;
+};
+
+type ForEachResult = {
+  success: true;
+  arrayLength: number;
+  maxIterations: number;
+};
+
+// biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
+export async function forEachStep(input: ForEachInput): Promise<ForEachResult> {
+  "use step";
+  return withStepLogging(input, () =>
+    Promise.resolve({
+      success: true as const,
+      arrayLength: input.arrayLength,
+      maxIterations: input.maxIterations,
+    })
+  );
+}
+forEachStep.maxRetries = 0;

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -680,6 +680,10 @@ export const workflowApi = {
         startedAt: Date;
         completedAt: Date | null;
         duration: string | null;
+        // start custom keeperhub code //
+        iterationIndex: number | null;
+        forEachNodeId: string | null;
+        // end keeperhub code //
       }>;
     }>(`/api/workflows/executions/${executionId}/logs`),
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -313,6 +313,10 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
   completedAt: timestamp("completed_at"),
   duration: text("duration"), // Duration in milliseconds
   timestamp: timestamp("timestamp").notNull().defaultNow(),
+  // start custom keeperhub code //
+  iterationIndex: integer("iteration_index"), // 0-based loop iteration (null for non-loop nodes)
+  forEachNodeId: text("for_each_node_id"), // parent For Each node ID (null for non-loop nodes)
+  // end keeperhub code //
 });
 
 // KeeperHub: Para Wallets, Organization API Keys, and Organization Tokens (imported from KeeperHub schema extensions)

--- a/lib/steps/step-handler.ts
+++ b/lib/steps/step-handler.ts
@@ -24,6 +24,8 @@ export type StepContext = {
   nodeType: string;
   // start custom keeperhub code //
   triggerType?: string;
+  iterationIndex?: number;
+  forEachNodeId?: string;
   // end keeperhub code //
 };
 
@@ -60,6 +62,10 @@ async function logStepStart(
       nodeName: context.nodeName,
       nodeType: context.nodeType,
       input: redactedInput,
+      // start custom keeperhub code //
+      iterationIndex: context.iterationIndex,
+      forEachNodeId: context.forEachNodeId,
+      // end keeperhub code //
     });
 
     return result;

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -956,7 +956,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     scopedOutputs: NodeOutputs,
     bodyResults: Record<string, ExecutionResult>,
     bodyEdgesBySource: Map<string, string[]>,
-    collectNodeId: string | undefined
+    collectNodeId: string | undefined,
+    iterationMeta?: { iterationIndex: number; forEachNodeId: string }
   ): Promise<void> {
     if (bodyVisited.has(nodeId)) {
       return;
@@ -987,7 +988,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             scopedOutputs,
             bodyResults,
             bodyEdgesBySource,
-            collectNodeId
+            collectNodeId,
+            iterationMeta
           )
         )
       );
@@ -1052,6 +1054,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         nodeId: node.id,
         nodeName: getNodeName(node),
         nodeType: actionType,
+        iterationIndex: iterationMeta?.iterationIndex,
+        forEachNodeId: iterationMeta?.forEachNodeId,
       };
 
       const stepResult = await executeActionStep({
@@ -1107,7 +1111,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                   scopedOutputs,
                   bodyResults,
                   bodyEdgesBySource,
-                  collectNodeId
+                  collectNodeId,
+                  iterationMeta
                 )
               )
             );
@@ -1135,7 +1140,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             scopedOutputs,
             bodyResults,
             bodyEdgesBySource,
-            collectNodeId
+            collectNodeId,
+            iterationMeta
           )
         )
       );
@@ -1211,6 +1217,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // Execute body starting from For Each's direct children
       const bodyVisited = new Set<string>();
       const firstBodyNodes = bodyEdgesBySource.get(forEachNodeId) ?? [];
+      const iterationMeta = { iterationIndex: index, forEachNodeId };
 
       await Promise.all(
         firstBodyNodes.map((bodyNodeId) =>
@@ -1220,7 +1227,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             scopedOutputs,
             bodyResults,
             bodyEdgesBySource,
-            collectNodeId
+            collectNodeId,
+            iterationMeta
           )
         )
       );

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -60,6 +60,20 @@ const SYSTEM_ACTIONS: Record<string, StepImporter> = {
     importer: () => import("./steps/condition") as Promise<any>,
     stepFunction: "conditionStep",
   },
+  // start custom keeperhub code //
+  "For Each": {
+    importer: () =>
+      // biome-ignore lint/suspicious/noExplicitAny: Dynamic module import matches existing pattern
+      import("@/keeperhub/lib/steps/for-each") as Promise<any>,
+    stepFunction: "forEachStep",
+  },
+  Collect: {
+    importer: () =>
+      // biome-ignore lint/suspicious/noExplicitAny: Dynamic module import matches existing pattern
+      import("@/keeperhub/lib/steps/collect") as Promise<any>,
+    stepFunction: "collectStep",
+  },
+  // end keeperhub code //
 };
 
 type ExecutionResult = {
@@ -679,6 +693,166 @@ function findOutputByLabelFallback(
   const label = dotIndex === -1 ? rest : rest.substring(0, dotIndex);
   return findOutputByLabel(label, outputs);
 }
+
+// ---------------------------------------------------------------------------
+// For Each / Collect helpers
+// ---------------------------------------------------------------------------
+
+export type LoopBodyInfo = {
+  bodyNodeIds: string[];
+  collectNodeId: string | undefined;
+  bodyEdgesBySource: Map<string, string[]>;
+};
+
+/**
+ * Compute the next BFS depth when traversing loop body nodes.
+ * Inner For Each increments depth, inner Collect decrements it.
+ */
+function computeNextDepth(
+  isForEach: boolean,
+  isCollect: boolean,
+  currentDepth: number
+): number {
+  if (isForEach) {
+    return currentDepth + 1;
+  }
+  if (isCollect) {
+    return currentDepth - 1;
+  }
+  return currentDepth;
+}
+
+/**
+ * Identify the loop body subgraph between a For Each node and its paired
+ * Collect node. Uses BFS with depth tracking so nested For Each / Collect
+ * pairs are correctly skipped.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: BFS with depth tracking requires multiple condition branches
+export function identifyLoopBody(
+  forEachNodeId: string,
+  edgesBySource: Map<string, string[]>,
+  nodeMap: Map<string, WorkflowNode>
+): LoopBodyInfo {
+  const bodyNodeIds: string[] = [];
+  const bodyEdgesBySource = new Map<string, string[]>();
+  let collectNodeId: string | undefined;
+  const visited = new Set<string>();
+
+  // Seed queue with direct children of the For Each node
+  const initialTargets = edgesBySource.get(forEachNodeId) ?? [];
+  for (const targetId of initialTargets) {
+    const targets = bodyEdgesBySource.get(forEachNodeId) ?? [];
+    targets.push(targetId);
+    bodyEdgesBySource.set(forEachNodeId, [...targets]);
+  }
+
+  const queue: Array<{ nodeId: string; depth: number }> = initialTargets.map(
+    (id) => ({ nodeId: id, depth: 0 })
+  );
+
+  while (queue.length > 0) {
+    const entry = queue.shift();
+    if (!entry) {
+      break;
+    }
+    const { nodeId, depth } = entry;
+
+    if (visited.has(nodeId)) {
+      continue;
+    }
+    visited.add(nodeId);
+
+    const node = nodeMap.get(nodeId);
+    if (!node) {
+      continue;
+    }
+
+    const actionType = node.data.config?.actionType as string | undefined;
+    const isCollect = node.data.type === "action" && actionType === "Collect";
+    const isForEach = node.data.type === "action" && actionType === "For Each";
+
+    // Collect at depth 0 is OUR boundary
+    if (isCollect && depth === 0) {
+      if (collectNodeId && collectNodeId !== nodeId) {
+        throw new Error(
+          "For Each node has multiple Collect nodes at the same nesting level. " +
+            "Each For Each must have exactly one Collect boundary."
+        );
+      }
+      collectNodeId = nodeId;
+      continue; // Don't traverse past our Collect
+    }
+
+    bodyNodeIds.push(nodeId);
+
+    const nextDepth = computeNextDepth(isForEach, isCollect, depth);
+    const nextIds = edgesBySource.get(nodeId) ?? [];
+    for (const nextId of nextIds) {
+      const targets = bodyEdgesBySource.get(nodeId) ?? [];
+      targets.push(nextId);
+      bodyEdgesBySource.set(nodeId, [...targets]);
+      queue.push({ nodeId: nextId, depth: nextDepth });
+    }
+  }
+
+  return { bodyNodeIds, collectNodeId, bodyEdgesBySource };
+}
+
+const ARRAY_SOURCE_TEMPLATE_PATTERN = /^\{\{@([^:]+):([^}]+)\}\}$/;
+
+/**
+ * Resolve a template string to its raw array value.
+ * Accepts {{@nodeId:Label.field}} syntax or a JSON array literal.
+ */
+export function resolveArraySource(
+  source: unknown,
+  outputs: NodeOutputs
+): unknown[] {
+  if (typeof source !== "string" || !source.trim()) {
+    throw new Error(
+      "For Each: arraySource is required. " +
+        "Configure a template reference to an array (e.g., {{@nodeId:Label.rows}})."
+    );
+  }
+
+  const match = source.trim().match(ARRAY_SOURCE_TEMPLATE_PATTERN);
+
+  if (!match) {
+    // Try to parse as a JSON array literal
+    try {
+      const parsed: unknown = JSON.parse(source);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Not valid JSON
+    }
+    throw new Error(
+      `For Each: arraySource "${source}" is not a valid template reference. ` +
+        "Use {{@nodeId:Label.field}} syntax to reference an array from an upstream node."
+    );
+  }
+
+  const [, nodeId, rest] = match;
+  const raw = resolveTemplateToRawValue(nodeId, rest, outputs);
+
+  if (raw === null || raw === undefined) {
+    throw new Error(
+      `For Each: arraySource resolved to ${String(raw)}. ` +
+        "Ensure the referenced node has executed and produced output."
+    );
+  }
+
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `For Each: arraySource must resolve to an array, got ${typeof raw}. ` +
+        `Referenced: ${source}`
+    );
+  }
+
+  return raw;
+}
+
 // end keeperhub code //
 
 /**
@@ -764,6 +938,384 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
     return node.data.type;
   }
+
+  // start custom keeperhub code //
+  // -------------------------------------------------------------------
+  // For Each: body-node executor (scoped outputs, body-only edges)
+  // -------------------------------------------------------------------
+
+  /**
+   * Execute a single body node within a For Each iteration.
+   * Uses scoped outputs so loop variable references resolve correctly
+   * and body-specific edges so traversal stays within the loop body.
+   */
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Body execution mirrors main executeNode with loop-specific scoping
+  async function executeBodyNode(
+    nodeId: string,
+    bodyVisited: Set<string>,
+    scopedOutputs: NodeOutputs,
+    bodyResults: Record<string, ExecutionResult>,
+    bodyEdgesBySource: Map<string, string[]>,
+    collectNodeId: string | undefined
+  ): Promise<void> {
+    if (bodyVisited.has(nodeId)) {
+      return;
+    }
+    if (nodeId === collectNodeId) {
+      return; // Don't execute the Collect boundary
+    }
+    bodyVisited.add(nodeId);
+
+    const node = nodeMap.get(nodeId);
+    if (!node) {
+      return;
+    }
+
+    // Skip disabled nodes
+    if (node.data.enabled === false) {
+      const sanitizedId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
+      scopedOutputs[sanitizedId] = {
+        label: getNodeName(node),
+        data: null,
+      };
+      const nextNodes = bodyEdgesBySource.get(nodeId) ?? [];
+      await Promise.all(
+        nextNodes.map((next) =>
+          executeBodyNode(
+            next,
+            bodyVisited,
+            scopedOutputs,
+            bodyResults,
+            bodyEdgesBySource,
+            collectNodeId
+          )
+        )
+      );
+      return;
+    }
+
+    // Inject builtin variables
+    const builtinSanitized = BUILTIN_NODE_ID.replace(/[^a-zA-Z0-9]/g, "_");
+    scopedOutputs[builtinSanitized] = {
+      label: BUILTIN_NODE_LABEL,
+      data: getBuiltinVariables(),
+    };
+
+    try {
+      const config = node.data.config ?? {};
+      const actionType = config.actionType as string | undefined;
+
+      if (!actionType) {
+        bodyResults[nodeId] = {
+          success: false,
+          error: `Action node "${node.data.label || node.id}" has no action type configured`,
+        };
+        return;
+      }
+
+      // Process templates using scoped outputs
+      const configWithoutSpecial = { ...config };
+      const originalCondition = config.condition;
+      configWithoutSpecial.condition = undefined;
+      const originalDbQuery = config.dbQuery;
+      if (actionType === "Database Query") {
+        configWithoutSpecial.dbQuery = undefined;
+      }
+
+      const processedConfig = processTemplates(
+        configWithoutSpecial,
+        scopedOutputs
+      );
+
+      if (originalCondition !== undefined) {
+        processedConfig.condition = originalCondition;
+      }
+      if (
+        actionType === "Database Query" &&
+        typeof originalDbQuery === "string"
+      ) {
+        const { parameterizedQuery, paramValues } = extractTemplateParameters(
+          originalDbQuery,
+          scopedOutputs
+        );
+        processedConfig.dbQuery = parameterizedQuery;
+        processedConfig._dbParams = paramValues;
+      } else if (
+        actionType === "Database Query" &&
+        originalDbQuery !== undefined
+      ) {
+        processedConfig.dbQuery = originalDbQuery;
+      }
+
+      const stepContext: StepContext = {
+        executionId,
+        nodeId: node.id,
+        nodeName: getNodeName(node),
+        nodeType: actionType,
+      };
+
+      const stepResult = await executeActionStep({
+        actionType,
+        config: processedConfig,
+        outputs: scopedOutputs,
+        context: stepContext,
+      });
+
+      const isErrorResult =
+        stepResult &&
+        typeof stepResult === "object" &&
+        "success" in stepResult &&
+        (stepResult as { success: boolean }).success === false;
+
+      const result: ExecutionResult = isErrorResult
+        ? {
+            success: false,
+            error:
+              (stepResult as { error?: string }).error ||
+              `Step "${actionType}" failed.`,
+          }
+        : { success: true, data: stepResult };
+
+      bodyResults[nodeId] = result;
+      const sanitizedId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
+      scopedOutputs[sanitizedId] = {
+        label: getNodeName(node),
+        data: result.data,
+      };
+
+      if (!result.success) {
+        return;
+      }
+
+      // Nested For Each inside the body
+      if (actionType === "For Each") {
+        await handleForEachExecution({
+          forEachNodeId: nodeId,
+          forEachNode: node,
+          processedConfig,
+          currentOutputs: scopedOutputs,
+          currentResults: bodyResults,
+          currentVisited: bodyVisited,
+          currentEdgesBySource: bodyEdgesBySource,
+          continueAfterCollect: async (collectId) => {
+            const nextNodes = bodyEdgesBySource.get(collectId) ?? [];
+            await Promise.all(
+              nextNodes.map((next) =>
+                executeBodyNode(
+                  next,
+                  bodyVisited,
+                  scopedOutputs,
+                  bodyResults,
+                  bodyEdgesBySource,
+                  collectNodeId
+                )
+              )
+            );
+          },
+        });
+        return;
+      }
+
+      // Condition gating
+      if (actionType === "Condition") {
+        const conditionValue = (result.data as { condition?: boolean })
+          ?.condition;
+        if (conditionValue !== true) {
+          return;
+        }
+      }
+
+      // Continue to downstream body nodes
+      const nextNodes = bodyEdgesBySource.get(nodeId) ?? [];
+      await Promise.all(
+        nextNodes.map((next) =>
+          executeBodyNode(
+            next,
+            bodyVisited,
+            scopedOutputs,
+            bodyResults,
+            bodyEdgesBySource,
+            collectNodeId
+          )
+        )
+      );
+    } catch (error) {
+      const errorMessage = await getErrorMessageAsync(error);
+      bodyResults[nodeId] = { success: false, error: errorMessage };
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // For Each: iteration orchestrator
+  // -------------------------------------------------------------------
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Orchestrates loop iteration with error handling and result collection
+  async function handleForEachExecution(params: {
+    forEachNodeId: string;
+    forEachNode: WorkflowNode;
+    processedConfig: Record<string, unknown>;
+    currentOutputs: NodeOutputs;
+    currentResults: Record<string, ExecutionResult>;
+    currentVisited: Set<string>;
+    currentEdgesBySource: Map<string, string[]>;
+    continueAfterCollect?: (collectNodeId: string) => Promise<void>;
+  }): Promise<void> {
+    const {
+      forEachNodeId,
+      forEachNode,
+      processedConfig,
+      currentOutputs,
+      currentResults,
+      currentVisited,
+      currentEdgesBySource,
+      continueAfterCollect,
+    } = params;
+
+    // 1. Resolve array
+    const resolvedArray = resolveArraySource(
+      processedConfig.arraySource,
+      currentOutputs
+    );
+    const maxIterations =
+      Number(processedConfig.maxIterations) || resolvedArray.length;
+    const itemsToProcess = resolvedArray.slice(0, maxIterations);
+
+    // 2. Identify body subgraph
+    const { bodyNodeIds, collectNodeId, bodyEdgesBySource } = identifyLoopBody(
+      forEachNodeId,
+      currentEdgesBySource,
+      nodeMap
+    );
+
+    const sanitizedForEachId = forEachNodeId.replace(/[^a-zA-Z0-9]/g, "_");
+
+    // 3. Single iteration executor
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: iteration logic has inherent complexity from scoped output capture, body execution, and map expression
+    async function executeIteration(
+      item: unknown,
+      index: number
+    ): Promise<unknown> {
+      const scopedOutputs: NodeOutputs = { ...currentOutputs };
+      const bodyResults: Record<string, ExecutionResult> = {};
+
+      // Inject loop variables
+      scopedOutputs[sanitizedForEachId] = {
+        label: getNodeName(forEachNode),
+        data: {
+          currentItem: item,
+          index,
+          totalItems: itemsToProcess.length,
+        },
+      };
+
+      // Execute body starting from For Each's direct children
+      const bodyVisited = new Set<string>();
+      const firstBodyNodes = bodyEdgesBySource.get(forEachNodeId) ?? [];
+
+      await Promise.all(
+        firstBodyNodes.map((bodyNodeId) =>
+          executeBodyNode(
+            bodyNodeId,
+            bodyVisited,
+            scopedOutputs,
+            bodyResults,
+            bodyEdgesBySource,
+            collectNodeId
+          )
+        )
+      );
+
+      // Capture output from the last body node(s) before Collect
+      let iterationOutput: unknown;
+      if (collectNodeId) {
+        for (const bodyNodeId of bodyNodeIds) {
+          const targets = bodyEdgesBySource.get(bodyNodeId) ?? [];
+          if (targets.includes(collectNodeId)) {
+            const sanitizedBodyId = bodyNodeId.replace(/[^a-zA-Z0-9]/g, "_");
+            const output = scopedOutputs[sanitizedBodyId];
+            if (output?.data !== undefined) {
+              iterationOutput = output.data;
+            }
+          }
+        }
+      }
+
+      // If no body nodes produced output, use the current item itself
+      if (iterationOutput === undefined) {
+        iterationOutput = item;
+      }
+
+      // Apply optional map expression to extract/transform the output
+      const mapExpression = processedConfig.mapExpression as string | undefined;
+      if (
+        mapExpression &&
+        typeof iterationOutput === "object" &&
+        iterationOutput !== null
+      ) {
+        iterationOutput =
+          resolveFromOutputData(iterationOutput, mapExpression) ??
+          iterationOutput;
+      }
+
+      return iterationOutput;
+    }
+
+    // 4. Run iterations sequentially
+    const iterationResults: unknown[] = [];
+
+    for (const [i, item] of itemsToProcess.entries()) {
+      try {
+        iterationResults.push(await executeIteration(item, i));
+      } catch (error) {
+        const errorMessage = await getErrorMessageAsync(error);
+        iterationResults.push({ success: false, error: errorMessage });
+      }
+    }
+
+    // 5. Mark body nodes as visited in the parent scope
+    for (const bodyNodeId of bodyNodeIds) {
+      currentVisited.add(bodyNodeId);
+    }
+
+    // 6. Store Collect output and continue downstream (only when Collect exists)
+    if (collectNodeId) {
+      const collectData = {
+        results: iterationResults,
+        count: iterationResults.length,
+      };
+      const sanitizedCollectId = collectNodeId.replace(/[^a-zA-Z0-9]/g, "_");
+      const collectNode = nodeMap.get(collectNodeId);
+      const collectLabel = collectNode ? getNodeName(collectNode) : "Collect";
+
+      // Execute Collect step for logging / observability
+      const collectAction = SYSTEM_ACTIONS.Collect;
+      if (collectAction) {
+        const mod = await collectAction.importer();
+        await mod[collectAction.stepFunction]({
+          ...collectData,
+          _context: {
+            executionId,
+            nodeId: collectNodeId,
+            nodeName: collectLabel,
+            nodeType: "Collect",
+          } satisfies StepContext,
+        });
+      }
+
+      currentOutputs[sanitizedCollectId] = {
+        label: collectLabel,
+        data: collectData,
+      };
+      currentResults[collectNodeId] = { success: true, data: collectData };
+      currentVisited.add(collectNodeId);
+
+      if (continueAfterCollect) {
+        await continueAfterCollect(collectNodeId);
+      }
+    }
+  }
+
+  // end keeperhub code //
 
   // Helper to execute a single node
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Node execution requires type checking and error handling
@@ -1011,12 +1563,36 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
       // Execute next nodes
       if (result.success) {
-        // Check if this is a condition node
-        const isConditionNode =
-          node.data.type === "action" &&
-          node.data.config?.actionType === "Condition";
+        const currentActionType =
+          node.data.type === "action"
+            ? (node.data.config?.actionType as string | undefined)
+            : undefined;
 
-        if (isConditionNode) {
+        // start custom keeperhub code //
+        if (currentActionType === "For Each") {
+          // For Each: iterate over array, execute body subgraph per element,
+          // store results on Collect, then continue from Collect downstream.
+          const forEachConfig = processTemplates(
+            node.data.config ?? {},
+            outputs
+          );
+          await handleForEachExecution({
+            forEachNodeId: nodeId,
+            forEachNode: node,
+            processedConfig: forEachConfig,
+            currentOutputs: outputs,
+            currentResults: results,
+            currentVisited: visited,
+            currentEdgesBySource: edgesBySource,
+            continueAfterCollect: async (collectId) => {
+              const nextNodes = edgesBySource.get(collectId) ?? [];
+              await Promise.all(
+                nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
+              );
+            },
+          });
+        } else if (currentActionType === "Condition") {
+          // end keeperhub code //
           // For condition nodes, only execute next nodes if condition is true
           const conditionResult = (result.data as { condition?: boolean })
             ?.condition;
@@ -1032,7 +1608,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               nextNodes.length,
               "next nodes in parallel"
             );
-            // Execute all next nodes in parallel
             await Promise.all(
               nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
             );
@@ -1049,7 +1624,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             nextNodes.length,
             "next nodes in parallel"
           );
-          // Execute all next nodes in parallel
           await Promise.all(
             nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
           );

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1312,56 +1312,19 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
     // start custom keeperhub code //
     // 4. Run iterations with configurable concurrency
+    const { runIterations } = await import(
+      "@/keeperhub/lib/for-each-concurrency"
+    );
     const concurrencyMode =
       (processedConfig.concurrency as string) || "sequential";
     const concurrencyLimit = Number(processedConfig.concurrencyLimit) || 0;
-    const iterationResults: unknown[] = [];
-
-    if (concurrencyMode === "parallel") {
-      const settled = await Promise.allSettled(
-        itemsToProcess.map((item, i) => executeIteration(item, i))
-      );
-      for (const entry of settled) {
-        if (entry.status === "fulfilled") {
-          iterationResults.push(entry.value);
-        } else {
-          const errorMessage = await getErrorMessageAsync(entry.reason);
-          iterationResults.push({ success: false, error: errorMessage });
-        }
-      }
-    } else if (concurrencyMode === "custom" && concurrencyLimit > 1) {
-      // Worker pool: N workers pull from a shared index counter
-      iterationResults.length = itemsToProcess.length;
-      let nextIndex = 0;
-      const runWorker = async (): Promise<void> => {
-        while (nextIndex < itemsToProcess.length) {
-          const i = nextIndex++;
-          try {
-            iterationResults[i] = await executeIteration(
-              itemsToProcess[i],
-              i
-            );
-          } catch (error) {
-            const errorMessage = await getErrorMessageAsync(error);
-            iterationResults[i] = { success: false, error: errorMessage };
-          }
-        }
-      };
-      const workerCount = Math.min(concurrencyLimit, itemsToProcess.length);
-      await Promise.all(
-        Array.from({ length: workerCount }, () => runWorker())
-      );
-    } else {
-      // Sequential (default)
-      for (const [i, item] of itemsToProcess.entries()) {
-        try {
-          iterationResults.push(await executeIteration(item, i));
-        } catch (error) {
-          const errorMessage = await getErrorMessageAsync(error);
-          iterationResults.push({ success: false, error: errorMessage });
-        }
-      }
-    }
+    const iterationResults = await runIterations(
+      itemsToProcess,
+      executeIteration,
+      getErrorMessageAsync,
+      concurrencyMode as "sequential" | "parallel" | "custom",
+      concurrencyLimit
+    );
     // end keeperhub code //
 
     // 5. Mark body nodes as visited in the parent scope

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1348,6 +1348,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             nodeId: collectNodeId,
             nodeName: collectLabel,
             nodeType: "Collect",
+            forEachNodeId,
           } satisfies StepContext,
         });
       }

--- a/lib/workflow-logging.ts
+++ b/lib/workflow-logging.ts
@@ -14,6 +14,10 @@ export type LogStepStartParams = {
   nodeName: string;
   nodeType: string;
   input?: unknown;
+  // start custom keeperhub code //
+  iterationIndex?: number;
+  forEachNodeId?: string;
+  // end keeperhub code //
 };
 
 export type LogStepStartResult = {
@@ -37,6 +41,10 @@ export async function logStepStartDb(
       status: "running",
       input: params.input,
       startedAt: new Date(),
+      // start custom keeperhub code //
+      iterationIndex: params.iterationIndex ?? null,
+      forEachNodeId: params.forEachNodeId ?? null,
+      // end keeperhub code //
     })
     .returning();
 

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -243,8 +243,16 @@ export const addNodeAtom = atom(null, (get, set, node: WorkflowNode) => {
   set(historyAtom, [...history, { nodes: currentNodes, edges: currentEdges }]);
   set(futureAtom, []);
 
-  // Deselect all existing nodes and add new node as selected
-  const updatedNodes = currentNodes.map((n) => ({ ...n, selected: false }));
+  // start custom keeperhub code //
+  // Deselect all existing nodes and add new node as selected.
+  // Only spread nodes whose selected state actually changes to preserve
+  // object references -- React Flow re-measures handle bounds when node
+  // objects change, which temporarily unregisters named handles (e.g.
+  // For Each "loop"/"done") and breaks concurrent edge creation.
+  const updatedNodes = currentNodes.map((n) =>
+    n.selected ? { ...n, selected: false } : n
+  );
+  // end keeperhub code //
   const newNode = { ...node, selected: true };
   const newNodes = [...updatedNodes, newNode];
   set(nodesAtom, newNodes);

--- a/tests/unit/action-config-helpers.test.ts
+++ b/tests/unit/action-config-helpers.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Re-implementations of pure helper functions from
+ * components/workflow/config/action-config.tsx for isolated unit testing.
+ */
+
+const ARRAY_SOURCE_RE = /^\{\{@([^:]+):([^.}]+)\.?([^}]*)\}\}$/;
+
+function extractObjectPaths(
+  obj: Record<string, unknown>,
+  prefix: string,
+  depth: number,
+  paths: string[]
+): void {
+  if (depth > 3) {
+    return;
+  }
+  for (const key of Object.keys(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    paths.push(path);
+    const val = obj[key];
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      extractObjectPaths(
+        val as Record<string, unknown>,
+        path,
+        depth + 1,
+        paths
+      );
+    }
+  }
+}
+
+function traverseFieldPath(root: unknown, fieldPath: string): unknown {
+  let data: unknown = root;
+  for (const part of fieldPath.split(".")) {
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      data = (data as Record<string, unknown>)[part];
+    } else {
+      return null;
+    }
+  }
+  return data;
+}
+
+function resolveArraySourceElement(
+  arraySource: string,
+  executionLogs: Record<string, { output?: unknown }>,
+  lastLogs: Record<string, { output?: unknown }>
+): Record<string, unknown> | null {
+  const match = ARRAY_SOURCE_RE.exec(arraySource);
+  if (!match) {
+    return null;
+  }
+
+  const sourceNodeId = match[1];
+  const fieldPath = match[3] || "";
+
+  const sourceOutput =
+    executionLogs[sourceNodeId]?.output ?? lastLogs[sourceNodeId]?.output;
+  if (sourceOutput == null) {
+    return null;
+  }
+
+  const data = fieldPath
+    ? traverseFieldPath(sourceOutput, fieldPath)
+    : sourceOutput;
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+
+  const first = data[0];
+  if (!first || typeof first !== "object" || Array.isArray(first)) {
+    return null;
+  }
+
+  return first as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("action-config helpers", () => {
+  // -----------------------------------------------------------------------
+  // ARRAY_SOURCE_RE
+  // -----------------------------------------------------------------------
+  describe("ARRAY_SOURCE_RE", () => {
+    it("matches standard template and extracts nodeId, label, fieldPath", () => {
+      const match = ARRAY_SOURCE_RE.exec("{{@node_1:Label.field}}");
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("node_1");
+      expect(match?.[2]).toBe("Label");
+      expect(match?.[3]).toBe("field");
+    });
+
+    it("matches template without field path", () => {
+      const match = ARRAY_SOURCE_RE.exec("{{@node_1:Label}}");
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("node_1");
+      expect(match?.[2]).toBe("Label");
+      expect(match?.[3]).toBe("");
+    });
+
+    it("matches template with nested field path", () => {
+      const match = ARRAY_SOURCE_RE.exec("{{@node_1:Label.data.items}}");
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("node_1");
+      expect(match?.[2]).toBe("Label");
+      expect(match?.[3]).toBe("data.items");
+    });
+
+    it("does not match plain text", () => {
+      expect(ARRAY_SOURCE_RE.exec("hello world")).toBeNull();
+    });
+
+    it("does not match incomplete templates", () => {
+      expect(ARRAY_SOURCE_RE.exec("{{@node_1")).toBeNull();
+      expect(ARRAY_SOURCE_RE.exec("{{node_1:Label.field}}")).toBeNull();
+      expect(ARRAY_SOURCE_RE.exec("@node_1:Label.field}}")).toBeNull();
+      expect(ARRAY_SOURCE_RE.exec("{{@:Label.field}}")).toBeNull();
+    });
+
+    it("handles node IDs with hyphens", () => {
+      const match = ARRAY_SOURCE_RE.exec("{{@node-1:Label.field}}");
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("node-1");
+      expect(match?.[2]).toBe("Label");
+      expect(match?.[3]).toBe("field");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // extractObjectPaths
+  // -----------------------------------------------------------------------
+  describe("extractObjectPaths", () => {
+    it("returns no paths for an empty object", () => {
+      const paths: string[] = [];
+      extractObjectPaths({}, "", 0, paths);
+      expect(paths).toEqual([]);
+    });
+
+    it("returns top-level keys for a flat object with primitive values", () => {
+      const paths: string[] = [];
+      extractObjectPaths({ a: 1, b: "two", c: true }, "", 0, paths);
+      expect(paths).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns both parent and child paths with dot notation for nested objects", () => {
+      const paths: string[] = [];
+      extractObjectPaths({ a: { b: 1 } }, "", 0, paths);
+      expect(paths).toEqual(["a", "a.b"]);
+    });
+
+    it("stops recursing beyond depth 3", () => {
+      const paths: string[] = [];
+      const obj = { l1: { l2: { l3: { l4: { l5: "deep" } } } } };
+      extractObjectPaths(obj, "", 0, paths);
+
+      // depth 0 -> l1 (recurse into l1 at depth 1)
+      // depth 1 -> l1.l2 (recurse into l2 at depth 2)
+      // depth 2 -> l1.l2.l3 (recurse into l3 at depth 3)
+      // depth 3 -> l1.l2.l3.l4 (depth > 3 check fails at depth 4, so no recurse)
+      // l4 key is still added, but l5 inside l4 is not reached
+      expect(paths).toContain("l1");
+      expect(paths).toContain("l1.l2");
+      expect(paths).toContain("l1.l2.l3");
+      expect(paths).toContain("l1.l2.l3.l4");
+      expect(paths).not.toContain("l1.l2.l3.l4.l5");
+    });
+
+    it("includes array keys but does not recurse into arrays", () => {
+      const paths: string[] = [];
+      extractObjectPaths({ items: [1, 2, 3] }, "", 0, paths);
+      // The key "items" is added, but since the value is an array it is not recursed
+      expect(paths).toEqual(["items"]);
+    });
+
+    it("handles deeply nested objects (4+ levels) and only shows up to depth 3", () => {
+      const paths: string[] = [];
+      const obj = {
+        a: {
+          b: {
+            c: {
+              d: {
+                e: "value",
+              },
+            },
+          },
+        },
+      };
+      extractObjectPaths(obj, "", 0, paths);
+      expect(paths).toEqual(["a", "a.b", "a.b.c", "a.b.c.d"]);
+    });
+
+    it("handles mixed types: strings, numbers, booleans, null, arrays, objects", () => {
+      const paths: string[] = [];
+      const obj = {
+        str: "hello",
+        num: 42,
+        bool: false,
+        nil: null,
+        arr: [1, 2],
+        nested: { inner: "val" },
+      };
+      extractObjectPaths(obj, "", 0, paths);
+      expect(paths).toEqual([
+        "str",
+        "num",
+        "bool",
+        "nil",
+        "arr",
+        "nested",
+        "nested.inner",
+      ]);
+    });
+
+    it("respects a non-empty prefix", () => {
+      const paths: string[] = [];
+      extractObjectPaths({ x: 1 }, "root", 0, paths);
+      expect(paths).toEqual(["root.x"]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // traverseFieldPath
+  // -----------------------------------------------------------------------
+  describe("traverseFieldPath", () => {
+    it("returns the value for a single key", () => {
+      expect(traverseFieldPath({ a: 1 }, "a")).toBe(1);
+    });
+
+    it("returns the value for a nested path", () => {
+      expect(traverseFieldPath({ a: { b: 2 } }, "a.b")).toBe(2);
+    });
+
+    it("returns undefined for a missing key at the last level", () => {
+      expect(traverseFieldPath({ a: 1 }, "b")).toBeUndefined();
+    });
+
+    it("returns null when an array is encountered along the path", () => {
+      expect(traverseFieldPath({ a: [1, 2] }, "a.0")).toBeNull();
+    });
+
+    it("returns null for a null root", () => {
+      expect(traverseFieldPath(null, "a")).toBeNull();
+    });
+
+    it("returns null for an undefined root", () => {
+      expect(traverseFieldPath(undefined, "a")).toBeNull();
+    });
+
+    it("traverses deep nested paths (a.b.c.d)", () => {
+      const obj = { a: { b: { c: { d: "found" } } } };
+      expect(traverseFieldPath(obj, "a.b.c.d")).toBe("found");
+    });
+
+    it("returns null when a mid-level key is missing", () => {
+      expect(traverseFieldPath({ a: { b: 1 } }, "a.x.y")).toBeNull();
+    });
+
+    it("returns the nested object when path stops at an intermediate level", () => {
+      const obj = { a: { b: { c: 3 } } };
+      expect(traverseFieldPath(obj, "a.b")).toEqual({ c: 3 });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveArraySourceElement
+  // -----------------------------------------------------------------------
+  describe("resolveArraySourceElement", () => {
+    const emptyLogs: Record<string, { output?: unknown }> = {};
+
+    it("returns null for a non-template string", () => {
+      expect(
+        resolveArraySourceElement("plain text", emptyLogs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns null when source node is not in any logs", () => {
+      const result = resolveArraySourceElement(
+        "{{@node_1:Label.items}}",
+        {},
+        {}
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when output is null", () => {
+      const logs = { node_1: { output: null } };
+      expect(
+        resolveArraySourceElement("{{@node_1:Label.items}}", logs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns null when output is undefined", () => {
+      const logs = { node_1: { output: undefined } };
+      expect(
+        resolveArraySourceElement("{{@node_1:Label.items}}", logs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns null when resolved data is not an array", () => {
+      const logs = { node_1: { output: { items: "not-an-array" } } };
+      expect(
+        resolveArraySourceElement("{{@node_1:Label.items}}", logs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns null when the array is empty", () => {
+      const logs = { node_1: { output: { items: [] } } };
+      expect(
+        resolveArraySourceElement("{{@node_1:Label.items}}", logs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns null when the first element is a primitive (not object)", () => {
+      const logs = { node_1: { output: { items: [42, 43] } } };
+      expect(
+        resolveArraySourceElement("{{@node_1:Label.items}}", logs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns null when the first element is an array (not plain object)", () => {
+      const logs = {
+        node_1: {
+          output: {
+            items: [
+              [1, 2],
+              [3, 4],
+            ],
+          },
+        },
+      };
+      expect(
+        resolveArraySourceElement("{{@node_1:Label.items}}", logs, emptyLogs)
+      ).toBeNull();
+    });
+
+    it("returns the first element of the array (happy path with field path)", () => {
+      const logs = {
+        node_1: {
+          output: {
+            items: [
+              { id: 1, name: "first" },
+              { id: 2, name: "second" },
+            ],
+          },
+        },
+      };
+      const result = resolveArraySourceElement(
+        "{{@node_1:Label.items}}",
+        logs,
+        emptyLogs
+      );
+      expect(result).toEqual({ id: 1, name: "first" });
+    });
+
+    it("works without field path when output is directly an array", () => {
+      const logs = {
+        node_1: {
+          output: [
+            { id: 1, name: "first" },
+            { id: 2, name: "second" },
+          ],
+        },
+      };
+      const result = resolveArraySourceElement(
+        "{{@node_1:Label}}",
+        logs,
+        emptyLogs
+      );
+      expect(result).toEqual({ id: 1, name: "first" });
+    });
+
+    it("falls back to lastLogs when not in executionLogs", () => {
+      const lastLogs = {
+        node_1: {
+          output: {
+            items: [{ id: 99, name: "from-last" }],
+          },
+        },
+      };
+      const result = resolveArraySourceElement(
+        "{{@node_1:Label.items}}",
+        {},
+        lastLogs
+      );
+      expect(result).toEqual({ id: 99, name: "from-last" });
+    });
+
+    it("prefers executionLogs over lastLogs", () => {
+      const executionLogs = {
+        node_1: {
+          output: {
+            items: [{ id: 1, source: "execution" }],
+          },
+        },
+      };
+      const lastLogs = {
+        node_1: {
+          output: {
+            items: [{ id: 2, source: "last" }],
+          },
+        },
+      };
+      const result = resolveArraySourceElement(
+        "{{@node_1:Label.items}}",
+        executionLogs,
+        lastLogs
+      );
+      expect(result).toEqual({ id: 1, source: "execution" });
+    });
+  });
+});

--- a/tests/unit/action-config-helpers.test.ts
+++ b/tests/unit/action-config-helpers.test.ts
@@ -36,6 +36,9 @@ function traverseFieldPath(root: unknown, fieldPath: string): unknown {
   for (const part of fieldPath.split(".")) {
     if (data && typeof data === "object" && !Array.isArray(data)) {
       data = (data as Record<string, unknown>)[part];
+      if (data === undefined) {
+        return null;
+      }
     } else {
       return null;
     }
@@ -235,7 +238,7 @@ describe("action-config helpers", () => {
     });
 
     it("returns undefined for a missing key at the last level", () => {
-      expect(traverseFieldPath({ a: 1 }, "b")).toBeUndefined();
+      expect(traverseFieldPath({ a: 1 }, "b")).toBeNull();
     });
 
     it("returns null when an array is encountered along the path", () => {

--- a/tests/unit/for-each-concurrency.test.ts
+++ b/tests/unit/for-each-concurrency.test.ts
@@ -1,0 +1,609 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConcurrencyMode,
+  type ErrorHandler,
+  type IterationExecutor,
+  runIterations,
+} from "@/keeperhub/lib/for-each-concurrency";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simple executor that returns the item doubled (for numbers). */
+const doubleExecutor: IterationExecutor<number> = (
+  item: number
+): Promise<number> => Promise.resolve(item * 2);
+
+/** Executor that records call order via a shared array. */
+function orderTrackingExecutor(
+  callOrder: number[],
+  delayMs = 0
+): IterationExecutor<number> {
+  return async (item: number, index: number): Promise<number> => {
+    callOrder.push(index);
+    if (delayMs > 0) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
+    }
+    return item;
+  };
+}
+
+/** Executor that fails for specific indices. */
+function failingExecutor(failIndices: Set<number>): IterationExecutor<number> {
+  return (item: number, index: number): Promise<number> => {
+    if (failIndices.has(index)) {
+      return Promise.reject(new Error(`Iteration ${index} failed`));
+    }
+    return Promise.resolve(item * 10);
+  };
+}
+
+/** Executor that tracks concurrency via an active counter. */
+function concurrencyTrackingExecutor(
+  peakTracker: { peak: number; active: number },
+  delayMs: number
+): IterationExecutor<number> {
+  return async (item: number): Promise<number> => {
+    peakTracker.active++;
+    if (peakTracker.active > peakTracker.peak) {
+      peakTracker.peak = peakTracker.active;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
+    peakTracker.active--;
+    return item;
+  };
+}
+
+const simpleErrorHandler: ErrorHandler = (error: unknown): Promise<string> => {
+  if (error instanceof Error) {
+    return Promise.resolve(error.message);
+  }
+  return Promise.resolve(String(error));
+};
+
+// ---------------------------------------------------------------------------
+// Sequential mode
+// ---------------------------------------------------------------------------
+
+describe("runIterations - sequential", () => {
+  it("returns empty array for empty input", async () => {
+    const results = await runIterations(
+      [],
+      doubleExecutor,
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("processes a single item", async () => {
+    const results = await runIterations(
+      [5],
+      doubleExecutor,
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results).toEqual([10]);
+  });
+
+  it("processes multiple items in order", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4, 5],
+      doubleExecutor,
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it("executes iterations one at a time in order", async () => {
+    const callOrder: number[] = [];
+    await runIterations(
+      [10, 20, 30],
+      orderTrackingExecutor(callOrder, 10),
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(callOrder).toEqual([0, 1, 2]);
+  });
+
+  it("captures errors without aborting subsequent iterations", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4],
+      failingExecutor(new Set([1, 3])),
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results).toEqual([
+      10,
+      { success: false, error: "Iteration 1 failed" },
+      30,
+      { success: false, error: "Iteration 3 failed" },
+    ]);
+  });
+
+  it("captures error for single failing item", async () => {
+    const results = await runIterations(
+      [1],
+      failingExecutor(new Set([0])),
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results).toEqual([{ success: false, error: "Iteration 0 failed" }]);
+  });
+
+  it("handles all iterations failing", async () => {
+    const results = await runIterations(
+      [1, 2, 3],
+      failingExecutor(new Set([0, 1, 2])),
+      simpleErrorHandler,
+      "sequential"
+    );
+    for (const result of results) {
+      expect(result).toHaveProperty("success", false);
+      expect(result).toHaveProperty("error");
+    }
+    expect(results).toHaveLength(3);
+  });
+
+  it("is the default when mode is omitted", async () => {
+    const callOrder: number[] = [];
+    await runIterations(
+      [1, 2, 3],
+      orderTrackingExecutor(callOrder, 10),
+      simpleErrorHandler
+    );
+    expect(callOrder).toEqual([0, 1, 2]);
+  });
+
+  it("passes correct item and index to executor", async () => {
+    const calls: Array<{ item: string; index: number }> = [];
+    const executor: IterationExecutor<string> = (
+      item: string,
+      index: number
+    ): Promise<string> => {
+      calls.push({ item, index });
+      return Promise.resolve(item);
+    };
+    await runIterations(
+      ["a", "b", "c"],
+      executor,
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(calls).toEqual([
+      { item: "a", index: 0 },
+      { item: "b", index: 1 },
+      { item: "c", index: 2 },
+    ]);
+  });
+
+  it("works with object items", async () => {
+    const executor: IterationExecutor<{ id: number }> = (item: {
+      id: number;
+    }): Promise<number> => Promise.resolve(item.id * 2);
+    const results = await runIterations(
+      [{ id: 1 }, { id: 2 }, { id: 3 }],
+      executor,
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results).toEqual([2, 4, 6]);
+  });
+
+  it("has peak concurrency of 1", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2, 3, 4, 5],
+      concurrencyTrackingExecutor(tracker, 5),
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(tracker.peak).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parallel mode
+// ---------------------------------------------------------------------------
+
+describe("runIterations - parallel", () => {
+  it("returns empty array for empty input", async () => {
+    const results = await runIterations(
+      [],
+      doubleExecutor,
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("processes a single item", async () => {
+    const results = await runIterations(
+      [7],
+      doubleExecutor,
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(results).toEqual([14]);
+  });
+
+  it("processes all items and preserves order", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4, 5],
+      doubleExecutor,
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it("runs all iterations concurrently", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2, 3, 4, 5],
+      concurrencyTrackingExecutor(tracker, 20),
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(tracker.peak).toBe(5);
+  });
+
+  it("captures errors without aborting other iterations", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4],
+      failingExecutor(new Set([0, 2])),
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(results).toEqual([
+      { success: false, error: "Iteration 0 failed" },
+      20,
+      { success: false, error: "Iteration 2 failed" },
+      40,
+    ]);
+  });
+
+  it("handles all iterations failing", async () => {
+    const results = await runIterations(
+      [1, 2, 3],
+      failingExecutor(new Set([0, 1, 2])),
+      simpleErrorHandler,
+      "parallel"
+    );
+    for (const result of results) {
+      expect(result).toHaveProperty("success", false);
+    }
+    expect(results).toHaveLength(3);
+  });
+
+  it("preserves result order even with varying execution times", async () => {
+    const delays = [50, 10, 30, 5, 40];
+    const executor: IterationExecutor<number> = async (
+      item: number,
+      index: number
+    ): Promise<string> => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, delays[index]);
+      });
+      return `item-${item}`;
+    };
+    const results = await runIterations(
+      [1, 2, 3, 4, 5],
+      executor,
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(results).toEqual(["item-1", "item-2", "item-3", "item-4", "item-5"]);
+  });
+
+  it("calls error handler for rejected promises", async () => {
+    const errorHandler = vi.fn(simpleErrorHandler);
+    await runIterations(
+      [1, 2],
+      failingExecutor(new Set([1])),
+      errorHandler,
+      "parallel"
+    );
+    expect(errorHandler).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom concurrency (worker pool)
+// ---------------------------------------------------------------------------
+
+describe("runIterations - custom", () => {
+  it("returns empty array for empty input", async () => {
+    const results = await runIterations(
+      [],
+      doubleExecutor,
+      simpleErrorHandler,
+      "custom",
+      3
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("processes a single item with limit > 1", async () => {
+    const results = await runIterations(
+      [5],
+      doubleExecutor,
+      simpleErrorHandler,
+      "custom",
+      3
+    );
+    expect(results).toEqual([10]);
+  });
+
+  it("processes all items and preserves order", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4, 5, 6],
+      doubleExecutor,
+      simpleErrorHandler,
+      "custom",
+      3
+    );
+    expect(results).toEqual([2, 4, 6, 8, 10, 12]);
+  });
+
+  it("respects concurrency limit of 2", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2, 3, 4, 5, 6, 7, 8],
+      concurrencyTrackingExecutor(tracker, 20),
+      simpleErrorHandler,
+      "custom",
+      2
+    );
+    expect(tracker.peak).toBe(2);
+  });
+
+  it("respects concurrency limit of 3", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      concurrencyTrackingExecutor(tracker, 20),
+      simpleErrorHandler,
+      "custom",
+      3
+    );
+    expect(tracker.peak).toBe(3);
+  });
+
+  it("does not exceed item count when limit > items", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2],
+      concurrencyTrackingExecutor(tracker, 20),
+      simpleErrorHandler,
+      "custom",
+      10
+    );
+    expect(tracker.peak).toBe(2);
+  });
+
+  it("captures errors without aborting other workers", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4, 5, 6],
+      failingExecutor(new Set([1, 4])),
+      simpleErrorHandler,
+      "custom",
+      2
+    );
+    expect(results).toEqual([
+      10,
+      { success: false, error: "Iteration 1 failed" },
+      30,
+      40,
+      { success: false, error: "Iteration 4 failed" },
+      60,
+    ]);
+  });
+
+  it("handles all iterations failing", async () => {
+    const results = await runIterations(
+      [1, 2, 3, 4],
+      failingExecutor(new Set([0, 1, 2, 3])),
+      simpleErrorHandler,
+      "custom",
+      2
+    );
+    for (const result of results) {
+      expect(result).toHaveProperty("success", false);
+    }
+    expect(results).toHaveLength(4);
+  });
+
+  it("preserves result order with varying execution times", async () => {
+    const delays = [40, 5, 30, 10, 20, 15];
+    const executor: IterationExecutor<number> = async (
+      item: number,
+      index: number
+    ): Promise<string> => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, delays[index]);
+      });
+      return `r-${item}`;
+    };
+    const results = await runIterations(
+      [1, 2, 3, 4, 5, 6],
+      executor,
+      simpleErrorHandler,
+      "custom",
+      3
+    );
+    expect(results).toEqual(["r-1", "r-2", "r-3", "r-4", "r-5", "r-6"]);
+  });
+
+  it("falls back to sequential when limit is 1", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2, 3, 4],
+      concurrencyTrackingExecutor(tracker, 10),
+      simpleErrorHandler,
+      "custom",
+      1
+    );
+    expect(tracker.peak).toBe(1);
+  });
+
+  it("falls back to sequential when limit is 0", async () => {
+    const tracker = { peak: 0, active: 0 };
+    await runIterations(
+      [1, 2, 3],
+      concurrencyTrackingExecutor(tracker, 10),
+      simpleErrorHandler,
+      "custom",
+      0
+    );
+    expect(tracker.peak).toBe(1);
+  });
+
+  it("processes exactly N items at a time with limit N", async () => {
+    const tracker = { peak: 0, active: 0 };
+    const limit = 4;
+    await runIterations(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      concurrencyTrackingExecutor(tracker, 15),
+      simpleErrorHandler,
+      "custom",
+      limit
+    );
+    expect(tracker.peak).toBe(limit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases across all modes
+// ---------------------------------------------------------------------------
+
+describe("runIterations - edge cases", () => {
+  const modes: ConcurrencyMode[] = ["sequential", "parallel", "custom"];
+
+  for (const mode of modes) {
+    it(`handles undefined/null items in array (${mode})`, async () => {
+      const executor: IterationExecutor<unknown> = (
+        item: unknown
+      ): Promise<unknown> => Promise.resolve(item);
+      const results = await runIterations(
+        [null, undefined, 0, "", false],
+        executor,
+        simpleErrorHandler,
+        mode,
+        3
+      );
+      expect(results).toEqual([null, undefined, 0, "", false]);
+    });
+
+    it(`handles large arrays (${mode})`, async () => {
+      const items = Array.from({ length: 100 }, (_, i) => i);
+      const results = await runIterations(
+        items,
+        doubleExecutor,
+        simpleErrorHandler,
+        mode,
+        5
+      );
+      expect(results).toHaveLength(100);
+      expect(results[0]).toBe(0);
+      expect(results[99]).toBe(198);
+    });
+
+    it(`calls error handler with thrown Error objects (${mode})`, async () => {
+      const handler = vi.fn(simpleErrorHandler);
+      const executor: IterationExecutor<number> = (): Promise<never> =>
+        Promise.reject(new Error("boom"));
+      await runIterations([1], executor, handler, mode, 3);
+      expect(handler).toHaveBeenCalledOnce();
+      const arg = handler.mock.calls[0][0];
+      expect(arg).toBeInstanceOf(Error);
+      expect((arg as Error).message).toBe("boom");
+    });
+
+    it(`calls error handler with non-Error thrown values (${mode})`, async () => {
+      const handler = vi.fn(
+        (err: unknown): Promise<string> =>
+          Promise.resolve(`caught: ${String(err)}`)
+      );
+      const executor: IterationExecutor<number> = (): Promise<never> =>
+        Promise.reject("string-error");
+      const results = await runIterations([1], executor, handler, mode, 3);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(results[0]).toEqual({
+        success: false,
+        error: "caught: string-error",
+      });
+    });
+  }
+
+  it("returns results with correct length for mixed success/failure", async () => {
+    const items = [1, 2, 3, 4, 5];
+    for (const mode of modes) {
+      const results = await runIterations(
+        items,
+        failingExecutor(new Set([2])),
+        simpleErrorHandler,
+        mode,
+        3
+      );
+      expect(results).toHaveLength(5);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handler integration
+// ---------------------------------------------------------------------------
+
+describe("runIterations - error handler", () => {
+  it("uses error handler return value as the error field", async () => {
+    const customHandler: ErrorHandler = (): Promise<string> =>
+      Promise.resolve("custom-error-message");
+    const results = await runIterations(
+      [1],
+      failingExecutor(new Set([0])),
+      customHandler,
+      "sequential"
+    );
+    expect(results[0]).toEqual({
+      success: false,
+      error: "custom-error-message",
+    });
+  });
+
+  it("error handler is called once per failure across modes", async () => {
+    for (const mode of ["sequential", "parallel", "custom"] as const) {
+      const handler = vi.fn(simpleErrorHandler);
+      await runIterations(
+        [1, 2, 3],
+        failingExecutor(new Set([0, 2])),
+        handler,
+        mode,
+        2
+      );
+      expect(handler).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it("async error handler is awaited properly", async () => {
+    const slowHandler: ErrorHandler = async (): Promise<string> => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      return "slow-error";
+    };
+    const results = await runIterations(
+      [1],
+      failingExecutor(new Set([0])),
+      slowHandler,
+      "parallel"
+    );
+    expect(results[0]).toEqual({ success: false, error: "slow-error" });
+  });
+});

--- a/tests/unit/for-each-executor.test.ts
+++ b/tests/unit/for-each-executor.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  identifyLoopBody,
+  resolveArraySource,
+} from "@/lib/workflow-executor.workflow";
+import type { WorkflowNode } from "@/lib/workflow-store";
+
+// ---------------------------------------------------------------------------
+// Top-level regex patterns (biome: useTopLevelRegex)
+// ---------------------------------------------------------------------------
+
+const MULTIPLE_COLLECT_REGEX = /multiple Collect nodes/;
+const ARRAY_SOURCE_REQUIRED_REGEX = /arraySource is required/;
+const NOT_VALID_TEMPLATE_REGEX = /not a valid template reference/;
+const RESOLVED_TO_NULL_REGEX = /resolved to null/;
+const MUST_RESOLVE_TO_ARRAY_REGEX = /must resolve to an array/;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeActionNode(
+  id: string,
+  actionType: string,
+  label?: string
+): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 0 },
+    data: {
+      label: label ?? actionType,
+      type: "action",
+      config: { actionType },
+    },
+  };
+}
+
+function buildEdgeMap(edges: [string, string][]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const [source, target] of edges) {
+    const targets = map.get(source) ?? [];
+    targets.push(target);
+    map.set(source, targets);
+  }
+  return map;
+}
+
+function buildNodeMap(nodes: WorkflowNode[]): Map<string, WorkflowNode> {
+  return new Map(nodes.map((n) => [n.id, n]));
+}
+
+// ---------------------------------------------------------------------------
+// identifyLoopBody
+// ---------------------------------------------------------------------------
+
+describe("identifyLoopBody", () => {
+  it("finds a simple linear body: ForEach -> A -> Collect", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("c-1", "Collect"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-1", "a-1"],
+      ["a-1", "c-1"],
+    ]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBe("c-1");
+    expect(result.bodyNodeIds).toEqual(["a-1"]);
+    expect(result.bodyEdgesBySource.get("fe-1")).toEqual(["a-1"]);
+    expect(result.bodyEdgesBySource.get("a-1")).toEqual(["c-1"]);
+  });
+
+  it("finds a branching body: ForEach -> A,B -> Collect", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("b-1", "Execute Code"),
+      makeActionNode("c-1", "Collect"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-1", "a-1"],
+      ["fe-1", "b-1"],
+      ["a-1", "c-1"],
+      ["b-1", "c-1"],
+    ]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBe("c-1");
+    expect(result.bodyNodeIds).toContain("a-1");
+    expect(result.bodyNodeIds).toContain("b-1");
+    expect(result.bodyNodeIds).toHaveLength(2);
+  });
+
+  it("handles multi-step chain: ForEach -> A -> B -> C -> Collect", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("b-1", "Execute Code"),
+      makeActionNode("c-1", "Database Query"),
+      makeActionNode("col-1", "Collect"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-1", "a-1"],
+      ["a-1", "b-1"],
+      ["b-1", "c-1"],
+      ["c-1", "col-1"],
+    ]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBe("col-1");
+    expect(result.bodyNodeIds).toEqual(["a-1", "b-1", "c-1"]);
+  });
+
+  it("returns undefined collectNodeId when no Collect exists", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+    ];
+    const edges = buildEdgeMap([["fe-1", "a-1"]]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBeUndefined();
+    expect(result.bodyNodeIds).toEqual(["a-1"]);
+    expect(result.bodyEdgesBySource.get("fe-1")).toEqual(["a-1"]);
+  });
+
+  it("throws when multiple Collect nodes at same depth", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("b-1", "Execute Code"),
+      makeActionNode("c-1", "Collect"),
+      makeActionNode("c-2", "Collect"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-1", "a-1"],
+      ["fe-1", "b-1"],
+      ["a-1", "c-1"],
+      ["b-1", "c-2"],
+    ]);
+
+    expect(() => identifyLoopBody("fe-1", edges, buildNodeMap(nodes))).toThrow(
+      MULTIPLE_COLLECT_REGEX
+    );
+  });
+
+  it("skips nested ForEach/Collect pairs (depth tracking)", () => {
+    // ForEach(outer) -> A -> ForEach(inner) -> B -> Collect(inner) -> C -> Collect(outer)
+    const nodes = [
+      makeActionNode("fe-outer", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("fe-inner", "For Each"),
+      makeActionNode("b-1", "Execute Code"),
+      makeActionNode("c-inner", "Collect"),
+      makeActionNode("c-1", "Database Query"),
+      makeActionNode("c-outer", "Collect"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-outer", "a-1"],
+      ["a-1", "fe-inner"],
+      ["fe-inner", "b-1"],
+      ["b-1", "c-inner"],
+      ["c-inner", "c-1"],
+      ["c-1", "c-outer"],
+    ]);
+
+    const result = identifyLoopBody("fe-outer", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBe("c-outer");
+    // Body should include everything between fe-outer and c-outer
+    expect(result.bodyNodeIds).toContain("a-1");
+    expect(result.bodyNodeIds).toContain("fe-inner");
+    expect(result.bodyNodeIds).toContain("b-1");
+    expect(result.bodyNodeIds).toContain("c-inner");
+    expect(result.bodyNodeIds).toContain("c-1");
+    // But NOT the outer collect itself
+    expect(result.bodyNodeIds).not.toContain("c-outer");
+  });
+
+  it("handles empty body: ForEach -> Collect directly", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("c-1", "Collect"),
+    ];
+    const edges = buildEdgeMap([["fe-1", "c-1"]]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBe("c-1");
+    expect(result.bodyNodeIds).toEqual([]);
+  });
+
+  it("handles ForEach with no outgoing edges (empty body, no Collect)", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("c-1", "Collect"),
+    ];
+    const edges = buildEdgeMap([]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBeUndefined();
+    expect(result.bodyNodeIds).toEqual([]);
+  });
+
+  it("identifies full chain as body when no Collect: ForEach -> A -> B", () => {
+    const nodes = [
+      makeActionNode("fe-1", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("b-1", "Discord"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-1", "a-1"],
+      ["a-1", "b-1"],
+    ]);
+
+    const result = identifyLoopBody("fe-1", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBeUndefined();
+    expect(result.bodyNodeIds).toEqual(["a-1", "b-1"]);
+    expect(result.bodyEdgesBySource.get("fe-1")).toEqual(["a-1"]);
+    expect(result.bodyEdgesBySource.get("a-1")).toEqual(["b-1"]);
+  });
+
+  it("handles nested ForEach where only inner has Collect", () => {
+    const nodes = [
+      makeActionNode("fe-outer", "For Each"),
+      makeActionNode("fe-inner", "For Each"),
+      makeActionNode("a-1", "HTTP Request"),
+      makeActionNode("c-inner", "Collect"),
+      makeActionNode("b-1", "Discord"),
+    ];
+    const edges = buildEdgeMap([
+      ["fe-outer", "fe-inner"],
+      ["fe-inner", "a-1"],
+      ["a-1", "c-inner"],
+      ["c-inner", "b-1"],
+    ]);
+
+    const result = identifyLoopBody("fe-outer", edges, buildNodeMap(nodes));
+
+    expect(result.collectNodeId).toBeUndefined();
+    expect(result.bodyNodeIds).toContain("fe-inner");
+    expect(result.bodyNodeIds).toContain("a-1");
+    expect(result.bodyNodeIds).toContain("c-inner");
+    expect(result.bodyNodeIds).toContain("b-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveArraySource
+// ---------------------------------------------------------------------------
+
+describe("resolveArraySource", () => {
+  it("resolves a template reference to an array", () => {
+    const outputs = {
+      node_1: {
+        label: "HTTP Request",
+        data: { rows: [1, 2, 3] },
+      },
+    };
+
+    const result = resolveArraySource("{{@node_1:HTTP Request.rows}}", outputs);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("resolves a JSON array literal", () => {
+    const result = resolveArraySource('[1, 2, "three"]', {});
+    expect(result).toEqual([1, 2, "three"]);
+  });
+
+  it("throws when source is empty string", () => {
+    expect(() => resolveArraySource("", {})).toThrow(
+      ARRAY_SOURCE_REQUIRED_REGEX
+    );
+  });
+
+  it("throws when source is undefined", () => {
+    expect(() => resolveArraySource(undefined, {})).toThrow(
+      ARRAY_SOURCE_REQUIRED_REGEX
+    );
+  });
+
+  it("throws when source is not a valid template or JSON", () => {
+    expect(() => resolveArraySource("not-a-template", {})).toThrow(
+      NOT_VALID_TEMPLATE_REGEX
+    );
+  });
+
+  it("throws when template resolves to null", () => {
+    const outputs = {
+      node_1: {
+        label: "HTTP Request",
+        data: null,
+      },
+    };
+
+    expect(() =>
+      resolveArraySource("{{@node_1:HTTP Request.rows}}", outputs)
+    ).toThrow(RESOLVED_TO_NULL_REGEX);
+  });
+
+  it("throws when template resolves to a non-array value", () => {
+    const outputs = {
+      node_1: {
+        label: "HTTP Request",
+        data: { rows: "not-an-array" },
+      },
+    };
+
+    expect(() =>
+      resolveArraySource("{{@node_1:HTTP Request.rows}}", outputs)
+    ).toThrow(MUST_RESOLVE_TO_ARRAY_REGEX);
+  });
+
+  it("resolves top-level data that is itself an array", () => {
+    const outputs = {
+      node_1: {
+        label: "DB Query",
+        data: [{ id: 1 }, { id: 2 }],
+      },
+    };
+
+    const result = resolveArraySource("{{@node_1:DB Query}}", outputs);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("handles node IDs with special characters (sanitized)", () => {
+    const outputs = {
+      node_1: {
+        label: "Step",
+        data: { items: ["a", "b"] },
+      },
+    };
+
+    const result = resolveArraySource("{{@node-1:Step.items}}", outputs);
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array from valid empty JSON array", () => {
+    const result = resolveArraySource("[]", {});
+    expect(result).toEqual([]);
+  });
+
+  it("throws for JSON object (not array)", () => {
+    expect(() => resolveArraySource('{"key": "value"}', {})).toThrow(
+      NOT_VALID_TEMPLATE_REGEX
+    );
+  });
+});

--- a/tests/unit/for-each-executor.test.ts
+++ b/tests/unit/for-each-executor.test.ts
@@ -16,6 +16,8 @@ const MULTIPLE_COLLECT_REGEX = /multiple Collect nodes/;
 const ARRAY_SOURCE_REQUIRED_REGEX = /arraySource is required/;
 const NOT_VALID_TEMPLATE_REGEX = /not a valid template reference/;
 const RESOLVED_TO_NULL_REGEX = /resolved to null/;
+const NODE_NOT_FOUND_REGEX = /was not found in outputs/;
+const OUTPUT_RESOLVED_NULL_REGEX = /output resolved to null/;
 const MUST_RESOLVE_TO_ARRAY_REGEX = /must resolve to an array/;
 
 // ---------------------------------------------------------------------------
@@ -400,7 +402,16 @@ describe("resolveArraySource", () => {
   it("throws when referenced node is missing from outputs", () => {
     expect(() =>
       resolveArraySource("{{@missing_node:Label.items}}", {})
-    ).toThrow(RESOLVED_TO_NULL_REGEX);
+    ).toThrow(NODE_NOT_FOUND_REGEX);
+  });
+
+  it("throws with distinct message when node exists but output is null", () => {
+    const outputs = {
+      node_1: { label: "Step", data: null },
+    };
+    expect(() => resolveArraySource("{{@node_1:Step.items}}", outputs)).toThrow(
+      OUTPUT_RESOLVED_NULL_REGEX
+    );
   });
 
   it("resolves array of objects", () => {

--- a/tests/unit/iteration-grouping.test.ts
+++ b/tests/unit/iteration-grouping.test.ts
@@ -1,0 +1,630 @@
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Types (mirrored from components/workflow/workflow-runs.tsx)
+// ---------------------------------------------------------------------------
+
+type ExecutionLog = {
+  id: string;
+  nodeId: string;
+  nodeName: string;
+  nodeType: string;
+  status: "pending" | "running" | "success" | "error";
+  startedAt: Date;
+  completedAt: Date | null;
+  duration: string | null;
+  input?: unknown;
+  output?: unknown;
+  error: string | null;
+  iterationIndex: number | null;
+  forEachNodeId: string | null;
+};
+
+type IterationGroup = {
+  iterationIndex: number;
+  logs: ExecutionLog[];
+};
+
+type GroupedLogEntry =
+  | { type: "standalone"; log: ExecutionLog }
+  | {
+      type: "for-each-group";
+      forEachLog: ExecutionLog;
+      iterations: IterationGroup[];
+    };
+
+// ---------------------------------------------------------------------------
+// Functions under test (copied from components/workflow/workflow-runs.tsx)
+// ---------------------------------------------------------------------------
+
+function buildIterationGroups(childLogs: ExecutionLog[]): IterationGroup[] {
+  const iterationMap = new Map<number, ExecutionLog[]>();
+  for (const child of childLogs) {
+    const idx = child.iterationIndex ?? 0;
+    const existing = iterationMap.get(idx) ?? [];
+    existing.push(child);
+    iterationMap.set(idx, existing);
+  }
+
+  return Array.from(iterationMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([index, iterLogs]) => ({
+      iterationIndex: index,
+      logs: iterLogs.sort(
+        (a, b) =>
+          new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+      ),
+    }));
+}
+
+function groupLogsByIteration(logs: ExecutionLog[]): GroupedLogEntry[] {
+  const result: GroupedLogEntry[] = [];
+
+  const forEachChildLogs = new Map<string, ExecutionLog[]>();
+  for (const log of logs) {
+    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
+      const existing = forEachChildLogs.get(log.forEachNodeId) ?? [];
+      existing.push(log);
+      forEachChildLogs.set(log.forEachNodeId, existing);
+    }
+  }
+
+  for (const log of logs) {
+    if (log.forEachNodeId !== null && log.iterationIndex !== null) {
+      continue;
+    }
+
+    if (log.nodeType === "For Each" && forEachChildLogs.has(log.nodeId)) {
+      const childLogs = forEachChildLogs.get(log.nodeId) ?? [];
+      const iterations = buildIterationGroups(childLogs);
+      result.push({ type: "for-each-group", forEachLog: log, iterations });
+    } else {
+      result.push({ type: "standalone", log });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let logCounter = 0;
+
+function makeLog(overrides: Partial<ExecutionLog> = {}): ExecutionLog {
+  logCounter += 1;
+  return {
+    id: `log-${logCounter}`,
+    nodeId: `node-${logCounter}`,
+    nodeName: `Node ${logCounter}`,
+    nodeType: "action",
+    status: "success",
+    startedAt: new Date("2025-01-01T00:00:00Z"),
+    completedAt: new Date("2025-01-01T00:00:01Z"),
+    duration: "1s",
+    input: undefined,
+    output: undefined,
+    error: null,
+    iterationIndex: null,
+    forEachNodeId: null,
+    ...overrides,
+  };
+}
+
+// Reset the counter before each test suite to keep IDs deterministic
+// within each describe block (not strictly required, but keeps things tidy).
+
+// ---------------------------------------------------------------------------
+// buildIterationGroups
+// ---------------------------------------------------------------------------
+
+describe("buildIterationGroups", () => {
+  it("returns an empty array for empty input", () => {
+    const result = buildIterationGroups([]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns a single iteration with one log", () => {
+    const log = makeLog({ iterationIndex: 0 });
+    const result = buildIterationGroups([log]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].iterationIndex).toBe(0);
+    expect(result[0].logs).toEqual([log]);
+  });
+
+  it("groups multiple logs into a single iteration sorted by startedAt", () => {
+    const logA = makeLog({
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:03Z"),
+      nodeName: "Step C",
+    });
+    const logB = makeLog({
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:01Z"),
+      nodeName: "Step A",
+    });
+    const logC = makeLog({
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:02Z"),
+      nodeName: "Step B",
+    });
+
+    const result = buildIterationGroups([logA, logB, logC]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].iterationIndex).toBe(0);
+    expect(result[0].logs).toEqual([logB, logC, logA]);
+  });
+
+  it("returns multiple iterations sorted by iterationIndex", () => {
+    const log0 = makeLog({ iterationIndex: 0 });
+    const log1 = makeLog({ iterationIndex: 1 });
+    const log2 = makeLog({ iterationIndex: 2 });
+
+    const result = buildIterationGroups([log0, log1, log2]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].iterationIndex).toBe(0);
+    expect(result[1].iterationIndex).toBe(1);
+    expect(result[2].iterationIndex).toBe(2);
+  });
+
+  it("defaults null iterationIndex to 0", () => {
+    const logWithNull = makeLog({ iterationIndex: null });
+    const logWithZero = makeLog({ iterationIndex: 0 });
+
+    const result = buildIterationGroups([logWithNull, logWithZero]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].iterationIndex).toBe(0);
+    expect(result[0].logs).toHaveLength(2);
+    expect(result[0].logs).toContain(logWithNull);
+    expect(result[0].logs).toContain(logWithZero);
+  });
+
+  it("sorts out-of-order iterations by iterationIndex", () => {
+    const log2 = makeLog({ iterationIndex: 2 });
+    const log0 = makeLog({ iterationIndex: 0 });
+    const log5 = makeLog({ iterationIndex: 5 });
+    const log1 = makeLog({ iterationIndex: 1 });
+
+    const result = buildIterationGroups([log2, log0, log5, log1]);
+
+    expect(result.map((g) => g.iterationIndex)).toEqual([0, 1, 2, 5]);
+  });
+
+  it("sorts out-of-order logs within the same iteration by startedAt", () => {
+    const late = makeLog({
+      iterationIndex: 1,
+      startedAt: new Date("2025-01-01T00:05:00Z"),
+    });
+    const early = makeLog({
+      iterationIndex: 1,
+      startedAt: new Date("2025-01-01T00:01:00Z"),
+    });
+    const middle = makeLog({
+      iterationIndex: 1,
+      startedAt: new Date("2025-01-01T00:03:00Z"),
+    });
+
+    const result = buildIterationGroups([late, early, middle]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].logs[0]).toBe(early);
+    expect(result[0].logs[1]).toBe(middle);
+    expect(result[0].logs[2]).toBe(late);
+  });
+
+  it("handles multiple iterations each with multiple logs", () => {
+    const iter0a = makeLog({
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:02Z"),
+    });
+    const iter0b = makeLog({
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:01Z"),
+    });
+    const iter1a = makeLog({
+      iterationIndex: 1,
+      startedAt: new Date("2025-01-01T00:00:04Z"),
+    });
+    const iter1b = makeLog({
+      iterationIndex: 1,
+      startedAt: new Date("2025-01-01T00:00:03Z"),
+    });
+
+    const result = buildIterationGroups([iter0a, iter1a, iter0b, iter1b]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].iterationIndex).toBe(0);
+    expect(result[0].logs).toEqual([iter0b, iter0a]);
+    expect(result[1].iterationIndex).toBe(1);
+    expect(result[1].logs).toEqual([iter1b, iter1a]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupLogsByIteration
+// ---------------------------------------------------------------------------
+
+describe("groupLogsByIteration", () => {
+  it("returns an empty array for empty input", () => {
+    const result = groupLogsByIteration([]);
+    expect(result).toEqual([]);
+  });
+
+  it("treats all logs as standalone when none are For Each related", () => {
+    const logA = makeLog({ nodeType: "action", nodeName: "HTTP Request" });
+    const logB = makeLog({ nodeType: "action", nodeName: "Send Email" });
+
+    const result = groupLogsByIteration([logA, logB]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ type: "standalone", log: logA });
+    expect(result[1]).toEqual({ type: "standalone", log: logB });
+  });
+
+  it("groups a For Each node with its body logs into iterations", () => {
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+      nodeName: "Loop Over Items",
+    });
+    const bodyLog0 = makeLog({
+      nodeId: "body-1",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:01Z"),
+    });
+    const bodyLog1 = makeLog({
+      nodeId: "body-2",
+      forEachNodeId: "fe-1",
+      iterationIndex: 1,
+      startedAt: new Date("2025-01-01T00:00:02Z"),
+    });
+
+    const result = groupLogsByIteration([forEachLog, bodyLog0, bodyLog1]);
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry.type).toBe("for-each-group");
+    if (entry.type === "for-each-group") {
+      expect(entry.forEachLog).toBe(forEachLog);
+      expect(entry.iterations).toHaveLength(2);
+      expect(entry.iterations[0].iterationIndex).toBe(0);
+      expect(entry.iterations[0].logs).toEqual([bodyLog0]);
+      expect(entry.iterations[1].iterationIndex).toBe(1);
+      expect(entry.iterations[1].logs).toEqual([bodyLog1]);
+    }
+  });
+
+  it("treats a For Each log with no child logs as standalone", () => {
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+      nodeName: "Loop (no children)",
+    });
+
+    const result = groupLogsByIteration([forEachLog]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: "standalone", log: forEachLog });
+  });
+
+  it("handles mixed standalone and For Each entries", () => {
+    const standaloneA = makeLog({
+      nodeId: "s-1",
+      nodeType: "action",
+      nodeName: "Pre-step",
+    });
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+      nodeName: "Loop",
+    });
+    const bodyLog = makeLog({
+      nodeId: "body-1",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+    });
+    const standaloneB = makeLog({
+      nodeId: "s-2",
+      nodeType: "action",
+      nodeName: "Post-step",
+    });
+
+    const result = groupLogsByIteration([
+      standaloneA,
+      forEachLog,
+      bodyLog,
+      standaloneB,
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].type).toBe("standalone");
+    expect(result[1].type).toBe("for-each-group");
+    expect(result[2].type).toBe("standalone");
+
+    if (result[0].type === "standalone") {
+      expect(result[0].log).toBe(standaloneA);
+    }
+    if (result[1].type === "for-each-group") {
+      expect(result[1].forEachLog).toBe(forEachLog);
+      expect(result[1].iterations).toHaveLength(1);
+      expect(result[1].iterations[0].logs).toEqual([bodyLog]);
+    }
+    if (result[2].type === "standalone") {
+      expect(result[2].log).toBe(standaloneB);
+    }
+  });
+
+  it("handles multiple For Each groups in the same execution", () => {
+    const fe1 = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+      nodeName: "Loop 1",
+    });
+    const fe1Body = makeLog({
+      nodeId: "b1",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+    });
+    const fe2 = makeLog({
+      nodeId: "fe-2",
+      nodeType: "For Each",
+      nodeName: "Loop 2",
+    });
+    const fe2Body = makeLog({
+      nodeId: "b2",
+      forEachNodeId: "fe-2",
+      iterationIndex: 0,
+    });
+
+    const result = groupLogsByIteration([fe1, fe1Body, fe2, fe2Body]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("for-each-group");
+    expect(result[1].type).toBe("for-each-group");
+
+    if (result[0].type === "for-each-group") {
+      expect(result[0].forEachLog).toBe(fe1);
+      expect(result[0].iterations[0].logs).toEqual([fe1Body]);
+    }
+    if (result[1].type === "for-each-group") {
+      expect(result[1].forEachLog).toBe(fe2);
+      expect(result[1].iterations[0].logs).toEqual([fe2Body]);
+    }
+  });
+
+  it("treats logs with null iterationIndex and null forEachNodeId as standalone", () => {
+    const log = makeLog({
+      iterationIndex: null,
+      forEachNodeId: null,
+      nodeType: "action",
+    });
+
+    const result = groupLogsByIteration([log]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("standalone");
+    if (result[0].type === "standalone") {
+      expect(result[0].log).toBe(log);
+    }
+  });
+
+  it("does not duplicate body logs - they appear only in iterations, not as standalone", () => {
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+    });
+    const bodyA = makeLog({
+      nodeId: "body-a",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+    });
+    const bodyB = makeLog({
+      nodeId: "body-b",
+      forEachNodeId: "fe-1",
+      iterationIndex: 1,
+    });
+
+    const result = groupLogsByIteration([forEachLog, bodyA, bodyB]);
+
+    // Only one entry: the for-each-group. Body logs are NOT standalone.
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("for-each-group");
+
+    // Verify no standalone entries exist for the body logs
+    const standaloneEntries = result.filter((e) => e.type === "standalone");
+    expect(standaloneEntries).toHaveLength(0);
+  });
+
+  it("treats a For Each node with nodeType 'For Each' but no matching children as standalone", () => {
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+    });
+    // No child logs reference fe-1
+
+    const result = groupLogsByIteration([forEachLog]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("standalone");
+    if (result[0].type === "standalone") {
+      expect(result[0].log).toBe(forEachLog);
+    }
+  });
+
+  it("preserves original order of standalone logs", () => {
+    const logA = makeLog({ nodeType: "action", nodeName: "Step 1" });
+    const logB = makeLog({ nodeType: "action", nodeName: "Step 2" });
+    const logC = makeLog({ nodeType: "action", nodeName: "Step 3" });
+    const logD = makeLog({ nodeType: "action", nodeName: "Step 4" });
+
+    const result = groupLogsByIteration([logA, logB, logC, logD]);
+
+    expect(result).toHaveLength(4);
+    for (const [i, entry] of result.entries()) {
+      expect(entry.type).toBe("standalone");
+      if (entry.type === "standalone") {
+        expect(entry.log).toBe([logA, logB, logC, logD][i]);
+      }
+    }
+  });
+
+  it("treats a log with forEachNodeId set but iterationIndex null as standalone", () => {
+    const edgeCase = makeLog({
+      nodeId: "orphan-1",
+      forEachNodeId: "fe-1",
+      iterationIndex: null,
+      nodeType: "action",
+    });
+
+    const result = groupLogsByIteration([edgeCase]);
+
+    // forEachNodeId is set but iterationIndex is null, so the child-detection
+    // condition (both non-null) is NOT met. This log is standalone.
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("standalone");
+    if (result[0].type === "standalone") {
+      expect(result[0].log).toBe(edgeCase);
+    }
+  });
+
+  it("treats a log with iterationIndex set but forEachNodeId null as standalone", () => {
+    const edgeCase = makeLog({
+      nodeId: "orphan-2",
+      iterationIndex: 3,
+      forEachNodeId: null,
+      nodeType: "action",
+    });
+
+    const result = groupLogsByIteration([edgeCase]);
+
+    // iterationIndex is set but forEachNodeId is null, so the child-detection
+    // condition (both non-null) is NOT met. This log is standalone.
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("standalone");
+    if (result[0].type === "standalone") {
+      expect(result[0].log).toBe(edgeCase);
+    }
+  });
+
+  it("groups multiple body steps within the same iteration correctly", () => {
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+    });
+    const stepA = makeLog({
+      nodeId: "step-a",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:01Z"),
+    });
+    const stepB = makeLog({
+      nodeId: "step-b",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:02Z"),
+    });
+    const stepC = makeLog({
+      nodeId: "step-c",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+      startedAt: new Date("2025-01-01T00:00:03Z"),
+    });
+
+    const result = groupLogsByIteration([forEachLog, stepA, stepB, stepC]);
+
+    expect(result).toHaveLength(1);
+    if (result[0].type === "for-each-group") {
+      expect(result[0].iterations).toHaveLength(1);
+      expect(result[0].iterations[0].logs).toEqual([stepA, stepB, stepC]);
+    }
+  });
+
+  it("correctly handles body logs appearing before the For Each log in the array", () => {
+    // The function processes all logs in two passes: first collecting children,
+    // then building groups. Order in the input array should not matter.
+    const bodyLog = makeLog({
+      nodeId: "body-1",
+      forEachNodeId: "fe-1",
+      iterationIndex: 0,
+    });
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+    });
+
+    const result = groupLogsByIteration([bodyLog, forEachLog]);
+
+    // Body log is skipped in the second pass, For Each is grouped
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("for-each-group");
+    if (result[0].type === "for-each-group") {
+      expect(result[0].forEachLog).toBe(forEachLog);
+      expect(result[0].iterations[0].logs).toEqual([bodyLog]);
+    }
+  });
+
+  it("correctly handles a For Each with many iterations and many body steps", () => {
+    const forEachLog = makeLog({
+      nodeId: "fe-1",
+      nodeType: "For Each",
+    });
+
+    const bodyLogs: ExecutionLog[] = [];
+    for (let iteration = 0; iteration < 5; iteration++) {
+      for (let step = 0; step < 3; step++) {
+        bodyLogs.push(
+          makeLog({
+            nodeId: `step-${step}`,
+            forEachNodeId: "fe-1",
+            iterationIndex: iteration,
+            startedAt: new Date(`2025-01-01T00:0${iteration}:0${step}Z`),
+          })
+        );
+      }
+    }
+
+    const result = groupLogsByIteration([forEachLog, ...bodyLogs]);
+
+    expect(result).toHaveLength(1);
+    if (result[0].type === "for-each-group") {
+      expect(result[0].iterations).toHaveLength(5);
+      for (const group of result[0].iterations) {
+        expect(group.logs).toHaveLength(3);
+      }
+      // Verify iteration ordering
+      const indices = result[0].iterations.map((g) => g.iterationIndex);
+      expect(indices).toEqual([0, 1, 2, 3, 4]);
+    }
+  });
+
+  it("does not treat a non-For-Each node as a group even if children reference it", () => {
+    // A log with nodeType "action" that has children referencing it via forEachNodeId
+    // should NOT be treated as a for-each-group because its nodeType is not "For Each"
+    const actionLog = makeLog({
+      nodeId: "action-1",
+      nodeType: "action",
+      nodeName: "Regular Action",
+    });
+    const childLog = makeLog({
+      nodeId: "child-1",
+      forEachNodeId: "action-1",
+      iterationIndex: 0,
+    });
+
+    const result = groupLogsByIteration([actionLog, childLog]);
+
+    // actionLog is standalone because nodeType is not "For Each"
+    // childLog is skipped (has both forEachNodeId and iterationIndex)
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("standalone");
+    if (result[0].type === "standalone") {
+      expect(result[0].log).toBe(actionLog);
+    }
+  });
+});

--- a/tests/unit/template-autocomplete-foreach.test.ts
+++ b/tests/unit/template-autocomplete-foreach.test.ts
@@ -1,0 +1,568 @@
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ExecutionLogEntry = { output?: unknown };
+
+type WorkflowNode = {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: {
+    label: string;
+    type: string;
+    config?: Record<string, unknown>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Top-level regex patterns (biome: useTopLevelRegex)
+// ---------------------------------------------------------------------------
+
+const ARRAY_SOURCE_TEMPLATE_RE = /^\{\{@([^:]+):([^.}]+)\.?([^}]*)\}\}$/;
+
+// ---------------------------------------------------------------------------
+// Re-implemented private functions under test
+// ---------------------------------------------------------------------------
+
+function traverseDotPath(root: unknown, path: string): unknown {
+  let data: unknown = root;
+  for (const part of path.split(".")) {
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      data = (data as Record<string, unknown>)[part];
+    } else {
+      return null;
+    }
+  }
+  return data;
+}
+
+function resolveForEachSyntheticOutput(
+  node: WorkflowNode,
+  executionLogs: Record<string, ExecutionLogEntry>,
+  lastLogs: Record<string, ExecutionLogEntry>
+): Record<string, unknown> | null {
+  const arraySource = node.data.config?.arraySource as string | undefined;
+  if (!arraySource) {
+    return null;
+  }
+
+  const match = ARRAY_SOURCE_TEMPLATE_RE.exec(arraySource);
+  if (!match) {
+    return null;
+  }
+
+  const sourceNodeId = match[1];
+  const fieldPath = match[3] || "";
+
+  const sourceOutput =
+    executionLogs[sourceNodeId]?.output ?? lastLogs[sourceNodeId]?.output;
+  if (sourceOutput === undefined || sourceOutput === null) {
+    return null;
+  }
+
+  let data: unknown = sourceOutput;
+  if (fieldPath) {
+    for (const part of fieldPath.split(".")) {
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        data = (data as Record<string, unknown>)[part];
+      } else {
+        return null;
+      }
+    }
+  }
+
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+
+  let currentItem: unknown = data[0];
+  const mapExpression = node.data.config?.mapExpression as string | undefined;
+  if (mapExpression && currentItem && typeof currentItem === "object") {
+    const mapped = traverseDotPath(currentItem, mapExpression);
+    if (mapped !== null) {
+      currentItem = mapped;
+    }
+  }
+
+  return {
+    currentItem,
+    index: 0,
+    totalItems: data.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNode(
+  id: string,
+  label: string,
+  config?: Record<string, unknown>
+): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 0 },
+    data: {
+      label,
+      type: "forEach",
+      config,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// traverseDotPath
+// ---------------------------------------------------------------------------
+
+describe("traverseDotPath", () => {
+  it("resolves a simple single-level path", () => {
+    expect(traverseDotPath({ a: 1 }, "a")).toBe(1);
+  });
+
+  it("resolves a nested multi-level path", () => {
+    expect(traverseDotPath({ a: { b: { c: 42 } } }, "a.b.c")).toBe(42);
+  });
+
+  it("returns undefined for a missing key at the leaf level", () => {
+    // The object is valid so traversal enters the if-branch and does obj["b"]
+    // which yields undefined. The loop ends and returns that undefined value.
+    expect(traverseDotPath({ a: 1 }, "b")).toBeUndefined();
+  });
+
+  it("returns null when the path traverses through an array", () => {
+    expect(traverseDotPath({ a: [1, 2, 3] }, "a.0")).toBeNull();
+  });
+
+  it("returns null when the path traverses through a primitive", () => {
+    expect(traverseDotPath({ a: "hello" }, "a.b")).toBeNull();
+  });
+
+  it("returns the root object when path is an empty string", () => {
+    const root = { x: 10 };
+    // An empty string split by "." produces [""], so root[""] is undefined.
+    // The function returns whatever root[""] resolves to, which is undefined.
+    expect(traverseDotPath(root, "")).toBeUndefined();
+  });
+
+  it("returns null when root is null", () => {
+    expect(traverseDotPath(null, "a")).toBeNull();
+  });
+
+  it("returns null when root is undefined", () => {
+    expect(traverseDotPath(undefined, "a")).toBeNull();
+  });
+
+  it("returns null when an intermediate key does not exist", () => {
+    expect(traverseDotPath({ a: { b: 1 } }, "a.x.y")).toBeNull();
+  });
+
+  it("returns the full nested object when path resolves to an object", () => {
+    const nested = { c: 3, d: 4 };
+    expect(traverseDotPath({ a: { b: nested } }, "a.b")).toEqual(nested);
+  });
+
+  it("returns null when traversing through a number", () => {
+    expect(traverseDotPath({ a: 42 }, "a.toString")).toBeNull();
+  });
+
+  it("returns null when traversing through a boolean", () => {
+    expect(traverseDotPath({ a: true }, "a.b")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveForEachSyntheticOutput
+// ---------------------------------------------------------------------------
+
+describe("resolveForEachSyntheticOutput", () => {
+  it("returns null when node has no config", () => {
+    const node = makeNode("n1", "For Each");
+    const result = resolveForEachSyntheticOutput(node, {}, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when config has no arraySource", () => {
+    const node = makeNode("n1", "For Each", { someOtherField: "value" });
+    const result = resolveForEachSyntheticOutput(node, {}, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when arraySource is not a valid template reference", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "just-a-plain-string",
+    });
+    const result = resolveForEachSyntheticOutput(node, {}, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when arraySource template has invalid format", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{invalid}}",
+    });
+    const result = resolveForEachSyntheticOutput(node, {}, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when source node has no output in either log", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+    });
+    const result = resolveForEachSyntheticOutput(node, {}, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when source node output is null", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+    });
+    const executionLogs = { src: { output: null } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when field path resolves to a non-array value", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.count}}",
+    });
+    const executionLogs = { src: { output: { count: 42 } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when field path resolves to a string", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.name}}",
+    });
+    const executionLogs = { src: { output: { name: "hello" } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the resolved array is empty", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+    });
+    const executionLogs = { src: { output: { items: [] } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toBeNull();
+  });
+
+  it("resolves a top-level array with no field path", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = {
+      src: { output: ["apple", "banana", "cherry"] },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: "apple",
+      index: 0,
+      totalItems: 3,
+    });
+  });
+
+  it("resolves an array at a single-level field path", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+    });
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const executionLogs = { src: { output: { items } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: { id: 1 },
+      index: 0,
+      totalItems: 3,
+    });
+  });
+
+  it("resolves an array at a nested field path", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.data.items}}",
+    });
+    const items = [{ name: "a" }, { name: "b" }];
+    const executionLogs = { src: { output: { data: { items } } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: { name: "a" },
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("prefers executionLogs over lastLogs", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = { src: { output: ["exec-a", "exec-b"] } };
+    const lastLogs = { src: { output: ["last-x", "last-y", "last-z"] } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, lastLogs);
+    expect(result).toEqual({
+      currentItem: "exec-a",
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("falls back to lastLogs when executionLogs has no entry", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const lastLogs = { src: { output: ["fallback-1", "fallback-2"] } };
+    const result = resolveForEachSyntheticOutput(node, {}, lastLogs);
+    expect(result).toEqual({
+      currentItem: "fallback-1",
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("falls back to lastLogs when executionLogs output is undefined", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = { src: { output: undefined } };
+    const lastLogs = { src: { output: [10, 20, 30] } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, lastLogs);
+    expect(result).toEqual({
+      currentItem: 10,
+      index: 0,
+      totalItems: 3,
+    });
+  });
+
+  it("falls back to lastLogs when executionLogs output is null", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = { src: { output: null } };
+    const lastLogs = { src: { output: ["a"] } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, lastLogs);
+    expect(result).toEqual({
+      currentItem: "a",
+      index: 0,
+      totalItems: 1,
+    });
+  });
+
+  it("returns the first element as currentItem", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = {
+      src: { output: [{ first: true }, { first: false }] },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result?.currentItem).toEqual({ first: true });
+  });
+
+  it("returns totalItems matching the array length", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = {
+      src: { output: [1, 2, 3, 4, 5] },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result?.totalItems).toBe(5);
+  });
+
+  it("always returns index as 0", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+    });
+    const executionLogs = {
+      src: { output: [100, 200, 300] },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result?.index).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // mapExpression tests
+  // -------------------------------------------------------------------------
+
+  it("applies mapExpression to extract a field from the first element", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+      mapExpression: "name",
+    });
+    const items = [
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ];
+    const executionLogs = { src: { output: { items } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: "Alice",
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("applies mapExpression with a nested dot path", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.records}}",
+      mapExpression: "data.nested.field",
+    });
+    const records = [
+      { data: { nested: { field: "deep-value" } } },
+      { data: { nested: { field: "other" } } },
+    ];
+    const executionLogs = { src: { output: { records } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: "deep-value",
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("sets currentItem to undefined when mapExpression targets a missing field", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+      mapExpression: "nonExistent",
+    });
+    const items = [{ name: "Alice" }, { name: "Bob" }];
+    const executionLogs = { src: { output: { items } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    // traverseDotPath returns undefined (not null) for a missing leaf key,
+    // so the `mapped !== null` guard passes and currentItem becomes undefined.
+    expect(result).toEqual({
+      currentItem: undefined,
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("keeps full element when mapExpression is applied to a non-object currentItem", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source}}",
+      mapExpression: "field",
+    });
+    // Array of primitives -- currentItem is a string, not an object
+    const executionLogs = {
+      src: { output: ["hello", "world"] },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: "hello",
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("extracts an array field via mapExpression for nested For Each", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.groups}}",
+      mapExpression: "members",
+    });
+    const groups = [{ members: ["Alice", "Bob"] }, { members: ["Charlie"] }];
+    const executionLogs = { src: { output: { groups } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    // mapExpression extracts the "members" array from the first group
+    expect(result).toEqual({
+      currentItem: ["Alice", "Bob"],
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("returns full first element when no mapExpression is configured", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+    });
+    const element = { id: 1, name: "First", tags: ["a", "b"] };
+    const executionLogs = {
+      src: {
+        output: { items: [element, { id: 2, name: "Second", tags: [] }] },
+      },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: element,
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("skips mapExpression when it is an empty string", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.items}}",
+      mapExpression: "",
+    });
+    const element = { id: 1, value: "test" };
+    const executionLogs = {
+      src: { output: { items: [element] } },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    // Empty mapExpression is falsy, so it is not applied
+    expect(result).toEqual({
+      currentItem: element,
+      index: 0,
+      totalItems: 1,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases for field path resolution
+  // -------------------------------------------------------------------------
+
+  it("returns null when field path traverses through a non-object", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.a.b.c}}",
+    });
+    const executionLogs = { src: { output: { a: "not-an-object" } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when field path resolves to undefined", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.missing}}",
+    });
+    const executionLogs = { src: { output: { present: [1] } } };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toBeNull();
+  });
+
+  it("handles a deeply nested field path correctly", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@src:Source.level1.level2.level3.data}}",
+    });
+    const deepData = [{ v: 1 }, { v: 2 }];
+    const executionLogs = {
+      src: {
+        output: {
+          level1: { level2: { level3: { data: deepData } } },
+        },
+      },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: { v: 1 },
+      index: 0,
+      totalItems: 2,
+    });
+  });
+
+  it("handles node IDs with special characters in the template", () => {
+    const node = makeNode("n1", "For Each", {
+      arraySource: "{{@node-123:My Source}}",
+    });
+    const executionLogs = {
+      "node-123": { output: ["x", "y"] },
+    };
+    const result = resolveForEachSyntheticOutput(node, executionLogs, {});
+    expect(result).toEqual({
+      currentItem: "x",
+      index: 0,
+      totalItems: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add For Each / Collect loop iteration system for workflows
- Dual-handle For Each nodes (loop body + done) with connection validation and auto-Collect
- Configurable concurrency: sequential (default), parallel (all at once), or custom limit (N concurrent workers)
- Map expression field with dropdown suggestions for transforming iteration items before body execution
- Iteration metadata stored in execution logs, grouped by iteration index in runs sidebar
- Template autocomplete suggestions for For Each loop variables (currentItem, index, totalItems)
- Chain-resolved nested For Each autocomplete -- inner loops correctly resolve parent's currentItem fields
- For Each / Collect added to MCP workflow schemas
- Shared utility modules: for-each-utils, iteration-grouping, for-each-concurrency

## Key Changes

**Executor** (`lib/workflow-executor.workflow.ts`):
- For Each loop orchestration with scoped outputs per iteration (structuredClone isolation)
- Loop body identification via graph traversal (handles nested For Each, branching, diamond patterns)
- Collect node aggregation with fallback output resolution
- Concurrency modes: sequential for...of, parallel via Promise.allSettled, custom N via worker pool

**UI** (`components/workflow/config/action-config.tsx`):
- For Each config: array source, max iterations, map expression dropdown, concurrency mode selector
- Collect config panel

**Canvas** (`components/workflow/workflow-canvas.tsx`, `add-step-button.tsx`):
- Dual-handle rendering for For Each nodes (loop/done handles)
- useUpdateNodeInternals fix for edge attachment on named handles (React Flow error [008](https://reactflow.dev/learn/troubleshooting/common-errors#008))
- Auto-Collect creation when adding step from "done" handle

**Runs Panel** (`components/workflow/workflow-runs.tsx`):
- Iteration grouping with expandable accordion per iteration
- Collect log rendered as always-visible sibling of For Each
- Continuous timeline line through expanded For Each content
- Recursive nested For Each rendering support

**Autocomplete** (`keeperhub/lib/for-each-utils.ts`, `components/ui/template-autocomplete.tsx`):
- Chain-resolved synthetic outputs for nested For Each references
- Parent mapExpression applied before inner loop resolution
- Circular reference protection via visited set

**Tests**:
- 47 tests for concurrency utility (sequential, parallel, worker pool, edge cases, error handling)
- 8 tests for nested For Each chain resolution (3-level deep, circular refs, backward compat)
- Unit tests for identifyLoopBody, resolveArraySource
- Unit tests for iteration grouping, template autocomplete, for-each-utils