### PR TITLE
feat: KEEP-1362 collapse write operation retries in execution history

### DIFF
--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -592,9 +592,6 @@ function ExecutionProgress({ execution }: { execution: WorkflowExecution }) {
 }
 
 // start custom keeperhub code //
-// Types and functions (ExecutionLog, IterationGroup, GroupedLogEntry,
-// buildIterationGroups, groupLogsByIteration) imported from
-// @/keeperhub/lib/iteration-grouping
 
 /** Sum the duration (ms) of all logs in an iteration. */
 function computeIterationDuration(

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -24,6 +24,7 @@ import {
   type ChildLogsLookup,
   type IterationGroup,
 } from "@/keeperhub/lib/iteration-grouping";
+import { collapseRetries } from "@/keeperhub/lib/retry-grouping";
 // end keeperhub code //
 import { api } from "@/lib/api-client";
 import {
@@ -55,6 +56,8 @@ type ExecutionLog = {
   // start custom keeperhub code //
   iterationIndex: number | null;
   forEachNodeId: string | null;
+  retryCount?: number;
+  retryLogs?: ExecutionLog[];
   // end keeperhub code //
 };
 
@@ -843,6 +846,13 @@ function ExecutionLogEntry({
                 <span className="truncate font-medium text-sm transition-colors group-hover:text-foreground">
                   {log.nodeName || log.nodeType}
                 </span>
+                {/* start custom keeperhub code */}
+                {log.retryCount != null && log.retryCount > 0 && (
+                  <span className="shrink-0 rounded-sm bg-amber-500/10 px-1.5 py-0.5 font-mono text-amber-600 text-[10px]">
+                    retried {log.retryCount}x
+                  </span>
+                )}
+                {/* end keeperhub code */}
               </div>
             </div>
 
@@ -1301,8 +1311,9 @@ export function WorkflowRuns({
                   <div className="p-4">
                     {/* start custom keeperhub code */}
                     {(() => {
-                      const lookup = buildChildLogsLookup(executionLogs);
-                      const grouped = groupLogsByIteration(executionLogs, lookup);
+                      const collapsedLogs = collapseRetries(executionLogs);
+                      const lookup = buildChildLogsLookup(collapsedLogs);
+                      const grouped = groupLogsByIteration(collapsedLogs, lookup);
                       return grouped.map(
                         (entry, entryIndex, entries) => {
                           if (entry.type === FOR_EACH_GROUP_TYPE) {

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -847,7 +847,7 @@ function ExecutionLogEntry({
                   {log.nodeName || log.nodeType}
                 </span>
                 {/* start custom keeperhub code */}
-                {log.retryCount != null && log.retryCount > 0 && (
+                {(log.retryCount ?? 0) > 0 && (
                   <span className="shrink-0 rounded-sm bg-amber-500/10 px-1.5 py-0.5 font-mono text-amber-600 text-[10px]">
                     retried {log.retryCount}x
                   </span>

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -13,6 +13,14 @@ import {
   X,
 } from "lucide-react";
 import Image from "next/image";
+// start custom keeperhub code //
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+// end keeperhub code //
 import type { JSX } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
@@ -792,6 +800,82 @@ function ForEachLogGroup({
 
 // end keeperhub code //
 
+// start custom keeperhub code //
+function LogDataDisplay({
+  attempt,
+}: {
+  attempt: Pick<ExecutionLog, "input" | "output" | "error">;
+}) {
+  return (
+    <>
+      {attempt.input !== null && attempt.input !== undefined && (
+        <CollapsibleSection copyData={attempt.input} title="Input">
+          <pre className="overflow-auto rounded-lg border bg-muted/50 p-3 font-mono text-xs leading-relaxed">
+            <JsonWithLinks data={attempt.input} />
+          </pre>
+        </CollapsibleSection>
+      )}
+      {attempt.output !== null && attempt.output !== undefined && (
+        <OutputDisplay input={attempt.input} output={attempt.output} />
+      )}
+      {attempt.error && (
+        <CollapsibleSection
+          copyData={attempt.error}
+          defaultExpanded
+          isError
+          title="Error"
+        >
+          <pre className="overflow-auto rounded-lg border border-red-500/20 bg-red-500/5 p-3 font-mono text-red-600 text-xs leading-relaxed">
+            {attempt.error}
+          </pre>
+        </CollapsibleSection>
+      )}
+      {!(attempt.input || attempt.output || attempt.error) && (
+        <div className="rounded-lg border bg-muted/30 py-4 text-center text-muted-foreground text-xs">
+          No data recorded
+        </div>
+      )}
+    </>
+  );
+}
+
+function AttemptTabs({ log }: { log: CollapsedLog }) {
+  const allAttempts = [...(log.retryLogs ?? []), log];
+  const lastIndex = String(allAttempts.length - 1);
+
+  return (
+    <Tabs defaultValue={lastIndex}>
+      <TabsList className="h-7 w-full">
+        {allAttempts.map((attempt, i) => (
+          <TabsTrigger
+            className="h-5 gap-1 px-2 text-[11px]"
+            key={attempt.id ?? i}
+            value={String(i)}
+          >
+            <span
+              className={cn(
+                "inline-block h-1.5 w-1.5 rounded-full",
+                attempt.status === "error" ? "bg-red-500" : "bg-emerald-500"
+              )}
+            />
+            Attempt {i + 1}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {allAttempts.map((attempt, i) => (
+        <TabsContent
+          className="space-y-3"
+          key={attempt.id ?? i}
+          value={String(i)}
+        >
+          <LogDataDisplay attempt={attempt} />
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}
+// end keeperhub code //
+
 // Component for rendering individual execution log entries
 function ExecutionLogEntry({
   log,
@@ -871,33 +955,13 @@ function ExecutionLogEntry({
 
         {isExpanded && (
           <div className="mt-2 mb-2 space-y-3 px-3">
-            {log.input !== null && log.input !== undefined && (
-              <CollapsibleSection copyData={log.input} title="Input">
-                <pre className="overflow-auto rounded-lg border bg-muted/50 p-3 font-mono text-xs leading-relaxed">
-                  <JsonWithLinks data={log.input} />
-                </pre>
-              </CollapsibleSection>
+            {/* start custom keeperhub code */}
+            {log.retryCount > 0 ? (
+              <AttemptTabs log={log} />
+            ) : (
+              <LogDataDisplay attempt={log} />
             )}
-            {log.output !== null && log.output !== undefined && (
-              <OutputDisplay input={log.input} output={log.output} />
-            )}
-            {log.error && (
-              <CollapsibleSection
-                copyData={log.error}
-                defaultExpanded
-                isError
-                title="Error"
-              >
-                <pre className="overflow-auto rounded-lg border border-red-500/20 bg-red-500/5 p-3 font-mono text-red-600 text-xs leading-relaxed">
-                  {log.error}
-                </pre>
-              </CollapsibleSection>
-            )}
-            {!(log.input || log.output || log.error) && (
-              <div className="rounded-lg border bg-muted/30 py-4 text-center text-muted-foreground text-xs">
-                No data recorded
-              </div>
-            )}
+            {/* end keeperhub code */}
           </div>
         )}
       </div>

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -1215,6 +1215,9 @@ export function WorkflowRuns({
             new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
           );
         });
+        // start custom keeperhub code //
+        const collapsedLogs = collapseRetries(executionLogs);
+        // end keeperhub code //
 
         return (
           <div
@@ -1268,15 +1271,17 @@ export function WorkflowRuns({
                       </span>
                     </>
                   )}
-                  {executionLogs.length > 0 && (
+                  {/* start custom keeperhub code */}
+                  {collapsedLogs.length > 0 && (
                     <>
                       <span>•</span>
                       <span>
-                        {executionLogs.length}{" "}
-                        {executionLogs.length === 1 ? "step" : "steps"}
+                        {collapsedLogs.length}{" "}
+                        {collapsedLogs.length === 1 ? "step" : "steps"}
                       </span>
                     </>
                   )}
+                  {/* end keeperhub code */}
                 </div>
               </button>
 
@@ -1311,7 +1316,6 @@ export function WorkflowRuns({
                   <div className="p-4">
                     {/* start custom keeperhub code */}
                     {(() => {
-                      const collapsedLogs = collapseRetries(executionLogs);
                       const lookup = buildChildLogsLookup(collapsedLogs);
                       const grouped = groupLogsByIteration(collapsedLogs, lookup);
                       return grouped.map(

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -24,7 +24,10 @@ import {
   type ChildLogsLookup,
   type IterationGroup,
 } from "@/keeperhub/lib/iteration-grouping";
-import { collapseRetries } from "@/keeperhub/lib/retry-grouping";
+import {
+  collapseRetries,
+  type RetryCollapsedLog,
+} from "@/keeperhub/lib/retry-grouping";
 // end keeperhub code //
 import { api } from "@/lib/api-client";
 import {
@@ -56,10 +59,12 @@ type ExecutionLog = {
   // start custom keeperhub code //
   iterationIndex: number | null;
   forEachNodeId: string | null;
-  retryCount?: number;
-  retryLogs?: ExecutionLog[];
   // end keeperhub code //
 };
+
+// start custom keeperhub code //
+type CollapsedLog = RetryCollapsedLog<ExecutionLog>;
+// end keeperhub code //
 
 type WorkflowExecution = {
   id: string;
@@ -660,10 +665,10 @@ function ForEachLogGroup({
   isFirst,
   isLast,
 }: {
-  forEachLog: ExecutionLog;
-  iterations: IterationGroup<ExecutionLog>[];
-  collectLog: ExecutionLog | null;
-  lookup: ChildLogsLookup<ExecutionLog>;
+  forEachLog: CollapsedLog;
+  iterations: IterationGroup<CollapsedLog>[];
+  collectLog: CollapsedLog | null;
+  lookup: ChildLogsLookup<CollapsedLog>;
   expandedLogs: Set<string>;
   onToggleLog: (id: string) => void;
   getStatusIcon: (status: string) => JSX.Element;
@@ -799,7 +804,7 @@ function ExecutionLogEntry({
   isFirst,
   isLast,
 }: {
-  log: ExecutionLog;
+  log: RetryCollapsedLog<ExecutionLog>;
   isExpanded: boolean;
   onToggle: () => void;
   getStatusIcon: (status: string) => JSX.Element;

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -122,9 +122,10 @@ function isBase64ImageOutput(output: unknown): output is { base64: string } {
 }
 
 // Helper to convert execution logs to a map by nodeId for the global atom.
-// For nodes that appear multiple times (e.g., For Each body nodes),
-// this intentionally keeps only the last entry -- used by template
-// autocomplete which only needs the most recent output.
+// For nodes that appear multiple times (e.g., For Each body nodes or
+// retry attempts), this intentionally keeps only the last entry -- used
+// by template autocomplete which only needs the most recent output.
+// Receives uncollapsed logs so retries are naturally overwritten.
 function createExecutionLogsMap(logs: ExecutionLog[]): Record<
   string,
   {

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -1,16 +1,3 @@
-/**
- * Pure helper functions for collapsing retry logs in execution history.
- *
- * When the Workflow DevKit retries a failed step, each attempt creates a
- * separate workflowExecutionLogs row with the same nodeId. This module
- * collapses those duplicate entries into a single log showing the final
- * result with a retry count badge.
- *
- * Shared by:
- *   - components/workflow/workflow-runs.tsx (UI rendering)
- *   - tests/unit/retry-grouping.test.ts
- */
-
 /** Minimal fields required from a log entry for retry detection. */
 export type RetryLogFields = {
   nodeId: string;

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -15,6 +15,7 @@
 export type RetryLogFields = {
   nodeId: string;
   status: string;
+  startedAt: Date;
   iterationIndex: number | null;
   forEachNodeId: string | null;
 };
@@ -43,8 +44,9 @@ function retryKey(log: RetryLogFields): string {
  *
  * Groups logs by (nodeId, forEachNodeId, iterationIndex). When multiple
  * logs share the same key, they represent retry attempts of the same step.
- * The **last** entry (final attempt) becomes the display entry. Earlier
- * entries are stored in `retryLogs` for optional expansion.
+ * Each group is sorted by `startedAt` ascending so the latest attempt
+ * becomes the display entry regardless of the input order (the API may
+ * return logs newest-first). Earlier attempts are stored in `retryLogs`.
  *
  * Preserves original ordering based on the first occurrence of each group.
  */
@@ -76,9 +78,12 @@ export function collapseRetries<T extends RetryLogFields>(
     if (group.length === 1) {
       result.push({ ...group[0], retryCount: 0 });
     } else {
-      // group.length >= 2 guaranteed by the if/else above
-      const finalAttempt = group.at(-1) as T;
-      const failedAttempts = group.slice(0, -1);
+      const sorted = group.toSorted(
+        (a, b) =>
+          new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+      );
+      const finalAttempt = sorted.at(-1) as T;
+      const failedAttempts = sorted.slice(0, -1);
       result.push({
         ...finalAttempt,
         retryCount: failedAttempts.length,

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -33,7 +33,7 @@ function collapseGroup<T extends RetryLogFields>(
     return [{ ...group[0], retryCount: 0 }];
   }
 
-  const sorted = [...group].sort(
+  const sorted = group.toSorted(
     (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
   );
 

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -26,14 +26,45 @@ function retryKey(log: RetryLogFields): string {
   return `${log.nodeId}::${forEach}::${iteration}`;
 }
 
+function collapseGroup<T extends RetryLogFields>(
+  group: T[]
+): RetryCollapsedLog<T>[] {
+  if (group.length === 1) {
+    return [{ ...group[0], retryCount: 0 }];
+  }
+
+  const sorted = [...group].sort(
+    (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+  );
+
+  const hasFailedPrecursors = sorted
+    .slice(0, -1)
+    .some((log) => log.status === "error");
+
+  if (!hasFailedPrecursors) {
+    return sorted.map((log) => ({ ...log, retryCount: 0 }));
+  }
+
+  const finalAttempt = sorted.at(-1);
+  if (!finalAttempt) {
+    return [];
+  }
+  const failedAttempts = sorted.slice(0, -1);
+  return [
+    {
+      ...finalAttempt,
+      retryCount: failedAttempts.length,
+      retryLogs: failedAttempts,
+    },
+  ];
+}
+
 /**
  * Collapse retry entries in a flat log array.
  *
  * Groups logs by (nodeId, forEachNodeId, iterationIndex). When multiple
- * logs share the same key, they represent retry attempts of the same step.
- * Each group is sorted by `startedAt` ascending so the latest attempt
- * becomes the display entry regardless of the input order (the API may
- * return logs newest-first). Earlier attempts are stored in `retryLogs`.
+ * logs share the same key and earlier attempts have error status, they
+ * are collapsed into a single entry showing the final result.
  *
  * Preserves original ordering based on the first occurrence of each group.
  */
@@ -61,35 +92,7 @@ export function collapseRetries<T extends RetryLogFields>(
     if (!group) {
       continue;
     }
-
-    if (group.length === 1) {
-      result.push({ ...group[0], retryCount: 0 });
-      continue;
-    }
-
-    const sorted = [...group].sort(
-      (a, b) =>
-        new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
-    );
-
-    const hasFailedPrecursors = sorted
-      .slice(0, -1)
-      .some((log) => log.status === "error");
-
-    if (!hasFailedPrecursors) {
-      for (const log of sorted) {
-        result.push({ ...log, retryCount: 0 });
-      }
-      continue;
-    }
-
-    const finalAttempt = sorted[sorted.length - 1];
-    const failedAttempts = sorted.slice(0, -1);
-    result.push({
-      ...finalAttempt,
-      retryCount: failedAttempts.length,
-      retryLogs: failedAttempts,
-    });
+    result.push(...collapseGroup(group));
   }
 
   return result;

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -77,19 +77,32 @@ export function collapseRetries<T extends RetryLogFields>(
 
     if (group.length === 1) {
       result.push({ ...group[0], retryCount: 0 });
-    } else {
-      const sorted = group.toSorted(
-        (a, b) =>
-          new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
-      );
-      const finalAttempt = sorted.at(-1) as T;
-      const failedAttempts = sorted.slice(0, -1);
-      result.push({
-        ...finalAttempt,
-        retryCount: failedAttempts.length,
-        retryLogs: failedAttempts,
-      });
+      continue;
     }
+
+    const sorted = [...group].sort(
+      (a, b) =>
+        new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+    );
+
+    const hasFailedPrecursors = sorted
+      .slice(0, -1)
+      .some((log) => log.status === "error");
+
+    if (!hasFailedPrecursors) {
+      for (const log of sorted) {
+        result.push({ ...log, retryCount: 0 });
+      }
+      continue;
+    }
+
+    const finalAttempt = sorted[sorted.length - 1];
+    const failedAttempts = sorted.slice(0, -1);
+    result.push({
+      ...finalAttempt,
+      retryCount: failedAttempts.length,
+      retryLogs: failedAttempts,
+    });
   }
 
   return result;

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -8,7 +8,7 @@
  *
  * Shared by:
  *   - components/workflow/workflow-runs.tsx (UI rendering)
- *   - keeperhub/lib/__tests__/retry-grouping.test.ts
+ *   - tests/unit/retry-grouping.test.ts
  */
 
 /** Minimal fields required from a log entry for retry detection. */

--- a/keeperhub/lib/retry-grouping.ts
+++ b/keeperhub/lib/retry-grouping.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure helper functions for collapsing retry logs in execution history.
+ *
+ * When the Workflow DevKit retries a failed step, each attempt creates a
+ * separate workflowExecutionLogs row with the same nodeId. This module
+ * collapses those duplicate entries into a single log showing the final
+ * result with a retry count badge.
+ *
+ * Shared by:
+ *   - components/workflow/workflow-runs.tsx (UI rendering)
+ *   - keeperhub/lib/__tests__/retry-grouping.test.ts
+ */
+
+/** Minimal fields required from a log entry for retry detection. */
+export type RetryLogFields = {
+  nodeId: string;
+  status: string;
+  iterationIndex: number | null;
+  forEachNodeId: string | null;
+};
+
+/** A log entry augmented with retry metadata after collapsing. */
+export type RetryCollapsedLog<T extends RetryLogFields> = T & {
+  retryCount: number;
+  retryLogs?: T[];
+};
+
+/**
+ * Build a grouping key that distinguishes retries from loop iterations.
+ *
+ * Two logs are retries of the same step when they share the same nodeId,
+ * forEachNodeId, and iterationIndex. Different iterationIndex values
+ * indicate loop iterations, not retries.
+ */
+function retryKey(log: RetryLogFields): string {
+  const forEach = log.forEachNodeId ?? "__none__";
+  const iteration = log.iterationIndex ?? "__none__";
+  return `${log.nodeId}::${forEach}::${iteration}`;
+}
+
+/**
+ * Collapse retry entries in a flat log array.
+ *
+ * Groups logs by (nodeId, forEachNodeId, iterationIndex). When multiple
+ * logs share the same key, they represent retry attempts of the same step.
+ * The **last** entry (final attempt) becomes the display entry. Earlier
+ * entries are stored in `retryLogs` for optional expansion.
+ *
+ * Preserves original ordering based on the first occurrence of each group.
+ */
+export function collapseRetries<T extends RetryLogFields>(
+  logs: T[]
+): RetryCollapsedLog<T>[] {
+  const groups = new Map<string, T[]>();
+  const insertionOrder: string[] = [];
+
+  for (const log of logs) {
+    const key = retryKey(log);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(log);
+    } else {
+      groups.set(key, [log]);
+      insertionOrder.push(key);
+    }
+  }
+
+  const result: RetryCollapsedLog<T>[] = [];
+
+  for (const key of insertionOrder) {
+    const group = groups.get(key);
+    if (!group) {
+      continue;
+    }
+
+    if (group.length === 1) {
+      result.push({ ...group[0], retryCount: 0 });
+    } else {
+      // group.length >= 2 guaranteed by the if/else above
+      const finalAttempt = group.at(-1) as T;
+      const failedAttempts = group.slice(0, -1);
+      result.push({
+        ...finalAttempt,
+        retryCount: failedAttempts.length,
+        retryLogs: failedAttempts,
+      });
+    }
+  }
+
+  return result;
+}

--- a/tests/unit/retry-grouping.test.ts
+++ b/tests/unit/retry-grouping.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   collapseRetries,
   type RetryLogFields,
@@ -10,16 +10,23 @@ import {
 
 let logCounter = 0;
 
+const BASE_TIME = new Date("2025-01-01T00:00:00Z");
+
 function makeLog(overrides: Partial<RetryLogFields> = {}): RetryLogFields {
   logCounter += 1;
   return {
     nodeId: `node-${logCounter}`,
     status: "success",
+    startedAt: new Date(BASE_TIME.getTime() + logCounter * 1000),
     iterationIndex: null,
     forEachNodeId: null,
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  logCounter = 0;
+});
 
 // ---------------------------------------------------------------------------
 // collapseRetries
@@ -49,8 +56,16 @@ describe("collapseRetries", () => {
 
   it("collapses two logs with the same nodeId into one with retryCount=1", () => {
     const logs = [
-      makeLog({ nodeId: "write-1", status: "error" }),
-      makeLog({ nodeId: "write-1", status: "success" }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:01Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        startedAt: new Date("2025-01-01T00:00:02Z"),
+      }),
     ];
 
     const result = collapseRetries(logs);
@@ -65,9 +80,21 @@ describe("collapseRetries", () => {
 
   it("collapses three logs (2 failures + 1 success) into retryCount=2", () => {
     const logs = [
-      makeLog({ nodeId: "write-1", status: "error" }),
-      makeLog({ nodeId: "write-1", status: "error" }),
-      makeLog({ nodeId: "write-1", status: "success" }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:01Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:02Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        startedAt: new Date("2025-01-01T00:00:03Z"),
+      }),
     ];
 
     const result = collapseRetries(logs);
@@ -78,11 +105,23 @@ describe("collapseRetries", () => {
     expect(result[0].retryLogs).toHaveLength(2);
   });
 
-  it("collapses all-failed retries using last attempt as display entry", () => {
+  it("collapses all-failed retries using latest attempt as display entry", () => {
     const logs = [
-      makeLog({ nodeId: "write-1", status: "error" }),
-      makeLog({ nodeId: "write-1", status: "error" }),
-      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:01Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:02Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:03Z"),
+      }),
     ];
 
     const result = collapseRetries(logs);
@@ -197,5 +236,37 @@ describe("collapseRetries", () => {
     const result = collapseRetries(logs);
 
     expect(result.map((r) => r.nodeId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("selects the latest attempt when logs arrive in reverse chronological order", () => {
+    const logs = [
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        startedAt: new Date("2025-01-01T00:00:03Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:02Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        startedAt: new Date("2025-01-01T00:00:01Z"),
+      }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("success");
+    expect(result[0].retryCount).toBe(2);
+    expect(result[0].retryLogs?.[0].startedAt).toEqual(
+      new Date("2025-01-01T00:00:01Z")
+    );
+    expect(result[0].retryLogs?.[1].startedAt).toEqual(
+      new Date("2025-01-01T00:00:02Z")
+    );
   });
 });

--- a/tests/unit/retry-grouping.test.ts
+++ b/tests/unit/retry-grouping.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  collapseRetries,
+  type RetryLogFields,
+} from "@/keeperhub/lib/retry-grouping";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let logCounter = 0;
+
+function makeLog(overrides: Partial<RetryLogFields> = {}): RetryLogFields {
+  logCounter += 1;
+  return {
+    nodeId: `node-${logCounter}`,
+    status: "success",
+    iterationIndex: null,
+    forEachNodeId: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// collapseRetries
+// ---------------------------------------------------------------------------
+
+describe("collapseRetries", () => {
+  it("returns an empty array for empty input", () => {
+    const result = collapseRetries([]);
+    expect(result).toEqual([]);
+  });
+
+  it("passes through logs with no retries unchanged", () => {
+    const logs = [
+      makeLog({ nodeId: "trigger-1", status: "success" }),
+      makeLog({ nodeId: "write-1", status: "success" }),
+      makeLog({ nodeId: "notify-1", status: "success" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(3);
+    for (const entry of result) {
+      expect(entry.retryCount).toBe(0);
+      expect(entry.retryLogs).toBeUndefined();
+    }
+  });
+
+  it("collapses two logs with the same nodeId into one with retryCount=1", () => {
+    const logs = [
+      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({ nodeId: "write-1", status: "success" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].nodeId).toBe("write-1");
+    expect(result[0].status).toBe("success");
+    expect(result[0].retryCount).toBe(1);
+    expect(result[0].retryLogs).toHaveLength(1);
+    expect(result[0].retryLogs?.[0].status).toBe("error");
+  });
+
+  it("collapses three logs (2 failures + 1 success) into retryCount=2", () => {
+    const logs = [
+      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({ nodeId: "write-1", status: "success" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("success");
+    expect(result[0].retryCount).toBe(2);
+    expect(result[0].retryLogs).toHaveLength(2);
+  });
+
+  it("collapses all-failed retries using last attempt as display entry", () => {
+    const logs = [
+      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({ nodeId: "write-1", status: "error" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("error");
+    expect(result[0].retryCount).toBe(2);
+  });
+
+  it("handles mixed nodes where only some have retries", () => {
+    const logs = [
+      makeLog({ nodeId: "trigger-1", status: "success" }),
+      makeLog({ nodeId: "write-1", status: "error" }),
+      makeLog({ nodeId: "write-1", status: "success" }),
+      makeLog({ nodeId: "notify-1", status: "success" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].nodeId).toBe("trigger-1");
+    expect(result[0].retryCount).toBe(0);
+    expect(result[1].nodeId).toBe("write-1");
+    expect(result[1].retryCount).toBe(1);
+    expect(result[2].nodeId).toBe("notify-1");
+    expect(result[2].retryCount).toBe(0);
+  });
+
+  it("does not collapse logs with same nodeId but different iterationIndex", () => {
+    const logs = [
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        iterationIndex: 0,
+        forEachNodeId: "fe-1",
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        iterationIndex: 1,
+        forEachNodeId: "fe-1",
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        iterationIndex: 2,
+        forEachNodeId: "fe-1",
+      }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(3);
+    for (const entry of result) {
+      expect(entry.retryCount).toBe(0);
+    }
+  });
+
+  it("collapses retries within the same iteration", () => {
+    const logs = [
+      makeLog({
+        nodeId: "write-1",
+        status: "error",
+        iterationIndex: 0,
+        forEachNodeId: "fe-1",
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        iterationIndex: 0,
+        forEachNodeId: "fe-1",
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        iterationIndex: 1,
+        forEachNodeId: "fe-1",
+      }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].retryCount).toBe(1);
+    expect(result[0].iterationIndex).toBe(0);
+    expect(result[1].retryCount).toBe(0);
+    expect(result[1].iterationIndex).toBe(1);
+  });
+
+  it("does not collapse logs with same nodeId but different forEachNodeId", () => {
+    const logs = [
+      makeLog({ nodeId: "write-1", status: "success", forEachNodeId: "fe-1" }),
+      makeLog({ nodeId: "write-1", status: "success", forEachNodeId: "fe-2" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(entry.retryCount).toBe(0);
+    }
+  });
+
+  it("preserves insertion order based on first occurrence", () => {
+    const logs = [
+      makeLog({ nodeId: "a", status: "success" }),
+      makeLog({ nodeId: "b", status: "error" }),
+      makeLog({ nodeId: "b", status: "success" }),
+      makeLog({ nodeId: "c", status: "success" }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result.map((r) => r.nodeId)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/tests/unit/retry-grouping.test.ts
+++ b/tests/unit/retry-grouping.test.ts
@@ -238,6 +238,28 @@ describe("collapseRetries", () => {
     expect(result.map((r) => r.nodeId)).toEqual(["a", "b", "c"]);
   });
 
+  it("does not collapse multiple successful runs of the same node", () => {
+    const logs = [
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        startedAt: new Date("2025-01-01T00:00:01Z"),
+      }),
+      makeLog({
+        nodeId: "write-1",
+        status: "success",
+        startedAt: new Date("2025-01-01T00:00:02Z"),
+      }),
+    ];
+
+    const result = collapseRetries(logs);
+
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(entry.retryCount).toBe(0);
+    }
+  });
+
   it("selects the latest attempt when logs arrive in reverse chronological order", () => {
     const logs = [
       makeLog({


### PR DESCRIPTION
## Summary

- Write operation retries (caused by the Workflow DevKit framework default `maxRetries`) now collapse into a single execution history entry showing the final result, with an amber "retried Nx" badge when retries occurred
- Implemented as a client-side grouping utility (`collapseRetries`) that runs before the existing For Each iteration grouping, matching the same pure-function pattern
- Distinguishes retries from loop iterations by keying on `(nodeId, forEachNodeId, iterationIndex)` so For Each body nodes are not incorrectly collapsed

## Test plan

- [x] 10 unit tests covering: no retries, single/multiple retries, all-failed retries, mixed nodes, For Each iteration distinction, same-iteration retries, different forEachNodeId distinction, insertion order
- [x] Visual verification: trigger a workflow with a write operation that retries and confirm execution history shows collapsed view with badge
- [x] Lint (`pnpm check`) passes
- [x] Type check (`pnpm type-check`) passes (only pre-existing generated file errors)