### PR TITLE
hotfix: KEEP-1488 enrich event trigger data with block explorer links

### DIFF
--- a/keeperhub/lib/steps/enrich-explorer-links.ts
+++ b/keeperhub/lib/steps/enrich-explorer-links.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
+import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { eq } from "drizzle-orm";
 
 /**
  * Enrich trigger data with block explorer links for transaction hashes

--- a/keeperhub/lib/steps/enrich-explorer-links.ts
+++ b/keeperhub/lib/steps/enrich-explorer-links.ts
@@ -1,0 +1,40 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+import { explorerConfigs } from "@/lib/db/schema";
+import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { eq } from "drizzle-orm";
+
+/**
+ * Enrich trigger data with block explorer links for transaction hashes
+ * and addresses. Returns the mutated triggerData object with
+ * `transactionLink` and/or `addressLink` fields added when available.
+ */
+export async function enrichExplorerLinks(
+  triggerData: Record<string, unknown>,
+  network: string | number
+): Promise<void> {
+  "use step";
+  const chainId = getChainIdFromNetwork(network);
+  const explorerConfig = await db.query.explorerConfigs.findFirst({
+    where: eq(explorerConfigs.chainId, chainId),
+  });
+
+  if (!explorerConfig) {
+    return;
+  }
+
+  if (typeof triggerData.transactionHash === "string") {
+    triggerData.transactionLink = getTransactionUrl(
+      explorerConfig,
+      triggerData.transactionHash
+    );
+  }
+  if (typeof triggerData.address === "string") {
+    triggerData.addressLink = getAddressUrl(
+      explorerConfig,
+      triggerData.address
+    );
+  }
+}

--- a/keeperhub/protocols/index.ts
+++ b/keeperhub/protocols/index.ts
@@ -8,7 +8,7 @@
  * This ensures the protocol registry is populated when the Next.js
  * server starts (via the plugin import chain).
  *
- * Registered protocols: ajna, pendle, safe-wallet, sky, weth
+ * Registered protocols: ajna, pendle, safe, sky, weth
  */
 
 import {

--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: ai-gateway, ajna, clerk, code, database, discord, linear, math, pendle, protocol, resend, safe, safe-wallet, sendgrid, sky, slack, telegram, v0, web3, webflow, webhook, weth
+ * Generated types: ai-gateway, ajna, clerk, code, database, discord, linear, math, pendle, protocol, resend, safe, sendgrid, sky, slack, telegram, v0, web3, webflow, webhook, weth
  */
 
 // Integration type union - plugins + system integrations

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -46,12 +46,6 @@ import type { StepContext } from "./steps/step-handler";
 import { triggerStep } from "./steps/trigger";
 import { deserializeEventTriggerData, getErrorMessageAsync } from "./utils";
 import type { WorkflowEdge, WorkflowNode } from "./workflow-store";
-import { db } from "@/lib/db";
-import { explorerConfigs } from "@/lib/db/schema";
-import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork } from "@/lib/rpc";
-import { eq } from "drizzle-orm";
-
 // end keeperhub code //
 
 // System actions that don't have plugins - maps to module import functions
@@ -1668,30 +1662,17 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             };
 
             // Enrich event data with explorer links so the execution log UI
-            // can render clickable transaction/address links
+            // can render clickable transaction/address links.
+            // Uses a step function to keep db/schema out of the workflow bundle.
             if (config.network) {
               try {
-                const chainId = getChainIdFromNetwork(
+                const { enrichExplorerLinks } = await import(
+                  "@/keeperhub/lib/steps/enrich-explorer-links"
+                );
+                await enrichExplorerLinks(
+                  triggerData,
                   config.network as string | number
                 );
-                const explorerConfig =
-                  await db.query.explorerConfigs.findFirst({
-                    where: eq(explorerConfigs.chainId, chainId),
-                  });
-                if (explorerConfig) {
-                  if (typeof triggerData.transactionHash === "string") {
-                    triggerData.transactionLink = getTransactionUrl(
-                      explorerConfig,
-                      triggerData.transactionHash
-                    );
-                  }
-                  if (typeof triggerData.address === "string") {
-                    triggerData.addressLink = getAddressUrl(
-                      explorerConfig,
-                      triggerData.address
-                    );
-                  }
-                }
               } catch {
                 // Non-critical: skip explorer links if lookup fails
               }

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -46,6 +46,11 @@ import type { StepContext } from "./steps/step-handler";
 import { triggerStep } from "./steps/trigger";
 import { deserializeEventTriggerData, getErrorMessageAsync } from "./utils";
 import type { WorkflowEdge, WorkflowNode } from "./workflow-store";
+import { db } from "@/lib/db";
+import { explorerConfigs } from "@/lib/db/schema";
+import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
+import { getChainIdFromNetwork } from "@/lib/rpc";
+import { eq } from "drizzle-orm";
 
 // end keeperhub code //
 
@@ -1661,6 +1666,36 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               ...triggerData,
               ...deserialized,
             };
+
+            // Enrich event data with explorer links so the execution log UI
+            // can render clickable transaction/address links
+            if (config.network) {
+              try {
+                const chainId = getChainIdFromNetwork(
+                  config.network as string | number
+                );
+                const explorerConfig =
+                  await db.query.explorerConfigs.findFirst({
+                    where: eq(explorerConfigs.chainId, chainId),
+                  });
+                if (explorerConfig) {
+                  if (typeof triggerData.transactionHash === "string") {
+                    triggerData.transactionLink = getTransactionUrl(
+                      explorerConfig,
+                      triggerData.transactionHash
+                    );
+                  }
+                  if (typeof triggerData.address === "string") {
+                    triggerData.addressLink = getAddressUrl(
+                      explorerConfig,
+                      triggerData.address
+                    );
+                  }
+                }
+              } catch {
+                // Non-critical: skip explorer links if lookup fails
+              }
+            }
           } else {
             // For other trigger types, use as-is
             triggerData = { ...triggerData, ...triggerInput };


### PR DESCRIPTION
## Summary
- Adds `transactionLink` and `addressLink` fields to event trigger output by looking up the explorer config for the chain
- Enables clickable links in the execution log UI for transaction hashes and addresses

## Test plan
- [ ] Trigger an event-based workflow on a supported chain and verify `transactionLink` appears in the execution log
- [ ] Verify `addressLink` is populated when an address is present in the trigger data
- [ ] Confirm workflows on chains without an explorer config still execute without error (links are simply omitted)