### PR TITLE
ci: KEEP-1500 add maintainability workflow for repo health checks

### DIFF
--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -187,7 +187,9 @@ jobs:
                 .|./) continue ;;
                 *\**) continue ;;
               esac
-              if [ ! -e "$dir/$src" ]; then
+              # Check relative to Dockerfile dir first, then repo root
+              # (Dockerfiles may be built with a parent directory as context)
+              if [ ! -e "$dir/$src" ] && [ ! -e "./$src" ]; then
                 echo "::error file=$dockerfile::COPY/ADD source does not exist: $src"
                 failed=1
               fi

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -1,0 +1,293 @@
+name: Maintainability
+
+on:
+  pull_request:
+    branches: [staging]
+
+jobs:
+  compose-validation:
+    name: Docker Compose Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate docker-compose.yml
+        run: docker compose -f docker-compose.yml config --quiet
+
+      - name: Validate docker-compose.test.yml
+        run: docker compose -f docker-compose.test.yml config --quiet
+
+  makefile-dry-run:
+    name: Makefile Dry Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dry run core targets
+        run: |
+          failed=0
+          for target in install build dev-up dev-down dev-logs dev-migrate test test-unit test-integration; do
+            if ! make -n "$target" > /dev/null 2>&1; then
+              echo "FAIL: make -n $target"
+              make -n "$target" 2>&1
+              failed=1
+            fi
+          done
+          exit $failed
+
+  fork-markers:
+    name: Fork Marker Integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check balanced markers
+        run: |
+          failed=0
+          for file in $(grep -rl "start custom keeperhub code" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.mjs" --include="*.css" . 2>/dev/null | grep -v node_modules | grep -v .next); do
+            starts=$(grep -c "start custom keeperhub code" "$file")
+            ends=$(grep -c "end keeperhub code" "$file")
+            if [ "$starts" -ne "$ends" ]; then
+              echo "::warning file=$file::Imbalanced fork markers: $starts start(s), $ends end(s)"
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "Fork markers must be balanced. Every 'start custom keeperhub code' needs a matching 'end keeperhub code'."
+            exit 1
+          fi
+          echo "All fork markers balanced."
+
+      - name: Check unmarked custom code outside keeperhub/
+        run: |
+          unmarked=""
+          for file in $(grep -rl "from.*[@/]keeperhub/" --include="*.ts" --include="*.tsx" app/ components/ lib/ plugins/ 2>/dev/null | grep -v node_modules | grep -v .next); do
+            if ! grep -q "start custom keeperhub code" "$file"; then
+              unmarked="$unmarked$file\n"
+              echo "::warning file=$file::Imports from keeperhub/ but has no fork markers"
+            fi
+          done
+          if [ -n "$unmarked" ]; then
+            count=$(echo -e "$unmarked" | grep -c .)
+            echo ""
+            echo "$count file(s) outside keeperhub/ import from keeperhub/ without fork markers."
+            echo "Either move these files into keeperhub/ with re-export wrappers, or add start/end markers."
+          fi
+
+  shellcheck:
+    name: Shell Script Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        run: |
+          scripts=$(find . -name "*.sh" -not -path "./node_modules/*" -not -path "./.next/*" -not -path "./.git/*")
+          if [ -z "$scripts" ]; then
+            echo "No shell scripts found."
+            exit 0
+          fi
+          echo "Checking: $scripts"
+          echo "$scripts" | xargs shellcheck --severity=warning --format=gcc
+
+  actionlint:
+    name: GitHub Actions Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install actionlint
+        run: |
+          curl -sL "https://github.com/rhysd/actionlint/releases/download/v1.7.11/actionlint_1.7.11_linux_amd64.tar.gz" \
+            | tar xz -C /usr/local/bin actionlint
+
+      - name: Run actionlint (structural only)
+        run: |
+          output=$(actionlint -shellcheck="" 2>&1) || true
+          if [ -n "$output" ]; then
+            echo "$output"
+            echo ""
+            echo "Structural issues found in GitHub Actions workflows."
+            exit 1
+          fi
+          echo "All workflows structurally valid."
+
+  hadolint:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Lint Dockerfiles
+        run: |
+          failed=0
+          for dockerfile in $(find . -name "Dockerfile" -not -path "./node_modules/*" -not -path "./.git/*"); do
+            echo "=== $dockerfile ==="
+            if ! docker run --rm -i hadolint/hadolint --failure-threshold warning < "$dockerfile"; then
+              failed=1
+            fi
+          done
+          exit $failed
+
+  dockerfile-sources:
+    name: Dockerfile COPY Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check COPY/ADD sources exist
+        run: |
+          failed=0
+          for dockerfile in $(find . -name "Dockerfile" -not -path "./node_modules/*" -not -path "./.git/*"); do
+            dir=$(dirname "$dockerfile")
+            echo "=== $dockerfile (context: $dir) ==="
+            grep -E "^(COPY|ADD)" "$dockerfile" \
+              | grep -v "\-\-from=" \
+              | while read -r instruction; do
+                  # Extract source (second token, skip flags like --chown)
+                  src=$(echo "$instruction" | sed 's/^[A-Z]* //' | sed 's/--[a-z]*=[^ ]* //g' | awk '{print $1}')
+                  # Skip wildcards and current directory
+                  case "$src" in
+                    .|./) continue ;;
+                    *\**) continue ;;
+                  esac
+                  if [ ! -e "$dir/$src" ]; then
+                    echo "::error file=$dockerfile::COPY/ADD source does not exist: $src"
+                    failed=1
+                  fi
+                done
+          done
+          exit $failed
+
+  env-sync:
+    name: Environment Variable Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check .env.example completeness
+        run: |
+          # Extract documented vars
+          grep -oP '^[A-Z_][A-Z0-9_]*' .env.example 2>/dev/null | sort -u > /tmp/env-documented
+
+          # Extract vars used in code (excluding node_modules, .next, test files)
+          grep -rhoP 'process\.env\.([A-Z_][A-Z0-9_]*)' \
+            --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" \
+            . 2>/dev/null \
+            | grep -v node_modules \
+            | grep -v .next \
+            | sed 's/process\.env\.//' \
+            | sort -u > /tmp/env-used
+
+          # Filter out framework/platform vars that don't belong in .env.example
+          grep -vE '^(NODE_ENV|NODE_OPTIONS|__NEXT_|VERCEL_|CI|HOSTNAME|HOME|PATH|PWD|SHELL|USER|TERM|LANG|LC_|TZ|PORT|npm_|NEXT_RUNTIME|CF_PAGES|DYNO|FLY_|RAILWAY_|RENDER_|AWS_LAMBDA_)' \
+            /tmp/env-used > /tmp/env-used-filtered
+
+          # Vars in code but not documented
+          missing=$(comm -13 /tmp/env-documented /tmp/env-used-filtered)
+          if [ -n "$missing" ]; then
+            echo "Environment variables used in code but missing from .env.example:"
+            echo "$missing" | while read -r var; do
+              echo "  - $var"
+            done
+            echo ""
+            echo "::warning::$(echo "$missing" | wc -l) env var(s) used in code but not documented in .env.example"
+          fi
+
+          # Vars documented but not used
+          dead=$(comm -23 /tmp/env-documented /tmp/env-used)
+          if [ -n "$dead" ]; then
+            echo ""
+            echo "Environment variables in .env.example but not found in code:"
+            echo "$dead" | while read -r var; do
+              echo "  - $var"
+            done
+            echo ""
+            echo "::warning::$(echo "$dead" | wc -l) env var(s) in .env.example may be dead or renamed"
+          fi
+
+  compose-consistency:
+    name: Cross-Compose Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare env vars across compose files
+        run: |
+          # Extract env var names from each compose file
+          grep -oP '[A-Z_][A-Z0-9_]*(?=[:=])' docker-compose.yml \
+            | sort -u > /tmp/compose-dev-vars
+          grep -oP '[A-Z_][A-Z0-9_]*(?=[:=])' docker-compose.test.yml \
+            | sort -u > /tmp/compose-test-vars
+
+          # Vars in dev but not test
+          dev_only=$(comm -23 /tmp/compose-dev-vars /tmp/compose-test-vars)
+
+          # Filter to operationally significant vars (API keys, URLs, service config)
+          significant=$(echo "$dev_only" | grep -E '(API_KEY|API_URL|SERVICE_|_URL|_HOST|_PORT|ENCRYPTION|SECRET|PASSWORD|TOKEN)' || true)
+
+          if [ -n "$significant" ]; then
+            echo "Operationally significant env vars in docker-compose.yml but missing from docker-compose.test.yml:"
+            echo "$significant" | while read -r var; do
+              echo "  - $var"
+            done
+            echo ""
+            echo "::warning::Test compose may be missing service configuration that dev compose has"
+          else
+            echo "No significant env var gaps between compose files."
+          fi
+
+  plugin-integrity:
+    name: Plugin Discovery Integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate plugin structure
+        run: |
+          failed=0
+          for plugin_dir in keeperhub/plugins/*/; do
+            plugin=$(basename "$plugin_dir")
+            for required in index.ts icon.tsx; do
+              if [ ! -f "$plugin_dir$required" ]; then
+                echo "::error::Plugin '$plugin' missing required file: $required"
+                failed=1
+              fi
+            done
+            if [ ! -d "${plugin_dir}steps" ]; then
+              echo "::error::Plugin '$plugin' missing required directory: steps/"
+              failed=1
+            fi
+          done
+          exit $failed
+
+      - name: Verify discovery produces consistent registry
+        run: |
+          cp keeperhub/plugins/index.ts /tmp/plugins-before.ts
+          cp plugins/index.ts /tmp/core-plugins-before.ts
+          pnpm discover-plugins
+          if ! diff -q keeperhub/plugins/index.ts /tmp/plugins-before.ts > /dev/null 2>&1; then
+            echo "::error::keeperhub/plugins/index.ts is stale. Run 'pnpm discover-plugins' and commit the result."
+            diff keeperhub/plugins/index.ts /tmp/plugins-before.ts || true
+            exit 1
+          fi
+          if ! diff -q plugins/index.ts /tmp/core-plugins-before.ts > /dev/null 2>&1; then
+            echo "::error::plugins/index.ts is stale. Run 'pnpm discover-plugins' and commit the result."
+            diff plugins/index.ts /tmp/core-plugins-before.ts || true
+            exit 1
+          fi
+          echo "Plugin registry is up to date."

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -124,7 +124,7 @@ jobs:
           failed=0
           for dockerfile in $(find . -name "Dockerfile" -not -path "./node_modules/*" -not -path "./.git/*"); do
             echo "=== $dockerfile ==="
-            if ! docker run --rm -i hadolint/hadolint hadolint --failure-threshold warning - < "$dockerfile"; then
+            if ! docker run --rm -i -v "$PWD/.hadolint.yaml:/.config/hadolint.yaml" hadolint/hadolint hadolint --failure-threshold warning - < "$dockerfile"; then
               failed=1
             fi
           done

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -124,7 +124,7 @@ jobs:
           failed=0
           for dockerfile in $(find . -name "Dockerfile" -not -path "./node_modules/*" -not -path "./.git/*"); do
             echo "=== $dockerfile ==="
-            if ! docker run --rm -i hadolint/hadolint --failure-threshold warning < "$dockerfile"; then
+            if ! docker run --rm -i hadolint/hadolint hadolint --failure-threshold warning - < "$dockerfile"; then
               failed=1
             fi
           done

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -5,8 +5,42 @@ on:
     branches: [staging]
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      compose: ${{ steps.filter.outputs.compose }}
+      makefile: ${{ steps.filter.outputs.makefile }}
+      shell: ${{ steps.filter.outputs.shell }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
+      plugins: ${{ steps.filter.outputs.plugins }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            compose:
+              - 'docker-compose*.yml'
+            makefile:
+              - 'Makefile'
+            shell:
+              - '**/*.sh'
+            workflows:
+              - '.github/workflows/**'
+            dockerfiles:
+              - '**/Dockerfile*'
+              - '.hadolint.yaml'
+            plugins:
+              - 'keeperhub/plugins/**'
+              - 'plugins/**'
+
   compose-validation:
     name: Docker Compose Validation
