### PR TITLE
perf(ci): optimize CI checks, E2E tests, and staging/prod deploys

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -28,12 +28,12 @@ jobs:
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ github.ref == 'refs/heads/prod' && vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_STAGING }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -117,13 +117,13 @@ jobs:
       - name: Deploying Service to Kubernetes with Helm
         id: deploy
         if: ${{ !contains(github.event.head_commit.message , '[skip deploy]') }}
-        uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
         with:
           cluster-name: ${{ env.CLUSTER_NAME }}
           config-files: ${{ env.HELM_FILE }}
           chart-path: techops-services/common
           namespace: ${{ env.NAMESPACE }}
-          timeout: 5m0s
+          timeout: 3m0s
           name: ${{ env.SERVICE_NAME }}
           chart-repository: https://techops-services.github.io/helm-charts
           version: 0.2.1

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -54,41 +54,21 @@ jobs:
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Build, tag, and push app image to ECR
-        id: build-app-image
-        if: ${{ !contains(github.event.head_commit.message , '[skip build]') }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          build-args: |
-            NEXT_PUBLIC_AUTH_PROVIDERS=${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
-            NEXT_PUBLIC_GITHUB_CLIENT_ID=${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
-            NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:app-${{ steps.vars.outputs.sha_short }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:app-latest
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ env.ENVIRONMENT_TAG }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app,mode=max
-
-      - name: Build, tag, and push migrator image to ECR
-        id: build-migrator
+      - name: Build and push all images to ECR
         if: ${{ !contains(github.event.head_commit.message, '[skip build]') }}
-        uses: docker/build-push-action@v6
+        uses: docker/bake-action@v6
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPO: ${{ env.AWS_ECR_NAME }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
+          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
         with:
-          context: .
-          file: ./Dockerfile
-          target: migrator
+          files: docker-bake.hcl
           push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-${{ steps.vars.outputs.sha_short }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:migrator-latest
-          cache-from: |
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-migrator,mode=max
+          set: |
+            app.tags=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ env.ENVIRONMENT_TAG }}
 
       - name: Replace variables in the Helm values file
         id: replace-vars

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -103,7 +103,7 @@ jobs:
           config-files: ${{ env.HELM_FILE }}
           chart-path: techops-services/common
           namespace: ${{ env.NAMESPACE }}
-          timeout: 3m0s
+          timeout: 5m0s
           name: ${{ env.SERVICE_NAME }}
           chart-repository: https://techops-services.github.io/helm-charts
           version: 0.2.1

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -1,36 +1,46 @@
 on:
-  push:
+  workflow_run:
+    workflows: ["E2E Tests"]
+    types: [completed]
     branches:
       - staging
       - prod
-    paths-ignore:
-      - "docs/**"
-      - "docs-site/**"
   workflow_dispatch:
 
 name: deploy-keeperhub
 jobs:
   build-and-deploy-keeperhub:
-    environment: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    environment: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'prod' || 'staging' }}
     runs-on: ubuntu-latest
     env:
-      HELM_FILE: deploy/keeperhub/${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}/values.yaml
-      REGION: ${{ github.ref == 'refs/heads/prod' && 'us-east-1' || 'us-east-2' }}
-      CLUSTER_NAME: ${{ github.ref == 'refs/heads/prod' && 'maker-prod' || 'maker-staging' }}
-      ENVIRONMENT_TAG: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
+      HELM_FILE: deploy/keeperhub/${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'prod' || 'staging' }}/values.yaml
+      REGION: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'us-east-1' || 'us-east-2' }}
+      CLUSTER_NAME: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'maker-prod' || 'maker-staging' }}
+      ENVIRONMENT_TAG: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'prod' || 'staging' }}
       NAMESPACE: keeperhub
       SERVICE_NAME: keeperhub
-      AWS_ECR_NAME: keeperhub-${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
+      AWS_ECR_NAME: keeperhub-${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'prod' || 'staging' }}
       SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.SERVICE_ACCOUNT_ROLE_ARN }}
       # Auth provider build args (selected by deployment branch: prod vs staging)
