### PR TITLE
fix: KEEP-1530 DB fallback when triggerStep completion fails

### DIFF
--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -1,5 +1,4 @@
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
-import { logWorkflowCompleteDb } from "@/lib/workflow-logging";
 
 type FallbackCompleteParams = {
   executionId: string;
@@ -9,22 +8,45 @@ type FallbackCompleteParams = {
   startTime: number;
 };
 
+const INTERNAL_SERVICE_KEY = process.env.EVENTS_SERVICE_API_KEY ?? "";
+const APP_PORT = process.env.PORT ?? "3000";
+
 /**
- * Direct DB fallback for when triggerStep({ _workflowComplete }) fails.
- * Calls logWorkflowCompleteDb directly, bypassing the workflow SDK queue.
+ * Fallback for when triggerStep({ _workflowComplete }) fails.
+ * Uses fetch() to PATCH /api/internal/executions/[executionId] via HTTP loopback,
+ * avoiding direct DB module imports that break the workflow bundler (nanoid/Node.js).
  */
 export async function fallbackCompleteExecution(
   params: FallbackCompleteParams
 ): Promise<void> {
   try {
-    await logWorkflowCompleteDb(params);
+    const response = await fetch(
+      `http://localhost:${APP_PORT}/api/internal/executions/${params.executionId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Service-Key": INTERNAL_SERVICE_KEY,
+        },
+        body: JSON.stringify({
+          status: params.status,
+          error: params.error,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`HTTP ${response.status}: ${body}`);
+    }
+
     console.error(
-      `[Execution Fallback] Successfully updated execution ${params.executionId} via DB fallback`
+      `[Execution Fallback] Successfully updated execution ${params.executionId} via HTTP fallback`
     );
   } catch (fallbackError) {
     logSystemError(
       ErrorCategory.DATABASE,
-      "[Execution Fallback] DB fallback also failed:",
+      "[Execution Fallback] HTTP fallback also failed:",
       fallbackError,
       { execution_id: params.executionId }
     );

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -14,16 +14,21 @@ type FallbackCompleteParams = {
 export async function fallbackCompleteExecution(
   params: FallbackCompleteParams
 ): Promise<void> {
-  const serviceKey = process.env.EVENTS_SERVICE_API_KEY ?? "";
+  const serviceKey = process.env.EVENTS_SERVICE_API_KEY;
   const baseUrl =
     process.env.NEXT_PUBLIC_APP_URL ??
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
 
-  if (!baseUrl) {
+  if (!baseUrl || !serviceKey) {
+    const missing = [
+      !baseUrl && "NEXT_PUBLIC_APP_URL or VERCEL_URL",
+      !serviceKey && "EVENTS_SERVICE_API_KEY",
+    ].filter(Boolean).join(", ");
+
     logSystemError(
       ErrorCategory.INFRASTRUCTURE,
-      "[Execution Fallback] Missing required config: NEXT_PUBLIC_APP_URL or VERCEL_URL not set",
-      new Error("Missing fallback URL configuration"),
+      `[Execution Fallback] Missing required config: ${missing}`,
+      new Error("Missing fallback configuration"),
       { execution_id: params.executionId }
     );
     return;

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -38,7 +38,7 @@ export async function fallbackCompleteExecution(
       throw new Error(`HTTP ${response.status}: ${body}`);
     }
 
-    console.error(
+    console.warn(
       `[Execution Fallback] Successfully updated execution ${params.executionId} via HTTP fallback`
     );
   } catch (fallbackError) {

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -19,11 +19,13 @@ export async function fallbackCompleteExecution(
     process.env.NEXT_PUBLIC_APP_URL ??
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
 
-  if (!baseUrl || !serviceKey) {
+  if (!(baseUrl && serviceKey)) {
     const missing = [
       !baseUrl && "NEXT_PUBLIC_APP_URL or VERCEL_URL",
       !serviceKey && "EVENTS_SERVICE_API_KEY",
-    ].filter(Boolean).join(", ");
+    ]
+      .filter(Boolean)
+      .join(", ");
 
     logSystemError(
       ErrorCategory.INFRASTRUCTURE,

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -15,11 +15,23 @@ export async function fallbackCompleteExecution(
   params: FallbackCompleteParams
 ): Promise<void> {
   const serviceKey = process.env.EVENTS_SERVICE_API_KEY ?? "";
-  const port = process.env.PORT ?? "3000";
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
+
+  if (!baseUrl) {
+    logSystemError(
+      ErrorCategory.INFRASTRUCTURE,
+      "[Execution Fallback] Missing required config: NEXT_PUBLIC_APP_URL or VERCEL_URL not set",
+      new Error("Missing fallback URL configuration"),
+      { execution_id: params.executionId }
+    );
+    return;
+  }
 
   try {
     const response = await fetch(
-      `http://localhost:${port}/api/internal/executions/${params.executionId}`,
+      `${baseUrl}/api/internal/executions/${params.executionId}`,
       {
         method: "PATCH",
         headers: {

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -43,7 +43,7 @@ export async function fallbackCompleteExecution(
     );
   } catch (fallbackError) {
     logSystemError(
-      ErrorCategory.DATABASE,
+      ErrorCategory.INFRASTRUCTURE,
       "[Execution Fallback] HTTP fallback also failed:",
       fallbackError,
       { execution_id: params.executionId }

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -8,9 +8,6 @@ type FallbackCompleteParams = {
   startTime: number;
 };
 
-const INTERNAL_SERVICE_KEY = process.env.EVENTS_SERVICE_API_KEY ?? "";
-const APP_PORT = process.env.PORT ?? "3000";
-
 /**
  * Fallback for when triggerStep({ _workflowComplete }) fails.
  * Uses fetch() to PATCH /api/internal/executions/[executionId] via HTTP loopback,
@@ -19,14 +16,17 @@ const APP_PORT = process.env.PORT ?? "3000";
 export async function fallbackCompleteExecution(
   params: FallbackCompleteParams
 ): Promise<void> {
+  const serviceKey = process.env.EVENTS_SERVICE_API_KEY ?? "";
+  const port = process.env.PORT ?? "3000";
+
   try {
     const response = await fetch(
-      `http://localhost:${APP_PORT}/api/internal/executions/${params.executionId}`,
+      `http://localhost:${port}/api/internal/executions/${params.executionId}`,
       {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          "X-Service-Key": INTERNAL_SERVICE_KEY,
+          "X-Service-Key": serviceKey,
         },
         body: JSON.stringify({
           status: params.status,

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -1,0 +1,32 @@
+import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
+import { logWorkflowCompleteDb } from "@/lib/workflow-logging";
+
+type FallbackCompleteParams = {
+  executionId: string;
+  status: "success" | "error";
+  output?: unknown;
+  error?: string;
+  startTime: number;
+};
+
+/**
+ * Direct DB fallback for when triggerStep({ _workflowComplete }) fails.
+ * Calls logWorkflowCompleteDb directly, bypassing the workflow SDK queue.
+ */
+export async function fallbackCompleteExecution(
+  params: FallbackCompleteParams
+): Promise<void> {
+  try {
+    await logWorkflowCompleteDb(params);
+    console.error(
+      `[Execution Fallback] Successfully updated execution ${params.executionId} via DB fallback`
+    );
+  } catch (fallbackError) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[Execution Fallback] DB fallback also failed:",
+      fallbackError,
+      { execution_id: params.executionId }
+    );
+  }
+}

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -3,9 +3,7 @@ import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 type FallbackCompleteParams = {
   executionId: string;
   status: "success" | "error";
-  output?: unknown;
   error?: string;
-  startTime: number;
 };
 
 /**

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1977,9 +1977,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         await fallbackCompleteExecution({
           executionId,
           status: finalSuccess ? "success" : "error",
-          output: Object.values(results).at(-1)?.data,
           error: Object.values(results).find((r) => !r.success)?.error,
-          startTime: workflowStartTime,
         });
         // end keeperhub code //
       }
@@ -2042,7 +2040,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           executionId,
           status: "error",
           error: errorMessage,
-          startTime: Date.now(),
         });
         // end keeperhub code //
       }

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -27,6 +27,7 @@ import {
   detectTriggerType,
   recordWorkflowComplete,
 } from "@/keeperhub/lib/metrics/instrumentation/workflow";
+import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
 import { ARRAY_SOURCE_RE } from "@/keeperhub/lib/for-each-utils";
 import {
   buildEdgesBySourceHandle,
@@ -1972,6 +1973,15 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             ...(executionId ? { execution_id: executionId } : {}),
           }
         );
+        // start custom keeperhub code //
+        await fallbackCompleteExecution({
+          executionId,
+          status: finalSuccess ? "success" : "error",
+          output: Object.values(results).at(-1)?.data,
+          error: Object.values(results).find((r) => !r.success)?.error,
+          startTime: workflowStartTime,
+        });
+        // end keeperhub code //
       }
     }
 
@@ -2027,6 +2037,14 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             ...(executionId ? { execution_id: executionId } : {}),
           }
         );
+        // start custom keeperhub code //
+        await fallbackCompleteExecution({
+          executionId,
+          status: "error",
+          error: errorMessage,
+          startTime: Date.now(),
+        });
+        // end keeperhub code //
       }
     }
 

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockLogWorkflowCompleteDb = vi.fn();
+vi.mock("@/lib/workflow-logging", () => ({
+  logWorkflowCompleteDb: (...args: unknown[]) =>
+    mockLogWorkflowCompleteDb(...args),
+}));
+
+const mockLogSystemError = vi.fn();
+vi.mock("@/keeperhub/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
+}));
+
+import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
+
+describe("fallbackCompleteExecution", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("calls logWorkflowCompleteDb with the provided params", async () => {
+    mockLogWorkflowCompleteDb.mockResolvedValue(undefined);
+
+    const params = {
+      executionId: "exec_1",
+      status: "success" as const,
+      output: { result: "ok" },
+      startTime: Date.now() - 5000,
+    };
+
+    await fallbackCompleteExecution(params);
+
+    expect(mockLogWorkflowCompleteDb).toHaveBeenCalledWith(params);
+  });
+
+  it("logs success message when DB update succeeds", async () => {
+    mockLogWorkflowCompleteDb.mockResolvedValue(undefined);
+
+    await fallbackCompleteExecution({
+      executionId: "exec_1",
+      status: "error",
+      error: "workflow failed",
+      startTime: Date.now(),
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("exec_1")
+    );
+    expect(mockLogSystemError).not.toHaveBeenCalled();
+  });
+
+  it("calls logSystemError when DB fallback fails", async () => {
+    const dbError = new Error("connection refused");
+    mockLogWorkflowCompleteDb.mockRejectedValue(dbError);
+
+    await fallbackCompleteExecution({
+      executionId: "exec_2",
+      status: "error",
+      error: "workflow failed",
+      startTime: Date.now(),
+    });
+
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "DATABASE",
+      expect.stringContaining("DB fallback also failed"),
+      dbError,
+      { execution_id: "exec_2" }
+    );
+  });
+
+  it("does not throw when DB fallback fails", async () => {
+    mockLogWorkflowCompleteDb.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      fallbackCompleteExecution({
+        executionId: "exec_3",
+        status: "error",
+        startTime: Date.now(),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes error status and message correctly", async () => {
+    mockLogWorkflowCompleteDb.mockResolvedValue(undefined);
+
+    await fallbackCompleteExecution({
+      executionId: "exec_4",
+      status: "error",
+      error: "step 3 failed: timeout",
+      startTime: 1000,
+    });
+
+    expect(mockLogWorkflowCompleteDb).toHaveBeenCalledWith({
+      executionId: "exec_4",
+      status: "error",
+      error: "step 3 failed: timeout",
+      startTime: 1000,
+    });
+  });
+});

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -31,7 +31,6 @@ describe("fallbackCompleteExecution", () => {
     await fallbackCompleteExecution({
       executionId: "exec_1",
       status: "success",
-      startTime: Date.now(),
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -53,7 +52,6 @@ describe("fallbackCompleteExecution", () => {
       executionId: "exec_1",
       status: "error",
       error: "step 3 failed",
-      startTime: Date.now(),
     });
 
     const callArgs = mockFetch.mock.calls[0];
@@ -68,7 +66,6 @@ describe("fallbackCompleteExecution", () => {
       executionId: "exec_1",
       status: "error",
       error: "workflow failed",
-      startTime: Date.now(),
     });
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -88,7 +85,6 @@ describe("fallbackCompleteExecution", () => {
       executionId: "exec_2",
       status: "error",
       error: "workflow failed",
-      startTime: Date.now(),
     });
 
     expect(mockLogSystemError).toHaveBeenCalledWith(
@@ -105,7 +101,6 @@ describe("fallbackCompleteExecution", () => {
     await fallbackCompleteExecution({
       executionId: "exec_3",
       status: "error",
-      startTime: Date.now(),
     });
 
     expect(mockLogSystemError).toHaveBeenCalledWith(
@@ -123,7 +118,6 @@ describe("fallbackCompleteExecution", () => {
       fallbackCompleteExecution({
         executionId: "exec_4",
         status: "error",
-        startTime: Date.now(),
       })
     ).resolves.toBeUndefined();
   });

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -48,6 +48,23 @@ describe("fallbackCompleteExecution", () => {
     );
   });
 
+  it("logs error and returns early when service key is not configured", async () => {
+    delete process.env.EVENTS_SERVICE_API_KEY;
+
+    await fallbackCompleteExecution({
+      executionId: "exec_no_key",
+      status: "error",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "INFRASTRUCTURE",
+      expect.stringContaining("EVENTS_SERVICE_API_KEY"),
+      expect.any(Error),
+      { execution_id: "exec_no_key" }
+    );
+  });
+
   it("uses VERCEL_URL when NEXT_PUBLIC_APP_URL is not set", async () => {
     delete process.env.NEXT_PUBLIC_APP_URL;
     process.env.VERCEL_URL = "my-app.vercel.app";

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -1,13 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
-const mockLogWorkflowCompleteDb = vi.fn();
-vi.mock("@/lib/workflow-logging", () => ({
-  logWorkflowCompleteDb: (...args: unknown[]) =>
-    mockLogWorkflowCompleteDb(...args),
-}));
-
 const mockLogSystemError = vi.fn();
 vi.mock("@/keeperhub/lib/logging", () => ({
   ErrorCategory: { DATABASE: "DATABASE" },
@@ -18,35 +10,59 @@ import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
 
 describe("fallbackCompleteExecution", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  const mockFetch = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", mockFetch);
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    vi.unstubAllGlobals();
   });
 
-  it("calls logWorkflowCompleteDb with the provided params", async () => {
-    mockLogWorkflowCompleteDb.mockResolvedValue(undefined);
+  it("sends PATCH request to internal executions endpoint", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
 
-    const params = {
+    await fallbackCompleteExecution({
       executionId: "exec_1",
-      status: "success" as const,
-      output: { result: "ok" },
-      startTime: Date.now() - 5000,
-    };
+      status: "success",
+      startTime: Date.now(),
+    });
 
-    await fallbackCompleteExecution(params);
-
-    expect(mockLogWorkflowCompleteDb).toHaveBeenCalledWith(params);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/internal/executions/exec_1"),
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-Service-Key": expect.any(String),
+        }),
+      })
+    );
   });
 
-  it("logs success message when DB update succeeds", async () => {
-    mockLogWorkflowCompleteDb.mockResolvedValue(undefined);
+  it("sends correct status and error in request body", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await fallbackCompleteExecution({
+      executionId: "exec_1",
+      status: "error",
+      error: "step 3 failed",
+      startTime: Date.now(),
+    });
+
+    const callArgs = mockFetch.mock.calls[0];
+    const body = JSON.parse(callArgs[1].body as string);
+    expect(body).toEqual({ status: "error", error: "step 3 failed" });
+  });
+
+  it("logs success message when HTTP request succeeds", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
 
     await fallbackCompleteExecution({
       executionId: "exec_1",
@@ -61,9 +77,12 @@ describe("fallbackCompleteExecution", () => {
     expect(mockLogSystemError).not.toHaveBeenCalled();
   });
 
-  it("calls logSystemError when DB fallback fails", async () => {
-    const dbError = new Error("connection refused");
-    mockLogWorkflowCompleteDb.mockRejectedValue(dbError);
+  it("calls logSystemError when HTTP request fails", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
 
     await fallbackCompleteExecution({
       executionId: "exec_2",
@@ -74,39 +93,38 @@ describe("fallbackCompleteExecution", () => {
 
     expect(mockLogSystemError).toHaveBeenCalledWith(
       "DATABASE",
-      expect.stringContaining("DB fallback also failed"),
-      dbError,
+      expect.stringContaining("HTTP fallback also failed"),
+      expect.any(Error),
       { execution_id: "exec_2" }
     );
   });
 
-  it("does not throw when DB fallback fails", async () => {
-    mockLogWorkflowCompleteDb.mockRejectedValue(new Error("db down"));
+  it("calls logSystemError when fetch throws", async () => {
+    mockFetch.mockRejectedValue(new Error("connection refused"));
+
+    await fallbackCompleteExecution({
+      executionId: "exec_3",
+      status: "error",
+      startTime: Date.now(),
+    });
+
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "DATABASE",
+      expect.stringContaining("HTTP fallback also failed"),
+      expect.any(Error),
+      { execution_id: "exec_3" }
+    );
+  });
+
+  it("does not throw when fallback fails", async () => {
+    mockFetch.mockRejectedValue(new Error("network error"));
 
     await expect(
       fallbackCompleteExecution({
-        executionId: "exec_3",
+        executionId: "exec_4",
         status: "error",
         startTime: Date.now(),
       })
     ).resolves.toBeUndefined();
-  });
-
-  it("passes error status and message correctly", async () => {
-    mockLogWorkflowCompleteDb.mockResolvedValue(undefined);
-
-    await fallbackCompleteExecution({
-      executionId: "exec_4",
-      status: "error",
-      error: "step 3 failed: timeout",
-      startTime: 1000,
-    });
-
-    expect(mockLogWorkflowCompleteDb).toHaveBeenCalledWith({
-      executionId: "exec_4",
-      status: "error",
-      error: "step 3 failed: timeout",
-      startTime: 1000,
-    });
   });
 });

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -31,8 +31,8 @@ describe("fallbackCompleteExecution", () => {
   });
 
   it("logs error and returns early when base URL is not configured", async () => {
-    delete process.env.NEXT_PUBLIC_APP_URL;
-    delete process.env.VERCEL_URL;
+    Reflect.deleteProperty(process.env, "NEXT_PUBLIC_APP_URL");
+    Reflect.deleteProperty(process.env, "VERCEL_URL");
 
     await fallbackCompleteExecution({
       executionId: "exec_no_url",
@@ -49,7 +49,7 @@ describe("fallbackCompleteExecution", () => {
   });
 
   it("logs error and returns early when service key is not configured", async () => {
-    delete process.env.EVENTS_SERVICE_API_KEY;
+    Reflect.deleteProperty(process.env, "EVENTS_SERVICE_API_KEY");
 
     await fallbackCompleteExecution({
       executionId: "exec_no_key",
@@ -66,7 +66,7 @@ describe("fallbackCompleteExecution", () => {
   });
 
   it("uses VERCEL_URL when NEXT_PUBLIC_APP_URL is not set", async () => {
-    delete process.env.NEXT_PUBLIC_APP_URL;
+    Reflect.deleteProperty(process.env, "NEXT_PUBLIC_APP_URL");
     process.env.VERCEL_URL = "my-app.vercel.app";
     mockFetch.mockResolvedValue({ ok: true });
 

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -9,19 +9,19 @@ vi.mock("@/keeperhub/lib/logging", () => ({
 import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
 
 describe("fallbackCompleteExecution", () => {
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   const mockFetch = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    consoleErrorSpy = vi
-      .spyOn(console, "error")
+    consoleWarnSpy = vi
+      .spyOn(console, "warn")
       .mockImplementation(() => undefined);
     vi.stubGlobal("fetch", mockFetch);
   });
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
     vi.unstubAllGlobals();
   });
 
@@ -68,7 +68,7 @@ describe("fallbackCompleteExecution", () => {
       error: "workflow failed",
     });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining("exec_1")
     );
     expect(mockLogSystemError).not.toHaveBeenCalled();

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLogSystemError = vi.fn();
 vi.mock("@/keeperhub/lib/logging", () => ({
-  ErrorCategory: { DATABASE: "DATABASE" },
+  ErrorCategory: { INFRASTRUCTURE: "INFRASTRUCTURE" },
   logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
 }));
 
@@ -88,7 +88,7 @@ describe("fallbackCompleteExecution", () => {
     });
 
     expect(mockLogSystemError).toHaveBeenCalledWith(
-      "DATABASE",
+      "INFRASTRUCTURE",
       expect.stringContaining("HTTP fallback also failed"),
       expect.any(Error),
       { execution_id: "exec_2" }
@@ -104,7 +104,7 @@ describe("fallbackCompleteExecution", () => {
     });
 
     expect(mockLogSystemError).toHaveBeenCalledWith(
-      "DATABASE",
+      "INFRASTRUCTURE",
       expect.stringContaining("HTTP fallback also failed"),
       expect.any(Error),
       { execution_id: "exec_3" }

--- a/tests/unit/execution-fallback.test.ts
+++ b/tests/unit/execution-fallback.test.ts
@@ -12,17 +12,56 @@ describe("fallbackCompleteExecution", () => {
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   const mockFetch = vi.fn();
 
+  const originalEnv = { ...process.env };
+
   beforeEach(() => {
     vi.clearAllMocks();
     consoleWarnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
     vi.stubGlobal("fetch", mockFetch);
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.keeperhub.io";
+    process.env.EVENTS_SERVICE_API_KEY = "test-service-key";
   });
 
   afterEach(() => {
     consoleWarnSpy.mockRestore();
     vi.unstubAllGlobals();
+    process.env = { ...originalEnv };
+  });
+
+  it("logs error and returns early when base URL is not configured", async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.VERCEL_URL;
+
+    await fallbackCompleteExecution({
+      executionId: "exec_no_url",
+      status: "error",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "INFRASTRUCTURE",
+      expect.stringContaining("Missing required config"),
+      expect.any(Error),
+      { execution_id: "exec_no_url" }
+    );
+  });
+
+  it("uses VERCEL_URL when NEXT_PUBLIC_APP_URL is not set", async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.VERCEL_URL = "my-app.vercel.app";
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await fallbackCompleteExecution({
+      executionId: "exec_vercel",
+      status: "success",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://my-app.vercel.app/api/internal/executions/exec_vercel",
+      expect.any(Object)
+    );
   });
 
   it("sends PATCH request to internal executions endpoint", async () => {


### PR DESCRIPTION
## Summary

- When `triggerStep({ _workflowComplete })` fails, execution records stay stuck in "running" forever because the catch block only logs
- Adds direct DB fallback via `logWorkflowCompleteDb` in both completion catch blocks (normal and fatal error paths)
- Fallback is wrapped in its own try/catch so it never throws
- Includes unit tests (5 tests)

## Test plan

- [x] Verify `pnpm check` and `pnpm type-check` pass
- [x] Run `pnpm vitest tests/unit/execution-fallback.test.ts`
- [ ] Code review: verify fallback calls match the params passed to `triggerStep`
- [ ] Monitor production logs for `[Execution Fallback]` messages after deploy