+    needs: changes
+    if: needs.changes.outputs.compose == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -19,6 +53,8 @@ jobs:
 
   makefile-dry-run:
     name: Makefile Dry Run
+    needs: changes
+    if: needs.changes.outputs.makefile == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -77,6 +113,8 @@ jobs:
 
   shellcheck:
     name: Shell Script Lint
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -93,6 +131,8 @@ jobs:
 
   actionlint:
     name: GitHub Actions Lint
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -115,6 +155,8 @@ jobs:
 
   hadolint:
     name: Dockerfile Lint
+    needs: changes
+    if: needs.changes.outputs.dockerfiles == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -209,6 +251,8 @@ jobs:
 
   compose-consistency:
     name: Cross-Compose Consistency
+    needs: changes
+    if: needs.changes.outputs.compose == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -240,6 +284,8 @@ jobs:
 
   plugin-integrity:
     name: Plugin Discovery Integrity
+    needs: changes
+    if: needs.changes.outputs.plugins == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -162,15 +162,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Lint Dockerfiles
-        run: |
-          failed=0
-          for dockerfile in $(find . -name "Dockerfile" -not -path "./node_modules/*" -not -path "./.git/*"); do
-            echo "=== $dockerfile ==="
-            if ! docker run --rm -i -v "$PWD/.hadolint.yaml:/.config/hadolint.yaml" hadolint/hadolint hadolint --failure-threshold warning - < "$dockerfile"; then
-              failed=1
-            fi
-          done
-          exit $failed
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          recursive: true
+          failure-threshold: warning
 
   dockerfile-sources:
     name: Dockerfile COPY Validation
