### PR TITLE
perf(analytics): replace correlated subqueries with JOIN and add indexes

### DIFF
--- a/drizzle/0024_analytics-indexes.sql
+++ b/drizzle/0024_analytics-indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_exec_logs_execution_id ON workflow_execution_logs (execution_id);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_workflow_executions_workflow_started ON workflow_executions (workflow_id, started_at DESC);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_workflows_org_id ON workflows (organization_id);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1771831464086,
       "tag": "0023_public_stick",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1772006400000,
+      "tag": "0024_analytics-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -676,8 +676,17 @@ async function fetchWorkflowRuns(
       )`,
     })
     .from(workflowExecutionLogs)
+    .innerJoin(
+      workflowExecutions,
+      eq(workflowExecutionLogs.executionId, workflowExecutions.id)
+    )
     .where(
-      sql`(${logOutputField("gasUsed")} IS NOT NULL OR ${logOutputField("transactionHash")} IS NOT NULL)`
+      and(
+        sql`${workflowExecutions.workflowId} IN (${orgWorkflowIds})`,
+        gte(workflowExecutions.startedAt, rangeStart),
+        lt(workflowExecutions.startedAt, rangeEnd),
+        sql`(${logOutputField("gasUsed")} IS NOT NULL OR ${logOutputField("transactionHash")} IS NOT NULL)`
+      )
     )
     .groupBy(workflowExecutionLogs.executionId)
     .as("log_summary");

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -311,17 +311,6 @@ function logOutputField(field: string): ReturnType<typeof sql> {
 }
 
 /**
- * Same as logOutputField but for raw SQL subqueries referencing the table alias "l".
- */
-function logOutputFieldRaw(field: string): string {
-  return `CASE
-    WHEN jsonb_typeof(l.output) = 'string'
-    THEN (l.output #>> '{}')::jsonb->>'${field}'
-    ELSE l.output->>'${field}'
-  END`;
-}
-
-/**
  * Build SQL to extract a field from workflow_execution_logs input JSONB.
  * Same double-encoding handling as output.
  */
@@ -330,17 +319,6 @@ function logInputField(field: string): ReturnType<typeof sql> {
     WHEN jsonb_typeof(${workflowExecutionLogs.input}) = 'string'
     THEN (${workflowExecutionLogs.input} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
     ELSE ${workflowExecutionLogs.input}->>${sql.raw(`'${field}'`)}
-  END`;
-}
-
-/**
- * Same as logInputField but for raw SQL subqueries referencing the table alias "l".
- */
-function logInputFieldRaw(field: string): string {
-  return `CASE
-    WHEN jsonb_typeof(l.input) = 'string'
-    THEN (l.input #>> '{}')::jsonb->>'${field}'
-    ELSE l.input->>'${field}'
   END`;
 }
 
@@ -682,6 +660,28 @@ async function fetchWorkflowRuns(
     conditions.push(lt(workflowExecutions.startedAt, new Date(cursor)));
   }
 
+  const logSummary = db
+    .select({
+      executionId: workflowExecutionLogs.executionId,
+      gasUsedWei: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+      network: sql<string | null>`MIN(
+        CASE WHEN ${logOutputField("gasUsed")} IS NOT NULL
+        THEN ${logInputField("network")}
+        END
+      )`,
+      transactionHash: sql<string | null>`MIN(
+        CASE WHEN ${logOutputField("transactionHash")} IS NOT NULL
+        THEN ${logOutputField("transactionHash")}
+        END
+      )`,
+    })
+    .from(workflowExecutionLogs)
+    .where(
+      sql`(${logOutputField("gasUsed")} IS NOT NULL OR ${logOutputField("transactionHash")} IS NOT NULL)`
+    )
+    .groupBy(workflowExecutionLogs.executionId)
+    .as("log_summary");
+
   const result = await db
     .select({
       id: workflowExecutions.id,
@@ -693,29 +693,13 @@ async function fetchWorkflowRuns(
       workflowName: workflows.name,
       totalSteps: workflowExecutions.totalSteps,
       completedSteps: workflowExecutions.completedSteps,
-      gasUsedWei: sql<string | null>`(
-        SELECT COALESCE(SUM(CAST(${sql.raw(logOutputFieldRaw("gasUsed"))} AS NUMERIC)), 0)::text
-        FROM workflow_execution_logs l
-        WHERE l.execution_id = ${workflowExecutions.id}
-          AND ${sql.raw(logOutputFieldRaw("gasUsed"))} IS NOT NULL
-      )`,
-      network: sql<string | null>`(
-        SELECT ${sql.raw(logInputFieldRaw("network"))}
-        FROM workflow_execution_logs l
-        WHERE l.execution_id = ${workflowExecutions.id}
-          AND ${sql.raw(logOutputFieldRaw("gasUsed"))} IS NOT NULL
-        LIMIT 1
-      )`,
-      transactionHash: sql<string | null>`(
-        SELECT ${sql.raw(logOutputFieldRaw("transactionHash"))}
-        FROM workflow_execution_logs l
-        WHERE l.execution_id = ${workflowExecutions.id}
-          AND ${sql.raw(logOutputFieldRaw("transactionHash"))} IS NOT NULL
-        LIMIT 1
-      )`,
+      gasUsedWei: logSummary.gasUsedWei,
+      network: logSummary.network,
+      transactionHash: logSummary.transactionHash,
     })
     .from(workflowExecutions)
     .leftJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+    .leftJoin(logSummary, eq(workflowExecutions.id, logSummary.executionId))
     .where(and(...conditions))
     .orderBy(desc(workflowExecutions.startedAt))
     .limit(limit);


### PR DESCRIPTION
## Summary

- Replace 3 correlated subqueries in fetchWorkflowRuns with a single pre-aggregated LEFT JOIN (log_summary) for gas, network, and transaction hash data
- Add database indexes on workflow_execution_logs(execution_id), workflow_executions(workflow_id, started_at), and workflows(organization_id)
- Remove unused logOutputFieldRaw and logInputFieldRaw helper functions

## Test plan

- [ ] Verify analytics dashboard loads correctly with gas data displayed on workflow runs
- [ ] Confirm pagination still works for workflow runs list
- [ ] Run migration on a test database and verify indexes are created
- [ ] Check query performance with EXPLAIN ANALYZE on fetchWorkflowRuns query