### PR TITLE
feat: onboarding checklist and anonymous user UX

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,21 +98,31 @@ const Home = () => {
 
   // start custom keeperhub code //
   // Handler to add initial nodes and create the workflow.
-  // Creation is done here (not in a useEffect watching nodes) to avoid a race
-  // condition where stale nodes from a previously-open workflow would be picked
-  // up by the effect before the init effect's setNodes([placeholder]) is applied.
+  // If the user already has workflows, navigate to the most recent one instead
+  // of creating a new one. Anonymous users are limited to a single workflow.
   const handleAddNode = useCallback(async () => {
     if (hasCreatedWorkflowRef.current) {
       return;
     }
     hasCreatedWorkflowRef.current = true;
 
-    const { nodes: defaultNodes, edges: defaultEdges } = createDefaultNodes();
-    setNodes(defaultNodes);
-    setEdges(defaultEdges);
-
     try {
       await ensureSession();
+
+      const existing = await api.workflow.getAll();
+      if (existing.length > 0) {
+        const latest = existing.sort(
+          (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+        )[0];
+        setIsTransitioningFromHomepage(true);
+        router.replace(`/workflows/${latest.id}`);
+        return;
+      }
+
+      const { nodes: defaultNodes, edges: defaultEdges } = createDefaultNodes();
+      setNodes(defaultNodes);
+      setEdges(defaultEdges);
 
       const newWorkflow = await api.workflow.create({
         name: "Untitled Workflow",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,11 @@ import { nanoid } from "nanoid";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
+// start custom keeperhub code //
+import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
+// end keeperhub code //
 import {
   currentWorkflowIdAtom,
   currentWorkflowNameAtom,
@@ -118,6 +121,7 @@ const Home = () => {
         edges: defaultEdges,
       });
 
+      refetchSidebar();
       sessionStorage.setItem("animate-sidebar", "true");
       setIsTransitioningFromHomepage(true);
       router.replace(`/workflows/${newWorkflow.id}`);

--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { ChevronLeft, ChevronRight, LayoutTemplate, Plus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Globe, Plus } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
 import { NodeConfigPanel } from "@/components/workflow/node-config-panel";
 import { useIsMobile } from "@/hooks/use-mobile";
 // start custom keeperhub code //
-import { FeaturedOverlay } from "@/keeperhub/components/overlays/featured-overlay";
 import {
   getPendingClaim,
   useClaimWorkflow,
@@ -176,7 +174,6 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
   const setGlobalIntegrations = useSetAtom(integrationsAtom);
   const setIntegrationsLoaded = useSetAtom(integrationsLoadedAtom);
   const integrationsVersion = useAtomValue(integrationsVersionAtom);
-  const { open: openOverlay } = useOverlay();
   const { data: session } = useSession();
 
   // Helper to create anonymous session if needed
@@ -830,13 +827,11 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
               </Button>
               <Button
                 className="gap-2"
-                onClick={() =>
-                  openOverlay(FeaturedOverlay, {}, { size: "full" })
-                }
+                onClick={() => router.push("/hub")}
                 variant="outline"
               >
-                <LayoutTemplate className="size-4" />
-                Explore Workflows
+                <Globe className="size-4" />
+                Browse Templates
               </Button>
             </div>
           </div>

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -90,13 +90,20 @@ function CreateApiKeyOverlay({
 
   return (
     <Overlay
-      actions={[{ label: "Create", onClick: handleCreate, loading: creating }]}
+      actions={[
+        {
+          label: "Create",
+          onClick: handleCreate,
+          loading: creating,
+          disabled: !keyName.trim(),
+        },
+      ]}
       overlayId={overlayId}
       title="Create API Key"
     >
       <p className="mb-4 text-muted-foreground text-sm">{description}</p>
       <div className="space-y-2">
-        <Label htmlFor="key-name">Label (optional)</Label>
+        <Label htmlFor="key-name">Label</Label>
         <Input
           id="key-name"
           onChange={(e) => setKeyName(e.target.value)}

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -772,7 +772,7 @@ export function ActionConfig({
   const globalIntegrations = useAtomValue(integrationsAtom);
   const { push } = useOverlay();
 
-  // start keeperhub - anonymous check for email action restriction
+  // start keeperhub - anonymous check for action restrictions
   const [isAnonymous, setIsAnonymous] = useState(false);
   useEffect(() => {
     let cancelled = false;
@@ -958,7 +958,14 @@ export function ActionConfig({
       {/* start keeperhub - show Connection for plugin actions that require credentials or system actions that use an integration (e.g. Database Query) */}
       {integrationType &&
         isOwner &&
-        (requiresCredentials || SYSTEM_ACTION_INTEGRATIONS[actionType]) && (
+        (requiresCredentials || SYSTEM_ACTION_INTEGRATIONS[actionType]) &&
+        (isAnonymous && requiresCredentials ? (
+          <div className="rounded-lg border bg-muted/50 p-3">
+            <p className="text-muted-foreground text-sm">
+              Please sign in to add a connection.
+            </p>
+          </div>
+        ) : (
           <div className="space-y-2">
             <div className="ml-1 flex items-center justify-between">
               <div className="flex items-center gap-1">
@@ -996,7 +1003,7 @@ export function ActionConfig({
               value={(config?.integrationId as string) || ""}
             />
           </div>
-        )}
+        ))}
       {/* end keeperhub */}
 
       {/* System actions - hardcoded config fields */}
@@ -1008,21 +1015,9 @@ export function ActionConfig({
       />
 
       {/* Plugin actions - declarative config fields */}
-      {/* start custom keeperhub code // */}
       {pluginAction &&
         !SYSTEM_ACTION_IDS.includes(actionType) &&
-        isAnonymous &&
-        pluginAction.integration === "sendgrid" && (
-          <div className="rounded-lg border bg-muted/50 p-3">
-            <p className="text-muted-foreground text-sm">
-              Please sign in to configure email actions.
-            </p>
-          </div>
-        )}
-      {/* end keeperhub code // */}
-      {pluginAction &&
-        !SYSTEM_ACTION_IDS.includes(actionType) &&
-        !(isAnonymous && pluginAction.integration === "sendgrid") && (
+        !(isAnonymous && requiresCredentials) && (
           <ActionConfigRenderer
             config={config}
             disabled={disabled}

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -228,7 +228,7 @@ export function ActionGrid({
   );
   const [collapsedSuperCategories, setCollapsedSuperCategories] = useState<
     Set<SuperCategory>
-  >(() => new Set(SUPER_CATEGORY_ORDER));
+  >(() => new Set());
   const [hiddenGroups, setHiddenGroups] = useState<Set<string>>(
     getInitialHiddenGroups
   );

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -181,6 +181,41 @@ function getInitialViewMode(): ViewMode {
   }
 }
 
+// start custom keeperhub code //
+// Super-category definitions for the action panel
+const SUPER_CATEGORY_ORDER = ["Web3", "Messaging", "System"] as const;
+type SuperCategory = (typeof SUPER_CATEGORY_ORDER)[number];
+
+const MESSAGING_CATEGORIES: ReadonlySet<string> = new Set([
+  "Discord",
+  "Email",
+  "Slack",
+  "Telegram",
+]);
+const SYSTEM_CATEGORIES: ReadonlySet<string> = new Set([
+  "System",
+  "Code",
+  "Math",
+  "Webhook",
+]);
+
+function getSuperCategory(category: string): SuperCategory {
+  if (SYSTEM_CATEGORIES.has(category)) {
+    return "System";
+  }
+  if (MESSAGING_CATEGORIES.has(category)) {
+    return "Messaging";
+  }
+  return "Web3";
+}
+
+type PluginGroup = { category: string; actions: ActionType[] };
+type SuperCategoryGroup = {
+  superCategory: SuperCategory;
+  pluginGroups: PluginGroup[];
+};
+// end keeperhub code //
+
 export function ActionGrid({
   onSelectAction,
   disabled,
@@ -248,40 +283,56 @@ export function ActionGrid({
     );
   });
 
-  // Group actions by category
-  const groupedActions = useMemo(() => {
-    const groups: Record<string, ActionType[]> = {};
+  // start custom keeperhub code //
+  // Group actions by super-category, then by plugin category within each
+  const superCategoryGroups = useMemo((): SuperCategoryGroup[] => {
+    const categoryMap: Record<string, ActionType[]> = {};
 
     for (const action of filteredActions) {
-      const category = action.category;
-      if (!groups[category]) {
-        groups[category] = [];
+      if (!categoryMap[action.category]) {
+        categoryMap[action.category] = [];
       }
-      groups[category].push(action);
+      categoryMap[action.category].push(action);
     }
 
-    // start custom keeperhub code //
-    // Sort categories: Web3 first, System second, then alphabetically
-    const sortedCategories = Object.keys(groups).sort((a, b) => {
+    const superMap: Record<SuperCategory, PluginGroup[]> = {
+      Web3: [],
+      Messaging: [],
+      System: [],
+    };
+
+    const sortedCategories = Object.keys(categoryMap).sort((a, b) => {
       if (a === "Web3") return -1;
       if (b === "Web3") return 1;
-      if (a === "System") return -1;
-      if (b === "System") return 1;
       return a.localeCompare(b);
     });
-    // end keeperhub code //
 
-    return sortedCategories.map((category) => ({
-      category,
-      actions: groups[category],
-    }));
+    for (const category of sortedCategories) {
+      const sc = getSuperCategory(category);
+      superMap[sc].push({ category, actions: categoryMap[category] });
+    }
+
+    return SUPER_CATEGORY_ORDER.map((sc) => ({
+      superCategory: sc,
+      pluginGroups: superMap[sc],
+    })).filter((g) => g.pluginGroups.length > 0);
   }, [filteredActions]);
 
   // Filter groups based on hidden state
-  const visibleGroups = useMemo(() => {
-    if (showHidden) return groupedActions;
-    return groupedActions.filter((g) => !hiddenGroups.has(g.category));
-  }, [groupedActions, hiddenGroups, showHidden]);
+  const visibleSuperGroups = useMemo((): SuperCategoryGroup[] => {
+    if (showHidden) {
+      return superCategoryGroups;
+    }
+    return superCategoryGroups
+      .map((sg) => ({
+        ...sg,
+        pluginGroups: sg.pluginGroups.filter(
+          (pg) => !hiddenGroups.has(pg.category)
+        ),
+      }))
+      .filter((sg) => sg.pluginGroups.length > 0);
+  }, [superCategoryGroups, hiddenGroups, showHidden]);
+  // end keeperhub code //
 
   const hiddenCount = hiddenGroups.size;
 
@@ -358,14 +409,14 @@ export function ActionGrid({
             No actions found
           </p>
         )}
-        {filteredActions.length > 0 && visibleGroups.length === 0 && (
+        {filteredActions.length > 0 && visibleSuperGroups.length === 0 && (
           <p className="py-4 text-center text-muted-foreground text-sm">
             All groups are hidden
           </p>
         )}
 
         {/* Grid View */}
-        {viewMode === "grid" && visibleGroups.length > 0 && (
+        {viewMode === "grid" && visibleSuperGroups.length > 0 && (
           <div
             className="grid gap-2 p-1"
             style={{
@@ -397,90 +448,148 @@ export function ActionGrid({
           </div>
         )}
 
-        {/* List View */}
+        {/* start custom keeperhub code */}
+        {/* List View - Flat search results (no category headers) */}
         {viewMode === "list" &&
-          visibleGroups.length > 0 &&
-          visibleGroups.map((group, groupIndex) => {
-            const isCollapsed = collapsedGroups.has(group.category);
-            const isHidden = hiddenGroups.has(group.category);
-            return (
-              <div key={group.category}>
-                {groupIndex > 0 && <div className="my-2 h-px bg-border" />}
-                <div
-                  className={cn(
-                    "sticky top-0 z-10 mb-1 flex items-center gap-2 bg-background px-3 py-2 font-medium text-muted-foreground text-xs uppercase tracking-wider",
-                    isHidden && "opacity-50"
+          filter &&
+          filteredActions.length > 0 &&
+          filteredActions
+            .filter(
+              (action) => showHidden || !hiddenGroups.has(action.category)
+            )
+            .map((action) => (
+              <button
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-muted",
+                  disabled && "pointer-events-none opacity-50"
+                )}
+                data-testid={`action-option-${action.id.toLowerCase().replace(/\s+/g, "-")}`}
+                disabled={disabled}
+                key={action.id}
+                onClick={() => onSelectAction(action.id)}
+                type="button"
+              >
+                <ActionIcon action={action} className="size-4 shrink-0" />
+                <span className="min-w-0 flex-1 truncate">
+                  <span className="font-medium">{action.label}</span>
+                  {action.description && (
+                    <span className="text-muted-foreground text-xs">
+                      {" "}
+                      - {action.description}
+                    </span>
                   )}
-                >
-                  <button
-                    className="flex flex-1 items-center gap-2 text-left hover:text-foreground"
-                    onClick={() => toggleGroup(group.category)}
-                    type="button"
-                  >
-                    <ChevronRight
+                </span>
+              </button>
+            ))}
+
+        {/* List View - Grouped by super-category */}
+        {viewMode === "list" &&
+          !filter &&
+          visibleSuperGroups.length > 0 &&
+          visibleSuperGroups.map((sg, sgIndex) => (
+            <div key={sg.superCategory}>
+              {/* Super-category header */}
+              <div
+                className={cn(
+                  "flex items-center gap-2 px-3 pb-1.5",
+                  sgIndex === 0 ? "pt-1" : "pt-4"
+                )}
+              >
+                <span className="shrink-0 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/60">
+                  {sg.superCategory}
+                </span>
+                <div className="h-px flex-1 bg-border/40" />
+              </div>
+
+              {/* Plugin groups within super-category */}
+              {sg.pluginGroups.map((group, groupIndex) => {
+                const isCollapsed = collapsedGroups.has(group.category);
+                const isHidden = hiddenGroups.has(group.category);
+                return (
+                  <div key={group.category}>
+                    {groupIndex > 0 && (
+                      <div className="my-2 h-px bg-border" />
+                    )}
+                    <div
                       className={cn(
-                        "size-3.5 transition-transform",
-                        !isCollapsed && "rotate-90"
+                        "sticky top-0 z-10 mb-1 flex items-center gap-2 bg-background px-3 py-2 font-medium text-muted-foreground text-xs uppercase tracking-wider",
+                        isHidden && "opacity-50"
                       )}
-                    />
-                    <GroupIcon group={group} />
-                    {group.category}
-                  </button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
+                    >
                       <button
-                        className="rounded p-0.5 hover:bg-muted hover:text-foreground"
+                        className="flex flex-1 items-center gap-2 text-left hover:text-foreground"
+                        onClick={() => toggleGroup(group.category)}
                         type="button"
                       >
-                        <MoreHorizontal className="size-4" />
+                        <ChevronRight
+                          className={cn(
+                            "size-3.5 transition-transform",
+                            !isCollapsed && "rotate-90"
+                          )}
+                        />
+                        <GroupIcon group={group} />
+                        {group.category}
                       </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={() => toggleHideGroup(group.category)}
-                      >
-                        {isHidden ? (
-                          <>
-                            <Eye className="mr-2 size-4" />
-                            Show group
-                          </>
-                        ) : (
-                          <>
-                            <EyeOff className="mr-2 size-4" />
-                            Hide group
-                          </>
-                        )}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-                {!isCollapsed &&
-                  group.actions.map((action) => (
-                    <button
-                      className={cn(
-                        "flex w-full items-center rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-muted",
-                        disabled && "pointer-events-none opacity-50"
-                      )}
-                      data-testid={`action-option-${action.id.toLowerCase().replace(/\s+/g, "-")}`}
-                      disabled={disabled}
-                      key={action.id}
-                      onClick={() => onSelectAction(action.id)}
-                      type="button"
-                    >
-                      <span className="min-w-0 flex-1 truncate">
-                        <span className="font-medium">{action.label}</span>
-                        {action.description && (
-                          <span className="text-muted-foreground text-xs">
-                            {" "}
-                            - {action.description}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            className="rounded p-0.5 hover:bg-muted hover:text-foreground"
+                            type="button"
+                          >
+                            <MoreHorizontal className="size-4" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => toggleHideGroup(group.category)}
+                          >
+                            {isHidden ? (
+                              <>
+                                <Eye className="mr-2 size-4" />
+                                Show group
+                              </>
+                            ) : (
+                              <>
+                                <EyeOff className="mr-2 size-4" />
+                                Hide group
+                              </>
+                            )}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                    {!isCollapsed &&
+                      group.actions.map((action) => (
+                        <button
+                          className={cn(
+                            "flex w-full items-center rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-muted",
+                            disabled && "pointer-events-none opacity-50"
+                          )}
+                          data-testid={`action-option-${action.id.toLowerCase().replace(/\s+/g, "-")}`}
+                          disabled={disabled}
+                          key={action.id}
+                          onClick={() => onSelectAction(action.id)}
+                          type="button"
+                        >
+                          <span className="min-w-0 flex-1 truncate">
+                            <span className="font-medium">
+                              {action.label}
+                            </span>
+                            {action.description && (
+                              <span className="text-muted-foreground text-xs">
+                                {" "}
+                                - {action.description}
+                              </span>
+                            )}
                           </span>
-                        )}
-                      </span>
-                    </button>
-                  ))}
-              </div>
-            );
-          })}
+                        </button>
+                      ))}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        {/* end keeperhub code */}
       </div>
     </div>
   );

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -221,16 +221,16 @@ export function ActionGrid({
   disabled,
   isNewlyCreated,
 }: ActionGridProps) {
+  const actions = useAllActions();
   const [filter, setFilter] = useState("");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
-    new Set()
+    () => new Set(actions.map((a) => a.category))
   );
   const [hiddenGroups, setHiddenGroups] = useState<Set<string>>(
     getInitialHiddenGroups
   );
   const [showHidden, setShowHidden] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
-  const actions = useAllActions();
   const inputRef = useRef<HTMLInputElement>(null);
   const isTouch = useIsTouch();
 

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -252,6 +252,21 @@ export function ActionGrid({
     });
   };
 
+  const toggleSuperCategory = (groups: PluginGroup[]): void => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      const allCollapsed = groups.every((g) => next.has(g.category));
+      for (const g of groups) {
+        if (allCollapsed) {
+          next.delete(g.category);
+        } else {
+          next.add(g.category);
+        }
+      }
+      return next;
+    });
+  };
+
   const toggleHideGroup = (category: string) => {
     setHiddenGroups((prev) => {
       const next = new Set(prev);
@@ -489,17 +504,20 @@ export function ActionGrid({
           visibleSuperGroups.map((sg, sgIndex) => (
             <div key={sg.superCategory}>
               {/* Super-category header */}
-              <div
+              <button
                 className={cn(
-                  "flex items-center gap-2 px-3 pb-1.5",
+                  "flex w-full items-center gap-2 px-3 pb-1.5 transition-opacity hover:opacity-80",
                   sgIndex === 0 ? "pt-1" : "pt-4"
                 )}
+                onClick={() => toggleSuperCategory(sg.pluginGroups)}
+                type="button"
               >
-                <span className="shrink-0 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/60">
+                <div className="h-px flex-1 bg-border/40" />
+                <span className="shrink-0 text-[10px] font-medium uppercase tracking-widest text-emerald-500/80">
                   {sg.superCategory}
                 </span>
                 <div className="h-px flex-1 bg-border/40" />
-              </div>
+              </button>
 
               {/* Plugin groups within super-category */}
               {sg.pluginGroups.map((group, groupIndex) => {

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -226,6 +226,9 @@ export function ActionGrid({
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     () => new Set(actions.map((a) => a.category))
   );
+  const [collapsedSuperCategories, setCollapsedSuperCategories] = useState<
+    Set<SuperCategory>
+  >(() => new Set(SUPER_CATEGORY_ORDER));
   const [hiddenGroups, setHiddenGroups] = useState<Set<string>>(
     getInitialHiddenGroups
   );
@@ -252,16 +255,13 @@ export function ActionGrid({
     });
   };
 
-  const toggleSuperCategory = (groups: PluginGroup[]): void => {
-    setCollapsedGroups((prev) => {
+  const toggleSuperCategory = (sc: SuperCategory): void => {
+    setCollapsedSuperCategories((prev) => {
       const next = new Set(prev);
-      const allCollapsed = groups.every((g) => next.has(g.category));
-      for (const g of groups) {
-        if (allCollapsed) {
-          next.delete(g.category);
-        } else {
-          next.add(g.category);
-        }
+      if (next.has(sc)) {
+        next.delete(sc);
+      } else {
+        next.add(sc);
       }
       return next;
     });
@@ -509,7 +509,7 @@ export function ActionGrid({
                   "flex w-full items-center gap-2 px-3 pb-1.5 transition-opacity hover:opacity-80",
                   sgIndex === 0 ? "pt-1" : "pt-4"
                 )}
-                onClick={() => toggleSuperCategory(sg.pluginGroups)}
+                onClick={() => toggleSuperCategory(sg.superCategory)}
                 type="button"
               >
                 <div className="h-px flex-1 bg-border/40" />
@@ -520,7 +520,8 @@ export function ActionGrid({
               </button>
 
               {/* Plugin groups within super-category */}
-              {sg.pluginGroups.map((group, groupIndex) => {
+              {!collapsedSuperCategories.has(sg.superCategory) &&
+              sg.pluginGroups.map((group, groupIndex) => {
                 const isCollapsed = collapsedGroups.has(group.category);
                 const isHidden = hiddenGroups.has(group.category);
                 return (

--- a/components/workflow/nodes/add-node.tsx
+++ b/components/workflow/nodes/add-node.tsx
@@ -22,10 +22,9 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
 
   return (
     <div className="flex flex-col items-center justify-center gap-8 rounded-lg border border-border border-dashed bg-background/50 p-8 backdrop-blur-sm">
-      <div className="text-center">
-        <h1 className="mb-2 flex items-center justify-center gap-2 font-bold text-3xl">
-          {CustomLogo && <CustomLogo className="size-10" />} {appName}
-        </h1>
+      <div className="flex flex-col items-center text-center">
+        {CustomLogo && <CustomLogo className="mb-2 size-10" />}
+        <h1 className="mb-1 font-bold text-3xl">{appName}</h1>
         <p className="text-muted-foreground">Automate anything onchain</p>
       </div>
       {/* start custom keeperhub code */}

--- a/components/workflow/nodes/add-node.tsx
+++ b/components/workflow/nodes/add-node.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import type { NodeProps } from "@xyflow/react";
-import { LayoutTemplate, Plus } from "lucide-react";
 // start custom keeperhub code //
-import { useOverlay } from "@/components/overlays/overlay-provider";
+import { Globe, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { FeaturedOverlay } from "@/keeperhub/components/overlays/featured-overlay";
+import { GettingStartedChecklist } from "@/keeperhub/components/onboarding/getting-started-checklist";
 // end keeperhub code //
 import { getAppName, getCustomLogo } from "@/lib/extension-registry";
 
@@ -17,11 +17,7 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
   const CustomLogo = getCustomLogo();
   const appName = getAppName();
   // start custom keeperhub code //
-  const { open } = useOverlay();
-
-  const handleOpenFeatured = () => {
-    open(FeaturedOverlay, {}, { size: "full" });
-  };
+  const router = useRouter();
   // end keeperhub code //
 
   return (
@@ -30,38 +26,10 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
         <h1 className="mb-2 flex items-center justify-center gap-2 font-bold text-3xl">
           {CustomLogo && <CustomLogo className="size-10" />} {appName}
         </h1>
-        <p className="text-muted-foreground">
-          Automate anything onchain
-          {/* ,{" "}
-          <a
-            className="underline underline-offset-2 transition duration-200 ease-out hover:text-foreground"
-            href="https://ai-sdk.dev/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            AI SDK
-          </a>
-          ,{" "}
-          <a
-            className="underline underline-offset-2 transition duration-200 ease-out hover:text-foreground"
-            href="https://vercel.com/ai-gateway"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            AI Gateway
-          </a>{" "}
-          and{" "}
-          <a
-            className="underline underline-offset-2 transition duration-200 ease-out hover:text-foreground"
-            href="https://ai-sdk.dev/elements"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            AI Elements
-          </a> */}
-        </p>
+        <p className="text-muted-foreground">Automate anything onchain</p>
       </div>
       {/* start custom keeperhub code */}
+      <GettingStartedChecklist onCreateWorkflow={data.onClick} />
       <div className="flex gap-3">
         <Button
           className="gap-2 shadow-lg"
@@ -73,12 +41,12 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
         </Button>
         <Button
           className="gap-2 shadow-lg"
-          onClick={handleOpenFeatured}
+          onClick={() => router.push("/hub")}
           size="default"
           variant="outline"
         >
-          <LayoutTemplate className="size-4" />
-          Explore Workflows
+          <Globe className="size-4" />
+          Browse Templates
         </Button>
       </div>
       {/* end keeperhub code */}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1408,15 +1408,32 @@ function SaveButton({
   state: ReturnType<typeof useWorkflowState>;
   handleSave: () => Promise<void>;
 }) {
-  return (
+  // start custom keeperhub code //
+  const isAnonymous =
+    !state.session?.user ||
+    state.session.user.name === "Anonymous" ||
+    state.session.user.email?.startsWith("temp-");
+
+  const disabled =
+    isAnonymous ||
+    !state.currentWorkflowId ||
+    state.isGenerating ||
+    state.isSaving;
+  // end keeperhub code //
+
+  const button = (
     <Button
       className="relative border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-      disabled={
-        !state.currentWorkflowId || state.isGenerating || state.isSaving
-      }
+      disabled={disabled}
       onClick={handleSave}
       size="icon"
-      title={state.isSaving ? "Saving..." : "Save workflow"}
+      title={
+        isAnonymous
+          ? "Sign in to save workflows"
+          : state.isSaving
+            ? "Saving..."
+            : "Save workflow"
+      }
       variant="secondary"
     >
       {state.isSaving ? (
@@ -1424,11 +1441,26 @@ function SaveButton({
       ) : (
         <Save className="size-4" />
       )}
-      {state.hasUnsavedChanges && !state.isSaving && (
+      {state.hasUnsavedChanges && !state.isSaving && !isAnonymous && (
         <div className="absolute top-1.5 right-1.5 size-2 rounded-full bg-primary" />
       )}
     </Button>
   );
+
+  // start custom keeperhub code //
+  if (isAnonymous) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-block">{button}</span>
+        </TooltipTrigger>
+        <TooltipContent>Sign in to save workflows</TooltipContent>
+      </Tooltip>
+    );
+  }
+  // end keeperhub code //
+
+  return button;
 }
 
 // Download Button Component

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1360,16 +1360,16 @@ function ToolbarActions({
       </ButtonGroup>
 
       {/* Save/Download - Mobile Vertical */}
-      <ButtonGroup className="flex lg:hidden" orientation="vertical">
+      <div className="flex flex-col gap-1 lg:hidden">
         <SaveButton handleSave={actions.handleSave} state={state} />
         <DownloadButton actions={actions} state={state} />
-      </ButtonGroup>
+      </div>
 
       {/* Save/Download - Desktop Horizontal */}
-      <ButtonGroup className="hidden lg:flex" orientation="horizontal">
+      <div className="hidden gap-1 lg:flex">
         <SaveButton handleSave={actions.handleSave} state={state} />
         <DownloadButton actions={actions} state={state} />
-      </ButtonGroup>
+      </div>
 
       {/* Visibility Toggle */}
       <VisibilityButton actions={actions} state={state} />

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -37,6 +37,7 @@ import { GoLiveOverlay } from "@/keeperhub/components/overlays/go-live-overlay";
 import { Switch } from "@/keeperhub/components/ui/switch";
 // start custom keeperhub code //
 import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
+import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { api, type Project, type Tag } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import { getCustomLogo } from "@/lib/extension-registry";
@@ -1073,12 +1074,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
     }
 
     // When enabling, check if user is logged in (not anonymous)
-    const isAnonymous =
-      !session?.user ||
-      session.user.name === "Anonymous" ||
-      session.user.email?.startsWith("temp-");
-
-    if (isAnonymous) {
+    if (isAnonymousUser(session?.user)) {
       toast.error("Please sign in to activate your workflow");
       return;
     }
@@ -1409,11 +1405,7 @@ function SaveButton({
   handleSave: () => Promise<void>;
 }) {
   // start custom keeperhub code //
-  const isAnonymous =
-    !state.session?.user ||
-    state.session.user.name === "Anonymous" ||
-    state.session.user.email?.startsWith("temp-");
-
+  const isAnonymous = isAnonymousUser(state.session?.user);
   const disabled =
     isAnonymous ||
     !state.currentWorkflowId ||

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { registerSidebarRefetch } from "@/keeperhub/lib/refetch-sidebar";
 import type { Project, SavedWorkflow, Tag } from "@/lib/api-client";
 import { api } from "@/lib/api-client";
@@ -350,16 +351,6 @@ const NAV_ITEMS = [
   },
 ];
 
-function checkIsAnonymous(
-  session: ReturnType<typeof useSession>["data"]
-): boolean {
-  return (
-    !session?.user ||
-    session.user.name === "Anonymous" ||
-    Boolean(session.user.email?.startsWith("temp-"))
-  );
-}
-
 export function NavigationSidebar(): React.ReactNode {
   const isMobile = useIsMobile();
   const { data: session } = useSession();
@@ -420,7 +411,7 @@ export function NavigationSidebar(): React.ReactNode {
     }
   }, [dataLoading, navState.validateSelections, projects, tags]);
 
-  const isAnonymous = checkIsAnonymous(session);
+  const isAnonymous = isAnonymousUser(session?.user);
 
   const visibleWorkflows = workflows.filter((w) => w.name !== "__current__");
 

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -124,6 +124,7 @@ function ProjectsPanel({
   selectedProjectId,
   onSelectProject,
   loading,
+  isAnonymous,
 }: {
   projects: Project[];
   ungrouped: WorkflowEntry[];
@@ -132,6 +133,7 @@ function ProjectsPanel({
   selectedProjectId: string | null;
   onSelectProject: (id: string) => void;
   loading: boolean;
+  isAnonymous: boolean;
 }): React.ReactNode {
   if (loading) {
     return (
@@ -146,7 +148,7 @@ function ProjectsPanel({
   if (!hasAny) {
     return (
       <p className="py-4 text-center text-muted-foreground text-sm">
-        No workflows found
+        {isAnonymous ? "Sign in to save workflows" : "No workflows found"}
       </p>
     );
   }
@@ -348,6 +350,16 @@ const NAV_ITEMS = [
   },
 ];
 
+function checkIsAnonymous(
+  session: ReturnType<typeof useSession>["data"]
+): boolean {
+  return (
+    !session?.user ||
+    session.user.name === "Anonymous" ||
+    Boolean(session.user.email?.startsWith("temp-"))
+  );
+}
+
 export function NavigationSidebar(): React.ReactNode {
   const isMobile = useIsMobile();
   const { data: session } = useSession();
@@ -367,9 +379,9 @@ export function NavigationSidebar(): React.ReactNode {
   const fetchData = useCallback(async (): Promise<void> => {
     try {
       const [w, p, t] = await Promise.all([
-        api.workflow.getAll(),
-        api.project.getAll(),
-        api.tag.getAll(),
+        api.workflow.getAll().catch(() => [] as SavedWorkflow[]),
+        api.project.getAll().catch(() => [] as Project[]),
+        api.tag.getAll().catch(() => [] as Tag[]),
       ]);
       setWorkflows(w);
       setProjects(p);
@@ -407,6 +419,8 @@ export function NavigationSidebar(): React.ReactNode {
       );
     }
   }, [dataLoading, navState.validateSelections, projects, tags]);
+
+  const isAnonymous = checkIsAnonymous(session);
 
   const visibleWorkflows = workflows.filter((w) => w.name !== "__current__");
 
@@ -718,6 +732,7 @@ export function NavigationSidebar(): React.ReactNode {
         <ProjectsPanel
           activeWorkflowId={workflowId}
           byProject={byProject}
+          isAnonymous={isAnonymous}
           loading={dataLoading}
           onSelectProject={handleSelectProject}
           projects={projects}

--- a/keeperhub/components/onboarding/getting-started-checklist.tsx
+++ b/keeperhub/components/onboarding/getting-started-checklist.tsx
@@ -49,6 +49,52 @@ function ProgressBar({
   );
 }
 
+type StepRowProps = {
+  config: StepConfig;
+  isComplete: boolean;
+  onAction: () => void;
+};
+
+function StepRow({
+  config,
+  isComplete,
+  onAction,
+}: StepRowProps): React.ReactElement {
+  const Icon = config.icon;
+
+  const handleClick = (e: React.MouseEvent): void => {
+    if ((e.target as Element).closest("[data-checklist-tooltip]")) {
+      return;
+    }
+    onAction();
+  };
+
+  return (
+    <button
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden transition-colors select-none hover:bg-accent hover:text-accent-foreground",
+        isComplete && "opacity-50"
+      )}
+      onClick={handleClick}
+      type="button"
+    >
+      <Icon
+        className={cn(
+          "size-4 shrink-0",
+          isComplete ? "text-emerald-500" : "text-muted-foreground"
+        )}
+      />
+      <span className={cn(isComplete && "line-through")}>{config.title}</span>
+      {config.extra ? (
+        <span data-checklist-tooltip="">{config.extra}</span>
+      ) : null}
+      {isComplete && (
+        <Check className="ml-auto size-3.5 shrink-0 text-emerald-500" />
+      )}
+    </button>
+  );
+}
+
 function SkeletonRows(): React.ReactElement {
   return (
     <div className="space-y-0.5 p-1">
@@ -198,38 +244,18 @@ export function GettingStartedChecklist({
               {stepConfigs.map((config) => {
                 const step = steps.find((s) => s.id === config.id);
                 const isComplete = step?.complete ?? false;
-                const Icon = config.icon;
-                const handleClick =
+                const action =
                   isAnonymous && config.requiresAuth
                     ? promptSignIn
                     : config.action;
 
                 return (
-                  <button
-                    className={cn(
-                      "relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden transition-colors select-none hover:bg-accent hover:text-accent-foreground",
-                      isComplete && "opacity-50"
-                    )}
+                  <StepRow
+                    config={config}
+                    isComplete={isComplete}
                     key={config.id}
-                    onClick={handleClick}
-                    type="button"
-                  >
-                    <Icon
-                      className={cn(
-                        "size-4 shrink-0",
-                        isComplete
-                          ? "text-emerald-500"
-                          : "text-muted-foreground"
-                      )}
-                    />
-                    <span className={cn(isComplete && "line-through")}>
-                      {config.title}
-                    </span>
-                    {config.extra}
-                    {isComplete && (
-                      <Check className="ml-auto size-3.5 shrink-0 text-emerald-500" />
-                    )}
-                  </button>
+                    onAction={action}
+                  />
                 );
               })}
             </div>

--- a/keeperhub/components/onboarding/getting-started-checklist.tsx
+++ b/keeperhub/components/onboarding/getting-started-checklist.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Coins, Info, KeyRound, Wallet, Workflow } from "lucide-react";
+import { Check, Info, KeyRound, Wallet, Workflow } from "lucide-react";
 import { useRef } from "react";
 import { AuthDialog } from "@/components/auth/dialog";
 import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { WalletOverlay } from "@/keeperhub/components/overlays/wallet-overlay";
 import { useOnboardingStatus } from "@/keeperhub/lib/hooks/use-onboarding-status";
+import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
@@ -51,7 +52,7 @@ function ProgressBar({
 function SkeletonRows(): React.ReactElement {
   return (
     <div className="space-y-0.5 p-1">
-      {Array.from({ length: 4 }, (_, i) => (
+      {Array.from({ length: 3 }, (_, i) => (
         <div
           className="flex items-center gap-2 rounded-sm px-2 py-1.5"
           key={`skeleton-${String(i)}`}
@@ -61,23 +62,6 @@ function SkeletonRows(): React.ReactElement {
         </div>
       ))}
     </div>
-  );
-}
-
-function isAnonymousSession(
-  user: {
-    name?: string | null;
-    email?: string | null;
-  } | null
-): boolean {
-  if (!user) {
-    return true;
-  }
-  return (
-    user.name === "Anonymous" ||
-    Boolean(user.email?.includes("@http://")) ||
-    Boolean(user.email?.includes("@https://")) ||
-    Boolean(user.email?.startsWith("temp-"))
   );
 }
 
@@ -98,7 +82,7 @@ export function GettingStartedChecklist({
   const { data: session } = useSession();
   const authTriggerRef = useRef<HTMLButtonElement>(null);
 
-  const isAnonymous = isAnonymousSession(session?.user ?? null);
+  const isAnonymous = isAnonymousUser(session?.user);
 
   if (allComplete) {
     return null;
@@ -156,7 +140,7 @@ export function GettingStartedChecklist({
               <Info className="size-3.5 text-muted-foreground" />
             </TooltipTrigger>
             <TooltipContent className="max-w-64 text-xs" side="top">
-              Powered by{" "}
+              Non-custodial wallet powered by{" "}
               <a
                 className="underline"
                 href="https://www.getpara.com/"
@@ -165,26 +149,7 @@ export function GettingStartedChecklist({
               >
                 Para
               </a>
-              , enterprise-grade MPC wallet infrastructure
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ),
-      action: () => openOverlay(WalletOverlay, undefined, { onClose: refetch }),
-    },
-    {
-      id: "fund-wallet",
-      icon: Coins,
-      title: "Fund Wallet",
-      requiresAuth: true,
-      extra: (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="size-3.5 text-muted-foreground" />
-            </TooltipTrigger>
-            <TooltipContent className="text-xs" side="top">
-              Your wallet works across multiple networks
+              . Works across multiple networks.
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/keeperhub/components/onboarding/getting-started-checklist.tsx
+++ b/keeperhub/components/onboarding/getting-started-checklist.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import {
-  Check,
-  ChevronDown,
-  Coins,
-  Info,
-  KeyRound,
-  Wallet,
-  Workflow,
-} from "lucide-react";
+import { Check, Coins, Info, KeyRound, Wallet, Workflow } from "lucide-react";
 import { useRef } from "react";
 import { AuthDialog } from "@/components/auth/dialog";
 import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
@@ -196,12 +188,15 @@ export function GettingStartedChecklist({
     <div className="w-full min-w-[14rem] max-w-[16rem]">
       {hidden ? (
         <button
-          className="flex w-full items-center rounded-md border bg-popover px-2 py-1.5 text-sm font-medium shadow-md transition-colors hover:bg-accent"
+          className="flex w-full items-center gap-2 px-3 py-1.5 transition-opacity hover:opacity-80"
           onClick={show}
           type="button"
         >
-          <span>Setup Guide</span>
-          <ChevronDown className="ml-auto size-4 text-muted-foreground" />
+          <div className="h-px flex-1 bg-border/40" />
+          <span className="shrink-0 text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+            Setup Guide
+          </span>
+          <div className="h-px flex-1 bg-border/40" />
         </button>
       ) : (
         <div className="rounded-md border bg-popover p-1 shadow-md">

--- a/keeperhub/components/onboarding/getting-started-checklist.tsx
+++ b/keeperhub/components/onboarding/getting-started-checklist.tsx
@@ -84,8 +84,16 @@ function isAnonymousSession(
 export function GettingStartedChecklist({
   onCreateWorkflow,
 }: GettingStartedChecklistProps): React.ReactElement | null {
-  const { steps, isLoading, allComplete, completedCount, hidden, hide, show } =
-    useOnboardingStatus();
+  const {
+    steps,
+    isLoading,
+    allComplete,
+    completedCount,
+    hidden,
+    hide,
+    show,
+    refetch,
+  } = useOnboardingStatus();
   const { open: openOverlay } = useOverlay();
   const { data: session } = useSession();
   const authTriggerRef = useRef<HTMLButtonElement>(null);
@@ -133,7 +141,8 @@ export function GettingStartedChecklist({
           </Tooltip>
         </TooltipProvider>
       ),
-      action: () => openOverlay(ApiKeysOverlay),
+      action: () =>
+        openOverlay(ApiKeysOverlay, undefined, { onClose: refetch }),
     },
     {
       id: "create-wallet",
@@ -161,7 +170,7 @@ export function GettingStartedChecklist({
           </Tooltip>
         </TooltipProvider>
       ),
-      action: () => openOverlay(WalletOverlay),
+      action: () => openOverlay(WalletOverlay, undefined, { onClose: refetch }),
     },
     {
       id: "fund-wallet",
@@ -180,7 +189,7 @@ export function GettingStartedChecklist({
           </Tooltip>
         </TooltipProvider>
       ),
-      action: () => openOverlay(WalletOverlay),
+      action: () => openOverlay(WalletOverlay, undefined, { onClose: refetch }),
     },
   ];
 
@@ -272,6 +281,18 @@ export function GettingStartedChecklist({
           </div>
         </div>
       )}
+
+      <p className="mt-1.5 text-center text-base tracking-wide text-muted-foreground/40">
+        Read{" "}
+        <a
+          className="underline decoration-muted-foreground/20 underline-offset-2 transition-colors hover:text-muted-foreground hover:decoration-muted-foreground/40"
+          href="https://docs.keeperhub.com/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          docs
+        </a>
+      </p>
     </div>
   );
 }

--- a/keeperhub/components/onboarding/getting-started-checklist.tsx
+++ b/keeperhub/components/onboarding/getting-started-checklist.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import {
+  Check,
+  ChevronDown,
+  Coins,
+  Info,
+  KeyRound,
+  Wallet,
+  Workflow,
+} from "lucide-react";
+import { useRef } from "react";
+import { AuthDialog } from "@/components/auth/dialog";
+import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
+import { useOverlay } from "@/components/overlays/overlay-provider";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { WalletOverlay } from "@/keeperhub/components/overlays/wallet-overlay";
+import { useOnboardingStatus } from "@/keeperhub/lib/hooks/use-onboarding-status";
+import { useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+
+type StepConfig = {
+  id: string;
+  icon: typeof Workflow;
+  title: string;
+  extra?: React.ReactNode;
+  requiresAuth: boolean;
+  action: () => void;
+};
+
+type GettingStartedChecklistProps = {
+  onCreateWorkflow?: () => void;
+};
+
+function ProgressBar({
+  completed,
+  total,
+}: {
+  completed: number;
+  total: number;
+}): React.ReactElement {
+  const percentage = total > 0 ? (completed / total) * 100 : 0;
+
+  return (
+    <div className="h-1 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+        style={{ width: `${Math.max(8, percentage)}%` }}
+      />
+    </div>
+  );
+}
+
+function SkeletonRows(): React.ReactElement {
+  return (
+    <div className="space-y-0.5 p-1">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div
+          className="flex items-center gap-2 rounded-sm px-2 py-1.5"
+          key={`skeleton-${String(i)}`}
+        >
+          <div className="size-4 animate-pulse rounded bg-muted" />
+          <div className="h-3.5 w-28 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function isAnonymousSession(
+  user: {
+    name?: string | null;
+    email?: string | null;
+  } | null
+): boolean {
+  if (!user) {
+    return true;
+  }
+  return (
+    user.name === "Anonymous" ||
+    Boolean(user.email?.includes("@http://")) ||
+    Boolean(user.email?.includes("@https://")) ||
+    Boolean(user.email?.startsWith("temp-"))
+  );
+}
+
+export function GettingStartedChecklist({
+  onCreateWorkflow,
+}: GettingStartedChecklistProps): React.ReactElement | null {
+  const { steps, isLoading, allComplete, completedCount, hidden, hide, show } =
+    useOnboardingStatus();
+  const { open: openOverlay } = useOverlay();
+  const { data: session } = useSession();
+  const authTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const isAnonymous = isAnonymousSession(session?.user ?? null);
+
+  if (allComplete) {
+    return null;
+  }
+
+  const promptSignIn = (): void => {
+    authTriggerRef.current?.click();
+  };
+
+  const stepConfigs: StepConfig[] = [
+    {
+      id: "create-workflow",
+      icon: Workflow,
+      title: "Create a Workflow",
+      requiresAuth: false,
+      action: () => onCreateWorkflow?.(),
+    },
+    {
+      id: "generate-api-key",
+      icon: KeyRound,
+      title: "Generate API Key",
+      requiresAuth: true,
+      extra: (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="size-3.5 text-muted-foreground" />
+            </TooltipTrigger>
+            <TooltipContent className="text-xs" side="top">
+              See{" "}
+              <a
+                className="underline"
+                href="https://docs.keeperhub.com/ai-tools/mcp-server"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                MCP docs
+              </a>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ),
+      action: () => openOverlay(ApiKeysOverlay),
+    },
+    {
+      id: "create-wallet",
+      icon: Wallet,
+      title: "Create Wallet",
+      requiresAuth: true,
+      extra: (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="size-3.5 text-muted-foreground" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-64 text-xs" side="top">
+              Powered by{" "}
+              <a
+                className="underline"
+                href="https://www.getpara.com/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Para
+              </a>
+              , enterprise-grade MPC wallet infrastructure
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ),
+      action: () => openOverlay(WalletOverlay),
+    },
+    {
+      id: "fund-wallet",
+      icon: Coins,
+      title: "Fund Wallet",
+      requiresAuth: true,
+      extra: (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="size-3.5 text-muted-foreground" />
+            </TooltipTrigger>
+            <TooltipContent className="text-xs" side="top">
+              Your wallet works across multiple networks
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ),
+      action: () => openOverlay(WalletOverlay),
+    },
+  ];
+
+  return (
+    <div className="w-full min-w-[14rem] max-w-[16rem]">
+      {hidden ? (
+        <button
+          className="flex w-full items-center rounded-md border bg-popover px-2 py-1.5 text-sm font-medium shadow-md transition-colors hover:bg-accent"
+          onClick={show}
+          type="button"
+        >
+          <span>Setup Guide</span>
+          <ChevronDown className="ml-auto size-4 text-muted-foreground" />
+        </button>
+      ) : (
+        <div className="rounded-md border bg-popover p-1 shadow-md">
+          <AuthDialog>
+            <button className="hidden" ref={authTriggerRef} type="button" />
+          </AuthDialog>
+
+          <div className="flex items-center justify-between px-2 py-1.5">
+            <span className="font-medium text-sm">Setup Guide</span>
+            <button
+              className="text-muted-foreground text-xs transition-colors hover:text-foreground"
+              onClick={hide}
+              type="button"
+            >
+              Hide
+            </button>
+          </div>
+
+          <div className="-mx-1 my-1 h-px bg-border" />
+
+          {isLoading ? (
+            <SkeletonRows />
+          ) : (
+            <div>
+              {stepConfigs.map((config) => {
+                const step = steps.find((s) => s.id === config.id);
+                const isComplete = step?.complete ?? false;
+                const Icon = config.icon;
+                const handleClick =
+                  isAnonymous && config.requiresAuth
+                    ? promptSignIn
+                    : config.action;
+
+                return (
+                  <button
+                    className={cn(
+                      "relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden transition-colors select-none hover:bg-accent hover:text-accent-foreground",
+                      isComplete && "opacity-50"
+                    )}
+                    key={config.id}
+                    onClick={handleClick}
+                    type="button"
+                  >
+                    <Icon
+                      className={cn(
+                        "size-4 shrink-0",
+                        isComplete
+                          ? "text-emerald-500"
+                          : "text-muted-foreground"
+                      )}
+                    />
+                    <span className={cn(isComplete && "line-through")}>
+                      {config.title}
+                    </span>
+                    {config.extra}
+                    {isComplete && (
+                      <Check className="ml-auto size-3.5 shrink-0 text-emerald-500" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="-mx-1 my-1 h-px bg-border" />
+
+          <div className="px-2 py-1.5">
+            {isLoading ? (
+              <div className="h-1 w-full animate-pulse rounded-full bg-muted" />
+            ) : (
+              <ProgressBar completed={completedCount} total={steps.length} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/keeperhub/lib/hooks/use-onboarding-status.ts
+++ b/keeperhub/lib/hooks/use-onboarding-status.ts
@@ -26,6 +26,7 @@ type OnboardingStatus = {
   isLoading: boolean;
   allComplete: boolean;
   completedCount: number;
+  refetch: () => void;
   hidden: boolean;
   hide: () => void;
   show: () => void;
@@ -71,6 +72,11 @@ export function useOnboardingStatus(): OnboardingStatus {
   ]);
   const [isLoading, setIsLoading] = useState(true);
   const [hidden, setHidden] = useState(isDismissed);
+  const [refetchKey, setRefetchKey] = useState(0);
+
+  const refetch = useCallback(() => {
+    setRefetchKey((k) => k + 1);
+  }, []);
 
   const isAuthenticated = Boolean(session?.user);
 
@@ -92,6 +98,7 @@ export function useOnboardingStatus(): OnboardingStatus {
     }
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refetchKey intentionally triggers re-fetch
   useEffect(() => {
     if (!isAuthenticated) {
       setIsLoading(false);
@@ -150,7 +157,7 @@ export function useOnboardingStatus(): OnboardingStatus {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated]);
+  }, [isAuthenticated, refetchKey]);
 
   const completedCount = steps.filter((s) => s.complete).length;
   const allComplete = completedCount === steps.length;
@@ -163,5 +170,6 @@ export function useOnboardingStatus(): OnboardingStatus {
     hidden,
     hide,
     show,
+    refetch,
   };
 }

--- a/keeperhub/lib/hooks/use-onboarding-status.ts
+++ b/keeperhub/lib/hooks/use-onboarding-status.ts
@@ -40,35 +40,12 @@ function isFulfilledArray(result: PromiseSettledResult<unknown>): boolean {
   );
 }
 
-type ChainBalanceData = {
-  nativeBalance?: string;
-  tokens?: { balance?: string }[];
-};
-
-function chainHasFunds(chain: ChainBalanceData): boolean {
-  if (chain.nativeBalance && chain.nativeBalance !== "0") {
-    return true;
-  }
-  if (!Array.isArray(chain.tokens)) {
-    return false;
-  }
-  return chain.tokens.some((t) => t.balance && t.balance !== "0");
-}
-
-function hasNonZeroBalance(result: PromiseSettledResult<unknown>): boolean {
-  if (result.status !== "fulfilled" || !Array.isArray(result.value)) {
-    return false;
-  }
-  return (result.value as ChainBalanceData[]).some(chainHasFunds);
-}
-
 export function useOnboardingStatus(): OnboardingStatus {
   const { data: session } = useSession();
   const [steps, setSteps] = useState<OnboardingStep[]>([
     { id: "create-workflow", complete: false },
     { id: "generate-api-key", complete: false },
     { id: "create-wallet", complete: false },
-    { id: "fund-wallet", complete: false },
   ]);
   const [isLoading, setIsLoading] = useState(true);
   const [hidden, setHidden] = useState(isDismissed);
@@ -127,27 +104,10 @@ export function useOnboardingStatus(): OnboardingStatus {
         (walletResult.value as { hasWallet?: boolean } | null)?.hasWallet ===
           true;
 
-      // Only check balances if wallet exists
-      let hasFunds = false;
-      if (hasWallet) {
-        const balancesResult = await fetch("/api/user/wallet/balances")
-          .then((r) => r.json())
-          .catch(() => []);
-        hasFunds = hasNonZeroBalance({
-          status: "fulfilled",
-          value: balancesResult,
-        });
-      }
-
-      if (cancelled) {
-        return;
-      }
-
       setSteps([
         { id: "create-workflow", complete: isFulfilledArray(workflowsResult) },
         { id: "generate-api-key", complete: isFulfilledArray(keysResult) },
         { id: "create-wallet", complete: hasWallet },
-        { id: "fund-wallet", complete: hasFunds },
       ]);
       setIsLoading(false);
     }

--- a/keeperhub/lib/hooks/use-onboarding-status.ts
+++ b/keeperhub/lib/hooks/use-onboarding-status.ts
@@ -5,6 +5,17 @@ import { useSession } from "@/lib/auth-client";
 
 const DISMISSED_KEY = "keeperhub-onboarding-dismissed";
 
+function isDismissed(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return localStorage.getItem(DISMISSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 export type OnboardingStep = {
   id: string;
   complete: boolean;
@@ -19,17 +30,6 @@ type OnboardingStatus = {
   hide: () => void;
   show: () => void;
 };
-
-function isDismissed(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  try {
-    return localStorage.getItem(DISMISSED_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
 
 function isFulfilledArray(result: PromiseSettledResult<unknown>): boolean {
   return (
@@ -93,11 +93,6 @@ export function useOnboardingStatus(): OnboardingStatus {
   }, []);
 
   useEffect(() => {
-    if (hidden) {
-      setIsLoading(false);
-      return;
-    }
-
     if (!isAuthenticated) {
       setIsLoading(false);
       return;
@@ -141,7 +136,7 @@ export function useOnboardingStatus(): OnboardingStatus {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, hidden]);
+  }, [isAuthenticated]);
 
   const completedCount = steps.filter((s) => s.complete).length;
   const allComplete = completedCount === steps.length;

--- a/keeperhub/lib/hooks/use-onboarding-status.ts
+++ b/keeperhub/lib/hooks/use-onboarding-status.ts
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "@/lib/auth-client";
+
+const DISMISSED_KEY = "keeperhub-onboarding-dismissed";
+
+export type OnboardingStep = {
+  id: string;
+  complete: boolean;
+};
+
+type OnboardingStatus = {
+  steps: OnboardingStep[];
+  isLoading: boolean;
+  allComplete: boolean;
+  completedCount: number;
+  hidden: boolean;
+  hide: () => void;
+  show: () => void;
+};
+
+function isDismissed(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return localStorage.getItem(DISMISSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function isFulfilledArray(result: PromiseSettledResult<unknown>): boolean {
+  return (
+    result.status === "fulfilled" &&
+    Array.isArray(result.value) &&
+    (result.value as unknown[]).length > 0
+  );
+}
+
+type ChainBalanceData = {
+  nativeBalance?: string;
+  tokens?: { balance?: string }[];
+};
+
+function chainHasFunds(chain: ChainBalanceData): boolean {
+  if (chain.nativeBalance && chain.nativeBalance !== "0") {
+    return true;
+  }
+  if (!Array.isArray(chain.tokens)) {
+    return false;
+  }
+  return chain.tokens.some((t) => t.balance && t.balance !== "0");
+}
+
+function hasNonZeroBalance(result: PromiseSettledResult<unknown>): boolean {
+  if (result.status !== "fulfilled" || !Array.isArray(result.value)) {
+    return false;
+  }
+  return (result.value as ChainBalanceData[]).some(chainHasFunds);
+}
+
+export function useOnboardingStatus(): OnboardingStatus {
+  const { data: session } = useSession();
+  const [steps, setSteps] = useState<OnboardingStep[]>([
+    { id: "create-workflow", complete: false },
+    { id: "generate-api-key", complete: false },
+    { id: "create-wallet", complete: false },
+    { id: "fund-wallet", complete: false },
+  ]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hidden, setHidden] = useState(isDismissed);
+
+  const isAuthenticated = Boolean(session?.user);
+
+  const hide = useCallback(() => {
+    setHidden(true);
+    try {
+      localStorage.setItem(DISMISSED_KEY, "true");
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const show = useCallback(() => {
+    setHidden(false);
+    try {
+      localStorage.removeItem(DISMISSED_KEY);
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  useEffect(() => {
+    if (hidden) {
+      setIsLoading(false);
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchStatus(): Promise<void> {
+      setIsLoading(true);
+
+      const results = await Promise.allSettled([
+        fetch("/api/workflows").then((r) => r.json()),
+        fetch("/api/api-keys").then((r) => r.json()),
+        fetch("/api/user/wallet").then((r) => r.json()),
+        fetch("/api/user/wallet/balances").then((r) => r.json()),
+      ]);
+
+      if (cancelled) {
+        return;
+      }
+
+      const [workflowsResult, keysResult, walletResult, balancesResult] =
+        results;
+
+      const hasWallet =
+        walletResult.status === "fulfilled" &&
+        (walletResult.value as { hasWallet?: boolean } | null)?.hasWallet ===
+          true;
+
+      setSteps([
+        { id: "create-workflow", complete: isFulfilledArray(workflowsResult) },
+        { id: "generate-api-key", complete: isFulfilledArray(keysResult) },
+        { id: "create-wallet", complete: hasWallet },
+        { id: "fund-wallet", complete: hasNonZeroBalance(balancesResult) },
+      ]);
+      setIsLoading(false);
+    }
+
+    fetchStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, hidden]);
+
+  const completedCount = steps.filter((s) => s.complete).length;
+  const allComplete = completedCount === steps.length;
+
+  return {
+    steps,
+    isLoading,
+    allComplete,
+    completedCount,
+    hidden,
+    hide,
+    show,
+  };
+}

--- a/keeperhub/lib/hooks/use-onboarding-status.ts
+++ b/keeperhub/lib/hooks/use-onboarding-status.ts
@@ -105,28 +105,42 @@ export function useOnboardingStatus(): OnboardingStatus {
 
       const results = await Promise.allSettled([
         fetch("/api/workflows").then((r) => r.json()),
-        fetch("/api/api-keys").then((r) => r.json()),
+        fetch("/api/keeperhub/keys").then((r) => r.json()),
         fetch("/api/user/wallet").then((r) => r.json()),
-        fetch("/api/user/wallet/balances").then((r) => r.json()),
       ]);
 
       if (cancelled) {
         return;
       }
 
-      const [workflowsResult, keysResult, walletResult, balancesResult] =
-        results;
+      const [workflowsResult, keysResult, walletResult] = results;
 
       const hasWallet =
         walletResult.status === "fulfilled" &&
         (walletResult.value as { hasWallet?: boolean } | null)?.hasWallet ===
           true;
 
+      // Only check balances if wallet exists
+      let hasFunds = false;
+      if (hasWallet) {
+        const balancesResult = await fetch("/api/user/wallet/balances")
+          .then((r) => r.json())
+          .catch(() => []);
+        hasFunds = hasNonZeroBalance({
+          status: "fulfilled",
+          value: balancesResult,
+        });
+      }
+
+      if (cancelled) {
+        return;
+      }
+
       setSteps([
         { id: "create-workflow", complete: isFulfilledArray(workflowsResult) },
         { id: "generate-api-key", complete: isFulfilledArray(keysResult) },
         { id: "create-wallet", complete: hasWallet },
-        { id: "fund-wallet", complete: hasNonZeroBalance(balancesResult) },
+        { id: "fund-wallet", complete: hasFunds },
       ]);
       setIsLoading(false);
     }

--- a/keeperhub/lib/is-anonymous.ts
+++ b/keeperhub/lib/is-anonymous.ts
@@ -1,0 +1,17 @@
+/**
+ * Detects anonymous/temporary users by checking name and email patterns.
+ * Works with session user objects, API responses, or any object with name/email.
+ */
+export function isAnonymousUser(
+  user: { name?: string | null; email?: string | null } | null | undefined
+): boolean {
+  if (!user) {
+    return true;
+  }
+  return (
+    user.name === "Anonymous" ||
+    Boolean(user.email?.includes("@http://")) ||
+    Boolean(user.email?.includes("@https://")) ||
+    Boolean(user.email?.startsWith("temp-"))
+  );
+}

--- a/keeperhub/lib/refetch-sidebar.ts
+++ b/keeperhub/lib/refetch-sidebar.ts
@@ -12,12 +12,24 @@ type RefetchOptions = {
 type RefetchCallback = (options?: RefetchOptions) => void;
 
 const refetchCallbacks: Set<RefetchCallback> = new Set();
+let pendingOptions: RefetchOptions | null = null;
 
 /**
- * Register a refetch callback (called from NavigationSidebar)
+ * Register a refetch callback (called from NavigationSidebar).
+ * Replays any pending refetch that fired before registration.
  */
 export function registerSidebarRefetch(callback: RefetchCallback): () => void {
   refetchCallbacks.add(callback);
+
+  if (pendingOptions !== null) {
+    const opts = pendingOptions;
+    pendingOptions = null;
+    try {
+      callback(opts);
+    } catch {
+      /* ignore replay errors */
+    }
+  }
 
   return () => {
     refetchCallbacks.delete(callback);
@@ -27,14 +39,19 @@ export function registerSidebarRefetch(callback: RefetchCallback): () => void {
 /**
  * Trigger all registered sidebar refetch callbacks.
  * Call this after org switch, project/tag changes, or any action
- * that changes sidebar data.
+ * that changes sidebar data. Queues the call if no callbacks are
+ * registered yet, replaying when the first one registers.
  */
 export function refetchSidebar(options?: RefetchOptions): void {
+  if (refetchCallbacks.size === 0) {
+    pendingOptions = options ?? {};
+    return;
+  }
   for (const callback of refetchCallbacks) {
     try {
       callback(options);
-    } catch (error) {
-      console.error("[refetchSidebar] Error in callback:", error);
+    } catch {
+      /* ignore callback errors */
     }
   }
 }

--- a/scripts/seed-user.ts
+++ b/scripts/seed-user.ts
@@ -1,0 +1,101 @@
+/**
+ * Seed a local dev user with email/password auth.
+ * Uses Better Auth's hashPassword so the credentials work with sign-in.
+ *
+ * Usage: pnpm tsx scripts/seed-user.ts
+ *
+ * Default credentials:
+ *   Email:    dev@keeperhub.local
+ *   Password: Test1234!
+ *
+ * Override via env:
+ *   SEED_EMAIL=me@example.com SEED_PASSWORD=secret pnpm tsx scripts/seed-user.ts
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { getDatabaseUrl } from "../lib/db/connection-utils";
+import { accounts, users } from "../lib/db/schema";
+import { generateId } from "../lib/utils/id";
+
+const EMAIL = process.env.SEED_EMAIL ?? "dev@keeperhub.local";
+const PASSWORD = process.env.SEED_PASSWORD ?? "Test1234!";
+const NAME = process.env.SEED_NAME ?? "Dev User";
+
+async function hashPassword(password: string): Promise<string> {
+  const mod = await import(
+    // @ts-ignore -- better-auth internal module has no type declarations
+    "../node_modules/.ignored/better-auth/dist/crypto-DgVHxgLL.mjs"
+  );
+  return mod.i(password) as Promise<string>;
+}
+
+async function main(): Promise<void> {
+  const connectionString = getDatabaseUrl();
+  const client = postgres(connectionString, { max: 1 });
+  const db = drizzle(client);
+
+  try {
+    const existing = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, EMAIL))
+      .limit(1);
+
+    if (existing.length > 0) {
+      const userId = existing[0].id;
+      const hash = await hashPassword(PASSWORD);
+
+      await db
+        .update(accounts)
+        .set({ password: hash, updatedAt: new Date() })
+        .where(eq(accounts.userId, userId));
+
+      await db
+        .update(users)
+        .set({ emailVerified: true, updatedAt: new Date() })
+        .where(eq(users.id, userId));
+
+      console.log(`Updated existing user: ${EMAIL}`);
+      console.log(`  Password reset to: ${PASSWORD}`);
+    } else {
+      const userId = generateId();
+      const accountId = generateId();
+      const hash = await hashPassword(PASSWORD);
+      const now = new Date();
+
+      await db.insert(users).values({
+        id: userId,
+        name: NAME,
+        email: EMAIL,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+        isAnonymous: false,
+      });
+
+      await db.insert(accounts).values({
+        id: accountId,
+        accountId: userId,
+        providerId: "credential",
+        userId,
+        password: hash,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      console.log(`Created user: ${EMAIL}`);
+      console.log(`  Password: ${PASSWORD}`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error("Failed to seed user:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add setup guide checklist on the workflow canvas with 4 onboarding steps (create workflow, generate API key, create wallet, fund wallet), progress bar, and hide/show toggle persisted via localStorage
- Disable save button for anonymous users with tooltip explaining they need to sign in
- Show "Sign in to save workflows" in empty sidebar for anonymous users, with graceful error handling on API calls
- Group action grid by super-categories (Web3, Messaging, System) with collapsible headers and flat search results when filtering
- Replace FeaturedOverlay with "Browse Templates" link to /hub
- Queue sidebar refetch calls fired before mount, replay when first callback registers

## Test plan
- [ ] Verify checklist appears on canvas for both anonymous and authenticated users
- [ ] Confirm auth-required steps prompt sign-in dialog for anonymous users
- [ ] Test hide/show toggle persists across page refreshes
- [ ] Verify save button is disabled with tooltip for anonymous users
- [ ] Check sidebar shows "Sign in to save workflows" for anonymous users
- [ ] Verify action grid super-category grouping (Web3, Messaging, System)
- [ ] Test action grid search shows flat results without category headers
- [ ] Confirm "Browse Templates" button navigates to /hub