### PR TITLE
fix(analytics): progressive loading, gas calculation, and parallel queries

### DIFF
--- a/keeperhub/components/analytics/analytics-page.tsx
+++ b/keeperhub/components/analytics/analytics-page.tsx
@@ -73,20 +73,6 @@ export function AnalyticsPage(): ReactNode {
     return <AuthGate error={error} />;
   }
 
-  // Show a neutral loading state until the first fetch completes,
-  // so the analytics skeleton doesn't flash before an auth error.
-  if (summary === null && !error) {
-    return (
-      <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-        <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-          <div className="flex min-h-[60vh] items-center justify-center">
-            <div className="size-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   const hasNoData =
     summary !== null && summary.totalRuns === 0 && summary.activeRuns === 0;
 

--- a/keeperhub/components/analytics/use-analytics.ts
+++ b/keeperhub/components/analytics/use-analytics.ts
@@ -40,30 +40,41 @@ function buildQuery(params: Record<string, string | undefined>): string {
   return new URLSearchParams(entries).toString();
 }
 
-function validateResponses(
-  responses: [Response, Response, Response, Response]
-): void {
-  const authError = responses.find((r) => r.status === 401 || r.status === 403);
-  if (authError) {
-    throw new Error(
-      authError.status === 401 ? "AUTH_REQUIRED" : "ORG_REQUIRED"
-    );
-  }
-
-  const labels = ["Summary", "Time series", "Networks", "Runs"] as const;
-  for (const [i, res] of responses.entries()) {
-    if (!res.ok) {
-      throw new Error(`${labels[i]} fetch failed: ${res.status}`);
-    }
-  }
-}
-
-function isAuthError(message: string): boolean {
-  return message === "AUTH_REQUIRED" || message === "ORG_REQUIRED";
-}
-
 function toErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : "Failed to fetch analytics";
+}
+
+type FetchContext = {
+  aborted: boolean;
+  onAbort: (message: string) => void;
+  onError: (message: string) => void;
+};
+
+async function processSection<T>(
+  promise: Promise<Response>,
+  label: string,
+  ctx: FetchContext,
+  onSuccess: (data: T) => void
+): Promise<void> {
+  if (ctx.aborted) {
+    return;
+  }
+  const res = await promise;
+  if (ctx.aborted) {
+    return;
+  }
+  if (res.status === 401 || res.status === 403) {
+    const message = res.status === 401 ? "AUTH_REQUIRED" : "ORG_REQUIRED";
+    ctx.onAbort(message);
+    return;
+  }
+  if (!res.ok) {
+    throw new Error(`${label} fetch failed: ${res.status}`);
+  }
+  const data = (await res.json()) as T;
+  if (!ctx.aborted) {
+    onSuccess(data);
+  }
 }
 
 export function useAnalytics(): UseAnalyticsReturn {
@@ -82,8 +93,13 @@ export function useAnalytics(): UseAnalyticsReturn {
 
   const eventSourceRef = useRef<EventSource | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const fetchData = useCallback(async (): Promise<void> => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     setLoading(true);
     setError(null);
 
@@ -94,47 +110,100 @@ export function useAnalytics(): UseAnalyticsReturn {
       source: sourceFilter,
     });
 
-    try {
-      const [summaryRes, timeSeriesRes, networksRes, runsRes] =
-        await Promise.all([
-          fetch(`/api/analytics/summary?${baseQuery}`),
-          fetch(`/api/analytics/time-series?${baseQuery}`),
-          fetch(`/api/analytics/networks?${baseQuery}`),
-          fetch(`/api/analytics/runs?${runsQuery}`),
-        ]);
+    const { signal } = controller;
 
-      validateResponses([summaryRes, timeSeriesRes, networksRes, runsRes]);
+    // Fire all fetches in parallel
+    const summaryPromise = fetch(`/api/analytics/summary?${baseQuery}`, {
+      signal,
+    });
+    const timeSeriesPromise = fetch(`/api/analytics/time-series?${baseQuery}`, {
+      signal,
+    });
+    const networksPromise = fetch(`/api/analytics/networks?${baseQuery}`, {
+      signal,
+    });
+    const runsPromise = fetch(`/api/analytics/runs?${runsQuery}`, { signal });
 
-      const [summary, timeSeriesData, networksData, runs] = (await Promise.all([
-        summaryRes.json(),
-        timeSeriesRes.json(),
-        networksRes.json(),
-        runsRes.json(),
-      ])) as [
-        AnalyticsSummary,
-        { buckets: TimeSeriesBucket[] },
-        { networks: NetworkBreakdown[] },
-        RunsResponse,
-      ];
+    let pendingCount = 4;
+    const ctx: FetchContext = {
+      aborted: false,
+      onAbort: (message: string): void => {
+        ctx.aborted = true;
+        setError(message);
+        setLoading(false);
+        clearInterval(pollIntervalRef.current ?? undefined);
+        pollIntervalRef.current = null;
+        eventSourceRef.current?.close();
+        eventSourceRef.current = null;
+      },
+      onError: (message: string): void => {
+        if (!ctx.aborted) {
+          setError(message);
+        }
+      },
+    };
 
-      setSummary(summary);
-      setTimeSeries(timeSeriesData.buckets);
-      setNetworks(networksData.networks);
-      setRuns(runs);
-      setLastUpdated(new Date());
-    } catch (err: unknown) {
-      const message = toErrorMessage(err);
-      setError(message);
-      if (!isAuthError(message)) {
-        return;
+    const onSectionDone = (): void => {
+      pendingCount -= 1;
+      if (pendingCount === 0) {
+        setLoading(false);
       }
-      clearInterval(pollIntervalRef.current ?? undefined);
-      pollIntervalRef.current = null;
-      eventSourceRef.current?.close();
-      eventSourceRef.current = null;
-    } finally {
-      setLoading(false);
-    }
+    };
+
+    const wrapSection = async (task: Promise<void>): Promise<void> => {
+      try {
+        await task;
+      } catch (err: unknown) {
+        if (signal.aborted) {
+          return;
+        }
+        ctx.onError(toErrorMessage(err));
+      } finally {
+        if (!signal.aborted) {
+          onSectionDone();
+        }
+      }
+    };
+
+    // Process each fetch independently so atoms update as data arrives
+    await Promise.all([
+      wrapSection(
+        processSection<AnalyticsSummary>(
+          summaryPromise,
+          "Summary",
+          ctx,
+          (data) => {
+            setSummary(data);
+            setLastUpdated(new Date());
+          }
+        )
+      ),
+      wrapSection(
+        processSection<{ buckets: TimeSeriesBucket[] }>(
+          timeSeriesPromise,
+          "Time series",
+          ctx,
+          (data) => {
+            setTimeSeries(data.buckets);
+          }
+        )
+      ),
+      wrapSection(
+        processSection<{ networks: NetworkBreakdown[] }>(
+          networksPromise,
+          "Networks",
+          ctx,
+          (data) => {
+            setNetworks(data.networks);
+          }
+        )
+      ),
+      wrapSection(
+        processSection<RunsResponse>(runsPromise, "Runs", ctx, (data) => {
+          setRuns(data);
+        })
+      ),
+    ]);
   }, [
     range,
     statusFilter,
@@ -219,6 +288,11 @@ export function useAnalytics(): UseAnalyticsReturn {
     fetchData().catch(() => {
       /* initial fetch errors handled in fetchData */
     });
+
+    return (): void => {
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+    };
   }, [fetchData]);
 
   // Manage SSE / polling based on live state

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -586,6 +586,7 @@ export async function getNetworkBreakdown(
 
 /**
  * Fetch unified runs with cursor-based pagination.
+ * Runs fetch + count in parallel to avoid sequential blocking.
  */
 export async function getUnifiedRuns(
   organizationId: string,
@@ -611,29 +612,30 @@ export async function getUnifiedRuns(
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const pageLimit = Math.min(limit, 100);
 
-  const workflowRuns =
+  // Fire run fetches and count queries in parallel
+  const [workflowRuns, directRuns, total] = await Promise.all([
     source === "direct"
-      ? []
-      : await fetchWorkflowRuns(
+      ? ([] as UnifiedRun[])
+      : fetchWorkflowRuns(
           organizationId,
           rangeStart,
           rangeEnd,
           status,
           cursor,
           pageLimit + 1
-        );
-
-  const directRuns =
+        ),
     source === "workflow"
-      ? []
-      : await fetchDirectRuns(
+      ? ([] as UnifiedRun[])
+      : fetchDirectRuns(
           organizationId,
           rangeStart,
           rangeEnd,
           status,
           cursor,
           pageLimit + 1
-        );
+        ),
+    getUnifiedRunsTotal(organizationId, rangeStart, rangeEnd, status, source),
+  ]);
 
   const allRuns = [...workflowRuns, ...directRuns].sort(
     (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
@@ -642,14 +644,6 @@ export async function getUnifiedRuns(
   const hasMore = allRuns.length > pageLimit;
   const pagedRuns = allRuns.slice(0, pageLimit);
   const nextCursor = hasMore ? (pagedRuns.at(-1)?.startedAt ?? null) : null;
-
-  const total = await getUnifiedRunsTotal(
-    organizationId,
-    rangeStart,
-    rangeEnd,
-    status,
-    source
-  );
 
   return { runs: pagedRuns, nextCursor, total };
 }
@@ -871,20 +865,15 @@ async function getUnifiedRunsTotal(
   status: NormalizedStatus | undefined,
   source: RunSource | undefined
 ): Promise<number> {
-  const workflowTotal =
+  // Run both count queries in parallel
+  const [workflowTotal, directTotal] = await Promise.all([
     source === "direct"
       ? 0
-      : await getWorkflowRunsTotal(
-          organizationId,
-          rangeStart,
-          rangeEnd,
-          status
-        );
-
-  const directTotal =
+      : getWorkflowRunsTotal(organizationId, rangeStart, rangeEnd, status),
     source === "workflow"
       ? 0
-      : await getDirectRunsTotal(organizationId, rangeStart, rangeEnd, status);
+      : getDirectRunsTotal(organizationId, rangeStart, rangeEnd, status),
+  ]);
 
   return workflowTotal + directTotal;
 }

--- a/keeperhub/lib/atoms/analytics.ts
+++ b/keeperhub/lib/atoms/analytics.ts
@@ -19,7 +19,7 @@ export const analyticsTimeSeriesAtom = atom<TimeSeriesBucket[]>([]);
 export const analyticsNetworksAtom = atom<NetworkBreakdown[]>([]);
 export const analyticsRunsAtom = atom<RunsResponse | null>(null);
 
-export const analyticsLoadingAtom = atom(false);
+export const analyticsLoadingAtom = atom<boolean>(true);
 export const analyticsErrorAtom = atom<string | null>(null);
 
 export const analyticsStatusFilterAtom = atom<NormalizedStatus | undefined>(

--- a/keeperhub/plugins/web3/steps/transfer-funds-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-funds-core.ts
@@ -238,6 +238,9 @@ export async function transferFundsCore(
       // Mark transaction as confirmed
       await nonceManager.confirmTransaction(tx.hash);
 
+      // Compute gas cost in wei: gasUnits * effectiveGasPrice
+      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
+
       // Fetch explorer config for transaction link
       const explorerConfig = await db.query.explorerConfigs.findFirst({
         where: eq(explorerConfigs.chainId, chainId),
@@ -250,7 +253,7 @@ export async function transferFundsCore(
         success: true,
         transactionHash: receipt.hash,
         transactionLink,
-        gasUsed: receipt.gasUsed.toString(),
+        gasUsed: gasCostWei,
       };
     } catch (error) {
       logUserError(

--- a/keeperhub/plugins/web3/steps/transfer-token-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-token-core.ts
@@ -403,6 +403,9 @@ export async function transferTokenCore(
       // Mark transaction as confirmed
       await nonceManager.confirmTransaction(tx.hash);
 
+      // Compute gas cost in wei: gasUnits * effectiveGasPrice
+      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
+
       // Fetch explorer config for transaction link
       const explorerConfig = await db.query.explorerConfigs.findFirst({
         where: eq(explorerConfigs.chainId, chainId),
@@ -415,7 +418,7 @@ export async function transferTokenCore(
         success: true,
         transactionHash: receipt.hash,
         transactionLink,
-        gasUsed: receipt.gasUsed.toString(),
+        gasUsed: gasCostWei,
         amount,
         symbol,
         recipient: recipientAddress,

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -322,10 +322,14 @@ export async function writeContractCore(
       // Mark transaction as confirmed
       await nonceManager.confirmTransaction(tx.hash);
 
+      // Compute gas cost in wei: gasUnits * effectiveGasPrice
+      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
+
       console.log("[Write Contract] Transaction confirmed:", {
         hash: receipt.hash,
         gasUsed: receipt.gasUsed.toString(),
         effectiveGasPrice: `${ethers.formatUnits(receipt.gasPrice, "gwei")} gwei`,
+        gasCostWei,
       });
 
       // Fetch explorer config for transaction link
@@ -340,7 +344,7 @@ export async function writeContractCore(
         success: true,
         transactionHash: receipt.hash,
         transactionLink,
-        gasUsed: receipt.gasUsed.toString(),
+        gasUsed: gasCostWei,
         result: undefined,
       };
     } catch (error) {

--- a/scripts/seed/seed-analytics-data.ts
+++ b/scripts/seed/seed-analytics-data.ts
@@ -323,7 +323,7 @@ async function createStepLogs(
         ? JSON.stringify({
             success: true,
             transactionHash: `0x${randomHex(64)}`,
-            gasUsed: String(randomInt(21000, 350000)),
+            gasUsed: realisticGasWei(network ?? "ethereum"),
           })
         : null;
 

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -662,7 +662,7 @@ describe("Direct Execution API", () => {
           network: "ethereum",
           status: "completed",
           transactionHash: "0xabc",
-          gasUsedWei: "21000",
+          gasUsedWei: "441000000000000",
           input: {},
           output: { transactionLink: "https://etherscan.io/tx/0xabc" },
           error: null,


### PR DESCRIPTION
## Summary
- Remove full-page spinner; show skeleton layout immediately with per-component loading states
- Progressive data loading: each API response renders independently instead of blocking on all four
- Add AbortController to cancel stale requests on rapid range/filter changes
- Fix gas display showing zero: compute `gasUsed * gasPrice` (wei cost) instead of raw gas units
- Parallelize run fetch + count queries in getUnifiedRuns

## Test plan
- [ ] Load /analytics -- should see skeletons immediately, no spinner
- [ ] KPI cards, chart, runs table populate independently as data arrives
- [ ] Change time range rapidly -- no stale data flash
- [ ] Gas column shows non-zero ETH values for direct executions
- [ ] Gas Spent KPI card shows non-zero total