### PR TITLE
refactor: KEEP-1456 replace Or divider with tabs in database connection overlays

### DIFF
--- a/components/overlays/edit-connection-overlay.tsx
+++ b/components/overlays/edit-connection-overlay.tsx
@@ -1,23 +1,18 @@
 "use client";
 
-import { Check, Pencil, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { api, type Integration } from "@/lib/api-client";
-import { hasValidDatabaseConfig } from "@/lib/db/connection-utils";
 // start keeperhub
+import {
+  DatabaseConnectionForm,
+  detectDefaultTab,
+  validateDatabaseConfig,
+  type DatabaseTab,
+} from "@/keeperhub/components/database-connection-form";
 import { getCustomIntegrationFormHandler } from "@/lib/extension-registry";
 import type { IntegrationConfig } from "@/lib/types/integration";
 import { getIntegration, getIntegrationLabels } from "@/plugins";
@@ -56,101 +51,6 @@ type EditConnectionOverlayProps = {
 };
 
 /**
- * Secret field with "Configured" state for edit mode
- */
-function SecretField({
-  fieldId,
-  label,
-  configKey,
-  placeholder,
-  helpText,
-  helpLink,
-  value,
-  onChange,
-}: {
-  fieldId: string;
-  label: string;
-  configKey: string;
-  placeholder?: string;
-  helpText?: string;
-  helpLink?: { url: string; text: string };
-  value: string;
-  onChange: (key: string, value: string) => void;
-}) {
-  const [isEditing, setIsEditing] = useState(false);
-  const isMobile = useIsMobile();
-  const hasNewValue = value.length > 0;
-
-  // Show "Configured" state until user clicks Change
-  if (!(isEditing || hasNewValue)) {
-    return (
-      <div className="space-y-2">
-        <Label htmlFor={fieldId}>{label}</Label>
-        <div className="flex items-center gap-2">
-          <div className="flex h-9 flex-1 items-center gap-2 rounded-md border bg-muted/30 px-3">
-            <Check className="size-4 text-green-600" />
-            <span className="text-muted-foreground text-sm">Configured</span>
-          </div>
-          <Button
-            onClick={() => setIsEditing(true)}
-            type="button"
-            variant="outline"
-          >
-            <Pencil className="mr-1.5 size-3" />
-            Change
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      <Label htmlFor={fieldId}>{label}</Label>
-      <div className="flex items-center gap-2">
-        <Input
-          autoFocus={isEditing && !isMobile}
-          className="flex-1"
-          id={fieldId}
-          onChange={(e) => onChange(configKey, e.target.value)}
-          placeholder={placeholder}
-          type="password"
-          value={value}
-        />
-        {(isEditing || hasNewValue) && (
-          <Button
-            onClick={() => {
-              onChange(configKey, "");
-              setIsEditing(false);
-            }}
-            size="icon"
-            type="button"
-            variant="ghost"
-          >
-            <X className="size-4" />
-          </Button>
-        )}
-      </div>
-      {(helpText || helpLink) && (
-        <p className="text-muted-foreground text-xs">
-          {helpText}
-          {helpLink && (
-            <a
-              className="underline hover:text-foreground"
-              href={helpLink.url}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {helpLink.text}
-            </a>
-          )}
-        </p>
-      )}
-    </div>
-  );
-}
-
-/**
  * Overlay for editing an existing connection
  */
 export function EditConnectionOverlay({
@@ -175,11 +75,21 @@ export function EditConnectionOverlay({
     }
     return {};
   });
+  const [dbTab, setDbTab] = useState<DatabaseTab>(() => {
+    if (hasConfigFromProps && integrationWithConfig.config) {
+      return detectDefaultTab(normalizeConfig(integrationWithConfig.config));
+    }
+    return "url";
+  });
 
   useEffect(() => {
     if (hasConfigFromProps && integrationWithConfig.config) {
       setName(integration.name);
-      setConfig(normalizeConfig(integrationWithConfig.config));
+      const normalized = normalizeConfig(integrationWithConfig.config);
+      setConfig(normalized);
+      if (integration.type === "database") {
+        setDbTab(detectDefaultTab(normalized));
+      }
       setLoading(false);
       return;
     }
@@ -192,7 +102,11 @@ export function EditConnectionOverlay({
           return;
         }
         setName(full.name);
-        setConfig(normalizeConfig(full.config));
+        const normalized = normalizeConfig(full.config);
+        setConfig(normalized);
+        if (integration.type === "database") {
+          setDbTab(detectDefaultTab(normalized));
+        }
         setLoading(false);
       })
       .catch(() => {
@@ -208,6 +122,7 @@ export function EditConnectionOverlay({
   }, [
     integration.id,
     integration.name,
+    integration.type,
     hasConfigFromProps,
     integrationWithConfig.config,
   ]);
@@ -236,10 +151,7 @@ export function EditConnectionOverlay({
     if (!hasNewDatabaseSecrets) {
       return null;
     }
-    if (!hasValidDatabaseConfig(config)) {
-      return "Enter either a connection string or the connection details below.";
-    }
-    return null;
+    return validateDatabaseConfig(config, dbTab);
   };
 
   /**
@@ -419,97 +331,13 @@ export function EditConnectionOverlay({
 
     if (integration.type === "database") {
       return (
-        <div className="space-y-4">
-          <p className="text-muted-foreground text-xs">
-            Enter either a connection string or the connection details below.
-          </p>
-          <SecretField
-            configKey="url"
-            fieldId="db-url"
-            helpText="Connection string: postgresql://user:password@host:port/database (passwords with @ are supported)"
-            label="Connection string"
-            onChange={updateConfig}
-            placeholder="postgresql://user:password@host:port/database"
-            value={config.url || ""}
-          />
-          <div className="border-t pt-3 font-medium text-muted-foreground text-xs">
-            Or use connection details
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label htmlFor="db-host">Host</Label>
-              <Input
-                id="db-host"
-                onChange={(e) => updateConfig("host", e.target.value)}
-                placeholder="e.g. db.example.com or your-provider.supabase.co"
-                value={config.host || ""}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="db-port">Port</Label>
-              <Input
-                id="db-port"
-                onChange={(e) => updateConfig("port", e.target.value)}
-                placeholder="5432"
-                value={config.port || ""}
-              />
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label htmlFor="db-username">Username</Label>
-              <Input
-                id="db-username"
-                onChange={(e) => updateConfig("username", e.target.value)}
-                placeholder="postgres"
-                value={config.username || ""}
-              />
-            </div>
-            <div className="space-y-2">
-              <SecretField
-                configKey="password"
-                fieldId="db-password"
-                label="Password"
-                onChange={updateConfig}
-                placeholder=""
-                value={config.password || ""}
-              />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="db-database">Database name</Label>
-            <Input
-              id="db-database"
-              onChange={(e) => updateConfig("database", e.target.value)}
-              placeholder="postgres"
-              value={config.database || ""}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="database-ssl-mode">SSL mode</Label>
-            <Select
-              onValueChange={(value: string) => updateConfig("sslMode", value)}
-              value={(config.sslMode as string) || "auto"}
-            >
-              <SelectTrigger id="database-ssl-mode">
-                <SelectValue placeholder="SSL mode" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">
-                  Auto (use SSL for remote hosts)
-                </SelectItem>
-                <SelectItem value="require">Require</SelectItem>
-                <SelectItem value="prefer">Prefer</SelectItem>
-                <SelectItem value="disable">Disable</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-muted-foreground text-xs">
-              Use Require for cloud providers (e.g. Supabase). Auto enables SSL
-              for remote hosts. For Supabase, use the connection pooler host if
-              your environment cannot resolve IPv6; the pooler uses IPv4.
-            </p>
-          </div>
-        </div>
+        <DatabaseConnectionForm
+          config={config}
+          defaultTab={dbTab}
+          isEditMode
+          onTabChange={setDbTab}
+          updateConfig={updateConfig}
+        />
       );
     }
 
@@ -517,51 +345,33 @@ export function EditConnectionOverlay({
       return null;
     }
 
-    return formFields.map((field) => {
-      if (field.type === "password") {
-        return (
-          <SecretField
-            configKey={field.configKey}
-            fieldId={field.id}
-            helpLink={field.helpLink}
-            helpText={field.helpText}
-            key={field.id}
-            label={field.label}
-            onChange={updateConfig}
-            placeholder={field.placeholder}
-            value={config[field.configKey] || ""}
-          />
-        );
-      }
-
-      return (
-        <div className="space-y-2" key={field.id}>
-          <Label htmlFor={field.id}>{field.label}</Label>
-          <Input
-            id={field.id}
-            onChange={(e) => updateConfig(field.configKey, e.target.value)}
-            placeholder={field.placeholder}
-            type={field.type}
-            value={config[field.configKey] || ""}
-          />
-          {(field.helpText || field.helpLink) && (
-            <p className="text-muted-foreground text-xs">
-              {field.helpText}
-              {field.helpLink && (
-                <a
-                  className="underline hover:text-foreground"
-                  href={field.helpLink.url}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  {field.helpLink.text}
-                </a>
-              )}
-            </p>
-          )}
-        </div>
-      );
-    });
+    return formFields.map((field) => (
+      <div className="space-y-2" key={field.id}>
+        <Label htmlFor={field.id}>{field.label}</Label>
+        <Input
+          id={field.id}
+          onChange={(e) => updateConfig(field.configKey, e.target.value)}
+          placeholder={field.placeholder}
+          type={field.type}
+          value={config[field.configKey] || ""}
+        />
+        {(field.helpText || field.helpLink) && (
+          <p className="text-muted-foreground text-xs">
+            {field.helpText}
+            {field.helpLink && (
+              <a
+                className="underline hover:text-foreground"
+                href={field.helpLink.url}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {field.helpLink.text}
+              </a>
+            )}
+          </p>
+        )}
+      </div>
+    ));
   };
 
   return (

--- a/components/overlays/overlay.tsx
+++ b/components/overlays/overlay.tsx
@@ -44,7 +44,7 @@ export function Overlay({
   className,
 }: OverlayComponentProps) {
   return (
-    <div className={cn("flex flex-col", className)}>
+    <div className={cn("flex max-h-[85vh] flex-col", className)}>
       {/* Header with smart back button detection */}
       {(title || description) && (
         <SmartOverlayHeader

--- a/keeperhub/components/database-connection-form.tsx
+++ b/keeperhub/components/database-connection-form.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { Check, Pencil, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+export type DatabaseTab = "url" | "details";
+
+type SecretFieldProps = {
+  fieldId: string;
+  label: string;
+  configKey: string;
+  placeholder?: string;
+  helpText?: string;
+  value: string;
+  onChange: (key: string, value: string) => void;
+  isEditMode?: boolean;
+};
+
+function SecretField({
+  fieldId,
+  label,
+  configKey,
+  placeholder,
+  helpText,
+  value,
+  onChange,
+  isEditMode,
+}: SecretFieldProps): React.JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const isMobile = useIsMobile();
+  const hasNewValue = value.length > 0;
+
+  if (isEditMode && !isEditing && !hasNewValue) {
+    return (
+      <div className="space-y-2">
+        <Label htmlFor={fieldId}>{label}</Label>
+        <div className="flex items-center gap-2">
+          <div className="flex h-9 flex-1 items-center gap-2 rounded-md border bg-muted/30 px-3">
+            <Check className="size-4 text-green-600" />
+            <span className="text-muted-foreground text-sm">Configured</span>
+          </div>
+          <Button
+            onClick={() => setIsEditing(true)}
+            type="button"
+            variant="outline"
+          >
+            <Pencil className="mr-1.5 size-3" />
+            Change
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={fieldId}>{label}</Label>
+      <div className="flex items-center gap-2">
+        <Input
+          autoFocus={isEditMode && isEditing && !isMobile}
+          className="flex-1"
+          id={fieldId}
+          onChange={(e) => onChange(configKey, e.target.value)}
+          placeholder={placeholder}
+          type="password"
+          value={value}
+        />
+        {isEditMode && (isEditing || hasNewValue) && (
+          <Button
+            onClick={() => {
+              onChange(configKey, "");
+              setIsEditing(false);
+            }}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <X className="size-4" />
+          </Button>
+        )}
+      </div>
+      {helpText && <p className="text-muted-foreground text-xs">{helpText}</p>}
+    </div>
+  );
+}
+
+type DatabaseConnectionFormProps = {
+  config: Record<string, string>;
+  updateConfig: (key: string, value: string) => void;
+  isEditMode?: boolean;
+  onTabChange?: (tab: DatabaseTab) => void;
+  defaultTab?: DatabaseTab;
+};
+
+export function DatabaseConnectionForm({
+  config,
+  updateConfig,
+  isEditMode = false,
+  onTabChange,
+  defaultTab = "url",
+}: DatabaseConnectionFormProps): React.JSX.Element {
+  const [activeTab, setActiveTab] = useState<DatabaseTab>(defaultTab);
+
+  useEffect(() => {
+    setActiveTab(defaultTab);
+  }, [defaultTab]);
+
+  const handleTabChange = (value: string): void => {
+    const tab = value as DatabaseTab;
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
+
+  return (
+    <Tabs onValueChange={handleTabChange} value={activeTab}>
+      <TabsList className="w-full">
+        <TabsTrigger value="url">Connection String</TabsTrigger>
+        <TabsTrigger value="details">Connection Details</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="url">
+        <div className="space-y-4 pt-2">
+          <SecretField
+            configKey="url"
+            fieldId="db-url"
+            helpText="Format: postgresql://user:password@host:port/database"
+            isEditMode={isEditMode}
+            label="Connection string"
+            onChange={updateConfig}
+            placeholder="postgresql://user:password@host:port/database"
+            value={config.url || ""}
+          />
+        </div>
+      </TabsContent>
+
+      <TabsContent value="details">
+        <div className="space-y-4 pt-2">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="db-host">Host</Label>
+              <Input
+                id="db-host"
+                onChange={(e) => updateConfig("host", e.target.value)}
+                placeholder="e.g. db.example.com"
+                value={config.host || ""}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="db-port">Port</Label>
+              <Input
+                id="db-port"
+                onChange={(e) => updateConfig("port", e.target.value)}
+                placeholder="5432"
+                value={config.port || ""}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="db-username">Username</Label>
+              <Input
+                id="db-username"
+                onChange={(e) => updateConfig("username", e.target.value)}
+                placeholder="postgres"
+                value={config.username || ""}
+              />
+            </div>
+            <div className="space-y-2">
+              <SecretField
+                configKey="password"
+                fieldId="db-password"
+                isEditMode={isEditMode}
+                label="Password"
+                onChange={updateConfig}
+                placeholder=""
+                value={config.password || ""}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="db-database">Database name</Label>
+            <Input
+              id="db-database"
+              onChange={(e) => updateConfig("database", e.target.value)}
+              placeholder="postgres"
+              value={config.database || ""}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="database-ssl-mode">SSL mode</Label>
+            <Select
+              onValueChange={(value: string) => updateConfig("sslMode", value)}
+              value={(config.sslMode as string) || "auto"}
+            >
+              <SelectTrigger id="database-ssl-mode">
+                <SelectValue placeholder="SSL mode" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">
+                  Auto (use SSL for remote hosts)
+                </SelectItem>
+                <SelectItem value="require">Require</SelectItem>
+                <SelectItem value="prefer">Prefer</SelectItem>
+                <SelectItem value="disable">Disable</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-muted-foreground text-xs">
+              Use Require for cloud providers (e.g. Supabase). Auto enables SSL
+              for remote hosts. For Supabase, use the connection pooler host if
+              your environment cannot resolve IPv6; the pooler uses IPv4.
+            </p>
+          </div>
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+/**
+ * Validates database config based on the active tab.
+ * Returns an error message string, or null if valid.
+ */
+export function validateDatabaseConfig(
+  config: Record<string, string>,
+  activeTab: DatabaseTab
+): string | null {
+  if (activeTab === "url") {
+    const hasUrl = typeof config.url === "string" && config.url.trim() !== "";
+    if (!hasUrl) {
+      return "Please enter a connection string.";
+    }
+    return null;
+  }
+
+  const hasHost = typeof config.host === "string" && config.host.trim() !== "";
+  const hasUsername =
+    typeof config.username === "string" && config.username.trim() !== "";
+  const hasDatabase =
+    typeof config.database === "string" && config.database.trim() !== "";
+
+  if (!(hasHost && hasUsername && hasDatabase)) {
+    return "Please fill in at least the host, username, and database fields.";
+  }
+  return null;
+}
+
+/**
+ * Detects which tab to default to based on existing config values.
+ * For edit mode: if URL was configured, use "url" tab; if host fields exist, use "details".
+ */
+export function detectDefaultTab(config: Record<string, string>): DatabaseTab {
+  const hasDetailFields =
+    (config.host !== undefined && config.host !== "") ||
+    (config.username !== undefined && config.username !== "") ||
+    (config.database !== undefined && config.database !== "");
+
+  if (hasDetailFields) {
+    return "details";
+  }
+  return "url";
+}


### PR DESCRIPTION
## Summary

- Extract shared `DatabaseConnectionForm` component with tab-based UI (Connection String / Connection Details) replacing the unintuitive "Or use connection details" divider
- Both add and edit connection overlays now use the shared component, reducing code duplication
- Add `max-h` constraint to `Overlay` for proper scrolling on small viewports