### PR TITLE
feat: Playwright discovery framework with a11y and test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+tests/e2e/playwright/.probes/
+tests/e2e/playwright/.auth/
 
 # next.js
 /.next/

--- a/.mcp.json
+++ b/.mcp.json
@@ -29,6 +29,10 @@
         "hashicorp/terraform-mcp-server"
       ]
     },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    },
     "memory": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-memory"],

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -135,7 +135,9 @@ export const UserMenu = () => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
+            aria-label="User menu"
             className="relative h-9 w-9 rounded-full border p-0"
+            data-testid="user-menu"
             variant="ghost"
           >
             <Avatar className="h-9 w-9">

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -554,10 +554,12 @@ export function NavigationSidebar(): React.ReactNode {
         <Tooltip key={item.id}>
           <TooltipTrigger asChild>
             <button
+              aria-label={item.label}
               className={cn(
                 "flex h-9 w-full cursor-default items-center rounded-md text-muted-foreground transition-colors",
                 layoutClass
               )}
+              data-testid={`nav-${item.id}`}
               key={item.id}
               type="button"
             >
@@ -576,11 +578,13 @@ export function NavigationSidebar(): React.ReactNode {
 
     const button = (
       <button
+        aria-label={item.label}
         className={cn(
           "flex h-9 w-full items-center rounded-md transition-colors hover:bg-muted",
           layoutClass,
           active && "bg-muted"
         )}
+        data-testid={`nav-${item.id}`}
         key={item.id}
         onClick={() => handleNavClick(item.id, item.href)}
         type="button"
@@ -629,7 +633,11 @@ export function NavigationSidebar(): React.ReactNode {
         ref={sidebarRef}
         style={{ width: currentWidth }}
       >
-        <nav className="flex flex-1 flex-col gap-1 overflow-hidden px-2.5 pt-3">
+        <nav
+          aria-label="Main navigation"
+          className="flex flex-1 flex-col gap-1 overflow-hidden px-2.5 pt-3"
+          data-testid="navigation-sidebar"
+        >
           {navItems.map(renderNavItem)}
         </nav>
 
@@ -646,6 +654,7 @@ export function NavigationSidebar(): React.ReactNode {
           <div className="absolute inset-y-0 right-0 w-px bg-border transition-colors group-hover:w-1 group-hover:bg-blue-500 group-active:w-1 group-active:bg-blue-600" />
           {dragWidth === null && (
             <button
+              aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
               className="-translate-y-1/2 absolute top-1/2 right-0 flex size-6 translate-x-1/2 items-center justify-center rounded-full border bg-background opacity-0 shadow-sm transition-opacity hover:bg-muted group-hover:opacity-100"
               onClick={(e) => {
                 e.stopPropagation();

--- a/keeperhub/components/organization/org-switcher.tsx
+++ b/keeperhub/components/organization/org-switcher.tsx
@@ -113,7 +113,9 @@ export function OrgSwitcher() {
         <PopoverTrigger asChild>
           <Button
             aria-expanded={open}
+            aria-label="Switch organization"
             className="w-[200px] justify-between"
+            data-testid="org-switcher"
             role="combobox"
             variant="outline"
           >

--- a/keeperhub/components/overlays/wallet-overlay.tsx
+++ b/keeperhub/components/overlays/wallet-overlay.tsx
@@ -148,9 +148,9 @@ function TokenItemWithActions({
       {!isUnavailable && tokenAddress && (
         <div className="flex items-center gap-1">
           <button
+            aria-label="Copy token address"
             className="text-muted-foreground hover:text-foreground"
             onClick={copyTokenAddress}
-            title="Copy token address"
             type="button"
           >
             <Copy className="h-3 w-3" />
@@ -649,6 +649,8 @@ function BalanceListSection({
             </Button>
           </div>
           <Button
+            aria-label="Refresh balances"
+            data-testid="wallet-refresh-button"
             disabled={refreshing}
             onClick={onRefresh}
             size="sm"
@@ -884,7 +886,9 @@ function AccountDetailsSection({
               {truncateAddress(walletAddress)}
             </code>
             <button
+              aria-label="Copy wallet address"
               className="text-muted-foreground hover:text-foreground"
+              data-testid="wallet-copy-address"
               onClick={copyAddress}
               type="button"
             >

--- a/keeperhub/components/workflow/add-step-button.tsx
+++ b/keeperhub/components/workflow/add-step-button.tsx
@@ -207,7 +207,9 @@ export function AddStepButton({
   return (
     <>
       <button
+        aria-label={hasNoTargets ? "Add step" : "Add branch"}
         className="add-step-button group nopan nodrag -translate-y-1/2 absolute"
+        data-testid="add-step-button"
         onClick={handleClick}
         style={{
           left: `calc(100% + ${BUTTON_DISTANCE}px)`,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:e2e": "playwright test",
+    "discover": "tsx tests/e2e/playwright/discover.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:vitest": "vitest run tests/e2e/vitest",
     "test:e2e:schedule": "vitest run tests/e2e/vitest/schedule-pipeline.test.ts",

--- a/tests/e2e/playwright/discover.ts
+++ b/tests/e2e/playwright/discover.ts
@@ -1,0 +1,299 @@
+#!/usr/bin/env npx tsx
+/**
+ * Standalone page discovery CLI.
+ *
+ * Usage:
+ *   pnpm discover /                           # Discover unauthenticated page
+ *   pnpm discover / --auth                     # With authentication
+ *   pnpm discover / --highlight                # With numbered element overlays
+ *   pnpm discover / --auth --steps "click:button:has-text('New')" "probe:after"
+ *   pnpm discover / --json                     # JSON to stdout
+ *
+ * Output: tests/e2e/playwright/.probes/<label>-<timestamp>/
+ */
+
+import { chromium, type Page } from "@playwright/test";
+import * as dotenv from "dotenv";
+import { expand } from "dotenv-expand";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  clearHighlights,
+  diffReports,
+  formatDiff,
+  highlightElements,
+  printReport,
+  probe,
+  type DiscoveryReport,
+} from "./utils/discover";
+import { signIn } from "./utils/auth";
+import {
+  PERSISTENT_TEST_USER_EMAIL,
+  PERSISTENT_TEST_PASSWORD,
+} from "./utils/db";
+
+expand(dotenv.config());
+
+interface CliOptions {
+  path: string;
+  auth: boolean;
+  highlight: boolean;
+  json: boolean;
+  label: string;
+  steps: string[];
+  baseUrl: string;
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    path: "/",
+    auth: false,
+    highlight: false,
+    json: false,
+    label: "discover",
+    steps: [],
+    baseUrl: process.env.BASE_URL || "http://localhost:3000",
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--auth") {
+      options.auth = true;
+    } else if (arg === "--highlight") {
+      options.highlight = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--label" && args[i + 1]) {
+      i++;
+      options.label = args[i];
+    } else if (arg === "--base-url" && args[i + 1]) {
+      i++;
+      options.baseUrl = args[i];
+    } else if (arg === "--steps") {
+      i++;
+      while (i < args.length && !args[i].startsWith("--")) {
+        options.steps.push(args[i]);
+        i++;
+      }
+      continue;
+    } else if (!arg.startsWith("--")) {
+      options.path = arg.startsWith("/") ? arg : `/${arg}`;
+    }
+
+    i++;
+  }
+
+  return options;
+}
+
+async function executeStep(page: Page, step: string): Promise<void> {
+  const colonIdx = step.indexOf(":");
+  const action = colonIdx === -1 ? step : step.substring(0, colonIdx);
+  const value = colonIdx === -1 ? "" : step.substring(colonIdx + 1);
+
+  switch (action) {
+    case "click":
+      await page.locator(value).click();
+      break;
+    case "fill": {
+      const eqIdx = value.indexOf("=");
+      const selector = value.substring(0, eqIdx);
+      const text = value.substring(eqIdx + 1);
+      await page.locator(selector).fill(text);
+      break;
+    }
+    case "wait":
+      await page.waitForTimeout(Number.parseInt(value) || 1000);
+      break;
+    case "goto":
+      await page.goto(value, { waitUntil: "domcontentloaded" });
+      break;
+    case "probe":
+      await probe(page, value || "step");
+      break;
+    default:
+      console.error(`Unknown step action: ${action}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Page Discovery CLI - Capture page state for writing Playwright tests
+
+Usage: pnpm discover <path> [options]
+
+Options:
+  --auth          Authenticate as persistent test user before navigating
+  --highlight     Add numbered red overlays to interactive elements
+  --json          Output report as JSON to stdout
+  --label <name>  Name for the probe output directory (default: "discover")
+  --base-url <url> Base URL (default: BASE_URL env or http://localhost:3000)
+  --steps <...>   Execute steps before final probe. Step format:
+                    click:<selector>       Click an element
+                    fill:<selector>=<text> Fill an input
+                    wait:<ms>              Wait N milliseconds
+                    goto:<path>            Navigate to path
+                    probe:<label>          Take intermediate probe
+
+Examples:
+  pnpm discover /
+  pnpm discover /workflow/abc --auth --highlight
+  pnpm discover / --auth --steps "click:button:has-text('New')" "probe:after-click"
+`);
+    process.exit(0);
+  }
+
+  const options = parseArgs(args);
+
+  const authStatePath = resolve(
+    process.cwd(),
+    "tests/e2e/playwright/.auth/user.json"
+  );
+  const hasAuthState = options.auth && existsSync(authStatePath);
+
+  const browser = await chromium.launch({ headless: true });
+
+  const context = hasAuthState
+    ? await browser.newContext({
+        storageState: JSON.parse(readFileSync(authStatePath, "utf-8")),
+      })
+    : await browser.newContext();
+
+  if (hasAuthState) {
+    console.log("Using saved auth state");
+  }
+
+  const page = await context.newPage();
+
+  try {
+    if (options.auth && !hasAuthState) {
+      console.log(`Signing in as ${PERSISTENT_TEST_USER_EMAIL}...`);
+      await signIn(page, PERSISTENT_TEST_USER_EMAIL, PERSISTENT_TEST_PASSWORD);
+      console.log("Signed in");
+    }
+
+    const url = `${options.baseUrl}${options.path}`;
+    console.log(`Navigating to ${url}...`);
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    // Track probes for auto-diffing between steps
+    let lastProbe: DiscoveryReport | null = null;
+
+    if (options.steps.length > 0) {
+      // Take initial probe before any steps so we can diff
+      lastProbe = await probe(page, `${options.label}-before`);
+    }
+
+    for (let s = 0; s < options.steps.length; s++) {
+      const step = options.steps[s];
+      console.log(`Step: ${step}`);
+
+      const colonIdx = step.indexOf(":");
+      const action = colonIdx === -1 ? step : step.substring(0, colonIdx);
+      const value = colonIdx === -1 ? "" : step.substring(colonIdx + 1);
+
+      if (action === "probe") {
+        const current = await probe(page, value || "step");
+        if (lastProbe) {
+          const diff = diffReports(lastProbe, current);
+          console.log(`\n--- Diff: ${diff.summary} ---\n`);
+          const diffMd = formatDiff(diff);
+          const probeDir = join(
+            process.cwd(),
+            "tests",
+            "e2e",
+            "playwright",
+            ".probes"
+          );
+          const dirs = readdirSync(probeDir)
+            .filter((d) => d.startsWith(value || "step"))
+            .sort()
+            .reverse();
+          if (dirs[0]) {
+            writeFileSync(join(probeDir, dirs[0], "diff.md"), diffMd);
+          }
+        }
+        lastProbe = current;
+      } else {
+        await executeStep(page, step);
+      }
+    }
+
+    if (options.highlight) {
+      const elements = await highlightElements(page, { visible: true });
+      console.log(`Highlighted ${elements.length} elements`);
+    }
+
+    const report = await probe(page, options.label);
+
+    // Auto-diff against last probe if we had steps
+    if (lastProbe) {
+      const diff = diffReports(lastProbe, report);
+      console.log(`\n--- Diff from last state: ${diff.summary} ---`);
+      const probeDir = join(
+        process.cwd(),
+        "tests",
+        "e2e",
+        "playwright",
+        ".probes"
+      );
+      const dirs = readdirSync(probeDir)
+        .filter((d) => d.startsWith(options.label))
+        .sort()
+        .reverse();
+      if (dirs[0]) {
+        writeFileSync(
+          join(probeDir, dirs[0], "diff.md"),
+          formatDiff(diff)
+        );
+      }
+    }
+
+    if (options.highlight) {
+      const highlightedScreenshot = await page.screenshot({ fullPage: true });
+      const probeDir = join(
+        process.cwd(),
+        "tests",
+        "e2e",
+        "playwright",
+        ".probes"
+      );
+      const dirs = readdirSync(probeDir)
+        .filter((d) => d.startsWith(options.label))
+        .sort()
+        .reverse();
+      if (dirs[0]) {
+        writeFileSync(
+          join(probeDir, dirs[0], "screenshot-highlighted.png"),
+          highlightedScreenshot
+        );
+      }
+      await clearHighlights(page);
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      printReport(report);
+      console.log(
+        `\nFull report saved to tests/e2e/playwright/.probes/${options.label}-*/`
+      );
+      console.log(
+        "Files: screenshot.png, report.json, elements.md, accessibility.md, summary.txt"
+      );
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error("Discovery failed:", error);
+  process.exit(1);
+});

--- a/tests/e2e/playwright/discover.ts
+++ b/tests/e2e/playwright/discover.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env npx tsx
+
 /**
  * Standalone page discovery CLI.
  *
@@ -12,25 +13,25 @@
  * Output: tests/e2e/playwright/.probes/<label>-<timestamp>/
  */
 
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { chromium, type Page } from "@playwright/test";
 import * as dotenv from "dotenv";
 import { expand } from "dotenv-expand";
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { signIn } from "./utils/auth";
+import {
+  PERSISTENT_TEST_PASSWORD,
+  PERSISTENT_TEST_USER_EMAIL,
+} from "./utils/db";
 import {
   clearHighlights,
+  type DiscoveryReport,
   diffReports,
   formatDiff,
   highlightElements,
   printReport,
   probe,
-  type DiscoveryReport,
 } from "./utils/discover";
-import { signIn } from "./utils/auth";
-import {
-  PERSISTENT_TEST_USER_EMAIL,
-  PERSISTENT_TEST_PASSWORD,
-} from "./utils/db";
 
 expand(dotenv.config());
 
@@ -248,10 +249,7 @@ Examples:
         .sort()
         .reverse();
       if (dirs[0]) {
-        writeFileSync(
-          join(probeDir, dirs[0], "diff.md"),
-          formatDiff(diff)
-        );
+        writeFileSync(join(probeDir, dirs[0], "diff.md"), formatDiff(diff));
       }
     }
 

--- a/tests/e2e/playwright/explore.test.ts
+++ b/tests/e2e/playwright/explore.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Discovery Test Harness
+ *
+ * NOT a real test suite. A scratchpad for iterative exploration.
+ *
+ * Workflow:
+ * 1. Edit the EXPLORATION STEPS section below
+ * 2. Run: pnpm test:e2e --grep "explore"
+ * 3. Read probe outputs from .probes/ directory
+ * 4. Edit steps again based on what you learned
+ * 5. Once page structure is understood, write the real test in a new file
+ *
+ * Auto-probe mode (PW_DISCOVER=1):
+ *   Automatically captures state on every URL change.
+ *   Run: PW_DISCOVER=1 pnpm test:e2e --grep "explore"
+ */
+
+import { test } from "@playwright/test";
+import {
+  autoProbe,
+  clearHighlights,
+  highlightElements,
+  isDiscoveryMode,
+  probe,
+} from "./utils/discover";
+
+test.describe("explore", () => {
+  test.describe.configure({ mode: "serial" });
+
+  // ================================================================
+  // EXPLORATION STEPS - Edit this section, then run the test
+  // ================================================================
+
+  test("discover page", async ({ page }) => {
+    // Auto-probe: captures state on every navigation when PW_DISCOVER=1
+    const handle = await autoProbe(page);
+
+    // Step 1: Navigate to the page you want to explore
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    // Step 2: Take a manual probe (always runs, even without PW_DISCOVER)
+    await probe(page, "initial");
+
+    // Step 3: Highlight elements for annotated screenshot
+    await highlightElements(page, { visible: true });
+    await page.screenshot({
+      path: "tests/e2e/playwright/.probes/highlighted.png",
+      fullPage: true,
+    });
+    await clearHighlights(page);
+
+    // Step 4: Interact to reveal new state, then probe again
+    // Examples (uncomment/modify as needed):
+    //
+    // Click a button:
+    //   await page.locator('button:has-text("Sign In")').first().click();
+    //   await probe(page, "after-click-signin");
+    //
+    // Fill a form:
+    //   await page.locator('#email').fill('test@example.com');
+    //   await probe(page, "after-fill-email");
+    //
+    // Wait for dialog:
+    //   await page.locator('[role="dialog"]').waitFor({ state: 'visible' });
+    //   await probe(page, "dialog-open");
+    //
+    // Hover to reveal tooltip/menu:
+    //   await page.locator('[data-testid="user-menu"]').hover();
+    //   await probe(page, "menu-hover");
+    //
+    // Select from dropdown (Radix combobox):
+    //   await page.locator('button[role="combobox"]').click();
+    //   await probe(page, "dropdown-open");
+
+    // Stop auto-probe listener
+    const autoProbes = handle.stop();
+    if (isDiscoveryMode() && autoProbes.length > 0) {
+      console.log(
+        `Auto-probe captured ${autoProbes.length} state(s) during navigation`
+      );
+    }
+  });
+});

--- a/tests/e2e/playwright/invitations.test.ts
+++ b/tests/e2e/playwright/invitations.test.ts
@@ -25,7 +25,10 @@ async function gotoAcceptInvite(
   for (let attempt = 0; attempt < 5; attempt++) {
     await page.goto(url, { waitUntil: "networkidle" });
     // Verify we landed on the accept-invite page AND it's not a 404
-    const is404 = await page.locator("text=This page could not be found").isVisible().catch(() => false);
+    const is404 = await page
+      .locator("text=This page could not be found")
+      .isVisible()
+      .catch(() => false);
     if (page.url().includes("accept-invite") && !is404) {
       return;
     }
@@ -198,7 +201,7 @@ async function sendInvite(page: Page, inviteeEmail: string): Promise<string> {
     .fill(inviteeEmail);
 
   const inviteButton = dialog.locator('button:has-text("Invite")');
-  await expect(inviteButton).toBeEnabled({ timeout: 5_000 });
+  await expect(inviteButton).toBeEnabled({ timeout: 5000 });
   await inviteButton.click();
 
   // Wait for any toast to appear, then check it's the success toast
@@ -208,7 +211,7 @@ async function sendInvite(page: Page, inviteeEmail: string): Promise<string> {
   const successToast = page
     .locator("[data-sonner-toast]")
     .filter({ hasText: `Invitation sent to ${inviteeEmail}` });
-  await expect(successToast).toBeVisible({ timeout: 5_000 });
+  await expect(successToast).toBeVisible({ timeout: 5000 });
 
   const invitationId = await getInvitationIdFromDb(inviteeEmail);
   return invitationId;
@@ -649,7 +652,9 @@ test.describe("Organization Invitations", () => {
         { timeout: 15_000 }
       );
       await Promise.race([
-        welcomeToast.waitFor({ state: "visible", timeout: 15_000 }).catch(() => {}),
+        welcomeToast
+          .waitFor({ state: "visible", timeout: 15_000 })
+          .catch(() => {}),
         notOnAcceptPage.catch(() => {}),
       ]);
 

--- a/tests/e2e/playwright/organization-wallet.test.ts
+++ b/tests/e2e/playwright/organization-wallet.test.ts
@@ -71,6 +71,26 @@ async function openWalletOverlay(page: Page): Promise<void> {
   });
 }
 
+// Create a wallet via the overlay form and wait for the success toast
+async function createWalletViaOverlay(page: Page): Promise<void> {
+  await page
+    .locator('button:has-text("Create Organization Wallet")')
+    .click();
+
+  const createBtn = page.locator('button:has-text("Create Wallet")');
+  await expect(createBtn).toBeEnabled({ timeout: 5_000 });
+  await createBtn.click();
+
+  // Wait for any toast to appear, then verify success
+  const anyToast = page.locator("[data-sonner-toast]").first();
+  await expect(anyToast).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: WALLET_CREATED_PATTERN })
+  ).toBeVisible({ timeout: 5_000 });
+}
+
 // Run tests serially to avoid session state conflicts
 test.describe.configure({ mode: "serial" });
 
@@ -227,14 +247,20 @@ test.describe("Para Wallet Management", () => {
       await expect(emailInput).toHaveValue(email);
 
       // Submit the form
-      await overlay.locator('button:has-text("Create Wallet")').click();
+      const createBtn = overlay.locator('button:has-text("Create Wallet")');
+      await expect(createBtn).toBeEnabled({ timeout: 5_000 });
+      await createBtn.click();
 
-      // Verify success toast
+      // Wait for any toast (success or error) to understand outcome
+      const anyToast = page.locator("[data-sonner-toast]").first();
+      await expect(anyToast).toBeVisible({ timeout: 30_000 });
+
+      // Assert it's the success toast
       await expect(
         page
           .locator("[data-sonner-toast]")
           .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 30_000 });
+      ).toBeVisible({ timeout: 5_000 });
 
       // Verify wallet details are shown
       await expect(overlay.locator("text=Account details")).toBeVisible({
@@ -248,27 +274,15 @@ test.describe("Para Wallet Management", () => {
       const { email } = await signUpAndVerify(page);
 
       await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
 
       // Create wallet
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-      await overlay.locator('button:has-text("Create Wallet")').click();
-
-      // Wait for wallet creation
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 30_000 });
+      await createWalletViaOverlay(page);
 
       // Verify wallet address is displayed (format: 0x...xxxx)
-      await expect(overlay.locator("code")).toContainText(ADDRESS_PATTERN);
+      await expect(page.locator("code")).toContainText(ADDRESS_PATTERN);
 
       // Verify email is displayed
-      await expect(overlay.locator(`text=${email}`)).toBeVisible();
+      await expect(page.locator(`text=${email}`)).toBeVisible();
     });
 
     test("WALLET-CREATE-3: wallet form can be cancelled", async ({ page }) => {
@@ -327,32 +341,21 @@ test.describe("Para Wallet Management", () => {
       await signUpAndVerify(page);
 
       await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
 
       // Create wallet
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-      await overlay.locator('button:has-text("Create Wallet")').click();
-
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 30_000 });
+      await createWalletViaOverlay(page);
 
       // Verify balance section appears
-      await expect(overlay.locator('h3:has-text("Balances")')).toBeVisible({
+      await expect(page.locator('h3:has-text("Balances")')).toBeVisible({
         timeout: 10_000,
       });
 
       // Verify mainnet/testnet toggle exists
       await expect(
-        overlay.locator('button:has-text("Mainnets")')
+        page.locator('button:has-text("Mainnets")')
       ).toBeVisible();
       await expect(
-        overlay.locator('button:has-text("Testnets")')
+        page.locator('button:has-text("Testnets")')
       ).toBeVisible();
     });
 
@@ -362,38 +365,27 @@ test.describe("Para Wallet Management", () => {
       await signUpAndVerify(page);
 
       await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
 
       // Create wallet first
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-      await overlay.locator('button:has-text("Create Wallet")').click();
-
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 30_000 });
+      await createWalletViaOverlay(page);
 
       // Wait for balance section
-      await expect(overlay.locator('h3:has-text("Balances")')).toBeVisible({
+      await expect(page.locator('h3:has-text("Balances")')).toBeVisible({
         timeout: 10_000,
       });
 
       // Click testnets button
-      await overlay.locator('button:has-text("Testnets")').click();
+      await page.locator('button:has-text("Testnets")').click();
 
       // Testnets button should now have the active style (verify it's selected)
-      const testnetsButton = overlay.locator('button:has-text("Testnets")');
+      const testnetsButton = page.locator('button:has-text("Testnets")');
       await expect(testnetsButton).toBeVisible();
 
       // Click mainnets button
-      await overlay.locator('button:has-text("Mainnets")').click();
+      await page.locator('button:has-text("Mainnets")').click();
 
       // Mainnets button should be active again
-      const mainnetsButton = overlay.locator('button:has-text("Mainnets")');
+      const mainnetsButton = page.locator('button:has-text("Mainnets")');
       await expect(mainnetsButton).toBeVisible();
     });
 
@@ -401,23 +393,12 @@ test.describe("Para Wallet Management", () => {
       await signUpAndVerify(page);
 
       await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
 
       // Create wallet
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-      await overlay.locator('button:has-text("Create Wallet")').click();
-
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 30_000 });
+      await createWalletViaOverlay(page);
 
       // Wait for balance section
-      await expect(overlay.locator('h3:has-text("Balances")')).toBeVisible({
+      await expect(page.locator('h3:has-text("Balances")')).toBeVisible({
         timeout: 10_000,
       });
 
@@ -438,23 +419,12 @@ test.describe("Para Wallet Management", () => {
       await signUpAndVerify(page);
 
       await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
 
       // Create wallet
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-      await overlay.locator('button:has-text("Create Wallet")').click();
-
-      await expect(
-        page
-          .locator("[data-sonner-toast]")
-          .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 30_000 });
+      await createWalletViaOverlay(page);
 
       // Wait for wallet details to load
-      await expect(overlay.locator("text=Account details")).toBeVisible({
+      await expect(page.locator("text=Account details")).toBeVisible({
         timeout: 5000,
       });
 

--- a/tests/e2e/playwright/organization-wallet.test.ts
+++ b/tests/e2e/playwright/organization-wallet.test.ts
@@ -73,12 +73,10 @@ async function openWalletOverlay(page: Page): Promise<void> {
 
 // Create a wallet via the overlay form and wait for the success toast
 async function createWalletViaOverlay(page: Page): Promise<void> {
-  await page
-    .locator('button:has-text("Create Organization Wallet")')
-    .click();
+  await page.locator('button:has-text("Create Organization Wallet")').click();
 
   const createBtn = page.locator('button:has-text("Create Wallet")');
-  await expect(createBtn).toBeEnabled({ timeout: 5_000 });
+  await expect(createBtn).toBeEnabled({ timeout: 5000 });
   await createBtn.click();
 
   // Wait for any toast to appear, then verify success
@@ -88,7 +86,7 @@ async function createWalletViaOverlay(page: Page): Promise<void> {
     page
       .locator("[data-sonner-toast]")
       .filter({ hasText: WALLET_CREATED_PATTERN })
-  ).toBeVisible({ timeout: 5_000 });
+  ).toBeVisible({ timeout: 5000 });
 }
 
 // Run tests serially to avoid session state conflicts
@@ -248,7 +246,7 @@ test.describe("Para Wallet Management", () => {
 
       // Submit the form
       const createBtn = overlay.locator('button:has-text("Create Wallet")');
-      await expect(createBtn).toBeEnabled({ timeout: 5_000 });
+      await expect(createBtn).toBeEnabled({ timeout: 5000 });
       await createBtn.click();
 
       // Wait for any toast (success or error) to understand outcome
@@ -260,7 +258,7 @@ test.describe("Para Wallet Management", () => {
         page
           .locator("[data-sonner-toast]")
           .filter({ hasText: WALLET_CREATED_PATTERN })
-      ).toBeVisible({ timeout: 5_000 });
+      ).toBeVisible({ timeout: 5000 });
 
       // Verify wallet details are shown
       await expect(overlay.locator("text=Account details")).toBeVisible({
@@ -351,12 +349,8 @@ test.describe("Para Wallet Management", () => {
       });
 
       // Verify mainnet/testnet toggle exists
-      await expect(
-        page.locator('button:has-text("Mainnets")')
-      ).toBeVisible();
-      await expect(
-        page.locator('button:has-text("Testnets")')
-      ).toBeVisible();
+      await expect(page.locator('button:has-text("Mainnets")')).toBeVisible();
+      await expect(page.locator('button:has-text("Testnets")')).toBeVisible();
     });
 
     test("WALLET-DISPLAY-2: user can toggle between mainnets and testnets", async ({
@@ -403,9 +397,7 @@ test.describe("Para Wallet Management", () => {
       });
 
       // Find and click refresh button (has RefreshCw icon)
-      const refreshButton = overlay.locator(
-        "button:has(svg.lucide-refresh-cw)"
-      );
+      const refreshButton = page.locator("button:has(svg.lucide-refresh-cw)");
       await expect(refreshButton).toBeVisible();
       await refreshButton.click();
 
@@ -429,7 +421,7 @@ test.describe("Para Wallet Management", () => {
       });
 
       // Click copy button (near the address)
-      const copyButton = overlay
+      const copyButton = page
         .locator("button")
         .filter({ has: page.locator("svg.lucide-copy") })
         .first();

--- a/tests/e2e/playwright/utils/discover.ts
+++ b/tests/e2e/playwright/utils/discover.ts
@@ -1018,9 +1018,15 @@ export async function autoProbe(
   let probeInProgress = false;
   let navigationCount = 0;
 
+  // Declared here so `stop()` can reference it; assigned after definition below
+  let onNavigation: ((frame: { url: () => string }) => Promise<void>) | null =
+    null;
+
   const handle: AutoProbeHandle = {
     stop: () => {
-      page.removeListener("framenavigated", onNavigation);
+      if (onNavigation) {
+        page.removeListener("framenavigated", onNavigation);
+      }
       return probes;
     },
     lastProbe: () => lastReport,
@@ -1068,7 +1074,7 @@ export async function autoProbe(
     }
   };
 
-  const onNavigation = async (frame: { url: () => string }): Promise<void> => {
+  onNavigation = async (frame: { url: () => string }): Promise<void> => {
     // Only probe main frame navigations
     if (frame !== page.mainFrame()) return;
 

--- a/tests/e2e/playwright/utils/discover.ts
+++ b/tests/e2e/playwright/utils/discover.ts
@@ -1,6 +1,6 @@
-import type { Page } from "@playwright/test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { Page } from "@playwright/test";
 
 // ------------------------------------------------------------------
 // Types
@@ -114,9 +114,7 @@ export async function getInteractiveElements(
     // (function declarations get decorated, which breaks page.evaluate)
     const truncate = (str: string, max: number): string => {
       const cleaned = str.replace(/\s+/g, " ").trim();
-      return cleaned.length > max
-        ? `${cleaned.substring(0, max)}...`
-        : cleaned;
+      return cleaned.length > max ? `${cleaned.substring(0, max)}...` : cleaned;
     };
 
     const getParentContext = (el: Element): string | null => {
@@ -235,7 +233,7 @@ export async function getInteractiveElements(
     }
 
     results.sort((a, b) => {
-      if (!a.bounds || !b.bounds) return 0;
+      if (!(a.bounds && b.bounds)) return 0;
       const yDiff = a.bounds.y - b.bounds.y;
       if (Math.abs(yDiff) > 10) return yDiff;
       return a.bounds.x - b.bounds.x;
@@ -267,9 +265,7 @@ export async function getPageStructure(page: Page): Promise<PageStructure> {
 
     const truncate = (str: string, max: number): string => {
       const cleaned = str.replace(/\s+/g, " ").trim();
-      return cleaned.length > max
-        ? `${cleaned.substring(0, max)}...`
-        : cleaned;
+      return cleaned.length > max ? `${cleaned.substring(0, max)}...` : cleaned;
     };
 
     const headings: Array<{ level: number; text: string }> = [];
@@ -312,9 +308,7 @@ export async function getPageStructure(page: Page): Promise<PageStructure> {
 
     const dialogs: Array<{ title: string | null; visible: boolean }> = [];
     const dialogEls = Array.from(
-      document.querySelectorAll(
-        '[role="dialog"], [role="alertdialog"], dialog'
-      )
+      document.querySelectorAll('[role="dialog"], [role="alertdialog"], dialog')
     );
     for (let i = 0; i < dialogEls.length; i++) {
       const d = dialogEls[i];
@@ -463,9 +457,7 @@ function parseAriaSnapshot(snapshot: string): AccessibilityNode {
  * Get the raw ARIA snapshot string from Playwright.
  * This is the most compact, directly useful format for writing tests.
  */
-export async function getAriaSnapshotRaw(
-  page: Page
-): Promise<string | null> {
+export async function getAriaSnapshotRaw(page: Page): Promise<string | null> {
   try {
     return await page.locator("body").ariaSnapshot();
   } catch {
@@ -664,13 +656,7 @@ export function formatDiff(diff: StateDiff): string {
 // Core: probe
 // ------------------------------------------------------------------
 
-const PROBE_DIR = join(
-  process.cwd(),
-  "tests",
-  "e2e",
-  "playwright",
-  ".probes"
-);
+const PROBE_DIR = join(process.cwd(), "tests", "e2e", "playwright", ".probes");
 
 /**
  * Capture current page state: screenshot + element map + structure.
@@ -708,11 +694,12 @@ export async function probe(
     `Elements with data-testid: ${withTestId}`,
     `Headings: ${structure.headings.map((h) => `${"#".repeat(h.level)} ${h.text}`).join(", ")}`,
     structure.dialogs.length > 0
-      ? `Open dialogs: ${structure.dialogs.filter((d) => d.visible).map((d) => d.title).join(", ")}`
+      ? `Open dialogs: ${structure.dialogs
+          .filter((d) => d.visible)
+          .map((d) => d.title)
+          .join(", ")}`
       : "No open dialogs",
-    structure.toasts.length > 0
-      ? `Toasts: ${structure.toasts.join(", ")}`
-      : "",
+    structure.toasts.length > 0 ? `Toasts: ${structure.toasts.join(", ")}` : "",
   ]
     .filter(Boolean)
     .join("\n");
@@ -767,7 +754,11 @@ export async function highlightElements(
   });
 
   await page.evaluate(
-    (els: Array<{ bounds: { x: number; y: number; width: number; height: number } | null }>) => {
+    (
+      els: Array<{
+        bounds: { x: number; y: number; width: number; height: number } | null;
+      }>
+    ) => {
       const existing = Array.from(
         document.querySelectorAll("[data-pw-highlight]")
       );
@@ -845,10 +836,7 @@ export async function clearHighlights(page: Page): Promise<void> {
  * Shows role, name, and relevant states. This is the best data source
  * for writing getByRole/getByLabel locators.
  */
-function formatAccessibilityTree(
-  node: AccessibilityNode,
-  depth = 0
-): string {
+function formatAccessibilityTree(node: AccessibilityNode, depth = 0): string {
   const indent = "  ".repeat(depth);
   const parts: string[] = [];
 
@@ -858,8 +846,10 @@ function formatAccessibilityTree(
 
   const states: string[] = [];
   if (node.disabled) states.push("disabled");
-  if (node.checked !== undefined) states.push(`checked=${String(node.checked)}`);
-  if (node.pressed !== undefined) states.push(`pressed=${String(node.pressed)}`);
+  if (node.checked !== undefined)
+    states.push(`checked=${String(node.checked)}`);
+  if (node.pressed !== undefined)
+    states.push(`pressed=${String(node.pressed)}`);
   if (node.expanded !== undefined)
     states.push(`expanded=${String(node.expanded)}`);
   if (node.level) states.push(`level=${node.level}`);
@@ -957,10 +947,8 @@ function formatForClaude(report: DiscoveryReport): string {
     lines.push("");
     lines.push("## Accessibility Tree");
     lines.push("");
-    lines.push(
-      "Use this to write `getByRole` / `getByLabel` locators."
-    );
-    lines.push("Each line shows: **role** \"accessible name\" (states)");
+    lines.push("Use this to write `getByRole` / `getByLabel` locators.");
+    lines.push('Each line shows: **role** "accessible name" (states)');
     lines.push("");
     lines.push(formatAccessibilityTree(report.accessibility));
   }
@@ -1080,7 +1068,8 @@ export async function autoProbe(
 
     navigationCount++;
     const url = new URL(frame.url());
-    const pathLabel = url.pathname.replace(/\//g, "-").replace(/^-/, "") || "root";
+    const pathLabel =
+      url.pathname.replace(/\//g, "-").replace(/^-/, "") || "root";
     await captureProbe(`auto-nav-${navigationCount}-${pathLabel}`);
   };
 
@@ -1144,10 +1133,7 @@ export function printReport(report: DiscoveryReport): void {
       "searchbox",
       "spinbutton",
     ]);
-    const printA11yNode = (
-      node: AccessibilityNode,
-      depth: number
-    ): void => {
+    const printA11yNode = (node: AccessibilityNode, depth: number): void => {
       const indent = "  ".repeat(depth);
       if (interactiveRoles.has(node.role)) {
         const states: string[] = [];
@@ -1157,13 +1143,14 @@ export function printReport(report: DiscoveryReport): void {
         if (node.expanded !== undefined)
           states.push(`expanded=${String(node.expanded)}`);
         const stateStr = states.length > 0 ? ` [${states.join(", ")}]` : "";
-        console.log(
-          `${indent}${node.role}: "${node.name}"${stateStr}`
-        );
+        console.log(`${indent}${node.role}: "${node.name}"${stateStr}`);
       }
       if (node.children) {
         for (let i = 0; i < node.children.length; i++) {
-          printA11yNode(node.children[i], depth + (interactiveRoles.has(node.role) ? 1 : 0));
+          printA11yNode(
+            node.children[i],
+            depth + (interactiveRoles.has(node.role) ? 1 : 0)
+          );
         }
       }
     };

--- a/tests/e2e/playwright/utils/discover.ts
+++ b/tests/e2e/playwright/utils/discover.ts
@@ -1,0 +1,1166 @@
+import type { Page } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ------------------------------------------------------------------
+// Types
+// ------------------------------------------------------------------
+
+export interface ElementInfo {
+  locator: string;
+  tag: string;
+  role: string | null;
+  testId: string | null;
+  id: string | null;
+  text: string;
+  ariaLabel: string | null;
+  placeholder: string | null;
+  inputType: string | null;
+  visible: boolean;
+  disabled: boolean;
+  bounds: { x: number; y: number; width: number; height: number } | null;
+  parentContext: string | null;
+}
+
+export interface PageStructure {
+  title: string;
+  url: string;
+  headings: Array<{ level: number; text: string }>;
+  landmarks: Array<{ role: string; label: string | null }>;
+  dialogs: Array<{ title: string | null; visible: boolean }>;
+  forms: Array<{ id: string | null; action: string | null; fields: number }>;
+  navItems: string[];
+  toasts: string[];
+}
+
+export interface AccessibilityNode {
+  role: string;
+  name: string;
+  value?: string;
+  description?: string;
+  disabled?: boolean;
+  checked?: boolean | "mixed";
+  pressed?: boolean | "mixed";
+  expanded?: boolean;
+  level?: number;
+  children?: AccessibilityNode[];
+}
+
+export interface DiscoveryReport {
+  timestamp: string;
+  structure: PageStructure;
+  interactive: ElementInfo[];
+  accessibility: AccessibilityNode | null;
+  summary: string;
+}
+
+export interface StateDiff {
+  url: { before: string; after: string };
+  newElements: ElementInfo[];
+  removedElements: ElementInfo[];
+  newDialogs: Array<{ title: string | null }>;
+  closedDialogs: Array<{ title: string | null }>;
+  newToasts: string[];
+  newHeadings: Array<{ level: number; text: string }>;
+  removedHeadings: Array<{ level: number; text: string }>;
+  summary: string;
+}
+
+// ------------------------------------------------------------------
+// Core: getInteractiveElements
+// ------------------------------------------------------------------
+
+/**
+ * Extract all interactive elements from the page with structured metadata.
+ * Returns a flat list sorted by position (top-to-bottom, left-to-right).
+ */
+export async function getInteractiveElements(
+  page: Page
+): Promise<ElementInfo[]> {
+  const elements: ElementInfo[] = await page.evaluate(() => {
+    // tsx/esbuild injects __name decorators that don't exist in browser context
+    // biome-ignore lint/suspicious/noExplicitAny: polyfill for esbuild decorator
+    if (typeof (globalThis as any).__name === "undefined") {
+      // biome-ignore lint/suspicious/noExplicitAny: polyfill for esbuild decorator
+      (globalThis as any).__name = (target: any) => target;
+    }
+
+    const interactive = Array.from(
+      document.querySelectorAll(
+        [
+          "a[href]",
+          "button",
+          "input",
+          "select",
+          "textarea",
+          '[role="button"]',
+          '[role="link"]',
+          '[role="tab"]',
+          '[role="menuitem"]',
+          '[role="option"]',
+          '[role="switch"]',
+          '[role="checkbox"]',
+          '[role="radio"]',
+          '[role="combobox"]',
+          '[role="listbox"]',
+          '[role="slider"]',
+          '[tabindex]:not([tabindex="-1"])',
+          "[contenteditable]",
+        ].join(", ")
+      )
+    );
+
+    // Arrow functions to avoid tsx/esbuild __name decorator injection
+    // (function declarations get decorated, which breaks page.evaluate)
+    const truncate = (str: string, max: number): string => {
+      const cleaned = str.replace(/\s+/g, " ").trim();
+      return cleaned.length > max
+        ? `${cleaned.substring(0, max)}...`
+        : cleaned;
+    };
+
+    const getParentContext = (el: Element): string | null => {
+      let current = el.parentElement;
+      while (current) {
+        const role = current.getAttribute("role");
+        const landmark = current.tagName.toLowerCase();
+        if (
+          role === "dialog" ||
+          role === "navigation" ||
+          role === "main" ||
+          role === "banner" ||
+          role === "complementary" ||
+          landmark === "nav" ||
+          landmark === "header" ||
+          landmark === "main" ||
+          landmark === "aside" ||
+          landmark === "footer"
+        ) {
+          return (
+            current.getAttribute("aria-label") ||
+            current.getAttribute("data-testid") ||
+            role ||
+            landmark
+          );
+        }
+        current = current.parentElement;
+      }
+      return null;
+    };
+
+    const suggestLocator = (el: Element): string => {
+      const testId = el.getAttribute("data-testid");
+      if (testId) return `[data-testid="${testId}"]`;
+
+      const role = el.getAttribute("role");
+      const ariaLabel = el.getAttribute("aria-label");
+      if (role && ariaLabel) return `role=${role}[name="${ariaLabel}"]`;
+
+      const elId = el.getAttribute("id");
+      if (elId) return `#${elId}`;
+
+      const text = truncate(el.textContent || "", 40);
+      const tag = el.tagName.toLowerCase();
+      if (tag === "button" && text) return `button:has-text("${text}")`;
+      if (tag === "a" && text) return `a:has-text("${text}")`;
+
+      if (role) return `[role="${role}"]`;
+
+      const name = el.getAttribute("name");
+      if (name) return `[name="${name}"]`;
+
+      const ph = el.getAttribute("placeholder");
+      if (ph) return `[placeholder="${ph}"]`;
+
+      return tag;
+    };
+
+    const results: Array<{
+      locator: string;
+      tag: string;
+      role: string | null;
+      testId: string | null;
+      id: string | null;
+      text: string;
+      ariaLabel: string | null;
+      placeholder: string | null;
+      inputType: string | null;
+      visible: boolean;
+      disabled: boolean;
+      bounds: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      } | null;
+      parentContext: string | null;
+    }> = [];
+
+    for (let idx = 0; idx < interactive.length; idx++) {
+      const el = interactive[idx];
+      const rect = el.getBoundingClientRect();
+      const style = window.getComputedStyle(el);
+      const isVisible =
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        style.opacity !== "0" &&
+        rect.width > 0 &&
+        rect.height > 0;
+
+      results.push({
+        locator: suggestLocator(el),
+        tag: el.tagName.toLowerCase(),
+        role: el.getAttribute("role"),
+        testId: el.getAttribute("data-testid"),
+        id: el.getAttribute("id"),
+        text: truncate(el.textContent || "", 80),
+        ariaLabel: el.getAttribute("aria-label"),
+        placeholder: el.getAttribute("placeholder"),
+        inputType:
+          el.tagName === "INPUT" ? (el as HTMLInputElement).type : null,
+        visible: isVisible,
+        disabled:
+          (el as HTMLButtonElement).disabled ||
+          el.getAttribute("aria-disabled") === "true",
+        bounds: isVisible
+          ? {
+              x: Math.round(rect.x),
+              y: Math.round(rect.y),
+              width: Math.round(rect.width),
+              height: Math.round(rect.height),
+            }
+          : null,
+        parentContext: getParentContext(el),
+      });
+    }
+
+    results.sort((a, b) => {
+      if (!a.bounds || !b.bounds) return 0;
+      const yDiff = a.bounds.y - b.bounds.y;
+      if (Math.abs(yDiff) > 10) return yDiff;
+      return a.bounds.x - b.bounds.x;
+    });
+
+    return results;
+  });
+
+  return elements;
+}
+
+// ------------------------------------------------------------------
+// Core: getPageStructure
+// ------------------------------------------------------------------
+
+/**
+ * Extract semantic page structure: headings, landmarks, dialogs, forms, nav.
+ */
+export async function getPageStructure(page: Page): Promise<PageStructure> {
+  const title = await page.title();
+  const url = page.url();
+
+  const structure = await page.evaluate(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: polyfill for esbuild decorator
+    if (typeof (globalThis as any).__name === "undefined") {
+      // biome-ignore lint/suspicious/noExplicitAny: polyfill for esbuild decorator
+      (globalThis as any).__name = (target: any) => target;
+    }
+
+    const truncate = (str: string, max: number): string => {
+      const cleaned = str.replace(/\s+/g, " ").trim();
+      return cleaned.length > max
+        ? `${cleaned.substring(0, max)}...`
+        : cleaned;
+    };
+
+    const headings: Array<{ level: number; text: string }> = [];
+    const headingEls = Array.from(
+      document.querySelectorAll("h1, h2, h3, h4, h5, h6")
+    );
+    for (let i = 0; i < headingEls.length; i++) {
+      const h = headingEls[i];
+      headings.push({
+        level: Number.parseInt(h.tagName[1]),
+        text: truncate(h.textContent || "", 60),
+      });
+    }
+
+    const landmarks: Array<{ role: string; label: string | null }> = [];
+    const landmarkEls = Array.from(
+      document.querySelectorAll(
+        [
+          "header",
+          "nav",
+          "main",
+          "aside",
+          "footer",
+          '[role="banner"]',
+          '[role="navigation"]',
+          '[role="main"]',
+          '[role="complementary"]',
+          '[role="contentinfo"]',
+          '[role="search"]',
+        ].join(", ")
+      )
+    );
+    for (let i = 0; i < landmarkEls.length; i++) {
+      const el = landmarkEls[i];
+      landmarks.push({
+        role: el.getAttribute("role") || el.tagName.toLowerCase(),
+        label: el.getAttribute("aria-label"),
+      });
+    }
+
+    const dialogs: Array<{ title: string | null; visible: boolean }> = [];
+    const dialogEls = Array.from(
+      document.querySelectorAll(
+        '[role="dialog"], [role="alertdialog"], dialog'
+      )
+    );
+    for (let i = 0; i < dialogEls.length; i++) {
+      const d = dialogEls[i];
+      const titleEl = d.querySelector("h1, h2, h3, [class*=title]");
+      const style = window.getComputedStyle(d);
+      dialogs.push({
+        title: titleEl ? truncate(titleEl.textContent || "", 60) : null,
+        visible: style.display !== "none" && style.visibility !== "hidden",
+      });
+    }
+
+    const forms: Array<{
+      id: string | null;
+      action: string | null;
+      fields: number;
+    }> = [];
+    const formEls = Array.from(document.querySelectorAll("form"));
+    for (let i = 0; i < formEls.length; i++) {
+      const f = formEls[i];
+      forms.push({
+        id: f.getAttribute("id"),
+        action: f.getAttribute("action"),
+        fields: f.querySelectorAll("input, select, textarea").length,
+      });
+    }
+
+    const navItems: string[] = [];
+    const navEls = Array.from(
+      document.querySelectorAll("nav, [role=navigation]")
+    );
+    for (let i = 0; i < navEls.length; i++) {
+      const links = Array.from(navEls[i].querySelectorAll("a"));
+      for (let j = 0; j < links.length; j++) {
+        const text = truncate(links[j].textContent || "", 40);
+        if (text) navItems.push(text);
+      }
+    }
+
+    const toasts: string[] = [];
+    const toastEls = Array.from(
+      document.querySelectorAll(
+        "[data-sonner-toast], [role=status], [role=alert]"
+      )
+    );
+    for (let i = 0; i < toastEls.length; i++) {
+      const text = truncate(toastEls[i].textContent || "", 80);
+      if (text) toasts.push(text);
+    }
+
+    return { headings, landmarks, dialogs, forms, navItems, toasts };
+  });
+
+  return { title, url, ...structure };
+}
+
+// ------------------------------------------------------------------
+// Core: getAccessibilityTree
+// ------------------------------------------------------------------
+
+/**
+ * Get the ARIA snapshot from Playwright (v1.49+).
+ * Uses locator.ariaSnapshot() which returns a YAML-like string showing
+ * the accessibility tree: roles, names, values, and states.
+ * This maps directly to Playwright's getByRole/getByLabel locators.
+ */
+export async function getAccessibilityTree(
+  page: Page
+): Promise<AccessibilityNode | null> {
+  try {
+    const snapshot = await page.locator("body").ariaSnapshot();
+    if (!snapshot) return null;
+
+    // Parse the YAML-like aria snapshot into our AccessibilityNode structure
+    return parseAriaSnapshot(snapshot);
+  } catch {
+    // Fallback: ariaSnapshot not available
+    return null;
+  }
+}
+
+/**
+ * Parse Playwright's YAML-like aria snapshot format into structured nodes.
+ * Format is like:
+ *   - banner:
+ *     - link "KeeperHub Logo"
+ *     - button "Sign In"
+ *   - main:
+ *     - button "Start building"
+ */
+function parseAriaSnapshot(snapshot: string): AccessibilityNode {
+  const lines = snapshot.split("\n").filter((l) => l.trim().length > 0);
+  const root: AccessibilityNode = { role: "page", name: "", children: [] };
+  const stack: Array<{ node: AccessibilityNode; indent: number }> = [
+    { node: root, indent: -2 },
+  ];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const stripped = line.replace(/^(\s*)- /, "$1");
+    const indent = line.search(/\S/);
+    const content = stripped.trim();
+
+    // Parse role and name: "button "Sign In"" or "banner:" or "link "Home" [disabled]"
+    const match = content.match(
+      /^(\w+)(?:\s+"([^"]*)")?(?:\s+\[([^\]]+)\])?:?\s*$/
+    );
+    if (!match) continue;
+
+    const role = match[1];
+    const name = match[2] || "";
+    const stateStr = match[3];
+    const hasChildren = content.endsWith(":");
+
+    const node: AccessibilityNode = { role, name };
+    if (stateStr) {
+      const states = stateStr.split(/,\s*/);
+      for (let s = 0; s < states.length; s++) {
+        const state = states[s].trim();
+        if (state === "disabled") node.disabled = true;
+        if (state === "checked") node.checked = true;
+        if (state === "pressed") node.pressed = true;
+        if (state === "expanded") node.expanded = true;
+        if (state.startsWith("level="))
+          node.level = Number.parseInt(state.split("=")[1]);
+      }
+    }
+    if (hasChildren) node.children = [];
+
+    // Find parent based on indentation
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1].node;
+    if (!parent.children) parent.children = [];
+    parent.children.push(node);
+
+    if (hasChildren) {
+      stack.push({ node, indent });
+    }
+  }
+
+  return root;
+}
+
+/**
+ * Get the raw ARIA snapshot string from Playwright.
+ * This is the most compact, directly useful format for writing tests.
+ */
+export async function getAriaSnapshotRaw(
+  page: Page
+): Promise<string | null> {
+  try {
+    return await page.locator("body").ariaSnapshot();
+  } catch {
+    return null;
+  }
+}
+
+// ------------------------------------------------------------------
+// Core: diffReports
+// ------------------------------------------------------------------
+
+/**
+ * Compare two discovery reports and return what changed.
+ * Use this after an interaction to understand what appeared/disappeared.
+ *
+ * Usage:
+ *   const before = await probe(page, "before-click");
+ *   await page.click('button:has-text("Sign In")');
+ *   const after = await probe(page, "after-click");
+ *   const diff = diffReports(before, after);
+ */
+export function diffReports(
+  before: DiscoveryReport,
+  after: DiscoveryReport
+): StateDiff {
+  const elementKey = (el: ElementInfo): string =>
+    `${el.locator}|${el.tag}|${el.testId || ""}|${el.id || ""}`;
+
+  const beforeKeys = new Set(
+    before.interactive.filter((e) => e.visible).map(elementKey)
+  );
+  const afterKeys = new Set(
+    after.interactive.filter((e) => e.visible).map(elementKey)
+  );
+
+  const newElements = after.interactive
+    .filter((e) => e.visible)
+    .filter((e) => !beforeKeys.has(elementKey(e)));
+  const removedElements = before.interactive
+    .filter((e) => e.visible)
+    .filter((e) => !afterKeys.has(elementKey(e)));
+
+  const beforeDialogTitles = new Set(
+    before.structure.dialogs.filter((d) => d.visible).map((d) => d.title)
+  );
+  const afterDialogTitles = new Set(
+    after.structure.dialogs.filter((d) => d.visible).map((d) => d.title)
+  );
+  const newDialogs = after.structure.dialogs
+    .filter((d) => d.visible)
+    .filter((d) => !beforeDialogTitles.has(d.title))
+    .map((d) => ({ title: d.title }));
+  const closedDialogs = before.structure.dialogs
+    .filter((d) => d.visible)
+    .filter((d) => !afterDialogTitles.has(d.title))
+    .map((d) => ({ title: d.title }));
+
+  const beforeToasts = new Set(before.structure.toasts);
+  const newToasts = after.structure.toasts.filter((t) => !beforeToasts.has(t));
+
+  const headingKey = (h: { level: number; text: string }): string =>
+    `${h.level}:${h.text}`;
+  const beforeHeadings = new Set(before.structure.headings.map(headingKey));
+  const afterHeadings = new Set(after.structure.headings.map(headingKey));
+  const newHeadings = after.structure.headings.filter(
+    (h) => !beforeHeadings.has(headingKey(h))
+  );
+  const removedHeadings = before.structure.headings.filter(
+    (h) => !afterHeadings.has(headingKey(h))
+  );
+
+  const summaryParts: string[] = [];
+  if (before.structure.url !== after.structure.url) {
+    summaryParts.push(
+      `URL changed: ${before.structure.url} -> ${after.structure.url}`
+    );
+  }
+  if (newDialogs.length > 0) {
+    summaryParts.push(
+      `Opened: ${newDialogs.map((d) => d.title || "(untitled dialog)").join(", ")}`
+    );
+  }
+  if (closedDialogs.length > 0) {
+    summaryParts.push(
+      `Closed: ${closedDialogs.map((d) => d.title || "(untitled dialog)").join(", ")}`
+    );
+  }
+  if (newElements.length > 0) {
+    summaryParts.push(`${newElements.length} new elements appeared`);
+  }
+  if (removedElements.length > 0) {
+    summaryParts.push(`${removedElements.length} elements disappeared`);
+  }
+  if (newToasts.length > 0) {
+    summaryParts.push(`Toasts: ${newToasts.join(", ")}`);
+  }
+  if (summaryParts.length === 0) {
+    summaryParts.push("No visible changes detected");
+  }
+
+  return {
+    url: {
+      before: before.structure.url,
+      after: after.structure.url,
+    },
+    newElements,
+    removedElements,
+    newDialogs,
+    closedDialogs,
+    newToasts,
+    newHeadings,
+    removedHeadings,
+    summary: summaryParts.join("\n"),
+  };
+}
+
+/**
+ * Format a state diff as readable markdown.
+ */
+export function formatDiff(diff: StateDiff): string {
+  const lines: string[] = [];
+  lines.push("# State Diff");
+  lines.push("");
+
+  if (diff.url.before !== diff.url.after) {
+    lines.push(`URL: ${diff.url.before} -> ${diff.url.after}`);
+    lines.push("");
+  }
+
+  if (diff.newDialogs.length > 0) {
+    lines.push("## Dialogs Opened");
+    for (const d of diff.newDialogs) {
+      lines.push(`- ${d.title || "(untitled)"}`);
+    }
+    lines.push("");
+  }
+
+  if (diff.closedDialogs.length > 0) {
+    lines.push("## Dialogs Closed");
+    for (const d of diff.closedDialogs) {
+      lines.push(`- ${d.title || "(untitled)"}`);
+    }
+    lines.push("");
+  }
+
+  if (diff.newToasts.length > 0) {
+    lines.push("## New Toasts");
+    for (const t of diff.newToasts) {
+      lines.push(`- ${t}`);
+    }
+    lines.push("");
+  }
+
+  if (diff.newElements.length > 0) {
+    lines.push("## New Elements");
+    lines.push("");
+    lines.push("| Locator | Tag | Text | Disabled |");
+    lines.push("|---------|-----|------|----------|");
+    for (const el of diff.newElements) {
+      const text = el.text || el.ariaLabel || el.placeholder || "-";
+      lines.push(
+        `| \`${el.locator}\` | ${el.tag} | ${text.substring(0, 40)} | ${el.disabled ? "yes" : "-"} |`
+      );
+    }
+    lines.push("");
+  }
+
+  if (diff.removedElements.length > 0) {
+    lines.push("## Removed Elements");
+    lines.push("");
+    lines.push("| Locator | Tag | Text |");
+    lines.push("|---------|-----|------|");
+    for (const el of diff.removedElements) {
+      const text = el.text || el.ariaLabel || "-";
+      lines.push(
+        `| \`${el.locator}\` | ${el.tag} | ${text.substring(0, 40)} |`
+      );
+    }
+    lines.push("");
+  }
+
+  if (
+    diff.newElements.length === 0 &&
+    diff.removedElements.length === 0 &&
+    diff.newDialogs.length === 0 &&
+    diff.closedDialogs.length === 0 &&
+    diff.newToasts.length === 0
+  ) {
+    lines.push("No visible changes detected.");
+  }
+
+  return lines.join("\n");
+}
+
+// ------------------------------------------------------------------
+// Core: probe
+// ------------------------------------------------------------------
+
+const PROBE_DIR = join(
+  process.cwd(),
+  "tests",
+  "e2e",
+  "playwright",
+  ".probes"
+);
+
+/**
+ * Capture current page state: screenshot + element map + structure.
+ * Saves to tests/e2e/playwright/.probes/<label>-<timestamp>/
+ *
+ * Drop this into any test to understand what's on screen:
+ *   await probe(page, "after-login");
+ *   await probe(page, "dialog-open");
+ */
+export async function probe(
+  page: Page,
+  label = "probe"
+): Promise<DiscoveryReport> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const dirName = `${label}-${timestamp}`;
+  const outputDir = join(PROBE_DIR, dirName);
+  mkdirSync(outputDir, { recursive: true });
+
+  const [structure, interactive, accessibility, ariaRaw, screenshot] =
+    await Promise.all([
+      getPageStructure(page),
+      getInteractiveElements(page),
+      getAccessibilityTree(page),
+      getAriaSnapshotRaw(page),
+      page.screenshot({ fullPage: true }),
+    ]);
+
+  const visibleCount = interactive.filter((e) => e.visible).length;
+  const hiddenCount = interactive.length - visibleCount;
+  const withTestId = interactive.filter((e) => e.testId).length;
+
+  const summary = [
+    `Page: ${structure.title} (${structure.url})`,
+    `Interactive elements: ${visibleCount} visible, ${hiddenCount} hidden`,
+    `Elements with data-testid: ${withTestId}`,
+    `Headings: ${structure.headings.map((h) => `${"#".repeat(h.level)} ${h.text}`).join(", ")}`,
+    structure.dialogs.length > 0
+      ? `Open dialogs: ${structure.dialogs.filter((d) => d.visible).map((d) => d.title).join(", ")}`
+      : "No open dialogs",
+    structure.toasts.length > 0
+      ? `Toasts: ${structure.toasts.join(", ")}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const report: DiscoveryReport = {
+    timestamp: new Date().toISOString(),
+    structure,
+    interactive,
+    accessibility,
+    summary,
+  };
+
+  writeFileSync(join(outputDir, "screenshot.png"), screenshot);
+  writeFileSync(
+    join(outputDir, "report.json"),
+    JSON.stringify(report, null, 2)
+  );
+  writeFileSync(join(outputDir, "summary.txt"), summary);
+
+  const claudeView = formatForClaude(report);
+  writeFileSync(join(outputDir, "elements.md"), claudeView);
+
+  if (accessibility) {
+    const a11yView = formatAccessibilityTree(accessibility);
+    writeFileSync(join(outputDir, "accessibility.md"), a11yView);
+  }
+  if (ariaRaw) {
+    writeFileSync(join(outputDir, "aria-snapshot.yaml"), ariaRaw);
+  }
+
+  return report;
+}
+
+// ------------------------------------------------------------------
+// Core: highlightElements
+// ------------------------------------------------------------------
+
+/**
+ * Highlight interactive elements on the page with numbered red overlays.
+ * Take an annotated screenshot afterward, then reference elements by number.
+ */
+export async function highlightElements(
+  page: Page,
+  filter?: { visible?: boolean }
+): Promise<ElementInfo[]> {
+  const elements = await getInteractiveElements(page);
+  const filtered = elements.filter((el) => {
+    if (filter?.visible !== undefined && el.visible !== filter.visible) {
+      return false;
+    }
+    return true;
+  });
+
+  await page.evaluate(
+    (els: Array<{ bounds: { x: number; y: number; width: number; height: number } | null }>) => {
+      const existing = Array.from(
+        document.querySelectorAll("[data-pw-highlight]")
+      );
+      for (let i = 0; i < existing.length; i++) {
+        existing[i].remove();
+      }
+
+      for (let i = 0; i < els.length; i++) {
+        const el = els[i];
+        if (!el.bounds) continue;
+
+        const overlay = document.createElement("div");
+        overlay.setAttribute("data-pw-highlight", String(i));
+        overlay.style.cssText = [
+          "position: fixed",
+          `left: ${el.bounds.x}px`,
+          `top: ${el.bounds.y}px`,
+          `width: ${el.bounds.width}px`,
+          `height: ${el.bounds.height}px`,
+          "border: 2px solid #ff0000",
+          "background: rgba(255, 0, 0, 0.1)",
+          "z-index: 999999",
+          "pointer-events: none",
+          "box-sizing: border-box",
+        ].join(";");
+
+        const label = document.createElement("span");
+        label.style.cssText = [
+          "position: absolute",
+          "top: -8px",
+          "left: -8px",
+          "background: #ff0000",
+          "color: white",
+          "font-size: 10px",
+          "font-weight: bold",
+          "padding: 1px 4px",
+          "border-radius: 50%",
+          "min-width: 16px",
+          "text-align: center",
+          "line-height: 16px",
+          "font-family: monospace",
+        ].join(";");
+        label.textContent = String(i);
+        overlay.appendChild(label);
+
+        document.body.appendChild(overlay);
+      }
+    },
+    filtered.map((el) => ({ bounds: el.bounds }))
+  );
+
+  return filtered;
+}
+
+/**
+ * Remove all highlight overlays from the page.
+ */
+export async function clearHighlights(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const highlights = Array.from(
+      document.querySelectorAll("[data-pw-highlight]")
+    );
+    for (let i = 0; i < highlights.length; i++) {
+      highlights[i].remove();
+    }
+  });
+}
+
+// ------------------------------------------------------------------
+// Formatting
+// ------------------------------------------------------------------
+
+/**
+ * Format the accessibility tree as indented markdown.
+ * Shows role, name, and relevant states. This is the best data source
+ * for writing getByRole/getByLabel locators.
+ */
+function formatAccessibilityTree(
+  node: AccessibilityNode,
+  depth = 0
+): string {
+  const indent = "  ".repeat(depth);
+  const parts: string[] = [];
+
+  let line = `${indent}- **${node.role}**`;
+  if (node.name) line += ` "${node.name}"`;
+  if (node.value) line += ` = "${node.value}"`;
+
+  const states: string[] = [];
+  if (node.disabled) states.push("disabled");
+  if (node.checked !== undefined) states.push(`checked=${String(node.checked)}`);
+  if (node.pressed !== undefined) states.push(`pressed=${String(node.pressed)}`);
+  if (node.expanded !== undefined)
+    states.push(`expanded=${String(node.expanded)}`);
+  if (node.level) states.push(`level=${node.level}`);
+  if (states.length > 0) line += ` (${states.join(", ")})`;
+
+  parts.push(line);
+
+  if (node.children) {
+    for (let i = 0; i < node.children.length; i++) {
+      parts.push(formatAccessibilityTree(node.children[i], depth + 1));
+    }
+  }
+
+  return parts.join("\n");
+}
+
+function formatForClaude(report: DiscoveryReport): string {
+  const lines: string[] = [];
+
+  lines.push(`# Page Discovery: ${report.structure.title}`);
+  lines.push(`URL: ${report.structure.url}`);
+  lines.push(`Captured: ${report.timestamp}`);
+  lines.push("");
+
+  if (report.structure.headings.length > 0) {
+    lines.push("## Headings");
+    for (const h of report.structure.headings) {
+      lines.push(`${"  ".repeat(h.level - 1)}- ${h.text}`);
+    }
+    lines.push("");
+  }
+
+  if (report.structure.dialogs.some((d) => d.visible)) {
+    lines.push("## Open Dialogs");
+    for (const d of report.structure.dialogs.filter((d) => d.visible)) {
+      lines.push(`- ${d.title || "(untitled)"}`);
+    }
+    lines.push("");
+  }
+
+  if (report.structure.toasts.length > 0) {
+    lines.push("## Toasts");
+    for (const t of report.structure.toasts) {
+      lines.push(`- ${t}`);
+    }
+    lines.push("");
+  }
+
+  const visible = report.interactive.filter((e) => e.visible);
+  const groupedObj: Record<string, ElementInfo[]> = {};
+  for (const el of visible) {
+    const ctx = el.parentContext || "(page root)";
+    if (!groupedObj[ctx]) groupedObj[ctx] = [];
+    groupedObj[ctx].push(el);
+  }
+
+  lines.push("## Interactive Elements");
+  lines.push("");
+
+  const contexts = Object.keys(groupedObj);
+  for (let c = 0; c < contexts.length; c++) {
+    const context = contexts[c];
+    const elements = groupedObj[context];
+    lines.push(`### ${context}`);
+    lines.push("");
+    lines.push("| # | Locator | Tag | Text | Disabled |");
+    lines.push("|---|---------|-----|------|----------|");
+    for (let i = 0; i < elements.length; i++) {
+      const el = elements[i];
+      const text = el.text || el.ariaLabel || el.placeholder || "-";
+      lines.push(
+        `| ${i} | \`${el.locator}\` | ${el.tag} | ${text.substring(0, 40)} | ${el.disabled ? "yes" : "-"} |`
+      );
+    }
+    lines.push("");
+  }
+
+  const hidden = report.interactive.filter((e) => !e.visible);
+  if (hidden.length > 0) {
+    lines.push(
+      `<details><summary>${hidden.length} hidden elements</summary>\n`
+    );
+    lines.push("| Locator | Tag | Text |");
+    lines.push("|---------|-----|------|");
+    for (const el of hidden) {
+      const text = el.text || el.ariaLabel || "-";
+      lines.push(
+        `| \`${el.locator}\` | ${el.tag} | ${text.substring(0, 40)} |`
+      );
+    }
+    lines.push("\n</details>");
+  }
+
+  if (report.accessibility) {
+    lines.push("");
+    lines.push("## Accessibility Tree");
+    lines.push("");
+    lines.push(
+      "Use this to write `getByRole` / `getByLabel` locators."
+    );
+    lines.push("Each line shows: **role** \"accessible name\" (states)");
+    lines.push("");
+    lines.push(formatAccessibilityTree(report.accessibility));
+  }
+
+  return lines.join("\n");
+}
+
+// ------------------------------------------------------------------
+// Core: autoProbe
+// ------------------------------------------------------------------
+
+/**
+ * Whether discovery mode is active.
+ * Set PW_DISCOVER=1 to enable auto-probing in tests.
+ * Off by default, and always off in CI.
+ */
+export function isDiscoveryMode(): boolean {
+  if (process.env.CI) return false;
+  return process.env.PW_DISCOVER === "1" || process.env.PW_DISCOVER === "true";
+}
+
+interface AutoProbeHandle {
+  /** Stop listening and return all captured probes */
+  stop: () => DiscoveryReport[];
+  /** The last captured probe (or null if none yet) */
+  lastProbe: () => DiscoveryReport | null;
+}
+
+/**
+ * Attach auto-probing listeners to a page.
+ * Automatically captures a probe on:
+ *   - Main frame navigation (URL change)
+ *   - Dialog open/close (DOM mutation on [role="dialog"])
+ *
+ * Only active when PW_DISCOVER=1 (or forced with force=true).
+ * Always disabled in CI.
+ *
+ * Usage in tests:
+ *   const handle = await autoProbe(page);
+ *   // ... do your test interactions ...
+ *   const probes = handle.stop();
+ *
+ * Or in playwright.config.ts globalSetup for all tests:
+ *   if (isDiscoveryMode()) {
+ *     test.beforeEach(async ({ page }) => { await autoProbe(page); });
+ *   }
+ */
+export async function autoProbe(
+  page: Page,
+  options?: { force?: boolean }
+): Promise<AutoProbeHandle> {
+  const active = options?.force || isDiscoveryMode();
+  const probes: DiscoveryReport[] = [];
+  let lastReport: DiscoveryReport | null = null;
+  let probeInProgress = false;
+  let navigationCount = 0;
+
+  const handle: AutoProbeHandle = {
+    stop: () => {
+      page.removeListener("framenavigated", onNavigation);
+      return probes;
+    },
+    lastProbe: () => lastReport,
+  };
+
+  if (!active) return handle;
+
+  const captureProbe = async (label: string): Promise<void> => {
+    if (probeInProgress) return;
+    probeInProgress = true;
+    try {
+      // Small delay to let the page settle after navigation
+      await page.waitForLoadState("domcontentloaded").catch(() => {});
+      await page.waitForTimeout(300);
+
+      const before = lastReport;
+      const report = await probe(page, label);
+      probes.push(report);
+
+      if (before) {
+        const diff = diffReports(before, report);
+        if (diff.summary !== "No visible changes detected") {
+          const diffMd = formatDiff(diff);
+          const probeDir = join(
+            process.cwd(),
+            "tests",
+            "e2e",
+            "playwright",
+            ".probes"
+          );
+          const { readdirSync } = await import("node:fs");
+          const dirs = readdirSync(probeDir)
+            .filter((d) => d.startsWith(label))
+            .sort()
+            .reverse();
+          if (dirs[0]) {
+            writeFileSync(join(probeDir, dirs[0], "diff.md"), diffMd);
+          }
+        }
+      }
+
+      lastReport = report;
+    } finally {
+      probeInProgress = false;
+    }
+  };
+
+  const onNavigation = async (frame: { url: () => string }): Promise<void> => {
+    // Only probe main frame navigations
+    if (frame !== page.mainFrame()) return;
+
+    navigationCount++;
+    const url = new URL(frame.url());
+    const pathLabel = url.pathname.replace(/\//g, "-").replace(/^-/, "") || "root";
+    await captureProbe(`auto-nav-${navigationCount}-${pathLabel}`);
+  };
+
+  page.on("framenavigated", onNavigation);
+
+  // Take initial probe of current state
+  await captureProbe("auto-initial");
+
+  return handle;
+}
+
+/**
+ * Print a compact discovery report to stdout.
+ */
+export function printReport(report: DiscoveryReport): void {
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(report.summary);
+  console.log("=".repeat(60));
+
+  const visible = report.interactive.filter((e) => e.visible);
+  console.log("\nVisible interactive elements:");
+  console.log("-".repeat(60));
+
+  for (let i = 0; i < visible.length; i++) {
+    const el = visible[i];
+    const text = el.text || el.ariaLabel || el.placeholder || "";
+    const extra = [
+      el.disabled ? "DISABLED" : "",
+      el.inputType ? `type=${el.inputType}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    console.log(
+      `  [${String(i).padStart(2)}] ${el.locator.padEnd(45)} ${el.tag.padEnd(8)} ${text.substring(0, 30).padEnd(32)} ${extra}`
+    );
+  }
+
+  const hidden = report.interactive.filter((e) => !e.visible);
+  if (hidden.length > 0) {
+    console.log(`\n  (+ ${hidden.length} hidden elements)`);
+  }
+
+  if (report.accessibility) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log("Accessibility tree (interactive nodes):");
+    console.log("-".repeat(60));
+    const interactiveRoles = new Set([
+      "button",
+      "link",
+      "textbox",
+      "checkbox",
+      "radio",
+      "combobox",
+      "listbox",
+      "slider",
+      "switch",
+      "tab",
+      "menuitem",
+      "option",
+      "searchbox",
+      "spinbutton",
+    ]);
+    const printA11yNode = (
+      node: AccessibilityNode,
+      depth: number
+    ): void => {
+      const indent = "  ".repeat(depth);
+      if (interactiveRoles.has(node.role)) {
+        const states: string[] = [];
+        if (node.disabled) states.push("disabled");
+        if (node.checked !== undefined)
+          states.push(`checked=${String(node.checked)}`);
+        if (node.expanded !== undefined)
+          states.push(`expanded=${String(node.expanded)}`);
+        const stateStr = states.length > 0 ? ` [${states.join(", ")}]` : "";
+        console.log(
+          `${indent}${node.role}: "${node.name}"${stateStr}`
+        );
+      }
+      if (node.children) {
+        for (let i = 0; i < node.children.length; i++) {
+          printA11yNode(node.children[i], depth + (interactiveRoles.has(node.role) ? 1 : 0));
+        }
+      }
+    };
+    printA11yNode(report.accessibility, 1);
+  }
+}

--- a/tests/e2e/playwright/utils/index.ts
+++ b/tests/e2e/playwright/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth";
 export * from "./db";
+export * from "./discover";
 export * from "./workflow";


### PR DESCRIPTION
## Summary

- Add Playwright discovery framework for test authoring (`probe()`, `autoProbe()`, `diffReports()`, CLI via `pnpm discover`)
- Fix flaky Playwright tests: Date.now() collision in invitations, 404 retry in accept-invite, two-phase toast detection in wallet tests
- Add `aria-label` and `data-testid` attributes to sidebar nav, org switcher, user menu, wallet overlay, and add-step button
- Document React VDOM state capture as a future discovery enhancement

## Test plan

- [x] Playwright suite: 45 passed, 3 known flaky (2 timing, 1 Para API timeout), 1 skipped
- [x] Lint and type checks pass for all modified files
- [x] Discovery CLI (`pnpm discover / --auth --highlight`) produces structured reports
- [x] Verify a11y attributes render correctly in browser DevTools