@@ -184,21 +179,19 @@ jobs:
           for dockerfile in $(find . -name "Dockerfile" -not -path "./node_modules/*" -not -path "./.git/*"); do
             dir=$(dirname "$dockerfile")
             echo "=== $dockerfile (context: $dir) ==="
-            grep -E "^(COPY|ADD)" "$dockerfile" \
-              | grep -v "\-\-from=" \
-              | while read -r instruction; do
-                  # Extract source (second token, skip flags like --chown)
-                  src=$(echo "$instruction" | sed 's/^[A-Z]* //' | sed 's/--[a-z]*=[^ ]* //g' | awk '{print $1}')
-                  # Skip wildcards and current directory
-                  case "$src" in
-                    .|./) continue ;;
-                    *\**) continue ;;
-                  esac
-                  if [ ! -e "$dir/$src" ]; then
-                    echo "::error file=$dockerfile::COPY/ADD source does not exist: $src"
-                    failed=1
-                  fi
-                done
+            while read -r instruction; do
+              # Extract source (second token, skip flags like --chown)
+              src=$(echo "$instruction" | sed 's/^[A-Z]* //' | sed 's/--[a-z]*=[^ ]* //g' | awk '{print $1}')
+              # Skip wildcards and current directory
+              case "$src" in
+                .|./) continue ;;
+                *\**) continue ;;
+              esac
+              if [ ! -e "$dir/$src" ]; then
+                echo "::error file=$dockerfile::COPY/ADD source does not exist: $src"
+                failed=1
+              fi
+            done < <(grep -E "^(COPY|ADD)" "$dockerfile" | grep -v "\-\-from=")
           done
           exit $failed
 
