### PR TITLE
chore: add slash commands and skills

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,90 @@
+---
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)
+description: Code review a pull request
+argument-hint: [pr-number]
+disable-model-invocation: false
+---
+
+Provide a code review for the given pull request.
+
+To do this, follow these steps precisely:
+
+1. Use a Haiku agent to check if the pull request (a) is closed, (b) is a draft, (c) does not need a code review (eg. because it is an automated pull request, or is very simple and obviously ok), or (d) already has a code review from you from earlier. If so, do not proceed.
+2. Use another Haiku agent to give you a list of file paths to (but not the contents of) any relevant CLAUDE.md files from the codebase: the root CLAUDE.md file (if one exists), as well as any CLAUDE.md files in the directories whose files the pull request modified
+3. Use a Haiku agent to view the pull request, and ask the agent to return a summary of the change
+4. Then, launch 5 parallel Sonnet agents to independently code review the change. The agents should do the following, then return a list of issues and the reason each issue was flagged (eg. CLAUDE.md adherence, bug, historical git context, etc.):
+   a. Agent #1: Audit the changes to make sure they comply with the CLAUDE.md. Note that CLAUDE.md is guidance for Claude as it writes code, so not all instructions will be applicable during code review.
+   b. Agent #2: Read the file changes in the pull request, then do a shallow scan for obvious bugs. Avoid reading extra context beyond the changes, focusing just on the changes themselves. Focus on large bugs, and avoid small issues and nitpicks. Ignore likely false positives.
+   c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
+   d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current pull request.
+   e. Agent #5: Read code comments in the modified files, and make sure the changes in the pull request comply with any guidance in the comments.
+5. For each issue found in #4, launch a parallel Haiku agent that takes the PR, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
+   a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
+   b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
+   c. 50: Moderately confident. The agent was able to verify this is a real issue, but it might be a nitpick or not happen very often in practice. Relative to the rest of the PR, it's not very important.
+   d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
+   e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
+6. Filter out any issues with a score less than 80. If there are no issues that meet this criteria, do not proceed.
+7. Use a Haiku agent to repeat the eligibility check from #1, to make sure that the pull request is still eligible for code review.
+8. Finally, use the gh bash command to comment back on the pull request with the result. When writing your comment, keep in mind to:
+   a. Keep your output brief
+   b. Avoid emojis
+   c. Link and cite relevant code, files, and URLs
+
+Examples of false positives, for steps 4 and 5:
+
+- Pre-existing issues
+- Something that looks like a bug but is not actually a bug
+- Pedantic nitpicks that a senior engineer wouldn't call out
+- Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
+- General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
+- Changes in functionality that are likely intentional or are directly related to the broader change
+- Real issues, but on lines that the user did not modify in their pull request
+
+Notes:
+
+- Do not check build signal or attempt to build or typecheck the app. These will run separately, and are not relevant to your code review.
+- Use `gh` to interact with Github (eg. to fetch a pull request, or to create inline comments), rather than web fetch
+- Make a todo list first
+- You must cite and link each bug (eg. if referring to a CLAUDE.md, you must link it)
+- If $ARGUMENTS is provided, use it as the PR number. Otherwise, detect from current branch: run `gh pr list --head $(git branch --show-current) --json number --jq '.[0].number'`
+- For your final comment, follow the following format precisely (assuming for this example that you found 3 issues):
+
+---
+
+### Code review
+
+Found 3 issues:
+
+1. <brief description of bug> (CLAUDE.md says "<...>")
+
+<link to file and line with full sha1 + line range for context, note that you MUST provide the full sha and not use bash here, eg. https://github.com/anthropics/claude-code/blob/1d54823877c4de72b2316a64032a54afc404e619/README.md#L13-L17>
+
+2. <brief description of bug> (some/other/CLAUDE.md says "<...>")
+
+<link to file and line with full sha1 + line range for context>
+
+3. <brief description of bug> (bug due to <file and code snippet>)
+
+<link to file and line with full sha1 + line range for context>
+
+---
+
+- Or, if you found no issues:
+
+---
+
+### Code review
+
+No issues found. Checked for bugs and CLAUDE.md compliance.
+
+---
+
+- When linking to code, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/anthropics/claude-cli-internal/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
+  - Requires full git sha
+  - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
+  - Repo name must match the repo you're code reviewing
+  - # sign after the file name
+  - Line range format is L[start]-L[end]
+  - Provide at least 1 line of context before and after, centered on the line you are commenting about (eg. if you are commenting about lines 5-6, you should link to `L4-7`)

--- a/.claude/commands/create-slash-command.md
+++ b/.claude/commands/create-slash-command.md
@@ -1,0 +1,7 @@
+---
+description: Create a new slash command following best practices and patterns
+argument-hint: [command description or requirements]
+allowed-tools: Skill(create-slash-commands)
+---
+
+Invoke the create-slash-commands skill for: $ARGUMENTS

--- a/.claude/commands/heal-skill.md
+++ b/.claude/commands/heal-skill.md
@@ -1,0 +1,141 @@
+---
+description: Heal skill documentation by applying corrections discovered during execution with approval workflow
+argument-hint: [optional: specific issue to fix]
+allowed-tools: [Read, Edit, Bash(ls:*), Bash(git:*)]
+---
+
+<objective>
+Update a skill's SKILL.md and related files based on corrections discovered during execution.
+
+Analyze the conversation to detect which skill is running, reflect on what went wrong, propose specific fixes, get user approval, then apply changes with optional commit.
+</objective>
+
+<context>
+Skill detection: !`ls -1 ./skills/*/SKILL.md | head -5`
+</context>
+
+<quick_start>
+<workflow>
+1. **Detect skill** from conversation context (invocation messages, recent SKILL.md references)
+2. **Reflect** on what went wrong and how you discovered the fix
+3. **Present** proposed changes with before/after diffs
+4. **Get approval** before making any edits
+5. **Apply** changes and optionally commit
+</workflow>
+</quick_start>
+
+<process>
+<step_1 name="detect_skill">
+Identify the skill from conversation context:
+
+- Look for skill invocation messages
+- Check which SKILL.md was recently referenced
+- Examine current task context
+
+Set: `SKILL_NAME=[skill-name]` and `SKILL_DIR=./skills/$SKILL_NAME`
+
+If unclear, ask the user.
+</step_1>
+
+<step_2 name="reflection_and_analysis">
+Focus on $ARGUMENTS if provided, otherwise analyze broader context.
+
+Determine:
+- **What was wrong**: Quote specific sections from SKILL.md that are incorrect
+- **Discovery method**: Context7, error messages, trial and error, documentation lookup
+- **Root cause**: Outdated API, incorrect parameters, wrong endpoint, missing context
+- **Scope of impact**: Single section or multiple? Related files affected?
+- **Proposed fix**: Which files, which sections, before/after for each
+</step_2>
+
+<step_3 name="scan_affected_files">
+```bash
+ls -la $SKILL_DIR/
+ls -la $SKILL_DIR/references/ 2>/dev/null
+ls -la $SKILL_DIR/scripts/ 2>/dev/null
+```
+</step_3>
+
+<step_4 name="present_proposed_changes">
+Present changes in this format:
+
+```
+**Skill being healed:** [skill-name]
+**Issue discovered:** [1-2 sentence summary]
+**Root cause:** [brief explanation]
+
+**Files to be modified:**
+- [ ] SKILL.md
+- [ ] references/[file].md
+- [ ] scripts/[file].py
+
+**Proposed changes:**
+
+### Change 1: SKILL.md - [Section name]
+**Location:** Line [X] in SKILL.md
+
+**Current (incorrect):**
+```
+[exact text from current file]
+```
+
+**Corrected:**
+```
+[new text]
+```
+
+**Reason:** [why this fixes the issue]
+
+[repeat for each change across all files]
+
+**Impact assessment:**
+- Affects: [authentication/API endpoints/parameters/examples/etc.]
+
+**Verification:**
+These changes will prevent: [specific error that prompted this]
+```
+</step_4>
+
+<step_5 name="request_approval">
+```
+Should I apply these changes?
+
+1. Yes, apply and commit all changes
+2. Apply but don't commit (let me review first)
+3. Revise the changes (I'll provide feedback)
+4. Cancel (don't make changes)
+
+Choose (1-4):
+```
+
+**Wait for user response. Do not proceed without approval.**
+</step_5>
+
+<step_6 name="apply_changes">
+Only after approval (option 1 or 2):
+
+1. Use Edit tool for each correction across all files
+2. Read back modified sections to verify
+3. If option 1, commit with structured message showing what was healed
+4. Confirm completion with file list
+</step_6>
+</process>
+
+<success_criteria>
+- Skill correctly detected from conversation context
+- All incorrect sections identified with before/after
+- User approved changes before application
+- All edits applied across SKILL.md and related files
+- Changes verified by reading back
+- Commit created if user chose option 1
+- Completion confirmed with file list
+</success_criteria>
+
+<verification>
+Before completing:
+
+- Read back each modified section to confirm changes applied
+- Ensure cross-file consistency (SKILL.md examples match references/)
+- Verify git commit created if option 1 was selected
+- Check no unintended files were modified
+</verification>

