### PR TITLE
feat(web3): add calldata decoder step

### DIFF
--- a/.claude/commands/create-local-dev.md
+++ b/.claude/commands/create-local-dev.md
@@ -1,0 +1,140 @@
+Spin up a complete local development environment for KeeperHub. Follow these steps in order, checking each prerequisite before proceeding.
+
+## 1. Prerequisites Check
+
+Verify Docker is running:
+```bash
+docker info > /dev/null 2>&1
+```
+If Docker is not running, tell the user to start Docker Desktop and try again.
+
+Check if port 5432 is already in use:
+```bash
+lsof -i :5432
+```
+If something is already on 5432, check if it's a keeperhub-postgres container. If it is, reuse it. If it's something else, warn the user.
+
+## 2. Start Postgres
+
+Check for an existing keeperhub-postgres container:
+```bash
+docker ps -a --filter "name=keeperhub-postgres" --format "{{.Names}} {{.Status}}"
+```
+
+- If running: skip, reuse it
+- If stopped: `docker start keeperhub-postgres`
+- If not found: create it:
+```bash
+docker run -d --name keeperhub-postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=workflow \
+  -p 5432:5432 \
+  postgres:16-alpine
+```
+
+Wait for Postgres to be ready:
+```bash
+sleep 3 && docker exec keeperhub-postgres pg_isready
+```
+
+## 3. Configure Environment
+
+Read the current `.env` file. Check if `DATABASE_URL` and `BETTER_AUTH_SECRET` are already set.
+
+If NOT set, add them at the top of `.env`:
+```
+DATABASE_URL="postgres://postgres:postgres@localhost:5432/workflow"
+BETTER_AUTH_SECRET="local-dev-secret-change-me"
+BETTER_AUTH_URL="http://localhost:3000"
+```
+
+Do NOT overwrite existing values. Do NOT remove any existing env vars.
+
+## 4. Install Dependencies & Push Schema
+
+```bash
+pnpm install
+pnpm db:push
+pnpm db:seed-chains
+pnpm discover-plugins
+```
+
+## 5. Create Test User
+
+Use the Better Auth sign-up API to create a user with a proper password hash:
+```bash
+curl -s -X POST http://localhost:3000/api/auth/sign-up/email \
+  -H "Content-Type: application/json" \
+  -d '{"email":"dev@keeperhub.local","password":"testpass123","name":"Dev User"}'
+```
+
+NOTE: The dev server must be running for this step. If it's not running yet, start it first in the background with `pnpm dev`, wait for it to be ready, then create the user.
+
+If the user already exists, that's fine -- skip this step.
+
+After creating the user, mark email as verified and get the user ID:
+```bash
+docker exec keeperhub-postgres psql -U postgres -d workflow -c "
+  UPDATE users SET email_verified = true WHERE email = 'dev@keeperhub.local';
+  SELECT id FROM users WHERE email = 'dev@keeperhub.local';
+"
+```
+
+## 6. Create Test Organization
+
+Using the user ID from step 5:
+```bash
+docker exec keeperhub-postgres psql -U postgres -d workflow -c "
+  INSERT INTO organization (id, name, slug, created_at)
+  VALUES ('test-org-001', 'Test Org', 'test-org', NOW())
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO member (id, organization_id, user_id, role, created_at)
+  VALUES ('mem-001', 'test-org-001', '<USER_ID>', 'owner', NOW())
+  ON CONFLICT DO NOTHING;
+
+  UPDATE sessions SET active_organization_id = 'test-org-001'
+  WHERE user_id = '<USER_ID>';
+"
+```
+
+Replace `<USER_ID>` with the actual user ID from step 5.
+
+## 7. Start Dev Server (if not already running)
+
+```bash
+pnpm dev
+```
+
+Run in background and wait for "Ready" message.
+
+## 8. Present Summary
+
+After everything is set up, present the user with this information:
+
+```
+Local Dev Environment Ready
+
+  Postgres:  localhost:5432 (Docker: keeperhub-postgres)
+  App:       http://localhost:3000
+
+  Sign in:
+    Email:    dev@keeperhub.local
+    Password: testpass123
+
+  Organization: Test Org (test-org-001)
+
+  Useful commands:
+    pnpm dev           - Start dev server
+    pnpm db:studio     - Open Drizzle Studio (DB browser)
+    pnpm db:push       - Push schema changes
+    pnpm discover-plugins - Re-register plugins after changes
+```
+
+## Important Notes
+
+- Do NOT commit `.env` changes -- the file is gitignored
+- Do NOT create documentation files
+- If any step fails, stop and tell the user what went wrong with the specific error
+- The seed script at `scripts/seed-test-workflow.ts` can be used separately to create test workflows

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -230,12 +230,16 @@ export function ActionGrid({
       groups[category].push(action);
     }
 
-    // Sort categories: System first, then alphabetically
+    // start custom keeperhub code //
+    // Sort categories: Web3 first, System second, then alphabetically
     const sortedCategories = Object.keys(groups).sort((a, b) => {
+      if (a === "Web3") return -1;
+      if (b === "Web3") return 1;
       if (a === "System") return -1;
       if (b === "System") return 1;
       return a.localeCompare(b);
     });
+    // end keeperhub code //
 
     return sortedCategories.map((category) => ({
       category,

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -347,7 +347,7 @@ const web3Plugin: IntegrationPlugin = {
       label: "Decode Calldata",
       description:
         "Decode raw transaction calldata into human-readable function calls with parameter names and values",
-      category: "Security",
+      category: "Web3",
       stepFunction: "decodeCalldataStep",
       stepImportPath: "decode-calldata",
       outputFields: [

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -343,6 +343,88 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "decode-calldata",
+      label: "Decode Calldata",
+      description:
+        "Decode raw transaction calldata into human-readable function calls with parameter names and values",
+      category: "Security",
+      stepFunction: "decodeCalldataStep",
+      stepImportPath: "decode-calldata",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether decoding succeeded",
+        },
+        {
+          field: "selector",
+          description: "4-byte function selector (e.g., 0xa9059cbb)",
+        },
+        {
+          field: "functionName",
+          description:
+            "Decoded function name (e.g., transfer), or null if unknown",
+        },
+        {
+          field: "functionSignature",
+          description:
+            "Full function signature (e.g., transfer(address,uint256)), or null if unknown",
+        },
+        {
+          field: "parameters",
+          description: "Array of decoded parameters with name, type, and value",
+        },
+        {
+          field: "decodingSource",
+          description:
+            "How the function was identified: explorer, 4byte, manual-abi, selector-only, or none",
+        },
+        {
+          field: "error",
+          description: "Error message if decoding failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "calldata",
+          label: "Calldata",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.calldata}}",
+          example:
+            "0xa9059cbb0000000000000000000000001234567890abcdef1234567890abcdef12345678000000000000000000000000000000000000000000000000000000003b9aca00",
+          required: true,
+        },
+        {
+          key: "contractAddress",
+          label: "Contract Address",
+          type: "template-input",
+          placeholder:
+            "0x... or {{NodeName.contractAddress}} (optional, for ABI lookup)",
+          example: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        },
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          placeholder: "Select network (required if contract address provided)",
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "abi",
+              label: "ABI Override",
+              type: "template-textarea",
+              placeholder: "Paste ABI JSON to use instead of auto-fetching",
+              rows: 4,
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "write-contract",
       label: "Write Contract",
       description: "Write data to a smart contract (state-changing functions)",

--- a/keeperhub/plugins/web3/steps/decode-calldata.ts
+++ b/keeperhub/plugins/web3/steps/decode-calldata.ts
@@ -1,0 +1,404 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { db } from "@/lib/db";
+import { explorerConfigs } from "@/lib/db/schema";
+import { fetchContractAbi } from "@/lib/explorer";
+import { getChainIdFromNetwork } from "@/lib/rpc";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY ?? "";
+const FOURBYTE_API_URL = "https://www.4byte.directory/api/v1/signatures/";
+const HEX_PATTERN = /^0x[\da-fA-F]*$/;
+
+type DecodedParameter = {
+  name: string;
+  type: string;
+  value: string;
+};
+
+type DecodeCalldataResult =
+  | {
+      success: true;
+      selector: string;
+      functionName: string | null;
+      functionSignature: string | null;
+      parameters: DecodedParameter[];
+      decodingSource: string;
+    }
+  | { success: false; error: string };
+
+export type DecodeCalldataCoreInput = {
+  calldata: string;
+  contractAddress?: string;
+  network?: string;
+  abi?: string;
+};
+
+export type DecodeCalldataInput = StepInput & DecodeCalldataCoreInput;
+
+/**
+ * Serialize a decoded value to string, handling BigInt, arrays, and objects
+ */
+function serializeValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  return JSON.stringify(value, (_key, v: unknown) =>
+    typeof v === "bigint" ? v.toString() : v
+  );
+}
+
+/**
+ * Extract named parameters from a parsed transaction fragment
+ */
+function extractParameters(
+  fragment: ethers.FunctionFragment,
+  args: ethers.Result
+): DecodedParameter[] {
+  const params: DecodedParameter[] = [];
+  for (const [i, input] of fragment.inputs.entries()) {
+    params.push({
+      name: input.name || `param${i}`,
+      type: input.type,
+      value: serializeValue(args[i]),
+    });
+  }
+  return params;
+}
+
+/**
+ * Attempt to decode calldata using a known ABI
+ */
+function tryDecodeWithAbi(
+  calldata: string,
+  abi: ethers.InterfaceAbi
+): {
+  functionName: string;
+  functionSignature: string;
+  parameters: DecodedParameter[];
+} | null {
+  try {
+    const iface = new ethers.Interface(abi);
+    const parsed = iface.parseTransaction({ data: calldata });
+    if (!parsed) {
+      return null;
+    }
+    return {
+      functionName: parsed.name,
+      functionSignature: parsed.signature,
+      parameters: extractParameters(parsed.fragment, parsed.args),
+    };
+  } catch {
+    return null;
+  }
+}
+
+type FourByteResponse = {
+  count: number;
+  results: Array<{ text_signature: string }>;
+};
+
+/**
+ * Fetch known function signatures from 4byte.directory by selector
+ */
+async function fetch4byteSignatures(selector: string): Promise<string[]> {
+  try {
+    const response = await fetch(
+      `${FOURBYTE_API_URL}?hex_signature=${selector}&ordering=created_at`
+    );
+    if (!response.ok) {
+      return [];
+    }
+    const data = (await response.json()) as FourByteResponse;
+    return data.results.map((r) => r.text_signature);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Try each 4byte.directory signature until one decodes successfully
+ */
+function tryDecodeWith4byte(
+  calldata: string,
+  signatures: string[]
+): {
+  functionName: string;
+  functionSignature: string;
+  parameters: DecodedParameter[];
+} | null {
+  for (const sig of signatures) {
+    try {
+      const iface = new ethers.Interface([`function ${sig}`]);
+      const parsed = iface.parseTransaction({ data: calldata });
+      if (parsed) {
+        return {
+          functionName: parsed.name,
+          functionSignature: parsed.signature,
+          parameters: extractParameters(parsed.fragment, parsed.args),
+        };
+      }
+    } catch {
+      // Signature didn't match calldata encoding, try next
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch ABI from block explorer (Etherscan, Blockscout) for a verified contract
+ */
+async function fetchAbiFromExplorer(
+  contractAddress: string,
+  network: string
+): Promise<ethers.InterfaceAbi | null> {
+  try {
+    const chainId = getChainIdFromNetwork(network);
+    const explorerConfig = await db.query.explorerConfigs.findFirst({
+      where: eq(explorerConfigs.chainId, chainId),
+    });
+
+    if (!explorerConfig) {
+      console.log(
+        "[Decode Calldata] No explorer config found for chain:",
+        chainId
+      );
+      return null;
+    }
+
+    const result = await fetchContractAbi(
+      explorerConfig,
+      contractAddress,
+      chainId,
+      ETHERSCAN_API_KEY || undefined
+    );
+
+    if (result.success && result.abi) {
+      return result.abi as ethers.InterfaceAbi;
+    }
+
+    console.log("[Decode Calldata] Explorer ABI fetch failed:", result.error);
+    return null;
+  } catch (error) {
+    console.log(
+      "[Decode Calldata] Explorer ABI fetch error:",
+      getErrorMessage(error)
+    );
+    return null;
+  }
+}
+
+/**
+ * Validate and normalize raw calldata hex string.
+ * Returns normalized hex or an error result.
+ */
+function validateCalldata(
+  calldata: string
+): { normalized: string } | DecodeCalldataResult {
+  if (!calldata || typeof calldata !== "string") {
+    return { success: false, error: "Calldata is required" };
+  }
+
+  const normalized = calldata.startsWith("0x") ? calldata : `0x${calldata}`;
+
+  if (!HEX_PATTERN.test(normalized)) {
+    return { success: false, error: "Calldata must be a valid hex string" };
+  }
+
+  return { normalized };
+}
+
+/**
+ * Try decoding with a user-provided ABI JSON string
+ */
+function tryManualAbi(
+  normalized: string,
+  selector: string,
+  abi: string
+): DecodeCalldataResult | null {
+  try {
+    const parsedAbi = JSON.parse(abi) as ethers.InterfaceAbi;
+    const decoded = tryDecodeWithAbi(normalized, parsedAbi);
+    if (decoded) {
+      return {
+        success: true,
+        selector,
+        ...decoded,
+        decodingSource: "manual-abi",
+      };
+    }
+  } catch {
+    // Invalid ABI JSON, fall through
+  }
+  return null;
+}
+
+/**
+ * Try decoding via block explorer ABI lookup
+ */
+async function tryExplorerStrategy(
+  normalized: string,
+  selector: string,
+  contractAddress: string,
+  network: string
+): Promise<DecodeCalldataResult | null> {
+  if (!ethers.isAddress(contractAddress)) {
+    return {
+      success: false,
+      error: `Invalid contract address: ${contractAddress}`,
+    };
+  }
+
+  const explorerAbi = await fetchAbiFromExplorer(contractAddress, network);
+  if (!explorerAbi) {
+    return null;
+  }
+
+  const decoded = tryDecodeWithAbi(normalized, explorerAbi);
+  if (decoded) {
+    return { success: true, selector, ...decoded, decodingSource: "explorer" };
+  }
+  return null;
+}
+
+/**
+ * Try decoding via 4byte.directory signature lookup
+ */
+async function try4byteStrategy(
+  normalized: string,
+  selector: string
+): Promise<DecodeCalldataResult | null> {
+  const signatures = await fetch4byteSignatures(selector);
+  if (signatures.length === 0) {
+    return null;
+  }
+
+  const decoded = tryDecodeWith4byte(normalized, signatures);
+  if (decoded) {
+    return { success: true, selector, ...decoded, decodingSource: "4byte" };
+  }
+
+  const firstSig = signatures[0];
+  const funcName = firstSig.split("(")[0];
+  return {
+    success: true,
+    selector,
+    functionName: funcName,
+    functionSignature: firstSig,
+    parameters: [],
+    decodingSource: "4byte-partial",
+  };
+}
+
+/**
+ * Core decode calldata logic
+ *
+ * Decoding strategy (in order):
+ * 1. Manual ABI override (if provided)
+ * 2. Explorer ABI lookup via Etherscan/Blockscout (if contract address + network provided)
+ * 3. 4byte.directory signature database (fallback)
+ * 4. Selector-only result (if all else fails)
+ */
+async function stepHandler(
+  input: DecodeCalldataCoreInput
+): Promise<DecodeCalldataResult> {
+  const { calldata, contractAddress, network, abi } = input;
+
+  const validation = validateCalldata(calldata);
+  if (!("normalized" in validation)) {
+    return validation;
+  }
+  const { normalized } = validation;
+
+  if (normalized === "0x") {
+    return {
+      success: true,
+      selector: "0x",
+      functionName: null,
+      functionSignature: null,
+      parameters: [],
+      decodingSource: "none",
+    };
+  }
+
+  if (normalized.length < 10) {
+    return {
+      success: false,
+      error:
+        "Calldata must contain at least a 4-byte function selector (10 hex characters including 0x prefix)",
+    };
+  }
+
+  const selector = normalized.slice(0, 10).toLowerCase();
+
+  if (abi?.trim()) {
+    const result = tryManualAbi(normalized, selector, abi);
+    if (result) {
+      return result;
+    }
+  }
+
+  if (contractAddress?.trim() && network?.trim()) {
+    const result = await tryExplorerStrategy(
+      normalized,
+      selector,
+      contractAddress,
+      network
+    );
+    if (result) {
+      return result;
+    }
+  }
+
+  const fourByteResult = await try4byteStrategy(normalized, selector);
+  if (fourByteResult) {
+    return fourByteResult;
+  }
+
+  return {
+    success: true,
+    selector,
+    functionName: null,
+    functionSignature: null,
+    parameters: [],
+    decodingSource: "selector-only",
+  };
+}
+
+/**
+ * Decode Calldata Step
+ * Decodes raw transaction calldata into human-readable function calls
+ * with parameter names and values using ABI databases and signature registries.
+ *
+ * Security-critical: maxRetries = 0 (fail-safe, not fail-open)
+ */
+export async function decodeCalldataStep(
+  input: DecodeCalldataInput
+): Promise<DecodeCalldataResult> {
+  "use step";
+
+  return await withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "decode-calldata",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+decodeCalldataStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/scripts/seed-test-workflow.ts
+++ b/scripts/seed-test-workflow.ts
@@ -1,0 +1,170 @@
+/**
+ * Seed script for local testing of the decode-calldata plugin.
+ * Creates a test user, org, and a workflow with a decode-calldata step.
+ *
+ * Usage: pnpm tsx scripts/seed-test-workflow.ts
+ */
+
+import "dotenv/config";
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { getDatabaseUrl } from "../lib/db/connection-utils";
+import {
+  member,
+  organization,
+  sessions,
+  users,
+  workflows,
+} from "../lib/db/schema";
+import { generateId } from "../lib/utils/id";
+
+const connectionString = getDatabaseUrl();
+const client = postgres(connectionString, { max: 1 });
+const db = drizzle(client);
+
+const USER_ID = "test-user-001";
+const ORG_ID = "test-org-001";
+const SESSION_TOKEN = "test-session-token";
+const WORKFLOW_ID = generateId();
+
+// ERC-20 transfer(address,uint256) calldata for testing
+const SAMPLE_CALLDATA =
+  "0xa9059cbb000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000000000000000000000000000000000000003d0900";
+
+async function seed(): Promise<void> {
+  console.log("Seeding test data for decode-calldata plugin...\n");
+
+  const now = new Date();
+
+  // 1. User
+  await db
+    .insert(users)
+    .values({
+      id: USER_ID,
+      name: "Test User",
+      email: "test@keeperhub.local",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+  console.log("  + User: test@keeperhub.local");
+
+  // 2. Session (so the UI works)
+  await db
+    .insert(sessions)
+    .values({
+      id: generateId(),
+      token: SESSION_TOKEN,
+      userId: USER_ID,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+  console.log("  + Session created (30 day expiry)");
+
+  // 3. Organization
+  await db
+    .insert(organization)
+    .values({
+      id: ORG_ID,
+      name: "Test Org",
+      slug: "test-org",
+      createdAt: now,
+    })
+    .onConflictDoNothing();
+  console.log("  + Organization: Test Org");
+
+  // 4. Membership
+  await db
+    .insert(member)
+    .values({
+      id: generateId(),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      role: "owner",
+      createdAt: now,
+    })
+    .onConflictDoNothing();
+  console.log("  + Member: owner role");
+
+  // 5. Workflow with decode-calldata step
+  const triggerNodeId = "trigger-1";
+  const decodeNodeId = "decode-1";
+
+  const nodes = [
+    {
+      id: triggerNodeId,
+      type: "trigger",
+      position: { x: 250, y: 50 },
+      data: {
+        label: "Manual Trigger",
+        type: "trigger",
+        config: { triggerType: "manual" },
+        status: "idle",
+        enabled: true,
+      },
+    },
+    {
+      id: decodeNodeId,
+      type: "action",
+      position: { x: 250, y: 250 },
+      data: {
+        label: "Decode Calldata",
+        description: "Decode raw transaction calldata",
+        type: "action",
+        config: {
+          actionType: "web3/decode-calldata",
+          calldata: SAMPLE_CALLDATA,
+          contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          network: "ethereum",
+        },
+        status: "idle",
+        enabled: true,
+      },
+    },
+  ];
+
+  const edges = [
+    {
+      id: `${triggerNodeId}-${decodeNodeId}`,
+      source: triggerNodeId,
+      target: decodeNodeId,
+    },
+  ];
+
+  await db
+    .insert(workflows)
+    .values({
+      id: WORKFLOW_ID,
+      name: "Test: Decode USDT Transfer Calldata",
+      description:
+        "Decodes an ERC-20 transfer() call to USDT contract on Ethereum mainnet",
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      nodes,
+      edges,
+      visibility: "private",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+  console.log(`  + Workflow: ${WORKFLOW_ID}`);
+
+  console.log("\nDone! Test workflow created.");
+  console.log(
+    `\nOpen in browser: http://localhost:3000/workflows/${WORKFLOW_ID}`
+  );
+
+  await client.end();
+  process.exit(0);
+}
+
+seed().catch(async (err: unknown) => {
+  console.error("Seed failed:", err);
+  await client.end();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `decode-calldata` action under the Security category on the web3 plugin
- Cascading decode strategy: manual ABI -> Etherscan lookup -> 4byte.directory -> selector-only fallback
- `maxRetries = 0` for fail-safe behavior on security-critical steps
- No external SDK dependencies -- uses `fetch()` directly for all API calls

## Test plan
- [ ] Verify decode-calldata step appears in web3 plugin actions (Security category)
- [ ] Test with known ABI + calldata (e.g., ERC20 transfer)
- [ ] Test Etherscan auto-fetch with verified contract address
- [ ] Test 4byte.directory fallback with unknown contract
- [ ] Test selector-only fallback with completely unknown calldata
- [ ] Verify `pnpm type-check` and `pnpm check` pass