### PR TITLE
feat(web3): add ERC-20 approve-token and check-allowance actions

### DIFF
--- a/keeperhub/plugins/web3/index.ts
+++ b/keeperhub/plugins/web3/index.ts
@@ -962,6 +962,162 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "approve-token",
+      label: "Approve ERC20 Token",
+      description:
+        "Approve a spender contract to spend ERC20 tokens on behalf of your wallet (required before swaps and DeFi interactions)",
+      category: "Web3",
+      requiresCredentials: true,
+      stepFunction: "approveTokenStep",
+      stepImportPath: "approve-token",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the approval succeeded",
+        },
+        {
+          field: "transactionHash",
+          description: "The transaction hash of the approval",
+        },
+        {
+          field: "transactionLink",
+          description: "Explorer link to view the transaction",
+        },
+        {
+          field: "gasUsed",
+          description: "Gas cost in wei",
+        },
+        {
+          field: "approvedAmount",
+          description:
+            'The approved amount (human-readable, or "unlimited" for max approval)',
+        },
+        {
+          field: "spender",
+          description: "The spender address that was approved",
+        },
+        {
+          field: "symbol",
+          description: "The token symbol (e.g., USDC)",
+        },
+        {
+          field: "error",
+          description: "Error message if the approval failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "tokenConfig",
+          label: "Token",
+          type: "token-select",
+          networkField: "network",
+          required: true,
+        },
+        {
+          key: "spenderAddress",
+          label: "Spender Address",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.address}}",
+          example: "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          required: true,
+        },
+        {
+          key: "amount",
+          label: "Amount",
+          type: "template-input",
+          placeholder: '100.50 or "max" for unlimited',
+          example: "max",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "approve-token",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      slug: "check-allowance",
+      label: "Check ERC20 Allowance",
+      description:
+        "Check the current ERC20 token spending allowance granted by an owner to a spender",
+      category: "Web3",
+      stepFunction: "checkAllowanceStep",
+      stepImportPath: "check-allowance",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the allowance check succeeded",
+        },
+        {
+          field: "allowance",
+          description: "Current allowance in human-readable format",
+        },
+        {
+          field: "allowanceRaw",
+          description: "Current allowance in raw units (wei string)",
+        },
+        {
+          field: "symbol",
+          description: "The token symbol (e.g., USDC)",
+        },
+        {
+          field: "error",
+          description: "Error message if the check failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "tokenConfig",
+          label: "Token",
+          type: "token-select",
+          networkField: "network",
+          required: true,
+        },
+        {
+          key: "ownerAddress",
+          label: "Owner Address",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.address}}",
+          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          required: true,
+        },
+        {
+          key: "spenderAddress",
+          label: "Spender Address",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.address}}",
+          example: "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          required: true,
+        },
+      ],
+    },
+    {
       slug: "write-contract",
       label: "Write Contract",
       description: "Write data to a smart contract (state-changing functions)",

--- a/keeperhub/plugins/web3/steps/approve-token-core.ts
+++ b/keeperhub/plugins/web3/steps/approve-token-core.ts
@@ -1,0 +1,330 @@
+/**
+ * Core approve-token logic shared between web3 approve-token step and direct execution API.
+ *
+ * IMPORTANT: This file must NOT contain "use step" or be a step file.
+ * It exists so that multiple callers can reuse approval logic without
+ * exporting functions from "use step" files (which breaks the workflow bundler).
+ */
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeParaSigner,
+} from "@/keeperhub/lib/para/wallet-helpers";
+import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
+import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
+import { getNonceManager } from "@/keeperhub/lib/web3/nonce-manager";
+import { resolveOrganizationContext } from "@/keeperhub/lib/web3/resolve-org-context";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/keeperhub/lib/web3/transaction-manager";
+import { ERC20_ABI } from "@/lib/contracts";
+import { db } from "@/lib/db";
+import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { getTransactionUrl } from "@/lib/explorer";
+import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getErrorMessage } from "@/lib/utils";
+import { parseTokenAddress } from "./transfer-token-core";
+
+export type ApproveTokenCoreInput = {
+  network: string;
+  tokenConfig: string | Record<string, unknown>;
+  spenderAddress: string;
+  amount: string;
+  gasLimitMultiplier?: string;
+  tokenAddress?: string;
+  _context?: {
+    executionId?: string;
+    triggerType?: string;
+    organizationId?: string;
+  };
+};
+
+export type ApproveTokenResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      gasUsed: string;
+      approvedAmount: string;
+      spender: string;
+      symbol: string;
+    }
+  | { success: false; error: string };
+
+/**
+ * Core approve token logic
+ *
+ * Calls ERC20 approve(spender, amount) on the selected token contract.
+ * Supports human-readable amounts (converted via decimals) and "max" for unlimited approval.
+ * When _context.organizationId is provided, skips workflowExecutions lookup.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Token approval handler with comprehensive validation and error handling
+export async function approveTokenCore(
+  input: ApproveTokenCoreInput
+): Promise<ApproveTokenResult> {
+  const { network, spenderAddress, amount, gasLimitMultiplier, _context } =
+    input;
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+
+  // Get chain ID first (needed for token config parsing)
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Approve Token] Failed to resolve network",
+      error,
+      { plugin_name: "web3", action_name: "approve-token" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  // Parse token address from config
+  const tokenAddress = await parseTokenAddress(input, chainId);
+
+  // Validate token address
+  if (!(tokenAddress && ethers.isAddress(tokenAddress))) {
+    return {
+      success: false,
+      error: tokenAddress
+        ? `Invalid token address: ${tokenAddress}`
+        : "No token selected",
+    };
+  }
+
+  // Validate spender address
+  if (!ethers.isAddress(spenderAddress)) {
+    return {
+      success: false,
+      error: `Invalid spender address: ${spenderAddress}`,
+    };
+  }
+
+  // Validate amount
+  if (!amount || amount.trim() === "") {
+    return { success: false, error: "Amount is required" };
+  }
+
+  // Resolve organization context
+  if (!(_context?.executionId || _context?.organizationId)) {
+    return {
+      success: false,
+      error: "Execution ID or organization ID is required",
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context,
+    "[Approve Token]",
+    "approve-token"
+  );
+  if (!orgCtx.success) {
+    return orgCtx;
+  }
+
+  const { organizationId, userId } = orgCtx;
+
+  // Resolve RPC config
+  let rpcUrl: string;
+  try {
+    const rpcConfig = await resolveRpcConfig(chainId, userId);
+    if (!rpcConfig) {
+      throw new Error(`Chain ${chainId} not found or not enabled`);
+    }
+    rpcUrl = rpcConfig.primaryRpcUrl;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Approve Token] Failed to resolve RPC config",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "approve-token",
+        chain_id: String(chainId),
+      }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  // Get wallet address for nonce management
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  // Get workflow ID for transaction tracking (only for workflow executions)
+  let workflowId: string | undefined;
+  if (_context.executionId && !_context.organizationId) {
+    try {
+      const execution = await db
+        .select({ workflowId: workflowExecutions.workflowId })
+        .from(workflowExecutions)
+        .where(eq(workflowExecutions.id, _context.executionId))
+        .then((rows) => rows[0]);
+      workflowId = execution?.workflowId ?? undefined;
+    } catch {
+      // Non-critical - workflowId is optional for tracking
+    }
+  }
+
+  // Build transaction context
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context.executionId ?? "direct-execution",
+    workflowId,
+    chainId,
+    rpcUrl,
+    triggerType: _context.triggerType as TransactionContext["triggerType"],
+  };
+
+  // Execute transaction with nonce management and gas strategy
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    const nonceManager = getNonceManager();
+    const gasStrategy = getGasStrategy();
+
+    // Initialize Para signer
+    let signer: Awaited<ReturnType<typeof initializeParaSigner>>;
+    try {
+      signer = await initializeParaSigner(organizationId, rpcUrl);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize organization wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    // Create contract instance with signer
+    const contract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
+
+    try {
+      // Get token decimals and symbol
+      const [decimals, symbol] = await Promise.all([
+        contract.decimals() as Promise<bigint>,
+        contract.symbol() as Promise<string>,
+      ]);
+
+      const decimalsNum = Number(decimals);
+
+      // Convert amount to raw units (handle "max" for unlimited approval)
+      let amountRaw: bigint;
+      let approvedAmountDisplay: string;
+      if (amount.trim().toLowerCase() === "max") {
+        amountRaw = ethers.MaxUint256;
+        approvedAmountDisplay = "unlimited";
+      } else {
+        try {
+          amountRaw = ethers.parseUnits(amount, decimalsNum);
+          approvedAmountDisplay = amount;
+        } catch (error) {
+          return {
+            success: false,
+            error: `Invalid amount format: ${getErrorMessage(error)}`,
+          };
+        }
+      }
+
+      // Get nonce from session
+      const nonce = nonceManager.getNextNonce(session);
+
+      // Estimate gas for the approval
+      const estimatedGas = await contract.approve.estimateGas(
+        spenderAddress,
+        amountRaw
+      );
+
+      // Get gas configuration from strategy
+      const provider = signer.provider;
+      if (!provider) {
+        throw new Error("Signer has no provider");
+      }
+
+      const txGasConfig = await gasStrategy.getGasConfig(
+        provider,
+        txContext.triggerType ?? "manual",
+        estimatedGas,
+        chainId,
+        multiplierOverride,
+        gasLimitOverride
+      );
+
+      // Execute approve with managed nonce and gas config
+      const tx = await contract.approve(spenderAddress, amountRaw, {
+        nonce,
+        gasLimit: txGasConfig.gasLimit,
+        maxFeePerGas: txGasConfig.maxFeePerGas,
+        maxPriorityFeePerGas: txGasConfig.maxPriorityFeePerGas,
+      });
+
+      // Record pending transaction
+      await nonceManager.recordTransaction(
+        session,
+        nonce,
+        tx.hash,
+        workflowId,
+        txGasConfig.maxFeePerGas.toString()
+      );
+
+      // Wait for transaction to be mined
+      const receipt = await tx.wait();
+
+      if (!receipt) {
+        return {
+          success: false,
+          error: "Transaction sent but receipt not available",
+        };
+      }
+
+      // Mark transaction as confirmed
+      await nonceManager.confirmTransaction(tx.hash);
+
+      // Compute gas cost in wei: gasUnits * effectiveGasPrice
+      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
+
+      // Fetch explorer config for transaction link
+      const explorerConfig = await db.query.explorerConfigs.findFirst({
+        where: eq(explorerConfigs.chainId, chainId),
+      });
+      const transactionLink = explorerConfig
+        ? getTransactionUrl(explorerConfig, receipt.hash)
+        : "";
+
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+        gasUsed: gasCostWei,
+        approvedAmount: approvedAmountDisplay,
+        spender: spenderAddress,
+        symbol,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.TRANSACTION,
+        "[Approve Token] Transaction failed",
+        error,
+        {
+          plugin_name: "web3",
+          action_name: "approve-token",
+          chain_id: String(chainId),
+        }
+      );
+      return {
+        success: false,
+        error: `Token approval failed: ${getErrorMessage(error)}`,
+      };
+    }
+  });
+}

--- a/keeperhub/plugins/web3/steps/approve-token.ts
+++ b/keeperhub/plugins/web3/steps/approve-token.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { explorerConfigs } from "@/lib/db/schema";
+import { getAddressUrl } from "@/lib/explorer";
+import { getChainIdFromNetwork } from "@/lib/rpc";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import type {
+  ApproveTokenCoreInput,
+  ApproveTokenResult,
+} from "./approve-token-core";
+import { approveTokenCore } from "./approve-token-core";
+
+export type {
+  ApproveTokenCoreInput,
+  ApproveTokenResult,
+} from "./approve-token-core";
+
+export type ApproveTokenInput = StepInput & ApproveTokenCoreInput;
+
+/**
+ * Approve Token Step
+ * Calls ERC20 approve(spender, amount) to grant spending permission on the selected token
+ */
+export async function approveTokenStep(
+  input: ApproveTokenInput
+): Promise<ApproveTokenResult> {
+  "use step";
+
+  let enrichedInput: ApproveTokenInput & { spenderAddressLink?: string } =
+    input;
+  try {
+    const chainId = getChainIdFromNetwork(input.network);
+    const explorerConfig = await db.query.explorerConfigs.findFirst({
+      where: eq(explorerConfigs.chainId, chainId),
+    });
+    if (explorerConfig) {
+      const spenderAddressLink = getAddressUrl(
+        explorerConfig,
+        input.spenderAddress
+      );
+      if (spenderAddressLink) {
+        enrichedInput = { ...input, spenderAddressLink };
+      }
+    }
+  } catch {
+    // Non-critical: if lookup fails, input logs without the link
+  }
+
+  return withStepLogging(enrichedInput, () => approveTokenCore(input));
+}
+
+approveTokenStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/keeperhub/plugins/web3/steps/check-allowance.ts
+++ b/keeperhub/plugins/web3/steps/check-allowance.ts
@@ -1,0 +1,171 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
+import { ERC20_ABI } from "@/lib/contracts";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+import { parseTokenAddress } from "./transfer-token-core";
+
+export type CheckAllowanceCoreInput = {
+  network: string;
+  tokenConfig: string | Record<string, unknown>;
+  ownerAddress: string;
+  spenderAddress: string;
+  tokenAddress?: string;
+};
+
+export type CheckAllowanceInput = StepInput & CheckAllowanceCoreInput;
+
+type CheckAllowanceResult =
+  | {
+      success: true;
+      allowance: string;
+      allowanceRaw: string;
+      symbol: string;
+    }
+  | { success: false; error: string };
+
+async function getUserIdFromExecution(
+  executionId: string | undefined
+): Promise<string | undefined> {
+  if (!executionId) {
+    return;
+  }
+
+  const execution = await db
+    .select({ userId: workflowExecutions.userId })
+    .from(workflowExecutions)
+    .where(eq(workflowExecutions.id, executionId))
+    .limit(1);
+
+  return execution[0]?.userId;
+}
+
+async function stepHandler(
+  input: CheckAllowanceInput
+): Promise<CheckAllowanceResult> {
+  const { network, ownerAddress, spenderAddress, _context } = input;
+
+  // Get chain ID
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Check Allowance] Failed to resolve network",
+      error,
+      { plugin_name: "web3", action_name: "check-allowance" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  // Parse token address from config
+  const tokenAddress = await parseTokenAddress(input, chainId);
+
+  if (!(tokenAddress && ethers.isAddress(tokenAddress))) {
+    return {
+      success: false,
+      error: tokenAddress
+        ? `Invalid token address: ${tokenAddress}`
+        : "No token selected",
+    };
+  }
+
+  // Validate owner address
+  if (!ethers.isAddress(ownerAddress)) {
+    return {
+      success: false,
+      error: `Invalid owner address: ${ownerAddress}`,
+    };
+  }
+
+  // Validate spender address
+  if (!ethers.isAddress(spenderAddress)) {
+    return {
+      success: false,
+      error: `Invalid spender address: ${spenderAddress}`,
+    };
+  }
+
+  // Get userId from execution context (for user RPC preferences)
+  const userId = await getUserIdFromExecution(_context?.executionId);
+
+  // Resolve RPC config
+  let rpcUrl: string;
+  try {
+    const rpcConfig = await resolveRpcConfig(chainId, userId);
+    if (!rpcConfig) {
+      throw new Error(`Chain ${chainId} not found or not enabled`);
+    }
+    rpcUrl = rpcConfig.primaryRpcUrl;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Check Allowance] Failed to resolve RPC config",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "check-allowance",
+        chain_id: String(chainId),
+      }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  try {
+    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+
+    const [allowanceRaw, decimals, symbol] = await Promise.all([
+      contract.allowance(ownerAddress, spenderAddress) as Promise<bigint>,
+      contract.decimals() as Promise<bigint>,
+      contract.symbol() as Promise<string>,
+    ]);
+
+    const decimalsNum = Number(decimals);
+    const allowance = ethers.formatUnits(allowanceRaw, decimalsNum);
+
+    return {
+      success: true,
+      allowance,
+      allowanceRaw: allowanceRaw.toString(),
+      symbol,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Check Allowance] Failed to check allowance",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "check-allowance",
+        chain_id: String(chainId),
+      }
+    );
+    return {
+      success: false,
+      error: `Failed to check allowance: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Check Allowance Step
+ * Reads ERC20 allowance(owner, spender) to check the current spending approval
+ */
+// biome-ignore lint/suspicious/useAwait: "use step" directive requires async
+export async function checkAllowanceStep(
+  input: CheckAllowanceInput
+): Promise<CheckAllowanceResult> {
+  "use step";
+
+  return withStepLogging(input, () => stepHandler(input));
+}
+
+export const _integrationType = "web3";

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/keeperhub/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+    query: {
+      explorerConfigs: {
+        findFirst: () =>
+          Promise.resolve({ chainId: 1, baseUrl: "https://etherscan.io" }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: {
+    id: "id",
+    userId: "userId",
+    workflowId: "workflowId",
+  },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+  supportedTokens: {
+    id: "id",
+    chainId: "chainId",
+    tokenAddress: "tokenAddress",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  inArray: () => ({}),
+}));
+
+// Mock RPC resolution
+const mockGetChainIdFromNetwork = vi.fn();
+const mockResolveRpcConfig = vi.fn();
+
+vi.mock("@/lib/rpc", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+}));
+
+// Mock explorer
+vi.mock("@/lib/explorer", () => ({
+  getTransactionUrl: () => "https://etherscan.io/tx/0xabc",
+  getAddressUrl: () => "https://etherscan.io/address/0xabc",
+}));
+
+// Mock organization context
+const mockResolveOrgContext = vi.fn();
+vi.mock("@/keeperhub/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: (...args: unknown[]) =>
+    mockResolveOrgContext(...args),
+}));
+
+// Mock wallet helpers
+const mockGetWalletAddress = vi.fn();
+const mockInitializeSigner = vi.fn();
+vi.mock("@/keeperhub/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: (...args: unknown[]) =>
+    mockGetWalletAddress(...args),
+  initializeParaSigner: (...args: unknown[]) => mockInitializeSigner(...args),
+}));
+
+// Mock gas helpers
+vi.mock("@/keeperhub/lib/web3/gas-defaults", () => ({
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+const mockGetGasConfig = vi.fn();
+vi.mock("@/keeperhub/lib/web3/gas-strategy", () => ({
+  getGasStrategy: () => ({
+    getGasConfig: mockGetGasConfig,
+  }),
+}));
+
+const mockGetNextNonce = vi.fn();
+const mockRecordTransaction = vi.fn();
+const mockConfirmTransaction = vi.fn();
+vi.mock("@/keeperhub/lib/web3/nonce-manager", () => ({
+  getNonceManager: () => ({
+    getNextNonce: mockGetNextNonce,
+    recordTransaction: mockRecordTransaction,
+    confirmTransaction: mockConfirmTransaction,
+  }),
+}));
+
+vi.mock("@/keeperhub/lib/web3/transaction-manager", () => ({
+  withNonceSession: (
+    _ctx: unknown,
+    _wallet: unknown,
+    fn: (session: unknown) => unknown
+  ) => fn({ id: "mock-session" }),
+}));
+
+// Mock ethers
+const mockDecimals = vi.fn();
+const mockSymbol = vi.fn();
+const mockApproveEstimateGas = vi.fn();
+const mockApprove = vi.fn();
+
+vi.mock("ethers", async () => {
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      Contract: class MockContract {
+        decimals = mockDecimals;
+        symbol = mockSymbol;
+        approve = Object.assign(mockApprove, {
+          estimateGas: mockApproveEstimateGas,
+        });
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/contracts", () => ({
+  ERC20_ABI: [
+    { name: "approve", type: "function", inputs: [], outputs: [] },
+    { name: "decimals", type: "function", inputs: [], outputs: [] },
+    { name: "symbol", type: "function", inputs: [], outputs: [] },
+  ],
+}));
+
+// Must import AFTER all mocks
+import type { ApproveTokenCoreInput } from "@/keeperhub/plugins/web3/steps/approve-token-core";
+import { approveTokenCore } from "@/keeperhub/plugins/web3/steps/approve-token-core";
+
+const VALID_TOKEN = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const VALID_SPENDER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+
+function makeInput(
+  overrides: Partial<ApproveTokenCoreInput>
+): ApproveTokenCoreInput {
+  return {
+    network: "ethereum",
+    tokenConfig: VALID_TOKEN,
+    spenderAddress: VALID_SPENDER,
+    amount: "100",
+    _context: { organizationId: "org-1" },
+    ...overrides,
+  };
+}
+
+function setupMocks(): void {
+  mockGetChainIdFromNetwork.mockReturnValue(1);
+  mockResolveRpcConfig.mockResolvedValue({
+    primaryRpcUrl: "https://rpc.example.com",
+  });
+  mockResolveOrgContext.mockResolvedValue({
+    success: true,
+    organizationId: "org-1",
+    userId: undefined,
+  });
+  mockGetWalletAddress.mockResolvedValue("0xWalletAddress");
+  mockInitializeSigner.mockResolvedValue({
+    getAddress: () => Promise.resolve("0xWalletAddress"),
+    provider: {},
+  });
+  mockDecimals.mockResolvedValue(BigInt(18));
+  mockSymbol.mockResolvedValue("DAI");
+  mockApproveEstimateGas.mockResolvedValue(BigInt(46_000));
+  mockGetGasConfig.mockResolvedValue({
+    gasLimit: BigInt(60_000),
+    maxFeePerGas: BigInt(30_000_000_000),
+    maxPriorityFeePerGas: BigInt(1_500_000_000),
+  });
+  mockGetNextNonce.mockReturnValue(5);
+  mockRecordTransaction.mockResolvedValue(undefined);
+  mockConfirmTransaction.mockResolvedValue(undefined);
+  mockApprove.mockResolvedValue({
+    hash: "0xtxhash",
+    wait: () =>
+      Promise.resolve({
+        hash: "0xtxhash",
+        gasUsed: BigInt(45_000),
+        gasPrice: BigInt(25_000_000_000),
+      }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("approve-token - validation", () => {
+  it("fails when token address is invalid", async () => {
+    setupMocks();
+    const result = await approveTokenCore(
+      makeInput({ tokenConfig: "not-an-address" })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("No token selected");
+    }
+  });
+
+  it("fails when spender address is invalid", async () => {
+    setupMocks();
+    const result = await approveTokenCore(
+      makeInput({ spenderAddress: "invalid" })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid spender address");
+    }
+  });
+
+  it("fails when amount is empty", async () => {
+    setupMocks();
+    const result = await approveTokenCore(makeInput({ amount: "" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Amount is required");
+    }
+  });
+
+  it("fails when context is missing", async () => {
+    setupMocks();
+    const result = await approveTokenCore(makeInput({ _context: undefined }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Execution ID or organization ID");
+    }
+  });
+});
+
+describe("approve-token - successful approval", () => {
+  it("approves a specific amount", async () => {
+    setupMocks();
+    const result = await approveTokenCore(makeInput({ amount: "100" }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.transactionHash).toBe("0xtxhash");
+      expect(result.approvedAmount).toBe("100");
+      expect(result.spender).toBe(VALID_SPENDER);
+      expect(result.symbol).toBe("DAI");
+      expect(result.transactionLink).toBe("https://etherscan.io/tx/0xabc");
+    }
+  });
+
+  it("handles max approval", async () => {
+    setupMocks();
+    const result = await approveTokenCore(makeInput({ amount: "max" }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.approvedAmount).toBe("unlimited");
+    }
+  });
+
+  it("handles max approval case-insensitive", async () => {
+    setupMocks();
+    const result = await approveTokenCore(makeInput({ amount: " MAX " }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.approvedAmount).toBe("unlimited");
+    }
+  });
+
+  it("computes gas used correctly", async () => {
+    setupMocks();
+    const result = await approveTokenCore(makeInput({}));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // gasUsed=45000, gasPrice=25000000000 -> 1125000000000000
+      expect(result.gasUsed).toBe("1125000000000000");
+    }
+  });
+});
+
+describe("approve-token - error handling", () => {
+  it("fails when network resolution fails", async () => {
+    setupMocks();
+    mockGetChainIdFromNetwork.mockImplementation(() => {
+      throw new Error("Unknown network: foochain");
+    });
+    const result = await approveTokenCore(makeInput({ network: "foochain" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Unknown network");
+    }
+  });
+
+  it("fails when amount format is invalid", async () => {
+    setupMocks();
+    const result = await approveTokenCore(
+      makeInput({ amount: "not-a-number" })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid amount format");
+    }
+  });
+
+  it("fails when transaction reverts", async () => {
+    setupMocks();
+    mockApprove.mockRejectedValueOnce(
+      new Error("execution reverted: ERC20: approve from zero address")
+    );
+    const result = await approveTokenCore(makeInput({}));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Token approval failed");
+    }
+  });
+
+  it("fails when wallet initialization fails", async () => {
+    setupMocks();
+    mockInitializeSigner.mockRejectedValueOnce(new Error("Wallet not found"));
+    const result = await approveTokenCore(makeInput({}));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain(
+        "Failed to initialize organization wallet"
+      );
+    }
+  });
+});

--- a/tests/unit/check-allowance.test.ts
+++ b/tests/unit/check-allowance.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/keeperhub/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  supportedTokens: {
+    id: "id",
+    chainId: "chainId",
+    tokenAddress: "tokenAddress",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  inArray: () => ({}),
+}));
+
+// Mock RPC resolution
+const mockGetChainIdFromNetwork = vi.fn();
+const mockResolveRpcConfig = vi.fn();
+
+vi.mock("@/lib/rpc", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+}));
+
+// Mock ethers Contract methods
+const mockAllowance = vi.fn();
+const mockDecimals = vi.fn();
+const mockSymbol = vi.fn();
+
+vi.mock("ethers", async () => {
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      JsonRpcProvider: class MockProvider {},
+      Contract: class MockContract {
+        allowance = mockAllowance;
+        decimals = mockDecimals;
+        symbol = mockSymbol;
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/contracts", () => ({
+  ERC20_ABI: [
+    { name: "allowance", type: "function", inputs: [], outputs: [] },
+    { name: "decimals", type: "function", inputs: [], outputs: [] },
+    { name: "symbol", type: "function", inputs: [], outputs: [] },
+  ],
+}));
+
+// Must import AFTER all mocks
+import type { CheckAllowanceInput } from "@/keeperhub/plugins/web3/steps/check-allowance";
+import { checkAllowanceStep } from "@/keeperhub/plugins/web3/steps/check-allowance";
+
+const VALID_TOKEN = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const VALID_OWNER = "0x742D35CC6634c0532925A3b844BC9E7595F0BEb0";
+const VALID_SPENDER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+
+type CheckAllowanceResult =
+  | {
+      success: true;
+      allowance: string;
+      allowanceRaw: string;
+      symbol: string;
+    }
+  | { success: false; error: string };
+
+function makeInput(
+  overrides: Partial<CheckAllowanceInput>
+): CheckAllowanceInput {
+  return {
+    network: "ethereum",
+    tokenConfig: VALID_TOKEN,
+    ownerAddress: VALID_OWNER,
+    spenderAddress: VALID_SPENDER,
+    ...overrides,
+  } as CheckAllowanceInput;
+}
+
+function setupMocks(): void {
+  mockGetChainIdFromNetwork.mockReturnValue(1);
+  mockResolveRpcConfig.mockResolvedValue({
+    primaryRpcUrl: "https://rpc.example.com",
+  });
+  mockDecimals.mockResolvedValue(BigInt(18));
+  mockSymbol.mockResolvedValue("DAI");
+  mockAllowance.mockResolvedValue(BigInt("1000000000000000000"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("check-allowance - validation", () => {
+  it("fails when token address is invalid", async () => {
+    setupMocks();
+    const result = (await checkAllowanceStep(
+      makeInput({ tokenConfig: "not-an-address" })
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("No token selected");
+    }
+  });
+
+  it("fails when owner address is invalid", async () => {
+    setupMocks();
+    const result = (await checkAllowanceStep(
+      makeInput({ ownerAddress: "invalid" })
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid owner address");
+    }
+  });
+
+  it("fails when spender address is invalid", async () => {
+    setupMocks();
+    const result = (await checkAllowanceStep(
+      makeInput({ spenderAddress: "invalid" })
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid spender address");
+    }
+  });
+
+  it("fails when network resolution fails", async () => {
+    mockGetChainIdFromNetwork.mockImplementation(() => {
+      throw new Error("Unknown network: foochain");
+    });
+    const result = (await checkAllowanceStep(
+      makeInput({ network: "foochain" })
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Unknown network");
+    }
+  });
+});
+
+describe("check-allowance - successful checks", () => {
+  it("returns formatted allowance", async () => {
+    setupMocks();
+    mockAllowance.mockResolvedValue(BigInt("1000000000000000000"));
+
+    const result = (await checkAllowanceStep(
+      makeInput({})
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.allowance).toBe("1.0");
+      expect(result.allowanceRaw).toBe("1000000000000000000");
+      expect(result.symbol).toBe("DAI");
+    }
+  });
+
+  it("returns zero allowance", async () => {
+    setupMocks();
+    mockAllowance.mockResolvedValue(BigInt(0));
+
+    const result = (await checkAllowanceStep(
+      makeInput({})
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.allowance).toBe("0.0");
+      expect(result.allowanceRaw).toBe("0");
+    }
+  });
+
+  it("handles 6-decimal tokens (USDC)", async () => {
+    setupMocks();
+    mockDecimals.mockResolvedValue(BigInt(6));
+    mockSymbol.mockResolvedValue("USDC");
+    mockAllowance.mockResolvedValue(BigInt("500000000"));
+
+    const result = (await checkAllowanceStep(
+      makeInput({})
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.allowance).toBe("500.0");
+      expect(result.allowanceRaw).toBe("500000000");
+      expect(result.symbol).toBe("USDC");
+    }
+  });
+});
+
+describe("check-allowance - error handling", () => {
+  it("fails when RPC call throws", async () => {
+    setupMocks();
+    mockAllowance.mockRejectedValue(new Error("RPC timeout"));
+
+    const result = (await checkAllowanceStep(
+      makeInput({})
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Failed to check allowance");
+      expect(result.error).toContain("RPC timeout");
+    }
+  });
+
+  it("fails when RPC config is not found", async () => {
+    setupMocks();
+    mockResolveRpcConfig.mockResolvedValue(null);
+
+    const result = (await checkAllowanceStep(
+      makeInput({})
+    )) as CheckAllowanceResult;
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("not found or not enabled");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- DeFi protocols (Uniswap, Ajna, Pendle, etc.) require ERC-20 token approvals before they can spend tokens on behalf of a wallet -- without an approve step, swap transactions revert
- Adds `approve-token` (write) and `check-allowance` (read) actions to the web3 plugin, following the existing `transfer-token` / `transfer-token-core` pattern
- `approve-token` supports human-readable amounts and `"max"` for unlimited approval (`type(uint256).max`), with `maxRetries=0` for safety
- `check-allowance` is read-only, returns formatted + raw allowance values

## Test Plan
- [ ] `pnpm vitest run tests/unit/approve-token.test.ts` -- 12 tests pass
- [ ] `pnpm vitest run tests/unit/check-allowance.test.ts` -- 9 tests pass
- [ ] `pnpm discover-plugins` -- both actions appear in registry
- [ ] `pnpm check && pnpm type-check` -- clean