--- a/.claude/commands/suggest-workflows.md
+++ b/.claude/commands/suggest-workflows.md
@@ -1,0 +1,147 @@
+---
+description: Analyze a protocol, contract, or case study to find automation gaps and suggest high-value KeeperHub workflows
+argument-hint: <target> (protocol name, contract address, case study topic, or URL)
+---
+
+<objective>
+Analyze $ARGUMENTS to find automation gaps and deliver maximum value to web3 protocol dev and ops teams through KeeperHub workflows.
+
+The primary purpose is identifying where manual, fragile, or missing automations are costing the target time, money, or reliability -- then designing workflows that close those gaps. Where gaps reveal missing KeeperHub capabilities, propose the specific plugins needed so we can build them.
+
+Existing workflows (balance watchers, fillers, poker, event listeners) are the foundation -- the primitives. Build upon them to create workflows that solve real operational problems.
+</objective>
+
+<context>
+
+KeeperHub is the critical reliability layer for Web3 operations, protecting Sky Protocol (formerly MakerDAO) with zero downtime and ~30% gas savings. The platform provides no-code workflow automation for blockchain operations.
+
+## Loading Current Platform Capabilities
+
+**Step 1: Try MCP (source of truth)**
+Use the `mcp__keeperhub__list_action_schemas` tool with `include_full_schemas: true` to get the current list of triggers, actions, and node structure. This is the authoritative source and reflects the latest platform capabilities.
+
+**Step 2: If MCP is unavailable, use this fallback**
+
+### Fallback Trigger Types
+- Manual (on-demand), Schedule (cron), Webhook (HTTP), Event (blockchain event listener)
+
+### Fallback Action Types
+- **Web3**: `web3/check-balance`, `web3/check-token-balance`, `web3/transfer-funds`, `web3/transfer-token`, `web3/read-contract`, `web3/write-contract`
+- **System**: `Condition` (gate logic), `HTTP Request` (external API calls), `Database Query` (state persistence -- user provides connection details)
+- **Messaging**: `sendgrid/send-email`, `discord/send-message`
+- **Webhook**: `webhook/send-webhook` (outbound HTTP)
+
+### Existing Workflow Patterns (the basics -- already solved)
+- **Watcher**: Schedule -> Check Balance -> Condition -> Notify
+- **Filler**: Schedule -> Check Balance -> Condition -> Transfer + Notify
+- **Poker**: Schedule -> Write Contract (execute function)
+- **Events**: Event Listener -> Notify/Webhook
+- **Contract Interaction**: Read -> Condition -> Write -> Verify -> Notify
+- **Batch Distribution**: Schedule -> Multiple Transfers -> Notify
+
+### Node/Edge Structure
+Workflows are DAGs. Nodes have: id, type (trigger/action), label, config (with actionType). Nodes reference upstream outputs via `{{@node-id:Label.field}}` syntax. Edges connect source to target.
+
+### Current Limitations (opportunities for new plugins)
+- EVM only (no Solana, Arbitrum yet)
+- No price feeds / oracle data natively
+- No cross-chain operations
+- No loops or recursion in workflows
+- No human-in-the-loop approval nodes
+- No AI/LLM reasoning nodes
+- No DeFi-protocol-specific integrations (Aave, Uniswap, etc.)
+
+## Production Reference (Sky Protocol)
+12 wallet watchers, MegaPoker hourly poke(), 3 Safe multisig event watchers, Trustless Manifesto event listener. These are table stakes -- go beyond them.
+</context>
+
+<process>
+
+1. **Load current platform capabilities**:
+   - Call `mcp__keeperhub__list_action_schemas` with `include_full_schemas: true`
+   - If MCP is available, use the returned triggers and actions as the definitive list
+   - If MCP is unavailable, use the fallback lists in the context section above
+   - Note which source was used in the output
+
+2. **Research the target deeply**:
+   - If $ARGUMENTS is a contract address (0x...): Use the `analyse-contract` agent
+   - If $ARGUMENTS is a protocol name: Use the `analyse-protocols` agent AND `discover-keepers` agent in parallel
+   - If $ARGUMENTS is a URL: Fetch and analyze the content, then research the protocols/concepts referenced
+   - If $ARGUMENTS is a topic/case study: Use web research to understand the domain
+   - Identify the smart contracts, functions, events, operational patterns, and pain points
+
+3. **Find automation gaps** -- the core of this analysis:
+   - What operations are currently manual or fragile for this target?
+   - What cross-protocol interactions could be automated?
+   - What data from one contract could trigger actions on another?
+   - What multi-step DeFi strategies could become one-click workflows?
+   - What security monitoring doesn't exist but should?
+   - What operational intelligence could be derived from on-chain data?
+   - What would save the most time, gas, or reduce the most risk?
+
+4. **Design workflows that close those gaps** -- for each:
+   - Can this be built TODAY with existing triggers, actions, and nodes?
+   - If not, what specific new plugin or trigger is missing?
+   - What is the operational value: time saved, risk reduced, gas optimized, reliability improved?
+   - Think about: trigger types (existing or new), action sequences, conditional logic, state persistence via Database nodes, notification routing
+
+5. **Structure each workflow suggestion as**:
+
+   ```
+   ## Workflow: [Name]
+
+   **The gap**: What manual/fragile/missing automation this addresses
+   **The idea**: 1-2 sentence description of the automation
+   **Value**: Concrete operational benefit (time saved, risk reduced, gas optimized, etc.)
+
+   **Trigger**: [type] - [description]
+   (mark as EXISTING or NEW TRIGGER)
+
+   **Nodes**:
+   1. [node type] - [what it does]
+   2. [node type] - [what it does]
+   ...
+   (mark each as EXISTING or NEW PLUGIN with a brief spec for new ones)
+
+   **Flow**: visual representation of the DAG
+
+   **Buildable today?**: Yes / Partially (what's missing) / No (what needs to be built)
+   **Value proposition**: Why a team would pay for this
+   ```
+
+6. **Propose new plugin concepts** (only for gaps that require them):
+   For each new node type or plugin referenced, provide:
+   - Plugin name and category
+   - What it does (input -> output)
+   - Why it needs to be a first-class node (not just a webhook workaround)
+   - Which workflows it unlocks
+
+7. **Prioritize by value**:
+   - Rank workflows by operational impact (high/medium/low)
+   - Separate into: buildable today vs requires new plugins
+   - For new plugins, identify the highest-leverage one (unlocks the most valuable workflows)
+
+</process>
+
+<output>
+Structure the output as:
+
+1. **Target Analysis** - What we researched, key findings, and identified automation gaps
+2. **Capability Source** - Whether MCP or fallback was used for platform capabilities
+3. **Workflow Suggestions** (5-10) - Each with the full structure above, prioritized by operational value
+4. **Buildable Today** - Which workflows can be assembled immediately with existing capabilities
+5. **New Plugin / Node Type Proposals** - Specific new capabilities needed to close remaining gaps, with specs
+6. **Priority Ranking** - Workflows ranked by value to web3 protocol dev and ops teams, with buildability status
+7. **Competitive Moat** - Why these workflows would be hard to replicate and valuable to the target audience
+</output>
+
+<success_criteria>
+- Every workflow addresses a specific, real automation gap for the target -- not generic blockchain monitoring
+- Workflows are prioritized by operational value: time saved, risk reduced, gas optimized, reliability improved
+- Workflows use existing KeeperHub capabilities wherever possible -- prefer buildable-today solutions
+- When new plugins are proposed, they are driven by genuine gaps (not novelty for its own sake)
+- Every new plugin proposal includes: name, category, input/output spec, and which workflows it enables
+- Ideas go beyond "monitor and alert" -- include multi-step DeFi operations, cross-protocol coordination, intelligent automation
+- The output reads as a value-first analysis: "here are the biggest automation gaps and how KeeperHub closes them"
+- Platform capabilities were sourced from MCP when available, with fallback noted if used
+</success_criteria>

