### PR TITLE
fix(ci): add explicit branch_name_template for docs-sync workflow

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -248,6 +248,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           base_branch: staging
           branch_prefix: docs-sync-
+          branch_name_template: 'docs-sync-${{ steps.tag.outputs.release_tag }}-{{timestamp}}'
           prompt: |
             REPO: ${{ github.repository }}
             RELEASE TAG: ${{ steps.tag.outputs.release_tag }}


### PR DESCRIPTION
## Summary
- The `claude-code-action` default branch template uses `{{entityType}}-{{entityNumber}}` which are empty for `workflow_run` triggers (no issue/PR context)
- This caused the action to silently skip branch creation -- Claude's 35 turns of work ($1.42) were lost with the ephemeral CI runner
- Added explicit `branch_name_template` using the release tag and timestamp, which are always available

## Root Cause
The docs-sync workflow triggers on `workflow_run` (after a Release completes), not on issue/PR events. The default template `{{prefix}}{{entityType}}-{{entityNumber}}-{{timestamp}}` resolves to an empty string because there is no entity in that context.

## Test plan
- [ ] Re-trigger docs-sync workflow manually after merge
- [ ] Verify a `docs-sync-vX.Y.Z-<timestamp>` branch is created
- [ ] Verify a PR is automatically opened with docs changes