### PR TITLE
feat: project and tag support for workflows with MCP integration

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -334,6 +334,7 @@ export async function PATCH(
       );
     }
 
+    // start custom keeperhub code //
     // Validate projectId/tagId ownership when provided
     if (body.projectId !== undefined || body.tagId !== undefined) {
       const targetOrgId = existingWorkflow.organizationId || organizationId;
@@ -372,6 +373,7 @@ export async function PATCH(
         }
       }
     }
+    // end keeperhub code //
 
     const updateData = buildUpdateData(body);
 

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -7,7 +7,7 @@ import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
-import { publicTags, workflowPublicTags, workflows } from "@/lib/db/schema";
+import { projects, publicTags, tags, workflowPublicTags, workflows } from "@/lib/db/schema";
 import { syncWorkflowSchedule } from "@/lib/schedule-service";
 
 // end keeperhub code //
@@ -332,6 +332,45 @@ export async function PATCH(
         { error: "Invalid visibility value. Must be 'private' or 'public'" },
         { status: 400 }
       );
+    }
+
+    // Validate projectId/tagId ownership when provided
+    if (body.projectId !== undefined || body.tagId !== undefined) {
+      const targetOrgId = existingWorkflow.organizationId || organizationId;
+
+      if (!targetOrgId) {
+        if (body.projectId || body.tagId) {
+          return NextResponse.json(
+            { error: "Cannot assign project or tag without an organization" },
+            { status: 400 }
+          );
+        }
+      } else {
+        if (body.projectId) {
+          const projRows = await db
+            .select({ orgId: projects.organizationId })
+            .from(projects)
+            .where(eq(projects.id, body.projectId));
+          if (!(projRows[0] && projRows[0].orgId === targetOrgId)) {
+            return NextResponse.json(
+              { error: "Project not found in this organization" },
+              { status: 404 }
+            );
+          }
+        }
+        if (body.tagId) {
+          const tagRows = await db
+            .select({ orgId: tags.organizationId })
+            .from(tags)
+            .where(eq(tags.id, body.tagId));
+          if (!(tagRows[0] && tagRows[0].orgId === targetOrgId)) {
+            return NextResponse.json(
+              { error: "Tag not found in this organization" },
+              { status: 404 }
+            );
+          }
+        }
+      }
     }
 
     const updateData = buildUpdateData(body);

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -193,6 +193,7 @@ export async function POST(request: Request) {
         organizationId,
         isAnonymous,
         projectId: body.projectId || null,
+        tagId: body.tagId || null,
         // end keeperhub code //
       })
       .returning();

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -8,7 +8,7 @@ import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
-import { workflows } from "@/lib/db/schema";
+import { projects, tags, workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 
 // end keeperhub code //
@@ -175,6 +175,52 @@ export async function POST(request: Request) {
       userId,
       organizationId
     );
+
+    // Validate projectId/tagId ownership when provided
+    if (body.projectId !== undefined || body.tagId !== undefined) {
+      if (isAnonymous) {
+        return NextResponse.json(
+          { error: "Cannot assign project or tag without an organization" },
+          { status: 400 }
+        );
+      }
+
+      if (body.projectId) {
+        const projRows = await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.id, body.projectId),
+              eq(projects.organizationId, organizationId ?? "")
+            )
+          );
+        if (projRows.length === 0) {
+          return NextResponse.json(
+            { error: "Project not found in this organization" },
+            { status: 404 }
+          );
+        }
+      }
+
+      if (body.tagId) {
+        const tagRows = await db
+          .select({ id: tags.id })
+          .from(tags)
+          .where(
+            and(
+              eq(tags.id, body.tagId),
+              eq(tags.organizationId, organizationId ?? "")
+            )
+          );
+        if (tagRows.length === 0) {
+          return NextResponse.json(
+            { error: "Tag not found in this organization" },
+            { status: 404 }
+          );
+        }
+      }
+    }
     // end keeperhub code //
 
     // Generate workflow ID first

