### PR TITLE
hotfix: increase workflow queue concurrency limits

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -127,6 +127,12 @@ env:
   WORKFLOW_TARGET_WORLD:
     type: kv
     value: "@workflow/world-postgres"
+  WORKFLOW_LOCAL_QUEUE_CONCURRENCY:
+    type: kv
+    value: "5000"
+  WORKFLOW_POSTGRES_WORKER_CONCURRENCY:
+    type: kv
+    value: "50"
   NEXT_PUBLIC_API_URL:
     type: kv
     value: "http://localhost:3000"


### PR DESCRIPTION
## Summary

- Increase `WORKFLOW_LOCAL_QUEUE_CONCURRENCY` from 1000 (default) to 5000
- Increase `WORKFLOW_POSTGRES_WORKER_CONCURRENCY` from 10 (default) to 50

The workflow SDK local queue semaphore (1000 slots) was getting saturated under load, causing deadlocks where workflow steps couldn't complete because new steps were blocked behind the same semaphore. This results in executions stuck in "running" state with no steps recorded.