--- a/.claude/skills/create-slash-commands/SKILL.md
+++ b/.claude/skills/create-slash-commands/SKILL.md
@@ -1,0 +1,630 @@
+---
+name: create-slash-commands
+description: Expert guidance for creating Claude Code slash commands. Use when working with slash commands, creating custom commands, understanding command structure, or learning YAML configuration.
+---
+
+<objective>
+Create effective slash commands for Claude Code that enable users to trigger reusable prompts with `/command-name` syntax. Slash commands expand as prompts in the current conversation, allowing teams to standardize workflows and operations. This skill teaches you to structure commands with XML tags, YAML frontmatter, dynamic context loading, and intelligent argument handling.
+</objective>
+
+<quick_start>
+
+<workflow>
+1. Create `.claude/commands/` directory (project) or use `~/.claude/commands/` (personal)
+2. Create `command-name.md` file
+3. Add YAML frontmatter (at minimum: `description`)
+4. Write command prompt
+5. Test with `/command-name [args]`
+</workflow>
+
+<example>
+**File**: `.claude/commands/optimize.md`
+
+```markdown
+---
+description: Analyze this code for performance issues and suggest optimizations
+---
+
+Analyze the performance of this code and suggest three specific optimizations:
+```
+
+**Usage**: `/optimize`
+
+Claude receives the expanded prompt and analyzes the code in context.
+</example>
+</quick_start>
+
+<xml_structure>
+All generated slash commands should use XML tags in the body (after YAML frontmatter) for clarity and consistency.
+
+<required_tags>
+
+**`<objective>`** - What the command does and why it matters
+```markdown
+<objective>
+What needs to happen and why this matters.
+Context about who uses this and what it accomplishes.
+</objective>
+```
+
+**`<process>` or `<steps>`** - How to execute the command
+```markdown
+<process>
+Sequential steps to accomplish the objective:
+1. First step
+2. Second step
+3. Final step
+</process>
+```
+
+**`<success_criteria>`** - How to know the command succeeded
+```markdown
+<success_criteria>
+Clear, measurable criteria for successful completion.
+</success_criteria>
+```
+</required_tags>
+
+<conditional_tags>
+
+**`<context>`** - When loading dynamic state or files
+```markdown
+<context>
+Current state: ! `git status`
+Relevant files: @ package.json
+</context>
+```
+(Note: Remove the space after @ in actual usage)
+
+**`<verification>`** - When producing artifacts that need checking
+```markdown
+<verification>
+Before completing, verify:
+- Specific test or check to perform
+- How to confirm it works
+</verification>
+```
+
+**`<testing>`** - When running tests is part of the workflow
+```markdown
+<testing>
+Run tests: ! `npm test`
+Check linting: ! `npm run lint`
+</testing>
+```
+
+**`<output>`** - When creating/modifying specific files
+```markdown
+<output>
+Files created/modified:
+- `./path/to/file.ext` - Description
+</output>
+```
+</conditional_tags>
+
+<structure_example>
+
+```markdown
+---
+name: example-command
+description: Does something useful
+argument-hint: [input]
+---
+
+<objective>
+Process $ARGUMENTS to accomplish [goal].
+
+This helps [who] achieve [outcome].
+</objective>
+
+<context>
+Current state: ! `relevant command`
+Files: @ relevant/files
+</context>
+
+<process>
+1. Parse $ARGUMENTS
+2. Execute operation
+3. Verify results
+</process>
+
+<success_criteria>
+- Operation completed without errors
+- Output matches expected format
+</success_criteria>
+```
+</structure_example>
+
+<intelligence_rules>
+
+**Simple commands** (single operation, no artifacts):
+- Required: `<objective>`, `<process>`, `<success_criteria>`
+- Example: `/check-todos`, `/first-principles`
+
+**Complex commands** (multi-step, produces artifacts):
+- Required: `<objective>`, `<process>`, `<success_criteria>`
+- Add: `<context>` (if loading state), `<verification>` (if creating files), `<output>` (what gets created)
+- Example: `/commit`, `/create-prompt`, `/run-prompt`
+
+**Commands with dynamic arguments**:
+- Use `$ARGUMENTS` in `<objective>` or `<process>` tags
+- Include `argument-hint` in frontmatter
+- Make it clear what the arguments are for
+
+**Commands that produce files**:
+- Always include `<output>` tag specifying what gets created
+- Always include `<verification>` tag with checks to perform
+
+**Commands that run tests/builds**:
+- Include `<testing>` tag with specific commands
+- Include pass/fail criteria in `<success_criteria>`
+</intelligence_rules>
+</xml_structure>
+
+<arguments_intelligence>
+The skill should intelligently determine whether a slash command needs arguments.
+
+<commands_that_need_arguments>
+
+**User provides specific input:**
+- `/fix-issue [issue-number]` - Needs issue number
+- `/review-pr [pr-number]` - Needs PR number
+- `/optimize [file-path]` - Needs file to optimize
+- `/commit [type]` - Needs commit type (optional)
+
+**Pattern:** Task operates on user-specified data
+
+Include `argument-hint: [description]` in frontmatter and reference `$ARGUMENTS` in the body.
+</commands_that_need_arguments>
+
+<commands_without_arguments>
+
+**Self-contained procedures:**
+- `/check-todos` - Operates on known file (TO-DOS.md)
+- `/first-principles` - Operates on current conversation
+- `/whats-next` - Analyzes current context
+
+**Pattern:** Task operates on implicit context (current conversation, known files, project state)
+
+Omit `argument-hint` and don't reference `$ARGUMENTS`.
+</commands_without_arguments>
+
+<incorporating_arguments>
+
+**In `<objective>` tag:**
+```markdown
+<objective>
+Fix issue #$ARGUMENTS following project conventions.
+
+This ensures bugs are resolved systematically with proper testing.
+</objective>
+```
+
+**In `<process>` tag:**
+```markdown
+<process>
+1. Understand issue #$ARGUMENTS from issue tracker
+2. Locate relevant code
+3. Implement fix
+4. Add tests
+</process>
+```
+
+**In `<context>` tag:**
+```markdown
+<context>
+Issue details: @ issues/$ARGUMENTS.md
+Related files: ! `grep -r "TODO.*$ARGUMENTS" src/`
+</context>
+```
+(Note: Remove the space after the exclamation mark in actual usage)
+</incorporating_arguments>
+
+<positional_arguments>
+
+For structured input, use `$1`, `$2`, `$3`:
+
+```markdown
+---
+argument-hint: <pr-number> <priority> <assignee>
+---
+
+<objective>
+Review PR #$1 with priority $2 and assign to $3.
+</objective>
+```
+
+**Usage:** `/review-pr 456 high alice`
+</positional_arguments>
+</arguments_intelligence>
+
+<file_structure>
+
+**Project commands**: `.claude/commands/`
+- Shared with team via version control
+- Shows `(project)` in `/help` list
+
+**Personal commands**: `~/.claude/commands/`
+- Available across all your projects
+- Shows `(user)` in `/help` list
+
+**File naming**: `command-name.md` → invoked as `/command-name`
+</file_structure>
+
+<yaml_frontmatter>
+
+<field name="description">
+**Required** - Describes what the command does
+
+```yaml
+description: Analyze this code for performance issues and suggest optimizations
+```
+
+Shown in the `/help` command list.
+</field>
+
+<field name="allowed-tools">
+**Optional** - Restricts which tools Claude can use
+
+```yaml
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+```
+
+**Formats**:
+- Array: `allowed-tools: [Read, Edit, Write]`
+- Single tool: `allowed-tools: SequentialThinking`
+- Bash restrictions: `allowed-tools: Bash(git add:*)`
+
+If omitted: All tools available
+</field>
+</yaml_frontmatter>
+
+<arguments>
+<all_arguments_string>
+
+**Command file**: `.claude/commands/fix-issue.md`
+```markdown
+---
+description: Fix issue following coding standards
+---
+
+Fix issue #$ARGUMENTS following our coding standards
+```
+
+**Usage**: `/fix-issue 123 high-priority`
+
+**Claude receives**: "Fix issue #123 high-priority following our coding standards"
+</all_arguments_string>
+
+<positional_arguments_syntax>
+
+**Command file**: `.claude/commands/review-pr.md`
+```markdown
+---
+description: Review PR with priority and assignee
+---
+
+Review PR #$1 with priority $2 and assign to $3
+```
+
+**Usage**: `/review-pr 456 high alice`
+
+**Claude receives**: "Review PR #456 with priority high and assign to alice"
+
+See [references/arguments.md](references/arguments.md) for advanced patterns.
+</positional_arguments_syntax>
+</arguments>
+
+<dynamic_context>
+
+Execute bash commands before the prompt using the exclamation mark prefix directly before backticks (no space between).
+
+**Note:** Examples below show a space after the exclamation mark to prevent execution during skill loading. In actual slash commands, remove the space.
+
+Example:
+
+```markdown
+---
+description: Create a git commit
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+---
+
+## Context
+
+- Current git status: ! `git status`
+- Current git diff: ! `git diff HEAD`
+- Current branch: ! `git branch --show-current`
+- Recent commits: ! `git log --oneline -10`
+
+## Your task
+
+Based on the above changes, create a single git commit.
+```
+
+The bash commands execute and their output is included in the expanded prompt.
+</dynamic_context>
+
+<file_references>
+
+Use `@` prefix to reference specific files:
+
+```markdown
+---
+description: Review implementation
+---
+
+Review the implementation in @ src/utils/helpers.js
+```
+(Note: Remove the space after @ in actual usage)
+
+Claude can access the referenced file's contents.
+</file_references>
+
+<best_practices>
+
+**1. Always use XML structure**
+```yaml
+# All slash commands should have XML-structured bodies
+```
+
+After frontmatter, use XML tags:
+- `<objective>` - What and why (always)
+- `<process>` - How to do it (always)
+- `<success_criteria>` - Definition of done (always)
+- Additional tags as needed (see xml_structure section)
+
+**2. Clear descriptions**
+```yaml
+# Good
+description: Analyze this code for performance issues and suggest optimizations
+
+# Bad
+description: Optimize stuff
+```
+
+**3. Use dynamic context for state-dependent tasks**
+```markdown
+Current git status: ! `git status`
+Files changed: ! `git diff --name-only`
+```
+
+**4. Restrict tools when appropriate**
+```yaml
+# For git commands - prevent running arbitrary bash
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+
+# For analysis - thinking only
+allowed-tools: SequentialThinking
+```
+
+**5. Use $ARGUMENTS for flexibility**
+```markdown
+Find and fix issue #$ARGUMENTS
+```
+
+**6. Reference relevant files**
+```markdown
+Review @ package.json for dependencies
+Analyze @ src/database/* for schema
+```
+(Note: Remove the space after @ in actual usage)
+</best_practices>
+
+<common_patterns>
+
+**Simple analysis command**:
+```markdown
+---
+description: Review this code for security vulnerabilities
+---
+
+<objective>
+Review code for security vulnerabilities and suggest fixes.
+</objective>
+
+<process>
+1. Scan code for common vulnerabilities (XSS, SQL injection, etc.)
+2. Identify specific issues with line numbers
+3. Suggest remediation for each issue
+</process>
+
+<success_criteria>
+- All major vulnerability types checked
+- Specific issues identified with locations
+- Actionable fixes provided
+</success_criteria>
+```
+
+**Git workflow with context**:
+```markdown
+---
+description: Create a git commit
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+---
+
+<objective>
+Create a git commit for current changes following repository conventions.
+</objective>
+
+<context>
+- Current status: ! `git status`
+- Changes: ! `git diff HEAD`
+- Recent commits: ! `git log --oneline -5`
+</context>
+
+<process>
+1. Review staged and unstaged changes
+2. Stage relevant files
+3. Write commit message following recent commit style
+4. Create commit
+</process>
+
+<success_criteria>
+- All relevant changes staged
+- Commit message follows repository conventions
+- Commit created successfully
+</success_criteria>
+```
+
+**Parameterized command**:
+```markdown
+---
+description: Fix issue following coding standards
+argument-hint: [issue-number]
+---
+
+<objective>
+Fix issue #$ARGUMENTS following project coding standards.
+
+This ensures bugs are resolved systematically with proper testing.
+</objective>
+
+<process>
+1. Understand the issue described in ticket #$ARGUMENTS
+2. Locate the relevant code in codebase
+3. Implement a solution that addresses root cause
+4. Add appropriate tests
+5. Verify fix resolves the issue
+</process>
+
+<success_criteria>
+- Issue fully understood and addressed
+- Solution follows coding standards
+- Tests added and passing
+- No regressions introduced
+</success_criteria>
+```
+
+**File-specific command**:
+```markdown
+---
+description: Optimize code performance
+argument-hint: [file-path]
+---
+
+<objective>
+Analyze performance of @ $ARGUMENTS and suggest specific optimizations.
+
+This helps improve application performance through targeted improvements.
+</objective>
+
+<process>
+1. Review code in @ $ARGUMENTS for performance issues
+2. Identify bottlenecks and inefficiencies
+3. Suggest three specific optimizations with rationale
+4. Estimate performance impact of each
+</process>
+
+<success_criteria>
+- Performance issues clearly identified
+- Three concrete optimizations suggested
+- Implementation guidance provided
+- Performance impact estimated
+</success_criteria>
+```
+
+**Usage**: `/optimize src/utils/helpers.js`
+
+See [references/patterns.md](references/patterns.md) for more examples.
+</common_patterns>
+
+<reference_guides>
+
+**Arguments reference**: [references/arguments.md](references/arguments.md)
+- $ARGUMENTS variable
+- Positional arguments ($1, $2, $3)
+- Parsing strategies
+- Examples from official docs
+
+**Patterns reference**: [references/patterns.md](references/patterns.md)
+- Git workflows
+- Code analysis
+- File operations
+- Security reviews
+- Examples from official docs
+
+**Tool restrictions**: [references/tool-restrictions.md](references/tool-restrictions.md)
+- Bash command patterns
+- Security best practices
+- When to restrict tools
+- Examples from official docs
+</reference_guides>
+
+<generation_protocol>
+
+1. **Analyze the user's request**:
+   - What is the command's purpose?
+   - Does it need user input ($ARGUMENTS)?
+   - Does it produce files or artifacts?
+   - Does it require verification or testing?
+   - Is it simple (single-step) or complex (multi-step)?
+
+2. **Create frontmatter**:
+   ```yaml
+   ---
+   name: command-name
+   description: Clear description of what it does
+   argument-hint: [input] # Only if arguments needed
+   allowed-tools: [...] # Only if tool restrictions needed
+   ---
+   ```
+
+3. **Create XML-structured body**:
+
+   **Always include:**
+   - `<objective>` - What and why
+   - `<process>` - How to do it (numbered steps)
+   - `<success_criteria>` - Definition of done
+
+   **Include when relevant:**
+   - `<context>` - Dynamic state (! `commands`) or file references (@ files)
+   - `<verification>` - Checks to perform if creating artifacts
+   - `<testing>` - Test commands if tests are part of workflow
+   - `<output>` - Files created/modified
+
+4. **Integrate $ARGUMENTS properly**:
+   - If user input needed: Add `argument-hint` and use `$ARGUMENTS` in tags
+   - If self-contained: Omit `argument-hint` and `$ARGUMENTS`
+
+5. **Apply intelligence**:
+   - Simple commands: Keep it concise (objective + process + success criteria)
+   - Complex commands: Add context, verification, testing as needed
+   - Don't over-engineer simple commands
+   - Don't under-specify complex commands
+
+6. **Save the file**:
+   - Project: `.claude/commands/command-name.md`
+   - Personal: `~/.claude/commands/command-name.md`
+</generation_protocol>
+
+<success_criteria>
+A well-structured slash command meets these criteria:
+
+**YAML Frontmatter**:
+- `description` field is clear and concise
+- `argument-hint` present if command accepts arguments
+- `allowed-tools` specified if tool restrictions needed
+
+**XML Structure**:
+- All three required tags present: `<objective>`, `<process>`, `<success_criteria>`
+- Conditional tags used appropriately based on complexity
+- No raw markdown headings in body
+- All XML tags properly closed
+
+**Arguments Handling**:
+- `$ARGUMENTS` used when command operates on user-specified data
+- Positional arguments (`$1`, `$2`, etc.) used when structured input needed
+- No `$ARGUMENTS` reference for self-contained commands
+
+**Functionality**:
+- Command expands correctly when invoked
+- Dynamic context loads properly (bash commands, file references)
+- Tool restrictions prevent unauthorized operations
+- Command accomplishes intended purpose reliably
+
+**Quality**:
+- Clear, actionable instructions in `<process>` tag
+- Measurable completion criteria in `<success_criteria>`
+- Appropriate level of detail (not over-engineered for simple tasks)
+- Examples provided when beneficial
+</success_criteria>

