### PR TITLE
fix(ci): re-set git remote URL for docs-sync push step

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -491,6 +491,8 @@ jobs:
 
           echo "Found $COMMIT_COUNT new commit(s). Pushing branch and creating PR."
 
+          # Re-set remote URL with token (claude-code-action reconfigures git auth)
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH"
 
           BODY="Automated documentation sync triggered by release/manual workflow."


### PR DESCRIPTION
## Summary
- `claude-code-action` reconfigures git auth during its run, which breaks `git push` in subsequent steps
- Adds `git remote set-url` with the GH_TOKEN before pushing the docs branch

## Test plan
- [ ] Trigger docs-sync workflow and verify branch push + PR creation succeeds