### PR TITLE
fix: KEEP-1519 handle empty Etherscan tx list responses in query-transactions

### DIFF
--- a/lib/explorer/etherscan.ts
+++ b/lib/explorer/etherscan.ts
@@ -223,6 +223,9 @@ function buildTxListParams(
 }
 
 function isEmptyTxListResult(data: EtherscanTxListResponse): boolean {
+  if (Array.isArray(data.result) && data.result.length === 0) {
+    return true;
+  }
   if (typeof data.result !== "string") {
     return false;
   }

--- a/lib/explorer/etherscan.ts
+++ b/lib/explorer/etherscan.ts
@@ -222,12 +222,20 @@ function buildTxListParams(
   return `${apiUrl}?${params}`;
 }
 
+function isEmptyTxListResult(data: EtherscanTxListResponse): boolean {
+  if (typeof data.result !== "string") {
+    return false;
+  }
+  const lower = data.result.toLowerCase();
+  return (
+    lower.includes("no transactions found") ||
+    lower.includes("no records found")
+  );
+}
+
 function parseTxListResponse(data: EtherscanTxListResponse): TxPageResult {
   if (data.status !== "1") {
-    const isEmptyResult =
-      typeof data.result === "string" &&
-      data.result.toLowerCase().includes("no transactions found");
-    if (isEmptyResult) {
+    if (isEmptyTxListResult(data)) {
       return { done: true, transactions: [] };
     }
     const errorMessage = parseEtherscanError(


### PR DESCRIPTION
# Summary

Etherscan API "No records found" response was incorrectly treated as an error, causing query-transactions to return `success: false` and cancel downstream workflow execution.

# Details

- Etherscan returns `status: "0"` with `result: "No records found"` when no transactions exist in the queried block range
- Only `"No transactions found"` was recognized as a valid empty result; `"No records found"` fell through to error handling
- Extracted empty-result detection into `isEmptyTxListResult()` and added the missing message variant
- Both messages now correctly return an empty transaction list instead of an error