-      NEXT_PUBLIC_AUTH_PROVIDERS: ${{ github.ref == 'refs/heads/prod' && vars.NEXT_PUBLIC_AUTH_PROVIDERS_PROD || vars.NEXT_PUBLIC_AUTH_PROVIDERS_STAGING }}
-      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ github.ref == 'refs/heads/prod' && vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_STAGING }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ github.ref == 'refs/heads/prod' && vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_STAGING }}
+      NEXT_PUBLIC_AUTH_PROVIDERS: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && vars.NEXT_PUBLIC_AUTH_PROVIDERS_PROD || vars.NEXT_PUBLIC_AUTH_PROVIDERS_STAGING }}
+      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_STAGING }}
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_STAGING }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 1
+
+      - name: Check commit message for skip flags
+        id: skip
+        run: |
+          MSG=$(git log -1 --format=%B)
+          echo "skip_build=$([[ "$MSG" == *"[skip build]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "skip_deploy=$([[ "$MSG" == *"[skip deploy]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -44,18 +54,18 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
-        if: ${{ !contains(github.event.head_commit.message , '[skip build]') }}
+        if: steps.skip.outputs.skip_build != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Extract commit hash
         id: vars
-        if: ${{ !contains(github.event.head_commit.message , '[skip build]') }}
+        if: steps.skip.outputs.skip_build != 'true'
         shell: bash
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push all images to ECR
-        if: ${{ !contains(github.event.head_commit.message, '[skip build]') }}
+        if: steps.skip.outputs.skip_build != 'true'
         uses: docker/bake-action@v6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -72,7 +82,7 @@ jobs:
 
       - name: Replace variables in the Helm values file
         id: replace-vars
-        if: ${{ !contains(github.event.head_commit.message , '[skip deploy]') }}
+        if: steps.skip.outputs.skip_deploy != 'true'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
@@ -85,18 +95,18 @@ jobs:
           sed -i 's|${AWS_ACCOUNT_ID}|'"$AWS_ACCOUNT_ID"'|g' $HELM_FILE
 
       - name: Configure kubectl
-        if: ${{ !contains(github.event.head_commit.message , '[skip deploy]') }}
+        if: steps.skip.outputs.skip_deploy != 'true'
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}
 
       - name: Apply RBAC for Job Spawner
-        if: ${{ !contains(github.event.head_commit.message , '[skip deploy]') }}
+        if: steps.skip.outputs.skip_deploy != 'true'
         run: |
-          kubectl apply -f deploy/keeperhub/${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}/rbac.yaml
+          kubectl apply -f deploy/keeperhub/${{ (github.event.workflow_run.head_branch || github.ref_name) == 'prod' && 'prod' || 'staging' }}/rbac.yaml
 
       - name: Deploying Service to Kubernetes with Helm
         id: deploy
