### PR TITLE
feat: add address book support to protocol address fields

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -55,6 +55,7 @@ function TemplateInputField({
 }: FieldProps) {
   // start custom keeperhub code //
   const isAddressField =
+    field.isAddressField === true ||
     field.key === "contractAddress" ||
     field.key === "recipientAddress" ||
     field.key === "address" ||

--- a/keeperhub/lib/protocol-registry.ts
+++ b/keeperhub/lib/protocol-registry.ts
@@ -145,6 +145,7 @@ function buildConfigFieldsFromAction(
       type: "template-input",
       placeholder: input.default ?? "",
       required: true,
+      ...(input.type === "address" ? { isAddressField: true } : {}),
     });
   }
 

--- a/keeperhub/plugins/index.ts
+++ b/keeperhub/plugins/index.ts
@@ -7,7 +7,7 @@
  * KeeperHub-specific plugins that extend the base workflow builder.
  * These plugins are loaded in addition to the base plugins.
  *
- * Discovered plugins: code, discord, math, sendgrid, telegram, web3, webhook
+ * Discovered plugins: code, discord, math, protocol, safe, sendgrid, telegram, web3, webhook
  */
 
 import "./code";

--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: ai-gateway, clerk, code, database, discord, linear, math, resend, sendgrid, slack, telegram, v0, web3, webflow, webhook
+ * Generated types: ai-gateway, clerk, code, database, discord, linear, math, protocol, resend, safe, sendgrid, slack, telegram, v0, web3, webflow, webhook, weth
  */
 
 // Integration type union - plugins + system integrations
@@ -21,14 +21,17 @@ export type IntegrationType =
   | "discord"
   | "linear"
   | "math"
+  | "protocol"
   | "resend"
+  | "safe"
   | "sendgrid"
   | "slack"
   | "telegram"
   | "v0"
   | "web3"
   | "webflow"
-  | "webhook";
+  | "webhook"
+  | "weth";
 
 // Generic config type - plugins define their own keys via formFields[].configKey
 export type IntegrationConfig = Record<string, string | boolean | undefined>;

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -102,6 +102,9 @@ export type ActionConfigFieldBase = {
   // start custom keeperhub code //
   // Tooltip text shown next to the label via an info icon
   helpTip?: string;
+
+  // Whether this field represents an Ethereum address (enables address book support)
+  isAddressField?: boolean;
   // end keeperhub code //
 };
 


### PR DESCRIPTION
## Summary

- Add `isAddressField` boolean to `ActionConfigFieldBase` type in the plugin field system
- Set `isAddressField: true` in `buildConfigFieldsFromAction()` when a protocol input has Solidity `address` type
- Add `field.isAddressField` check to address book detection in `action-config-renderer.tsx`
- Regenerate plugin types to include safe/protocol/weth (fixes pre-existing type error on staging)

Protocol actions with address-type inputs now automatically get address book popover support.

## Test plan

- [ ] Open workflow builder, add a WETH balance-of node
- [ ] Verify the "Wallet Address" field shows the address book popover on focus
- [ ] Verify existing transfer-token/transfer-funds address book still works
- [ ] Verify non-address protocol fields (e.g., uint256 amounts) do not show address book