### PR TITLE
feat: KEEP-1443 Batch Read Contract

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -171,12 +171,12 @@ function SchemaBuilderField(props: FieldProps) {
   );
 }
 
-type AbiFunctionSelectProps = FieldProps & {
+export type AbiFunctionSelectProps = FieldProps & {
   abiValue: string;
   functionFilter?: "read" | "write";
 };
 
-function AbiFunctionSelectField({
+export function AbiFunctionSelectField({
   field,
   value,
   onChange,
@@ -270,12 +270,12 @@ function AbiFunctionSelectField({
   );
 }
 
-type AbiFunctionArgsProps = FieldProps & {
+export type AbiFunctionArgsProps = FieldProps & {
   abiValue: string;
   functionValue: string;
 };
 
-function AbiFunctionArgsField({
+export function AbiFunctionArgsField({
   field,
   value,
   onChange,

--- a/docs/plugins/web3.md
+++ b/docs/plugins/web3.md
@@ -143,11 +143,11 @@ Uses Multicall3's `aggregate3` with `allowFailure: true`. If one call reverts, t
 
 ### Cross-Chain Execution (Mixed Mode)
 
-When mixed mode calls target different networks, calls are automatically grouped by network. Each network group is executed as a separate Multicall3 call, and results are merged back in the original call order. This means you can batch reads across Ethereum, Polygon, and Arbitrum in a single node.
+When mixed mode calls target different networks, calls are automatically grouped by network. Each network group is executed in parallel via `Promise.all`, and results are merged back in the original call order. This means you can batch reads across Ethereum, Polygon, and Arbitrum in a single node with minimal latency overhead.
 
 ### Batch Size
 
-The `batchSize` parameter (default: 100) controls how many calls are included in each Multicall3 RPC request. If you have 250 calls with a batch size of 100, the node sends 3 sequential RPC requests (100 + 100 + 50). Lower values reduce payload size and are useful when RPC providers have response size limits.
+The `batchSize` parameter (default: 100, max: 500) controls how many calls are included in each Multicall3 RPC request. If you have 250 calls with a batch size of 100, the node sends 3 sequential RPC requests (100 + 100 + 50). Lower values reduce payload size and are useful when RPC providers have response size limits. Maximum total calls per execution is 5000.
 
 ### Result Structure
 

--- a/keeperhub/components/workflow/config/args-list-field.tsx
+++ b/keeperhub/components/workflow/config/args-list-field.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
+import type { ActionConfigFieldBase } from "@/plugins/registry";
+
+type FunctionInput = {
+  name: string;
+  type: string;
+};
+
+type ArgSetEntry = {
+  id: number;
+  values: string[];
+};
+
+function parseFunctionInputs(
+  abiValue: string,
+  functionValue: string
+): FunctionInput[] {
+  if (!(abiValue && functionValue && abiValue.trim() && functionValue.trim())) {
+    return [];
+  }
+
+  try {
+    const abi: unknown = JSON.parse(abiValue);
+    if (!Array.isArray(abi)) {
+      return [];
+    }
+
+    const func = abi.find(
+      (item: Record<string, unknown>) =>
+        item.type === "function" && item.name === functionValue
+    );
+
+    if (!(func?.inputs && Array.isArray(func.inputs))) {
+      return [];
+    }
+
+    return func.inputs.map((input: { name: string; type: string }) => ({
+      name: input.name || "unnamed",
+      type: input.type,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function parseArgsListValue(
+  value: string,
+  paramCount: number,
+  nextId: () => number
+): ArgSetEntry[] {
+  if (!value) {
+    return [{ id: nextId(), values: new Array(paramCount).fill("") }];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return [{ id: nextId(), values: new Array(paramCount).fill("") }];
+    }
+
+    return parsed.map((argSet: unknown) => {
+      const arr = Array.isArray(argSet) ? argSet : [];
+      const values: string[] = [];
+      for (let i = 0; i < paramCount; i++) {
+        values.push(
+          arr[i] !== undefined && arr[i] !== null ? String(arr[i]) : ""
+        );
+      }
+      return { id: nextId(), values };
+    });
+  } catch {
+    return [{ id: nextId(), values: new Array(paramCount).fill("") }];
+  }
+}
+
+function serializeArgsList(entries: ArgSetEntry[]): string {
+  const sets = entries
+    .filter((e) => e.values.some((v) => v.trim() !== ""))
+    .map((e) => e.values);
+  return sets.length > 0 ? JSON.stringify(sets) : "";
+}
+
+type ArgsListFieldProps = {
+  field: ActionConfigFieldBase;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  abiValue: string;
+  functionValue: string;
+};
+
+export function ArgsListField({
+  field,
+  value,
+  onChange,
+  disabled,
+  abiValue,
+  functionValue,
+}: ArgsListFieldProps): React.ReactNode {
+  const idCounter = useRef(0);
+  const nextId = (): number => {
+    idCounter.current += 1;
+    return idCounter.current;
+  };
+
+  const functionInputs = useMemo(
+    () => parseFunctionInputs(abiValue, functionValue),
+    [abiValue, functionValue]
+  );
+
+  const paramCount = functionInputs.length;
+
+  const [entries, setEntries] = useState<ArgSetEntry[]>(() =>
+    parseArgsListValue(value, paramCount, nextId)
+  );
+
+  // Reset entries when function changes
+  const lastFunctionRef = useRef(functionValue);
+  if (functionValue !== lastFunctionRef.current) {
+    lastFunctionRef.current = functionValue;
+    const newEntries = parseArgsListValue("", paramCount, nextId);
+    setEntries(newEntries);
+    onChange("");
+  }
+
+  function updateEntries(updated: ArgSetEntry[]): void {
+    setEntries(updated);
+    onChange(serializeArgsList(updated));
+  }
+
+  function addRow(): void {
+    updateEntries([
+      ...entries,
+      { id: nextId(), values: new Array(paramCount).fill("") },
+    ]);
+  }
+
+  function removeRow(targetId: number): void {
+    const updated = entries.filter((e) => e.id !== targetId);
+    updateEntries(
+      updated.length > 0
+        ? updated
+        : [{ id: nextId(), values: new Array(paramCount).fill("") }]
+    );
+  }
+
+  function updateArgValue(
+    targetId: number,
+    argIndex: number,
+    argValue: string
+  ): void {
+    const updated = entries.map((entry) => {
+      if (entry.id !== targetId) {
+        return entry;
+      }
+      const newValues = [...entry.values];
+      newValues[argIndex] = argValue;
+      return { ...entry, values: newValues };
+    });
+    updateEntries(updated);
+  }
+
+  if (paramCount === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-3 text-center text-muted-foreground text-sm">
+        {functionValue
+          ? "This function has no parameters"
+          : "Select a function above to configure arguments"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.map((entry, index) => (
+        <div
+          className="rounded-md border border-border space-y-2 p-3"
+          key={entry.id}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground">
+              Call {index + 1}
+            </span>
+            {entries.length > 1 && (
+              <Button
+                className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                disabled={disabled}
+                onClick={() => removeRow(entry.id)}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+
+          {functionInputs.map((input, argIndex) => (
+            <div
+              className="space-y-1.5"
+              key={`${field.key}-${entry.id}-arg-${argIndex}`}
+            >
+              <label
+                className="text-xs font-medium"
+                htmlFor={`${field.key}-${entry.id}-${argIndex}`}
+              >
+                {input.name}{" "}
+                <span className="text-muted-foreground">({input.type})</span>
+              </label>
+              <TemplateBadgeInput
+                disabled={disabled}
+                id={`${field.key}-${entry.id}-${argIndex}`}
+                onChange={(val) =>
+                  updateArgValue(entry.id, argIndex, String(val))
+                }
+                placeholder={`Enter ${input.type} value or {{NodeName.value}}`}
+                value={entry.values[argIndex] ?? ""}
+              />
+            </div>
+          ))}
+        </div>
+      ))}
+
+      <Button
+        className="w-full"
+        disabled={disabled}
+        onClick={addRow}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <Plus className="mr-1.5 h-3.5 w-3.5" />
+        Add Arg Set
+      </Button>
+    </div>
+  );
+}

--- a/keeperhub/components/workflow/config/args-list-field.tsx
+++ b/keeperhub/components/workflow/config/args-list-field.tsx
@@ -16,7 +16,7 @@ type ArgSetEntry = {
   values: string[];
 };
 
-function parseFunctionInputs(
+export function parseFunctionInputs(
   abiValue: string,
   functionValue: string
 ): FunctionInput[] {
@@ -48,7 +48,7 @@ function parseFunctionInputs(
   }
 }
 
-function parseArgsListValue(
+export function parseArgsListValue(
   value: string,
   paramCount: number,
   nextId: () => number
@@ -78,7 +78,7 @@ function parseArgsListValue(
   }
 }
 
-function serializeArgsList(entries: ArgSetEntry[]): string {
+export function serializeArgsList(entries: ArgSetEntry[]): string {
   const sets = entries
     .filter((e) => e.values.some((v) => v.trim() !== ""))
     .map((e) => e.values);

--- a/keeperhub/components/workflow/config/call-list-field.tsx
+++ b/keeperhub/components/workflow/config/call-list-field.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
+import {
+  AbiFunctionArgsField,
+  AbiFunctionSelectField,
+} from "@/components/workflow/config/action-config-renderer";
+
+import { SaveAddressBookmark } from "@/keeperhub/components/address-book/save-address-bookmark";
+import type { ActionConfigFieldBase } from "@/plugins/registry";
+import { AbiWithAutoFetchField } from "./abi-with-auto-fetch-field";
+import { ChainSelectField } from "./chain-select-field";
+
+type CallEntry = {
+  id: number;
+  network: string;
+  contractAddress: string;
+  abi: string;
+  abiFunction: string;
+  args: string;
+};
+
+function createEmptyEntry(id: number): CallEntry {
+  return {
+    id,
+    network: "",
+    contractAddress: "",
+    abi: "",
+    abiFunction: "",
+    args: "",
+  };
+}
+
+function parseCallsValue(value: string, nextId: () => number): CallEntry[] {
+  if (!value) {
+    return [createEmptyEntry(nextId())];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return [createEmptyEntry(nextId())];
+    }
+    return parsed.map((item: Record<string, unknown>) => ({
+      id: nextId(),
+      network: String(item.network ?? ""),
+      contractAddress: String(item.contractAddress ?? ""),
+      abi: String(item.abi ?? ""),
+      abiFunction: String(item.abiFunction ?? ""),
+      args: Array.isArray(item.args) ? JSON.stringify(item.args) : "",
+    }));
+  } catch {
+    return [createEmptyEntry(nextId())];
+  }
+}
+
+function serializeCalls(entries: CallEntry[]): string {
+  const calls = entries
+    .filter((e) => e.contractAddress.trim() || e.abiFunction.trim())
+    .map((e) => {
+      let args: unknown[] = [];
+      if (e.args.trim()) {
+        try {
+          const parsed: unknown = JSON.parse(e.args);
+          args = Array.isArray(parsed) ? parsed : [parsed];
+        } catch {
+          args = [e.args];
+        }
+      }
+      return {
+        network: e.network,
+        contractAddress: e.contractAddress,
+        abi: e.abi,
+        abiFunction: e.abiFunction,
+        args,
+      };
+    });
+  return calls.length > 0 ? JSON.stringify(calls) : "";
+}
+
+type CallListFieldProps = {
+  field: ActionConfigFieldBase;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+};
+
+export function CallListField({
+  field,
+  value,
+  onChange,
+  disabled,
+}: CallListFieldProps): React.ReactNode {
+  const idCounter = useRef(0);
+  const nextId = (): number => {
+    idCounter.current += 1;
+    return idCounter.current;
+  };
+
+  const [entries, setEntries] = useState<CallEntry[]>(() =>
+    parseCallsValue(value, nextId)
+  );
+
+  function updateEntries(updated: CallEntry[]): void {
+    setEntries(updated);
+    onChange(serializeCalls(updated));
+  }
+
+  function addRow(): void {
+    updateEntries([...entries, createEmptyEntry(nextId())]);
+  }
+
+  function removeRow(targetId: number): void {
+    const updated = entries.filter((e) => e.id !== targetId);
+    updateEntries(updated.length > 0 ? updated : [createEmptyEntry(nextId())]);
+  }
+
+  function updateField(
+    targetId: number,
+    key: keyof Omit<CallEntry, "id">,
+    fieldValue: string
+  ): void {
+    const updated = entries.map((entry) =>
+      entry.id === targetId ? { ...entry, [key]: fieldValue } : entry
+    );
+    updateEntries(updated);
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.map((entry, index) => (
+        <CallRow
+          disabled={disabled}
+          entry={entry}
+          fieldKey={field.key}
+          index={index}
+          key={entry.id}
+          onRemove={entries.length > 1 ? () => removeRow(entry.id) : undefined}
+          onUpdate={(key, val) => updateField(entry.id, key, val)}
+        />
+      ))}
+
+      <Button
+        className="w-full"
+        disabled={disabled}
+        onClick={addRow}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <Plus className="mr-1.5 h-3.5 w-3.5" />
+        Add Call
+      </Button>
+    </div>
+  );
+}
+
+type CallRowProps = {
+  entry: CallEntry;
+  index: number;
+  fieldKey: string;
+  disabled?: boolean;
+  onUpdate: (key: keyof Omit<CallEntry, "id">, value: string) => void;
+  onRemove?: () => void;
+};
+
+function CallRow({
+  entry,
+  index,
+  fieldKey,
+  disabled,
+  onUpdate,
+  onRemove,
+}: CallRowProps): React.ReactNode {
+  const rowConfig = useMemo<Record<string, unknown>>(
+    () => ({
+      contractAddress: entry.contractAddress,
+      network: entry.network,
+    }),
+    [entry.contractAddress, entry.network]
+  );
+
+  return (
+    <div className="rounded-md border border-border space-y-2 p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">
+          Call {index + 1}
+        </span>
+        {onRemove && (
+          <Button
+            className="h-6 w-6 text-muted-foreground hover:text-destructive"
+            disabled={disabled}
+            onClick={onRemove}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          className="text-xs font-medium"
+          htmlFor={`${fieldKey}-net-${entry.id}`}
+        >
+          Network
+        </label>
+        <ChainSelectField
+          chainTypeFilter="evm"
+          disabled={disabled}
+          field={{
+            key: `${fieldKey}-net-${entry.id}`,
+            label: "Network",
+            type: "chain-select",
+          }}
+          onChange={(val) => onUpdate("network", String(val))}
+          value={entry.network}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          className="text-xs font-medium"
+          htmlFor={`${fieldKey}-addr-${entry.id}`}
+        >
+          Contract Address
+        </label>
+        <SaveAddressBookmark address={entry.contractAddress}>
+          <TemplateBadgeInput
+            disabled={disabled}
+            id={`${fieldKey}-addr-${entry.id}`}
+            onChange={(val) => onUpdate("contractAddress", val)}
+            placeholder="0x... or {{NodeName.address}}"
+            value={entry.contractAddress}
+          />
+        </SaveAddressBookmark>
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          className="text-xs font-medium"
+          htmlFor={`${fieldKey}-abi-${entry.id}`}
+        >
+          ABI
+        </label>
+        <AbiWithAutoFetchField
+          config={rowConfig}
+          contractInteractionType="read"
+          disabled={disabled}
+          field={{
+            key: `${fieldKey}-abi-${entry.id}`,
+            label: "ABI",
+            type: "abi-with-auto-fetch",
+          }}
+          onChange={(val) => onUpdate("abi", String(val))}
+          value={entry.abi}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          className="text-xs font-medium"
+          htmlFor={`${fieldKey}-fn-${entry.id}`}
+        >
+          Function
+        </label>
+        <AbiFunctionSelectField
+          abiValue={entry.abi}
+          disabled={disabled}
+          field={{
+            key: `${fieldKey}-fn-${entry.id}`,
+            label: "Function",
+            type: "abi-function-select",
+            placeholder: "Select a function",
+          }}
+          functionFilter="read"
+          onChange={(val) => onUpdate("abiFunction", String(val))}
+          value={entry.abiFunction}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          className="text-xs font-medium"
+          htmlFor={`${fieldKey}-args-${entry.id}`}
+        >
+          Function Arguments
+        </label>
+        <AbiFunctionArgsField
+          abiValue={entry.abi}
+          disabled={disabled}
+          field={{
+            key: `${fieldKey}-args-${entry.id}`,
+            label: "Function Arguments",
+            type: "abi-function-args",
+          }}
+          functionValue={entry.abiFunction}
+          onChange={(val) => onUpdate("args", String(val))}
+          value={entry.args}
+        />
+      </div>
+    </div>
+  );
+}

--- a/keeperhub/lib/extensions.tsx
+++ b/keeperhub/lib/extensions.tsx
@@ -14,6 +14,7 @@ import { SendGridConnectionSection } from "@/keeperhub/components/settings/sendg
 import { Web3WalletSection } from "@/keeperhub/components/settings/web3-wallet-section";
 import { AbiEventSelectField } from "@/keeperhub/components/workflow/config/abi-event-select-field";
 import { AbiWithAutoFetchField } from "@/keeperhub/components/workflow/config/abi-with-auto-fetch-field";
+import { CallListField } from "@/keeperhub/components/workflow/config/call-list-field";
 import { ChainSelectField } from "@/keeperhub/components/workflow/config/chain-select-field";
 import { GasLimitMultiplierField } from "@/keeperhub/components/workflow/config/gas-limit-multiplier-field";
 import { TokenSelectField } from "@/keeperhub/components/workflow/config/token-select-field";
@@ -169,6 +170,34 @@ registerFieldRenderer(
           disabled={disabled}
           field={field}
           onChange={(val: unknown) => onUpdateConfig(field.key, val)}
+          value={value}
+        />
+      </div>
+    );
+  }
+);
+
+/**
+ * Call List Builder Field
+ * Dynamic list of contract call rows for batch-read-contract mixed mode
+ * Each row configures: network, contract address, ABI, function, and arguments
+ */
+registerFieldRenderer(
+  "call-list-builder",
+  ({ field, config, onUpdateConfig, disabled }) => {
+    const value =
+      (config[field.key] as string | undefined) ?? field.defaultValue ?? "";
+
+    return (
+      <div className="space-y-2" key={field.key}>
+        <Label className="ml-1" htmlFor={field.key}>
+          {field.label}
+          {field.required && <span className="text-red-500">*</span>}
+        </Label>
+        <CallListField
+          disabled={disabled}
+          field={field}
+          onChange={(val: string) => onUpdateConfig(field.key, val)}
           value={value}
         />
       </div>

--- a/keeperhub/lib/extensions.tsx
+++ b/keeperhub/lib/extensions.tsx
@@ -14,6 +14,7 @@ import { SendGridConnectionSection } from "@/keeperhub/components/settings/sendg
 import { Web3WalletSection } from "@/keeperhub/components/settings/web3-wallet-section";
 import { AbiEventSelectField } from "@/keeperhub/components/workflow/config/abi-event-select-field";
 import { AbiWithAutoFetchField } from "@/keeperhub/components/workflow/config/abi-with-auto-fetch-field";
+import { ArgsListField } from "@/keeperhub/components/workflow/config/args-list-field";
 import { CallListField } from "@/keeperhub/components/workflow/config/call-list-field";
 import { ChainSelectField } from "@/keeperhub/components/workflow/config/chain-select-field";
 import { GasLimitMultiplierField } from "@/keeperhub/components/workflow/config/gas-limit-multiplier-field";
@@ -197,6 +198,39 @@ registerFieldRenderer(
         <CallListField
           disabled={disabled}
           field={field}
+          onChange={(val: string) => onUpdateConfig(field.key, val)}
+          value={value}
+        />
+      </div>
+    );
+  }
+);
+
+/**
+ * Args List Builder Field
+ * Dynamic list of argument sets for batch-read-contract uniform mode
+ * Each row shows labeled inputs based on the selected function's ABI signature
+ */
+registerFieldRenderer(
+  "args-list-builder",
+  ({ field, config, onUpdateConfig, disabled }) => {
+    const abiField = field.abiField || "abi";
+    const functionField = field.abiFunctionField || "abiFunction";
+    const abiValue = (config[abiField] as string | undefined) ?? "";
+    const functionValue = (config[functionField] as string | undefined) ?? "";
+    const value =
+      (config[field.key] as string | undefined) ?? field.defaultValue ?? "";
+
+    return (
+      <div className="space-y-2" key={field.key}>
+        <Label className="ml-1" htmlFor={field.key}>
+          {field.label}
+        </Label>
+        <ArgsListField
+          abiValue={abiValue}
+          disabled={disabled}
+          field={field}
+          functionValue={functionValue}
           onChange={(val: string) => onUpdateConfig(field.key, val)}
           value={value}
         />

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -796,11 +796,11 @@ const web3Plugin: IntegrationPlugin = {
         {
           key: "argsList",
           label: "Args List",
-          type: "template-textarea",
-          placeholder: '[["0xaddr1"], ["0xaddr2"]] or {{NodeName.argsList}}',
-          rows: 4,
+          type: "args-list-builder",
+          abiField: "abi",
+          abiFunctionField: "abiFunction",
           helpTip:
-            'JSON array of argument arrays. Each inner array is the args for one call. Example: [["0xPool1"], ["0xPool2"]] for balanceOf(address).',
+            "Add argument sets for each call. Each row represents one call with the selected function's parameters.",
           showWhen: { field: "inputMode", oneOf: ["uniform", ""] },
         },
         {

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -709,6 +709,130 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "batch-read-contract",
+      label: "Batch Read Contract",
+      description:
+        "Call the same contract function with multiple argument sets in a single RPC call using Multicall3",
+      category: "Web3",
+      stepFunction: "batchReadContractStep",
+      stepImportPath: "batch-read-contract",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the batch call succeeded",
+        },
+        {
+          field: "results",
+          description:
+            "Array of results in call order, each with { success, result, error? }",
+        },
+        {
+          field: "totalCalls",
+          description: "Total number of calls executed",
+        },
+        {
+          field: "error",
+          description: "Error message if the entire batch failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "inputMode",
+          label: "Input Mode",
+          type: "select",
+          options: [
+            {
+              value: "uniform",
+              label: "Same function, multiple args",
+            },
+            {
+              value: "mixed",
+              label: "Different contracts/functions",
+            },
+          ],
+          defaultValue: "uniform",
+          required: true,
+          helpTip:
+            "Uniform: one contract + one function + array of arg sets. Mixed: each call has its own contract, function, and args.",
+        },
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          placeholder: "Select network",
+          required: true,
+          showWhen: { field: "inputMode", oneOf: ["uniform", ""] },
+        },
+        {
+          key: "contractAddress",
+          label: "Contract Address",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.contractAddress}}",
+          example: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          required: true,
+          showWhen: { field: "inputMode", oneOf: ["uniform", ""] },
+        },
+        {
+          key: "abi",
+          label: "Contract ABI",
+          type: "abi-with-auto-fetch",
+          contractAddressField: "contractAddress",
+          contractInteractionType: "read",
+          networkField: "network",
+          rows: 6,
+          required: true,
+          showWhen: { field: "inputMode", oneOf: ["uniform", ""] },
+        },
+        {
+          key: "abiFunction",
+          label: "Function",
+          type: "abi-function-select",
+          abiField: "abi",
+          placeholder: "Select a function",
+          required: true,
+          showWhen: { field: "inputMode", oneOf: ["uniform", ""] },
+        },
+        {
+          key: "argsList",
+          label: "Args List",
+          type: "template-textarea",
+          placeholder: '[["0xaddr1"], ["0xaddr2"]] or {{NodeName.argsList}}',
+          rows: 4,
+          helpTip:
+            'JSON array of argument arrays. Each inner array is the args for one call. Example: [["0xPool1"], ["0xPool2"]] for balanceOf(address).',
+          showWhen: { field: "inputMode", oneOf: ["uniform", ""] },
+        },
+        {
+          key: "calls",
+          label: "Calls",
+          type: "call-list-builder",
+          required: true,
+          helpTip:
+            "Add contract calls to batch. Each call has its own network, contract address, ABI, function, and arguments.",
+          showWhen: { field: "inputMode", equals: "mixed" },
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "batchSize",
+              label: "Batch Size",
+              type: "number",
+              placeholder: "100",
+              defaultValue: "100",
+              min: 1,
+              max: 500,
+              helpTip:
+                "Maximum calls per Multicall3 request. Lower values reduce RPC payload size.",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "write-contract",
       label: "Write Contract",
       description: "Write data to a smart contract (state-changing functions)",

--- a/keeperhub/plugins/web3/steps/batch-read-contract.ts
+++ b/keeperhub/plugins/web3/steps/batch-read-contract.ts
@@ -1,0 +1,760 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
+import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { MULTICALL3_ABI, MULTICALL3_ADDRESS } from "@/lib/contracts";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const LOG_PREFIX = "[Batch Read Contract]";
+const DEFAULT_BATCH_SIZE = 100;
+
+/**
+ * Get userId from executionId by querying the workflowExecutions table
+ */
+async function getUserIdFromExecution(
+  executionId: string | undefined
+): Promise<string | undefined> {
+  if (!executionId) {
+    return;
+  }
+
+  const execution = await db
+    .select({ userId: workflowExecutions.userId })
+    .from(workflowExecutions)
+    .where(eq(workflowExecutions.id, executionId))
+    .limit(1);
+
+  return execution[0]?.userId;
+}
+
+type CallResult = {
+  success: boolean;
+  result: unknown;
+  error?: string;
+};
+
+type BatchReadContractResult =
+  | { success: true; results: CallResult[]; totalCalls: number }
+  | { success: false; error: string };
+
+export type BatchReadContractCoreInput = {
+  network?: string;
+  abi?: string;
+  inputMode?: string;
+  contractAddress?: string;
+  abiFunction?: string;
+  argsList?: string;
+  calls?: string;
+  batchSize?: string;
+};
+
+export type BatchReadContractInput = StepInput & BatchReadContractCoreInput;
+
+type NormalizedCall = {
+  contractAddress: string;
+  abiFunction: string;
+  args: unknown[];
+  abi?: string;
+  network?: string;
+};
+
+type EncodedCall = {
+  target: string;
+  allowFailure: boolean;
+  callData: string;
+};
+
+type EncodedCallWithMeta = EncodedCall & {
+  abiFunction: string;
+  iface: ethers.Interface;
+  functionAbi?: { outputs?: { name?: string; type?: string }[] };
+};
+
+/**
+ * Parse and validate an ABI JSON string
+ */
+function parseAbi(abi: string): {
+  parsed: ethers.JsonFragment[];
+  error?: string;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(abi);
+  } catch (error) {
+    return { parsed: [], error: `Invalid ABI JSON: ${getErrorMessage(error)}` };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { parsed: [], error: "ABI must be a JSON array" };
+  }
+
+  return { parsed: parsed as ethers.JsonFragment[] };
+}
+
+/**
+ * Build normalized calls from uniform mode inputs
+ */
+function buildUniformCalls(
+  contractAddress: string | undefined,
+  abiFunction: string | undefined,
+  argsList: string | undefined
+): { calls: NormalizedCall[]; error?: string } {
+  if (!contractAddress) {
+    return { calls: [], error: "Contract Address is required in uniform mode" };
+  }
+
+  if (!ethers.isAddress(contractAddress)) {
+    return {
+      calls: [],
+      error: `Invalid contract address: ${contractAddress}`,
+    };
+  }
+
+  if (!abiFunction) {
+    return { calls: [], error: "Function is required in uniform mode" };
+  }
+
+  if (!argsList || argsList.trim() === "") {
+    return {
+      calls: [{ contractAddress, abiFunction, args: [] }],
+    };
+  }
+
+  let parsedArgsList: unknown;
+  try {
+    parsedArgsList = JSON.parse(argsList);
+  } catch (error) {
+    return {
+      calls: [],
+      error: `Invalid Args List JSON: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (!Array.isArray(parsedArgsList)) {
+    return { calls: [], error: "Args List must be a JSON array of arg arrays" };
+  }
+
+  const normalizedCalls: NormalizedCall[] = [];
+  for (const [index, argSet] of parsedArgsList.entries()) {
+    if (!Array.isArray(argSet)) {
+      return {
+        calls: [],
+        error: `Args List entry at index ${index} must be an array, got ${typeof argSet}`,
+      };
+    }
+    normalizedCalls.push({ contractAddress, abiFunction, args: argSet });
+  }
+
+  return { calls: normalizedCalls };
+}
+
+/**
+ * Validate and normalize a single call object from mixed mode input
+ */
+function validateMixedCall(
+  call: unknown,
+  index: number
+):
+  | { normalized: NormalizedCall; error?: undefined }
+  | { normalized?: undefined; error: string } {
+  if (typeof call !== "object" || call === null) {
+    return { error: `Call at index ${index} must be an object` };
+  }
+
+  const typedCall = call as Record<string, unknown>;
+  const addr = typedCall.contractAddress;
+  const fn = typedCall.abiFunction;
+  const args = typedCall.args;
+  const abi = typedCall.abi;
+  const callNetwork = typedCall.network;
+
+  if (typeof callNetwork !== "string" || !callNetwork) {
+    return { error: `Call at index ${index} missing network` };
+  }
+
+  if (typeof addr !== "string" || !addr) {
+    return { error: `Call at index ${index} missing contractAddress` };
+  }
+
+  if (!ethers.isAddress(addr)) {
+    return { error: `Call at index ${index} has invalid address: ${addr}` };
+  }
+
+  if (typeof fn !== "string" || !fn) {
+    return { error: `Call at index ${index} missing abiFunction` };
+  }
+
+  if (typeof abi !== "string" || !abi) {
+    return { error: `Call at index ${index} missing abi` };
+  }
+
+  return {
+    normalized: {
+      contractAddress: addr,
+      abiFunction: fn,
+      args: Array.isArray(args) ? args : [],
+      abi,
+      network: callNetwork,
+    },
+  };
+}
+
+/**
+ * Build normalized calls from mixed mode inputs
+ */
+function buildMixedCalls(callsJson: string | undefined): {
+  calls: NormalizedCall[];
+  error?: string;
+} {
+  if (!callsJson || callsJson.trim() === "") {
+    return { calls: [], error: "Calls JSON is required in mixed mode" };
+  }
+
+  let parsedCalls: unknown;
+  try {
+    parsedCalls = JSON.parse(callsJson);
+  } catch (error) {
+    return {
+      calls: [],
+      error: `Invalid Calls JSON: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (!Array.isArray(parsedCalls)) {
+    return { calls: [], error: "Calls must be a JSON array of call objects" };
+  }
+
+  const normalizedCalls: NormalizedCall[] = [];
+  for (const [index, call] of parsedCalls.entries()) {
+    const result = validateMixedCall(call, index);
+    if (result.error !== undefined) {
+      return { calls: [], error: result.error };
+    }
+    normalizedCalls.push(result.normalized);
+  }
+
+  return { calls: normalizedCalls };
+}
+
+/**
+ * Structure a decoded result based on ABI function outputs
+ */
+function structureDecodedResult(
+  decodedResult: ethers.Result,
+  functionAbi: { outputs?: { name?: string; type?: string }[] }
+): unknown {
+  const serialized = JSON.parse(
+    JSON.stringify(decodedResult, (_, value) =>
+      typeof value === "bigint" ? value.toString() : value
+    )
+  );
+
+  const outputs = functionAbi.outputs;
+  if (!outputs || outputs.length === 0) {
+    return serialized;
+  }
+
+  if (outputs.length === 1) {
+    const singleOutput = outputs[0];
+    const outputName = singleOutput.name?.trim();
+    const outputType = singleOutput.type ?? "";
+    const isArrayType = outputType.endsWith("[]");
+    const singleValue =
+      Array.isArray(serialized) && !isArrayType ? serialized[0] : serialized;
+    if (outputName) {
+      return { [outputName]: singleValue };
+    }
+    return singleValue;
+  }
+
+  if (Array.isArray(serialized)) {
+    const structured: Record<string, unknown> = {};
+    for (const [index, output] of outputs.entries()) {
+      const fieldName = output.name?.trim() || `unnamedOutput${index}`;
+      structured[fieldName] = serialized[index];
+    }
+    return structured;
+  }
+
+  return serialized;
+}
+
+/**
+ * Encode calls for uniform mode (shared ABI)
+ */
+function encodeUniformCalls(
+  normalizedCalls: NormalizedCall[],
+  parsedAbi: ethers.JsonFragment[]
+): { encoded: EncodedCallWithMeta[]; error?: string } {
+  let iface: ethers.Interface;
+  try {
+    iface = new ethers.Interface(parsedAbi);
+  } catch (error) {
+    return {
+      encoded: [],
+      error: `Failed to parse ABI: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const functionAbis = new Map<
+    string,
+    { outputs?: { name?: string; type?: string }[] }
+  >();
+  for (const item of parsedAbi) {
+    const abiItem = item as {
+      type?: string;
+      name?: string;
+      outputs?: { name?: string; type?: string }[];
+    };
+    if (abiItem.type === "function" && abiItem.name) {
+      functionAbis.set(abiItem.name, { outputs: abiItem.outputs });
+    }
+  }
+
+  const encoded: EncodedCallWithMeta[] = [];
+  for (const [index, call] of normalizedCalls.entries()) {
+    if (!functionAbis.has(call.abiFunction)) {
+      return {
+        encoded: [],
+        error: `Function '${call.abiFunction}' not found in ABI (call index ${index})`,
+      };
+    }
+
+    try {
+      const callData = iface.encodeFunctionData(call.abiFunction, call.args);
+      encoded.push({
+        target: call.contractAddress,
+        allowFailure: true,
+        callData,
+        abiFunction: call.abiFunction,
+        iface,
+        functionAbi: functionAbis.get(call.abiFunction),
+      });
+    } catch (error) {
+      return {
+        encoded: [],
+        error: `Failed to encode call at index ${index} (${call.abiFunction}): ${getErrorMessage(error)}`,
+      };
+    }
+  }
+
+  return { encoded };
+}
+
+/**
+ * Encode calls for mixed mode (per-call ABI)
+ */
+function encodeMixedCalls(normalizedCalls: NormalizedCall[]): {
+  encoded: EncodedCallWithMeta[];
+  error?: string;
+} {
+  const encoded: EncodedCallWithMeta[] = [];
+
+  for (const [index, call] of normalizedCalls.entries()) {
+    if (!call.abi) {
+      return {
+        encoded: [],
+        error: `Call at index ${index} missing ABI`,
+      };
+    }
+
+    const { parsed: callAbi, error: abiError } = parseAbi(call.abi);
+    if (abiError) {
+      return {
+        encoded: [],
+        error: `Call at index ${index}: ${abiError}`,
+      };
+    }
+
+    let iface: ethers.Interface;
+    try {
+      iface = new ethers.Interface(callAbi);
+    } catch (error) {
+      return {
+        encoded: [],
+        error: `Call at index ${index}: Failed to parse ABI: ${getErrorMessage(error)}`,
+      };
+    }
+
+    // Find the function in this call's ABI
+    const functionAbiItem = callAbi.find(
+      (item) =>
+        (item as { type?: string }).type === "function" &&
+        item.name === call.abiFunction
+    ) as { outputs?: { name?: string; type?: string }[] } | undefined;
+
+    if (!functionAbiItem) {
+      return {
+        encoded: [],
+        error: `Call at index ${index}: Function '${call.abiFunction}' not found in ABI`,
+      };
+    }
+
+    try {
+      const callData = iface.encodeFunctionData(call.abiFunction, call.args);
+      encoded.push({
+        target: call.contractAddress,
+        allowFailure: true,
+        callData,
+        abiFunction: call.abiFunction,
+        iface,
+        functionAbi: functionAbiItem,
+      });
+    } catch (error) {
+      return {
+        encoded: [],
+        error: `Failed to encode call at index ${index} (${call.abiFunction}): ${getErrorMessage(error)}`,
+      };
+    }
+  }
+
+  return { encoded };
+}
+
+/**
+ * Decode a single multicall result entry
+ */
+function decodeCallResult(
+  callSuccess: boolean,
+  returnData: string,
+  callMeta: EncodedCallWithMeta
+): CallResult {
+  if (!callSuccess) {
+    let revertReason = "Call reverted";
+    try {
+      const decoded = callMeta.iface.parseError(returnData);
+      if (decoded) {
+        revertReason = `Call reverted: ${decoded.name}(${decoded.args.join(", ")})`;
+      }
+    } catch {
+      if (returnData && returnData !== "0x") {
+        try {
+          const reason = ethers.AbiCoder.defaultAbiCoder().decode(
+            ["string"],
+            ethers.dataSlice(returnData, 4)
+          );
+          revertReason = `Call reverted: ${reason[0]}`;
+        } catch {
+          // Raw bytes
+        }
+      }
+    }
+    return { success: false, result: null, error: revertReason };
+  }
+
+  try {
+    const decoded = callMeta.iface.decodeFunctionResult(
+      callMeta.abiFunction,
+      returnData
+    );
+    const structured = callMeta.functionAbi
+      ? structureDecodedResult(decoded, callMeta.functionAbi)
+      : decoded;
+    return { success: true, result: structured };
+  } catch (error) {
+    return {
+      success: false,
+      result: null,
+      error: `Failed to decode result: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Execute a batch of encoded calls via Multicall3 on a single chain
+ */
+async function executeMulticallBatches(
+  encodedCalls: EncodedCallWithMeta[],
+  rpcUrl: string,
+  batchSize: number,
+  chainId: number
+): Promise<{ results: CallResult[]; error?: string }> {
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const multicall = new ethers.Contract(
+    MULTICALL3_ADDRESS,
+    MULTICALL3_ABI,
+    provider
+  );
+
+  const results: CallResult[] = [];
+  const totalBatches = Math.ceil(encodedCalls.length / batchSize);
+
+  for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
+    const batchStart = batchIndex * batchSize;
+    const batchEnd = Math.min(batchStart + batchSize, encodedCalls.length);
+    const batch = encodedCalls.slice(batchStart, batchEnd);
+
+    const multicallInput = batch.map(({ target, allowFailure, callData }) => ({
+      target,
+      allowFailure,
+      callData,
+    }));
+
+    try {
+      const batchResults: [boolean, string][] =
+        await multicall.aggregate3.staticCall(multicallInput);
+
+      for (let i = 0; i < batchResults.length; i++) {
+        const [callSuccess, returnData] = batchResults[i];
+        const callMeta = encodedCalls[batchStart + i];
+        results.push(decodeCallResult(callSuccess, returnData, callMeta));
+      }
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        `${LOG_PREFIX} Multicall batch ${batchIndex + 1} failed`,
+        error,
+        {
+          plugin_name: "web3",
+          action_name: "batch-read-contract",
+          chain_id: String(chainId),
+        }
+      );
+      return {
+        results: [],
+        error: `Multicall batch ${batchIndex + 1}/${totalBatches} failed: ${getErrorMessage(error)}`,
+      };
+    }
+  }
+
+  return { results };
+}
+
+/**
+ * Resolve chain ID and RPC URL for a network
+ */
+async function resolveChainRpc(
+  network: string,
+  userId: string | undefined
+): Promise<
+  | { chainId: number; rpcUrl: string; error?: undefined }
+  | { chainId?: undefined; rpcUrl?: undefined; error: string }
+> {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (resolveError) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      `${LOG_PREFIX} Failed to resolve network`,
+      resolveError,
+      { plugin_name: "web3", action_name: "batch-read-contract" }
+    );
+    return { error: getErrorMessage(resolveError) };
+  }
+
+  try {
+    const rpcConfig = await resolveRpcConfig(chainId, userId);
+    if (!rpcConfig) {
+      throw new Error(`Chain ${chainId} not found or not enabled`);
+    }
+    return { chainId, rpcUrl: rpcConfig.primaryRpcUrl };
+  } catch (rpcError) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      `${LOG_PREFIX} Failed to resolve RPC config`,
+      rpcError,
+      {
+        plugin_name: "web3",
+        action_name: "batch-read-contract",
+        chain_id: String(chainId),
+      }
+    );
+    return { error: getErrorMessage(rpcError) };
+  }
+}
+
+function parseBatchSize(batchSizeStr: string | undefined): number {
+  return batchSizeStr
+    ? Math.max(1, Number.parseInt(batchSizeStr, 10) || DEFAULT_BATCH_SIZE)
+    : DEFAULT_BATCH_SIZE;
+}
+
+function logValidationError(message: string): void {
+  logUserError(
+    ErrorCategory.VALIDATION,
+    `${LOG_PREFIX} ${message}`,
+    undefined,
+    {
+      plugin_name: "web3",
+      action_name: "batch-read-contract",
+    }
+  );
+}
+
+/**
+ * Execute uniform mode: all calls on a single network
+ */
+async function executeUniformMode(
+  input: BatchReadContractInput,
+  userId: string | undefined
+): Promise<BatchReadContractResult> {
+  const { network, abi } = input;
+
+  if (!network) {
+    return { success: false, error: "Network is required in uniform mode" };
+  }
+
+  if (!abi) {
+    return { success: false, error: "ABI is required in uniform mode" };
+  }
+
+  const { calls: normalizedCalls, error: callsError } = buildUniformCalls(
+    input.contractAddress,
+    input.abiFunction,
+    input.argsList
+  );
+
+  if (callsError) {
+    logValidationError(callsError);
+    return { success: false, error: callsError };
+  }
+
+  if (normalizedCalls.length === 0) {
+    return { success: false, error: "No calls to execute" };
+  }
+
+  const { parsed: parsedAbi, error: abiError } = parseAbi(abi);
+  if (abiError) {
+    logValidationError(abiError);
+    return { success: false, error: abiError };
+  }
+
+  const encodeResult = encodeUniformCalls(normalizedCalls, parsedAbi);
+  if (encodeResult.error) {
+    logValidationError(encodeResult.error);
+    return { success: false, error: encodeResult.error };
+  }
+
+  const chainRpc = await resolveChainRpc(network, userId);
+  if (chainRpc.error !== undefined) {
+    return { success: false, error: chainRpc.error };
+  }
+
+  const { results, error: batchError } = await executeMulticallBatches(
+    encodeResult.encoded,
+    chainRpc.rpcUrl,
+    parseBatchSize(input.batchSize),
+    chainRpc.chainId
+  );
+
+  if (batchError) {
+    return { success: false, error: batchError };
+  }
+
+  return { success: true, results, totalCalls: results.length };
+}
+
+type IndexedEncodedCall = EncodedCallWithMeta & { originalIndex: number };
+
+/**
+ * Execute mixed mode: calls grouped by network, results merged in original order
+ */
+async function executeMixedMode(
+  input: BatchReadContractInput,
+  userId: string | undefined
+): Promise<BatchReadContractResult> {
+  const { calls: normalizedCalls, error: callsError } = buildMixedCalls(
+    input.calls
+  );
+
+  if (callsError) {
+    logValidationError(callsError);
+    return { success: false, error: callsError };
+  }
+
+  if (normalizedCalls.length === 0) {
+    return { success: false, error: "No calls to execute" };
+  }
+
+  const encodeResult = encodeMixedCalls(normalizedCalls);
+  if (encodeResult.error) {
+    logValidationError(encodeResult.error);
+    return { success: false, error: encodeResult.error };
+  }
+
+  const batchSize = parseBatchSize(input.batchSize);
+
+  // Group encoded calls by network, preserving original order
+  const networkGroups = new Map<string, IndexedEncodedCall[]>();
+  for (const [index, call] of encodeResult.encoded.entries()) {
+    const callNetwork = normalizedCalls[index].network ?? "";
+    const group = networkGroups.get(callNetwork);
+    const indexed: IndexedEncodedCall = { ...call, originalIndex: index };
+    if (group) {
+      group.push(indexed);
+    } else {
+      networkGroups.set(callNetwork, [indexed]);
+    }
+  }
+
+  // Execute each network group
+  const allResults: CallResult[] = new Array(normalizedCalls.length);
+
+  for (const [networkKey, group] of networkGroups) {
+    const chainRpc = await resolveChainRpc(networkKey, userId);
+    if (chainRpc.error !== undefined) {
+      return { success: false, error: chainRpc.error };
+    }
+
+    const { results, error: batchError } = await executeMulticallBatches(
+      group,
+      chainRpc.rpcUrl,
+      batchSize,
+      chainRpc.chainId
+    );
+    if (batchError) {
+      return { success: false, error: batchError };
+    }
+
+    // Place results back in original order
+    for (const [resultIdx, groupCall] of group.entries()) {
+      allResults[groupCall.originalIndex] = results[resultIdx];
+    }
+  }
+
+  return { success: true, results: allResults, totalCalls: allResults.length };
+}
+
+/**
+ * Core batch read contract step handler
+ */
+async function stepHandler(
+  input: BatchReadContractInput
+): Promise<BatchReadContractResult> {
+  const userId = await getUserIdFromExecution(input._context?.executionId);
+  const isUniform = input.inputMode !== "mixed";
+
+  if (isUniform) {
+    return await executeUniformMode(input, userId);
+  }
+
+  return await executeMixedMode(input, userId);
+}
+
+/**
+ * Batch Read Contract Step
+ * Calls the same or different contract functions in a single RPC call using Multicall3
+ */
+export async function batchReadContractStep(
+  input: BatchReadContractInput
+): Promise<BatchReadContractResult> {
+  "use step";
+
+  return await withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "batch-read-contract",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+export const _integrationType = "web3";

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -36,7 +36,8 @@ export type ActionConfigFieldBase = {
     | "token-select" // Token selector with supported/custom toggle
     | "abi-event-select" // Dynamic dropdown that parses ABI and shows events
     // start custom keeperhub code //
-    | "gas-limit-multiplier"; // Gas limit multiplier with chain default display
+    | "gas-limit-multiplier" // Gas limit multiplier with chain default display
+    | "call-list-builder"; // Dynamic list of contract calls for batch operations
   // end keeperhub code //
 
   // For chain-select: filter by chain type (e.g., "evm" or "solana")

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -37,7 +37,8 @@ export type ActionConfigFieldBase = {
     | "abi-event-select" // Dynamic dropdown that parses ABI and shows events
     // start custom keeperhub code //
     | "gas-limit-multiplier" // Gas limit multiplier with chain default display
-    | "call-list-builder"; // Dynamic list of contract calls for batch operations
+    | "call-list-builder" // Dynamic list of contract calls for batch operations
+    | "args-list-builder"; // Dynamic list of argument sets for batch uniform mode
   // end keeperhub code //
 
   // For chain-select: filter by chain type (e.g., "evm" or "solana")

--- a/tests/unit/args-list-field.test.ts
+++ b/tests/unit/args-list-field.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  parseArgsListValue,
+  parseFunctionInputs,
+  serializeArgsList,
+} from "@/keeperhub/components/workflow/config/args-list-field";
+
+let idCounter = 0;
+function nextId(): number {
+  idCounter += 1;
+  return idCounter;
+}
+
+function resetIds(): void {
+  idCounter = 0;
+}
+
+const BALANCE_OF_ABI = JSON.stringify([
+  {
+    name: "balanceOf",
+    type: "function",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "balance", type: "uint256" }],
+  },
+]);
+
+const ALLOWANCE_ABI = JSON.stringify([
+  {
+    name: "allowance",
+    type: "function",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+]);
+
+const NO_PARAMS_ABI = JSON.stringify([
+  {
+    name: "totalSupply",
+    type: "function",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+]);
+
+const MIXED_ABI = JSON.stringify([
+  {
+    name: "balanceOf",
+    type: "function",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "Transfer",
+    type: "event",
+    inputs: [{ name: "from", type: "address" }],
+  },
+]);
+
+// ─── parseFunctionInputs ────────────────────────────────────────────────────
+
+describe("parseFunctionInputs", () => {
+  it("extracts single parameter from ABI", () => {
+    const result = parseFunctionInputs(BALANCE_OF_ABI, "balanceOf");
+    expect(result).toEqual([{ name: "account", type: "address" }]);
+  });
+
+  it("extracts multiple parameters from ABI", () => {
+    const result = parseFunctionInputs(ALLOWANCE_ABI, "allowance");
+    expect(result).toEqual([
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ]);
+  });
+
+  it("returns empty array for function with no parameters", () => {
+    const result = parseFunctionInputs(NO_PARAMS_ABI, "totalSupply");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when function not found", () => {
+    const result = parseFunctionInputs(BALANCE_OF_ABI, "nonExistent");
+    expect(result).toEqual([]);
+  });
+
+  it("ignores non-function entries (events)", () => {
+    const result = parseFunctionInputs(MIXED_ABI, "Transfer");
+    expect(result).toEqual([]);
+  });
+
+  it("finds correct function in mixed ABI", () => {
+    const result = parseFunctionInputs(MIXED_ABI, "balanceOf");
+    expect(result).toEqual([{ name: "account", type: "address" }]);
+  });
+
+  it("returns empty array for empty abiValue", () => {
+    expect(parseFunctionInputs("", "balanceOf")).toEqual([]);
+  });
+
+  it("returns empty array for empty functionValue", () => {
+    expect(parseFunctionInputs(BALANCE_OF_ABI, "")).toEqual([]);
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    expect(parseFunctionInputs("not json", "balanceOf")).toEqual([]);
+  });
+
+  it("returns empty array for non-array ABI", () => {
+    expect(parseFunctionInputs('{"not": "array"}', "balanceOf")).toEqual([]);
+  });
+
+  it("defaults unnamed parameters to 'unnamed'", () => {
+    const abi = JSON.stringify([
+      {
+        name: "test",
+        type: "function",
+        inputs: [{ name: "", type: "uint256" }],
+      },
+    ]);
+    const result = parseFunctionInputs(abi, "test");
+    expect(result).toEqual([{ name: "unnamed", type: "uint256" }]);
+  });
+});
+
+// ─── parseArgsListValue ─────────────────────────────────────────────────────
+
+describe("parseArgsListValue", () => {
+  beforeEach(resetIds);
+
+  it("returns one empty entry for empty value", () => {
+    const result = parseArgsListValue("", 2, nextId);
+    expect(result).toHaveLength(1);
+    expect(result[0].values).toEqual(["", ""]);
+  });
+
+  it("parses valid JSON arg sets", () => {
+    const result = parseArgsListValue('[["0xAddr1"], ["0xAddr2"]]', 1, nextId);
+    expect(result).toHaveLength(2);
+    expect(result[0].values).toEqual(["0xAddr1"]);
+    expect(result[1].values).toEqual(["0xAddr2"]);
+  });
+
+  it("parses multi-param arg sets", () => {
+    const result = parseArgsListValue(
+      '[["0xOwner", "0xSpender"], ["0xOwner2", "0xSpender2"]]',
+      2,
+      nextId
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].values).toEqual(["0xOwner", "0xSpender"]);
+    expect(result[1].values).toEqual(["0xOwner2", "0xSpender2"]);
+  });
+
+  it("pads missing values with empty strings", () => {
+    const result = parseArgsListValue('[["0xOnly"]]', 3, nextId);
+    expect(result[0].values).toEqual(["0xOnly", "", ""]);
+  });
+
+  it("truncates extra values to paramCount", () => {
+    const result = parseArgsListValue('[["a", "b", "c"]]', 2, nextId);
+    expect(result[0].values).toEqual(["a", "b"]);
+  });
+
+  it("converts non-string values to strings", () => {
+    const result = parseArgsListValue("[[42, true, null]]", 3, nextId);
+    expect(result[0].values).toEqual(["42", "true", ""]);
+  });
+
+  it("handles non-array arg set entries", () => {
+    const result = parseArgsListValue('["not-an-array"]', 1, nextId);
+    expect(result[0].values).toEqual([""]);
+  });
+
+  it("returns empty entry for invalid JSON", () => {
+    const result = parseArgsListValue("not json", 1, nextId);
+    expect(result).toHaveLength(1);
+    expect(result[0].values).toEqual([""]);
+  });
+
+  it("returns empty entry for empty array", () => {
+    const result = parseArgsListValue("[]", 1, nextId);
+    expect(result).toHaveLength(1);
+    expect(result[0].values).toEqual([""]);
+  });
+
+  it("returns empty entry for non-array JSON", () => {
+    const result = parseArgsListValue('{"not": "array"}', 1, nextId);
+    expect(result).toHaveLength(1);
+    expect(result[0].values).toEqual([""]);
+  });
+
+  it("assigns unique IDs to each entry", () => {
+    const result = parseArgsListValue('[["a"], ["b"], ["c"]]', 1, nextId);
+    const ids = result.map((e) => e.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("handles zero paramCount", () => {
+    const result = parseArgsListValue("[[], []]", 0, nextId);
+    expect(result).toHaveLength(2);
+    expect(result[0].values).toEqual([]);
+    expect(result[1].values).toEqual([]);
+  });
+});
+
+// ─── serializeArgsList ──────────────────────────────────────────────────────
+
+describe("serializeArgsList", () => {
+  it("serializes entries to JSON array of arrays", () => {
+    const result = serializeArgsList([
+      { id: 1, values: ["0xAddr1"] },
+      { id: 2, values: ["0xAddr2"] },
+    ]);
+    expect(JSON.parse(result)).toEqual([["0xAddr1"], ["0xAddr2"]]);
+  });
+
+  it("serializes multi-param entries", () => {
+    const result = serializeArgsList([
+      { id: 1, values: ["0xOwner", "0xSpender"] },
+    ]);
+    expect(JSON.parse(result)).toEqual([["0xOwner", "0xSpender"]]);
+  });
+
+  it("filters out entries with all empty values", () => {
+    const result = serializeArgsList([
+      { id: 1, values: ["0xAddr1"] },
+      { id: 2, values: ["", ""] },
+      { id: 3, values: ["0xAddr2"] },
+    ]);
+    expect(JSON.parse(result)).toEqual([["0xAddr1"], ["0xAddr2"]]);
+  });
+
+  it("returns empty string when all entries are empty", () => {
+    const result = serializeArgsList([
+      { id: 1, values: [""] },
+      { id: 2, values: ["", ""] },
+    ]);
+    expect(result).toBe("");
+  });
+
+  it("returns empty string for empty entries array", () => {
+    expect(serializeArgsList([])).toBe("");
+  });
+
+  it("keeps entries with at least one non-empty value", () => {
+    const result = serializeArgsList([{ id: 1, values: ["", "0xSpender"] }]);
+    expect(JSON.parse(result)).toEqual([["", "0xSpender"]]);
+  });
+
+  it("preserves whitespace-only values as empty after filter", () => {
+    const result = serializeArgsList([{ id: 1, values: ["  ", "   "] }]);
+    expect(result).toBe("");
+  });
+});
+
+// ─── Round-trip ─────────────────────────────────────────────────────────────
+
+describe("args-list-field round-trip", () => {
+  beforeEach(resetIds);
+
+  it("parse -> serialize produces equivalent output", () => {
+    const original = '[["0xAddr1"], ["0xAddr2"]]';
+    const parsed = parseArgsListValue(original, 1, nextId);
+    const serialized = serializeArgsList(parsed);
+    expect(JSON.parse(serialized)).toEqual(JSON.parse(original));
+  });
+
+  it("multi-param round-trip preserves values", () => {
+    const original = '[["0xOwner", "0xSpender"], ["0xOwner2", "0xSpender2"]]';
+    const parsed = parseArgsListValue(original, 2, nextId);
+    const serialized = serializeArgsList(parsed);
+    expect(JSON.parse(serialized)).toEqual(JSON.parse(original));
+  });
+
+  it("round-trip with empty value produces empty string", () => {
+    const parsed = parseArgsListValue("", 1, nextId);
+    const serialized = serializeArgsList(parsed);
+    expect(serialized).toBe("");
+  });
+});

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -1,0 +1,952 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/keeperhub/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/keeperhub/lib/logging", () => ({
+  ErrorCategory: { VALIDATION: "validation", NETWORK_RPC: "network_rpc" },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+}));
+
+// Mock RPC resolution
+const mockGetChainIdFromNetwork = vi.fn();
+const mockResolveRpcConfig = vi.fn();
+
+vi.mock("@/lib/rpc", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+}));
+
+// Mock ethers with enough fidelity for encoding/decoding tests
+const mockStaticCall = vi.fn();
+
+vi.mock("@/lib/contracts", () => ({
+  MULTICALL3_ADDRESS: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  MULTICALL3_ABI: [
+    {
+      name: "aggregate3",
+      type: "function",
+      inputs: [],
+      outputs: [],
+    },
+  ],
+}));
+
+import { ethers } from "ethers";
+
+// Create real ethers Interface for encoding/decoding in tests
+const ERC20_ABI = [
+  {
+    name: "balanceOf",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "balance", type: "uint256" }],
+  },
+  {
+    name: "totalSupply",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "allowance",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+];
+
+const MULTI_OUTPUT_ABI = [
+  {
+    name: "getReserves",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "reserve0", type: "uint112" },
+      { name: "reserve1", type: "uint112" },
+      { name: "blockTimestampLast", type: "uint32" },
+    ],
+  },
+];
+
+const erc20Iface = new ethers.Interface(ERC20_ABI);
+const multiOutputIface = new ethers.Interface(MULTI_OUTPUT_ABI);
+
+const VALID_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const VALID_ADDRESS_2 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+// Helper to encode a successful multicall result
+function encodeSuccessResult(
+  iface: ethers.Interface,
+  fnName: string,
+  values: unknown[]
+): [boolean, string] {
+  const encoded = iface.encodeFunctionResult(fnName, values);
+  return [true, encoded];
+}
+
+function encodeRevertResult(): [boolean, string] {
+  return [false, "0x"];
+}
+
+// Mock the Contract constructor to return our mock
+vi.mock("ethers", async () => {
+  const actual =
+    await vi.importActual<typeof import("ethers")>("ethers");
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      // biome-ignore lint/complexity/noStaticOnlyClass: vi.mock requires class for constructor mock
+      JsonRpcProvider: class MockProvider {},
+      Contract: class MockContract {
+        aggregate3 = { staticCall: mockStaticCall };
+      },
+    },
+  };
+});
+
+import {
+  type BatchReadContractCoreInput,
+  type BatchReadContractInput,
+  batchReadContractStep,
+} from "@/keeperhub/plugins/web3/steps/batch-read-contract";
+
+type SuccessResult = {
+  success: true;
+  results: { success: boolean; result: unknown; error?: string }[];
+  totalCalls: number;
+};
+
+type FailureResult = {
+  success: false;
+  error: string;
+};
+
+type BatchResult = SuccessResult | FailureResult;
+
+function makeInput(
+  overrides: Partial<BatchReadContractCoreInput>
+): BatchReadContractInput {
+  return {
+    inputMode: "uniform",
+    ...overrides,
+  } as BatchReadContractInput;
+}
+
+async function runBatch(
+  overrides: Partial<BatchReadContractCoreInput>
+): Promise<BatchResult> {
+  return (await batchReadContractStep(makeInput(overrides))) as BatchResult;
+}
+
+async function expectSuccess(
+  overrides: Partial<BatchReadContractCoreInput>
+): Promise<SuccessResult> {
+  const result = await runBatch(overrides);
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(result.success).toBe(true);
+  return result as SuccessResult;
+}
+
+async function expectFailure(
+  overrides: Partial<BatchReadContractCoreInput>
+): Promise<FailureResult> {
+  const result = await runBatch(overrides);
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(result.success).toBe(false);
+  return result as FailureResult;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function setupRpcMocks(chainId = 1): void {
+  mockGetChainIdFromNetwork.mockReturnValue(chainId);
+  mockResolveRpcConfig.mockResolvedValue({
+    primaryRpcUrl: "https://rpc.example.com",
+  });
+}
+
+// ─── Uniform Mode - Validation ──────────────────────────────────────────────
+
+describe("batch-read-contract - uniform mode validation", () => {
+  it("fails when network is missing", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("Network is required");
+  });
+
+  it("fails when ABI is missing", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("ABI is required");
+  });
+
+  it("fails when contract address is missing", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("Contract Address is required");
+  });
+
+  it("fails when contract address is invalid", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: "not-an-address",
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("Invalid contract address");
+  });
+
+  it("fails when function is missing", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+    });
+    expect(result.error).toContain("Function is required");
+  });
+
+  it("fails when ABI is invalid JSON", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: "not json",
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("Invalid ABI JSON");
+  });
+
+  it("fails when ABI is not an array", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: '{"not": "array"}',
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("ABI must be a JSON array");
+  });
+
+  it("fails when function is not found in ABI", async () => {
+    setupRpcMocks();
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "nonExistentFunction",
+    });
+    expect(result.error).toContain("not found in ABI");
+  });
+
+  it("fails when argsList is invalid JSON", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: "not json",
+    });
+    expect(result.error).toContain("Invalid Args List JSON");
+  });
+
+  it("fails when argsList is not an array", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: '{"not": "array"}',
+    });
+    expect(result.error).toContain("Args List must be a JSON array");
+  });
+
+  it("fails when argsList entry is not an array", async () => {
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: '["not-an-array"]',
+    });
+    expect(result.error).toContain("must be an array");
+  });
+});
+
+// ─── Uniform Mode - Execution ───────────────────────────────────────────────
+
+describe("batch-read-contract - uniform mode execution", () => {
+  it("executes single call with no args", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "totalSupply", [
+        BigInt("1000000000000000000"),
+      ]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "totalSupply",
+    });
+
+    expect(result.totalCalls).toBe(1);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].success).toBe(true);
+  });
+
+  it("executes multiple calls with argsList", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("200")]),
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("300")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([
+        [VALID_ADDRESS],
+        [VALID_ADDRESS_2],
+        [VALID_ADDRESS],
+      ]),
+    });
+
+    expect(result.totalCalls).toBe(3);
+    expect(result.results).toHaveLength(3);
+    for (const r of result.results) {
+      expect(r.success).toBe(true);
+    }
+  });
+
+  it("handles partial failure (one call reverts)", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+      encodeRevertResult(),
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("300")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([
+        [VALID_ADDRESS],
+        [VALID_ADDRESS_2],
+        [VALID_ADDRESS],
+      ]),
+    });
+
+    expect(result.totalCalls).toBe(3);
+    expect(result.results[0].success).toBe(true);
+    expect(result.results[1].success).toBe(false);
+    expect(result.results[1].error).toContain("reverted");
+    expect(result.results[2].success).toBe(true);
+  });
+
+  it("structures single named output", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("42")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([[VALID_ADDRESS]]),
+    });
+
+    expect(result.results[0].result).toEqual({ balance: "42" });
+  });
+
+  it("structures multiple named outputs", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(multiOutputIface, "getReserves", [
+        BigInt("1000"),
+        BigInt("2000"),
+        1700000000,
+      ]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(MULTI_OUTPUT_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "getReserves",
+    });
+
+    expect(result.results[0].result).toEqual({
+      reserve0: "1000",
+      reserve1: "2000",
+      blockTimestampLast: "1700000000",
+    });
+  });
+
+  it("returns single unnamed output as direct value", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "totalSupply", [
+        BigInt("1000000000000000000"),
+      ]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "totalSupply",
+    });
+
+    expect(result.results[0].result).toBe("1000000000000000000");
+  });
+
+  it("fails when RPC network resolution fails", async () => {
+    mockGetChainIdFromNetwork.mockImplementation(() => {
+      throw new Error("Unknown network: foochain");
+    });
+
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "foochain",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([[VALID_ADDRESS]]),
+    });
+
+    expect(result.error).toContain("Unknown network");
+  });
+
+  it("fails when RPC config is not found", async () => {
+    mockGetChainIdFromNetwork.mockReturnValue(99999);
+    mockResolveRpcConfig.mockResolvedValue(null);
+
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([[VALID_ADDRESS]]),
+    });
+
+    expect(result.error).toContain("not found or not enabled");
+  });
+
+  it("fails when multicall RPC call throws", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockRejectedValueOnce(new Error("RPC timeout"));
+
+    const result = await expectFailure({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([[VALID_ADDRESS]]),
+    });
+
+    expect(result.error).toContain("Multicall batch");
+    expect(result.error).toContain("RPC timeout");
+  });
+});
+
+// ─── Uniform Mode - Batch Size ──────────────────────────────────────────────
+
+describe("batch-read-contract - batch size", () => {
+  it("splits calls into multiple batches", async () => {
+    setupRpcMocks();
+
+    // 3 calls with batchSize=2 -> 2 batches (2 + 1)
+    mockStaticCall
+      .mockResolvedValueOnce([
+        encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+        encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("200")]),
+      ])
+      .mockResolvedValueOnce([
+        encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("300")]),
+      ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([
+        [VALID_ADDRESS],
+        [VALID_ADDRESS_2],
+        [VALID_ADDRESS],
+      ]),
+      batchSize: "2",
+    });
+
+    expect(result.totalCalls).toBe(3);
+    expect(mockStaticCall).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats invalid batchSize as default", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([[VALID_ADDRESS]]),
+      batchSize: "not-a-number",
+    });
+
+    expect(result.totalCalls).toBe(1);
+  });
+
+  it("clamps batchSize to minimum 1", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "uniform",
+      network: "ethereum",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+      argsList: JSON.stringify([[VALID_ADDRESS]]),
+      batchSize: "0",
+    });
+
+    expect(result.totalCalls).toBe(1);
+  });
+});
+
+// ─── Mixed Mode - Validation ────────────────────────────────────────────────
+
+describe("batch-read-contract - mixed mode validation", () => {
+  it("fails when calls JSON is missing", async () => {
+    const result = await expectFailure({ inputMode: "mixed" });
+    expect(result.error).toContain("Calls JSON is required");
+  });
+
+  it("fails when calls JSON is empty string", async () => {
+    const result = await expectFailure({ inputMode: "mixed", calls: "" });
+    expect(result.error).toContain("Calls JSON is required");
+  });
+
+  it("fails when calls JSON is invalid", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: "not json",
+    });
+    expect(result.error).toContain("Invalid Calls JSON");
+  });
+
+  it("fails when calls JSON is not an array", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: '{"not": "array"}',
+    });
+    expect(result.error).toContain("Calls must be a JSON array");
+  });
+
+  it("fails when call object is not an object", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: '["string-not-object"]',
+    });
+    expect(result.error).toContain("must be an object");
+  });
+
+  it("fails when call is missing network", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("missing network");
+  });
+
+  it("fails when call is missing contractAddress", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("missing contractAddress");
+  });
+
+  it("fails when call has invalid address", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: "0xinvalid",
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("invalid address");
+  });
+
+  it("fails when call is missing abiFunction", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("missing abiFunction");
+  });
+
+  it("fails when call is missing abi", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("missing abi");
+  });
+
+  it("fails when call ABI has function not found", async () => {
+    setupRpcMocks();
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "nonExistent",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("not found in ABI");
+  });
+
+  it("reports correct index for validation errors", async () => {
+    const result = await expectFailure({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+        {
+          network: "ethereum",
+          contractAddress: "0xinvalid",
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+    expect(result.error).toContain("index 1");
+    expect(result.error).toContain("invalid address");
+  });
+});
+
+// ─── Mixed Mode - Execution ────────────────────────────────────────────────
+
+describe("batch-read-contract - mixed mode execution", () => {
+  it("executes single mixed call", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("42")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+      ]),
+    });
+
+    expect(result.totalCalls).toBe(1);
+    expect(result.results[0].success).toBe(true);
+    expect(result.results[0].result).toEqual({ balance: "42" });
+  });
+
+  it("executes multiple mixed calls on same network", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+      encodeSuccessResult(erc20Iface, "totalSupply", [BigInt("1000000")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS_2,
+          abiFunction: "totalSupply",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [],
+        },
+      ]),
+    });
+
+    expect(result.totalCalls).toBe(2);
+    expect(result.results[0].result).toEqual({ balance: "100" });
+    expect(result.results[1].result).toBe("1000000");
+  });
+
+  it("groups calls by network and merges results in original order", async () => {
+    // Call 0: ethereum, Call 1: polygon, Call 2: ethereum
+    // Should group: ethereum=[0,2], polygon=[1]
+    // Results should come back in original order [0,1,2]
+
+    mockGetChainIdFromNetwork.mockImplementation((network: string) => {
+      if (network === "ethereum") return 1;
+      if (network === "polygon") return 137;
+      throw new Error(`Unknown network: ${network}`);
+    });
+    mockResolveRpcConfig.mockResolvedValue({
+      primaryRpcUrl: "https://rpc.example.com",
+    });
+
+    // Ethereum batch (calls 0 and 2)
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("300")]),
+    ]);
+    // Polygon batch (call 1)
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("200")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+        {
+          network: "polygon",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS_2],
+        },
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS_2,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+      ]),
+    });
+
+    expect(result.totalCalls).toBe(3);
+    // Verify results are in original call order, not grouped order
+    expect(result.results[0].result).toEqual({ balance: "100" });
+    expect(result.results[1].result).toEqual({ balance: "200" });
+    expect(result.results[2].result).toEqual({ balance: "300" });
+  });
+
+  it("handles partial failure in mixed mode", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "balanceOf", [BigInt("100")]),
+      encodeRevertResult(),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS_2,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+      ]),
+    });
+
+    expect(result.results[0].success).toBe(true);
+    expect(result.results[1].success).toBe(false);
+    expect(result.results[1].error).toContain("reverted");
+  });
+
+  it("treats missing args as empty array", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce([
+      encodeSuccessResult(erc20Iface, "totalSupply", [BigInt("999")]),
+    ]);
+
+    const result = await expectSuccess({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "totalSupply",
+          abi: JSON.stringify(ERC20_ABI),
+          // args intentionally omitted
+        },
+      ]),
+    });
+
+    expect(result.results[0].success).toBe(true);
+  });
+});
+
+// ─── Input Mode Routing ─────────────────────────────────────────────────────
+
+describe("batch-read-contract - input mode routing", () => {
+  it("defaults to uniform mode when inputMode is not set", async () => {
+    // Should require network (uniform mode validation)
+    const result = await expectFailure({
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("Network is required");
+  });
+
+  it("defaults to uniform mode when inputMode is empty string", async () => {
+    const result = await expectFailure({
+      inputMode: "",
+      abi: JSON.stringify(ERC20_ABI),
+      contractAddress: VALID_ADDRESS,
+      abiFunction: "balanceOf",
+    });
+    expect(result.error).toContain("Network is required");
+  });
+
+  it("uses mixed mode when inputMode is 'mixed'", async () => {
+    const result = await expectFailure({ inputMode: "mixed" });
+    expect(result.error).toContain("Calls JSON is required");
+  });
+});

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -126,13 +126,11 @@ function encodeRevertResult(): [boolean, string] {
 
 // Mock the Contract constructor to return our mock
 vi.mock("ethers", async () => {
-  const actual =
-    await vi.importActual<typeof import("ethers")>("ethers");
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
   return {
     ...actual,
     ethers: {
       ...actual.ethers,
-      // biome-ignore lint/complexity/noStaticOnlyClass: vi.mock requires class for constructor mock
       JsonRpcProvider: class MockProvider {},
       Contract: class MockContract {
         aggregate3 = { staticCall: mockStaticCall };
@@ -433,7 +431,7 @@ describe("batch-read-contract - uniform mode execution", () => {
       encodeSuccessResult(multiOutputIface, "getReserves", [
         BigInt("1000"),
         BigInt("2000"),
-        1700000000,
+        1_700_000_000,
       ]),
     ]);
 
@@ -489,7 +487,7 @@ describe("batch-read-contract - uniform mode execution", () => {
   });
 
   it("fails when RPC config is not found", async () => {
-    mockGetChainIdFromNetwork.mockReturnValue(99999);
+    mockGetChainIdFromNetwork.mockReturnValue(99_999);
     mockResolveRpcConfig.mockResolvedValue(null);
 
     const result = await expectFailure({
@@ -815,8 +813,12 @@ describe("batch-read-contract - mixed mode execution", () => {
     // Results should come back in original order [0,1,2]
 
     mockGetChainIdFromNetwork.mockImplementation((network: string) => {
-      if (network === "ethereum") return 1;
-      if (network === "polygon") return 137;
+      if (network === "ethereum") {
+        return 1;
+      }
+      if (network === "polygon") {
+        return 137;
+      }
       throw new Error(`Unknown network: ${network}`);
     });
     mockResolveRpcConfig.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Add `batch-read-contract` web3 step handler using Multicall3 for batched on-chain reads
- Two input modes: **uniform** (same function across multiple addresses) and **mixed** (different contracts/functions per call)
- Add `CallListField` UI component for mixed mode with per-row contract/ABI/function configuration
- Add `ArgsListField` UI component for uniform mode with dynamic labeled inputs based on ABI function signature
- Automatic batch sizing (default 50 calls per batch) and cross-chain grouping in mixed mode
- Comprehensive unit tests for step handler (43 tests) and ArgsListField (33 tests)
- Full plugin documentation with input/output tables, result structure, and 7 workflow examples