### PR TITLE
fix: KEEP-1534 decode contract revert errors in web3 plugin steps

### DIFF
--- a/keeperhub/lib/web3/decode-revert-error.ts
+++ b/keeperhub/lib/web3/decode-revert-error.ts
@@ -29,6 +29,13 @@ const COMMON_ERROR_FRAGMENTS: string[] = [
   "error NotInitializing()",
   "error MathOverflowedMulDiv()",
   "error SafeERC20FailedOperation(address token)",
+  "error NotAuthorized()",
+  "error InsufficientLiquidity()",
+  "error InsufficientBalance()",
+  "error InvalidAmount()",
+  "error InvalidAddress()",
+  "error Expired()",
+  "error AlreadyInitialized()",
 ];
 
 const COMMON_ERRORS_INTERFACE = new ethers.Interface(COMMON_ERROR_FRAGMENTS);

--- a/keeperhub/lib/web3/decode-revert-error.ts
+++ b/keeperhub/lib/web3/decode-revert-error.ts
@@ -1,0 +1,149 @@
+import { ethers } from "ethers";
+
+/**
+ * Well-known custom error selectors that appear frequently in contracts
+ * but may not be included in the user-provided ABI (e.g. inherited from
+ * OpenZeppelin base contracts).
+ */
+const COMMON_ERROR_FRAGMENTS: string[] = [
+  "error Unauthorized()",
+  "error OwnableUnauthorizedAccount(address account)",
+  "error OwnableInvalidOwner(address owner)",
+  "error EnforcedPause()",
+  "error ExpectedPause()",
+  "error AccessControlUnauthorizedAccount(address account, bytes32 neededRole)",
+  "error AccessControlBadConfirmation()",
+  "error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)",
+  "error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)",
+  "error ERC20InvalidSender(address sender)",
+  "error ERC20InvalidReceiver(address receiver)",
+  "error ERC20InvalidApprover(address approver)",
+  "error ERC20InvalidSpender(address spender)",
+  "error ERC721NonexistentToken(uint256 tokenId)",
+  "error ERC721InsufficientApproval(address operator, uint256 tokenId)",
+  "error FailedCall()",
+  "error InsufficientBalance(uint256 balance, uint256 needed)",
+  "error AddressInsufficientBalance(address account)",
+  "error ReentrancyGuardReentrantCall()",
+  "error InvalidInitialization()",
+  "error NotInitializing()",
+  "error MathOverflowedMulDiv()",
+  "error SafeERC20FailedOperation(address token)",
+];
+
+const COMMON_ERRORS_INTERFACE = new ethers.Interface(COMMON_ERROR_FRAGMENTS);
+
+function formatDecodedError(decoded: ethers.ErrorDescription): string {
+  if (decoded.args.length === 0) {
+    return decoded.name;
+  }
+  const formattedArgs = decoded.args.map((arg: unknown) =>
+    typeof arg === "bigint" ? arg.toString() : String(arg)
+  );
+  return `${decoded.name}(${formattedArgs.join(", ")})`;
+}
+
+/**
+ * Attempt to decode revert data from an ethers.js CALL_EXCEPTION error.
+ *
+ * Tries three strategies in order:
+ * 1. Parse against the contract's own ABI (catches contract-specific errors)
+ * 2. Parse against common OpenZeppelin/standard error selectors
+ * 3. Decode as a standard string revert reason (require("message"))
+ *
+ * Returns a human-readable string, or undefined if decoding fails entirely.
+ */
+export function decodeRevertReason(
+  error: unknown,
+  contractInterface?: ethers.Interface
+): string | undefined {
+  const revertData = extractRevertData(error);
+  if (!revertData || revertData === "0x") {
+    return;
+  }
+
+  // 1. Try the contract's own ABI
+  if (contractInterface) {
+    try {
+      const decoded = contractInterface.parseError(revertData);
+      if (decoded) {
+        return formatDecodedError(decoded);
+      }
+    } catch {
+      // Not in this ABI
+    }
+  }
+
+  // 2. Try common error selectors
+  try {
+    const decoded = COMMON_ERRORS_INTERFACE.parseError(revertData);
+    if (decoded) {
+      return formatDecodedError(decoded);
+    }
+  } catch {
+    // Not a known common error
+  }
+
+  // 3. Try standard string revert (Error(string))
+  try {
+    const reason = ethers.AbiCoder.defaultAbiCoder().decode(
+      ["string"],
+      ethers.dataSlice(revertData, 4)
+    );
+    if (reason[0]) {
+      return String(reason[0]);
+    }
+  } catch {
+    // Not a string revert
+  }
+
+  return;
+}
+
+/**
+ * Build a user-facing error message for a contract call failure.
+ *
+ * If the revert data can be decoded, produces a message like:
+ *   "Contract call failed: Unauthorized()"
+ *
+ * Otherwise falls back to the raw ethers.js error message.
+ */
+export function formatContractError(
+  error: unknown,
+  contractInterface?: ethers.Interface,
+  prefix?: string
+): string {
+  const label = prefix ?? "Contract call failed";
+
+  const decoded = decodeRevertReason(error, contractInterface);
+  if (decoded) {
+    return `${label}: ${decoded}`;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return `${label}: ${message}`;
+}
+
+function extractRevertData(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") {
+    return;
+  }
+  const err = error as Record<string, unknown>;
+
+  // ethers.js v6 CALL_EXCEPTION puts revert data in .data
+  if (typeof err.data === "string" && err.data.startsWith("0x")) {
+    return err.data;
+  }
+
+  // Some errors nest it under .error
+  if (err.error && typeof err.error === "object") {
+    return extractRevertData(err.error);
+  }
+
+  // Some RPC errors put it in .info.error.data
+  if (err.info && typeof err.info === "object") {
+    return extractRevertData(err.info);
+  }
+
+  return;
+}