--- a/.claude/skills/create-slash-commands/references/arguments.md
+++ b/.claude/skills/create-slash-commands/references/arguments.md
@@ -1,0 +1,252 @@
+# Arguments Reference
+
+Official documentation examples for using arguments in slash commands.
+
+## $ARGUMENTS - All Arguments
+
+**Source**: Official Claude Code documentation
+
+Captures all arguments as a single concatenated string.
+
+### Basic Example
+
+**Command file**: `.claude/commands/fix-issue.md`
+```markdown
+---
+description: Fix issue following coding standards
+---
+
+Fix issue #$ARGUMENTS following our coding standards
+```
+
+**Usage**:
+```
+/fix-issue 123 high-priority
+```
+
+**Claude receives**:
+```
+Fix issue #123 high-priority following our coding standards
+```
+
+### Multi-Step Workflow Example
+
+**Command file**: `.claude/commands/fix-issue.md`
+```markdown
+---
+description: Fix issue following coding standards
+---
+
+Fix issue #$ARGUMENTS. Follow these steps:
+
+1. Understand the issue described in the ticket
+2. Locate the relevant code in our codebase
+3. Implement a solution that addresses the root cause
+4. Add appropriate tests
+5. Prepare a concise PR description
+```
+
+**Usage**:
+```
+/fix-issue 456
+```
+
+**Claude receives the full prompt** with "456" replacing $ARGUMENTS.
+
+## Positional Arguments - $1, $2, $3
+
+**Source**: Official Claude Code documentation
+
+Access specific arguments individually.
+
+### Example
+
+**Command file**: `.claude/commands/review-pr.md`
+```markdown
+---
+description: Review PR with priority and assignee
+---
+
+Review PR #$1 with priority $2 and assign to $3
+```
+
+**Usage**:
+```
+/review-pr 456 high alice
+```
+
+**Claude receives**:
+```
+Review PR #456 with priority high and assign to alice
+```
+
+- `$1` becomes `456`
+- `$2` becomes `high`
+- `$3` becomes `alice`
+
+## Argument Patterns from Official Docs
+
+### Pattern 1: File Reference with Argument
+
+**Command**:
+```markdown
+---
+description: Optimize code performance
+---
+
+Analyze the performance of this code and suggest three specific optimizations:
+
+@ $ARGUMENTS
+```
+
+**Usage**:
+```
+/optimize src/utils/helpers.js
+```
+
+References the file specified in the argument.
+
+### Pattern 2: Issue Tracking
+
+**Command**:
+```markdown
+---
+description: Find and fix issue
+---
+
+Find and fix issue #$ARGUMENTS.
+
+Follow these steps:
+1. Understand the issue described in the ticket
+2. Locate the relevant code in our codebase
+3. Implement a solution that addresses the root cause
+4. Add appropriate tests
+5. Prepare a concise PR description
+```
+
+**Usage**:
+```
+/fix-issue 789
+```
+
+### Pattern 3: Code Review with Context
+
+**Command**:
+```markdown
+---
+description: Review PR with context
+---
+
+Review PR #$1 with priority $2 and assign to $3
+
+Context from git:
+- Changes: ! `gh pr diff $1`
+- Status: ! `gh pr view $1 --json state`
+```
+
+**Usage**:
+```
+/review-pr 123 critical bob
+```
+
+Combines positional arguments with dynamic bash execution.
+
+## Best Practices
+
+### Use $ARGUMENTS for Simple Commands
+
+When you just need to pass a value through:
+```markdown
+Fix issue #$ARGUMENTS
+Optimize @ $ARGUMENTS
+Summarize $ARGUMENTS
+```
+
+### Use Positional Arguments for Structure
+
+When different arguments have different meanings:
+```markdown
+Review PR #$1 with priority $2 and assign to $3
+Deploy $1 to $2 environment with tag $3
+```
+
+### Provide Clear Descriptions
+
+Help users understand what arguments are expected:
+```yaml
+# Good
+description: Fix issue following coding standards (usage: /fix-issue <issue-number>)
+
+# Better - if using argument-hint field
+description: Fix issue following coding standards
+argument-hint: <issue-number> [priority]
+```
+
+## Empty Arguments
+
+Commands work with or without arguments:
+
+**Command**:
+```markdown
+---
+description: Analyze code for issues
+---
+
+Analyze this code for issues: $ARGUMENTS
+
+If no specific file provided, analyze the current context.
+```
+
+**Usage 1**: `/analyze src/app.js`
+**Usage 2**: `/analyze` (analyzes current conversation context)
+
+## Combining with Other Features
+
+### Arguments + Dynamic Context
+
+```markdown
+---
+description: Review changes for issue
+---
+
+Issue #$ARGUMENTS
+
+Recent changes:
+- Status: ! `git status`
+- Diff: ! `git diff`
+
+Review the changes related to this issue.
+```
+
+### Arguments + File References
+
+```markdown
+---
+description: Compare files
+---
+
+Compare @ $1 with @ $2 and highlight key differences.
+```
+
+**Usage**: `/compare src/old.js src/new.js`
+
+### Arguments + Tool Restrictions
+
+```markdown
+---
+description: Commit changes for issue
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+---
+
+Create commit for issue #$ARGUMENTS
+
+Status: ! `git status`
+Changes: ! `git diff HEAD`
+```
+
+## Notes
+
+- Arguments are whitespace-separated by default
+- Quote arguments containing spaces: `/command "argument with spaces"`
+- Arguments are passed as-is (no special parsing)
+- Empty arguments are replaced with empty string

