### PR TITLE
fix: use-in-workflow button creates workflow with pre-configured action

### DIFF
--- a/keeperhub/plugins/index.ts
+++ b/keeperhub/plugins/index.ts
@@ -7,7 +7,7 @@
  * KeeperHub-specific plugins that extend the base workflow builder.
  * These plugins are loaded in addition to the base plugins.
  *
- * Discovered plugins: code, discord, math, sendgrid, telegram, web3, webhook
+ * Discovered plugins: code, discord, math, protocol, safe, sendgrid, telegram, web3, webhook
  */
 
 import "./code";

--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: ai-gateway, clerk, code, database, discord, linear, math, resend, sendgrid, slack, telegram, v0, web3, webflow, webhook
+ * Generated types: ai-gateway, clerk, code, database, discord, linear, math, protocol, resend, safe, sendgrid, slack, telegram, v0, web3, webflow, webhook, weth
  */
 
 // Integration type union - plugins + system integrations
@@ -21,14 +21,17 @@ export type IntegrationType =
   | "discord"
   | "linear"
   | "math"
+  | "protocol"
   | "resend"
+  | "safe"
   | "sendgrid"
   | "slack"
   | "telegram"
   | "v0"
   | "web3"
   | "webflow"
-  | "webhook";
+  | "webhook"
+  | "weth";
 
 // Generic config type - plugins define their own keys via formFields[].configKey
 export type IntegrationConfig = Record<string, string | boolean | undefined>;


### PR DESCRIPTION
## Summary

- Fix "Use in Workflow" button on protocol detail page (previously navigated to app root `/`)
- Button now creates a new workflow with Manual trigger + selected protocol action pre-configured
- Adds loading state per action row ("Creating..." while API call in flight)
- Falls back to anonymous sign-in if no session exists

## Test plan

- [ ] Navigate to Hub > Protocols > WETH
- [ ] Click "Use in Workflow" on any action (e.g., Get Balance)
- [ ] Verify a new workflow is created with Manual trigger + WETH action node
- [ ] Verify button shows "Creating..." during workflow creation
- [ ] Verify error toast appears if workflow creation fails