### PR TITLE
fix: Pendle protocol review follow-ups

### DIFF
--- a/keeperhub/protocols/pendle.ts
+++ b/keeperhub/protocols/pendle.ts
@@ -258,7 +258,7 @@ export default defineProtocol({
       function: "positionData",
       inputs: [{ name: "user", type: "address", label: "Wallet Address" }],
       outputs: [
-        { name: "amount", type: "uint128", label: "Locked PENDLE Amount" },
+        { name: "amount", type: "uint128", label: "Locked PENDLE Amount", decimals: 18 },
         { name: "expiry", type: "uint128", label: "Lock Expiry Timestamp" },
       ],
     },

--- a/keeperhub/protocols/pendle.ts
+++ b/keeperhub/protocols/pendle.ts
@@ -258,7 +258,12 @@ export default defineProtocol({
       function: "positionData",
       inputs: [{ name: "user", type: "address", label: "Wallet Address" }],
       outputs: [
-        { name: "amount", type: "uint128", label: "Locked PENDLE Amount", decimals: 18 },
+        {
+          name: "amount",
+          type: "uint128",
+          label: "Locked PENDLE Amount",
+          decimals: 18,
+        },
         { name: "expiry", type: "uint128", label: "Lock Expiry Timestamp" },
       ],
     },

--- a/tests/unit/protocol-pendle.test.ts
+++ b/tests/unit/protocol-pendle.test.ts
@@ -128,21 +128,31 @@ describe("Pendle Finance Protocol Definition", () => {
     }
   });
 
+  it("defines events", () => {
+    expect(pendleDef.events).toBeDefined();
+    expect(pendleDef.events?.length).toBeGreaterThan(0);
+  });
+
   it("all event slugs are valid kebab-case", () => {
-    for (const event of pendleDef.events) {
-      expect(event.slug, `event slug "${event.slug}"`).toMatch(KEBAB_CASE_REGEX);
+    const events = pendleDef.events ?? [];
+    for (const event of events) {
+      expect(event.slug, `event slug "${event.slug}"`).toMatch(
+        KEBAB_CASE_REGEX
+      );
     }
   });
 
   it("has no duplicate event slugs", () => {
-    const slugs = pendleDef.events.map((e) => e.slug);
+    const events = pendleDef.events ?? [];
+    const slugs = events.map((e) => e.slug);
     const uniqueSlugs = new Set(slugs);
     expect(slugs.length).toBe(uniqueSlugs.size);
   });
 
   it("every event references an existing contract", () => {
     const contractKeys = new Set(Object.keys(pendleDef.contracts));
-    for (const event of pendleDef.events) {
+    const events = pendleDef.events ?? [];
+    for (const event of events) {
       expect(
         contractKeys.has(event.contract),
         `event "${event.slug}" references unknown contract "${event.contract}"`
@@ -151,7 +161,8 @@ describe("Pendle Finance Protocol Definition", () => {
   });
 
   it("all events have at least one input", () => {
-    for (const event of pendleDef.events) {
+    const events = pendleDef.events ?? [];
+    for (const event of events) {
       expect(
         event.inputs.length,
         `event "${event.slug}" must have at least one input`
@@ -160,10 +171,17 @@ describe("Pendle Finance Protocol Definition", () => {
   });
 
   it("all event inputs have name and type", () => {
-    for (const event of pendleDef.events) {
+    const events = pendleDef.events ?? [];
+    for (const event of events) {
       for (const input of event.inputs) {
-        expect(input.name, `event "${event.slug}" input missing name`).toBeTruthy();
-        expect(input.type, `event "${event.slug}" input "${input.name}" missing type`).toBeTruthy();
+        expect(
+          input.name,
+          `event "${event.slug}" input missing name`
+        ).toBeTruthy();
+        expect(
+          input.type,
+          `event "${event.slug}" input "${input.name}" missing type`
+        ).toBeTruthy();
       }
     }
   });

--- a/tests/unit/protocol-pendle.test.ts
+++ b/tests/unit/protocol-pendle.test.ts
@@ -128,6 +128,46 @@ describe("Pendle Finance Protocol Definition", () => {
     }
   });
 
+  it("all event slugs are valid kebab-case", () => {
+    for (const event of pendleDef.events) {
+      expect(event.slug, `event slug "${event.slug}"`).toMatch(KEBAB_CASE_REGEX);
+    }
+  });
+
+  it("has no duplicate event slugs", () => {
+    const slugs = pendleDef.events.map((e) => e.slug);
+    const uniqueSlugs = new Set(slugs);
+    expect(slugs.length).toBe(uniqueSlugs.size);
+  });
+
+  it("every event references an existing contract", () => {
+    const contractKeys = new Set(Object.keys(pendleDef.contracts));
+    for (const event of pendleDef.events) {
+      expect(
+        contractKeys.has(event.contract),
+        `event "${event.slug}" references unknown contract "${event.contract}"`
+      ).toBe(true);
+    }
+  });
+
+  it("all events have at least one input", () => {
+    for (const event of pendleDef.events) {
+      expect(
+        event.inputs.length,
+        `event "${event.slug}" must have at least one input`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("all event inputs have name and type", () => {
+    for (const event of pendleDef.events) {
+      for (const input of event.inputs) {
+        expect(input.name, `event "${event.slug}" input missing name`).toBeTruthy();
+        expect(input.type, `event "${event.slug}" input "${input.name}" missing type`).toBeTruthy();
+      }
+    }
+  });
+
   it("registers in the protocol registry and is retrievable", () => {
     registerProtocol(pendleDef);
     const retrieved = getProtocol("pendle");

--- a/tests/unit/resolve-protocol-meta.test.ts
+++ b/tests/unit/resolve-protocol-meta.test.ts
@@ -1,0 +1,167 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { registerProtocol } from "@/keeperhub/lib/protocol-registry";
+import { resolveProtocolMeta } from "@/keeperhub/plugins/protocol/steps/resolve-protocol-meta";
+import pendleDef from "@/keeperhub/protocols/pendle";
+
+beforeAll(() => {
+  registerProtocol(pendleDef);
+});
+
+describe("resolveProtocolMeta", () => {
+  describe("_actionType resolution (authoritative)", () => {
+    it("derives metadata from a valid _actionType", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "pendle/get-ve-pendle-balance",
+      });
+
+      expect(result).toEqual({
+        protocolSlug: "pendle",
+        contractKey: "vePendle",
+        functionName: "balanceOf",
+        actionType: "read",
+      });
+    });
+
+    it("derives write action metadata", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "pendle/mint-py-from-sy",
+      });
+
+      expect(result).toEqual({
+        protocolSlug: "pendle",
+        contractKey: "router",
+        functionName: "mintPyFromSy",
+        actionType: "write",
+      });
+    });
+
+    it("returns undefined for unknown protocol slug", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "nonexistent/some-action",
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for unknown action slug", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "pendle/nonexistent-action",
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for malformed _actionType without slash", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "no-slash-here",
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for empty _actionType", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "",
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("_protocolMeta fallback (legacy nodes)", () => {
+    it("parses valid _protocolMeta JSON when _actionType is absent", () => {
+      const meta = {
+        protocolSlug: "pendle",
+        contractKey: "vePendle",
+        functionName: "balanceOf",
+        actionType: "read" as const,
+      };
+
+      const result = resolveProtocolMeta({
+        _protocolMeta: JSON.stringify(meta),
+      });
+
+      expect(result).toEqual(meta);
+    });
+
+    it("returns undefined for invalid JSON in _protocolMeta", () => {
+      const result = resolveProtocolMeta({
+        _protocolMeta: "not valid json{",
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for empty _protocolMeta string", () => {
+      const result = resolveProtocolMeta({
+        _protocolMeta: "",
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("resolution priority", () => {
+    it("_actionType takes priority over _protocolMeta when both are valid", () => {
+      const staleMeta = {
+        protocolSlug: "pendle",
+        contractKey: "market",
+        functionName: "expiry",
+        actionType: "read" as const,
+      };
+
+      const result = resolveProtocolMeta({
+        _actionType: "pendle/get-ve-pendle-balance",
+        _protocolMeta: JSON.stringify(staleMeta),
+      });
+
+      expect(result).toEqual({
+        protocolSlug: "pendle",
+        contractKey: "vePendle",
+        functionName: "balanceOf",
+        actionType: "read",
+      });
+    });
+
+    it("falls back to _protocolMeta when _actionType is non-protocol", () => {
+      const meta = {
+        protocolSlug: "pendle",
+        contractKey: "vePendle",
+        functionName: "balanceOf",
+        actionType: "read" as const,
+      };
+
+      const result = resolveProtocolMeta({
+        _actionType: "webhook/send-webhook",
+        _protocolMeta: JSON.stringify(meta),
+      });
+
+      expect(result).toEqual(meta);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns undefined when neither field is provided", () => {
+      const result = resolveProtocolMeta({});
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when both fields are undefined", () => {
+      const result = resolveProtocolMeta({
+        _actionType: undefined,
+        _protocolMeta: undefined,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("handles _actionType starting with slash", () => {
+      const result = resolveProtocolMeta({
+        _actionType: "/get-ve-pendle-balance",
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix missing `decimals: 18` on `positionData.amount` output (locked PENDLE amount was missing decimal metadata for display formatting)
- Add event definition tests to Pendle protocol suite (slug validation, duplicate checks, contract references, input fields)
- Add unit tests for `resolveProtocolMeta` resolution logic (priority ordering, legacy fallback, edge cases)

## Test plan

- [x] `pnpm vitest run tests/unit/protocol-pendle.test.ts` -- 24 tests pass
- [x] `pnpm vitest run tests/unit/resolve-protocol-meta.test.ts` -- 14 tests pass