--- a/.claude/skills/create-slash-commands/references/patterns.md
+++ b/.claude/skills/create-slash-commands/references/patterns.md
@@ -1,0 +1,796 @@
+# Command Patterns Reference
+
+Verified patterns from official Claude Code documentation.
+
+## Git Workflow Patterns
+
+### Pattern: Commit with Full Context
+
+**Source**: Official Claude Code documentation
+
+```markdown
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+
+<objective>
+Create a git commit for current changes following repository conventions.
+</objective>
+
+<context>
+- Current git status: ! `git status`
+- Current git diff (staged and unstaged changes): ! `git diff HEAD`
+- Current branch: ! `git branch --show-current`
+- Recent commits: ! `git log --oneline -10`
+</context>
+
+<process>
+1. Review staged and unstaged changes
+2. Stage relevant files with git add
+3. Write commit message following recent commit style
+4. Create commit
+</process>
+
+<success_criteria>
+- All relevant changes staged
+- Commit message follows repository conventions
+- Commit created successfully
+</success_criteria>
+```
+
+**Key features**:
+- Tool restrictions prevent running arbitrary bash commands
+- Dynamic context loaded via the exclamation mark prefix before backticks
+- Git state injected before prompt execution
+
+### Pattern: Simple Git Commit
+
+```markdown
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+
+<objective>
+Create a commit for current changes.
+</objective>
+
+<context>
+Current changes: ! `git status`
+</context>
+
+<process>
+1. Review changes
+2. Stage files
+3. Create commit
+</process>
+
+<success_criteria>
+- Changes committed successfully
+</success_criteria>
+```
+
+## Code Analysis Patterns
+
+### Pattern: Performance Optimization
+
+**Source**: Official Claude Code documentation
+
+**File**: `.claude/commands/optimize.md`
+```markdown
+---
+description: Analyze the performance of this code and suggest three specific optimizations
+---
+
+<objective>
+Analyze code performance and suggest three specific optimizations.
+
+This helps improve application performance through targeted improvements.
+</objective>
+
+<process>
+1. Review code in current conversation context
+2. Identify bottlenecks and inefficiencies
+3. Suggest three specific optimizations with rationale
+4. Estimate performance impact of each
+</process>
+
+<success_criteria>
+- Performance issues clearly identified
+- Three concrete optimizations suggested
+- Implementation guidance provided
+- Performance impact estimated
+</success_criteria>
+```
+
+**Usage**: `/optimize`
+
+Claude analyzes code in the current conversation context.
+
+### Pattern: Security Review
+
+**File**: `.claude/commands/security-review.md`
+```markdown
+---
+description: Review this code for security vulnerabilities
+---
+
+<objective>
+Review code for security vulnerabilities and suggest fixes.
+</objective>
+
+<process>
+1. Scan code for common vulnerabilities (XSS, SQL injection, CSRF, etc.)
+2. Identify specific issues with line numbers
+3. Assess severity of each vulnerability
+4. Suggest remediation for each issue
+</process>
+
+<success_criteria>
+- All major vulnerability types checked
+- Specific issues identified with locations
+- Severity levels assigned
+- Actionable fixes provided
+</success_criteria>
+```
+
+**Usage**: `/security-review`
+
+### Pattern: File-Specific Analysis
+
+```markdown
+---
+description: Optimize specific file
+argument-hint: [file-path]
+---
+
+<objective>
+Analyze performance of @ $ARGUMENTS and suggest three specific optimizations.
+
+This helps improve application performance through targeted file improvements.
+</objective>
+
+<process>
+1. Review code in @ $ARGUMENTS for performance issues
+2. Identify bottlenecks and inefficiencies
+3. Suggest three specific optimizations with rationale
+4. Estimate performance impact of each
+</process>
+
+<success_criteria>
+- File analyzed thoroughly
+- Performance issues identified
+- Three concrete optimizations suggested
+- Implementation guidance provided
+</success_criteria>
+```
+
+**Usage**: `/optimize src/utils/helpers.js`
+
+References the specified file.
+
+## Issue Tracking Patterns
+
+### Pattern: Fix Issue with Workflow
+
+**Source**: Official Claude Code documentation
+
+```markdown
+---
+description: Find and fix issue following workflow
+argument-hint: [issue-number]
+---
+
+<objective>
+Find and fix issue #$ARGUMENTS following project workflow.
+
+This ensures bugs are resolved systematically with proper testing and documentation.
+</objective>
+
+<process>
+1. Understand the issue described in ticket #$ARGUMENTS
+2. Locate the relevant code in codebase
+3. Implement a solution that addresses the root cause
+4. Add appropriate tests
+5. Prepare a concise PR description
+</process>
+
+<success_criteria>
+- Issue fully understood and addressed
+- Solution addresses root cause
+- Tests added and passing
+- PR description clearly explains fix
+</success_criteria>
+```
+
+**Usage**: `/fix-issue 123`
+
+### Pattern: PR Review with Context
+
+```markdown
+---
+description: Review PR with priority and assignment
+argument-hint: <pr-number> <priority> <assignee>
+---
+
+<objective>
+Review PR #$1 with priority $2 and assign to $3.
+
+This ensures PRs are reviewed systematically with proper prioritization and assignment.
+</objective>
+
+<process>
+1. Fetch PR #$1 details
+2. Review code changes
+3. Assess based on priority $2
+4. Provide feedback
+5. Assign to $3
+</process>
+
+<success_criteria>
+- PR reviewed thoroughly
+- Priority considered in review depth
+- Constructive feedback provided
+- Assigned to correct person
+</success_criteria>
+```
+
+**Usage**: `/review-pr 456 high alice`
+
+Uses positional arguments for structured input.
+
+## File Operation Patterns
+
+### Pattern: File Reference
+
+**Source**: Official Claude Code documentation
+
+```markdown
+---
+description: Review implementation
+---
+
+<objective>
+Review the implementation in @ src/utils/helpers.js.
+
+This ensures code quality and identifies potential improvements.
+</objective>
+
+<process>
+1. Read @ src/utils/helpers.js
+2. Analyze code structure and patterns
+3. Check for best practices
+4. Identify potential improvements
+5. Suggest specific changes
+</process>
+
+<success_criteria>
+- File reviewed thoroughly
+- Code quality assessed
+- Specific improvements identified
+- Actionable suggestions provided
+</success_criteria>
+```
+
+Uses `@` prefix to reference specific files.
+
+### Pattern: Dynamic File Reference
+
+```markdown
+---
+description: Review specific file
+argument-hint: [file-path]
+---
+
+<objective>
+Review the implementation in @ $ARGUMENTS.
+
+This allows flexible file review based on user specification.
+</objective>
+
+<process>
+1. Read @ $ARGUMENTS
+2. Analyze code structure and patterns
+3. Check for best practices
+4. Identify potential improvements
+5. Suggest specific changes
+</process>
+
+<success_criteria>
+- File reviewed thoroughly
+- Code quality assessed
+- Specific improvements identified
+- Actionable suggestions provided
+</success_criteria>
+```
+
+**Usage**: `/review src/app.js`
+
+File path comes from argument.
+
+### Pattern: Multi-File Analysis
+
+```markdown
+---
+description: Compare two files
+argument-hint: <file1> <file2>
+---
+
+<objective>
+Compare @ $1 with @ $2 and highlight key differences.
+
+This helps understand changes and identify important variations between files.
+</objective>
+
+<process>
+1. Read @ $1 and @ $2
+2. Identify structural differences
+3. Compare functionality and logic
+4. Highlight key changes
+5. Assess impact of differences
+</process>
+
+<success_criteria>
+- Both files analyzed
+- Key differences identified
+- Impact of changes assessed
+- Clear comparison provided
+</success_criteria>
+```
+
+**Usage**: `/compare src/old.js src/new.js`
+
+## Thinking-Only Patterns
+
+### Pattern: Deep Analysis
+
+```markdown
+---
+description: Analyze problem from first principles
+allowed-tools: SequentialThinking
+---
+
+<objective>
+Analyze the current problem from first principles.
+
+This helps discover optimal solutions by stripping away assumptions and rebuilding from fundamental truths.
+</objective>
+
+<process>
+1. Identify the core problem
+2. Strip away all assumptions
+3. Identify fundamental truths and constraints
+4. Rebuild solution from first principles
+5. Compare with current approach
+</process>
+
+<success_criteria>
+- Problem analyzed from ground up
+- Assumptions identified and questioned
+- Solution rebuilt from fundamentals
+- Novel insights discovered
+</success_criteria>
+```
+
+Tool restriction ensures Claude only uses SequentialThinking.
+
+### Pattern: Strategic Planning
+
+```markdown
+---
+description: Plan implementation strategy
+allowed-tools: SequentialThinking
+argument-hint: [task description]
+---
+
+<objective>
+Create a detailed implementation strategy for: $ARGUMENTS
+
+This ensures complex tasks are approached systematically with proper planning.
+</objective>
+
+<process>
+1. Break down task into phases
+2. Identify dependencies between phases
+3. Estimate complexity for each phase
+4. Suggest optimal approach
+5. Identify potential risks
+</process>
+
+<success_criteria>
+- Task broken into clear phases
+- Dependencies mapped
+- Complexity estimated
+- Optimal approach identified
+- Risks and mitigations outlined
+</success_criteria>
+```
+
+## Bash Execution Patterns
+
+### Pattern: Dynamic Environment Loading
+
+```markdown
+---
+description: Check project status
+---
+
+<objective>
+Provide a comprehensive project health summary.
+
+This helps understand current project state across git, dependencies, and tests.
+</objective>
+
+<context>
+- Git: ! `git status --short`
+- Node: ! `npm list --depth=0 2>/dev/null | head -20`
+- Tests: ! `npm test -- --listTests 2>/dev/null | wc -l`
+</context>
+
+<process>
+1. Analyze git status for uncommitted changes
+2. Review npm dependencies for issues
+3. Check test coverage
+4. Identify potential problems
+5. Provide actionable recommendations
+</process>
+
+<success_criteria>
+- All metrics checked
+- Current state clearly described
+- Issues identified
+- Recommendations provided
+</success_criteria>
+```
+
+Multiple bash commands load environment state.
+
+### Pattern: Conditional Execution
+
+```markdown
+---
+description: Deploy if tests pass
+allowed-tools: Bash(npm test:*), Bash(npm run deploy:*)
+---
+
+<objective>
+Deploy to production only if all tests pass.
+
+This ensures deployment safety through automated testing gates.
+</objective>
+
+<context>
+Test results: ! `npm test`
+</context>
+
+<process>
+1. Review test results
+2. If all tests passed, proceed to deployment
+3. If any tests failed, report failures and abort
+4. Monitor deployment process
+5. Confirm successful deployment
+</process>
+
+<success_criteria>
+- All tests verified passing
+- Deployment executed only on test success
+- Deployment confirmed successful
+- Or deployment aborted with clear failure reasons
+</success_criteria>
+```
+
+## Multi-Step Workflow Patterns
+
+### Pattern: Structured Workflow
+
+```markdown
+---
+description: Complete feature development workflow
+argument-hint: [feature description]
+---
+
+<objective>
+Complete full feature development workflow for: $ARGUMENTS
+
+This ensures features are developed systematically with proper planning, implementation, testing, and documentation.
+</objective>
+
+<process>
+1. **Planning**
+   - Review requirements
+   - Design approach
+   - Identify files to modify
+
+2. **Implementation**
+   - Write code
+   - Add tests
+   - Update documentation
+
+3. **Review**
+   - Run tests: ! `npm test`
+   - Check lint: ! `npm run lint`
+   - Verify changes: ! `git diff`
+
+4. **Completion**
+   - Create commit
+   - Write PR description
+</process>
+
+<testing>
+- Run tests: ! `npm test`
+- Check lint: ! `npm run lint`
+</testing>
+
+<verification>
+Before completing:
+- All tests passing
+- No lint errors
+- Documentation updated
+- Changes verified with git diff
+</verification>
+
+<success_criteria>
+- Feature fully implemented
+- Tests added and passing
+- Code passes linting
+- Documentation updated
+- Commit created
+- PR description written
+</success_criteria>
+```
+
+## Command Chaining Patterns
+
+### Pattern: Analysis → Action
+
+```markdown
+---
+description: Analyze and fix performance issues
+argument-hint: [file-path]
+---
+
+<objective>
+Analyze and fix performance issues in @ $ARGUMENTS.
+
+This provides end-to-end performance improvement from analysis through verification.
+</objective>
+
+<process>
+1. Analyze @ $ARGUMENTS for performance issues
+2. Identify top 3 most impactful optimizations
+3. Implement the optimizations
+4. Verify improvements with benchmarks
+</process>
+
+<verification>
+Before completing:
+- Benchmarks run showing performance improvement
+- No functionality regressions
+- Code quality maintained
+</verification>
+
+<success_criteria>
+- Performance issues identified and fixed
+- Measurable performance improvement
+- Benchmarks confirm gains
+- No regressions introduced
+</success_criteria>
+```
+
+Sequential steps in single command.
+
+## Tool Restriction Patterns
+
+### Pattern: Git-Only Command
+
+```markdown
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(git commit:*)
+description: Git workflow command
+---
+
+<objective>
+Perform git operations safely with tool restrictions.
+
+This prevents running arbitrary bash commands while allowing necessary git operations.
+</objective>
+
+<context>
+Current git state: ! `git status`
+</context>
+
+<process>
+1. Review git status
+2. Perform git operations
+3. Verify changes
+</process>
+
+<success_criteria>
+- Git operations completed successfully
+- No arbitrary commands executed
+- Repository state as expected
+</success_criteria>
+```
+
+Prevents running non-git bash commands.
+
+### Pattern: Read-Only Analysis
+
+```markdown
+---
+allowed-tools: [Read, Grep, Glob]
+description: Analyze codebase
+argument-hint: [search pattern]
+---
+
+<objective>
+Search codebase for pattern: $ARGUMENTS
+
+This provides safe codebase analysis without modification or execution permissions.
+</objective>
+
+<process>
+1. Use Grep to search for pattern across codebase
+2. Analyze findings
+3. Identify relevant files and code sections
+4. Provide summary of results
+</process>
+
+<success_criteria>
+- Pattern search completed
+- All matches identified
+- Relevant context provided
+- No files modified
+</success_criteria>
+```
+
+No write or execution permissions.
+
+### Pattern: Specific Bash Commands
+
+```markdown
+---
+allowed-tools: Bash(npm test:*), Bash(npm run lint:*)
+description: Run project checks
+---
+
+<objective>
+Run project quality checks (tests and linting).
+
+This ensures code quality while restricting to specific npm scripts.
+</objective>
+
+<testing>
+Tests: ! `npm test`
+Lint: ! `npm run lint`
+</testing>
+
+<process>
+1. Run tests and capture results
+2. Run linting and capture results
+3. Analyze both outputs
+4. Report on pass/fail status
+5. Provide specific failure details if any
+</process>
+
+<success_criteria>
+- All tests passing
+- No lint errors
+- Clear report of results
+- Or specific failures identified with details
+</success_criteria>
+```
+
+Only allows specific npm scripts.
+
+## Best Practices
+
+### 1. Use Tool Restrictions for Safety
+
+```yaml
+# Git commands
+allowed-tools: Bash(git add:*), Bash(git status:*)
+
+# Analysis only
+allowed-tools: [Read, Grep, Glob]
+
+# Thinking only
+allowed-tools: SequentialThinking
+```
+
+### 2. Load Dynamic Context When Needed
+
+```markdown
+Current state: ! `git status`
+Recent activity: ! `git log --oneline -5`
+```
+
+### 3. Reference Files Explicitly
+
+```markdown
+Review @ package.json for dependencies
+Check @ src/config/* for settings
+```
+
+### 4. Structure Complex Commands
+
+```markdown
+## Step 1: Analysis
+[analysis prompt]
+
+## Step 2: Implementation
+[implementation prompt]
+
+## Step 3: Verification
+[verification prompt]
+```
+
+### 5. Use Arguments for Flexibility
+
+```markdown
+# Simple
+Fix issue #$ARGUMENTS
+
+# Positional
+Review PR #$1 with priority $2
+
+# File reference
+Analyze @ $ARGUMENTS
+```
+
+## Anti-Patterns to Avoid
+
+### ❌ No Description
+
+```yaml
+---
+# Missing description field
+---
+```
+
+### ❌ Overly Broad Tool Access
+
+```yaml
+# Git command with no restrictions
+---
+description: Create commit
+---
+```
+
+Better:
+```yaml
+---
+description: Create commit
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+---
+```
+
+### ❌ Vague Instructions
+
+```markdown
+Do the thing for $ARGUMENTS
+```
+
+Better:
+```markdown
+Fix issue #$ARGUMENTS by:
+1. Understanding the issue
+2. Locating relevant code
+3. Implementing solution
+4. Adding tests
+```
+
+### ❌ Missing Context for State-Dependent Tasks
+
+```markdown
+Create a git commit
+```
+
+Better:
+```markdown
+Current changes: ! `git status`
+Diff: ! `git diff`
+
+Create a git commit for these changes
+```

