### PR TITLE
feat: KEEP-1503 fix new workflow cloning previous workflow data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import {
+  currentWorkflowIdAtom,
   currentWorkflowNameAtom,
   edgesAtom,
   hasSidebarBeenShownAtom,
@@ -63,10 +64,9 @@ function createDefaultNodes() {
 const Home = () => {
   const router = useRouter();
   const { data: session } = useSession();
-  const nodes = useAtomValue(nodesAtom);
-  const edges = useAtomValue(edgesAtom);
   const setNodes = useSetAtom(nodesAtom);
   const setEdges = useSetAtom(edgesAtom);
+  const setCurrentWorkflowId = useSetAtom(currentWorkflowIdAtom);
   const setCurrentWorkflowName = useSetAtom(currentWorkflowNameAtom);
   const setHasSidebarBeenShown = useSetAtom(hasSidebarBeenShownAtom);
   const setIsTransitioningFromHomepage = useSetAtom(
@@ -94,12 +94,45 @@ const Home = () => {
   }, [session]);
 
   // start custom keeperhub code //
-  // Handler to add initial nodes (replaces the "add" placeholder)
-  const handleAddNode = useCallback(() => {
+  // Handler to add initial nodes and create the workflow.
+  // Creation is done here (not in a useEffect watching nodes) to avoid a race
+  // condition where stale nodes from a previously-open workflow would be picked
+  // up by the effect before the init effect's setNodes([placeholder]) is applied.
+  const handleAddNode = useCallback(async () => {
+    if (hasCreatedWorkflowRef.current) {
+      return;
+    }
+    hasCreatedWorkflowRef.current = true;
+
     const { nodes: defaultNodes, edges: defaultEdges } = createDefaultNodes();
     setNodes(defaultNodes);
     setEdges(defaultEdges);
-  }, [setNodes, setEdges]);
+
+    try {
+      await ensureSession();
+
+      const newWorkflow = await api.workflow.create({
+        name: "Untitled Workflow",
+        description: "",
+        nodes: defaultNodes,
+        edges: defaultEdges,
+      });
+
+      sessionStorage.setItem("animate-sidebar", "true");
+      setIsTransitioningFromHomepage(true);
+      router.replace(`/workflows/${newWorkflow.id}`);
+    } catch (error) {
+      console.error("Failed to create workflow:", error);
+      toast.error("Failed to create workflow");
+      hasCreatedWorkflowRef.current = false;
+    }
+  }, [
+    setNodes,
+    setEdges,
+    ensureSession,
+    router,
+    setIsTransitioningFromHomepage,
+  ]);
   // end keeperhub code //
 
   // Initialize with a temporary "add" node on mount
@@ -118,48 +151,16 @@ const Home = () => {
     };
     setNodes([addNodePlaceholder]);
     setEdges([]);
+    setCurrentWorkflowId(null);
     setCurrentWorkflowName("New Workflow");
     hasCreatedWorkflowRef.current = false;
-  }, [setNodes, setEdges, setCurrentWorkflowName, handleAddNode]);
-
-  // Create workflow when first real node is added
-  useEffect(() => {
-    const createWorkflowAndRedirect = async () => {
-      // Filter out the placeholder "add" node
-      const realNodes = nodes.filter((node) => node.type !== "add");
-
-      // Only create when we have at least one real node and haven't created a workflow yet
-      if (realNodes.length === 0 || hasCreatedWorkflowRef.current) {
-        return;
-      }
-      hasCreatedWorkflowRef.current = true;
-
-      try {
-        await ensureSession();
-
-        // Create workflow with all real nodes
-        const newWorkflow = await api.workflow.create({
-          name: "Untitled Workflow",
-          description: "",
-          nodes: realNodes,
-          edges,
-        });
-
-        // Set flags to indicate we're coming from homepage (for sidebar animation)
-        sessionStorage.setItem("animate-sidebar", "true");
-        setIsTransitioningFromHomepage(true);
-
-        // Redirect to the workflow page
-        console.log("[Homepage] Navigating to workflow page");
-        router.replace(`/workflows/${newWorkflow.id}`);
-      } catch (error) {
-        console.error("Failed to create workflow:", error);
-        toast.error("Failed to create workflow");
-      }
-    };
-
-    createWorkflowAndRedirect();
-  }, [nodes, edges, router, ensureSession, setIsTransitioningFromHomepage]);
+  }, [
+    setNodes,
+    setEdges,
+    setCurrentWorkflowId,
+    setCurrentWorkflowName,
+    handleAddNode,
+  ]);
 
   // Canvas and toolbar are rendered by PersistentCanvas in the layout
   return null;


### PR DESCRIPTION
## Summary
- Fixed a race condition in `app/page.tsx` where clicking "New Workflow" after having a workflow open would create a new workflow containing the previous workflow's data
- Root cause: two `useEffect` hooks ran in the same render cycle -- the init effect called `setNodes([placeholder])` but the state update wasn't applied before the create effect read the stale `nodes` closure (still containing the old workflow's data)
- Merged workflow creation logic directly into `handleAddNode` so it uses freshly-created nodes from `createDefaultNodes()` instead of reading stale Jotai atom closures
- Added `setCurrentWorkflowId(null)` on home page mount to clear stale workflow ID from the Jotai store

## Test plan
- [ ] Open an existing workflow with multiple configured nodes
- [ ] Click "New Workflow" in the navigation sidebar
- [ ] Verify the canvas shows the "+" placeholder (not the previous workflow)
- [ ] Click the placeholder to start a new workflow
- [ ] Verify the new workflow opens with a fresh trigger + empty action node (not a copy of the previous workflow)
- [ ] Verify creating workflows from the home page on a fresh session (no prior workflow) still works