### PR TITLE
fix: KEEP-1486 show actual PostgreSQL error for failed DB queries

### DIFF
--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -59,11 +59,23 @@ interface PgQueryError extends Error {
   hint?: string;
 }
 
+const PG_SEVERITIES = new Set([
+  "ERROR",
+  "FATAL",
+  "PANIC",
+  "WARNING",
+  "NOTICE",
+  "DEBUG",
+  "INFO",
+  "LOG",
+]);
+
 function isPgQueryError(error: Error): error is PgQueryError {
-  return (
-    "severity" in error &&
-    typeof (error as { severity: unknown }).severity === "string"
-  );
+  if (!("severity" in error)) {
+    return false;
+  }
+  const severity = (error as { severity: unknown }).severity;
+  return typeof severity === "string" && PG_SEVERITIES.has(severity);
 }
 
 /** Format a PostgreSQL query error with optional detail/hint context. */

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -51,6 +51,7 @@ export function ensureEncodedConnectionString(
   return `${protocol}${encodeURIComponent(username)}:${encodeURIComponent(password)}@${hostAndDb}`;
 }
 
+// start custom keeperhub code //
 interface PgQueryError extends Error {
   severity: string;
   code?: string;
@@ -76,6 +77,7 @@ function formatPgQueryError(error: PgQueryError): string {
   }
   return message;
 }
+// end keeperhub code //
 
 /**
  * Returns a safe, user-facing message for database errors.
@@ -87,6 +89,7 @@ export function getDatabaseErrorMessage(error: unknown): string {
     return "Unknown database error";
   }
 
+  // start custom keeperhub code //
   // PostgreSQL query errors (syntax errors, constraint violations, etc.)
   // are safe to show -- they describe the SQL problem, not credentials.
   // Drizzle ORM wraps PostgresError in error.cause, so check both levels.
@@ -97,6 +100,7 @@ export function getDatabaseErrorMessage(error: unknown): string {
   if (cause instanceof Error && isPgQueryError(cause)) {
     return formatPgQueryError(cause);
   }
+  // end keeperhub code //
 
   // Connection-level errors -- sanitize to avoid leaking credentials
   const errorMessage = error.message;

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -78,9 +78,12 @@ function isPgQueryError(error: Error): error is PgQueryError {
   return typeof severity === "string" && PG_SEVERITIES.has(severity);
 }
 
-/** Format a PostgreSQL query error with optional detail/hint context. */
+/** Format a PostgreSQL query error with code, detail and hint context. */
 function formatPgQueryError(error: PgQueryError): string {
   let message = error.message;
+  if (error.code) {
+    message += ` (code: ${error.code})`;
+  }
   if (error.detail) {
     message += ` Detail: ${error.detail}`;
   }

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -83,6 +83,10 @@ function formatPgQueryError(error: PgQueryError): string {
  * Returns a safe, user-facing message for database errors.
  * Shows query errors from PostgreSQL directly (they don't contain credentials).
  * Sanitizes connection errors to avoid leaking internal details.
+ *
+ * NOTE: This function is only used for user-provided external database connections
+ * (Database Query step and test-connection). Do not use it for KeeperHub's internal
+ * database errors, as PG query messages can expose schema/table/column names.
  */
 export function getDatabaseErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) {


### PR DESCRIPTION
## Summary
- `getDatabaseErrorMessage()` now detects PostgreSQL query errors (syntax errors, constraint violations, missing relations, etc.) and returns the actual error message from PostgreSQL
- Handles both direct postgres.js errors and Drizzle ORM wrapped errors (where PostgresError is nested in `error.cause`)
- Connection-level errors continue to be sanitized to avoid leaking credentials
- Previously, any query error that didn't match a known connection pattern fell through to the misleading message "Database connection failed. Please verify your connection settings."