@@ -216,9 +209,8 @@ jobs:
           # Extract vars used in code (excluding node_modules, .next, test files)
           grep -rhoP 'process\.env\.([A-Z_][A-Z0-9_]*)' \
             --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" \
+            --exclude-dir=node_modules --exclude-dir=.next \
             . 2>/dev/null \
-            | grep -v node_modules \
-            | grep -v .next \
             | sed 's/process\.env\.//' \
             | sort -u > /tmp/env-used
 

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+ignored:
+  # Alpine package versions are tied to the base image tag (node:25-alpine).
+  # Pinning apk packages independently breaks when the base image updates.
+  - DL3018

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN wget -O /etc/ssl/certs/rds-combined-ca-bundle.pem https://truststore.pki.rds
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./
@@ -19,7 +19,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # Stage 2: Source (dependencies + source files, no build)
 FROM node:25-alpine AS source
 WORKDIR /app
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
@@ -45,7 +45,7 @@ RUN pnpm build
 # Stage 2.6: Migration stage (for running migrations and seeding)
 FROM node:25-alpine AS migrator
 WORKDIR /app
-RUN npm install -g pnpm tsx
+RUN npm install -g pnpm@9 tsx@4
 COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Copy dependencies, migration files, and seed scripts
@@ -72,7 +72,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 # Use main project package.json (scheduler/package.json was removed)
 COPY package.json pnpm-lock.yaml ./
