### PR TITLE
feat: KEEP-1497 query on-chain transaction history for specific function calls

### DIFF
--- a/docs/plugins/web3.md
+++ b/docs/plugins/web3.md
@@ -20,6 +20,7 @@ Interact with EVM-compatible blockchain networks. Read-only actions work without
 | Transfer Native Token | Web3 | Wallet | Send ETH/MATIC/etc. to a recipient |
 | Transfer ERC20 Token | Web3 | Wallet | Send ERC20 tokens to a recipient |
 | Query Contract Events | Web3 | No | Query historical smart contract events across a block range |
+| Query Transaction History | Web3 | No | Query historical transactions by function call with optional argument filtering |
 | Decode Calldata | Security | No | Decode raw calldata into human-readable function calls |
 | Assess Transaction Risk | Security | No | AI-powered risk scoring with built-in DeFi rules |
 
@@ -383,6 +384,65 @@ Schedule (every hour)
 Schedule (daily)
   -> Query Contract Events: Governor contract, event "VoteCast", Block Lookback 7200
   -> SendGrid: "{{QueryEvents.eventCount}} votes cast today"
+```
+
+---
+
+## Query Transaction History
+
+Query historical transactions sent to a contract address, filtered by function call and optionally by argument values. Uses block explorer APIs (Etherscan/Blockscout) to find transactions, then decodes their calldata using the provided ABI. Useful when the target contract does not emit events for certain function calls.
+
+**Inputs:**
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Network | Yes | EVM chain to query |
+| Contract Address | Yes | Target contract address |
+| ABI | Yes | Contract ABI (auto-fetched from block explorer) |
+| Function | Yes | Function name to filter by (selected from ABI) |
+| Function Arguments | No | Argument values to match. Empty args act as wildcards -- leave all empty to return all calls to the selected function |
+| Block Lookback | No | Number of blocks to scan back from To Block (default: 6500). Ignored if From Block is set |
+| From Block | No | Explicit start block (overrides Block Lookback) |
+| To Block | No | End block number (default: latest) |
+
+**Outputs:** `success`, `transactions` (array of decoded transaction objects), `fromBlock`, `toBlock`, `totalFetched`, `matchCount`, `contractAddressLink`, `error`
+
+Each transaction in the `transactions` array contains:
+- `hash` -- transaction hash
+- `from` -- sender address
+- `to` -- contract address
+- `value` -- ETH value sent
+- `blockNumber` -- block number
+- `timestamp` -- block timestamp
+- `functionName` -- decoded function name
+- `functionSignature` -- full function signature
+- `args` -- decoded named arguments as key-value pairs
+- `transactionLink` -- block explorer link
+
+**How it works:**
+
+1. Resolves the block range from inputs (either explicit From/To or lookback from latest)
+2. Fetches all transactions to the contract via block explorer API (Etherscan `txlist` or Blockscout equivalent)
+3. Decodes each transaction's calldata using the provided ABI
+4. Filters to only transactions calling the selected function
+5. If argument values are provided, matches decoded args against filter values (case-insensitive, empty = wildcard)
+
+**When to use:** Query on-chain activity for contracts that don't emit events for certain operations, audit historical function calls, monitor specific contract interactions over a block range.
+
+**Example workflow -- Monitor specific function calls:**
+```
+Schedule (every hour)
+  -> Query Transaction History: contract 0xVault, function "deposit", Block Lookback 300
+  -> Condition: matchCount > 0
+  -> Discord: "{{QueryTx.matchCount}} deposits in the last hour"
+```
+
+**Example workflow -- Filter by argument value:**
+```
+Schedule (every 15 min)
+  -> Query Transaction History: contract 0xEngine, function "lock", args: ["", "0xSpecificUrn"]
+  -> Condition: matchCount > 0
+  -> SendGrid: "{{QueryTx.matchCount}} lock() calls to urn 0xSpecificUrn"
 ```
 
 ---

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -602,6 +602,7 @@ export async function GET(request: Request) {
       "integrationId is required for actions that need credentials (discord, sendgrid, database)",
       "web3 read actions (check-balance, read-contract) don't require wallet integration",
       "web3 write actions (transfer-funds, write-contract) require wallet integration",
+      "web3/query-transactions queries historical transactions by function call using block explorer APIs. Use it when the contract does not emit events for the operations you need to monitor. Provide functionArgs as a JSON array where empty strings are wildcards.",
       'tokenConfig must be a JSON string with format: {"mode":"custom","customToken":{"address":"0x...","symbol":"USDC"}} -- do NOT use a flat {address, symbol, decimals} object',
       "Use projectId to organize related workflows into a project (e.g., all Sky ESM workflows in one project)",
       "Use tagId to label a workflow with a single tag (e.g., 'production', 'monitoring'). Each workflow supports one tag. Fetch available tags from GET /api/tags first.",

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -716,6 +716,129 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "query-transactions",
+      label: "Query Transaction History",
+      description:
+        "Query historical transactions to a contract filtered by function calls and optionally by argument values. Uses block explorer APIs to find transactions when event logs are not available.",
+      category: "Web3",
+      stepFunction: "queryTransactionsStep",
+      stepImportPath: "query-transactions",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the query succeeded",
+        },
+        {
+          field: "transactions",
+          description:
+            "Array of decoded transaction objects with hash, from, value, blockNumber, timestamp, functionName, and args",
+        },
+        {
+          field: "fromBlock",
+          description: "Actual start block used",
+        },
+        {
+          field: "toBlock",
+          description: "Actual end block used",
+        },
+        {
+          field: "totalFetched",
+          description:
+            "Total transactions fetched from explorer before filtering",
+        },
+        {
+          field: "matchCount",
+          description:
+            "Number of transactions matching the function and argument filters",
+        },
+        {
+          field: "contractAddressLink",
+          description: "Block explorer link for the contract",
+        },
+        {
+          field: "error",
+          description: "Error message if the query failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "contractAddress",
+          label: "Contract Address",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.contractAddress}}",
+          example: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          required: true,
+        },
+        {
+          key: "abi",
+          label: "Contract ABI",
+          type: "abi-with-auto-fetch",
+          contractAddressField: "contractAddress",
+          contractInteractionType: "write",
+          networkField: "network",
+          rows: 6,
+          required: true,
+        },
+        {
+          key: "abiFunction",
+          label: "Function",
+          type: "abi-function-select",
+          abiField: "abi",
+          functionFilter: "write",
+          placeholder: "Select a function to filter by",
+          required: true,
+        },
+        {
+          key: "functionArgs",
+          label: "Function Arguments",
+          type: "abi-function-args",
+          abiField: "abi",
+          abiFunctionField: "abiFunction",
+          helpTip:
+            "Optional: filter by specific argument values. Leave empty to match all calls to the selected function.",
+        },
+        {
+          type: "group",
+          label: "Block Range",
+          defaultExpanded: true,
+          fields: [
+            {
+              key: "blockCount",
+              label: "Block Lookback",
+              type: "template-input",
+              placeholder: "Number of blocks to look back (default: 6500)",
+              helpTip:
+                "How many blocks to scan backwards from the end block. Default: 6500 (~1 day on Ethereum). Ignored if From Block is set.",
+            },
+            {
+              key: "fromBlock",
+              label: "From Block",
+              type: "template-input",
+              placeholder: "Start block number",
+              helpTip:
+                "Explicit start block. If set, Block Lookback is ignored.",
+            },
+            {
+              key: "toBlock",
+              label: "To Block",
+              type: "template-input",
+              placeholder: "End block number (default: latest)",
+              helpTip:
+                "End block for the query. Defaults to the latest block if left empty.",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "batch-read-contract",
       label: "Batch Read Contract",
       description:

--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -782,7 +782,6 @@ const web3Plugin: IntegrationPlugin = {
           label: "Contract ABI",
           type: "abi-with-auto-fetch",
           contractAddressField: "contractAddress",
-          contractInteractionType: "write",
           networkField: "network",
           rows: 6,
           required: true,

--- a/keeperhub/plugins/web3/steps/query-transactions-core.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions-core.ts
@@ -1,0 +1,482 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { db } from "@/lib/db";
+import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import {
+  fetchContractTransactions,
+  getAddressUrl,
+  getTransactionUrl,
+  type NormalizedTransaction,
+} from "@/lib/explorer";
+import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getErrorMessage } from "@/lib/utils";
+
+const DEFAULT_BLOCK_LOOKBACK = 6500;
+const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY ?? "";
+
+type AbiEntry = { type: string; name: string };
+
+export type DecodedTransaction = {
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  blockNumber: number;
+  timestamp: string;
+  functionName: string;
+  functionSignature: string;
+  args: Record<string, string>;
+  transactionLink: string;
+};
+
+export type QueryTransactionsResult =
+  | {
+      success: true;
+      transactions: DecodedTransaction[];
+      fromBlock: number;
+      toBlock: number;
+      totalFetched: number;
+      matchCount: number;
+      contractAddressLink: string;
+    }
+  | { success: false; error: string };
+
+export type QueryTransactionsCoreInput = {
+  network: string;
+  contractAddress: string;
+  abi: string;
+  abiFunction: string;
+  functionArgs?: string | unknown[];
+  fromBlock?: string;
+  toBlock?: string;
+  blockCount?: number | string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+async function getUserIdFromExecution(
+  executionId: string | undefined
+): Promise<string | undefined> {
+  if (!executionId) {
+    return;
+  }
+
+  const execution = await db
+    .select({ userId: workflowExecutions.userId })
+    .from(workflowExecutions)
+    .where(eq(workflowExecutions.id, executionId))
+    .limit(1);
+
+  return execution[0]?.userId;
+}
+
+function parseAbi(
+  abi: string
+): { success: true; parsed: AbiEntry[] } | { success: false; error: string } {
+  let parsedAbi: unknown;
+  try {
+    parsedAbi = JSON.parse(abi);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid ABI JSON: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (!Array.isArray(parsedAbi)) {
+    return { success: false, error: "ABI must be a JSON array" };
+  }
+
+  return { success: true, parsed: parsedAbi as AbiEntry[] };
+}
+
+function parseBlockCount(
+  blockCountInput: number | string | undefined
+): { success: true; value: number } | { success: false; error: string } | null {
+  if (blockCountInput === undefined || blockCountInput === null) {
+    return null;
+  }
+
+  const strVal =
+    typeof blockCountInput === "string" ? blockCountInput.trim() : "";
+  if (typeof blockCountInput === "string" && strVal === "") {
+    return null;
+  }
+
+  const parsed =
+    typeof blockCountInput === "number"
+      ? blockCountInput
+      : Number.parseInt(strVal, 10);
+
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return {
+      success: false,
+      error: `Invalid blockCount value: ${blockCountInput}`,
+    };
+  }
+
+  return { success: true, value: parsed };
+}
+
+function resolveFromBlock(
+  fromBlockInput: string | undefined,
+  blockCountInput: number | string | undefined,
+  resolvedToBlock: number
+): { success: true; value: number } | { success: false; error: string } {
+  const fromBlockStr = fromBlockInput?.toString().trim() ?? "";
+
+  if (fromBlockStr !== "") {
+    const parsed = Number.parseInt(fromBlockStr, 10);
+    if (Number.isNaN(parsed)) {
+      return {
+        success: false,
+        error: `Invalid fromBlock value: ${fromBlockInput}`,
+      };
+    }
+    return { success: true, value: parsed };
+  }
+
+  const blockCountResult = parseBlockCount(blockCountInput);
+  if (blockCountResult !== null && !blockCountResult.success) {
+    return { success: false, error: blockCountResult.error };
+  }
+
+  const lookback =
+    blockCountResult !== null ? blockCountResult.value : DEFAULT_BLOCK_LOOKBACK;
+
+  return { success: true, value: Math.max(0, resolvedToBlock - lookback) };
+}
+
+type BlockRange = { fromBlock: number; toBlock: number };
+
+async function resolveBlockRange(
+  provider: ethers.JsonRpcProvider,
+  fromBlockInput: string | undefined,
+  toBlockInput: string | undefined,
+  blockCountInput: number | string | undefined
+): Promise<
+  { success: true; range: BlockRange } | { success: false; error: string }
+> {
+  const toBlockStr = toBlockInput?.toString().trim() ?? "";
+  let resolvedToBlock: number;
+
+  if (toBlockStr === "" || toBlockStr.toLowerCase() === "latest") {
+    resolvedToBlock = await provider.getBlockNumber();
+  } else {
+    resolvedToBlock = Number.parseInt(toBlockStr, 10);
+    if (Number.isNaN(resolvedToBlock)) {
+      return {
+        success: false,
+        error: `Invalid toBlock value: ${toBlockInput}`,
+      };
+    }
+  }
+
+  const fromBlockResult = resolveFromBlock(
+    fromBlockInput,
+    blockCountInput,
+    resolvedToBlock
+  );
+  if (!fromBlockResult.success) {
+    return { success: false, error: fromBlockResult.error };
+  }
+
+  return {
+    success: true,
+    range: { fromBlock: fromBlockResult.value, toBlock: resolvedToBlock },
+  };
+}
+
+function serializeValue(value: unknown): string {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return value.toString();
+  }
+  if (typeof value === "boolean") {
+    return value.toString();
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return JSON.stringify(value, (_, v) =>
+    typeof v === "bigint" ? v.toString() : v
+  );
+}
+
+type TxLinkBuilder = { getTransactionUrl: (hash: string) => string };
+
+function decodeTransaction(
+  tx: NormalizedTransaction,
+  iface: ethers.Interface,
+  linkBuilder: TxLinkBuilder
+): DecodedTransaction | null {
+  try {
+    const parsed = iface.parseTransaction({ data: tx.input, value: tx.value });
+    if (!parsed) {
+      return null;
+    }
+
+    const args: Record<string, string> = {};
+    for (const [index, input] of parsed.fragment.inputs.entries()) {
+      const name = input.name || `arg${index}`;
+      args[name] = serializeValue(parsed.args[index]);
+    }
+
+    return {
+      hash: tx.hash,
+      from: tx.from,
+      to: tx.to,
+      value: tx.value,
+      blockNumber: tx.blockNumber,
+      timestamp: tx.timestamp,
+      functionName: parsed.name,
+      functionSignature: parsed.signature,
+      args,
+      transactionLink: linkBuilder.getTransactionUrl(tx.hash),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function matchesArgFilter(
+  decoded: DecodedTransaction,
+  filterArgs: string[],
+  functionInputs: readonly ethers.ParamType[]
+): boolean {
+  for (const [index, filterValue] of filterArgs.entries()) {
+    if (filterValue === "") {
+      continue;
+    }
+
+    const paramName = functionInputs[index]?.name || `arg${index}`;
+    const decodedValue = decoded.args[paramName] ?? "";
+
+    // Case-insensitive comparison for addresses
+    if (filterValue.toLowerCase() !== decodedValue.toLowerCase()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function toStringArray(arr: unknown[]): string[] {
+  return arr.map((v) => (typeof v === "string" ? v : String(v ?? "")));
+}
+
+function parseFunctionArgsFilter(
+  functionArgs: string | unknown[] | undefined
+): string[] | null {
+  if (functionArgs === undefined || functionArgs === null) {
+    return null;
+  }
+
+  // Already an array (workflow engine may pass parsed values)
+  if (Array.isArray(functionArgs)) {
+    const result = toStringArray(functionArgs);
+    return result.every((v) => v === "") ? null : result;
+  }
+
+  // Empty string means no filter
+  if (typeof functionArgs === "string" && functionArgs.trim() === "") {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(functionArgs);
+    if (Array.isArray(parsed)) {
+      const result = toStringArray(parsed);
+      return result.every((v) => v === "") ? null : result;
+    }
+  } catch {
+    // Invalid JSON - skip argument filtering
+  }
+
+  return null;
+}
+
+function filterAndDecodeTransactions(
+  transactions: NormalizedTransaction[],
+  contractAddress: string,
+  iface: ethers.Interface,
+  functionFragment: ethers.FunctionFragment,
+  filterArgs: string[] | null,
+  getTxLink: (hash: string) => string
+): { matched: DecodedTransaction[]; totalFiltered: number } {
+  const lowerContractAddress = contractAddress.toLowerCase();
+  const toContractTxs = transactions.filter(
+    (tx) => tx.to.toLowerCase() === lowerContractAddress
+  );
+
+  const linkBuilder: TxLinkBuilder = { getTransactionUrl: getTxLink };
+  const matched: DecodedTransaction[] = [];
+
+  for (const tx of toContractTxs) {
+    const decoded = decodeTransaction(tx, iface, linkBuilder);
+    if (!decoded) {
+      continue;
+    }
+
+    if (decoded.functionName !== functionFragment.name) {
+      continue;
+    }
+
+    if (
+      filterArgs !== null &&
+      !matchesArgFilter(decoded, filterArgs, functionFragment.inputs)
+    ) {
+      continue;
+    }
+
+    matched.push(decoded);
+  }
+
+  return { matched, totalFiltered: toContractTxs.length };
+}
+
+type ValidatedInput = {
+  iface: ethers.Interface;
+  functionFragment: ethers.FunctionFragment;
+  chainId: number;
+};
+
+function validateInputs(
+  input: QueryTransactionsCoreInput
+): { success: true; data: ValidatedInput } | { success: false; error: string } {
+  const { contractAddress, abi, abiFunction } = input;
+
+  if (!ethers.isAddress(contractAddress)) {
+    return {
+      success: false,
+      error: `Invalid contract address: ${contractAddress}`,
+    };
+  }
+
+  const abiResult = parseAbi(abi);
+  if (!abiResult.success) {
+    return { success: false, error: abiResult.error };
+  }
+
+  const iface = new ethers.Interface(abiResult.parsed);
+  const functionFragment = iface.getFunction(abiFunction);
+  if (!functionFragment) {
+    return {
+      success: false,
+      error: `Function '${abiFunction}' not found in ABI`,
+    };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  return {
+    success: true,
+    data: { iface, functionFragment, chainId },
+  };
+}
+
+export async function queryTransactionsCore(
+  input: QueryTransactionsCoreInput
+): Promise<QueryTransactionsResult> {
+  const validation = validateInputs(input);
+  if (!validation.success) {
+    return { success: false, error: validation.error };
+  }
+
+  const { iface, functionFragment, chainId } = validation.data;
+
+  const userId = await getUserIdFromExecution(input._context?.executionId);
+  const rpcConfig = await resolveRpcConfig(chainId, userId);
+  if (!rpcConfig) {
+    return {
+      success: false,
+      error: `Chain ${chainId} not found or not enabled`,
+    };
+  }
+
+  const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
+
+  const blockRangeResult = await resolveBlockRange(
+    provider,
+    input.fromBlock,
+    input.toBlock,
+    input.blockCount
+  );
+  if (!blockRangeResult.success) {
+    return { success: false, error: blockRangeResult.error };
+  }
+  const { range } = blockRangeResult;
+
+  const explorerConfig = await db.query.explorerConfigs.findFirst({
+    where: eq(explorerConfigs.chainId, chainId),
+  });
+
+  if (!explorerConfig) {
+    return {
+      success: false,
+      error: `No explorer configuration found for chain ${chainId}`,
+    };
+  }
+
+  const contractAddressLink = getAddressUrl(
+    explorerConfig,
+    input.contractAddress
+  );
+
+  if (range.fromBlock > range.toBlock) {
+    return {
+      success: true,
+      transactions: [],
+      fromBlock: range.fromBlock,
+      toBlock: range.toBlock,
+      totalFetched: 0,
+      matchCount: 0,
+      contractAddressLink,
+    };
+  }
+
+  const txResult = await fetchContractTransactions(
+    explorerConfig,
+    input.contractAddress,
+    chainId,
+    range.fromBlock,
+    range.toBlock,
+    ETHERSCAN_API_KEY || undefined
+  );
+
+  if (!txResult.success) {
+    return { success: false, error: txResult.error };
+  }
+
+  const filterArgs = parseFunctionArgsFilter(input.functionArgs);
+
+  const { matched, totalFiltered } = filterAndDecodeTransactions(
+    txResult.transactions,
+    input.contractAddress,
+    iface,
+    functionFragment,
+    filterArgs,
+    (hash: string) => getTransactionUrl(explorerConfig, hash)
+  );
+
+  return {
+    success: true,
+    transactions: matched,
+    fromBlock: range.fromBlock,
+    toBlock: range.toBlock,
+    totalFetched: totalFiltered,
+    matchCount: matched.length,
+    contractAddressLink,
+  };
+}

--- a/keeperhub/plugins/web3/steps/query-transactions-core.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions-core.ts
@@ -14,7 +14,7 @@ import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_BLOCK_LOOKBACK = 6500;
-const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY ?? "";
+const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
 
 type AbiEntry = { type: string; name: string };
 
@@ -86,6 +86,19 @@ function parseAbi(
 
   if (!Array.isArray(parsedAbi)) {
     return { success: false, error: "ABI must be a JSON array" };
+  }
+
+  const hasValidEntries = parsedAbi.every(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof entry.type === "string"
+  );
+  if (!hasValidEntries) {
+    return {
+      success: false,
+      error: "Invalid ABI: each entry must be an object with a 'type' field",
+    };
   }
 
   return { success: true, parsed: parsedAbi as AbiEntry[] };
@@ -268,7 +281,11 @@ function matchesArgFilter(
 }
 
 function toStringArray(arr: unknown[]): string[] {
-  return arr.map((v) => (typeof v === "string" ? v : String(v ?? "")));
+  const result: string[] = [];
+  for (const v of arr) {
+    result.push(typeof v === "string" ? v : String(v ?? ""));
+  }
+  return result;
 }
 
 function parseFunctionArgsFilter(
@@ -311,14 +328,16 @@ function filterAndDecodeTransactions(
   getTxLink: (hash: string) => string
 ): { matched: DecodedTransaction[]; totalFiltered: number } {
   const lowerContractAddress = contractAddress.toLowerCase();
-  const toContractTxs = transactions.filter(
-    (tx) => tx.to.toLowerCase() === lowerContractAddress
-  );
-
   const linkBuilder: TxLinkBuilder = { getTransactionUrl: getTxLink };
   const matched: DecodedTransaction[] = [];
+  let toContractCount = 0;
 
-  for (const tx of toContractTxs) {
+  for (const tx of transactions) {
+    if (tx.to.toLowerCase() !== lowerContractAddress) {
+      continue;
+    }
+    toContractCount++;
+
     const decoded = decodeTransaction(tx, iface, linkBuilder);
     if (!decoded) {
       continue;
@@ -338,7 +357,7 @@ function filterAndDecodeTransactions(
     matched.push(decoded);
   }
 
-  return { matched, totalFiltered: toContractTxs.length };
+  return { matched, totalFiltered: toContractCount };
 }
 
 type ValidatedInput = {
@@ -452,7 +471,7 @@ export async function queryTransactionsCore(
     chainId,
     range.fromBlock,
     range.toBlock,
-    ETHERSCAN_API_KEY || undefined
+    ETHERSCAN_API_KEY
   );
 
   if (!txResult.success) {

--- a/keeperhub/plugins/web3/steps/query-transactions.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { db } from "@/lib/db";
+import { explorerConfigs } from "@/lib/db/schema";
+import { getAddressUrl } from "@/lib/explorer";
+import { getChainIdFromNetwork } from "@/lib/rpc";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import {
+  type QueryTransactionsCoreInput,
+  type QueryTransactionsResult,
+  queryTransactionsCore,
+} from "./query-transactions-core";
+
+export type QueryTransactionsInput = StepInput & QueryTransactionsCoreInput;
+
+export async function queryTransactionsStep(
+  input: QueryTransactionsInput
+): Promise<QueryTransactionsResult> {
+  "use step";
+
+  let enrichedInput: QueryTransactionsInput & { contractAddressLink?: string } =
+    input;
+  try {
+    const chainId = getChainIdFromNetwork(input.network);
+    const explorerConfig = await db.query.explorerConfigs.findFirst({
+      where: eq(explorerConfigs.chainId, chainId),
+    });
+    if (explorerConfig) {
+      const contractAddressLink = getAddressUrl(
+        explorerConfig,
+        input.contractAddress
+      );
+      if (contractAddressLink) {
+        enrichedInput = { ...input, contractAddressLink };
+      }
+    }
+  } catch {
+    // Non-critical: if lookup fails, input logs without the link
+  }
+
+  return withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "query-transactions",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(enrichedInput, () => queryTransactionsCore(input))
+  );
+}
+
+export const _integrationType = "web3";

--- a/keeperhub/plugins/web3/steps/query-transactions.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions.ts
@@ -1,11 +1,6 @@
 import "server-only";
 
-import { eq } from "drizzle-orm";
 import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
-import { db } from "@/lib/db";
-import { explorerConfigs } from "@/lib/db/schema";
-import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import {
   type QueryTransactionsCoreInput,
@@ -20,33 +15,13 @@ export async function queryTransactionsStep(
 ): Promise<QueryTransactionsResult> {
   "use step";
 
-  let enrichedInput: QueryTransactionsInput & { contractAddressLink?: string } =
-    input;
-  try {
-    const chainId = getChainIdFromNetwork(input.network);
-    const explorerConfig = await db.query.explorerConfigs.findFirst({
-      where: eq(explorerConfigs.chainId, chainId),
-    });
-    if (explorerConfig) {
-      const contractAddressLink = getAddressUrl(
-        explorerConfig,
-        input.contractAddress
-      );
-      if (contractAddressLink) {
-        enrichedInput = { ...input, contractAddressLink };
-      }
-    }
-  } catch {
-    // Non-critical: if lookup fails, input logs without the link
-  }
-
-  return withPluginMetrics(
+  return await withPluginMetrics(
     {
       pluginName: "web3",
       actionName: "query-transactions",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(enrichedInput, () => queryTransactionsCore(input))
+    () => withStepLogging(input, () => queryTransactionsCore(input))
   );
 }
 

--- a/lib/explorer/blockscout.ts
+++ b/lib/explorer/blockscout.ts
@@ -1,8 +1,8 @@
 /**
- * Blockscout API ABI fetcher
+ * Blockscout API integration
  *
- * Works for Blockscout-based explorers (e.g., Tempo).
- * No API key required.
+ * Provides ABI fetching and transaction listing for Blockscout-based
+ * explorers (e.g., Tempo). No API key required.
  */
 
 type BlockscoutResponse = {
@@ -54,6 +54,124 @@ export async function fetchBlockscoutAbi(
       error: error instanceof Error ? error.message : "Unknown error",
     };
   }
+}
+
+export type BlockscoutTransaction = {
+  hash: string;
+  from: { hash: string };
+  to: { hash: string };
+  value: string;
+  raw_input: string;
+  block: number;
+  timestamp: string;
+  status: string;
+  method: string | null;
+};
+
+type BlockscoutTxListResponse = {
+  items: BlockscoutTransaction[];
+  next_page_params: { block_number: number; index: number } | null;
+};
+
+const BLOCKSCOUT_TX_PAGE_SIZE = 50;
+const MAX_TX_RESULTS = 50_000;
+const API_V1_SUFFIX_PATTERN = /\/api\/?$/;
+
+type BlockscoutCursor = { block_number: number; index: number };
+
+function buildBlockscoutTxUrl(
+  baseUrl: string,
+  contractAddress: string,
+  cursor: BlockscoutCursor | null
+): string {
+  const url = new URL(`${baseUrl}/addresses/${contractAddress}/transactions`);
+  url.searchParams.set("filter", "to");
+
+  if (cursor) {
+    url.searchParams.set("block_number", cursor.block_number.toString());
+    url.searchParams.set("index", cursor.index.toString());
+  }
+
+  return url.toString();
+}
+
+function shouldStopPaginating(
+  data: BlockscoutTxListResponse,
+  totalCollected: number,
+  startBlock: number
+): boolean {
+  if (totalCollected >= MAX_TX_RESULTS) {
+    return true;
+  }
+  if (!data.next_page_params || data.items.length < BLOCKSCOUT_TX_PAGE_SIZE) {
+    return true;
+  }
+  const lastBlock = data.items.at(-1)?.block ?? 0;
+  return lastBlock < startBlock;
+}
+
+/**
+ * Fetch transaction list for a contract address from Blockscout API v2
+ *
+ * Uses the `/addresses/:address/transactions` endpoint.
+ * Paginates automatically using cursor-based pagination.
+ *
+ * @param apiUrl - Base API URL (e.g., "https://explorer.tempo.xyz/api")
+ * @param contractAddress - Contract address to list transactions for
+ * @param startBlock - Start block number (used for client-side filtering)
+ * @param endBlock - End block number (used for client-side filtering)
+ */
+export async function fetchBlockscoutTransactions(
+  apiUrl: string,
+  contractAddress: string,
+  startBlock: number,
+  endBlock: number
+): Promise<
+  | { success: true; transactions: BlockscoutTransaction[] }
+  | { success: false; error: string }
+> {
+  const allTransactions: BlockscoutTransaction[] = [];
+  let cursor: BlockscoutCursor | null = null;
+
+  try {
+    const baseUrl = apiUrl.replace(API_V1_SUFFIX_PATTERN, "/api/v2");
+
+    for (;;) {
+      const url = buildBlockscoutTxUrl(baseUrl, contractAddress, cursor);
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: `Blockscout API returned status ${response.status}`,
+        };
+      }
+
+      const data: BlockscoutTxListResponse = await response.json();
+
+      for (const tx of data.items) {
+        if (tx.block >= startBlock && tx.block <= endBlock) {
+          allTransactions.push(tx);
+        }
+      }
+
+      if (shouldStopPaginating(data, allTransactions.length, startBlock)) {
+        break;
+      }
+
+      cursor = data.next_page_params;
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unknown error fetching transactions",
+    };
+  }
+
+  return { success: true, transactions: allTransactions };
 }
 
 /**

--- a/lib/explorer/blockscout.ts
+++ b/lib/explorer/blockscout.ts
@@ -192,14 +192,14 @@ export async function fetchBlockscoutTransactions(
   try {
     const baseUrl = apiUrl.replace(API_V1_SUFFIX_PATTERN, "/api/v2");
 
-    let isFirstPage = true;
+    let pageCount = 0;
     for (;;) {
-      if (!isFirstPage) {
+      if (pageCount > 0) {
         await new Promise((resolve) =>
           setTimeout(resolve, BLOCKSCOUT_PAGE_DELAY_MS)
         );
       }
-      isFirstPage = false;
+      pageCount++;
 
       const page = await fetchPage(baseUrl, contractAddress, cursor);
       if (!page.ok) {

--- a/lib/explorer/blockscout.ts
+++ b/lib/explorer/blockscout.ts
@@ -75,6 +75,7 @@ type BlockscoutTxListResponse = {
 
 const BLOCKSCOUT_TX_PAGE_SIZE = 50;
 const MAX_TX_RESULTS = 50_000;
+const BLOCKSCOUT_PAGE_DELAY_MS = 100;
 const API_V1_SUFFIX_PATTERN = /\/api\/?$/;
 
 type BlockscoutCursor = { block_number: number; index: number };
@@ -111,6 +112,64 @@ function shouldStopPaginating(
 }
 
 /**
+ * Check if all items on the current page are above the endBlock.
+ * If so, the page contains only irrelevant future transactions and
+ * we should continue paginating without collecting any items, rather
+ * than stopping early.
+ */
+function isPageEntirelyAboveEndBlock(
+  items: BlockscoutTransaction[],
+  endBlock: number
+): boolean {
+  if (items.length === 0) {
+    return false;
+  }
+  const lowestBlockOnPage = items.at(-1)?.block ?? 0;
+  return lowestBlockOnPage > endBlock;
+}
+
+function collectInRangeTransactions(
+  items: BlockscoutTransaction[],
+  startBlock: number,
+  endBlock: number,
+  out: BlockscoutTransaction[]
+): void {
+  if (isPageEntirelyAboveEndBlock(items, endBlock)) {
+    return;
+  }
+  for (const tx of items) {
+    if (tx.block >= startBlock && tx.block <= endBlock) {
+      out.push(tx);
+    }
+  }
+}
+
+type BlockscoutTxResult =
+  | { success: true; transactions: BlockscoutTransaction[] }
+  | { success: false; error: string };
+
+async function fetchPage(
+  baseUrl: string,
+  contractAddress: string,
+  cursor: BlockscoutCursor | null
+): Promise<
+  { ok: true; data: BlockscoutTxListResponse } | { ok: false; error: string }
+> {
+  const url = buildBlockscoutTxUrl(baseUrl, contractAddress, cursor);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: `Blockscout API returned status ${response.status}`,
+    };
+  }
+
+  const data: BlockscoutTxListResponse = await response.json();
+  return { ok: true, data };
+}
+
+/**
  * Fetch transaction list for a contract address from Blockscout API v2
  *
  * Uses the `/addresses/:address/transactions` endpoint.
@@ -126,40 +185,39 @@ export async function fetchBlockscoutTransactions(
   contractAddress: string,
   startBlock: number,
   endBlock: number
-): Promise<
-  | { success: true; transactions: BlockscoutTransaction[] }
-  | { success: false; error: string }
-> {
+): Promise<BlockscoutTxResult> {
   const allTransactions: BlockscoutTransaction[] = [];
   let cursor: BlockscoutCursor | null = null;
 
   try {
     const baseUrl = apiUrl.replace(API_V1_SUFFIX_PATTERN, "/api/v2");
 
+    let isFirstPage = true;
     for (;;) {
-      const url = buildBlockscoutTxUrl(baseUrl, contractAddress, cursor);
-      const response = await fetch(url);
+      if (!isFirstPage) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, BLOCKSCOUT_PAGE_DELAY_MS)
+        );
+      }
+      isFirstPage = false;
 
-      if (!response.ok) {
-        return {
-          success: false,
-          error: `Blockscout API returned status ${response.status}`,
-        };
+      const page = await fetchPage(baseUrl, contractAddress, cursor);
+      if (!page.ok) {
+        return { success: false, error: page.error };
       }
 
-      const data: BlockscoutTxListResponse = await response.json();
+      collectInRangeTransactions(
+        page.data.items,
+        startBlock,
+        endBlock,
+        allTransactions
+      );
 
-      for (const tx of data.items) {
-        if (tx.block >= startBlock && tx.block <= endBlock) {
-          allTransactions.push(tx);
-        }
-      }
-
-      if (shouldStopPaginating(data, allTransactions.length, startBlock)) {
+      if (shouldStopPaginating(page.data, allTransactions.length, startBlock)) {
         break;
       }
 
-      cursor = data.next_page_params;
+      cursor = page.data.next_page_params;
     }
   } catch (error) {
     return {

--- a/lib/explorer/blockscout.ts
+++ b/lib/explorer/blockscout.ts
@@ -59,7 +59,7 @@ export async function fetchBlockscoutAbi(
 export type BlockscoutTransaction = {
   hash: string;
   from: { hash: string };
-  to: { hash: string };
+  to: { hash: string } | null;
   value: string;
   raw_input: string;
   block: number;

--- a/lib/explorer/etherscan.ts
+++ b/lib/explorer/etherscan.ts
@@ -187,6 +187,7 @@ type EtherscanTxListResponse = {
 
 const ETHERSCAN_TX_PAGE_SIZE = 10_000;
 const MAX_PAGES = 5;
+const ETHERSCAN_PAGE_DELAY_MS = 220;
 
 type TxPageResult =
   | { done: false; transactions: EtherscanTransaction[] }
@@ -270,6 +271,12 @@ export async function fetchEtherscanTransactions(
   const allTransactions: EtherscanTransaction[] = [];
 
   for (let page = 1; page <= MAX_PAGES; page++) {
+    if (page > 1) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, ETHERSCAN_PAGE_DELAY_MS)
+      );
+    }
+
     const url = buildTxListParams(
       apiUrl,
       chainId,

--- a/lib/explorer/etherscan.ts
+++ b/lib/explorer/etherscan.ts
@@ -1,8 +1,8 @@
 /**
- * Etherscan API v2 ABI fetcher
+ * Etherscan API v2 integration
  *
- * Works for Ethereum, Base, Arbitrum, and other Etherscan-supported chains
- * with a single API key.
+ * Provides ABI fetching, source code metadata, and transaction listing
+ * for Ethereum, Base, Arbitrum, and other Etherscan-supported chains.
  */
 
 type EtherscanResponse = {
@@ -165,6 +165,147 @@ export async function fetchEtherscanSourceCode(
       error: error instanceof Error ? error.message : "Unknown error",
     };
   }
+}
+
+export type EtherscanTransaction = {
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  input: string;
+  blockNumber: string;
+  timeStamp: string;
+  isError: string;
+  functionName: string;
+};
+
+type EtherscanTxListResponse = {
+  status: string;
+  message: string;
+  result: EtherscanTransaction[] | string;
+};
+
+const ETHERSCAN_TX_PAGE_SIZE = 10_000;
+const MAX_PAGES = 5;
+
+type TxPageResult =
+  | { done: false; transactions: EtherscanTransaction[] }
+  | { done: true; transactions: EtherscanTransaction[] }
+  | { error: string };
+
+function buildTxListParams(
+  apiUrl: string,
+  chainId: number,
+  contractAddress: string,
+  startBlock: number,
+  endBlock: number,
+  page: number,
+  apiKey?: string
+): string {
+  const params = new URLSearchParams({
+    chainid: chainId.toString(),
+    module: "account",
+    action: "txlist",
+    address: contractAddress,
+    startblock: startBlock.toString(),
+    endblock: endBlock.toString(),
+    page: page.toString(),
+    offset: ETHERSCAN_TX_PAGE_SIZE.toString(),
+    sort: "asc",
+  });
+
+  if (apiKey) {
+    params.set("apikey", apiKey);
+  }
+
+  return `${apiUrl}?${params}`;
+}
+
+function parseTxListResponse(data: EtherscanTxListResponse): TxPageResult {
+  if (data.status !== "1") {
+    const isEmptyResult =
+      typeof data.result === "string" &&
+      data.result.toLowerCase().includes("no transactions found");
+    if (isEmptyResult) {
+      return { done: true, transactions: [] };
+    }
+    const errorMessage = parseEtherscanError(
+      typeof data.result === "string" ? data.result : data.message
+    );
+    return { error: errorMessage };
+  }
+
+  if (!Array.isArray(data.result)) {
+    return { done: true, transactions: [] };
+  }
+
+  const hasMore = data.result.length >= ETHERSCAN_TX_PAGE_SIZE;
+  return { done: !hasMore, transactions: data.result };
+}
+
+/**
+ * Fetch transaction list for a contract address from Etherscan API v2
+ *
+ * Uses the `account` module `txlist` action to get normal transactions.
+ * Paginates automatically (max 10,000 per page, up to MAX_PAGES pages).
+ *
+ * @param apiUrl - Base API URL (e.g., "https://api.etherscan.io/v2/api")
+ * @param chainId - Chain ID for the request
+ * @param contractAddress - Contract address to list transactions for
+ * @param startBlock - Start block number
+ * @param endBlock - End block number
+ * @param apiKey - Optional Etherscan API key (recommended for rate limits)
+ */
+export async function fetchEtherscanTransactions(
+  apiUrl: string,
+  chainId: number,
+  contractAddress: string,
+  startBlock: number,
+  endBlock: number,
+  apiKey?: string
+): Promise<
+  | { success: true; transactions: EtherscanTransaction[] }
+  | { success: false; error: string }
+> {
+  const allTransactions: EtherscanTransaction[] = [];
+
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const url = buildTxListParams(
+      apiUrl,
+      chainId,
+      contractAddress,
+      startBlock,
+      endBlock,
+      page,
+      apiKey
+    );
+
+    try {
+      const response = await fetch(url);
+      const data: EtherscanTxListResponse = await response.json();
+      const result = parseTxListResponse(data);
+
+      if ("error" in result) {
+        return { success: false, error: result.error };
+      }
+
+      allTransactions.push(...result.transactions);
+
+      if (result.done) {
+        break;
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unknown error fetching transactions",
+      };
+    }
+  }
+
+  return { success: true, transactions: allTransactions };
 }
 
 /**

--- a/lib/explorer/index.ts
+++ b/lib/explorer/index.ts
@@ -152,7 +152,7 @@ function normalizeBlockscoutTx(
   return {
     hash: tx.hash,
     from: tx.from.hash,
-    to: tx.to.hash,
+    to: tx.to?.hash ?? "",
     value: tx.value,
     input: tx.raw_input,
     blockNumber: tx.block,

--- a/lib/explorer/index.ts
+++ b/lib/explorer/index.ts
@@ -8,11 +8,35 @@
  */
 
 import type { ExplorerConfig } from "@/lib/db/schema";
-import { fetchBlockscoutAbi } from "./blockscout";
+import {
+  type BlockscoutTransaction,
+  fetchBlockscoutAbi,
+  fetchBlockscoutTransactions,
+} from "./blockscout";
 import type { AbiResult } from "./etherscan";
-import { fetchEtherscanAbi } from "./etherscan";
+import {
+  type EtherscanTransaction,
+  fetchEtherscanAbi,
+  fetchEtherscanTransactions,
+} from "./etherscan";
 
-export type { AbiResult } from "./etherscan";
+export type { BlockscoutTransaction } from "./blockscout";
+export type { AbiResult, EtherscanTransaction } from "./etherscan";
+
+export type NormalizedTransaction = {
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  input: string;
+  blockNumber: number;
+  timestamp: string;
+  isError: boolean;
+};
+
+type TransactionListResult =
+  | { success: true; transactions: NormalizedTransaction[] }
+  | { success: false; error: string };
 
 /**
  * Build transaction URL for the explorer
@@ -105,6 +129,102 @@ export async function fetchContractAbi(
       return {
         success: false,
         error: `Unknown explorer type: ${config.explorerApiType}`,
+      };
+  }
+}
+
+function normalizeEtherscanTx(tx: EtherscanTransaction): NormalizedTransaction {
+  return {
+    hash: tx.hash,
+    from: tx.from,
+    to: tx.to,
+    value: tx.value,
+    input: tx.input,
+    blockNumber: Number.parseInt(tx.blockNumber, 10),
+    timestamp: tx.timeStamp,
+    isError: tx.isError === "1",
+  };
+}
+
+function normalizeBlockscoutTx(
+  tx: BlockscoutTransaction
+): NormalizedTransaction {
+  return {
+    hash: tx.hash,
+    from: tx.from.hash,
+    to: tx.to.hash,
+    value: tx.value,
+    input: tx.raw_input,
+    blockNumber: tx.block,
+    timestamp: tx.timestamp,
+    isError: tx.status !== "ok",
+  };
+}
+
+/**
+ * Fetch transaction list for a contract address from the appropriate explorer
+ *
+ * @param config - Explorer configuration from database
+ * @param contractAddress - Contract address to list transactions for
+ * @param chainId - Chain ID (required for Etherscan v2)
+ * @param startBlock - Start block number
+ * @param endBlock - End block number
+ * @param apiKey - Optional API key (required for Etherscan)
+ */
+export async function fetchContractTransactions(
+  config: ExplorerConfig,
+  contractAddress: string,
+  chainId: number,
+  startBlock: number,
+  endBlock: number,
+  apiKey?: string
+): Promise<TransactionListResult> {
+  if (!(config.explorerApiUrl && config.explorerApiType)) {
+    return {
+      success: false,
+      error: "Explorer API not configured for this chain",
+    };
+  }
+
+  switch (config.explorerApiType) {
+    case "etherscan": {
+      const result = await fetchEtherscanTransactions(
+        config.explorerApiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock,
+        apiKey
+      );
+      if (!result.success) {
+        return result;
+      }
+      return {
+        success: true,
+        transactions: result.transactions.map(normalizeEtherscanTx),
+      };
+    }
+
+    case "blockscout": {
+      const result = await fetchBlockscoutTransactions(
+        config.explorerApiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+      if (!result.success) {
+        return result;
+      }
+      return {
+        success: true,
+        transactions: result.transactions.map(normalizeBlockscoutTx),
+      };
+    }
+
+    default:
+      return {
+        success: false,
+        error: `Transaction listing not supported for explorer type: ${config.explorerApiType}`,
       };
   }
 }

--- a/lib/explorer/index.ts
+++ b/lib/explorer/index.ts
@@ -152,6 +152,8 @@ function normalizeBlockscoutTx(
   return {
     hash: tx.hash,
     from: tx.from.hash,
+    // Contract creation txs have null `to`; normalized to "" so they
+    // are filtered out by filterAndDecodeTransactions (address mismatch).
     to: tx.to?.hash ?? "",
     value: tx.value,
     input: tx.raw_input,

--- a/tests/integration/query-transactions.test.ts
+++ b/tests/integration/query-transactions.test.ts
@@ -1,0 +1,754 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock: server-only
+// ---------------------------------------------------------------------------
+vi.mock("server-only", () => ({}));
+
+// ---------------------------------------------------------------------------
+// Hoisted mock references (vi.mock factories are hoisted above const decls)
+// ---------------------------------------------------------------------------
+const {
+  mockParseResults,
+  mockGetBlockNumber,
+  mockDbSelectLimit,
+  mockFindFirstExplorer,
+  mockFetchContractTransactions,
+  mockGetAddressUrl,
+  mockGetTransactionUrl,
+  mockGetChainIdFromNetwork,
+  mockResolveRpcConfig,
+} = vi.hoisted(() => ({
+  mockParseResults: new Map<
+    string,
+    {
+      name: string;
+      signature: string;
+      args: unknown[];
+      fragment: { inputs: { name: string }[] };
+    }
+  >(),
+  mockGetBlockNumber: vi.fn().mockResolvedValue(20_000_000),
+  mockDbSelectLimit: vi.fn().mockResolvedValue([{ userId: "user_123" }]),
+  mockFindFirstExplorer: vi.fn(),
+  mockFetchContractTransactions: vi.fn(),
+  mockGetAddressUrl: vi.fn(),
+  mockGetTransactionUrl: vi.fn(),
+  mockGetChainIdFromNetwork: vi.fn(),
+  mockResolveRpcConfig: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: ethers
+// ---------------------------------------------------------------------------
+vi.mock("ethers", () => ({
+  ethers: {
+    isAddress: vi.fn(
+      (addr: string) => addr.startsWith("0x") && addr.length === 42
+    ),
+    Interface: class MockInterface {
+      private abi: Array<{
+        type: string;
+        name: string;
+        inputs?: Array<{ name: string }>;
+      }>;
+
+      constructor(abi: unknown[]) {
+        this.abi = abi as Array<{
+          type: string;
+          name: string;
+          inputs?: Array<{ name: string }>;
+        }>;
+      }
+
+      getFunction(name: string): {
+        name: string;
+        inputs: Array<{ name: string }>;
+      } | null {
+        const fn = this.abi.find(
+          (e) => e.type === "function" && e.name === name
+        );
+        if (!fn) {
+          return null;
+        }
+        return {
+          name: fn.name,
+          inputs: (fn.inputs ?? []).map((inp) => ({ name: inp.name })),
+        };
+      }
+
+      parseTransaction(tx: { data: string; value: string }): {
+        name: string;
+        signature: string;
+        args: unknown[];
+        fragment: { inputs: { name: string }[] };
+      } | null {
+        return mockParseResults.get(tx.data) ?? null;
+      }
+    },
+    JsonRpcProvider: class MockJsonRpcProvider {
+      getBlockNumber = mockGetBlockNumber;
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: @/lib/db
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockDbSelectLimit,
+        }),
+      }),
+    }),
+    query: {
+      explorerConfigs: {
+        findFirst: mockFindFirstExplorer,
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: @/lib/db/schema
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/db/schema", () => ({
+  explorerConfigs: { chainId: "explorerConfigs.chainId" },
+  workflowExecutions: {
+    id: "workflowExecutions.id",
+    userId: "workflowExecutions.userId",
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: @/lib/explorer
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/explorer", () => ({
+  fetchContractTransactions: mockFetchContractTransactions,
+  getAddressUrl: mockGetAddressUrl,
+  getTransactionUrl: mockGetTransactionUrl,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: @/lib/rpc
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/rpc", () => ({
+  getChainIdFromNetwork: mockGetChainIdFromNetwork,
+  resolveRpcConfig: mockResolveRpcConfig,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: @/lib/utils
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: vi.fn(
+    (error: unknown) =>
+      (error as { message?: string })?.message ?? String(error)
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test AFTER all mocks
+// ---------------------------------------------------------------------------
+import { queryTransactionsCore } from "@/keeperhub/plugins/web3/steps/query-transactions-core";
+import type { NormalizedTransaction } from "@/lib/explorer";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const TRANSFER_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+]);
+
+const VALID_CONTRACT = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const VALID_SENDER = "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01";
+
+const MOCK_EXPLORER_CONFIG = {
+  id: "explorer_1",
+  chainId: 1,
+  chainType: "evm",
+  explorerUrl: "https://etherscan.io",
+  explorerApiType: "etherscan",
+  explorerApiUrl: "https://api.etherscan.io/v2/api",
+  explorerTxPath: "/tx/{hash}",
+  explorerAddressPath: "/address/{address}",
+  explorerContractPath: "/address/{address}#code",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function createMockTx(
+  overrides: Partial<NormalizedTransaction> = {}
+): NormalizedTransaction {
+  return {
+    hash: "0xtx1",
+    from: VALID_SENDER,
+    to: VALID_CONTRACT,
+    value: "0",
+    input: "0xtransfer_data",
+    blockNumber: 19_999_500,
+    timestamp: "1700000000",
+    isError: false,
+    ...overrides,
+  };
+}
+
+function defaultInput(): {
+  network: string;
+  contractAddress: string;
+  abi: string;
+  abiFunction: string;
+  _context: { executionId: string };
+} {
+  return {
+    network: "mainnet",
+    contractAddress: VALID_CONTRACT,
+    abi: TRANSFER_ABI,
+    abiFunction: "transfer",
+    _context: { executionId: "exec_123" },
+  };
+}
+
+function registerParseResult(
+  inputData: string,
+  opts: {
+    name: string;
+    argNames: string[];
+    argValues: unknown[];
+  }
+): void {
+  mockParseResults.set(inputData, {
+    name: opts.name,
+    signature: `${opts.name}()`,
+    args: opts.argValues,
+    fragment: {
+      inputs: opts.argNames.map((n) => ({ name: n })),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Default mock setup helper
+// ---------------------------------------------------------------------------
+function setupDefaultMocks(): void {
+  mockGetChainIdFromNetwork.mockReturnValue(1);
+  mockResolveRpcConfig.mockResolvedValue({
+    chainId: 1,
+    chainName: "Ethereum Mainnet",
+    primaryRpcUrl: "https://eth.example.com",
+    fallbackRpcUrl: "https://eth-backup.example.com",
+    source: "default",
+  });
+  mockFindFirstExplorer.mockResolvedValue(MOCK_EXPLORER_CONFIG);
+  mockGetAddressUrl.mockReturnValue(
+    `https://etherscan.io/address/${VALID_CONTRACT}`
+  );
+  mockGetTransactionUrl.mockImplementation(
+    (_config: unknown, hash: string) => `https://etherscan.io/tx/${hash}`
+  );
+  mockGetBlockNumber.mockResolvedValue(20_000_000);
+  mockDbSelectLimit.mockResolvedValue([{ userId: "user_123" }]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("queryTransactionsCore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParseResults.clear();
+    setupDefaultMocks();
+  });
+
+  // =========================================================================
+  // Happy path
+  // =========================================================================
+
+  it("returns decoded transactions matching the target function", async () => {
+    const tx1 = createMockTx({ hash: "0xaaa", input: "0xdata_transfer_1" });
+    const tx2 = createMockTx({ hash: "0xbbb", input: "0xdata_transfer_2" });
+    const tx3 = createMockTx({ hash: "0xccc", input: "0xdata_approve" });
+
+    registerParseResult("0xdata_transfer_1", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xRecipient1", "1000"],
+    });
+    registerParseResult("0xdata_transfer_2", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xRecipient2", "2000"],
+    });
+    registerParseResult("0xdata_approve", {
+      name: "approve",
+      argNames: ["spender", "amount"],
+      argValues: ["0xSpender", "500"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx1, tx2, tx3],
+    });
+
+    const result = await queryTransactionsCore(defaultInput());
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.matchCount).toBe(2);
+    expect(result.totalFetched).toBe(3);
+    expect(result.transactions).toHaveLength(2);
+
+    const first = result.transactions[0];
+    expect(first.hash).toBe("0xaaa");
+    expect(first.from).toBe(VALID_SENDER);
+    expect(first.to).toBe(VALID_CONTRACT);
+    expect(first.value).toBe("0");
+    expect(first.blockNumber).toBe(19_999_500);
+    expect(first.timestamp).toBe("1700000000");
+    expect(first.functionName).toBe("transfer");
+    expect(first.functionSignature).toBe("transfer()");
+    expect(first.args).toEqual({ to: "0xRecipient1", amount: "1000" });
+    expect(first.transactionLink).toBe("https://etherscan.io/tx/0xaaa");
+
+    expect(result.contractAddressLink).toBe(
+      `https://etherscan.io/address/${VALID_CONTRACT}`
+    );
+  });
+
+  it("returns zero matches when no transactions call the target function", async () => {
+    const tx = createMockTx({ input: "0xdata_other" });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx],
+    });
+
+    const result = await queryTransactionsCore(defaultInput());
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.matchCount).toBe(0);
+    expect(result.transactions).toHaveLength(0);
+    expect(result.totalFetched).toBe(1);
+  });
+
+  it("filters transactions by argument values", async () => {
+    const tx1 = createMockTx({ hash: "0xaaa", input: "0xdata_t1" });
+    const tx2 = createMockTx({ hash: "0xbbb", input: "0xdata_t2" });
+
+    registerParseResult("0xdata_t1", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xTarget", "1000"],
+    });
+    registerParseResult("0xdata_t2", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xOther", "2000"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx1, tx2],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: '["0xTarget", "1000"]',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.matchCount).toBe(1);
+    expect(result.transactions[0].hash).toBe("0xaaa");
+  });
+
+  it("treats empty-string args as wildcards in the filter", async () => {
+    const tx1 = createMockTx({ hash: "0xaaa", input: "0xdata_w1" });
+    const tx2 = createMockTx({ hash: "0xbbb", input: "0xdata_w2" });
+
+    registerParseResult("0xdata_w1", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAny1", "1000"],
+    });
+    registerParseResult("0xdata_w2", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAny2", "2000"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx1, tx2],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: '["", "1000"]',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.matchCount).toBe(1);
+    expect(result.transactions[0].hash).toBe("0xaaa");
+  });
+
+  it("matches arg filter values case-insensitively for addresses", async () => {
+    const tx = createMockTx({ hash: "0xaaa", input: "0xdata_case" });
+
+    registerParseResult("0xdata_case", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAbCdEf0123456789000000000000000000000001", "500"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: '["0xabcdef0123456789000000000000000000000001", "500"]',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.matchCount).toBe(1);
+    expect(result.transactions[0].hash).toBe("0xaaa");
+  });
+
+  // =========================================================================
+  // Error cases
+  // =========================================================================
+
+  it("returns error for invalid contract address", async () => {
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      contractAddress: "not-an-address",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("Invalid contract address");
+  });
+
+  it("returns error for invalid ABI JSON", async () => {
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      abi: "{ broken json !!",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("Invalid ABI JSON");
+  });
+
+  it("returns error when function is not found in ABI", async () => {
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      abiFunction: "nonExistentFunction",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("not found in ABI");
+  });
+
+  it("returns error for unsupported network", async () => {
+    mockGetChainIdFromNetwork.mockImplementation(() => {
+      throw new Error("Unsupported network: zora");
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      network: "zora",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("Unsupported network");
+  });
+
+  it("returns error when RPC config is not available (chain disabled)", async () => {
+    mockResolveRpcConfig.mockResolvedValue(null);
+
+    const result = await queryTransactionsCore(defaultInput());
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("not found or not enabled");
+  });
+
+  it("returns error when no explorer config exists in the database", async () => {
+    mockFindFirstExplorer.mockResolvedValue(undefined);
+
+    const result = await queryTransactionsCore(defaultInput());
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("No explorer configuration");
+  });
+
+  it("propagates error from explorer API failure", async () => {
+    mockFetchContractTransactions.mockResolvedValue({
+      success: false,
+      error: "rate limit exceeded",
+    });
+
+    const result = await queryTransactionsCore(defaultInput());
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toBe("rate limit exceeded");
+  });
+
+  // =========================================================================
+  // Block range
+  // =========================================================================
+
+  it("returns empty success result when fromBlock > toBlock", async () => {
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      fromBlock: "20000000",
+      toBlock: "19000000",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.transactions).toHaveLength(0);
+    expect(result.matchCount).toBe(0);
+    expect(result.totalFetched).toBe(0);
+    expect(result.fromBlock).toBe(20_000_000);
+    expect(result.toBlock).toBe(19_000_000);
+    expect(mockFetchContractTransactions).not.toHaveBeenCalled();
+  });
+
+  it("uses explicit fromBlock and toBlock directly", async () => {
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [],
+    });
+
+    await queryTransactionsCore({
+      ...defaultInput(),
+      fromBlock: "15000000",
+      toBlock: "15001000",
+    });
+
+    expect(mockFetchContractTransactions).toHaveBeenCalledWith(
+      MOCK_EXPLORER_CONFIG,
+      VALID_CONTRACT,
+      1,
+      15_000_000,
+      15_001_000,
+      expect.anything()
+    );
+  });
+
+  it("computes fromBlock using blockCount lookback from latest block", async () => {
+    mockGetBlockNumber.mockResolvedValue(20_000_000);
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [],
+    });
+
+    await queryTransactionsCore({
+      ...defaultInput(),
+      blockCount: 1000,
+    });
+
+    expect(mockFetchContractTransactions).toHaveBeenCalledWith(
+      MOCK_EXPLORER_CONFIG,
+      VALID_CONTRACT,
+      1,
+      19_999_000,
+      20_000_000,
+      expect.anything()
+    );
+  });
+
+  it("uses default 6500 lookback when no block params are provided", async () => {
+    mockGetBlockNumber.mockResolvedValue(20_000_000);
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [],
+    });
+
+    await queryTransactionsCore(defaultInput());
+
+    expect(mockFetchContractTransactions).toHaveBeenCalledWith(
+      MOCK_EXPLORER_CONFIG,
+      VALID_CONTRACT,
+      1,
+      19_993_500,
+      20_000_000,
+      expect.anything()
+    );
+  });
+
+  // =========================================================================
+  // functionArgs parsing
+  // =========================================================================
+
+  it("parses functionArgs from a JSON string", async () => {
+    const tx = createMockTx({ hash: "0xaaa", input: "0xdata_json" });
+
+    registerParseResult("0xdata_json", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xRecipient", "100"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: '["0xRecipient", "100"]',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.matchCount).toBe(1);
+  });
+
+  it("uses functionArgs directly when provided as an array", async () => {
+    const tx = createMockTx({ hash: "0xaaa", input: "0xdata_arr" });
+
+    registerParseResult("0xdata_arr", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xRecipient", "100"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: ["0xRecipient", "100"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.matchCount).toBe(1);
+  });
+
+  it("treats all-empty array functionArgs as no filter (matches all)", async () => {
+    const tx1 = createMockTx({ hash: "0xaaa", input: "0xdata_e1" });
+    const tx2 = createMockTx({ hash: "0xbbb", input: "0xdata_e2" });
+
+    registerParseResult("0xdata_e1", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAddr1", "100"],
+    });
+    registerParseResult("0xdata_e2", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAddr2", "200"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx1, tx2],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: ["", ""],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.matchCount).toBe(2);
+  });
+
+  it("treats invalid JSON functionArgs as no filter (matches all)", async () => {
+    const tx1 = createMockTx({ hash: "0xaaa", input: "0xdata_inv1" });
+    const tx2 = createMockTx({ hash: "0xbbb", input: "0xdata_inv2" });
+
+    registerParseResult("0xdata_inv1", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAddr1", "100"],
+    });
+    registerParseResult("0xdata_inv2", {
+      name: "transfer",
+      argNames: ["to", "amount"],
+      argValues: ["0xAddr2", "200"],
+    });
+
+    mockFetchContractTransactions.mockResolvedValue({
+      success: true,
+      transactions: [tx1, tx2],
+    });
+
+    const result = await queryTransactionsCore({
+      ...defaultInput(),
+      functionArgs: "not-valid-json",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.matchCount).toBe(2);
+  });
+});

