### PR TITLE
fix: only run local E2E tests with run-e2e-tests label

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,8 +30,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "run-e2e=true" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests') }}" == "true" ]] || \
-               [[ "${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-environment') }}" == "true" ]]; then
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests') }}" == "true" ]]; then
               echo "run-e2e=true" >> $GITHUB_OUTPUT
             fi
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then


### PR DESCRIPTION
## Summary

- `deploy-pr-environment` label no longer triggers local E2E tests (vitest + playwright)
- Only `run-e2e-tests` label triggers local E2E tests
- Deployed E2E tests continue to run automatically after deploy completes via `workflow_run` trigger

## Test plan

- [x] Add `deploy-pr-environment` label to a PR -- verify only the deploy workflow runs, not local E2E tests
- [x] Add `run-e2e-tests` label to a PR -- verify local E2E tests run