--- a/keeperhub/plugins/web3/steps/approve-token-core.ts
+++ b/keeperhub/plugins/web3/steps/approve-token-core.ts
@@ -237,6 +237,9 @@ export async function approveTokenCore(
         }
       }
 
+      // Simulate call first to get decodable revert data on failure
+      await contract.approve.staticCall(spenderAddress, amountRaw);
+
       // Get nonce from session
       const nonce = nonceManager.getNextNonce(session);
 

--- a/keeperhub/plugins/web3/steps/approve-token-core.ts
+++ b/keeperhub/plugins/web3/steps/approve-token-core.ts
@@ -14,6 +14,7 @@ import {
   getOrganizationWalletAddress,
   initializeParaSigner,
 } from "@/keeperhub/lib/para/wallet-helpers";
+import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
 import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
 import { getNonceManager } from "@/keeperhub/lib/web3/nonce-manager";
@@ -323,7 +324,11 @@ export async function approveTokenCore(
       );
       return {
         success: false,
-        error: `Token approval failed: ${getErrorMessage(error)}`,
+        error: formatContractError(
+          error,
+          contract.interface,
+          "Token approval failed"
+        ),
       };
     }
   });

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/keeperhub/lib/abi-struct-args";
 import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
+import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
@@ -252,6 +253,11 @@ export async function readContractCore(
     };
   }
 
+  // Build interface from parsed ABI for error decoding in catch block
+  const contractInterface = new ethers.Interface(
+    parsedAbi as ethers.InterfaceAbi
+  );
+
   // Call the contract function
   try {
     const provider = new ethers.JsonRpcProvider(rpcUrl);
@@ -351,7 +357,7 @@ export async function readContractCore(
     );
     return {
       success: false,
-      error: `Contract call failed: ${getErrorMessage(error)}`,
+      error: formatContractError(error, contractInterface),
     };
   }
 }

