### PR TITLE
fix: add Cloudflare Access headers for deployed E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -401,8 +401,12 @@ jobs:
       - name: Wait for PR environment to be ready
         run: |
           echo "Waiting for ${{ env.BASE_URL }}/api/health to return 200..."
+          CF_HEADERS=""
+          if [[ -n "$CF_ACCESS_CLIENT_ID" && -n "$CF_ACCESS_CLIENT_SECRET" ]]; then
+            CF_HEADERS="-H CF-Access-Client-Id:${CF_ACCESS_CLIENT_ID} -H CF-Access-Client-Secret:${CF_ACCESS_CLIENT_SECRET}"
+          fi
           for i in {1..30}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${{ env.BASE_URL }}/api/health")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" $CF_HEADERS "${{ env.BASE_URL }}/api/health")
             if [[ "$STATUS" == "200" ]]; then
               echo "PR environment is ready!"
               exit 0
@@ -412,11 +416,16 @@ jobs:
           done
           echo "PR environment did not become ready in time"
           exit 1
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
       - name: Run Playwright tests against deployed environment
         run: pnpm exec playwright test --grep-invert "happy-paths"
         env:
           BASE_URL: ${{ env.BASE_URL }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           CI: true
 
       - name: Upload Playwright report

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,6 +43,15 @@ export default defineConfig({
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     navigationTimeout: 60_000,
+    // Cloudflare Access headers for deployed PR environments
+    ...(isDeployedEnv &&
+      process.env.CF_ACCESS_CLIENT_ID &&
+      process.env.CF_ACCESS_CLIENT_SECRET && {
+        extraHTTPHeaders: {
+          "CF-Access-Client-Id": process.env.CF_ACCESS_CLIENT_ID,
+          "CF-Access-Client-Secret": process.env.CF_ACCESS_CLIENT_SECRET,
+        },
+      }),
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- Pass `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` to the health check curl and Playwright test runner in the deployed E2E job
- Playwright config conditionally sets `extraHTTPHeaders` when running against a deployed environment with CF credentials available
- Fixes HTTP 302 redirects from Cloudflare Access blocking deployed E2E tests

## Test plan

- [ ] Merge to staging, then trigger a deploy + deployed E2E run to verify health check returns 200 instead of 302