### PR TITLE
fix(analytics): include workflow gas data in analytics queries

### DIFF
--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -116,12 +116,14 @@ export async function getAnalyticsSummary(
     activeWorkflows,
     activeDirects,
     previousPeriod,
+    workflowGasWei,
   ] = await Promise.all([
     getWorkflowCounts(organizationId, rangeStart, rangeEnd),
     getDirectCounts(organizationId, rangeStart, rangeEnd),
     getActiveWorkflowCount(organizationId),
     getActiveDirectCount(organizationId),
     getPreviousPeriodSummary(organizationId, range, customStart, customEnd),
+    getWorkflowGasTotal(organizationId, rangeStart, rangeEnd),
   ]);
 
   const totalRuns = workflowStats.total + directStats.total;
@@ -134,7 +136,7 @@ export async function getAnalyticsSummary(
     workflowStats.durationCount + directStats.durationCount
   );
 
-  const totalGasWei = directStats.totalGasWei;
+  const totalGasWei = addBigIntStrings(directStats.totalGasWei, workflowGasWei);
 
   return {
     totalRuns,
@@ -263,9 +265,10 @@ async function getPreviousPeriodSummary(
 ): Promise<AnalyticsSummary["previousPeriod"]> {
   const { start, end } = getPreviousPeriodStart(range, customStart, customEnd);
 
-  const [workflowStats, directStats] = await Promise.all([
+  const [workflowStats, directStats, workflowGasWei] = await Promise.all([
     getWorkflowCounts(organizationId, start, end),
     getDirectCounts(organizationId, start, end),
+    getWorkflowGasTotal(organizationId, start, end),
   ]);
 
   return {
@@ -276,7 +279,7 @@ async function getPreviousPeriodSummary(
       workflowStats.durationSum + directStats.durationSum,
       workflowStats.durationCount + directStats.durationCount
     ),
-    totalGasWei: directStats.totalGasWei,
+    totalGasWei: addBigIntStrings(directStats.totalGasWei, workflowGasWei),
   };
 }
 
@@ -285,6 +288,87 @@ function computeAvgDuration(sum: number, durationCount: number): number | null {
     return null;
   }
   return Math.round(sum / durationCount);
+}
+
+function addBigIntStrings(a: string, b: string): string {
+  return (BigInt(a || "0") + BigInt(b || "0")).toString();
+}
+
+/**
+ * Build SQL to extract a field from workflow_execution_logs output JSONB.
+ *
+ * The output column is double-encoded: Drizzle stores a JSON string inside JSONB
+ * (jsonb_typeof = 'string') rather than a JSONB object. To extract a nested key
+ * we first unwrap the string with `#>> '{}'`, re-parse as jsonb, then extract.
+ * Falls back to direct `->>` for any rows where output is already an object.
+ */
+function logOutputField(field: string): ReturnType<typeof sql> {
+  return sql`CASE
+    WHEN jsonb_typeof(${workflowExecutionLogs.output}) = 'string'
+    THEN (${workflowExecutionLogs.output} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
+    ELSE ${workflowExecutionLogs.output}->>${sql.raw(`'${field}'`)}
+  END`;
+}
+
+/**
+ * Same as logOutputField but for raw SQL subqueries referencing the table alias "l".
+ */
+function logOutputFieldRaw(field: string): string {
+  return `CASE
+    WHEN jsonb_typeof(l.output) = 'string'
+    THEN (l.output #>> '{}')::jsonb->>'${field}'
+    ELSE l.output->>'${field}'
+  END`;
+}
+
+/**
+ * Build SQL to extract a field from workflow_execution_logs input JSONB.
+ * Same double-encoding handling as output.
+ */
+function logInputField(field: string): ReturnType<typeof sql> {
+  return sql`CASE
+    WHEN jsonb_typeof(${workflowExecutionLogs.input}) = 'string'
+    THEN (${workflowExecutionLogs.input} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
+    ELSE ${workflowExecutionLogs.input}->>${sql.raw(`'${field}'`)}
+  END`;
+}
+
+/**
+ * Same as logInputField but for raw SQL subqueries referencing the table alias "l".
+ */
+function logInputFieldRaw(field: string): string {
+  return `CASE
+    WHEN jsonb_typeof(l.input) = 'string'
+    THEN (l.input #>> '{}')::jsonb->>'${field}'
+    ELSE l.input->>'${field}'
+  END`;
+}
+
+async function getWorkflowGasTotal(
+  organizationId: string,
+  rangeStart: Date,
+  rangeEnd: Date
+): Promise<string> {
+  const result = await db
+    .select({
+      totalGas: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+    })
+    .from(workflowExecutionLogs)
+    .innerJoin(
+      workflowExecutions,
+      eq(workflowExecutionLogs.executionId, workflowExecutions.id)
+    )
+    .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+    .where(
+      and(
+        eq(workflows.organizationId, organizationId),
+        gte(workflowExecutionLogs.startedAt, rangeStart),
+        lt(workflowExecutionLogs.startedAt, rangeEnd),
+        sql`${logOutputField("gasUsed")} IS NOT NULL`
+      )
+    );
+
+  return result[0]?.totalGas ?? "0";
 }
 
 /**
@@ -408,32 +492,96 @@ export async function getNetworkBreakdown(
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
 
-  const result = await db
-    .select({
-      network: directExecutions.network,
-      totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-      executionCount: count(),
-      successCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
-      errorCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
-    })
-    .from(directExecutions)
-    .where(
-      and(
-        eq(directExecutions.organizationId, organizationId),
-        gte(directExecutions.createdAt, rangeStart),
-        lt(directExecutions.createdAt, rangeEnd)
+  const [directResult, workflowResult] = await Promise.all([
+    db
+      .select({
+        network: directExecutions.network,
+        totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+        executionCount: count(),
+        successCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
+        errorCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
+      })
+      .from(directExecutions)
+      .where(
+        and(
+          eq(directExecutions.organizationId, organizationId),
+          gte(directExecutions.createdAt, rangeStart),
+          lt(directExecutions.createdAt, rangeEnd)
+        )
       )
-    )
-    .groupBy(directExecutions.network)
-    .orderBy(sql`SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)) DESC`);
+      .groupBy(directExecutions.network),
+    db
+      .select({
+        network: sql<string>`${logInputField("network")}`,
+        totalGasWei: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+        executionCount: count(),
+        successCount: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.status} = 'success' THEN 1 ELSE 0 END)`,
+        errorCount: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.status} = 'error' THEN 1 ELSE 0 END)`,
+      })
+      .from(workflowExecutionLogs)
+      .innerJoin(
+        workflowExecutions,
+        eq(workflowExecutionLogs.executionId, workflowExecutions.id)
+      )
+      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+      .where(
+        and(
+          eq(workflows.organizationId, organizationId),
+          gte(workflowExecutionLogs.startedAt, rangeStart),
+          lt(workflowExecutionLogs.startedAt, rangeEnd),
+          sql`${logOutputField("gasUsed")} IS NOT NULL`
+        )
+      )
+      .groupBy(sql`${logInputField("network")}`),
+  ]);
 
-  return result.map((row) => ({
-    network: row.network,
-    totalGasWei: row.totalGasWei,
-    executionCount: Number(row.executionCount),
-    successCount: Number(row.successCount),
-    errorCount: Number(row.errorCount),
-  }));
+  const networkMap = new Map<string, NetworkBreakdown>();
+
+  for (const row of directResult) {
+    networkMap.set(row.network, {
+      network: row.network,
+      totalGasWei: row.totalGasWei,
+      executionCount: Number(row.executionCount),
+      successCount: Number(row.successCount),
+      errorCount: Number(row.errorCount),
+    });
+  }
+
+  for (const row of workflowResult) {
+    const { network } = row;
+    if (!network) {
+      continue;
+    }
+    const existing = networkMap.get(network);
+    if (existing) {
+      existing.totalGasWei = addBigIntStrings(
+        existing.totalGasWei,
+        row.totalGasWei
+      );
+      existing.executionCount += Number(row.executionCount);
+      existing.successCount += Number(row.successCount);
+      existing.errorCount += Number(row.errorCount);
+    } else {
+      networkMap.set(network, {
+        network,
+        totalGasWei: row.totalGasWei,
+        executionCount: Number(row.executionCount),
+        successCount: Number(row.successCount),
+        errorCount: Number(row.errorCount),
+      });
+    }
+  }
+
+  return [...networkMap.values()].sort((a, b) => {
+    const diff = BigInt(b.totalGasWei) - BigInt(a.totalGasWei);
+    if (diff > BigInt(0)) {
+      return 1;
+    }
+    if (diff < BigInt(0)) {
+      return -1;
+    }
+    return 0;
+  });
 }
 
 /**
@@ -551,6 +699,26 @@ async function fetchWorkflowRuns(
       workflowName: workflows.name,
       totalSteps: workflowExecutions.totalSteps,
       completedSteps: workflowExecutions.completedSteps,
+      gasUsedWei: sql<string | null>`(
+        SELECT COALESCE(SUM(CAST(${sql.raw(logOutputFieldRaw("gasUsed"))} AS NUMERIC)), 0)::text
+        FROM workflow_execution_logs l
+        WHERE l.execution_id = ${workflowExecutions.id}
+          AND ${sql.raw(logOutputFieldRaw("gasUsed"))} IS NOT NULL
+      )`,
+      network: sql<string | null>`(
+        SELECT ${sql.raw(logInputFieldRaw("network"))}
+        FROM workflow_execution_logs l
+        WHERE l.execution_id = ${workflowExecutions.id}
+          AND ${sql.raw(logOutputFieldRaw("gasUsed"))} IS NOT NULL
+        LIMIT 1
+      )`,
+      transactionHash: sql<string | null>`(
+        SELECT ${sql.raw(logOutputFieldRaw("transactionHash"))}
+        FROM workflow_execution_logs l
+        WHERE l.execution_id = ${workflowExecutions.id}
+          AND ${sql.raw(logOutputFieldRaw("transactionHash"))} IS NOT NULL
+        LIMIT 1
+      )`,
     })
     .from(workflowExecutions)
     .leftJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
@@ -568,9 +736,10 @@ async function fetchWorkflowRuns(
     workflowId: row.workflowId,
     workflowName: row.workflowName ?? "(Deleted)",
     directType: null,
-    network: null,
-    transactionHash: null,
-    gasUsedWei: null,
+    network: row.network ?? null,
+    transactionHash: row.transactionHash ?? null,
+    gasUsedWei:
+      row.gasUsedWei && row.gasUsedWei !== "0" ? row.gasUsedWei : null,
     totalSteps: row.totalSteps ? Number(row.totalSteps) : null,
     completedSteps: row.completedSteps ? Number(row.completedSteps) : null,
   }));
@@ -780,29 +949,52 @@ export async function getSpendCapData(organizationId: string): Promise<{
   const todayStart = new Date();
   todayStart.setUTCHours(0, 0, 0, 0);
 
-  const [capResult, usageResult] = await Promise.all([
-    db
-      .select({ dailyCapWei: organizationSpendCaps.dailyCapWei })
-      .from(organizationSpendCaps)
-      .where(eq(organizationSpendCaps.organizationId, organizationId))
-      .limit(1),
-    db
-      .select({
-        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-      })
-      .from(directExecutions)
-      .where(
-        and(
-          eq(directExecutions.organizationId, organizationId),
-          eq(directExecutions.status, "completed"),
-          gte(directExecutions.createdAt, todayStart)
+  const [capResult, directUsageResult, workflowUsageResult] = await Promise.all(
+    [
+      db
+        .select({ dailyCapWei: organizationSpendCaps.dailyCapWei })
+        .from(organizationSpendCaps)
+        .where(eq(organizationSpendCaps.organizationId, organizationId))
+        .limit(1),
+      db
+        .select({
+          totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+        })
+        .from(directExecutions)
+        .where(
+          and(
+            eq(directExecutions.organizationId, organizationId),
+            eq(directExecutions.status, "completed"),
+            gte(directExecutions.createdAt, todayStart)
+          )
+        ),
+      db
+        .select({
+          totalWei: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+        })
+        .from(workflowExecutionLogs)
+        .innerJoin(
+          workflowExecutions,
+          eq(workflowExecutionLogs.executionId, workflowExecutions.id)
         )
-      ),
-  ]);
+        .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+        .where(
+          and(
+            eq(workflows.organizationId, organizationId),
+            eq(workflowExecutionLogs.status, "success"),
+            gte(workflowExecutionLogs.startedAt, todayStart),
+            sql`${logOutputField("gasUsed")} IS NOT NULL`
+          )
+        ),
+    ]
+  );
 
   return {
     dailyCapWei: capResult[0]?.dailyCapWei ?? null,
-    dailyUsedWei: usageResult[0]?.totalWei ?? "0",
+    dailyUsedWei: addBigIntStrings(
+      directUsageResult[0]?.totalWei ?? "0",
+      workflowUsageResult[0]?.totalWei ?? "0"
+    ),
   };
 }
 

--- a/scripts/seed/seed-analytics-data.ts
+++ b/scripts/seed/seed-analytics-data.ts
@@ -305,11 +305,33 @@ async function createStepLogs(
     const errorMsg =
       stepStatus === "error" ? "Contract call reverted" : null;
 
+    const isWeb3Write = nodeType === "web3:write-contract";
+    const network = isWeb3Write ? randomChoice(NETWORKS) : null;
+
+    const inputData = isWeb3Write
+      ? JSON.stringify({
+          network: network === "ethereum" ? "1" : network === "base" ? "8453" : network === "polygon" ? "137" : "11155111",
+          contractAddress: `0x${randomHex(40)}`,
+          actionType: "web3/write-contract",
+          abiFunction: "transfer",
+          functionArgs: "[]",
+        })
+      : null;
+
+    const outputData =
+      isWeb3Write && stepStatus === "success"
+        ? JSON.stringify({
+            success: true,
+            transactionHash: `0x${randomHex(64)}`,
+            gasUsed: String(randomInt(21000, 350000)),
+          })
+        : null;
+
     await sql.unsafe(
       `INSERT INTO workflow_execution_logs (
         id, execution_id, node_id, node_name, node_type, status,
-        started_at, completed_at, duration, error
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        started_at, completed_at, duration, error, input, output
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb)`,
       [
         logId,
         executionId,
@@ -321,6 +343,8 @@ async function createStepLogs(
         completedAt,
         durationStr,
         errorMsg,
+        inputData,
+        outputData,
       ]
     );
 

--- a/tests/e2e/playwright/analytics-gas.test.ts
+++ b/tests/e2e/playwright/analytics-gas.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+import { signIn } from "./utils/auth";
+
+const ANALYTICS_EMAIL = "test-analytics@techops.services";
+const ANALYTICS_PASSWORD = "TestAnalytics123!";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("Analytics Gas Tracking", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("Gas Spent KPI card shows non-zero value", async ({ page }) => {
+    await signIn(page, ANALYTICS_EMAIL, ANALYTICS_PASSWORD);
+    await page.goto("/analytics", { waitUntil: "domcontentloaded" });
+
+    // Switch to 7d range (seed data spans 7 days)
+    const rangeButton = page.locator(
+      'nav[aria-label="Time range"] button:has-text("7d")'
+    );
+    await rangeButton.click();
+
+    // Wait for summary API response
+    await page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/analytics/summary") && res.status() === 200,
+      { timeout: 15_000 }
+    );
+
+    // Find the Gas Spent KPI card
+    const gasLabel = page.locator('p.text-sm:has-text("Gas Spent")');
+    await expect(gasLabel).toBeVisible({ timeout: 10_000 });
+
+    // The value is the sibling <p> with text-2xl
+    const gasValue = gasLabel.locator("..").locator("p.text-2xl");
+    await expect(gasValue).toBeVisible();
+    await expect(gasValue).not.toHaveText("0 ETH", { timeout: 10_000 });
+  });
+
+  test("workflow runs show gas and network data", async ({ page }) => {
+    await signIn(page, ANALYTICS_EMAIL, ANALYTICS_PASSWORD);
+    await page.goto("/analytics", { waitUntil: "domcontentloaded" });
+
+    // Switch to 7d range
+    await page
+      .locator('nav[aria-label="Time range"] button:has-text("7d")')
+      .click();
+
+    // Wait for initial runs load
+    await page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/analytics/runs") && res.status() === 200,
+      { timeout: 15_000 }
+    );
+
+    // Filter by workflow source: set up listener BEFORE clicking
+    const workflowFilter = page.locator(
+      'nav[aria-label="Source"] button:has-text("Workflow")'
+    );
+    await Promise.all([
+      page.waitForResponse(
+        (res) =>
+          res.url().includes("/api/analytics/runs") && res.status() === 200,
+        { timeout: 15_000 }
+      ),
+      workflowFilter.click(),
+    ]);
+
+    // Table rows (may need scrolling into view)
+    const rows = page.locator("table tbody tr");
+    await rows.first().scrollIntoViewIfNeeded();
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+
+    // Check that at least one workflow row has gas and network data
+    const gasCells = page.locator("table tbody tr td:nth-child(7)");
+    const gasCount = await gasCells.count();
+
+    let foundGas = false;
+    let foundNetwork = false;
+
+    for (let i = 0; i < gasCount; i++) {
+      const gasText = await gasCells.nth(i).textContent();
+      if (gasText && gasText.trim() !== "--" && gasText.trim() !== "0 ETH") {
+        foundGas = true;
+      }
+      const networkText = await page
+        .locator("table tbody tr td:nth-child(6)")
+        .nth(i)
+        .textContent();
+      if (networkText && networkText.trim() !== "--") {
+        foundNetwork = true;
+      }
+      if (foundGas && foundNetwork) {
+        break;
+      }
+    }
+
+    expect(foundGas).toBe(true);
+    expect(foundNetwork).toBe(true);
+  });
+
+  test("network breakdown API includes workflow gas", async ({ page }) => {
+    await signIn(page, ANALYTICS_EMAIL, ANALYTICS_PASSWORD);
+    await page.goto("/analytics", { waitUntil: "domcontentloaded" });
+
+    // Hit the networks endpoint directly via the page context (inherits auth cookies)
+    const response = await page.request.get("/api/analytics/networks?range=7d");
+    const responseBody = await response.text();
+    expect(
+      response.ok(),
+      `Networks API returned ${response.status()}: ${responseBody}`
+    ).toBe(true);
+
+    const data = await response.json();
+    expect(data.networks.length).toBeGreaterThan(0);
+
+    // Seed data uses chain IDs 1, 137, 8453, 11155111 for workflow gas
+    const networkIds = data.networks.map((n: { network: string }) => n.network);
+
+    // At least one workflow chain ID should be present
+    const workflowChainIds = ["1", "137", "8453", "11155111"];
+    const hasWorkflowNetwork = workflowChainIds.some((id) =>
+      networkIds.includes(id)
+    );
+    expect(hasWorkflowNetwork).toBe(true);
+
+    // All networks should have non-zero gas
+    for (const network of data.networks) {
+      expect(BigInt(network.totalGasWei)).toBeGreaterThan(BigInt(0));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Analytics dashboard showed 0 ETH gas for workflow executions because all queries only read from `direct_executions.gasUsedWei`, ignoring workflow gas stored in `workflow_execution_logs.output` JSONB
- Added JSONB extraction helpers that handle double-encoded output/input columns (Drizzle stores JSON strings inside JSONB)
- Updated all 5 analytics query functions (`getAnalyticsSummary`, `getPreviousPeriodSummary`, `fetchWorkflowRuns`, `getNetworkBreakdown`, `getSpendCapData`) to combine direct + workflow gas data

## Test plan
- [x] Seeded test data with `scripts/seed/seed-analytics-data.ts` including workflow execution logs with gas/network data
- [x] Verified raw SQL queries return correct gas totals, per-run gas, and network breakdown
- [x] Playwright E2E: Gas Spent KPI card shows non-zero value (0.1452 ETH)
- [x] Playwright E2E: Workflow runs table shows gas and network columns populated
- [x] Playwright E2E: Network breakdown API includes workflow chain IDs with non-zero gas
- [x] Lint (`pnpm check`) and type check (`pnpm type-check`) pass clean