### PR TITLE
fix: protocol step execution and logging

### DIFF
--- a/keeperhub/plugins/protocol/steps/protocol-read.ts
+++ b/keeperhub/plugins/protocol/steps/protocol-read.ts
@@ -8,7 +8,7 @@ import {
   type ReadContractResult,
   readContractCore,
 } from "@/keeperhub/plugins/web3/steps/read-contract-core";
-import type { StepInput } from "@/lib/steps/step-handler";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 
 type ProtocolMeta = {
   protocolSlug: string;
@@ -125,7 +125,7 @@ export async function protocolReadStep(
       : undefined,
   };
 
-  return await readContractCore(coreInput);
+  return await withStepLogging(input, () => readContractCore(coreInput));
 }
 
 export const _integrationType = "protocol";

--- a/keeperhub/plugins/protocol/steps/protocol-read.ts
+++ b/keeperhub/plugins/protocol/steps/protocol-read.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import "@/keeperhub/protocols";
 
 import { resolveAbi } from "@/keeperhub/lib/abi-cache";
 import { getProtocol } from "@/keeperhub/lib/protocol-registry";

--- a/keeperhub/plugins/protocol/steps/protocol-write.ts
+++ b/keeperhub/plugins/protocol/steps/protocol-write.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import "@/keeperhub/protocols";
 
 import { resolveAbi } from "@/keeperhub/lib/abi-cache";
 import { getProtocol } from "@/keeperhub/lib/protocol-registry";

--- a/keeperhub/plugins/protocol/steps/protocol-write.ts
+++ b/keeperhub/plugins/protocol/steps/protocol-write.ts
@@ -8,7 +8,7 @@ import {
   type WriteContractResult,
   writeContractCore,
 } from "@/keeperhub/plugins/web3/steps/write-contract-core";
-import type { StepInput } from "@/lib/steps/step-handler";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 
 type ProtocolMeta = {
   protocolSlug: string;
@@ -128,7 +128,7 @@ export async function protocolWriteStep(
       : undefined,
   };
 
-  return await writeContractCore(coreInput);
+  return await withStepLogging(input, () => writeContractCore(coreInput));
 }
 
 export const _integrationType = "protocol";


### PR DESCRIPTION
## Summary
- Fix "Unknown protocol: weth" error by adding side-effect import `import "@/keeperhub/protocols"` to both `protocol-read.ts` and `protocol-write.ts` -- step files are dynamically imported at runtime independent of server startup plugin chain, so the protocol registry must be populated within the step file's own import graph
- Fix protocol steps not appearing in workflow run UI by wrapping core calls with `withStepLogging` so execution logs are written to `workflow_execution_logs` table

## Test plan
- [x] Create workflow with WETH: Get Balance action
- [x] Run workflow -- no "Unknown protocol: weth" error
- [x] Verify both Manual and WETH steps appear in Runs panel (2 steps, not 1)
- [x] Lint and type-check pass