### PR TITLE
feat: KEEP-1530 stale execution reaper endpoint

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -1,0 +1,3 @@
+// start custom keeperhub code //
+export { GET } from "@/keeperhub/api/internal/reaper/route";
+// end keeperhub code //

--- a/keeperhub/api/internal/reaper/route.ts
+++ b/keeperhub/api/internal/reaper/route.ts
@@ -1,0 +1,103 @@
+// start custom keeperhub code //
+import { and, eq, lt, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+
+const DEFAULT_THRESHOLD_MINUTES = 30;
+
+function getThresholdMinutes(): number {
+  const envValue = process.env.STALE_EXECUTION_THRESHOLD_MINUTES;
+  if (!envValue) {
+    return DEFAULT_THRESHOLD_MINUTES;
+  }
+  const parsed = Number.parseInt(envValue, 10);
+  return Number.isNaN(parsed) ? DEFAULT_THRESHOLD_MINUTES : parsed;
+}
+
+/**
+ * GET /api/internal/reaper
+ *
+ * Finds workflow executions stuck in "running" state with no recent activity
+ * and marks them as "error" with a timeout message.
+ *
+ * Intended to be called by an external cron job (K8s CronJob).
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error ?? "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const thresholdMinutes = getThresholdMinutes();
+    const cutoff = new Date(Date.now() - thresholdMinutes * 60 * 1000);
+
+    const staleExecutions = await db
+      .select({
+        id: workflowExecutions.id,
+        workflowId: workflowExecutions.workflowId,
+        startedAt: workflowExecutions.startedAt,
+      })
+      .from(workflowExecutions)
+      .where(
+        and(
+          eq(workflowExecutions.status, "running"),
+          lt(workflowExecutions.startedAt, cutoff)
+        )
+      );
+
+    if (staleExecutions.length === 0) {
+      return NextResponse.json({ reapedCount: 0, reapedIds: [] });
+    }
+
+    const reapedIds: string[] = [];
+
+    for (const execution of staleExecutions) {
+      const lastLog = await db
+        .select({ completedAt: workflowExecutionLogs.completedAt })
+        .from(workflowExecutionLogs)
+        .where(eq(workflowExecutionLogs.executionId, execution.id))
+        .orderBy(sql`${workflowExecutionLogs.completedAt} DESC NULLS LAST`)
+        .limit(1);
+
+      const lastActivity = lastLog[0]?.completedAt;
+      const hasRecentActivity = lastActivity && new Date(lastActivity) > cutoff;
+
+      if (!hasRecentActivity) {
+        await db
+          .update(workflowExecutions)
+          .set({
+            status: "error",
+            error: `Execution timed out: no activity for ${thresholdMinutes} minutes`,
+            completedAt: new Date(),
+          })
+          .where(eq(workflowExecutions.id, execution.id));
+
+        reapedIds.push(execution.id);
+      }
+    }
+
+    return NextResponse.json({
+      reapedCount: reapedIds.length,
+      reapedIds,
+    });
+  } catch (error) {
+    console.error("[Reaper] Failed to reap stale executions:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to reap stale executions",
+      },
+      { status: 500 }
+    );
+  }
+}
+// end keeperhub code //

--- a/keeperhub/api/internal/reaper/route.ts
+++ b/keeperhub/api/internal/reaper/route.ts
@@ -1,5 +1,5 @@
 // start custom keeperhub code //
-import { and, eq, lt, sql } from "drizzle-orm";
+import { and, eq, lt, notInArray, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
@@ -38,50 +38,38 @@ export async function GET(request: Request): Promise<NextResponse> {
     const thresholdMinutes = getThresholdMinutes();
     const cutoff = new Date(Date.now() - thresholdMinutes * 60 * 1000);
 
-    const staleExecutions = await db
+    // Find execution IDs that have recent step activity (should NOT be reaped)
+    const activeExecutionIds = await db
       .select({
-        id: workflowExecutions.id,
-        workflowId: workflowExecutions.workflowId,
-        startedAt: workflowExecutions.startedAt,
+        executionId: workflowExecutionLogs.executionId,
       })
-      .from(workflowExecutions)
-      .where(
-        and(
-          eq(workflowExecutions.status, "running"),
-          lt(workflowExecutions.startedAt, cutoff)
-        )
-      );
+      .from(workflowExecutionLogs)
+      .where(sql`${workflowExecutionLogs.completedAt} > ${cutoff}`)
+      .groupBy(workflowExecutionLogs.executionId);
 
-    if (staleExecutions.length === 0) {
-      return NextResponse.json({ reapedCount: 0, reapedIds: [] });
-    }
+    const excludeIds = activeExecutionIds.map((row) => row.executionId);
 
-    const reapedIds: string[] = [];
+    // Bulk update all stale executions in a single query, excluding those with recent activity
+    const staleConditions = and(
+      eq(workflowExecutions.status, "running"),
+      lt(workflowExecutions.startedAt, cutoff),
+      excludeIds.length > 0
+        ? notInArray(workflowExecutions.id, excludeIds)
+        : undefined
+    );
 
-    for (const execution of staleExecutions) {
-      const lastLog = await db
-        .select({ completedAt: workflowExecutionLogs.completedAt })
-        .from(workflowExecutionLogs)
-        .where(eq(workflowExecutionLogs.executionId, execution.id))
-        .orderBy(sql`${workflowExecutionLogs.completedAt} DESC NULLS LAST`)
-        .limit(1);
+    const reaped = await db
+      .update(workflowExecutions)
+      .set({
+        status: "error",
+        error: `Execution timed out: no activity for ${thresholdMinutes} minutes`,
+        completedAt: new Date(),
+        duration: sql`EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000`,
+      })
+      .where(staleConditions)
+      .returning({ id: workflowExecutions.id });
 
-      const lastActivity = lastLog[0]?.completedAt;
-      const hasRecentActivity = lastActivity && new Date(lastActivity) > cutoff;
-
-      if (!hasRecentActivity) {
-        await db
-          .update(workflowExecutions)
-          .set({
-            status: "error",
-            error: `Execution timed out: no activity for ${thresholdMinutes} minutes`,
-            completedAt: new Date(),
-          })
-          .where(eq(workflowExecutions.id, execution.id));
-
-        reapedIds.push(execution.id);
-      }
-    }
+    const reapedIds = reaped.map((row) => row.id);
 
     return NextResponse.json({
       reapedCount: reapedIds.length,

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -117,8 +117,9 @@ describe("/api/internal/reaper", () => {
 
     await GET(createRequest());
 
-    const setArg = mockUpdateSet.mock.calls[0][0];
-    expect(setArg.duration).toBeDefined();
+    const calls = mockUpdateSet.mock.calls as unknown[][];
+    const setArg = calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(setArg?.duration).toBeDefined();
   });
 
   it("excludes executions with recent step activity", async () => {

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -10,44 +10,24 @@ vi.mock("@/keeperhub/lib/internal-service-auth", () => ({
   authenticateInternalService: vi.fn(() => mockAuthResult),
 }));
 
-let mockStaleExecutions: { id: string; workflowId: string; startedAt: Date }[] =
-  [];
-let mockLastLog: { completedAt: Date | null }[] = [];
-const mockUpdateWhere = vi.fn();
+let mockActiveExecutionIds: { executionId: string }[] = [];
+let mockReapedRows: { id: string }[] = [];
+const mockUpdateReturning = vi.fn(() => mockReapedRows);
+const mockUpdateWhere = vi.fn(() => ({ returning: mockUpdateReturning }));
 const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
-let selectCallCount = 0;
 
-vi.mock("@/lib/db", () => {
-  // The reaper calls db.select() twice per stale execution:
-  // 1st: select().from(workflowExecutions).where() -> stale executions list
-  // 2nd+: select().from(workflowExecutionLogs).where().orderBy().limit() -> last log
-  const selectFn = vi.fn(() => {
-    const callIndex = selectCallCount++;
-    if (callIndex === 0) {
-      return {
-        from: vi.fn(() => ({
-          where: vi.fn(() => mockStaleExecutions),
-        })),
-      };
-    }
-    return {
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          orderBy: vi.fn(() => ({
-            limit: vi.fn(() => mockLastLog),
-          })),
+          groupBy: vi.fn(() => mockActiveExecutionIds),
         })),
       })),
-    };
-  });
-
-  return {
-    db: {
-      select: selectFn,
-      update: vi.fn(() => ({ set: mockUpdateSet })),
-    },
-  };
-});
+    })),
+    update: vi.fn(() => ({ set: mockUpdateSet })),
+  },
+}));
 
 vi.mock("@/lib/db/schema", () => ({
   workflowExecutions: {
@@ -57,6 +37,7 @@ vi.mock("@/lib/db/schema", () => ({
     status: "status",
     completedAt: "completed_at",
     error: "error",
+    duration: "duration",
   },
   workflowExecutionLogs: {
     executionId: "execution_id",
@@ -76,10 +57,13 @@ function createRequest(): Request {
 describe("/api/internal/reaper", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockStaleExecutions = [];
-    mockLastLog = [];
-    selectCallCount = 0;
+    mockActiveExecutionIds = [];
+    mockReapedRows = [];
     mockAuthResult.authenticated = true;
+  });
+
+  afterEach(() => {
+    process.env.STALE_EXECUTION_THRESHOLD_MINUTES = undefined;
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -93,7 +77,7 @@ describe("/api/internal/reaper", () => {
   });
 
   it("returns empty result when no stale executions exist", async () => {
-    mockStaleExecutions = [];
+    mockReapedRows = [];
 
     const response = await GET(createRequest());
     const data = await response.json();
@@ -103,12 +87,8 @@ describe("/api/internal/reaper", () => {
     expect(data.reapedIds).toEqual([]);
   });
 
-  it("reaps executions with no step activity", async () => {
-    const oldDate = new Date(Date.now() - 60 * 60 * 1000);
-    mockStaleExecutions = [
-      { id: "exec_1", workflowId: "wf_1", startedAt: oldDate },
-    ];
-    mockLastLog = [];
+  it("reaps stale executions and returns their IDs", async () => {
+    mockReapedRows = [{ id: "exec_1" }];
 
     const response = await GET(createRequest());
     const data = await response.json();
@@ -116,55 +96,65 @@ describe("/api/internal/reaper", () => {
     expect(response.status).toBe(200);
     expect(data.reapedCount).toBe(1);
     expect(data.reapedIds).toEqual(["exec_1"]);
+  });
+
+  it("sets error status and timeout message on reaped executions", async () => {
+    mockReapedRows = [{ id: "exec_1" }];
+
+    await GET(createRequest());
+
     expect(mockUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         status: "error",
         error: expect.stringContaining("timed out"),
+        completedAt: expect.any(Date),
       })
     );
   });
 
-  it("skips executions with recent step activity", async () => {
-    const oldDate = new Date(Date.now() - 60 * 60 * 1000);
-    mockStaleExecutions = [
-      { id: "exec_1", workflowId: "wf_1", startedAt: oldDate },
-    ];
-    mockLastLog = [{ completedAt: new Date(Date.now() - 5 * 60 * 1000) }];
+  it("sets duration on reaped executions", async () => {
+    mockReapedRows = [{ id: "exec_1" }];
+
+    await GET(createRequest());
+
+    const setArg = mockUpdateSet.mock.calls[0][0];
+    expect(setArg.duration).toBeDefined();
+  });
+
+  it("excludes executions with recent step activity", async () => {
+    mockActiveExecutionIds = [{ executionId: "exec_active" }];
+    mockReapedRows = [];
 
     const response = await GET(createRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
     expect(data.reapedCount).toBe(0);
-    expect(data.reapedIds).toEqual([]);
-    expect(mockUpdateWhere).not.toHaveBeenCalled();
   });
 
-  it("reaps multiple stale executions", async () => {
-    const oldDate = new Date(Date.now() - 60 * 60 * 1000);
-    mockStaleExecutions = [
-      { id: "exec_1", workflowId: "wf_1", startedAt: oldDate },
-      { id: "exec_2", workflowId: "wf_2", startedAt: oldDate },
-    ];
-    mockLastLog = [];
+  it("reaps multiple stale executions in a single query", async () => {
+    mockReapedRows = [{ id: "exec_1" }, { id: "exec_2" }, { id: "exec_3" }];
 
     const response = await GET(createRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.reapedCount).toBe(2);
-    expect(data.reapedIds).toContain("exec_1");
-    expect(data.reapedIds).toContain("exec_2");
+    expect(data.reapedCount).toBe(3);
+    expect(data.reapedIds).toEqual(["exec_1", "exec_2", "exec_3"]);
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1);
   });
 
   it("uses configurable threshold from env var", async () => {
     process.env.STALE_EXECUTION_THRESHOLD_MINUTES = "60";
-    mockStaleExecutions = [];
+    mockReapedRows = [{ id: "exec_1" }];
 
-    const response = await GET(createRequest());
-    expect(response.status).toBe(200);
+    await GET(createRequest());
 
-    process.env.STALE_EXECUTION_THRESHOLD_MINUTES = undefined;
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining("60 minutes"),
+      })
+    );
   });
 
   it("calls authenticateInternalService with the request", async () => {

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockAuthResult = {
+  authenticated: true,
+  service: "scheduler" as const,
+};
+vi.mock("@/keeperhub/lib/internal-service-auth", () => ({
+  authenticateInternalService: vi.fn(() => mockAuthResult),
+}));
+
+let mockStaleExecutions: { id: string; workflowId: string; startedAt: Date }[] =
+  [];
+let mockLastLog: { completedAt: Date | null }[] = [];
+const mockUpdateWhere = vi.fn();
+const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+let selectCallCount = 0;
+
+vi.mock("@/lib/db", () => {
+  // The reaper calls db.select() twice per stale execution:
+  // 1st: select().from(workflowExecutions).where() -> stale executions list
+  // 2nd+: select().from(workflowExecutionLogs).where().orderBy().limit() -> last log
+  const selectFn = vi.fn(() => {
+    const callIndex = selectCallCount++;
+    if (callIndex === 0) {
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn(() => mockStaleExecutions),
+        })),
+      };
+    }
+    return {
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(() => ({
+            limit: vi.fn(() => mockLastLog),
+          })),
+        })),
+      })),
+    };
+  });
+
+  return {
+    db: {
+      select: selectFn,
+      update: vi.fn(() => ({ set: mockUpdateSet })),
+    },
+  };
+});
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: {
+    id: "id",
+    workflowId: "workflow_id",
+    startedAt: "started_at",
+    status: "status",
+    completedAt: "completed_at",
+    error: "error",
+  },
+  workflowExecutionLogs: {
+    executionId: "execution_id",
+    completedAt: "completed_at",
+  },
+}));
+
+import { GET } from "@/keeperhub/api/internal/reaper/route";
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+
+function createRequest(): Request {
+  return new Request("http://localhost:3000/api/internal/reaper", {
+    headers: { "X-Service-Key": "test-key" },
+  });
+}
+
+describe("/api/internal/reaper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStaleExecutions = [];
+    mockLastLog = [];
+    selectCallCount = 0;
+    mockAuthResult.authenticated = true;
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuthResult.authenticated = false;
+
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns empty result when no stale executions exist", async () => {
+    mockStaleExecutions = [];
+
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.reapedCount).toBe(0);
+    expect(data.reapedIds).toEqual([]);
+  });
+
+  it("reaps executions with no step activity", async () => {
+    const oldDate = new Date(Date.now() - 60 * 60 * 1000);
+    mockStaleExecutions = [
+      { id: "exec_1", workflowId: "wf_1", startedAt: oldDate },
+    ];
+    mockLastLog = [];
+
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.reapedCount).toBe(1);
+    expect(data.reapedIds).toEqual(["exec_1"]);
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        error: expect.stringContaining("timed out"),
+      })
+    );
+  });
+
+  it("skips executions with recent step activity", async () => {
+    const oldDate = new Date(Date.now() - 60 * 60 * 1000);
+    mockStaleExecutions = [
+      { id: "exec_1", workflowId: "wf_1", startedAt: oldDate },
+    ];
+    mockLastLog = [{ completedAt: new Date(Date.now() - 5 * 60 * 1000) }];
+
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.reapedCount).toBe(0);
+    expect(data.reapedIds).toEqual([]);
+    expect(mockUpdateWhere).not.toHaveBeenCalled();
+  });
+
+  it("reaps multiple stale executions", async () => {
+    const oldDate = new Date(Date.now() - 60 * 60 * 1000);
+    mockStaleExecutions = [
+      { id: "exec_1", workflowId: "wf_1", startedAt: oldDate },
+      { id: "exec_2", workflowId: "wf_2", startedAt: oldDate },
+    ];
+    mockLastLog = [];
+
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.reapedCount).toBe(2);
+    expect(data.reapedIds).toContain("exec_1");
+    expect(data.reapedIds).toContain("exec_2");
+  });
+
+  it("uses configurable threshold from env var", async () => {
+    process.env.STALE_EXECUTION_THRESHOLD_MINUTES = "60";
+    mockStaleExecutions = [];
+
+    const response = await GET(createRequest());
+    expect(response.status).toBe(200);
+
+    process.env.STALE_EXECUTION_THRESHOLD_MINUTES = undefined;
+  });
+
+  it("calls authenticateInternalService with the request", async () => {
+    const request = createRequest();
+    await GET(request);
+
+    expect(authenticateInternalService).toHaveBeenCalledWith(request);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds internal API endpoint `GET /api/internal/reaper` that finds workflow executions stuck in "running" state with no step activity beyond a configurable threshold (default 30 minutes) and marks them as timed out
- Secured with internal service auth (`X-Service-Key`), intended to be called by K8s CronJob
- Configurable via `STALE_EXECUTION_THRESHOLD_MINUTES` env var
- Includes integration tests (7 tests)

## Test plan

- [ ] Verify `pnpm check` and `pnpm type-check` pass
- [ ] Run `pnpm vitest tests/integration/reaper-route.test.ts`
- [ ] Deploy to staging, call endpoint with service key, verify empty response when no stale executions
- [ ] Create a stuck execution manually, verify it gets reaped