### PR TITLE
hotfix: KEEP-1516 handle native ETH transfers in assess-risk step

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
         "--rm",
         "--pull=always",
         "-e",
-        "KEEPERHUB_API_KEY=your-api-key-here",
+        "KEEPERHUB_API_KEY=kh_LkWnLQcWTEY-splTwIN8oAtPCWT0aft5",
         "-e",
         "KEEPERHUB_API_URL=https://app.keeperhub.com",
         "ghcr.io/techops-services/keeperhub-mcp:latest"

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
         "--rm",
         "--pull=always",
         "-e",
-        "KEEPERHUB_API_KEY=kh_LkWnLQcWTEY-splTwIN8oAtPCWT0aft5",
+        "KEEPERHUB_API_KEY=your-api-key-here",
         "-e",
         "KEEPERHUB_API_URL=https://app.keeperhub.com",
         "ghcr.io/techops-services/keeperhub-mcp:latest"

--- a/keeperhub/plugins/web3/steps/assess-risk.ts
+++ b/keeperhub/plugins/web3/steps/assess-risk.ts
@@ -442,11 +442,29 @@ function buildFailClosedResult(
 async function stepHandler(
   input: AssessRiskCoreInput
 ): Promise<AssessRiskResult> {
-  if (!input.calldata?.trim()) {
+  const calldata = input.calldata?.trim() ?? "";
+  const isNativeTransfer = !calldata || calldata === "0x";
+
+  if (isNativeTransfer) {
+    const valueFactors = checkValueRisks(input.value);
+    const interactionFactors = checkInteractionRisks(
+      input.contractAddress,
+      null,
+      ""
+    );
+    const factors = [...valueFactors, ...interactionFactors];
+    const assessment = computeRiskFromFactors(factors);
+
     return {
-      success: false,
-      error: "Transaction calldata is required for risk assessment",
-      riskLevel: "critical",
+      success: true,
+      riskLevel: assessment.riskLevel,
+      riskScore: assessment.riskScore,
+      factors:
+        factors.length > 0
+          ? factors.map((f) => f.description)
+          : ["Native ETH transfer with no calldata"],
+      decodedFunction: null,
+      reasoning: "Native value transfer -- no contract interaction",
     };
   }
 


### PR DESCRIPTION
## Summary
- The `web3/assess-risk` step hard-failed (`success: false`, `riskLevel: critical`) when calldata was `null` or `"0x"`, which happens on plain ETH transfers from Safe multisigs
- Now treats empty calldata as a native value transfer, runs value and interaction risk checks, and returns a proper success result

## Test plan
- [ ] Trigger the Safe Signing Alert workflow with a pending native ETH transfer (no calldata) -- should succeed with low risk
- [ ] Trigger with a pending contract-call transaction -- should still decode and assess as before
- [ ] Verify large-value native transfers still flag as medium/high risk