### PR TITLE
feat: add plugin docs and develop-plugin command

### DIFF
--- a/.claude/commands/develop-plugin.md
+++ b/.claude/commands/develop-plugin.md
@@ -1,0 +1,562 @@
+---
+description: Create a new KeeperHub workflow plugin with full architecture knowledge. Builds production-ready plugins following exact codebase conventions.
+argument-hint: [plugin-name] [description]
+---
+
+<objective>
+Create a new KeeperHub workflow plugin. If arguments provided, use $1 as plugin name and $2 as description. Otherwise, ask what plugin to build.
+
+This command has deep knowledge of the KeeperHub plugin architecture and creates plugins that follow every convention exactly -- correct imports, file structure, type patterns, metrics wrapping, and registration.
+</objective>
+
+<context>
+Existing keeperhub plugins: !`ls /Users/skp/Dev/TechOps\ Services/keeperhub/keeperhub/plugins/`
+Available integration types: !`cat /Users/skp/Dev/TechOps\ Services/keeperhub/lib/types/integration.ts`
+Current plugin index: @keeperhub/plugins/index.ts
+Plugin registry: @plugins/registry.ts
+CLAUDE.md rules: @CLAUDE.md
+Plugin development guide: @plugins/AGENTS.md
+</context>
+
+<architecture>
+CRITICAL: Follow these conventions EXACTLY. All custom plugins go in `keeperhub/plugins/` (NOT `plugins/`).
+
+DIRECTORY STRUCTURE for each plugin:
+```
+keeperhub/plugins/[plugin-name]/
+  index.ts          # Plugin definition + registerIntegration()
+  icon.tsx          # SVG icon component
+  credentials.ts    # Credential type (skip if requiresCredentials: false)
+  test.ts           # Connection test function
+  steps/
+    [action-slug].ts  # One file per action
+```
+
+FILE 1 - index.ts:
+```typescript
+import type { IntegrationPlugin } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry";
+import { PluginNameIcon } from "./icon";
+
+const pluginNamePlugin: IntegrationPlugin = {
+  type: "plugin-name",           // kebab-case, matches folder name
+  label: "Plugin Name",          // Display name
+  description: "Brief description",
+
+  icon: PluginNameIcon,
+
+  // Set false if plugin works without credentials (e.g., web3 read-only)
+  requiresCredentials: true,
+
+  // Set true if only one connection per user (e.g., web3 wallet)
+  // singleConnection: true,
+
+  formFields: [
+    {
+      id: "apiKey",
+      label: "API Key",
+      type: "password",           // "password" | "text" | "url" | "checkbox"
+      placeholder: "...",
+      configKey: "apiKey",        // Key stored in database
+      envVar: "PLUGIN_NAME_API_KEY",
+      helpText: "Description",
+      helpLink: { text: "Get key", url: "https://..." },
+    },
+  ],
+
+  testConfig: {
+    getTestFunction: async () => {
+      const { testPluginName } = await import("./test");
+      return testPluginName;
+    },
+  },
+
+  actions: [
+    {
+      slug: "action-slug",       // kebab-case
+      label: "Action Label",
+      description: "What it does",
+      category: "Plugin Name",   // Groups in UI
+      stepFunction: "actionSlugStep",    // camelCase + "Step"
+      stepImportPath: "action-slug",     // matches filename in steps/
+      requiresCredentials: true,         // Override plugin-level per action
+      outputFields: [
+        { field: "success", description: "Whether the action succeeded" },
+        { field: "result", description: "The action result" },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "inputField",
+          label: "Input Field",
+          type: "template-input",  // Supports {{NodeName.field}} syntax
+          placeholder: "Value or {{NodeName.field}}",
+          example: "example value",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+registerIntegration(pluginNamePlugin);
+export default pluginNamePlugin;
+```
+
+FILE 2 - steps/[action-slug].ts (TWO-LAYER PATTERN):
+```typescript
+import "server-only";
+
+import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+import type { PluginNameCredentials } from "../credentials";
+
+// Result type - ALWAYS use discriminated union
+type ActionSlugResult =
+  | { success: true; result: string }
+  | { success: false; error: string };
+
+// Core input - matches configFields keys
+export type ActionSlugCoreInput = {
+  inputField: string;
+};
+
+// Full input - extends StepInput, adds integrationId
+export type ActionSlugInput = StepInput &
+  ActionSlugCoreInput & {
+    integrationId?: string;
+  };
+
+/**
+ * Core logic - receives credentials as parameter
+ * Separation enables code export / reuse
+ */
+async function stepHandler(
+  input: ActionSlugCoreInput,
+  credentials: PluginNameCredentials
+): Promise<ActionSlugResult> {
+  const apiKey = credentials.PLUGIN_NAME_API_KEY;
+
+  if (!apiKey) {
+    return {
+      success: false,
+      error: "PLUGIN_NAME_API_KEY is not configured. Please add it in Project Integrations.",
+    };
+  }
+
+  try {
+    // Use fetch() directly - NO SDK dependencies
+    const response = await fetch("https://api.example.com/endpoint", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ field: input.inputField }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        error: errorData.message || `HTTP ${response.status}`,
+      };
+    }
+
+    const data = await response.json();
+    return { success: true, result: data.id };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Entry point - fetches credentials, wraps with logging + metrics
+ */
+export async function actionSlugStep(
+  input: ActionSlugInput
+): Promise<ActionSlugResult> {
+  "use step";
+
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId)
+    : {};
+
+  return withPluginMetrics(
+    {
+      pluginName: "plugin-name",
+      actionName: "action-slug",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input, credentials))
+  );
+}
+
+export const _integrationType = "plugin-name";
+```
+
+FILE 2b - steps/[action-slug].ts (SYSTEM PLUGIN VARIANT -- no credentials):
+Use this pattern for system/utility plugins that don't call external APIs.
+```typescript
+import "server-only";
+
+import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+// Result type - ALWAYS use discriminated union
+type ActionSlugResult =
+  | { success: true; result: string }
+  | { success: false; error: string };
+
+// Core input - matches configFields keys
+export type ActionSlugCoreInput = {
+  inputField: string;
+};
+
+// Full input - extends StepInput (no integrationId needed)
+export type ActionSlugInput = StepInput & ActionSlugCoreInput;
+
+/**
+ * Core logic - no credentials parameter
+ */
+async function stepHandler(
+  input: ActionSlugCoreInput
+): Promise<ActionSlugResult> {
+  try {
+    // Pure computation, no external API call
+    const result = processInput(input.inputField);
+    return { success: true, result };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Entry point - NO fetchCredentials, just logging + metrics
+ */
+export async function actionSlugStep(
+  input: ActionSlugInput
+): Promise<ActionSlugResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "plugin-name",
+      actionName: "action-slug",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+// Set maxRetries = 0 for security-critical steps (fail-safe, not fail-open)
+// actionSlugStep.maxRetries = 0;
+
+export const _integrationType = "plugin-name";
+```
+
+FILE 3 - credentials.ts:
+```typescript
+export type PluginNameCredentials = {
+  PLUGIN_NAME_API_KEY?: string;
+};
+```
+
+FILE 4 - test.ts:
+```typescript
+export function testPluginName(
+  _credentials: Record<string, string>
+): Promise<{ success: boolean; error?: string }> {
+  return Promise.resolve({ success: true });
+}
+```
+
+FILE 5 - icon.tsx:
+```typescript
+export function PluginNameIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-label="Plugin Name logo"
+      className={className}
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Plugin Name</title>
+      <path d="M12 2L2 12h3v8h6v-6h2v6h6v-8h3L12 2z" />
+    </svg>
+  );
+}
+```
+
+CONFIG FIELD TYPES:
+- template-input: Single-line, supports {{NodeName.field}} variables
+- template-textarea: Multi-line, supports {{NodeName.field}} variables
+- text: Plain text input
+- number: Numeric input (supports min)
+- select: Dropdown (needs options array)
+- chain-select: Dynamic chain selector (use chainTypeFilter: "evm" for EVM chains)
+- abi-with-auto-fetch: ABI textarea with Etherscan auto-fetch (needs contractAddressField, networkField, contractInteractionType)
+- abi-function-select: Function picker from ABI (needs abiField, optional functionFilter: "read"|"write")
+- abi-function-args: Dynamic args based on selected function (needs abiField, abiFunctionField)
+- token-select: Token selector (needs networkField)
+- abi-event-select: Event picker from ABI (needs abiField)
+- schema-builder: Structured output schema builder
+
+CONDITIONAL FIELDS:
+```typescript
+{ key: "field", showWhen: { field: "otherField", equals: "value" } }
+```
+
+FIELD GROUPS (collapsible):
+```typescript
+{ type: "group", label: "Advanced", defaultExpanded: false, fields: [...] }
+```
+
+NAMING CONVENTIONS:
+- Plugin folder/type: kebab-case (my-plugin)
+- Plugin variable: camelCase (myPluginPlugin)
+- Step function: camelCaseStep (myActionStep)
+- Credential type: PascalCaseCredentials (MyPluginCredentials)
+- Test function: testPascalCase (testMyPlugin)
+- Icon component: PascalCaseIcon (MyPluginIcon)
+- Env vars: SCREAMING_SNAKE_CASE (MY_PLUGIN_API_KEY)
+
+PLUGIN VARIANTS:
+
+1. CREDENTIAL-BASED PLUGIN (external API):
+   Pattern: discord, sendgrid, telegram
+   - requiresCredentials: true (or per-action)
+   - formFields with envVar mappings
+   - credentials.ts with typed credential interface
+   - test.ts validates API key
+   - Step handler receives credentials parameter
+
+2. SYSTEM PLUGIN (no credentials, pure logic):
+   Pattern: loop/iterate (from marketplace)
+   - requiresCredentials: false
+   - formFields: [] (empty)
+   - No credentials.ts needed
+   - Step handler takes only input, no credentials
+   - Good for: decode-calldata, state/store, math/delta, block-context
+
+3. INFRASTRUCTURE PLUGIN (uses existing infra, no external credentials):
+   Pattern: web3 (read-only actions like check-balance)
+   - requiresCredentials: false at plugin level, true per write-action
+   - Uses internal infrastructure (RPC, chain config, ethers.js)
+   - Credentials fetched from user's wallet, not API keys
+
+PER-ACTION CREDENTIAL OVERRIDE:
+requiresCredentials can be set at plugin level AND overridden per action.
+Example: web3 plugin has requiresCredentials: false but transfer-funds action
+has requiresCredentials: true (needs wallet). Read-only actions skip credentials.
+
+RETRY BEHAVIOR:
+- Default: steps retry on failure
+- Security/guard steps: Set `stepFunction.maxRetries = 0` after the function definition
+  This ensures fail-safe behavior (block on error, don't silently retry)
+  Example:
+  ```typescript
+  export async function decodeCalldataStep(input: DecodeCalldataInput): Promise<DecodeCalldataResult> {
+    "use step";
+    // ... implementation
+  }
+  decodeCalldataStep.maxRetries = 0;
+  ```
+- Use maxRetries = 0 for: security assessment, guard/gate steps, calldata decoding,
+  risk scoring, approval gates -- any step where a retry could mask a real threat
+
+CRITICAL RULES:
+1. Use fetch() not SDKs - reduces supply chain attack surface
+2. All step files must start with `import "server-only";`
+3. Entry point must have `"use step";` directive
+4. Must export `_integrationType` constant matching plugin type
+5. Wrap with withPluginMetrics AND withStepLogging (see discord/steps/send-message.ts)
+6. No emojis in code or comments
+7. All custom code in keeperhub/ directory
+8. Security-critical steps must set maxRetries = 0 (fail-safe, not fail-open)
+</architecture>
+
+<workflow_plugin_proposals>
+These are the plugin categories identified for KeeperHub's roadmap. Reference these when building plugins:
+
+SECURITY PLUGINS:
+- security/parse-advisory: Parse vulnerability advisories into structured data
+- security/decode-calldata: Decode transaction calldata against known ABIs
+- security/match-contracts: Match vulnerability patterns against contract addresses
+- security/contract-risk-score: Evaluate contract risk (age, verification, audit, TVL)
+- security/strategy-validator: Compare actions against allowed strategy
+
+AI PLUGINS:
+- ai/assess-risk: LLM-powered risk assessment with confidence scores
+
+WEB3 EXTENSIONS:
+- web3/simulate-tx: Fork-simulate transactions to see state changes
+- web3/flashbots-submit: Submit defensive transactions via Flashbots Protect
+- web3/batch-read: Call same function across dynamic list of addresses
+- web3/is-contract: Check if address is contract or EOA
+- web3/iterate-mapping: Read sequential mapping entries until revert
+
+SYSTEM PLUGINS:
+- state/store + state/recall: Persist data between workflow runs
+- state/merge + state/remove: Atomic array operations on persisted state
+- system/block-context: Expose current block number, timestamp, base fee
+- iterator/for-each: Execute sub-workflow for each item in list
+- approval-gate: Human approval step in workflow
+
+UTILITY PLUGINS:
+- math/max: Find max/min/sum/avg across array
+- math/delta: Calculate percentage change between values
+- delay/next-block: Wait for next block(s)
+</workflow_plugin_proposals>
+
+<process>
+1. DETERMINE PLUGIN DETAILS
+   - If $1 and $2 provided, use them as plugin name and description
+   - If only $1 provided, use as name and ask for description
+   - If neither provided, ask the user what plugin they want to build
+   - Convert name to kebab-case for folder/type
+   - Decide: NEW plugin or NEW ACTION on existing plugin?
+     - If the action shares infrastructure with an existing plugin (e.g., web3 chain config,
+       RPC, ethers.js), add it as a new action on that plugin instead of creating a new one
+     - Example: decode-calldata is a web3 action, not a new "security" plugin
+
+2. DETERMINE PLUGIN VARIANT
+   - Credential-based (external API): needs formFields, credentials.ts, test.ts
+   - System plugin (pure logic): no credentials, formFields: [], skip credentials.ts
+   - Infrastructure plugin (uses internal infra): like web3 read actions
+   - Determine if security-critical (maxRetries = 0)
+
+3. DETERMINE ACTIONS
+   - Ask the user what actions this plugin should have
+   - For each action, determine: slug, label, description, config fields, output fields
+   - Check if the plugin needs credentials or is credential-free
+   - For web3 plugins, use chain-select, abi-with-auto-fetch, etc.
+   - For security steps, plan for maxRetries = 0
+
+4. CREATE PLUGIN FILES
+   If NEW PLUGIN:
+   - Create directory: `keeperhub/plugins/[name]/`
+   - Create `keeperhub/plugins/[name]/steps/` directory
+   - Write index.ts following the exact pattern above
+   - Write icon.tsx (use a Lucide icon or placeholder SVG)
+   - Write credentials.ts (if requiresCredentials: true, skip for system plugins)
+   - Write test.ts
+   - Write steps/[action-slug].ts for each action
+   If ADDING ACTION TO EXISTING PLUGIN:
+   - Read existing plugin's index.ts to understand current patterns
+   - Add new action entry to the actions array in index.ts
+   - Create new step file: steps/[action-slug].ts
+   - Follow the same patterns as sibling steps in that plugin
+
+5. REGISTER PLUGIN
+   - Run: `pnpm discover-plugins`
+   - This auto-generates: keeperhub/plugins/index.ts, lib/types/integration.ts, lib/step-registry.ts
+
+6. VALIDATE
+   - Run: `pnpm type-check`
+   - Run: `pnpm check`
+   - If errors, run `pnpm fix` for auto-fixable issues, then fix remaining manually
+   - Re-run checks until clean
+
+7. DOCUMENT PLUGIN
+   Every plugin/action MUST be documented in the docs site at `docs/plugins/`.
+
+   If NEW PLUGIN:
+   - Create `docs/plugins/[plugin-name].md` following this template:
+     ```markdown
+     ---
+     title: "[Plugin Name] Plugin"
+     description: "One-line description of what this plugin does."
+     ---
+
+     # [Plugin Name] Plugin
+
+     Brief description (1-2 sentences).
+
+     ## Actions
+
+     | Action | Description |
+     |--------|-------------|
+     | Action Name | What it does |
+
+     ## Setup
+
+     (Connection/credential setup steps, skip if no credentials needed)
+
+     ## [Action Name]
+
+     What this action does (1-2 sentences).
+
+     **Inputs:** List of inputs
+
+     **Outputs:** `field1`, `field2`, `error`
+
+     **When to use:** 2-3 concrete use cases.
+
+     **Example workflow:**
+     ```
+     Trigger
+       -> Action 1
+       -> Condition
+       -> Action 2: "message with {{variables}}"
+     ```
+     ```
+   - Add the plugin to `docs/plugins/_meta.json` (maintains sidebar order)
+   - Add the route to `docs-site/middleware.ts` VALID_ROUTES if it is a new top-level route
+
+   If ADDING ACTION TO EXISTING PLUGIN:
+   - Read the existing `docs/plugins/[plugin-name].md`
+   - Add the new action section following the same pattern as sibling actions
+   - Add it to the Actions table at the top
+   - Include: description, inputs, outputs, when to use, example workflow
+
+   Documentation rules:
+   - Keep descriptions concise (no walls of text)
+   - Example workflows use pseudo-code (not full JSON), showing the flow visually
+   - "When to use" should list concrete scenarios, not abstract capabilities
+   - Include `{{NodeName.field}}` variable syntax in examples to show data flow
+   - Security actions should note fail-safe behavior (maxRetries = 0)
+
+8. REPORT
+   - Show the user what was created
+   - List all files (created or modified)
+   - Show the action IDs (e.g., "my-plugin/my-action")
+   - Note the docs page URL (e.g., /plugins/my-plugin)
+   - Suggest next steps (implement API logic, test in UI)
+</process>
+
+<verification>
+Before completing, verify:
+- All plugin files exist in keeperhub/plugins/[name]/
+- `pnpm discover-plugins` ran successfully (plugin appears in keeperhub/plugins/index.ts)
+- `pnpm type-check` passes with no errors
+- `pnpm check` passes with no lint errors
+- Plugin type appears in lib/types/integration.ts
+- Step functions appear in lib/step-registry.ts
+- Documentation exists at docs/plugins/[plugin-name].md (or action added to existing doc)
+- Plugin appears in docs/plugins/_meta.json
+</verification>
+
+<success_criteria>
+- Plugin directory created at keeperhub/plugins/[name]/
+- All required files present: index.ts, icon.tsx, test.ts, steps/*.ts
+- credentials.ts present if plugin requires credentials
+- Plugin registered via pnpm discover-plugins
+- TypeScript compilation passes
+- Lint checks pass
+- Plugin follows all naming conventions
+- Step functions use two-layer pattern with withPluginMetrics + withStepLogging
+- All imports use correct paths (@/plugins/registry, @/keeperhub/lib/metrics/...)
+- No SDK dependencies - uses fetch() directly
+- No emojis in any files
+- Documentation page created/updated at docs/plugins/ with actions table, inputs, outputs, example workflows, and when-to-use guidance
+</success_criteria>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - **Do not git push or create Github PRs without user's confirmation**
 - **Do not leave code comments with summaries of user's prompt**
 - **Do not include task codes in branch/PR names**
+- **PR titles must follow conventional commit format**: `<type>: <description>` or `<type>(scope): <description>`. Allowed types: `feat`, `fix`, `hotfix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `breaking`. This is enforced by the `pr-title-check` workflow on PRs targeting `staging`.
 
 ## Code Quality: Lint and Type Checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - **No co-authored with Claude in PR descriptions and git commits**
 - **Do not git push or create Github PRs without user's confirmation**
 - **Do not leave code comments with summaries of user's prompt**
+- **Do not include task codes in branch/PR names**
 
 ## Code Quality: Lint and Type Checking
 
@@ -48,6 +49,7 @@ When lint/type-check commands run, their output is saved to gitignored files:
 - `.claude/typecheck-output.txt` - Output from `pnpm type-check`
 
 **Workflow for fixing errors:**
+
 1. Run `pnpm check` or `pnpm type-check` once
 2. Read `.claude/lint-output.txt` or `.claude/typecheck-output.txt` for errors
 3. Fix the errors in code
@@ -60,11 +62,13 @@ When lint/type-check commands run, their output is saved to gitignored files:
 This project has Claude Code hooks configured in `.claude/settings.json`:
 
 **Pre-Edit Lint Context** (`.claude/hooks/pre-edit-lint-context.sh`):
+
 - Fires before Edit/Write on .ts/.tsx/.js/.jsx files
 - Injects key Ultracite/Biome lint rules into context
 - **Rationale**: Higher upfront token cost, but saves overall context by writing correct code the first time instead of the expensive cycle of: write code → run lint → see errors → fix partially → re-run lint → repeat
 
 **Pre-Commit Checks** (`.claude/hooks/pre-commit-checks.sh`):
+
 - Detects `git commit` commands
 - Runs `pnpm check` (lint) and `pnpm type-check` (TypeScript)
 - Saves output to `.claude/*.txt` files for reading without re-running
@@ -85,6 +89,7 @@ This project has Claude Code hooks configured in `.claude/settings.json`:
 - "It's faster to ignore than fix"
 
 When you must use an ignore comment:
+
 1. Use the most specific ignore possible (target the exact rule, not all rules)
 2. Add a brief comment explaining why the ignore is necessary
 3. Example:
@@ -189,6 +194,7 @@ pnpm test:e2e               # E2E tests
 ## MCP Schemas Endpoint
 
 **Files**:
+
 - `keeperhub/api/mcp/schemas/route.ts` - Implementation
 - `app/api/mcp/schemas/route.ts` - Thin wrapper (re-exports from keeperhub)
 
@@ -204,12 +210,12 @@ This endpoint serves workflow schemas to the KeeperHub MCP server. It's the sour
 
 These are defined directly in the file because they rarely change and aren't in a registry:
 
-| Section | When to Update |
-|---------|----------------|
-| `SYSTEM_ACTIONS` | Adding new system action (Condition, HTTP Request, Database Query) |
-| `TRIGGERS` | Adding new trigger type (Manual, Schedule, Webhook, Event) |
-| `TEMPLATE_SYNTAX` | If template syntax `{{@nodeId:Label.field}}` changes |
-| `tips` array | When adding guidance for AI workflow generation |
+| Section           | When to Update                                                     |
+| ----------------- | ------------------------------------------------------------------ |
+| `SYSTEM_ACTIONS`  | Adding new system action (Condition, HTTP Request, Database Query) |
+| `TRIGGERS`        | Adding new trigger type (Manual, Schedule, Webhook, Event)         |
+| `TEMPLATE_SYNTAX` | If template syntax `{{@nodeId:Label.field}}` changes               |
+| `tips` array      | When adding guidance for AI workflow generation                    |
 
 ### How to Update
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -17,7 +17,15 @@
       "!.work",
       "!.planning",
       "!.pnpm-store",
-      "!docs-site"
+      "!docs-site",
+      "!components/overlays",
+      "!scripts",
+      "!app/api/workflow",
+      "!app/api/workflows",
+      "!lib/workflow-executor.workflow.ts",
+      "!components/settings",
+      "!components/workflow",
+      "!lib/atoms"
     ]
   },
   "linter": {

--- a/docs-site/middleware.ts
+++ b/docs-site/middleware.ts
@@ -11,6 +11,7 @@ const VALID_ROUTES = new Set([
   "keeper-runs",
   "keepers",
   "notifications",
+  "plugins",
   "practices",
   "users-teams-orgs",
   "wallet-management",

--- a/docs/_meta.json
+++ b/docs/_meta.json
@@ -4,6 +4,7 @@
   "getting-started": "Getting Started",
   "keepers": "Nodes",
   "workflows": "Workflows",
+  "plugins": "Plugins",
   "keeper-runs": "Keeper Runs",
   "notifications": "Notifications",
   "wallet-management": "Wallet Management",

--- a/docs/plugins/_meta.json
+++ b/docs/plugins/_meta.json
@@ -1,0 +1,8 @@
+{
+  "overview": "Overview",
+  "web3": "Web3",
+  "discord": "Discord",
+  "telegram": "Telegram",
+  "sendgrid": "SendGrid",
+  "webhook": "Webhook"
+}

--- a/docs/plugins/discord.md
+++ b/docs/plugins/discord.md
@@ -1,0 +1,39 @@
+---
+title: "Discord Plugin"
+description: "Send messages to Discord channels via webhooks."
+---
+
+# Discord Plugin
+
+Send messages to Discord channels using webhook URLs. No bot setup required.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| Send Message | Send a text message to a Discord channel |
+
+## Setup
+
+1. In Discord, go to **Server Settings > Integrations > Webhooks**
+2. Click **New Webhook**, select a channel, and copy the webhook URL
+3. In KeeperHub, go to **Connections > Add Connection > Discord**
+4. Paste the webhook URL and save
+
+## Send Message
+
+Post a message to a Discord channel.
+
+**Inputs:** Message (supports `{{NodeName.field}}` variables)
+
+**Outputs:** `success`, `error`
+
+**When to use:** Alert your team about on-chain events, notify on balance changes, report workflow results, send security alerts.
+
+**Example workflow:**
+```
+Schedule (every 5 min)
+  -> Get Native Token Balance (treasury)
+  -> Condition: balance < 10 ETH
+  -> Discord: "Treasury balance low: {{CheckBalance.balance}} ETH"
+```

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -1,0 +1,43 @@
+---
+title: "Plugins"
+description: "Available workflow plugins for blockchain operations, notifications, and integrations."
+---
+
+# Plugins
+
+Plugins provide the actions available in your workflows. Each plugin adds one or more actions that you can drag onto the workflow canvas and configure.
+
+## Available Plugins
+
+| Plugin | Category | Actions | Credentials Required |
+|--------|----------|---------|---------------------|
+| [Web3](/plugins/web3) | Blockchain | Balance checks, contract reads/writes, transfers, calldata decoding, risk assessment | Wallet (for writes) |
+| [Discord](/plugins/discord) | Notifications | Send messages to channels | Webhook URL |
+| [Telegram](/plugins/telegram) | Notifications | Send messages to chats | Bot token |
+| [SendGrid](/plugins/sendgrid) | Notifications | Send emails | API key |
+| [Webhook](/plugins/webhook) | Integrations | Send HTTP requests to external services | None |
+
+## How Plugins Work
+
+1. **Add an action** -- Drag a plugin action from the action panel onto your workflow canvas
+2. **Configure inputs** -- Set parameters in the right-side panel. Use `{{NodeName.field}}` to reference outputs from previous steps
+3. **Connect nodes** -- Wire the action into your workflow flow using edges
+4. **Run** -- Execute the workflow. Each action runs in sequence following the edges
+
+## Plugin Categories
+
+### Blockchain (Web3)
+
+Core on-chain operations: reading balances, calling smart contracts, transferring tokens, and security analysis. Read-only actions work without a wallet. Write actions require a connected Para wallet.
+
+### Security
+
+Security-focused actions for transaction analysis and risk assessment. These actions use `maxRetries = 0` (fail-safe behavior) to ensure errors block execution rather than silently retrying.
+
+### Notifications
+
+Send alerts and messages through Discord, Telegram, email, and webhooks. Typically used as the final step in monitoring workflows to notify your team when conditions are met.
+
+### Integrations
+
+Connect to external services via webhooks and HTTP requests. Use these to trigger external systems, update dashboards, or integrate with third-party tools.

--- a/docs/plugins/sendgrid.md
+++ b/docs/plugins/sendgrid.md
@@ -1,0 +1,39 @@
+---
+title: "SendGrid Plugin"
+description: "Send emails via SendGrid for workflow notifications and reports."
+---
+
+# SendGrid Plugin
+
+Send transactional emails through SendGrid. Useful for formal notifications, reports, and alerts that need email delivery.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| Send Email | Send an email to one or more recipients |
+
+## Setup
+
+1. Create a [SendGrid account](https://sendgrid.com) and verify a sender identity
+2. Generate an API key at **Settings > API Keys**
+3. In KeeperHub, go to **Connections > Add Connection > SendGrid**
+4. Enter your API key and save
+
+## Send Email
+
+Send an email with customizable subject and body.
+
+**Inputs:** To (email address), From (verified sender), Subject, Body (supports `{{NodeName.field}}` variables)
+
+**Outputs:** `success`, `error`
+
+**When to use:** Daily/weekly DeFi position reports, formal security incident notifications, compliance audit trails, stakeholder updates.
+
+**Example workflow:**
+```
+Schedule (daily at 9:00 UTC)
+  -> Get ERC20 Token Balance (treasury USDC)
+  -> Get Native Token Balance (treasury ETH)
+  -> SendGrid: "Daily Treasury Report - USDC: {{TokenBalance.balance.balance}}, ETH: {{CheckBalance.balance}}"
+```

--- a/docs/plugins/telegram.md
+++ b/docs/plugins/telegram.md
@@ -1,0 +1,41 @@
+---
+title: "Telegram Plugin"
+description: "Send messages to Telegram chats via bot API."
+---
+
+# Telegram Plugin
+
+Send messages to Telegram chats or groups using a bot token.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| Send Message | Send a text message to a Telegram chat |
+
+## Setup
+
+1. Message [@BotFather](https://t.me/BotFather) on Telegram to create a bot
+2. Copy the bot token
+3. Add the bot to your target chat/group
+4. Get the chat ID (message the bot, then check `https://api.telegram.org/bot<token>/getUpdates`)
+5. In KeeperHub, go to **Connections > Add Connection > Telegram**
+6. Enter the bot token and save
+
+## Send Message
+
+Send a text message to a Telegram chat or group.
+
+**Inputs:** Chat ID, Message (supports `{{NodeName.field}}` variables)
+
+**Outputs:** `success`, `error`
+
+**When to use:** Personal alerts for critical events, mobile-friendly notifications, real-time DeFi position updates.
+
+**Example workflow:**
+```
+Schedule (every hour)
+  -> Read Contract: Aave healthFactor()
+  -> Condition: healthFactor < 1.2
+  -> Telegram: "URGENT: Health factor {{ReadContract.result}} - add collateral now"
+```

--- a/docs/plugins/web3.md
+++ b/docs/plugins/web3.md
@@ -1,0 +1,176 @@
+---
+title: "Web3 Plugin"
+description: "Blockchain operations including balance checks, contract interactions, transfers, calldata decoding, and AI-powered risk assessment."
+---
+
+# Web3 Plugin
+
+Interact with EVM-compatible blockchain networks. Read-only actions work without credentials. Write actions require a connected Para wallet.
+
+## Actions
+
+| Action | Category | Credentials | Description |
+|--------|----------|-------------|-------------|
+| Get Native Token Balance | Web3 | No | Check ETH/MATIC/etc. balance of any address |
+| Get ERC20 Token Balance | Web3 | No | Check token balance of any address |
+| Read Contract | Web3 | No | Call view/pure functions on smart contracts |
+| Write Contract | Web3 | Wallet | Execute state-changing contract functions |
+| Transfer Native Token | Web3 | Wallet | Send ETH/MATIC/etc. to a recipient |
+| Transfer ERC20 Token | Web3 | Wallet | Send ERC20 tokens to a recipient |
+| Decode Calldata | Security | No | Decode raw calldata into human-readable function calls |
+| Assess Transaction Risk | Security | No | AI-powered risk scoring with built-in DeFi rules |
+
+---
+
+## Get Native Token Balance
+
+Check the native token balance (ETH, MATIC, etc.) of any address on any supported EVM chain.
+
+**Inputs:** Network, Address
+
+**Outputs:** `success`, `balance` (human-readable), `balanceWei`, `address`, `error`
+
+**When to use:** Monitor wallet balances, trigger refills when balance drops below a threshold, track treasury holdings.
+
+**Example workflow:**
+```
+Schedule (every hour)
+  -> Get Native Token Balance (bot wallet)
+  -> Condition: balance < 0.1 ETH
+  -> Transfer Native Token (refill from treasury)
+  -> Discord: "Bot wallet refilled"
+```
+
+---
+
+## Get ERC20 Token Balance
+
+Check the balance of any ERC20 token for a given address.
+
+**Inputs:** Network, Address, Token (select from supported tokens or enter custom contract)
+
+**Outputs:** `success`, `balance.balance`, `balance.symbol`, `balance.decimals`, `balance.name`, `address`, `error`
+
+**When to use:** Track token holdings, monitor protocol positions, alert on balance changes.
+
+---
+
+## Read Contract
+
+Call view or pure functions on any verified smart contract. Automatically fetches the ABI from block explorers and supports proxy contracts.
+
+**Inputs:** Network, Contract Address, ABI (auto-fetched), Function, Function Arguments
+
+**Outputs:** `success`, `result` (structured based on ABI outputs), `error`
+
+**When to use:** Read on-chain state (prices, positions, governance proposals), check protocol health factors, monitor contract parameters.
+
+**Example workflow:**
+```
+Schedule (every 5 min)
+  -> Read Contract: Aave getLiquidationThreshold()
+  -> Condition: health factor < 1.5
+  -> Discord: "Liquidation risk alert"
+```
+
+---
+
+## Write Contract
+
+Execute state-changing functions on smart contracts using your Para wallet. Requires a connected wallet.
+
+**Inputs:** Network, Contract Address, ABI (auto-fetched), Function, Function Arguments
+
+**Outputs:** `success`, `transactionHash`, `result`, `error`
+
+**When to use:** Execute DeFi operations (harvest, compound, rebalance), respond to on-chain events, automate protocol maintenance.
+
+---
+
+## Transfer Native Token
+
+Send ETH, MATIC, or other native tokens from your Para wallet to a recipient address.
+
+**Inputs:** Network, Amount (ETH), Recipient Address
+
+**Outputs:** `success`, `transactionHash`, `error`
+
+**When to use:** Refill bot wallets, distribute funds, automate payroll.
+
+---
+
+## Transfer ERC20 Token
+
+Send ERC20 tokens from your Para wallet to a recipient address.
+
+**Inputs:** Network, Token, Amount, Recipient Address
+
+**Outputs:** `success`, `transactionHash`, `transactionLink`, `amount`, `symbol`, `recipient`, `error`
+
+**When to use:** Distribute tokens, move funds between wallets, automate token transfers based on conditions.
+
+---
+
+## Decode Calldata
+
+Decode raw transaction calldata into human-readable function calls with parameter names and values. Uses a cascading strategy: manual ABI, block explorer lookup, 4byte.directory, then selector-only fallback.
+
+**Inputs:** Calldata (hex string), Contract Address (optional), Network (optional), ABI Override (optional, advanced)
+
+**Outputs:** `success`, `selector`, `functionName`, `functionSignature`, `parameters` (array with name/type/value), `decodingSource`, `error`
+
+**When to use:** Analyze pending transactions before execution, audit governance proposals, inspect multisig queue items, feed decoded data into risk assessment.
+
+This is a security-critical action (`maxRetries = 0`). On error, it fails rather than retrying.
+
+**Example workflow:**
+```
+Webhook (receives pending tx)
+  -> Decode Calldata: {{Trigger.calldata}}
+  -> Condition: functionName == "transferOwnership"
+  -> Discord: "ALERT: Ownership transfer detected"
+```
+
+---
+
+## Assess Transaction Risk
+
+AI-powered risk assessment that combines built-in DeFi security rules with Claude AI analysis. Produces a risk score (0-100) and detailed risk factors.
+
+**Inputs:** Transaction Calldata, Contract Address (optional), Transaction Value in ETH (optional), Chain (optional), Sender Address (optional)
+
+**Outputs:** `success`, `riskLevel` (low/medium/high/critical), `riskScore` (0-100), `factors` (array of risk descriptions), `decodedFunction`, `reasoning`, `error`
+
+**How it works:**
+
+1. Auto-decodes calldata internally (no need for a separate Decode Calldata step)
+2. Runs built-in rules across 4 categories:
+   - **Approval risks** -- Unlimited approvals (MAX_UINT256), setApprovalForAll
+   - **Privileged operations** -- transferOwnership, upgradeTo, selfdestruct
+   - **Value risks** -- Large ETH transfers (>10 ETH)
+   - **Interaction risks** -- Zero address targets, unknown selectors, generic execution patterns
+3. Critical rule match short-circuits without AI call
+4. Otherwise, enhances assessment with Claude Haiku (3s timeout)
+5. Combines rule-based and AI findings, taking the higher risk level
+
+**Fail-closed policy:** If the AI call fails or times out, the risk level is elevated (not lowered). This is a security-critical action (`maxRetries = 0`).
+
+**When to use:** Guard transactions before execution, score governance proposals, audit multisig queues, build security monitoring workflows.
+
+**Example workflow -- Transaction Guardian:**
+```
+Webhook (receives pending tx from multisig)
+  -> Assess Transaction Risk: {{Trigger.calldata}}
+  -> Condition: riskLevel == "critical" OR riskLevel == "high"
+    -> YES: Discord #security-alerts: "HIGH RISK TX: {{AssessRisk.reasoning}}"
+    -> NO: Discord #operations: "TX approved ({{AssessRisk.riskLevel}})"
+```
+
+**Example workflow -- Approval Monitor:**
+```
+Schedule (every 15 min)
+  -> Read Contract: getApprovalQueue()
+  -> Assess Transaction Risk: {{ReadContract.result.calldata}}
+  -> Condition: riskScore > 50
+  -> SendGrid: "Review required: risk score {{AssessRisk.riskScore}}"
+```

--- a/docs/plugins/webhook.md
+++ b/docs/plugins/webhook.md
@@ -1,0 +1,33 @@
+---
+title: "Webhook Plugin"
+description: "Send HTTP requests to external services and APIs."
+---
+
+# Webhook Plugin
+
+Send HTTP requests to any external URL. No credentials required -- authentication is handled per-request via headers.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| Send Webhook | Send an HTTP POST request with a JSON payload |
+
+## Send Webhook
+
+Send an HTTP request to an external service.
+
+**Inputs:** URL, Payload (JSON, supports `{{NodeName.field}}` variables)
+
+**Outputs:** `success`, `error`
+
+**When to use:** Trigger external systems (CI/CD, Slack incoming webhooks, PagerDuty), push data to analytics platforms, integrate with custom APIs, chain with other automation tools.
+
+**Example workflow:**
+```
+Schedule (every 15 min)
+  -> Read Contract: getPrice()
+  -> Condition: price changed > 5%
+  -> Webhook: POST to analytics API with price data
+  -> Discord: "Price alert: {{ReadContract.result}}"
+```


### PR DESCRIPTION
## Summary
- Adds plugin documentation pages for web3, discord, sendgrid, telegram, and webhook
- Adds `develop-plugin` slash command for AI-assisted plugin development
- Adds `work-*` slash commands for project management workflows
- CLAUDE.md formatting fixes and task-code naming rule
- Adds `@biomejs/biome` as explicit devDependency

## Test plan
- [ ] Docs pages render correctly in docs-site
- [ ] Slash commands are discoverable by Claude Code
- [ ] Lint and type checks pass