### PR TITLE
hotfix: reduce pg-boss worker concurrency from 50 to 5

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -132,7 +132,7 @@ env:
     value: "5000"
   WORKFLOW_POSTGRES_WORKER_CONCURRENCY:
     type: kv
-    value: "50"
+    value: "5"
   NEXT_PUBLIC_API_URL:
     type: kv
     value: "http://localhost:3000"


### PR DESCRIPTION
## Summary

Reduce `WORKFLOW_POSTGRES_WORKER_CONCURRENCY` from 50 to 5 in prod.

With multiple pods, high worker counts cause race conditions where multiple workers pick up the same step job from pg-boss before the first marks it active. This leads to duplicate step execution and "Cannot modify step in terminal state" errors.

Fewer workers (5) with more queue headroom (5000 local slots from previous PR) is the correct config for multi-pod deployments.