@@ -84,7 +84,7 @@ RUN --mount=type=cache,id=pnpm-scheduler,target=/root/.local/share/pnpm/store \
 # Stage 2.7b: Scheduler stage (for schedule dispatcher and job spawner)
 FROM node:25-alpine AS scheduler
 WORKDIR /app
-RUN npm install -g tsx
+RUN npm install -g tsx@4
 COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Copy ONLY scheduler dependencies (not full node_modules - saves ~1.7GB)
@@ -108,7 +108,7 @@ ENV NODE_ENV=production
 # Stage 2.8: Workflow Runner stage (for executing workflows in K8s Jobs)
 FROM node:25-alpine AS workflow-runner
 WORKDIR /app
-RUN npm install -g pnpm tsx
+RUN npm install -g pnpm@9 tsx@4
 COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Copy dependencies and workflow execution files
@@ -131,7 +131,8 @@ COPY --from=builder /app/keeperhub/plugins/index.ts ./keeperhub/plugins/index.ts
 # Create a shim for 'server-only' package - the runner runs outside Next.js
 # so we replace the package with an empty module that doesn't throw
 # We need to replace it in the .pnpm folder where the actual package lives
-RUN find /app/node_modules -path "*server-only*/index.js" | while read f; do echo 'module.exports = {};' > "$f"; done
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+RUN find /app/node_modules -path "*server-only*/index.js" | while read -r f; do echo 'module.exports = {};' > "$f"; done
 
 ENV NODE_ENV=production
 

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -12,7 +12,7 @@ import { generateId } from "@/lib/utils/id";
 // start custom keeperhub code //
 import { remapTemplateRefsInString } from "@/lib/utils/template";
 
-// end custom keeperhub code //
+// end keeperhub code //
 
 // Node type for type-safe node manipulation
 type WorkflowNodeLike = {
@@ -84,7 +84,7 @@ function duplicateNodes(
     return newNode;
   });
 }
