### PR TITLE
fix: analytics 500 from decimal duration values

### DIFF
--- a/drizzle/0026_fix-decimal-duration-values.sql
+++ b/drizzle/0026_fix-decimal-duration-values.sql
@@ -6,5 +6,6 @@
 
 UPDATE "workflow_executions"
 SET "duration" = ROUND(CAST("duration" AS NUMERIC))::TEXT
-WHERE "duration" IS NOT NULL
+WHERE "status" = 'cancelled'
+  AND "duration" IS NOT NULL
   AND "duration" ~ '\.';

--- a/drizzle/0026_fix-decimal-duration-values.sql
+++ b/drizzle/0026_fix-decimal-duration-values.sql
@@ -1,0 +1,10 @@
+-- Fix duration values that were stored with decimal precision
+-- by a manual UPDATE that used EXTRACT(EPOCH ...) * 1000.
+-- The duration column is text storing integer milliseconds,
+-- but some rows now contain decimal strings like "1234567.890"
+-- which break CAST(duration AS INTEGER) in analytics queries.
+
+UPDATE "workflow_executions"
+SET "duration" = ROUND(CAST("duration" AS NUMERIC))::TEXT
+WHERE "duration" IS NOT NULL
+  AND "duration" ~ '\.';

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -166,7 +166,7 @@ async function getWorkflowCounts(
       total: count(),
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} IN ('error', 'cancelled') THEN 1 ELSE 0 END)`,
-      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS INTEGER)), 0)`,
+      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS NUMERIC))::INTEGER, 0)`,
       durationCount: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} IS NOT NULL THEN 1 ELSE 0 END)`,
     })
     .from(workflowExecutions)

--- a/keeperhub/lib/metrics/db-metrics.ts
+++ b/keeperhub/lib/metrics/db-metrics.ts
@@ -103,16 +103,16 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS INTEGER)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS NUMERIC))::INTEGER, 0)`,
         // Count executions in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 100 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 250 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 500 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 5000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 10000 THEN 1 ELSE 0 END)`,
-        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 30000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 100 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 250 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 500 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 1000 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 2000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 10000 THEN 1 ELSE 0 END)`,
+        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 30000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutions)
       .where(
@@ -236,15 +236,15 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS INTEGER)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS NUMERIC))::INTEGER, 0)`,
         // Count steps in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 50 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 100 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 250 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 500 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 50 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 100 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 250 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 500 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 1000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 2000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 5000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutionLogs)
       .where(


### PR DESCRIPTION
## Summary
- A manual SQL to cancel stuck executions stored duration as decimal strings, breaking analytics and metrics queries that used CAST(duration AS INTEGER)
- All duration casts changed from INTEGER to NUMERIC so decimal text values parse correctly
- Migration 0026 rounds existing decimal duration values back to integer strings

## Test plan
- [ ] Deploy to PR environment and verify /analytics page loads summary cards without 500
- [ ] Verify metrics endpoint still returns correct duration histograms
- [ ] Run migration 0026 and confirm decimal duration rows are rounded