--- a/.claude/skills/create-slash-commands/references/tool-restrictions.md
+++ b/.claude/skills/create-slash-commands/references/tool-restrictions.md
@@ -1,0 +1,376 @@
+# Tool Restrictions Reference
+
+Official documentation on restricting tool access in slash commands.
+
+## Why Restrict Tools
+
+Tool restrictions provide:
+- **Security**: Prevent accidental destructive operations
+- **Focus**: Limit scope for specialized commands
+- **Safety**: Ensure commands only perform intended operations
+
+## allowed-tools Field
+
+**Location**: YAML frontmatter
+
+**Format**: Array of tool names or patterns
+
+**Default**: If omitted, all tools available
+
+## Basic Patterns
+
+### Array Format
+
+```yaml
+---
+description: My command
+allowed-tools: [Read, Edit, Write]
+---
+```
+
+### Single Tool
+
+```yaml
+---
+description: Thinking command
+allowed-tools: SequentialThinking
+---
+```
+
+## Bash Command Restrictions
+
+**Source**: Official Claude Code documentation
+
+Restrict bash commands to specific patterns using wildcards.
+
+### Git-Only Commands
+
+```yaml
+---
+description: Create a git commit
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+---
+```
+
+**Allows**:
+- `git add <anything>`
+- `git status <anything>`
+- `git commit <anything>`
+
+**Prevents**:
+- `rm -rf`
+- `curl <url>`
+- Any non-git bash commands
+
+### NPM Script Restrictions
+
+```yaml
+---
+description: Run tests and lint
+allowed-tools: Bash(npm test:*), Bash(npm run lint:*)
+---
+```
+
+**Allows**:
+- `npm test`
+- `npm test -- --watch`
+- `npm run lint`
+- `npm run lint:fix`
+
+**Prevents**:
+- `npm install malicious-package`
+- `npm run deploy`
+- Other npm commands
+
+### Multiple Bash Patterns
+
+```yaml
+---
+description: Development workflow
+allowed-tools: Bash(git status:*), Bash(npm test:*), Bash(npm run build:*)
+---
+```
+
+Combines multiple bash command patterns.
+
+## Common Tool Restriction Patterns
+
+### Pattern 1: Git Workflows
+
+**Use case**: Commands that create commits, check status, etc.
+
+```yaml
+---
+description: Create a git commit
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(git commit:*)
+---
+
+Current status: ! `git status`
+Changes: ! `git diff HEAD`
+
+Create a commit for these changes.
+```
+
+**Security benefit**: Cannot accidentally run destructive commands like `rm -rf` or `curl malicious-site.com`
+
+### Pattern 2: Read-Only Analysis
+
+**Use case**: Commands that analyze code without modifying it
+
+```yaml
+---
+description: Analyze codebase for pattern
+allowed-tools: [Read, Grep, Glob]
+---
+
+Search codebase for: $ARGUMENTS
+```
+
+**Security benefit**: Cannot write files or execute code
+
+### Pattern 3: Thinking-Only Commands
+
+**Use case**: Deep analysis or planning without file operations
+
+```yaml
+---
+description: Analyze problem from first principles
+allowed-tools: SequentialThinking
+---
+
+Analyze the current problem from first principles.
+```
+
+**Focus benefit**: Claude focuses purely on reasoning, no file operations
+
+### Pattern 4: Controlled File Operations
+
+**Use case**: Commands that should only read/edit specific types
+
+```yaml
+---
+description: Update documentation
+allowed-tools: [Read, Edit(*.md)]
+---
+
+Update documentation in @ $ARGUMENTS
+```
+
+**Note**: File pattern restrictions may not be supported in all versions.
+
+## Real Examples from Official Docs
+
+### Example 1: Git Commit Command
+
+**Source**: Official Claude Code documentation
+
+```markdown
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+
+## Context
+
+- Current git status: ! `git status`
+- Current git diff (staged and unstaged changes): ! `git diff HEAD`
+- Current branch: ! `git branch --show-current`
+- Recent commits: ! `git log --oneline -10`
+
+## Your task
+
+Based on the above changes, create a single git commit.
+```
+
+**Allowed bash commands**:
+- `git add .`
+- `git add file.js`
+- `git status`
+- `git status --short`
+- `git commit -m "message"`
+- `git commit --amend`
+
+**Blocked commands**:
+- `rm file.js`
+- `curl https://malicious.com`
+- `npm install`
+- Any non-git commands
+
+### Example 2: Code Review (No Restrictions)
+
+```markdown
+---
+description: Review this code for security vulnerabilities
+---
+
+Review this code for security vulnerabilities:
+```
+
+**No allowed-tools field** = All tools available
+
+Claude can:
+- Read files
+- Write files
+- Execute bash commands
+- Use any tool
+
+**Use when**: Command needs full flexibility
+
+## When to Restrict Tools
+
+### ✅ Restrict when:
+
+1. **Security-sensitive operations**
+   ```yaml
+   # Git operations only
+   allowed-tools: Bash(git add:*), Bash(git status:*)
+   ```
+
+2. **Focused tasks**
+   ```yaml
+   # Deep thinking only
+   allowed-tools: SequentialThinking
+   ```
+
+3. **Read-only analysis**
+   ```yaml
+   # No modifications
+   allowed-tools: [Read, Grep, Glob]
+   ```
+
+4. **Specific bash commands**
+   ```yaml
+   # Only npm scripts
+   allowed-tools: Bash(npm run test:*), Bash(npm run build:*)
+   ```
+
+### ❌ Don't restrict when:
+
+1. **Command needs flexibility**
+   - Complex workflows
+   - Exploratory tasks
+   - Multi-step operations
+
+2. **Tool needs are unpredictable**
+   - General problem-solving
+   - Debugging unknown issues
+
+3. **Already in safe environment**
+   - Sandboxed execution
+   - Non-production systems
+
+## Best Practices
+
+### 1. Use Wildcards for Command Families
+
+```yaml
+# Good - allows all git commands
+allowed-tools: Bash(git *)
+
+# Better - specific git operations
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+
+# Best - minimal necessary permissions
+allowed-tools: Bash(git status:*), Bash(git diff:*)
+```
+
+### 2. Combine Tool Types Appropriately
+
+```yaml
+# Analysis with optional git context
+allowed-tools: [Read, Grep, Bash(git status:*)]
+```
+
+### 3. Test Restrictions
+
+Create command and verify:
+- Allowed operations work
+- Blocked operations are prevented
+- Error messages are clear
+
+### 4. Document Why
+
+```yaml
+---
+description: Create git commit (restricted to git commands only for security)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+---
+```
+
+## Tool Types
+
+### File Operations
+- `Read` - Read files
+- `Write` - Write new files
+- `Edit` - Modify existing files
+- `Grep` - Search file contents
+- `Glob` - Find files by pattern
+
+### Execution
+- `Bash(pattern:*)` - Execute bash commands matching pattern
+- `SequentialThinking` - Reasoning tool
+
+### Other
+- `Task` - Invoke subagents
+- `WebSearch` - Search the web
+- `WebFetch` - Fetch web pages
+
+## Security Patterns
+
+### Pattern: Prevent Data Exfiltration
+
+```yaml
+---
+description: Analyze code locally
+allowed-tools: [Read, Grep, Glob, SequentialThinking]
+# No Bash, WebFetch - cannot send data externally
+---
+```
+
+### Pattern: Prevent Destructive Operations
+
+```yaml
+---
+description: Review changes
+allowed-tools: [Read, Bash(git diff:*), Bash(git log:*)]
+# No Write, Edit, git reset, git push --force
+---
+```
+
+### Pattern: Controlled Deployment
+
+```yaml
+---
+description: Deploy to staging
+allowed-tools: Bash(npm run deploy:staging), Bash(git push origin:staging)
+# Cannot deploy to production accidentally
+---
+```
+
+## Limitations
+
+1. **Wildcard patterns** may vary by version
+2. **File-specific restrictions** (like `Edit(*.md)`) may not be supported
+3. **Cannot blacklist** - only whitelist
+4. **All or nothing** for tool types - can't partially restrict
+
+## Testing Tool Restrictions
+
+### Verify Restrictions Work
+
+1. Create command with restrictions
+2. Try to use restricted tool
+3. Confirm operation is blocked
+4. Check error message
+
+Example test:
+```markdown
+---
+description: Test restrictions
+allowed-tools: [Read]
+---
+
+Try to write a file - this should fail.
+```
+
+Expected: Write operations blocked with error message.


### PR DESCRIPTION
## Summary
- Add `/code-review` command (replaces old `address-pr-comments`) - multi-agent PR review with confidence scoring
- Add `/suggest-workflows` command for analyzing protocols and suggesting automations
- Add `/create-slash-command` and `/heal-skill` utility commands
- Add `create-slash-commands` skill with reference docs for building slash commands

## Test plan
- [ ] Verify `/code-review` triggers correctly with a PR number
- [ ] Verify `/suggest-workflows` runs against a protocol
- [ ] Verify `/create-slash-command` and `/heal-skill` load properly