### PR TITLE
fix(analytics): scope logSummary subquery to avoid full table scan and Drizzle ref conflict

### DIFF
--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -660,6 +660,17 @@ async function fetchWorkflowRuns(
     conditions.push(lt(workflowExecutions.startedAt, new Date(cursor)));
   }
 
+  const scopedExecutionIds = db
+    .select({ id: workflowExecutions.id })
+    .from(workflowExecutions)
+    .where(
+      and(
+        sql`${workflowExecutions.workflowId} IN (${orgWorkflowIds})`,
+        gte(workflowExecutions.startedAt, rangeStart),
+        lt(workflowExecutions.startedAt, rangeEnd)
+      )
+    );
+
   const logSummary = db
     .select({
       executionId: workflowExecutionLogs.executionId,
@@ -676,15 +687,9 @@ async function fetchWorkflowRuns(
       )`,
     })
     .from(workflowExecutionLogs)
-    .innerJoin(
-      workflowExecutions,
-      eq(workflowExecutionLogs.executionId, workflowExecutions.id)
-    )
     .where(
       and(
-        sql`${workflowExecutions.workflowId} IN (${orgWorkflowIds})`,
-        gte(workflowExecutions.startedAt, rangeStart),
-        lt(workflowExecutions.startedAt, rangeEnd),
+        sql`${workflowExecutionLogs.executionId} IN (${scopedExecutionIds})`,
         sql`(${logOutputField("gasUsed")} IS NOT NULL OR ${logOutputField("transactionHash")} IS NOT NULL)`
       )
     )


### PR DESCRIPTION
## Summary

- Scope the `logSummary` derived subquery in `fetchWorkflowRuns` to only aggregate logs for the current org's executions within the time range
- Use an `IN` subquery (`scopedExecutionIds`) instead of `innerJoin(workflowExecutions)` to avoid Drizzle's table reference conflict when the same table appears in both a `.as()` subquery and the outer query

Without this fix, the subquery either scans the entire `workflow_execution_logs` table (performance regression) or throws "tried to reference field from a subquery" at runtime when scoped via `innerJoin`.

## Test plan

- [ ] Verify analytics dashboard loads without the "Failed to fetch analytics runs" error
- [ ] Confirm gas data, network, and transaction hash display correctly on workflow runs
- [ ] Check pagination still works on the runs list