-// end custom keeperhub code //
+// end keeperhub code //
 
 // Edge type for type-safe edge manipulation
 type WorkflowEdgeLike = {
@@ -166,7 +166,7 @@ export async function POST(
       idMap.set(n.id, nanoid());
     }
     const newNodes = duplicateNodes(oldNodes, idMap);
-    // end custom keeperhub code //
+    // end keeperhub code //
     const newEdges = updateEdgeReferences(
       sourceWorkflow.edges as WorkflowEdgeLike[],
       oldNodes,

--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -146,4 +146,4 @@ export async function GET(request: Request) {
   }
 }
 
-// end custom keeperhub code //
+// end keeperhub code //

--- a/components/overlays/edit-connection-overlay.tsx
+++ b/components/overlays/edit-connection-overlay.tsx
@@ -189,6 +189,7 @@ export function EditConnectionOverlay({
     }
   };
 
+  // start custom keeperhub code //
   const runConnectionTest = (): Promise<{
     status: "success" | "error";
     message: string;

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -35,7 +35,7 @@ import {
   schemaToFields,
 } from "@/keeperhub/lib/template-helpers";
 import { getTriggerOutputFields } from "@/keeperhub/lib/trigger-output-fields";
-// end custom keeperhub code //
+// end keeperhub code //
 
 type TemplateAutocompleteProps = {
   isOpen: boolean;
@@ -156,7 +156,7 @@ const getCommonFields = (node: WorkflowNode) => {
         return outputFields;
       }
     }
-    // end custom keeperhub code //
+    // end keeperhub code //
 
     if (triggerType === "Webhook" && webhookSchema) {
       try {
@@ -180,7 +180,7 @@ const getCommonFields = (node: WorkflowNode) => {
         return outputFields;
       }
     }
-    // end custom keeperhub code //
+    // end keeperhub code //
 
     return [
       { field: "triggered", description: "Trigger status" },
@@ -211,7 +211,7 @@ export function TemplateAutocomplete({
   const currentWorkflowIdRef = useRef<string | null>(null);
   const lastFetchWorkflowIdRef = useRef<string | null>(null);
   currentWorkflowIdRef.current = currentWorkflowId;
-  // end custom keeperhub code //
+  // end keeperhub code //
   const [selectedIndex, setSelectedIndex] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -290,7 +290,7 @@ export function TemplateAutocomplete({
     lastExecutionLogs.workflowId,
     setLastExecutionLogs,
   ]);
-  // end custom keeperhub code //
+  // end keeperhub code //
 
   // Find all nodes that come before the current node
   const getUpstreamNodes = () => {
@@ -445,7 +445,7 @@ export function TemplateAutocomplete({
           template: `{{@${node.id}:${nodeName}.${fieldPath}}}`,
         });
       }
-      // end custom keeperhub code //
+      // end keeperhub code //
     } else {
       const fields = getCommonFields(node);
 

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -563,12 +563,12 @@ function renderField(
       <FieldRenderer
         // start custom keeperhub code //
         config={config}
-        // end custom keeperhub code //
+        // end keeperhub code //
         disabled={disabled}
         field={field}
         // start custom keeperhub code //
         nodeId={nodeId}
-        // end custom keeperhub code //
+        // end keeperhub code //
         onChange={(val: unknown) => onUpdateConfig(field.key, val)}
         value={value}
       />

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -479,8 +479,6 @@ function CollectFields() {
   );
 }
 
-// end keeperhub code //
-
 // System action fields wrapper - extracts conditional rendering to reduce complexity
 function SystemActionFields({
   actionType,

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -102,7 +102,7 @@ export function TriggerConfig({
                 Block
               </div>
             </SelectItem>
-            {/* end custom keeperhub code // */}
+            {/* end keeperhub code // */}
           </SelectContent>
         </Select>
       </div>
@@ -311,7 +311,7 @@ export function TriggerConfig({
             </>
           );
         })()}
-      {/* end custom keeperhub code // */}
+      {/* end keeperhub code // */}
     </>
   );
 }

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -1105,7 +1105,7 @@ export const PanelInner = () => {
                   isOwner={isOwner}
                   // start custom keeperhub code //
                   nodeId={selectedNode.id}
-                  // end custom keeperhub code //
+                  // end keeperhub code //
                   onUpdateConfig={handleUpdateConfig}
                 />
               ) : null}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1090,7 +1090,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       await updateWorkflowEnabled(true);
     }
   };
-  // end custom keeperhub code //
+  // end keeperhub code //
 
   const handleDuplicate = async () => {
     if (!currentWorkflowId) {
@@ -1393,7 +1393,7 @@ function ToolbarActions({
           </div>
         </>
       )}
-      {/* end custom keeperhub code // */}
+      {/* end keeperhub code // */}
 
       <RunButtonGroup actions={actions} state={state} />
     </>
@@ -1554,7 +1554,7 @@ function RunButtonGroup({
     state.nodes.length === 0 ||
     state.isGenerating ||
     isNonManualTrigger;
-  // end custom keeperhub code //
+  // end keeperhub code //
 
   const button = (
     <Button
@@ -1591,7 +1591,7 @@ function RunButtonGroup({
   }
 
   return button;
-  // end custom keeperhub code //
+  // end keeperhub code //
 }
 
 // Read-only badge - pill with a live green accent on the toolbar

--- a/deploy/local/deploy.sh
+++ b/deploy/local/deploy.sh
@@ -13,7 +13,6 @@ DRY_RUN=false
 SKIP_BUILD=false
 SKIP_RESOURCE_CHECK=false
 MIN_MEMORY_GB=4
-MIN_CPU_CORES=2
 
 # Track timing
 SCRIPT_START_TIME=$(date +%s)
@@ -93,8 +92,10 @@ check_resources() {
     local warnings=0
 
     # Check available memory
-    local total_mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-    local avail_mem_kb=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
+    local total_mem_kb
+    total_mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    local avail_mem_kb
+    avail_mem_kb=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
     local total_mem_gb=$((total_mem_kb / 1024 / 1024))
     local avail_mem_gb=$((avail_mem_kb / 1024 / 1024))
 
@@ -152,7 +153,8 @@ format_duration() {
 
 # Function to show timing summary
 show_timing_summary() {
-    local end_time=$(date +%s)
+    local end_time
+    end_time=$(date +%s)
     local total_duration=$((end_time - SCRIPT_START_TIME))
 
     echo ""

--- a/deploy/local/hybrid/deploy.sh
+++ b/deploy/local/hybrid/deploy.sh
@@ -79,14 +79,14 @@ build_and_load_images() {
     cd "$PROJECT_ROOT"
 
     # Use minikube's Docker daemon to build directly (faster than build + load)
-    eval $(minikube docker-env)
+    eval "$(minikube docker-env)"
 
     # Build executor image from submodule (schedule-executor: polls SQS, calls API)
     log_info "Building keeperhub-executor:latest in minikube..."
     docker build --target executor -t keeperhub-executor:latest ./keeperhub-scheduler
 
     # Reset to host Docker daemon
-    eval $(minikube docker-env -u)
+    eval "$(minikube docker-env -u)"
 
     log_info "Images built directly in minikube (no load needed)"
 }
@@ -95,7 +95,8 @@ generate_manifest() {
     # Generate or use existing encryption key
     # For local development, we use a deterministic key; in production, this would be securely managed
     local ENCRYPTION_KEY="${INTEGRATION_ENCRYPTION_KEY:-$(openssl rand -hex 32 2>/dev/null || echo '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')}"
-    local ENCRYPTION_KEY_BASE64=$(echo -n "$ENCRYPTION_KEY" | base64 -w0)
+    local ENCRYPTION_KEY_BASE64
+    ENCRYPTION_KEY_BASE64=$(echo -n "$ENCRYPTION_KEY" | base64 -w0)
 
     # Source .env for consistency with docker-compose (picks up POSTGRES_DB, etc.)
     if [ -f "$PROJECT_ROOT/.env" ]; then

--- a/deploy/local/setup-local.sh
+++ b/deploy/local/setup-local.sh
@@ -159,8 +159,10 @@ check_resources() {
     local warnings=0
 
     # Check available memory
-    local total_mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-    local avail_mem_kb=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
+    local total_mem_kb
+    total_mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    local avail_mem_kb
+    avail_mem_kb=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
     local total_mem_gb=$((total_mem_kb / 1024 / 1024))
     local avail_mem_gb=$((avail_mem_kb / 1024 / 1024))
 

--- a/keeperhub/components/workflow/config/abi-event-select-field.tsx
+++ b/keeperhub/components/workflow/config/abi-event-select-field.tsx
@@ -89,4 +89,4 @@ export function AbiEventSelectField({
     </Select>
   );
 }
-// end custom keeperhub code //
+// end keeperhub code //

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -25,7 +25,7 @@ export function remapTemplateRefsInString(
     return `{{@${newId}:${rest}}}`;
   });
 }
-// end custom keeperhub code //
+// end keeperhub code //
 
 export type NodeOutputs = {
   [nodeId: string]: {

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1574,7 +1574,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               triggerData.triggeredAt = triggerInput.triggerTime;
             }
           }
-          // end custom keeperhub code //
+          // end keeperhub code //
         }
 
         // Build context for logging

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -14,7 +14,7 @@ export enum WorkflowTriggerEnum {
   EVENT = "Event", // keeperhub custom field //
   BLOCK = "Block", // keeperhub custom field //
 }
-// end custom keeperhub code //
+// end keeperhub code //
 
 export type WorkflowTriggerType = `${WorkflowTriggerEnum}`;
 
@@ -515,7 +515,7 @@ export const resetWorkflowStateForOrgSwitchAtom = atom(null, (_get, set) => {
   set(historyAtom, []);
   set(futureAtom, []);
 });
-// end custom keeperhub code //
+// end keeperhub code //
 
 // Load workflow from database
 export const loadWorkflowAtom = atom(null, async (_get, set) => {

--- a/tests/integration/workflow-duplicate.test.ts
+++ b/tests/integration/workflow-duplicate.test.ts
@@ -87,7 +87,7 @@ vi.mock("@/keeperhub/lib/middleware/org-context", () => ({
     isAnonymous: false,
   }),
 }));
-// end custom keeperhub code //
+// end keeperhub code //
 
 const workflowWithArrayConfig = {
   ...sourceWorkflow,


### PR DESCRIPTION
## Summary

- Adds a new `maintainability.yml` workflow that runs 10 parallel repo health checks on PRs to staging
- Checks cover: compose validation, makefile dry-run, fork marker integrity, shellcheck, actionlint, hadolint, dockerfile COPY validation, env sync, cross-compose consistency, and plugin discovery integrity
- Env sync and cross-compose consistency are warn-only; the rest are blocking
- Uses `dorny/paths-filter@v3` to skip jobs when their relevant files are untouched in the PR

### Path filtering

Jobs are gated on a lightweight `changes` detection job that uses the GitHub API (no checkout) to determine which files were modified. Only jobs whose relevant files changed will run:

| Job | Runs when these paths change |
|-----|-----|
| compose-validation, compose-consistency | `docker-compose*.yml` |
| makefile-dry-run | `Makefile` |
| shellcheck | `**/*.sh` |
| actionlint | `.github/workflows/**` |
| hadolint | `**/Dockerfile*`, `.hadolint.yaml` |
| plugin-integrity | `keeperhub/plugins/**`, `plugins/**` |

Three jobs always run because they have reverse dependencies -- the files they validate can break without being directly modified:

| Job | Why it always runs |
|-----|-----|
| fork-markers | Any source file edit could introduce unbalanced markers or unmarked keeperhub imports |
| dockerfile-sources | A deleted or renamed file could break a Dockerfile COPY without the Dockerfile itself changing |
| env-sync | Any source file could add or remove `process.env.*` references |

## Test plan

- [x] Open PR to staging and verify all 10 jobs run in parallel
- [x] Confirm env-sync and compose-consistency produce warnings (not failures) given current repo state
- [x] Confirm fork-markers job warns on unmarked files but only fails on imbalanced markers