### PR TITLE
fix(analytics): add auth gate, real gas tracking, and UI improvements

### DIFF
--- a/keeperhub/api/execute/check-and-execute/route.ts
+++ b/keeperhub/api/execute/check-and-execute/route.ts
@@ -91,7 +91,7 @@ async function executeConditionalWrite(
     await completeExecution(executionId, {
       transactionHash: result.transactionHash,
       transactionLink: result.transactionLink,
-      gasUsedWei: "0",
+      gasUsedWei: result.gasUsed,
       output: result as unknown as Record<string, unknown>,
     });
   } else {

--- a/keeperhub/api/execute/contract-call/route.ts
+++ b/keeperhub/api/execute/contract-call/route.ts
@@ -132,7 +132,7 @@ async function handleWriteCall(
     await completeExecution(executionId, {
       transactionHash: result.transactionHash,
       transactionLink: result.transactionLink,
-      gasUsedWei: "0",
+      gasUsedWei: result.gasUsed,
       output: result as unknown as Record<string, unknown>,
     });
   } else {

--- a/keeperhub/api/execute/transfer/route.ts
+++ b/keeperhub/api/execute/transfer/route.ts
@@ -107,11 +107,10 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // 9. Handle result
   if (result.success) {
-    // MVP: gasUsedWei requires receipt lookup; set to "0" for now. Upgrade in HARD-03.
     await completeExecution(executionId, {
       transactionHash: result.transactionHash,
       transactionLink: result.transactionLink,
-      gasUsedWei: "0",
+      gasUsedWei: result.gasUsed,
       output: result as unknown as Record<string, unknown>,
     });
   } else {

--- a/keeperhub/components/analytics/analytics-page.tsx
+++ b/keeperhub/components/analytics/analytics-page.tsx
@@ -1,21 +1,91 @@
 "use client";
 
 import { useAtomValue } from "jotai";
+import { BarChart3, LogIn } from "lucide-react";
+import Link from "next/link";
 import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
 import { analyticsSummaryAtom } from "@/keeperhub/lib/atoms/analytics";
+import { useSession } from "@/lib/auth-client";
 import { AnalyticsHeader } from "./analytics-header";
 import { EmptyState } from "./empty-state";
-import { GasBreakdownChart } from "./gas-breakdown-chart";
 import { KpiCards } from "./kpi-cards";
 import { RunsFilters } from "./runs-filters";
 import { RunsTable } from "./runs-table";
-import { SpendCapGauge } from "./spend-cap-gauge";
 import { TimeSeriesChart } from "./time-series-chart";
 import { useAnalytics } from "./use-analytics";
 
+function AuthGate({ error }: { error: string }): ReactNode {
+  const isAuthRequired = error === "AUTH_REQUIRED";
+
+  return (
+    <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
+          <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
+            {isAuthRequired ? (
+              <LogIn className="size-10 text-muted-foreground" />
+            ) : (
+              <BarChart3 className="size-10 text-muted-foreground" />
+            )}
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold tracking-tight">
+              {isAuthRequired
+                ? "Sign in to view analytics"
+                : "Organization required"}
+            </h2>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              {isAuthRequired
+                ? "Sign in to your account to access execution analytics and gas tracking."
+                : "Create or join an organization to start tracking workflow executions."}
+            </p>
+          </div>
+          {!isAuthRequired && (
+            <Button asChild>
+              <Link href="/">Get Started</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function AnalyticsPage(): ReactNode {
+  const { data: session } = useSession();
   const { loading, error, refetch } = useAnalytics();
   const summary = useAtomValue(analyticsSummaryAtom);
+
+  useEffect(() => {
+    if (
+      session?.user &&
+      (error === "AUTH_REQUIRED" || error === "ORG_REQUIRED")
+    ) {
+      refetch().catch(() => {
+        // auth-triggered refetch errors handled in useAnalytics
+      });
+    }
+  }, [session, error, refetch]);
+
+  if (error === "AUTH_REQUIRED" || error === "ORG_REQUIRED") {
+    return <AuthGate error={error} />;
+  }
+
+  // Show a neutral loading state until the first fetch completes,
+  // so the analytics skeleton doesn't flash before an auth error.
+  if (summary === null && !error) {
+    return (
+      <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
+        <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+          <div className="flex min-h-[60vh] items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const hasNoData =
     summary !== null && summary.totalRuns === 0 && summary.activeRuns === 0;
@@ -47,11 +117,6 @@ export function AnalyticsPage(): ReactNode {
 
           <KpiCards />
           <TimeSeriesChart />
-
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            <GasBreakdownChart />
-            <SpendCapGauge />
-          </div>
 
           <RunsFilters />
           <RunsTable />

--- a/keeperhub/components/analytics/runs-filters.tsx
+++ b/keeperhub/components/analytics/runs-filters.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useAtom } from "jotai";
+import { Search } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import type {
   NormalizedStatus,
   RunSource,
 } from "@/keeperhub/lib/analytics/types";
 import {
+  analyticsSearchAtom,
   analyticsSourceFilterAtom,
   analyticsStatusFilterAtom,
 } from "@/keeperhub/lib/atoms/analytics";
@@ -75,6 +78,7 @@ function FilterGroup<T>({
 export function RunsFilters(): ReactNode {
   const [statusFilter, setStatusFilter] = useAtom(analyticsStatusFilterAtom);
   const [sourceFilter, setSourceFilter] = useAtom(analyticsSourceFilterAtom);
+  const [search, setSearch] = useAtom(analyticsSearchAtom);
 
   const handleStatusChange = useCallback(
     (value: NormalizedStatus | undefined): void => {
@@ -105,6 +109,15 @@ export function RunsFilters(): ReactNode {
         onChange={handleSourceChange}
         options={SOURCE_OPTIONS}
       />
+      <div className="relative ml-auto w-56">
+        <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          className="h-8 pl-9 text-sm"
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search runs..."
+          value={search}
+        />
+      </div>
     </div>
   );
 }

--- a/keeperhub/components/analytics/runs-table.tsx
+++ b/keeperhub/components/analytics/runs-table.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { ChevronDown, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -17,6 +17,7 @@ import {
   analyticsLoadingAtom,
   analyticsRangeAtom,
   analyticsRunsAtom,
+  analyticsSearchAtom,
   analyticsSourceFilterAtom,
   analyticsStatusFilterAtom,
 } from "@/keeperhub/lib/atoms/analytics";
@@ -118,7 +119,7 @@ type StepLogRowProps = {
 function StepLogRow({ step }: StepLogRowProps): ReactNode {
   return (
     <tr className="border-t border-dashed border-muted">
-      <td colSpan={8}>
+      <td colSpan={4}>
         <div className="flex items-center gap-3 py-1.5 pl-10 pr-3">
           <span
             className={cn(
@@ -132,16 +133,20 @@ function StepLogRow({ step }: StepLogRowProps): ReactNode {
               ({step.nodeType})
             </span>
           </span>
-          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-            {formatDuration(step.durationMs)}
-          </span>
           {step.error ? (
-            <span className="shrink-0 text-xs text-red-600 dark:text-red-400">
+            <span
+              className="max-w-[40%] truncate rounded bg-red-500/10 px-1.5 py-0.5 text-[11px] leading-tight text-red-700 dark:text-red-400"
+              title={step.error}
+            >
               {step.error}
             </span>
           ) : null}
         </div>
       </td>
+      <td className="whitespace-nowrap py-1.5 pr-3 text-xs text-muted-foreground">
+        {formatDuration(step.durationMs)}
+      </td>
+      <td colSpan={3} />
     </tr>
   );
 }
@@ -212,7 +217,7 @@ function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
 
   const handleNavigate = useCallback((): void => {
     if (run.source === "workflow" && run.workflowId) {
-      router.push(`/${run.workflowId}`);
+      router.push(`/workflows/${run.workflowId}`);
     }
   }, [run.source, run.workflowId, router]);
 
@@ -385,6 +390,7 @@ export function RunsTable(): ReactNode {
   const range = useAtomValue(analyticsRangeAtom);
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
   const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
+  const search = useAtomValue(analyticsSearchAtom);
   const [loadingMore, setLoadingMore] = useState(false);
 
   const handleLoadMore = useCallback(async (): Promise<void> => {
@@ -423,7 +429,24 @@ export function RunsTable(): ReactNode {
     }
   }, [runsData, range, statusFilter, sourceFilter, setRunsData]);
 
-  const runs = runsData?.runs ?? [];
+  const allRuns = runsData?.runs ?? [];
+
+  const runs = useMemo((): UnifiedRun[] => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return allRuns;
+    }
+    return allRuns.filter((run) => {
+      const name = run.workflowName ?? run.directType ?? "";
+      const network = run.network ?? "";
+      return (
+        name.toLowerCase().includes(query) ||
+        network.toLowerCase().includes(query) ||
+        run.status.includes(query)
+      );
+    });
+  }, [allRuns, search]);
+
   const isEmpty = runs.length === 0;
 
   return (

--- a/keeperhub/components/analytics/use-analytics.ts
+++ b/keeperhub/components/analytics/use-analytics.ts
@@ -40,6 +40,32 @@ function buildQuery(params: Record<string, string | undefined>): string {
   return new URLSearchParams(entries).toString();
 }
 
+function validateResponses(
+  responses: [Response, Response, Response, Response]
+): void {
+  const authError = responses.find((r) => r.status === 401 || r.status === 403);
+  if (authError) {
+    throw new Error(
+      authError.status === 401 ? "AUTH_REQUIRED" : "ORG_REQUIRED"
+    );
+  }
+
+  const labels = ["Summary", "Time series", "Networks", "Runs"] as const;
+  for (const [i, res] of responses.entries()) {
+    if (!res.ok) {
+      throw new Error(`${labels[i]} fetch failed: ${res.status}`);
+    }
+  }
+}
+
+function isAuthError(message: string): boolean {
+  return message === "AUTH_REQUIRED" || message === "ORG_REQUIRED";
+}
+
+function toErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Failed to fetch analytics";
+}
+
 export function useAnalytics(): UseAnalyticsReturn {
   const range = useAtomValue(analyticsRangeAtom);
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
@@ -77,18 +103,7 @@ export function useAnalytics(): UseAnalyticsReturn {
           fetch(`/api/analytics/runs?${runsQuery}`),
         ]);
 
-      if (!summaryRes.ok) {
-        throw new Error(`Summary fetch failed: ${summaryRes.status}`);
-      }
-      if (!timeSeriesRes.ok) {
-        throw new Error(`Time series fetch failed: ${timeSeriesRes.status}`);
-      }
-      if (!networksRes.ok) {
-        throw new Error(`Networks fetch failed: ${networksRes.status}`);
-      }
-      if (!runsRes.ok) {
-        throw new Error(`Runs fetch failed: ${runsRes.status}`);
-      }
+      validateResponses([summaryRes, timeSeriesRes, networksRes, runsRes]);
 
       const [summary, timeSeriesData, networksData, runs] = (await Promise.all([
         summaryRes.json(),
@@ -108,9 +123,15 @@ export function useAnalytics(): UseAnalyticsReturn {
       setRuns(runs);
       setLastUpdated(new Date());
     } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : "Failed to fetch analytics";
+      const message = toErrorMessage(err);
       setError(message);
+      if (!isAuthError(message)) {
+        return;
+      }
+      clearInterval(pollIntervalRef.current ?? undefined);
+      pollIntervalRef.current = null;
+      eventSourceRef.current?.close();
+      eventSourceRef.current = null;
     } finally {
       setLoading(false);
     }

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -22,6 +22,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { registerSidebarRefetch } from "@/keeperhub/lib/refetch-sidebar";
 import type { Project, SavedWorkflow, Tag } from "@/lib/api-client";
 import { api } from "@/lib/api-client";
+import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import type { NavPanelStates } from "../lib/hooks/use-persisted-nav-state";
 import { usePersistedNavState } from "../lib/hooks/use-persisted-nav-state";
@@ -325,8 +326,31 @@ function WorkflowsPanel({
   );
 }
 
+const NAV_ITEMS = [
+  {
+    id: "new",
+    icon: Plus,
+    label: "New Workflow",
+    href: "/" as string | null,
+  },
+  {
+    id: "workflows",
+    icon: List,
+    label: "All Workflows",
+    href: null as string | null,
+  },
+  { id: "hub", icon: Globe, label: "Hub", href: "/hub" as string | null },
+  {
+    id: "analytics",
+    icon: BarChart3,
+    label: "Analytics",
+    href: "/analytics" as string | null,
+  },
+];
+
 export function NavigationSidebar(): React.ReactNode {
   const isMobile = useIsMobile();
+  const { data: session } = useSession();
   const router = useRouter();
   const pathname = usePathname();
   const params = useParams();
@@ -389,6 +413,7 @@ export function NavigationSidebar(): React.ReactNode {
   const workflowId =
     typeof params.workflowId === "string" ? params.workflowId : undefined;
   const isHubPage = pathname === "/hub";
+  const isAnalyticsPage = pathname === "/analytics";
 
   const expanded = navState.state.sidebar;
   const setExpanded = navState.setSidebar;
@@ -500,13 +525,16 @@ export function NavigationSidebar(): React.ReactNode {
 
   function isActive(id: string): boolean {
     if (id === "new") {
-      return !(workflowId || isHubPage);
+      return !(workflowId || isHubPage || isAnalyticsPage);
     }
     if (id === "workflows") {
       return navState.state.panels.projects !== "closed";
     }
     if (id === "hub") {
       return isHubPage;
+    }
+    if (id === "analytics") {
+      return isAnalyticsPage;
     }
     return false;
   }
@@ -624,27 +652,9 @@ export function NavigationSidebar(): React.ReactNode {
     );
   }
 
-  const navItems = [
-    {
-      id: "new",
-      icon: Plus,
-      label: "New Workflow",
-      href: "/" as string | null,
-    },
-    {
-      id: "workflows",
-      icon: List,
-      label: "All Workflows",
-      href: null,
-    },
-    { id: "hub", icon: Globe, label: "Hub", href: "/hub" as string | null },
-    {
-      id: "analytics",
-      icon: BarChart3,
-      label: "Analytics",
-      href: "/analytics" as string | null,
-    },
-  ];
+  const navItems = NAV_ITEMS.filter(
+    (item) => item.id !== "analytics" || session
+  );
 
   return (
     <>

--- a/keeperhub/lib/atoms/analytics.ts
+++ b/keeperhub/lib/atoms/analytics.ts
@@ -27,5 +27,7 @@ export const analyticsStatusFilterAtom = atom<NormalizedStatus | undefined>(
 );
 export const analyticsSourceFilterAtom = atom<RunSource | undefined>(undefined);
 
+export const analyticsSearchAtom = atom("");
+
 export const analyticsLiveAtom = atom(true);
 export const analyticsLastUpdatedAtom = atom<Date | null>(null);

--- a/keeperhub/plugins/web3/steps/transfer-funds-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-funds-core.ts
@@ -41,7 +41,12 @@ export type TransferFundsCoreInput = {
 };
 
 export type TransferFundsResult =
-  | { success: true; transactionHash: string; transactionLink: string }
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      gasUsed: string;
+    }
   | { success: false; error: string };
 
 /**
@@ -245,6 +250,7 @@ export async function transferFundsCore(
         success: true,
         transactionHash: receipt.hash,
         transactionLink,
+        gasUsed: receipt.gasUsed.toString(),
       };
     } catch (error) {
       logUserError(

--- a/keeperhub/plugins/web3/steps/transfer-token-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-token-core.ts
@@ -52,6 +52,7 @@ export type TransferTokenResult =
       success: true;
       transactionHash: string;
       transactionLink: string;
+      gasUsed: string;
       amount: string;
       symbol: string;
       recipient: string;
@@ -414,6 +415,7 @@ export async function transferTokenCore(
         success: true,
         transactionHash: receipt.hash,
         transactionLink,
+        gasUsed: receipt.gasUsed.toString(),
         amount,
         symbol,
         recipient: recipientAddress,

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -47,6 +47,7 @@ export type WriteContractResult =
       success: true;
       transactionHash: string;
       transactionLink: string;
+      gasUsed: string;
       result?: unknown;
     }
   | { success: false; error: string };
@@ -339,6 +340,7 @@ export async function writeContractCore(
         success: true,
         transactionHash: receipt.hash,
         transactionLink,
+        gasUsed: receipt.gasUsed.toString(),
         result: undefined,
       };
     } catch (error) {

--- a/scripts/seed/seed-analytics-data.ts
+++ b/scripts/seed/seed-analytics-data.ts
@@ -1,0 +1,495 @@
+/**
+ * Seed script for analytics dashboard test data
+ *
+ * Seeds realistic workflow executions, execution logs, and direct executions
+ * for the test user's organization so the analytics dashboard has data to display.
+ *
+ * Idempotent: checks for existing seed data (workflows prefixed with "[Analytics Seed]")
+ * and skips insertion if found.
+ *
+ * Test credentials:
+ *   Email:    test-analytics@techops.services
+ *   Password: TestAnalytics123!
+ *
+ * Run with: pnpm tsx scripts/seed/seed-analytics-data.ts
+ */
+
+import dotenv from "dotenv";
+import { expand } from "dotenv-expand";
+
+expand(dotenv.config());
+
+import postgres from "postgres";
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+
+const TEST_USER_EMAIL = "test-analytics@techops.services";
+const SEED_PREFIX = "[Analytics Seed]";
+const FORCE_MODE = process.argv.includes("--force");
+
+const NETWORKS = ["ethereum", "base", "polygon", "sepolia"] as const;
+const DIRECT_TYPES = [
+  "transfer",
+  "contract-call",
+  "check-and-execute",
+] as const;
+const NODE_TYPES = [
+  "trigger",
+  "web3:read-contract",
+  "web3:write-contract",
+  "condition",
+  "http-request",
+] as const;
+
+function generateId(): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < 21; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomChoice<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randomHex(length: number): string {
+  const chars = "0123456789abcdef";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+function hoursAgo(hours: number): Date {
+  return new Date(Date.now() - hours * 60 * 60 * 1000);
+}
+
+function randomDateBetween(start: Date, end: Date): Date {
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  return new Date(startMs + Math.random() * (endMs - startMs));
+}
+
+type Db = ReturnType<typeof postgres>;
+
+async function lookupTestUser(sql: Db): Promise<{ userId: string; orgId: string }> {
+  const userResult = await sql`
+    SELECT id FROM users WHERE email = ${TEST_USER_EMAIL}
+  `;
+  if (userResult.length === 0) {
+    throw new Error(
+      `Test user "${TEST_USER_EMAIL}" not found. ` +
+        "Create it first (sign up via the UI or seed-test-wallet.ts pattern)."
+    );
+  }
+  const userId = userResult[0].id as string;
+
+  const orgResult = await sql`
+    SELECT organization_id FROM member WHERE user_id = ${userId} LIMIT 1
+  `;
+  if (orgResult.length === 0) {
+    throw new Error(
+      `Test user "${TEST_USER_EMAIL}" has no organization membership.`
+    );
+  }
+  const orgId = orgResult[0].organization_id as string;
+
+  return { userId, orgId };
+}
+
+async function hasSeedData(sql: Db, orgId: string): Promise<boolean> {
+  const result = await sql`
+    SELECT id FROM workflows
+    WHERE organization_id = ${orgId}
+      AND name LIKE ${`${SEED_PREFIX}%`}
+    LIMIT 1
+  `;
+  return result.length > 0;
+}
+
+async function deleteSeedData(sql: Db, orgId: string): Promise<void> {
+  const workflows = await sql`
+    SELECT id FROM workflows
+    WHERE organization_id = ${orgId}
+      AND name LIKE ${`${SEED_PREFIX}%`}
+  `;
+  const workflowIds = workflows.map((r) => r.id as string);
+
+  if (workflowIds.length > 0) {
+    for (const wfId of workflowIds) {
+      await sql`
+        DELETE FROM workflow_execution_logs
+        WHERE execution_id IN (
+          SELECT id FROM workflow_executions WHERE workflow_id = ${wfId}
+        )
+      `;
+      await sql`DELETE FROM workflow_executions WHERE workflow_id = ${wfId}`;
+      await sql`DELETE FROM workflows WHERE id = ${wfId}`;
+    }
+    console.log(`  Deleted ${workflowIds.length} seed workflows + executions`);
+  }
+
+  const directResult = await sql`
+    DELETE FROM direct_executions
+    WHERE organization_id = ${orgId}
+      AND created_at > ${hoursAgo(7 * 24 + 1)}
+    RETURNING id
+  `;
+  console.log(`  Deleted ${directResult.length} direct executions`);
+}
+
+async function createSeedWorkflows(
+  sql: Db,
+  userId: string,
+  orgId: string
+): Promise<string[]> {
+  const workflowNames = [
+    `${SEED_PREFIX} USDC Monitor`,
+    `${SEED_PREFIX} ETH Price Alert`,
+    `${SEED_PREFIX} LP Rebalancer`,
+  ];
+
+  const workflowIds: string[] = [];
+  const now = new Date();
+
+  for (const name of workflowNames) {
+    const id = generateId();
+    const nodes = JSON.stringify([
+      { id: "trigger-1", type: "trigger", position: { x: 0, y: 0 }, data: {} },
+      {
+        id: "action-1",
+        type: "web3:read-contract",
+        position: { x: 0, y: 100 },
+        data: {},
+      },
+    ]);
+    const edges = JSON.stringify([
+      { id: "e1", source: "trigger-1", target: "action-1" },
+    ]);
+
+    await sql.unsafe(
+      `INSERT INTO workflows (
+        id, name, description, user_id, organization_id, is_anonymous,
+        nodes, edges, visibility, enabled, created_at, updated_at
+      ) VALUES (
+        $1, $2, $3, $4, $5, false, $6::jsonb, $7::jsonb, 'private', true, $8, $9
+      )`,
+      [id, name, "Seeded for analytics testing", userId, orgId, nodes, edges, now, now]
+    );
+
+    workflowIds.push(id);
+    console.log(`  Created workflow: ${name} (${id})`);
+  }
+
+  return workflowIds;
+}
+
+async function createWorkflowExecutions(
+  sql: Db,
+  userId: string,
+  workflowIds: string[]
+): Promise<void> {
+  const sevenDaysAgo = hoursAgo(7 * 24);
+  const now = new Date();
+  let successCount = 0;
+  let errorCount = 0;
+  let otherCount = 0;
+
+  for (let i = 0; i < 30; i++) {
+    const execId = generateId();
+    const workflowId = randomChoice(workflowIds);
+    const startedAt = randomDateBetween(sevenDaysAgo, now);
+
+    const roll = Math.random();
+    let status: string;
+    let completedAt: Date | null = null;
+    let duration: string | null = null;
+
+    if (roll < 0.7) {
+      status = "success";
+      const durationMs = randomInt(500, 5000);
+      duration = String(durationMs);
+      completedAt = new Date(startedAt.getTime() + durationMs);
+      successCount++;
+    } else if (roll < 0.9) {
+      status = "error";
+      const durationMs = randomInt(200, 3000);
+      duration = String(durationMs);
+      completedAt = new Date(startedAt.getTime() + durationMs);
+      errorCount++;
+    } else {
+      status = Math.random() < 0.5 ? "running" : "pending";
+      otherCount++;
+    }
+
+    const totalSteps = String(randomInt(3, 5));
+    const completedSteps =
+      status === "success"
+        ? totalSteps
+        : status === "error"
+          ? String(randomInt(1, Number(totalSteps) - 1))
+          : String(randomInt(0, 2));
+
+    const errorMsg = status === "error" ? "Step execution failed: timeout exceeded" : null;
+
+    await sql.unsafe(
+      `INSERT INTO workflow_executions (
+        id, workflow_id, user_id, status, error, started_at, completed_at,
+        duration, total_steps, completed_steps
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        execId,
+        workflowId,
+        userId,
+        status,
+        errorMsg,
+        startedAt,
+        completedAt,
+        duration,
+        totalSteps,
+        completedSteps,
+      ]
+    );
+
+    const stepCount = randomInt(3, 5);
+    await createStepLogs(sql, execId, startedAt, stepCount, status);
+  }
+
+  console.log(
+    `  Created 30 workflow executions (${successCount} success, ${errorCount} error, ${otherCount} running/pending)`
+  );
+}
+
+async function createStepLogs(
+  sql: Db,
+  executionId: string,
+  executionStart: Date,
+  stepCount: number,
+  executionStatus: string
+): Promise<void> {
+  let currentTime = executionStart.getTime();
+
+  for (let i = 0; i < stepCount; i++) {
+    const logId = generateId();
+    const nodeId = `node-${i + 1}`;
+    const nodeName = `Step ${i + 1}`;
+    const nodeType = i === 0 ? "trigger" : randomChoice(NODE_TYPES.slice(1));
+    const stepDuration = randomInt(50, 1500);
+    const startedAt = new Date(currentTime);
+
+    let stepStatus: string;
+    if (executionStatus === "error" && i === stepCount - 1) {
+      stepStatus = "error";
+    } else if (executionStatus === "pending" && i > 1) {
+      stepStatus = "pending";
+    } else if (executionStatus === "running" && i === stepCount - 1) {
+      stepStatus = "running";
+    } else {
+      stepStatus = "success";
+    }
+
+    const completedAt =
+      stepStatus === "pending" || stepStatus === "running"
+        ? null
+        : new Date(currentTime + stepDuration);
+    const durationStr =
+      stepStatus === "pending" || stepStatus === "running"
+        ? null
+        : String(stepDuration);
+    const errorMsg =
+      stepStatus === "error" ? "Contract call reverted" : null;
+
+    await sql.unsafe(
+      `INSERT INTO workflow_execution_logs (
+        id, execution_id, node_id, node_name, node_type, status,
+        started_at, completed_at, duration, error
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        logId,
+        executionId,
+        nodeId,
+        nodeName,
+        nodeType,
+        stepStatus,
+        startedAt,
+        completedAt,
+        durationStr,
+        errorMsg,
+      ]
+    );
+
+    currentTime += stepDuration + randomInt(10, 100);
+  }
+}
+
+/**
+ * Generate a realistic gas cost in wei for a given network.
+ * gasUsedWei = gasUnits * gasPriceWei
+ */
+function realisticGasWei(network: string): string {
+  const gasUnits = randomInt(21000, 350000);
+  const gasPriceGwei: Record<string, [number, number]> = {
+    ethereum: [15, 80],
+    base: [0.01, 0.1],
+    polygon: [30, 200],
+    sepolia: [1, 10],
+  };
+  const [lo, hi] = gasPriceGwei[network] ?? [10, 50];
+  const priceGwei = lo + Math.random() * (hi - lo);
+  const priceWei = BigInt(Math.round(priceGwei * 1e9));
+  return (BigInt(gasUnits) * priceWei).toString();
+}
+
+async function createDirectExecutions(
+  sql: Db,
+  orgId: string
+): Promise<void> {
+  const sevenDaysAgo = hoursAgo(7 * 24);
+  const now = new Date();
+  const fakeApiKeyId = generateId();
+  let completedCount = 0;
+  let failedCount = 0;
+  let pendingCount = 0;
+
+  const TOTAL = 40;
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
+  for (let i = 0; i < TOTAL; i++) {
+    const execId = generateId();
+    const network = randomChoice(NETWORKS);
+    const type = randomChoice(DIRECT_TYPES);
+
+    const createdAt =
+      i < 8
+        ? randomDateBetween(todayStart, now)
+        : randomDateBetween(sevenDaysAgo, now);
+
+    const txHash = `0x${randomHex(64)}`;
+
+    const roll = Math.random();
+    let status: string;
+    let completedAt: Date | null = null;
+    let gasUsedWei: string | null = null;
+    let errorMsg: string | null = null;
+
+    if (roll < 0.75) {
+      status = "completed";
+      const durationMs = randomInt(1000, 8000);
+      completedAt = new Date(createdAt.getTime() + durationMs);
+      gasUsedWei = realisticGasWei(network);
+      completedCount++;
+    } else if (roll < 0.95) {
+      status = "failed";
+      const durationMs = randomInt(500, 3000);
+      completedAt = new Date(createdAt.getTime() + durationMs);
+      errorMsg = "Transaction reverted: insufficient funds";
+      failedCount++;
+    } else {
+      status = "pending";
+      pendingCount++;
+    }
+
+    await sql.unsafe(
+      `INSERT INTO direct_executions (
+        id, organization_id, api_key_id, type, status,
+        transaction_hash, network, error, gas_used_wei,
+        created_at, completed_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      [
+        execId,
+        orgId,
+        fakeApiKeyId,
+        type,
+        status,
+        status === "pending" ? null : txHash,
+        network,
+        errorMsg,
+        gasUsedWei,
+        createdAt,
+        completedAt,
+      ]
+    );
+  }
+
+  console.log(
+    `  Created ${TOTAL} direct executions (${completedCount} completed, ${failedCount} failed, ${pendingCount} pending)`
+  );
+}
+
+async function createSpendCap(
+  sql: Db,
+  orgId: string
+): Promise<void> {
+  const existing = await sql`
+    SELECT id FROM organization_spend_caps
+    WHERE organization_id = ${orgId}
+    LIMIT 1
+  `;
+  if (existing.length > 0) {
+    console.log("  Spend cap already exists, skipping.");
+    return;
+  }
+
+  const capId = generateId();
+  const dailyCapWei = (BigInt(5) * BigInt(1e16)).toString();
+  const now = new Date();
+
+  await sql.unsafe(
+    `INSERT INTO organization_spend_caps (
+      id, organization_id, daily_cap_wei, created_at, updated_at
+    ) VALUES ($1, $2, $3, $4, $5)`,
+    [capId, orgId, dailyCapWei, now, now]
+  );
+
+  console.log(`  Created spend cap: 0.05 ETH/day (${dailyCapWei} wei)`);
+}
+
+async function seedAnalyticsData(): Promise<void> {
+  const connectionString = getDatabaseUrl();
+  console.log("Connecting to database...");
+
+  const sql = postgres(connectionString, { max: 1 });
+
+  try {
+    const { userId, orgId } = await lookupTestUser(sql);
+    console.log(`Found test user (id: ${userId}, org: ${orgId})`);
+
+    if (await hasSeedData(sql, orgId)) {
+      if (FORCE_MODE) {
+        console.log("Force mode: deleting existing seed data...");
+        await deleteSeedData(sql, orgId);
+      } else {
+        console.log("Seed data already exists, skipping. Use --force to re-seed.");
+        return;
+      }
+    }
+
+    console.log("Seeding analytics data...");
+
+    const workflowIds = await createSeedWorkflows(sql, userId, orgId);
+    await createWorkflowExecutions(sql, userId, workflowIds);
+    await createDirectExecutions(sql, orgId);
+    await createSpendCap(sql, orgId);
+
+    console.log("\nAnalytics seed data ready.");
+    console.log(`  User:  ${TEST_USER_EMAIL}`);
+    console.log(`  Org:   ${orgId}`);
+    console.log(`  Visit: http://localhost:3000/analytics`);
+  } finally {
+    await sql.end();
+  }
+}
+
+seedAnalyticsData()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("Error seeding analytics data:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Add auth/org gate to analytics page with automatic refetch when user signs in
- Track real `gasUsed` from transaction receipts instead of hardcoded "0" in transfer, contract-call, and check-and-execute routes
- Add client-side search filter for runs table
- Move per-step duration to align under the Duration column header
- Hide analytics nav item for unauthenticated users
- Add seed script with realistic gas values (network-specific gas prices) and spend cap seeding (`--force` flag for re-seeding)

## Test plan
- [ ] Sign out, visit /analytics -- auth gate shows without Sign In button
- [ ] Sign in -- analytics loads automatically without manual refresh
- [ ] Verify gas breakdown chart shows differentiated values per network
- [ ] Verify spend cap gauge renders with seeded 0.05 ETH/day cap
- [ ] Expand a workflow run row -- step durations align under Duration column
- [ ] Type in search box -- runs table filters by name/network/status
- [ ] Run `pnpm tsx scripts/seed/seed-analytics-data.ts --force` -- clears and re-seeds