### PR TITLE
fix(deploy): authenticate buildx bake for private submodule cloning

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -74,6 +74,7 @@ jobs:
           NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
           NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
           NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+          BUILDX_BAKE_GIT_AUTH_TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
         with:
           files: docker-bake.hcl
           push: true

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -64,6 +64,22 @@ jobs:
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Verify submodule token access
+        if: steps.skip.outputs.skip_build != 'true'
+        env:
+          TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
+        run: |
+          for repo in keeperhub-events keeperhub-scheduler; do
+            status=$(curl -sf -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer $TOKEN" \
+              "https://api.github.com/repos/techops-services/$repo")
+            if [ "$status" != "200" ]; then
+              echo "::error::KEEPERHUB_SUBMODULE_TOKEN cannot access techops-services/$repo (HTTP $status). Token may be expired or revoked."
+              exit 1
+            fi
+            echo "Verified access to techops-services/$repo"
+          done
+
       - name: Build and push all images to ECR
         if: steps.skip.outputs.skip_build != 'true'
         uses: docker/bake-action@v6


### PR DESCRIPTION
## Summary

- Adds `BUILDX_BAKE_GIT_AUTH_TOKEN` to the docker bake step so Buildkit can authenticate when cloning private submodules (`keeperhub-events`, `keeperhub-scheduler`) over HTTPS
- Root cause: the switch from `build-push-action` to `bake-action` changed the build context from local checkout to git URL, triggering recursive submodule cloning that fails without credentials

## Test plan

- [ ] Merge to staging and verify the deploy workflow passes the "Build and push all images to ECR" step
- [ ] Confirm both app and migrator images are pushed to ECR