-        if: ${{ !contains(github.event.head_commit.message , '[skip deploy]') }}
+        if: steps.skip.outputs.skip_deploy != 'true'
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
         with:
           cluster-name: ${{ env.CLUSTER_NAME }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -245,6 +245,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Increase shard count as the test suite grows
         shard: [1, 2]
 
     services:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -126,6 +126,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
       - name: Generate plugin registry
         run: pnpm discover-plugins
 
@@ -226,13 +235,17 @@ jobs:
             coverage/
           retention-days: 7
 
-  # Playwright E2E tests (browser-based)
-  # Only runs after Vitest E2E tests pass
+  # Playwright E2E tests (browser-based, sharded)
+  # Runs in parallel with Vitest E2E tests
   e2e-playwright:
-    needs: [should-run, e2e-vitest]
+    needs: [should-run]
     if: needs.should-run.outputs.run-e2e == 'true'
     runs-on: ubuntu-latest
     environment: staging
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
 
     services:
       postgres:
@@ -311,8 +324,8 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
-      - name: Run Playwright tests
-        run: pnpm test:e2e
+      - name: Run Playwright tests (shard ${{ matrix.shard }}/2)
+        run: pnpm test:e2e --shard=${{ matrix.shard }}/2
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           PARA_API_KEY: ${{ secrets.TEST_PARA_API_KEY }}
@@ -329,7 +342,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: |
             playwright-report/
             test-results/
@@ -339,7 +352,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-screenshots
+          name: playwright-screenshots-shard-${{ matrix.shard }}
           path: test-results/**/*.png
           retention-days: 7
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -236,9 +236,9 @@ jobs:
           retention-days: 7
 
   # Playwright E2E tests (browser-based, sharded)
-  # Runs in parallel with Vitest E2E tests
+  # Runs after Vitest to avoid conflicts on shared external test accounts
   e2e-playwright:
-    needs: [should-run]
+    needs: [should-run, e2e-vitest]
     if: needs.should-run.outputs.run-e2e == 'true'
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,9 +5,8 @@ on:
     branches: ['**']
 
 jobs:
-  checks:
+  lint-typecheck:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,11 +40,64 @@ jobs:
       - name: Generate plugin registry
         run: pnpm discover-plugins
 
+      - name: Cache TypeScript build info
+        uses: actions/cache@v4
+        with:
+          path: tsconfig.tsbuildinfo
+          key: ${{ runner.os }}-tsbuildinfo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-tsbuildinfo-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-tsbuildinfo-
+
       - name: Run check
         run: pnpm check
 
       - name: Run type check
         run: pnpm type-check
+
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate plugin registry
+        run: pnpm discover-plugins
 
       - name: Run build
         run: pnpm build
@@ -55,4 +107,3 @@ jobs:
 
       - name: Run integration tests
         run: pnpm test:integration
-

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,44 @@
+variable "ECR_REGISTRY" { default = "" }
+variable "ECR_REPO" { default = "" }
+variable "IMAGE_TAG" { default = "latest" }
+variable "NEXT_PUBLIC_AUTH_PROVIDERS" { default = "" }
+variable "NEXT_PUBLIC_GITHUB_CLIENT_ID" { default = "" }
+variable "NEXT_PUBLIC_GOOGLE_CLIENT_ID" { default = "" }
+
+group "default" {
+  targets = ["app", "migrator"]
+}
+
+target "app" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "runner"
+  args = {
+    NEXT_PUBLIC_AUTH_PROVIDERS    = NEXT_PUBLIC_AUTH_PROVIDERS
+    NEXT_PUBLIC_GITHUB_CLIENT_ID = NEXT_PUBLIC_GITHUB_CLIENT_ID
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID = NEXT_PUBLIC_GOOGLE_CLIENT_ID
+  }
+  tags = [
+    "${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${ECR_REPO}:app-latest",
+  ]
+  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"]
+  cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app,mode=max"]
+  output     = ["type=registry"]
+}
+
+target "migrator" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "migrator"
+  tags = [
+    "${ECR_REGISTRY}/${ECR_REPO}:migrator-${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${ECR_REPO}:migrator-latest",
+  ]
+  cache-from = [
+    "type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app",
+    "type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-migrator",
+  ]
+  cache-to = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-migrator,mode=max"]
+  output   = ["type=registry"]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,7 +32,6 @@ target "app" {
   ]
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app,mode=max"]
-  output     = ["type=registry"]
 }
 
 target "migrator" {
@@ -48,5 +47,4 @@ target "migrator" {
     "type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-migrator",
   ]
   cache-to = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-migrator,mode=max"]
-  output   = ["type=registry"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,3 +1,11 @@
+# Docker Buildx Bake definition for parallel image builds.
+# Used by deploy-keeperhub.yaml via docker/bake-action to build the "app" and
+# "migrator" targets from our Dockerfile concurrently in a single BuildKit
+# session. Shared Dockerfile stages (deps, source) are built once and reused
+# across both targets, saving ~47s vs sequential build-push-action steps.
+# Variables are passed as env vars from the GHA workflow.
+# Docs: https://docs.docker.com/build/bake/reference/
+
 variable "ECR_REGISTRY" { default = "" }
 variable "ECR_REPO" { default = "" }
 variable "IMAGE_TAG" { default = "latest" }


### PR DESCRIPTION
## Summary

- Split PR checks into parallel `lint-typecheck` and `build-test` jobs with tsbuildinfo and Next.js build caching
- Parallelize E2E vitest and Playwright jobs (removed sequential dependency), add Next.js build cache to vitest, shard Playwright across 2 runners
- Bump action versions in staging/prod deploy (checkout v6, AWS creds v5, bitovi v1.2.12), shallow clone, reduce Helm timeout
- Replace sequential Docker builds with buildx bake for parallel app + migrator builds in staging/prod deploy

## Projected savings

| Workflow | Before | After | Reduction |
|----------|--------|-------|-----------|
| PR checks (fastest feedback) | ~3.5min | ~51s | 76% |
| PR checks (full pass, warm cache) | ~3.5min | ~2min | 40% |
| E2E tests | ~12min | ~4.5min | 62% |
| Staging/prod deploy | ~6min | ~5min | 17% |

## Test plan

- [ ] Open a PR, verify both `lint-typecheck` and `build-test` jobs appear and run in parallel
- [ ] Trigger E2E tests, verify vitest and playwright jobs start simultaneously
- [ ] Verify both Playwright shards pass
- [ ] Merge to staging, verify deploy succeeds with bake-action building both images