### PR TITLE
fix(ci): enable show_full_output for docs-sync debugging

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -329,6 +329,7 @@ jobs:
           base_branch: staging
           branch_prefix: docs-sync-
           branch_name_template: 'docs-sync-${{ steps.tag.outputs.release_tag }}-{{timestamp}}'
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             RELEASE TAG: ${{ steps.tag.outputs.release_tag }}


### PR DESCRIPTION
## Summary
- Enable `show_full_output: true` on claude-code-action to diagnose why the last run reported docs were updated but no branch/PR was created

## Context
Run #22079929770 completed in 35 turns ($1.64) and Claude's summary said it committed changes to 3 doc files, but no `branch_name` output was set and no PR appeared. Need full logs to see actual tool calls.