--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -40,6 +40,7 @@ export async function GET(request: Request) {
     // Optional projectId filter
     const { searchParams } = new URL(request.url);
     const projectIdFilter = searchParams.get("projectId");
+    const tagIdFilter = searchParams.get("tagId");
 
     const conditions =
       !organizationId && userId
@@ -51,6 +52,9 @@ export async function GET(request: Request) {
 
     if (projectIdFilter) {
       conditions.push(eq(workflows.projectId, projectIdFilter));
+    }
+    if (tagIdFilter) {
+      conditions.push(eq(workflows.tagId, tagIdFilter));
     }
 
     const userWorkflows = await db

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -13,7 +13,7 @@ Manage workflows programmatically.
 GET /api/workflows
 ```
 
-Returns all workflows for the authenticated user.
+Returns all workflows for the authenticated user (session) or organization (API key).
 
 ### Query Parameters
 
@@ -31,20 +31,18 @@ GET /api/workflows?projectId=proj_123&tagId=tag_456
 ### Response
 
 ```json
-{
-  "data": [
-    {
-      "id": "wf_123",
-      "name": "My Workflow",
-      "description": "Monitors ETH balance",
-      "visibility": "private",
-      "nodes": [...],
-      "edges": [...],
-      "createdAt": "2024-01-01T00:00:00Z",
-      "updatedAt": "2024-01-01T00:00:00Z"
-    }
-  ]
-}
+[
+  {
+    "id": "wf_123",
+    "name": "My Workflow",
+    "description": "Monitors ETH balance",
+    "visibility": "private",
+    "nodes": [],
+    "edges": [],
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:00:00Z"
+  }
+]
 ```
 
 ## Get Workflow
@@ -83,7 +81,7 @@ Public workflows include a `publicTags` array showing all assigned tags.
 ## Create Workflow
 
 ```http
-POST /api/workflows
+POST /api/workflows/create
 ```
 
 ### Request Body

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -20,11 +20,12 @@ Returns all workflows for the authenticated user.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `projectId` | string | Optional. Filter workflows by project ID |
+| `tagId` | string | Optional. Filter workflows by tag ID |
 
 ### Example
 
 ```http
-GET /api/workflows?projectId=proj_123
+GET /api/workflows?projectId=proj_123&tagId=tag_456
 ```
 
 ### Response

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -567,6 +567,24 @@ export async function GET(request: Request) {
       },
     },
 
+    // Tags - workflow labeling
+    tags: {
+      description:
+        "Workflows can be labeled with a single tag per workflow. Tags are organization-scoped and have a name and color. Use tagId when creating or updating workflows to assign a tag.",
+      endpoints: {
+        list: "GET /api/tags - List all tags for the org (includes workflowCount)",
+        create:
+          "POST /api/tags - Create tag with { name, color } (color is required, e.g. '#4A90D9')",
+        update: "PATCH /api/tags/:id - Update tag name/color",
+        delete:
+          "DELETE /api/tags/:id - Delete tag (workflows lose their tag assignment)",
+      },
+      workflowFields: {
+        tagId:
+          "string | null - Optional tag ID to assign to the workflow. Pass null to unassign. Each workflow can have at most one tag.",
+      },
+    },
+
     // Tips for AI workflow generation
     tips: [
       "actionType must match exactly (e.g., 'web3/check-balance', not 'Get Wallet Balance')",
@@ -580,6 +598,7 @@ export async function GET(request: Request) {
       "web3 write actions (transfer-funds, write-contract) require wallet integration",
       'tokenConfig must be a JSON string with format: {"mode":"custom","customToken":{"address":"0x...","symbol":"USDC"}} -- do NOT use a flat {address, symbol, decimals} object',
       "Use projectId to organize related workflows into a project (e.g., all Sky ESM workflows in one project)",
+      "Use tagId to label a workflow with a single tag (e.g., 'production', 'monitoring'). Each workflow supports one tag. Fetch available tags from GET /api/tags first.",
       `Use {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)`,
       "All trigger types expose a 'triggeredAt' output field (ISO timestamp). Reference it with {{@triggerId:TriggerLabel.data.triggeredAt}} to include when the workflow fired.",
     ],

--- a/keeperhub/api/projects/[projectId]/route.ts
+++ b/keeperhub/api/projects/[projectId]/route.ts
@@ -1,36 +1,8 @@
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
-import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-import { auth } from "@/lib/auth";
+import { resolveOrganizationId } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
-
-async function resolveOrganizationId(
-  request: Request
-): Promise<{ organizationId: string } | { error: string; status: number }> {
-  const apiKeyAuth = await authenticateApiKey(request);
-
-  if (apiKeyAuth.authenticated) {
-    const organizationId = apiKeyAuth.organizationId;
-    if (!organizationId) {
-      return { error: "No active organization", status: 400 };
-    }
-    return { organizationId };
-  }
-
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
-  }
-
-  const orgContext = await getOrgContext();
-  const organizationId = orgContext.organization?.id;
-  if (!organizationId) {
-    return { error: "No active organization", status: 400 };
-  }
-  return { organizationId };
-}
 
 export async function PATCH(
   request: Request,

--- a/keeperhub/api/projects/[projectId]/route.ts
+++ b/keeperhub/api/projects/[projectId]/route.ts
@@ -1,9 +1,36 @@
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
+
+async function resolveOrganizationId(
+  request: Request
+): Promise<{ organizationId: string } | { error: string; status: number }> {
+  const apiKeyAuth = await authenticateApiKey(request);
+
+  if (apiKeyAuth.authenticated) {
+    const organizationId = apiKeyAuth.organizationId;
+    if (!organizationId) {
+      return { error: "No active organization", status: 400 };
+    }
+    return { organizationId };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const orgContext = await getOrgContext();
+  const organizationId = orgContext.organization?.id;
+  if (!organizationId) {
+    return { error: "No active organization", status: 400 };
+  }
+  return { organizationId };
+}
 
 export async function PATCH(
   request: Request,
@@ -12,23 +39,15 @@ export async function PATCH(
   try {
     const { projectId } = await context.params;
 
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const orgContext = await getOrgContext();
-    const organizationId = orgContext.organization?.id;
-
-    if (!organizationId) {
+    const authResult = await resolveOrganizationId(request);
+    if ("error" in authResult) {
       return NextResponse.json(
-        { error: "No active organization" },
-        { status: 400 }
+        { error: authResult.error },
+        { status: authResult.status }
       );
     }
+
+    const { organizationId } = authResult;
 
     const body = await request.json().catch(() => ({}));
 
@@ -94,23 +113,15 @@ export async function DELETE(
   try {
     const { projectId } = await context.params;
 
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const orgContext = await getOrgContext();
-    const organizationId = orgContext.organization?.id;
-
-    if (!organizationId) {
+    const authResult = await resolveOrganizationId(request);
+    if ("error" in authResult) {
       return NextResponse.json(
-        { error: "No active organization" },
-        { status: 400 }
+        { error: authResult.error },
+        { status: authResult.status }
       );
     }
+
+    const { organizationId } = authResult;
 
     const result = await db
       .delete(projects)

--- a/keeperhub/api/projects/route.ts
+++ b/keeperhub/api/projects/route.ts
@@ -1,6 +1,7 @@
 import { count, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
+import { resolveCreatorContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
@@ -78,40 +79,6 @@ export async function GET(request: Request) {
       { status: 500 }
     );
   }
-}
-
-async function resolveCreatorContext(
-  request: Request
-): Promise<
-  { organizationId: string; userId: string } | { error: string; status: number }
-> {
-  const apiKeyAuth = await authenticateApiKey(request);
-  if (apiKeyAuth.authenticated) {
-    const organizationId = apiKeyAuth.organizationId || null;
-    const userId = apiKeyAuth.userId || null;
-    if (!organizationId) {
-      return { error: "No active organization", status: 400 };
-    }
-    if (!userId) {
-      return {
-        error: "API key has no associated user. Please recreate the API key.",
-        status: 400,
-      };
-    }
-    return { organizationId, userId };
-  }
-
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
-  }
-
-  const context = await getOrgContext();
-  const organizationId = context.organization?.id || null;
-  if (!organizationId) {
-    return { error: "No active organization", status: 400 };
-  }
-  return { organizationId, userId: session.user.id };
 }
 
 export async function POST(request: Request) {

--- a/keeperhub/api/projects/route.ts
+++ b/keeperhub/api/projects/route.ts
@@ -80,25 +80,50 @@ export async function GET(request: Request) {
   }
 }
 
+async function resolveCreatorContext(
+  request: Request
+): Promise<
+  { organizationId: string; userId: string } | { error: string; status: number }
+> {
+  const apiKeyAuth = await authenticateApiKey(request);
+  if (apiKeyAuth.authenticated) {
+    const organizationId = apiKeyAuth.organizationId || null;
+    const userId = apiKeyAuth.userId || null;
+    if (!organizationId) {
+      return { error: "No active organization", status: 400 };
+    }
+    if (!userId) {
+      return {
+        error: "API key has no associated user. Please recreate the API key.",
+        status: 400,
+      };
+    }
+    return { organizationId, userId };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const context = await getOrgContext();
+  const organizationId = context.organization?.id || null;
+  if (!organizationId) {
+    return { error: "No active organization", status: 400 };
+  }
+  return { organizationId, userId: session.user.id };
+}
+
 export async function POST(request: Request) {
   try {
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const context = await getOrgContext();
-    const organizationId = context.organization?.id;
-
-    if (!organizationId) {
+    const resolved = await resolveCreatorContext(request);
+    if ("error" in resolved) {
       return NextResponse.json(
-        { error: "No active organization" },
-        { status: 400 }
+        { error: resolved.error },
+        { status: resolved.status }
       );
     }
+    const { organizationId, userId: creatorUserId } = resolved;
 
     const body = await request.json().catch(() => ({}));
     const name = body.name?.trim();
@@ -122,7 +147,7 @@ export async function POST(request: Request) {
         description: body.description?.trim() || null,
         color,
         organizationId,
-        userId: session.user.id,
+        userId: creatorUserId,
       })
       .returning();
 

--- a/keeperhub/api/tags/[tagId]/route.ts
+++ b/keeperhub/api/tags/[tagId]/route.ts
@@ -1,9 +1,36 @@
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { tags } from "@/lib/db/schema";
+
+async function resolveOrganizationId(
+  request: Request
+): Promise<{ organizationId: string } | { error: string; status: number }> {
+  const apiKeyAuth = await authenticateApiKey(request);
+
+  if (apiKeyAuth.authenticated) {
+    const organizationId = apiKeyAuth.organizationId;
+    if (!organizationId) {
+      return { error: "No active organization", status: 400 };
+    }
+    return { organizationId };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const orgContext = await getOrgContext();
+  const organizationId = orgContext.organization?.id;
+  if (!organizationId) {
+    return { error: "No active organization", status: 400 };
+  }
+  return { organizationId };
+}
 
 export async function PATCH(
   request: Request,
@@ -12,23 +39,15 @@ export async function PATCH(
   try {
     const { tagId } = await context.params;
 
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const orgContext = await getOrgContext();
-    const organizationId = orgContext.organization?.id;
-
-    if (!organizationId) {
+    const authResult = await resolveOrganizationId(request);
+    if ("error" in authResult) {
       return NextResponse.json(
-        { error: "No active organization" },
-        { status: 400 }
+        { error: authResult.error },
+        { status: authResult.status }
       );
     }
+
+    const { organizationId } = authResult;
 
     const body = await request.json().catch(() => ({}));
 
@@ -90,23 +109,15 @@ export async function DELETE(
   try {
     const { tagId } = await context.params;
 
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const orgContext = await getOrgContext();
-    const organizationId = orgContext.organization?.id;
-
-    if (!organizationId) {
+    const authResult = await resolveOrganizationId(request);
+    if ("error" in authResult) {
       return NextResponse.json(
-        { error: "No active organization" },
-        { status: 400 }
+        { error: authResult.error },
+        { status: authResult.status }
       );
     }
+
+    const { organizationId } = authResult;
 
     const result = await db
       .delete(tags)

--- a/keeperhub/api/tags/[tagId]/route.ts
+++ b/keeperhub/api/tags/[tagId]/route.ts
@@ -1,36 +1,8 @@
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
-import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-import { auth } from "@/lib/auth";
+import { resolveOrganizationId } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { tags } from "@/lib/db/schema";
-
-async function resolveOrganizationId(
-  request: Request
-): Promise<{ organizationId: string } | { error: string; status: number }> {
-  const apiKeyAuth = await authenticateApiKey(request);
-
-  if (apiKeyAuth.authenticated) {
-    const organizationId = apiKeyAuth.organizationId;
-    if (!organizationId) {
-      return { error: "No active organization", status: 400 };
-    }
-    return { organizationId };
-  }
-
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
-  }
-
-  const orgContext = await getOrgContext();
-  const organizationId = orgContext.organization?.id;
-  if (!organizationId) {
-    return { error: "No active organization", status: 400 };
-  }
-  return { organizationId };
-}
 
 export async function PATCH(
   request: Request,

--- a/keeperhub/api/tags/route.ts
+++ b/keeperhub/api/tags/route.ts
@@ -68,25 +68,50 @@ export async function GET(request: Request): Promise<NextResponse> {
   }
 }
 
+async function resolveCreatorContext(
+  request: Request
+): Promise<
+  { organizationId: string; userId: string } | { error: string; status: number }
+> {
+  const apiKeyAuth = await authenticateApiKey(request);
+  if (apiKeyAuth.authenticated) {
+    const organizationId = apiKeyAuth.organizationId || null;
+    const userId = apiKeyAuth.userId || null;
+    if (!organizationId) {
+      return { error: "No active organization", status: 400 };
+    }
+    if (!userId) {
+      return {
+        error: "API key has no associated user. Please recreate the API key.",
+        status: 400,
+      };
+    }
+    return { organizationId, userId };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const context = await getOrgContext();
+  const organizationId = context.organization?.id || null;
+  if (!organizationId) {
+    return { error: "No active organization", status: 400 };
+  }
+  return { organizationId, userId: session.user.id };
+}
+
 export async function POST(request: Request): Promise<NextResponse> {
   try {
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const context = await getOrgContext();
-    const organizationId = context.organization?.id;
-
-    if (!organizationId) {
+    const resolved = await resolveCreatorContext(request);
+    if ("error" in resolved) {
       return NextResponse.json(
-        { error: "No active organization" },
-        { status: 400 }
+        { error: resolved.error },
+        { status: resolved.status }
       );
     }
+    const { organizationId, userId: creatorUserId } = resolved;
 
     const body = await request.json().catch(() => ({}));
     const name = body.name?.trim();
@@ -105,7 +130,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         name,
         color: body.color,
         organizationId,
-        userId: session.user.id,
+        userId: creatorUserId,
       })
       .returning();
 

--- a/keeperhub/api/tags/route.ts
+++ b/keeperhub/api/tags/route.ts
@@ -1,6 +1,7 @@
 import { count, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
+import { resolveCreatorContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
@@ -66,40 +67,6 @@ export async function GET(request: Request): Promise<NextResponse> {
       { status: 500 }
     );
   }
-}
-
-async function resolveCreatorContext(
-  request: Request
-): Promise<
-  { organizationId: string; userId: string } | { error: string; status: number }
-> {
-  const apiKeyAuth = await authenticateApiKey(request);
-  if (apiKeyAuth.authenticated) {
-    const organizationId = apiKeyAuth.organizationId || null;
-    const userId = apiKeyAuth.userId || null;
-    if (!organizationId) {
-      return { error: "No active organization", status: 400 };
-    }
-    if (!userId) {
-      return {
-        error: "API key has no associated user. Please recreate the API key.",
-        status: 400,
-      };
-    }
-    return { organizationId, userId };
-  }
-
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
-  }
-
-  const context = await getOrgContext();
-  const organizationId = context.organization?.id || null;
-  if (!organizationId) {
-    return { error: "No active organization", status: 400 };
-  }
-  return { organizationId, userId: session.user.id };
 }
 
 export async function POST(request: Request): Promise<NextResponse> {

--- a/keeperhub/lib/middleware/auth-helpers.ts
+++ b/keeperhub/lib/middleware/auth-helpers.ts
@@ -1,0 +1,71 @@
+import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
+import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
+import { auth } from "@/lib/auth";
+
+/**
+ * Resolves the organization ID from either an API key or session.
+ * Used by PATCH/DELETE routes that only need org-level authorization.
+ */
+export async function resolveOrganizationId(
+  request: Request
+): Promise<{ organizationId: string } | { error: string; status: number }> {
+  const apiKeyAuth = await authenticateApiKey(request);
+
+  if (apiKeyAuth.authenticated) {
+    const organizationId = apiKeyAuth.organizationId;
+    if (!organizationId) {
+      return { error: "No active organization", status: 400 };
+    }
+    return { organizationId };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const orgContext = await getOrgContext();
+  const organizationId = orgContext.organization?.id;
+  if (!organizationId) {
+    return { error: "No active organization", status: 400 };
+  }
+  return { organizationId };
+}
+
+/**
+ * Resolves both organization ID and user ID from either an API key or session.
+ * Used by POST routes that need to track the creator.
+ */
+export async function resolveCreatorContext(
+  request: Request
+): Promise<
+  { organizationId: string; userId: string } | { error: string; status: number }
+> {
+  const apiKeyAuth = await authenticateApiKey(request);
+  if (apiKeyAuth.authenticated) {
+    const organizationId = apiKeyAuth.organizationId || null;
+    const userId = apiKeyAuth.userId || null;
+    if (!organizationId) {
+      return { error: "No active organization", status: 400 };
+    }
+    if (!userId) {
+      return {
+        error: "API key has no associated user. Please recreate the API key.",
+        status: 400,
+      };
+    }
+    return { organizationId, userId };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const context = await getOrgContext();
+  const organizationId = context.organization?.id || null;
+  if (!organizationId) {
+    return { error: "No active organization", status: 400 };
+  }
+  return { organizationId, userId: session.user.id };
+}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -779,6 +779,7 @@ export type Tag = {
   color: string;
   workflowCount: number;
   organizationId: string;
+  userId: string;
   createdAt: string;
   updatedAt: string;
 };

--- a/types/dotenv-expand.d.ts
+++ b/types/dotenv-expand.d.ts
@@ -1,5 +1,0 @@
-declare module "dotenv-expand" {
-  // Minimal type stubs to satisfy type-checking in bundler mode
-  // The library expands values from a dotenv config object in-place.
-  export function expand(config: unknown): unknown;
-}

--- a/types/dotenv-expand.d.ts
+++ b/types/dotenv-expand.d.ts
@@ -1,0 +1,5 @@
+declare module "dotenv-expand" {
+  // Minimal type stubs to satisfy type-checking in bundler mode
+  // The library expands values from a dotenv config object in-place.
+  export function expand(config: unknown): unknown;
+}


### PR DESCRIPTION
This PR adds API key authentication to the projects/tags endpoints and exposes tags in the MCP so AI agents can assign tags when creating or managing workflows.
 
 
 ## Summary

  - Add project and tag CRUD endpoints with full API key auth support so MCP can create, list, update, and delete projects/tags using org API keys
  - Add projectId/tagId fields to workflow create and update, with org-ownership validation to prevent cross-org assignment
  - Add tagId filter to GET /api/workflows alongside the existing projectId filter
  - Document projects and tags in MCP schemas endpoint with endpoints, field references, and generation tips

  ## Changes

  **API key auth**
  - POST /api/projects and POST /api/tags now accept org API keys (resolves org + creator userId from key)
  - PATCH/DELETE for both resources also accept API keys

  **Workflow assignment**
  - Create and update workflows accept projectId and tagId
  - Both fields are validated: project/tag must belong to the same organization as the workflow

  **Filtering**
  - GET /api/workflows supports ?tagId= filter alongside ?projectId=

  **MCP schemas**
  - Projects and tags sections added with endpoint references and workflowField docs
  - Tips added for projectId/tagId discovery and assignment

  **Types and docs**
  - Tag client type updated to include userId (matches API response)
  - GET /api/workflows docs corrected (flat array response, /create endpoint)