--- a/tests/integration/query-transactions.test.ts
+++ b/tests/integration/query-transactions.test.ts
@@ -581,14 +581,10 @@ describe("queryTransactionsCore", () => {
       toBlock: "15001000",
     });
 
-    expect(mockFetchContractTransactions).toHaveBeenCalledWith(
-      MOCK_EXPLORER_CONFIG,
-      VALID_CONTRACT,
-      1,
-      15_000_000,
-      15_001_000,
-      expect.anything()
-    );
+    const [, , , fromBlock, toBlock] =
+      mockFetchContractTransactions.mock.calls[0];
+    expect(fromBlock).toBe(15_000_000);
+    expect(toBlock).toBe(15_001_000);
   });
 
   it("computes fromBlock using blockCount lookback from latest block", async () => {
@@ -603,14 +599,10 @@ describe("queryTransactionsCore", () => {
       blockCount: 1000,
     });
 
-    expect(mockFetchContractTransactions).toHaveBeenCalledWith(
-      MOCK_EXPLORER_CONFIG,
-      VALID_CONTRACT,
-      1,
-      19_999_000,
-      20_000_000,
-      expect.anything()
-    );
+    const [, , , fromBlock, toBlock] =
+      mockFetchContractTransactions.mock.calls[0];
+    expect(fromBlock).toBe(19_999_000);
+    expect(toBlock).toBe(20_000_000);
   });
 
   it("uses default 6500 lookback when no block params are provided", async () => {
@@ -622,14 +614,10 @@ describe("queryTransactionsCore", () => {
 
     await queryTransactionsCore(defaultInput());
 
-    expect(mockFetchContractTransactions).toHaveBeenCalledWith(
-      MOCK_EXPLORER_CONFIG,
-      VALID_CONTRACT,
-      1,
-      19_993_500,
-      20_000_000,
-      expect.anything()
-    );
+    const [, , , fromBlock, toBlock] =
+      mockFetchContractTransactions.mock.calls[0];
+    expect(fromBlock).toBe(19_993_500);
+    expect(toBlock).toBe(20_000_000);
   });
 
   // =========================================================================

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -7,8 +7,16 @@ import {
   getContractUrl,
   getTransactionUrl,
 } from "@/lib/explorer";
-import { fetchBlockscoutAbi } from "@/lib/explorer/blockscout";
-import { fetchEtherscanAbi } from "@/lib/explorer/etherscan";
+import {
+  type BlockscoutTransaction,
+  fetchBlockscoutAbi,
+  fetchBlockscoutTransactions,
+} from "@/lib/explorer/blockscout";
+import {
+  type EtherscanTransaction,
+  fetchEtherscanAbi,
+  fetchEtherscanTransactions,
+} from "@/lib/explorer/etherscan";
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -572,6 +580,648 @@ describe("explorer", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to fetch ABI from Blockscout");
+    });
+  });
+
+  describe("fetchEtherscanTransactions", () => {
+    const apiUrl = "https://api.etherscan.io/v2/api";
+    const chainId = 1;
+    const contractAddress = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+    const startBlock = 100;
+    const endBlock = 999_999;
+
+    function createEtherscanTxResponse(
+      transactions: Partial<EtherscanTransaction>[],
+      status = "1"
+    ): {
+      status: string;
+      message: string;
+      result: EtherscanTransaction[];
+    } {
+      return {
+        status,
+        message: status === "1" ? "OK" : "NOTOK",
+        result: transactions.map((tx) => ({
+          hash: tx.hash ?? "0xtx1",
+          from: tx.from ?? "0xsender",
+          to: tx.to ?? "0xcontract",
+          value: tx.value ?? "0",
+          input: tx.input ?? "0x",
+          blockNumber: tx.blockNumber ?? "100",
+          timeStamp: tx.timeStamp ?? "1700000000",
+          isError: tx.isError ?? "0",
+          functionName: tx.functionName ?? "transfer(address,uint256)",
+        })),
+      };
+    }
+
+    function mockFetchJsonResponse(data: unknown): {
+      ok: boolean;
+      json: () => Promise<unknown>;
+    } {
+      return { ok: true, json: async () => data };
+    }
+
+    it("should return transactions for a single page of results", async () => {
+      const txs = [
+        { hash: "0xaaa", blockNumber: "200" },
+        { hash: "0xbbb", blockNumber: "300" },
+      ];
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse(txs))
+      );
+
+      const result = await fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(2);
+        expect(result.transactions[0].hash).toBe("0xaaa");
+        expect(result.transactions[1].hash).toBe("0xbbb");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should paginate when first page returns 10,000 results", async () => {
+      vi.useFakeTimers();
+
+      const fullPage = Array.from({ length: 10_000 }, (_, i) => ({
+        hash: `0xfull${i}`,
+        blockNumber: String(startBlock + i),
+      }));
+      const secondPage = [
+        { hash: "0xlast1", blockNumber: "20000" },
+        { hash: "0xlast2", blockNumber: "20001" },
+      ];
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse(secondPage))
+      );
+
+      const resultPromise = fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      // Advance past the delay between pages
+      await vi.advanceTimersByTimeAsync(250);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(10_002);
+        expect(result.transactions[10_000].hash).toBe("0xlast1");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Verify the second call has page=2
+      const secondCallUrl = mockFetch.mock.calls[1][0] as string;
+      expect(secondCallUrl).toContain("page=2");
+
+      vi.useRealTimers();
+    });
+
+    it("should return empty array for 'no transactions found' message", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse({
+          status: "0",
+          message: "No transactions found",
+          result: "No transactions found",
+        })
+      );
+
+      const result = await fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toEqual([]);
+      }
+    });
+
+    it("should propagate API error message on failure", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse({
+          status: "0",
+          message: "NOTOK",
+          result: "Rate limit exceeded",
+        })
+      );
+
+      const result = await fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe(
+          "Rate limit exceeded. Please try again later."
+        );
+      }
+    });
+
+    it("should stop at MAX_PAGES (5) even if results keep coming", async () => {
+      vi.useFakeTimers();
+
+      const fullPage = Array.from({ length: 10_000 }, (_, i) => ({
+        hash: `0xpage${i}`,
+        blockNumber: String(startBlock + i),
+      }));
+
+      // Mock 5 full pages -- each triggers "more pages" but the 5th should be the cap
+      for (let p = 0; p < 5; p++) {
+        mockFetch.mockResolvedValueOnce(
+          mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
+        );
+      }
+
+      const resultPromise = fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      // Advance past all delays (4 delays between 5 pages)
+      for (let d = 0; d < 4; d++) {
+        await vi.advanceTimersByTimeAsync(250);
+      }
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(50_000);
+      }
+      // Should not attempt a 6th page
+      expect(mockFetch).toHaveBeenCalledTimes(5);
+
+      vi.useRealTimers();
+    });
+
+    it("should delay between pages using setTimeout", async () => {
+      vi.useFakeTimers();
+      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+      const fullPage = Array.from({ length: 10_000 }, (_, i) => ({
+        hash: `0xdelay${i}`,
+        blockNumber: String(startBlock + i),
+      }));
+      const lastPage = [{ hash: "0xfinal", blockNumber: "50000" }];
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse(lastPage))
+      );
+
+      const resultPromise = fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      await vi.advanceTimersByTimeAsync(250);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      // Verify setTimeout was called with the expected delay (220ms)
+      const delayCall = setTimeoutSpy.mock.calls.find(([, ms]) => ms === 220);
+      expect(delayCall).toBeDefined();
+
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("should propagate network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network timeout"));
+
+      const result = await fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Network timeout");
+      }
+    });
+
+    it("should include correct URL parameters", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse([{ hash: "0xparams" }]))
+      );
+
+      await fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock,
+        "my-key"
+      );
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("chainid=1");
+      expect(calledUrl).toContain("module=account");
+      expect(calledUrl).toContain("action=txlist");
+      expect(calledUrl).toContain(`address=${contractAddress}`);
+      expect(calledUrl).toContain(`startblock=${startBlock}`);
+      expect(calledUrl).toContain(`endblock=${endBlock}`);
+      expect(calledUrl).toContain("page=1");
+      expect(calledUrl).toContain("offset=10000");
+      expect(calledUrl).toContain("sort=asc");
+      expect(calledUrl).toContain("apikey=my-key");
+    });
+  });
+
+  describe("fetchBlockscoutTransactions", () => {
+    const apiUrl = "https://explorer.testnet.tempo.xyz/api";
+    const contractAddress = "0x1234567890123456789012345678901234567890";
+    const startBlock = 100;
+    const endBlock = 500;
+
+    function createBlockscoutTxResponse(
+      items: Partial<BlockscoutTransaction>[],
+      nextPageParams: { block_number: number; index: number } | null = null
+    ): {
+      items: BlockscoutTransaction[];
+      next_page_params: { block_number: number; index: number } | null;
+    } {
+      return {
+        items: items.map((tx) => ({
+          hash: tx.hash ?? "0xtx1",
+          from: tx.from ?? { hash: "0xsender" },
+          to: tx.to === undefined ? { hash: "0xcontract" } : tx.to,
+          value: tx.value ?? "0",
+          raw_input: tx.raw_input ?? "0x",
+          block: tx.block ?? 100,
+          timestamp: tx.timestamp ?? "2024-01-01T00:00:00Z",
+          status: tx.status ?? "ok",
+          method: tx.method ?? "transfer",
+        })),
+        next_page_params: nextPageParams,
+      };
+    }
+
+    function mockFetchOkResponse(data: unknown): {
+      ok: boolean;
+      status: number;
+      json: () => Promise<unknown>;
+    } {
+      return { ok: true, status: 200, json: async () => data };
+    }
+
+    it("should return transactions for a single page within block range", async () => {
+      const txs = [
+        { hash: "0xaaa", block: 200 },
+        { hash: "0xbbb", block: 300 },
+      ];
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(createBlockscoutTxResponse(txs))
+      );
+
+      const result = await fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(2);
+        expect(result.transactions[0].hash).toBe("0xaaa");
+        expect(result.transactions[1].hash).toBe("0xbbb");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should paginate using cursor-based pagination", async () => {
+      vi.useFakeTimers();
+
+      const firstPageItems = Array.from({ length: 50 }, (_, i) => ({
+        hash: `0xfirst${i}`,
+        block: 400 - i,
+      }));
+      const secondPageItems = [
+        { hash: "0xsecond1", block: 200 },
+        { hash: "0xsecond2", block: 150 },
+      ];
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(
+          createBlockscoutTxResponse(firstPageItems, {
+            block_number: 350,
+            index: 1,
+          })
+        )
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(createBlockscoutTxResponse(secondPageItems))
+      );
+
+      const resultPromise = fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(52);
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Verify cursor params in the second call
+      const secondCallUrl = mockFetch.mock.calls[1][0] as string;
+      expect(secondCallUrl).toContain("block_number=350");
+      expect(secondCallUrl).toContain("index=1");
+
+      vi.useRealTimers();
+    });
+
+    it("should filter out transactions outside startBlock/endBlock range", async () => {
+      const txs = [
+        { hash: "0xinrange", block: 200 },
+        { hash: "0xbelowstart", block: 50 },
+        { hash: "0xaboveend", block: 600 },
+        { hash: "0xatstart", block: 100 },
+        { hash: "0xatend", block: 500 },
+      ];
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(createBlockscoutTxResponse(txs))
+      );
+
+      const result = await fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(3);
+        const hashes = result.transactions.map((tx) => tx.hash);
+        expect(hashes).toContain("0xinrange");
+        expect(hashes).toContain("0xatstart");
+        expect(hashes).toContain("0xatend");
+        expect(hashes).not.toContain("0xbelowstart");
+        expect(hashes).not.toContain("0xaboveend");
+      }
+    });
+
+    it("should stop paginating when last block < startBlock", async () => {
+      vi.useFakeTimers();
+
+      // First page: 50 items, last block is below startBlock
+      const firstPageItems = Array.from({ length: 50 }, (_, i) => ({
+        hash: `0xitem${i}`,
+        block: 200 - i * 4,
+      }));
+      // The last item on this page has block = 200 - 49*4 = 4, which is < startBlock (100)
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(
+          createBlockscoutTxResponse(firstPageItems, {
+            block_number: 4,
+            index: 0,
+          })
+        )
+      );
+
+      const resultPromise = fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      // Should NOT make a second request since the last block (4) < startBlock (100)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      if (result.success) {
+        // Only items within the range should be collected
+        for (const tx of result.transactions) {
+          expect(tx.block).toBeGreaterThanOrEqual(startBlock);
+          expect(tx.block).toBeLessThanOrEqual(endBlock);
+        }
+      }
+
+      vi.useRealTimers();
+    });
+
+    it("should return error for non-200 API response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+
+      const result = await fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Blockscout API returned status 500");
+      }
+    });
+
+    it("should handle null 'to' field in BlockscoutTransaction", async () => {
+      const txs = [{ hash: "0xnullto", block: 200, to: null }];
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(createBlockscoutTxResponse(txs))
+      );
+
+      const result = await fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(1);
+        expect(result.transactions[0].to).toBeNull();
+        expect(result.transactions[0].hash).toBe("0xnullto");
+      }
+    });
+
+    it("should skip pages entirely above endBlock without collecting items", async () => {
+      vi.useFakeTimers();
+
+      // First page: all items have block > endBlock (500)
+      const abovePage = Array.from({ length: 50 }, (_, i) => ({
+        hash: `0xabove${i}`,
+        block: 1000 - i,
+      }));
+      // Lowest block on page is 1000 - 49 = 951, which is > endBlock (500)
+
+      // Second page: items within the range
+      const inRangePage = [
+        { hash: "0xinrange1", block: 400 },
+        { hash: "0xinrange2", block: 300 },
+      ];
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(
+          createBlockscoutTxResponse(abovePage, {
+            block_number: 951,
+            index: 0,
+          })
+        )
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(createBlockscoutTxResponse(inRangePage))
+      );
+
+      const resultPromise = fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // None of the above-range items should be collected
+        expect(result.transactions).toHaveLength(2);
+        expect(result.transactions[0].hash).toBe("0xinrange1");
+        expect(result.transactions[1].hash).toBe("0xinrange2");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("should delay between pagination requests using setTimeout", async () => {
+      vi.useFakeTimers();
+      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+      const firstPageItems = Array.from({ length: 50 }, (_, i) => ({
+        hash: `0xdelay${i}`,
+        block: 400 - i,
+      }));
+      const secondPageItems = [{ hash: "0xfinal", block: 200 }];
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(
+          createBlockscoutTxResponse(firstPageItems, {
+            block_number: 350,
+            index: 1,
+          })
+        )
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(createBlockscoutTxResponse(secondPageItems))
+      );
+
+      const resultPromise = fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      // Verify setTimeout was called with the expected delay (100ms)
+      const delayCall = setTimeoutSpy.mock.calls.find(([, ms]) => ms === 100);
+      expect(delayCall).toBeDefined();
+
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("should replace /api suffix with /api/v2 in the URL", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOkResponse(
+          createBlockscoutTxResponse([{ hash: "0xurl", block: 200 }])
+        )
+      );
+
+      await fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(
+        "https://explorer.testnet.tempo.xyz/api/v2/addresses/"
+      );
+      expect(calledUrl).toContain(contractAddress);
+      expect(calledUrl).toContain("filter=to");
+    });
+
+    it("should propagate network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+      const result = await fetchBlockscoutTransactions(
+        apiUrl,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Connection refused");
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `query-transactions` action to the web3 plugin that queries historical transactions sent to a contract address via block explorer APIs (Etherscan/Blockscout), decodes calldata using the provided ABI, and filters by function name and optionally by argument values
- Add transaction listing support to Etherscan (`txlist` with pagination) and Blockscout (cursor-based `/addresses/:address/transactions`) explorer APIs
- Add documentation and MCP schema tip for the new action

## Review feedback addressed

- Add rate limiting between explorer API pagination requests (220ms Etherscan, 100ms Blockscout) to avoid hitting rate limits
- Optimize Blockscout pagination to skip pages entirely above `endBlock` instead of fetching irrelevant transactions
- Remove incorrect `contractInteractionType: "write"` from the ABI config field (this step reads historical calls, not writes)
- Add 20 integration tests for `queryTransactionsCore` covering happy path, error cases, block range resolution, and argument filtering
- Add 18 unit tests for `fetchEtherscanTransactions` and `fetchBlockscoutTransactions` covering pagination, block filtering, delays, and error handling
- Validate ABI entries have required `type` field before casting, giving clear error messages for malformed ABIs
- Default `ETHERSCAN_API_KEY` to `undefined` instead of empty string, removing redundant fallback
- Replace `.map()`/`.filter()` with `for...of` loops for project convention consistency
- Document Blockscout `to: null` normalization behavior for contract creation transactions