--- a/keeperhub/plugins/web3/steps/transfer-funds-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-funds-core.ts
@@ -192,6 +192,9 @@ export async function transferFundsCore(
 
       const baseTx = { to: recipientAddress, value: amountInWei };
 
+      // Simulate call first to get decodable revert data on failure
+      await provider.call({ ...baseTx, from: walletAddress });
+
       // Estimate gas
       const estimatedGas = await provider.estimateGas({
         ...baseTx,

--- a/keeperhub/plugins/web3/steps/transfer-funds-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-funds-core.ts
@@ -14,6 +14,7 @@ import {
   getOrganizationWalletAddress,
   initializeParaSigner,
 } from "@/keeperhub/lib/para/wallet-helpers";
+import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
 import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
 import { getNonceManager } from "@/keeperhub/lib/web3/nonce-manager";
@@ -268,7 +269,7 @@ export async function transferFundsCore(
       );
       return {
         success: false,
-        error: `Transaction failed: ${getErrorMessage(error)}`,
+        error: formatContractError(error, undefined, "Transaction failed"),
       };
     }
   });

--- a/keeperhub/plugins/web3/steps/transfer-token-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-token-core.ts
@@ -14,6 +14,7 @@ import {
   getOrganizationWalletAddress,
   initializeParaSigner,
 } from "@/keeperhub/lib/para/wallet-helpers";
+import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
 import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
 import { getNonceManager } from "@/keeperhub/lib/web3/nonce-manager";
@@ -436,7 +437,11 @@ export async function transferTokenCore(
       );
       return {
         success: false,
-        error: `Token transfer failed: ${getErrorMessage(error)}`,
+        error: formatContractError(
+          error,
+          contract.interface,
+          "Token transfer failed"
+        ),
       };
     }
   });

--- a/keeperhub/plugins/web3/steps/transfer-token-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-token-core.ts
@@ -350,6 +350,9 @@ export async function transferTokenCore(
         };
       }
 
+      // Simulate call first to get decodable revert data on failure
+      await contract.transfer.staticCall(recipientAddress, amountRaw);
+
       // Get nonce from session
       const nonce = nonceManager.getNextNonce(session);
 

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -291,6 +291,10 @@ export async function writeContractCore(
       // Build value override for payable functions (e.g. WETH deposit)
       const valueOverride = parsedEthValue ? { value: parsedEthValue } : {};
 
+      // Simulate call first to get decodable revert data on failure
+      // (eth_call returns revert data reliably, eth_estimateGas often does not)
+      await contract[abiFunction].staticCall(...args, valueOverride);
+
       // Get nonce from session
       const nonce = nonceManager.getNextNonce(session);
 

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -15,6 +15,7 @@ import {
   getOrganizationWalletAddress,
   initializeParaSigner,
 } from "@/keeperhub/lib/para/wallet-helpers";
+import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
 import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
 import { getNonceManager } from "@/keeperhub/lib/web3/nonce-manager";
@@ -384,7 +385,7 @@ export async function writeContractCore(
       );
       return {
         success: false,
-        error: `Contract call failed: ${getErrorMessage(error)}`,
+        error: formatContractError(error, contract.interface),
       };
     }
   });

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -134,6 +134,7 @@ vi.mock("ethers", async () => {
         decimals = mockDecimals;
         symbol = mockSymbol;
         approve = Object.assign(mockApprove, {
+          staticCall: vi.fn().mockResolvedValue(true),
           estimateGas: mockApproveEstimateGas,
         });
       },


### PR DESCRIPTION
## Summary

- Add shared `decode-revert-error` utility that decodes revert data from ethers.js `CALL_EXCEPTION` errors against: the contract's own ABI, common OpenZeppelin/standard error selectors (e.g. `Unauthorized()`, `ERC20InsufficientAllowance`), and standard string revert reasons
- Update catch blocks in `write-contract-core`, `read-contract-core`, `transfer-token-core`, `approve-token-core`, and `transfer-funds-core` to produce actionable error messages instead of raw "unknown custom error"

## Test plan

- [x] Trigger a workflow that calls a contract function the signer is not authorized for and verify the error message now shows the decoded error name (e.g. `Unauthorized()`) instead of `unknown custom error`
- [x] Verify existing passing workflows are unaffected
- [x] Run `pnpm check` and `pnpm type-check` to confirm no regressions