### PR TITLE
fix(ci): use UTC dates in release workflow PR discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
 
           # Upper bound: the author date of HEAD (the prod push commit).
           # This prevents including staging PRs merged after the prod push.
-          UNTIL=$(git log -1 --format=%aI HEAD)
+          # Force UTC output so string comparison works with GitHub API dates (also UTC).
+          UNTIL=$(TZ=UTC git log -1 --format='%ad' --date=format-local:'%Y-%m-%dT%H:%M:%SZ' HEAD)
           echo "Upper bound (HEAD author date): $UNTIL"
 
           if [ "$FIRST_RELEASE" = "true" ]; then
@@ -60,8 +61,8 @@ jobs:
               --limit 200 \
               --jq "[.[] | select(.mergedAt <= \"$UNTIL\")]")
           else
-            # Get the date of the previous tag commit
-            SINCE=$(git log -1 --format=%aI "$PREV_TAG")
+            # Get the date of the previous tag commit (UTC to match GitHub API dates)
+            SINCE=$(TZ=UTC git log -1 --format='%ad' --date=format-local:'%Y-%m-%dT%H:%M:%SZ' "$PREV_TAG")
             echo "Finding PRs merged after: $SINCE and before: $UNTIL"
 
             PR_JSON=$(gh pr list \


### PR DESCRIPTION
## Summary

- Fix timezone mismatch in release workflow that caused PR #357's prod deploy to skip release creation
- `git log --format=%aI` outputs dates with the commit author's timezone offset (e.g. `+11:00`), but GitHub API `mergedAt` dates use UTC (`Z` suffix)
- jq string comparison across different timezone representations produces incorrect results, excluding valid PRs
- Force UTC output with `TZ=UTC` + `--date=format-local` so both sides use the same format

## Context

PR #357 (To Prod) merged 7 PRs from staging but the Release workflow found 0 PRs due to this bug, skipping release creation entirely.

## Test plan

- [ ] Verify next prod deploy correctly discovers PRs and creates a release