### PR TITLE
feat: KEEP-1535 use RPC failover in all web3 plugin steps

### DIFF
--- a/keeperhub/plugins/web3/steps/approve-token-core.ts
+++ b/keeperhub/plugins/web3/steps/approve-token-core.ts
@@ -26,7 +26,7 @@ import { ERC20_ABI } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 import { parseTokenAddress } from "./transfer-token-core";
 
@@ -132,14 +132,11 @@ export async function approveTokenCore(
 
   const { organizationId, userId } = orgCtx;
 
-  // Resolve RPC config
+  // Resolve RPC config (with failover)
   let rpcUrl: string;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
+    const rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = rpcManager.getCurrentRpcUrl();
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/approve-token-core.ts
+++ b/keeperhub/plugins/web3/steps/approve-token-core.ts
@@ -136,7 +136,7 @@ export async function approveTokenCore(
   let rpcUrl: string;
   try {
     const rpcManager = await getRpcProvider({ chainId, userId });
-    rpcUrl = rpcManager.getCurrentRpcUrl();
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/batch-read-contract.ts
+++ b/keeperhub/plugins/web3/steps/batch-read-contract.ts
@@ -7,7 +7,8 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { MULTICALL3_ABI, MULTICALL3_ADDRESS } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import type { RpcProviderManager } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -487,17 +488,10 @@ function decodeCallResult(
  */
 async function executeMulticallBatches(
   encodedCalls: EncodedCallWithMeta[],
-  rpcUrl: string,
+  rpcManager: RpcProviderManager,
   batchSize: number,
   chainId: number
 ): Promise<{ results: CallResult[]; error?: string }> {
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
-  const multicall = new ethers.Contract(
-    MULTICALL3_ADDRESS,
-    MULTICALL3_ABI,
-    provider
-  );
-
   const results: CallResult[] = [];
   const totalBatches = Math.ceil(encodedCalls.length / batchSize);
 
@@ -513,8 +507,16 @@ async function executeMulticallBatches(
     }));
 
     try {
-      const batchResults: [boolean, string][] =
-        await multicall.aggregate3.staticCall(multicallInput);
+      const batchResults = await rpcManager.executeWithFailover((provider) => {
+        const multicall = new ethers.Contract(
+          MULTICALL3_ADDRESS,
+          MULTICALL3_ABI,
+          provider
+        );
+        return multicall.aggregate3.staticCall(multicallInput) as Promise<
+          [boolean, string][]
+        >;
+      });
 
       for (const [i, batchResult] of batchResults.entries()) {
         const [callSuccess, returnData] = batchResult;
@@ -543,14 +545,14 @@ async function executeMulticallBatches(
 }
 
 /**
- * Resolve chain ID and RPC URL for a network
+ * Resolve chain ID and RPC provider manager for a network
  */
 async function resolveChainRpc(
   network: string,
   userId: string | undefined
 ): Promise<
-  | { chainId: number; rpcUrl: string; error?: undefined }
-  | { chainId?: undefined; rpcUrl?: undefined; error: string }
+  | { chainId: number; rpcManager: RpcProviderManager; error?: undefined }
+  | { chainId?: undefined; rpcManager?: undefined; error: string }
 > {
   let chainId: number;
   try {
@@ -566,11 +568,8 @@ async function resolveChainRpc(
   }
 
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    return { chainId, rpcUrl: rpcConfig.primaryRpcUrl };
+    const rpcManager = await getRpcProvider({ chainId, userId });
+    return { chainId, rpcManager };
   } catch (rpcError) {
     logUserError(
       ErrorCategory.VALIDATION,
@@ -667,7 +666,7 @@ async function executeUniformMode(
 
   const { results, error: batchError } = await executeMulticallBatches(
     encodeResult.encoded,
-    chainRpc.rpcUrl,
+    chainRpc.rpcManager,
     parseBatchSize(input.batchSize),
     chainRpc.chainId
   );
@@ -760,7 +759,7 @@ async function executeMixedMode(
 
       const batchResult = await executeMulticallBatches(
         group,
-        chainRpc.rpcUrl,
+        chainRpc.rpcManager,
         batchSize,
         chainRpc.chainId
       );

--- a/keeperhub/plugins/web3/steps/check-allowance.ts
+++ b/keeperhub/plugins/web3/steps/check-allowance.ts
@@ -6,7 +6,7 @@ import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
 import { ERC20_ABI } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { parseTokenAddress } from "./transfer-token-core";
@@ -96,14 +96,10 @@ async function stepHandler(
   // Get userId from execution context (for user RPC preferences)
   const userId = await getUserIdFromExecution(_context?.executionId);
 
-  // Resolve RPC config
-  let rpcUrl: string;
+  // Resolve RPC provider with failover support
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
+    rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
@@ -119,14 +115,15 @@ async function stepHandler(
   }
 
   try {
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
-    const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
-
-    const [allowanceRaw, decimals, symbol] = await Promise.all([
-      contract.allowance(ownerAddress, spenderAddress) as Promise<bigint>,
-      contract.decimals() as Promise<bigint>,
-      contract.symbol() as Promise<string>,
-    ]);
+    const [allowanceRaw, decimals, symbol] =
+      await rpcManager.executeWithFailover((provider) => {
+        const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+        return Promise.all([
+          contract.allowance(ownerAddress, spenderAddress) as Promise<bigint>,
+          contract.decimals() as Promise<bigint>,
+          contract.symbol() as Promise<string>,
+        ]);
+      });
 
     const decimalsNum = Number(decimals);
     const allowance = ethers.formatUnits(allowanceRaw, decimalsNum);

--- a/keeperhub/plugins/web3/steps/check-allowance.ts
+++ b/keeperhub/plugins/web3/steps/check-allowance.ts
@@ -6,7 +6,11 @@ import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
 import { ERC20_ABI } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { parseTokenAddress } from "./transfer-token-core";
@@ -97,7 +101,7 @@ async function stepHandler(
   const userId = await getUserIdFromExecution(_context?.executionId);
 
   // Resolve RPC provider with failover support
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/check-allowance.ts
+++ b/keeperhub/plugins/web3/steps/check-allowance.ts
@@ -7,9 +7,9 @@ import { ERC20_ABI } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";

--- a/keeperhub/plugins/web3/steps/check-balance.ts
+++ b/keeperhub/plugins/web3/steps/check-balance.ts
@@ -8,9 +8,9 @@ import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";

--- a/keeperhub/plugins/web3/steps/check-balance.ts
+++ b/keeperhub/plugins/web3/steps/check-balance.ts
@@ -7,7 +7,11 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -109,7 +113,7 @@ async function stepHandler(
   }
 
   // Resolve RPC provider with failover support
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/check-balance.ts
+++ b/keeperhub/plugins/web3/steps/check-balance.ts
@@ -7,7 +7,7 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -108,20 +108,10 @@ async function stepHandler(
     };
   }
 
-  // Resolve RPC config (with user preferences)
-  let rpcUrl: string;
+  // Resolve RPC provider with failover support
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
-    console.log(
-      "[Check Balance] Using RPC URL:",
-      rpcUrl,
-      "source:",
-      rpcConfig.source
-    );
+    rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
@@ -141,10 +131,11 @@ async function stepHandler(
 
   // Check balance
   try {
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
     console.log("[Check Balance] Checking balance for address:", address);
 
-    const balance = await provider.getBalance(address);
+    const balance = await rpcManager.executeWithFailover(async (provider) =>
+      provider.getBalance(address)
+    );
     const balanceEth = ethers.formatEther(balance);
 
     console.log("[Check Balance] Balance retrieved successfully:", {

--- a/keeperhub/plugins/web3/steps/check-token-balance.ts
+++ b/keeperhub/plugins/web3/steps/check-token-balance.ts
@@ -16,9 +16,9 @@ import {
 } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";

--- a/keeperhub/plugins/web3/steps/check-token-balance.ts
+++ b/keeperhub/plugins/web3/steps/check-token-balance.ts
@@ -15,7 +15,7 @@ import {
   workflowExecutions,
 } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -405,20 +405,10 @@ async function stepHandler(
     };
   }
 
-  // Resolve RPC config (with user preferences)
-  let rpcUrl: string;
+  // Resolve RPC provider with failover support
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
-    console.log(
-      "[Check Token Balance] Using RPC URL:",
-      rpcUrl,
-      "source:",
-      rpcConfig.source
-    );
+    rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
@@ -438,10 +428,9 @@ async function stepHandler(
 
   // Check balance for the token
   try {
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
-
-    // Fetch balance for the single token
-    const balance = await fetchTokenBalance(provider, address, tokenAddress);
+    const balance = await rpcManager.executeWithFailover(async (provider) =>
+      fetchTokenBalance(provider, address, tokenAddress)
+    );
 
     console.log("[Check Token Balance] Token balance retrieved successfully:", {
       address,

--- a/keeperhub/plugins/web3/steps/check-token-balance.ts
+++ b/keeperhub/plugins/web3/steps/check-token-balance.ts
@@ -15,7 +15,11 @@ import {
   workflowExecutions,
 } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -406,7 +410,7 @@ async function stepHandler(
   }
 
   // Resolve RPC provider with failover support
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/get-transaction.ts
+++ b/keeperhub/plugins/web3/steps/get-transaction.ts
@@ -7,9 +7,9 @@ import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";

--- a/keeperhub/plugins/web3/steps/get-transaction.ts
+++ b/keeperhub/plugins/web3/steps/get-transaction.ts
@@ -6,7 +6,7 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -84,13 +84,9 @@ async function stepHandler(
     };
   }
 
-  let rpcUrl: string;
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
+    rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
     return {
       success: false,
@@ -99,8 +95,9 @@ async function stepHandler(
   }
 
   try {
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
-    const tx = await provider.getTransaction(hash);
+    const tx = await rpcManager.executeWithFailover(async (provider) =>
+      provider.getTransaction(hash)
+    );
 
     if (!tx) {
       return {

--- a/keeperhub/plugins/web3/steps/get-transaction.ts
+++ b/keeperhub/plugins/web3/steps/get-transaction.ts
@@ -6,7 +6,11 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -84,7 +88,7 @@ async function stepHandler(
     };
   }
 
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/query-events.ts
+++ b/keeperhub/plugins/web3/steps/query-events.ts
@@ -7,9 +7,9 @@ import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";

--- a/keeperhub/plugins/web3/steps/query-events.ts
+++ b/keeperhub/plugins/web3/steps/query-events.ts
@@ -278,6 +278,16 @@ async function stepHandler(
 
   const userId = await getUserIdFromExecution(_context?.executionId);
 
+  // Validate event exists in ABI using ethers Interface (no provider needed)
+  const iface = new ethers.Interface(abiResult.parsed);
+  const eventFragment = iface.getEvent(eventName);
+  if (!eventFragment) {
+    return {
+      success: false,
+      error: `Event '${eventName}' not found in contract interface`,
+    };
+  }
+
   let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
@@ -288,6 +298,32 @@ async function stepHandler(
     };
   }
 
+  // Resolve block range (uses RPC for latest block number)
+  const blockRangeResult = await rpcManager.executeWithFailover(
+    async (provider) =>
+      resolveBlockRange(
+        provider,
+        input.fromBlock,
+        input.toBlock,
+        input.blockCount
+      )
+  );
+  if (!blockRangeResult.success) {
+    return { success: false, error: blockRangeResult.error };
+  }
+  const { range } = blockRangeResult;
+
+  if (range.fromBlock > range.toBlock) {
+    return {
+      success: true,
+      events: [],
+      fromBlock: range.fromBlock,
+      toBlock: range.toBlock,
+      eventCount: 0,
+    };
+  }
+
+  // Query events (uses RPC for log fetching)
   try {
     return await rpcManager.executeWithFailover(async (provider) => {
       const contract = new ethers.Contract(
@@ -295,32 +331,6 @@ async function stepHandler(
         abiResult.parsed,
         provider
       );
-
-      const eventFragment = contract.interface.getEvent(eventName);
-      if (!eventFragment) {
-        throw new Error(`Event '${eventName}' not found in contract interface`);
-      }
-
-      const blockRangeResult = await resolveBlockRange(
-        provider,
-        input.fromBlock,
-        input.toBlock,
-        input.blockCount
-      );
-      if (!blockRangeResult.success) {
-        throw new Error(blockRangeResult.error);
-      }
-      const { range } = blockRangeResult;
-
-      if (range.fromBlock > range.toBlock) {
-        return {
-          success: true as const,
-          events: [],
-          fromBlock: range.fromBlock,
-          toBlock: range.toBlock,
-          eventCount: 0,
-        };
-      }
 
       const events = await queryEventBatches(
         contract,

--- a/keeperhub/plugins/web3/steps/query-events.ts
+++ b/keeperhub/plugins/web3/steps/query-events.ts
@@ -6,7 +6,7 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -277,74 +277,71 @@ async function stepHandler(
   }
 
   const userId = await getUserIdFromExecution(_context?.executionId);
-  const rpcConfig = await resolveRpcConfig(chainId, userId);
-  if (!rpcConfig) {
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+  } catch (error) {
     return {
       success: false,
-      error: `Chain ${chainId} not found or not enabled`,
-    };
-  }
-
-  console.log(
-    "[Query Events] Using RPC URL:",
-    rpcConfig.primaryRpcUrl,
-    "source:",
-    rpcConfig.source
-  );
-
-  const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-  const contract = new ethers.Contract(
-    contractAddress,
-    abiResult.parsed,
-    provider
-  );
-
-  const eventFragment = contract.interface.getEvent(eventName);
-  if (!eventFragment) {
-    return {
-      success: false,
-      error: `Event '${eventName}' not found in contract interface`,
-    };
-  }
-
-  const blockRangeResult = await resolveBlockRange(
-    provider,
-    input.fromBlock,
-    input.toBlock,
-    input.blockCount
-  );
-  if (!blockRangeResult.success) {
-    return { success: false, error: blockRangeResult.error };
-  }
-  const { range } = blockRangeResult;
-
-  if (range.fromBlock > range.toBlock) {
-    return {
-      success: true,
-      events: [],
-      fromBlock: range.fromBlock,
-      toBlock: range.toBlock,
-      eventCount: 0,
+      error: getErrorMessage(error),
     };
   }
 
   try {
-    const events = await queryEventBatches(
-      contract,
-      eventName,
-      eventFragment,
-      range
-    );
+    return await rpcManager.executeWithFailover(async (provider) => {
+      const contract = new ethers.Contract(
+        contractAddress,
+        abiResult.parsed,
+        provider
+      );
 
-    console.log("[Query Events] Query complete. Events found:", events.length);
+      const eventFragment = contract.interface.getEvent(eventName);
+      if (!eventFragment) {
+        throw new Error(`Event '${eventName}' not found in contract interface`);
+      }
 
-    return {
-      success: true,
-      events,
-      fromBlock: range.fromBlock,
-      toBlock: range.toBlock,
-      eventCount: events.length,
-    };
+      const blockRangeResult = await resolveBlockRange(
+        provider,
+        input.fromBlock,
+        input.toBlock,
+        input.blockCount
+      );
+      if (!blockRangeResult.success) {
+        throw new Error(blockRangeResult.error);
+      }
+      const { range } = blockRangeResult;
+
+      if (range.fromBlock > range.toBlock) {
+        return {
+          success: true as const,
+          events: [],
+          fromBlock: range.fromBlock,
+          toBlock: range.toBlock,
+          eventCount: 0,
+        };
+      }
+
+      const events = await queryEventBatches(
+        contract,
+        eventName,
+        eventFragment,
+        range
+      );
+
+      console.log(
+        "[Query Events] Query complete. Events found:",
+        events.length
+      );
+
+      return {
+        success: true as const,
+        events,
+        fromBlock: range.fromBlock,
+        toBlock: range.toBlock,
+        eventCount: events.length,
+      };
+    });
   } catch (error) {
     return {
       success: false,

--- a/keeperhub/plugins/web3/steps/query-events.ts
+++ b/keeperhub/plugins/web3/steps/query-events.ts
@@ -6,7 +6,11 @@ import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugi
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -288,7 +292,7 @@ async function stepHandler(
     };
   }
 
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/query-transactions-core.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions-core.ts
@@ -10,7 +10,11 @@ import {
   getTransactionUrl,
   type NormalizedTransaction,
 } from "@/lib/explorer";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_BLOCK_LOOKBACK = 6500;
@@ -417,7 +421,7 @@ export async function queryTransactionsCore(
 
   const userId = await getUserIdFromExecution(input._context?.executionId);
 
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/query-transactions-core.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions-core.ts
@@ -11,9 +11,9 @@ import {
   type NormalizedTransaction,
 } from "@/lib/explorer";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 

--- a/keeperhub/plugins/web3/steps/query-transactions-core.ts
+++ b/keeperhub/plugins/web3/steps/query-transactions-core.ts
@@ -10,7 +10,7 @@ import {
   getTransactionUrl,
   type NormalizedTransaction,
 } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_BLOCK_LOOKBACK = 6500;
@@ -416,21 +416,25 @@ export async function queryTransactionsCore(
   const { iface, functionFragment, chainId } = validation.data;
 
   const userId = await getUserIdFromExecution(input._context?.executionId);
-  const rpcConfig = await resolveRpcConfig(chainId, userId);
-  if (!rpcConfig) {
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+  } catch (error) {
     return {
       success: false,
-      error: `Chain ${chainId} not found or not enabled`,
+      error: getErrorMessage(error),
     };
   }
 
-  const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-
-  const blockRangeResult = await resolveBlockRange(
-    provider,
-    input.fromBlock,
-    input.toBlock,
-    input.blockCount
+  const blockRangeResult = await rpcManager.executeWithFailover(
+    async (provider) =>
+      resolveBlockRange(
+        provider,
+        input.fromBlock,
+        input.toBlock,
+        input.blockCount
+      )
   );
   if (!blockRangeResult.success) {
     return { success: false, error: blockRangeResult.error };

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -15,9 +15,9 @@ import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import {
-  type RpcProviderManager,
   getChainIdFromNetwork,
   getRpcProvider,
+  type RpcProviderManager,
 } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -14,7 +14,7 @@ import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 export type ReadContractCoreInput = {
@@ -221,20 +221,10 @@ export async function readContractCore(
     };
   }
 
-  // Resolve RPC config (with user preferences)
-  let rpcUrl: string;
+  // Resolve RPC provider with failover support
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
-    console.log(
-      "[Read Contract] Using RPC URL:",
-      rpcUrl,
-      "source:",
-      rpcConfig.source
-    );
+    rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
@@ -254,31 +244,32 @@ export async function readContractCore(
 
   // Call the contract function
   try {
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
-
-    // Create contract instance
-    const contract = new ethers.Contract(contractAddress, parsedAbi, provider);
-    console.log("[Read Contract] Contract instance created");
-
-    // Check if function exists
-    if (typeof contract[abiFunction] !== "function") {
-      throw new Error(`Function '${abiFunction}' not found in contract ABI`);
-    }
-
-    console.log(
-      "[Read Contract] Calling function:",
-      abiFunction,
-      "with args:",
-      args
-    );
-
     const isView =
       functionAbi.stateMutability === "view" ||
       functionAbi.stateMutability === "pure";
 
-    const result = isView
-      ? await contract[abiFunction](...args)
-      : await contract[abiFunction].staticCall(...args);
+    const result = await rpcManager.executeWithFailover(async (provider) => {
+      const contract = new ethers.Contract(
+        contractAddress,
+        parsedAbi,
+        provider
+      );
+
+      if (typeof contract[abiFunction] !== "function") {
+        throw new Error(`Function '${abiFunction}' not found in contract ABI`);
+      }
+
+      console.log(
+        "[Read Contract] Calling function:",
+        abiFunction,
+        "with args:",
+        args
+      );
+
+      return isView
+        ? await contract[abiFunction](...args)
+        : await contract[abiFunction].staticCall(...args);
+    });
 
     console.log("[Read Contract] Function call successful, result:", result);
 

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -14,7 +14,11 @@ import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
+import {
+  type RpcProviderManager,
+  getChainIdFromNetwork,
+  getRpcProvider,
+} from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 export type ReadContractCoreInput = {
@@ -222,7 +226,7 @@ export async function readContractCore(
   }
 
   // Resolve RPC provider with failover support
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcManager: RpcProviderManager;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {

--- a/keeperhub/plugins/web3/steps/transfer-funds-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-funds-core.ts
@@ -25,7 +25,7 @@ import {
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 export type TransferFundsCoreInput = {
@@ -55,7 +55,6 @@ export type TransferFundsResult =
  * Shared between the web3 transfer-funds step and the direct execution API.
  * When _context.organizationId is provided, skips workflowExecutions lookup.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Transfer handler with comprehensive validation and error handling
 export async function transferFundsCore(
   input: TransferFundsCoreInput
 ): Promise<TransferFundsResult> {
@@ -107,17 +106,14 @@ export async function transferFundsCore(
 
   const { organizationId, userId } = orgCtx;
 
-  // Get chain ID and resolve RPC config
+  // Get chain ID and resolve RPC config (with failover)
   let chainId: number;
   let rpcUrl: string;
   try {
     chainId = getChainIdFromNetwork(network);
 
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
+    const rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = rpcManager.getCurrentRpcUrl();
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/transfer-funds-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-funds-core.ts
@@ -113,7 +113,7 @@ export async function transferFundsCore(
     chainId = getChainIdFromNetwork(network);
 
     const rpcManager = await getRpcProvider({ chainId, userId });
-    rpcUrl = rpcManager.getCurrentRpcUrl();
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/transfer-token-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-token-core.ts
@@ -30,7 +30,7 @@ import {
   workflowExecutions,
 } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 export type TransferTokenCoreInput = {
@@ -240,14 +240,11 @@ export async function transferTokenCore(
 
   const { organizationId, userId } = orgCtx;
 
-  // Resolve RPC config
+  // Resolve RPC config (with failover)
   let rpcUrl: string;
   try {
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-    rpcUrl = rpcConfig.primaryRpcUrl;
+    const rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = rpcManager.getCurrentRpcUrl();
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/transfer-token-core.ts
+++ b/keeperhub/plugins/web3/steps/transfer-token-core.ts
@@ -244,7 +244,7 @@ export async function transferTokenCore(
   let rpcUrl: string;
   try {
     const rpcManager = await getRpcProvider({ chainId, userId });
-    rpcUrl = rpcManager.getCurrentRpcUrl();
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -26,7 +26,7 @@ import {
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 import { getErrorMessage } from "@/lib/utils";
 
 export type WriteContractCoreInput = {
@@ -157,25 +157,16 @@ export async function writeContractCore(
   }
   const { organizationId, userId } = orgCtx;
 
-  // Get chain ID and resolve RPC config (with user preferences)
+  // Get chain ID and resolve RPC config (with user preferences + failover)
   let chainId: number;
   let rpcUrl: string;
   try {
     chainId = getChainIdFromNetwork(network);
     console.log("[Write Contract] Resolved chain ID:", chainId);
 
-    const rpcConfig = await resolveRpcConfig(chainId, userId);
-    if (!rpcConfig) {
-      throw new Error(`Chain ${chainId} not found or not enabled`);
-    }
-
-    rpcUrl = rpcConfig.primaryRpcUrl;
-    console.log(
-      "[Write Contract] Using RPC URL:",
-      rpcUrl,
-      "source:",
-      rpcConfig.source
-    );
+    const rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = rpcManager.getCurrentRpcUrl();
+    console.log("[Write Contract] Using RPC URL:", rpcUrl);
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -165,7 +165,7 @@ export async function writeContractCore(
     console.log("[Write Contract] Resolved chain ID:", chainId);
 
     const rpcManager = await getRpcProvider({ chainId, userId });
-    rpcUrl = rpcManager.getCurrentRpcUrl();
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
     console.log("[Write Contract] Using RPC URL:", rpcUrl);
   } catch (error) {
     logUserError(

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -354,13 +354,25 @@ export class RpcProviderManager {
   }
 
   /**
-   * Get the currently-active RPC URL, respecting failover state.
-   * Use this for write operations that need a raw URL (e.g. signer initialization).
+   * Get the currently-active RPC URL, respecting cached failover state.
+   * Does NOT probe the endpoint -- use resolveActiveRpcUrl() for write
+   * operations where you need to verify the endpoint is reachable first.
    */
   getCurrentRpcUrl(): string {
     return this.isUsingFallback && this.config.fallbackRpcUrl
       ? this.config.fallbackRpcUrl
       : this.config.primaryRpcUrl;
+  }
+
+  /**
+   * Probe the RPC endpoint with a lightweight getBlockNumber call via
+   * executeWithFailover, then return the URL of whichever provider responded.
+   * Use this for write operations that need a raw URL for signer construction
+   * but should still benefit from failover if the primary is unreachable.
+   */
+  async resolveActiveRpcUrl(): Promise<string> {
+    await this.executeWithFailover((provider) => provider.getBlockNumber());
+    return this.getCurrentRpcUrl();
   }
 
   /**

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -224,7 +224,11 @@ export class RpcProviderManager {
             })
           );
           this.isUsingFallback = false;
-          this.onFailoverStateChange?.(this.config.chainName, false, "recovery");
+          this.onFailoverStateChange?.(
+            this.config.chainName,
+            false,
+            "recovery"
+          );
           return primaryResult.result as T;
         }
 
@@ -308,6 +312,73 @@ export class RpcProviderManager {
     throw new Error(`RPC failed on primary endpoint: ${primaryResult.error}`);
   }
 
+  private recordAttempt(providerType: "primary" | "fallback"): void {
+    if (providerType === "primary") {
+      this.metrics.primaryAttempts += 1;
+      this.metricsCollector.recordPrimaryAttempt(this.config.chainName);
+    } else {
+      this.metrics.fallbackAttempts += 1;
+      this.metricsCollector.recordFallbackAttempt(this.config.chainName);
+    }
+  }
+
+  private recordFailure(providerType: "primary" | "fallback"): void {
+    if (providerType === "primary") {
+      this.metrics.primaryFailures += 1;
+      this.metricsCollector.recordPrimaryFailure(this.config.chainName);
+    } else {
+      this.metrics.fallbackFailures += 1;
+      this.metricsCollector.recordFallbackFailure(this.config.chainName);
+    }
+  }
+
+  /**
+   * Compute how long to wait before retrying, or return null to stop retrying.
+   * Handles 429 Retry-After headers and exponential backoff for other errors.
+   */
+  private getRetryDelayMs(error: unknown, attempt: number): number | null {
+    if (isError(error, "SERVER_ERROR") && error.response?.statusCode === 429) {
+      const retryAfterHeader = error.response.getHeader("retry-after");
+      const retryAfterSeconds = retryAfterHeader
+        ? Number.parseInt(retryAfterHeader, 10)
+        : Number.NaN;
+
+      if (
+        !Number.isNaN(retryAfterSeconds) &&
+        retryAfterSeconds > 0 &&
+        retryAfterSeconds <= RpcProviderManager.RETRY_AFTER_CAP_SECONDS
+      ) {
+        return retryAfterSeconds * 1000;
+      }
+
+      return null;
+    }
+
+    return Math.min(1000 * 2 ** attempt, 5000);
+  }
+
+  /**
+   * Evaluate a caught error and decide what to do next.
+   * Throws for non-retryable errors, returns null to stop retrying,
+   * or returns the delay in ms before the next attempt.
+   */
+  private evaluateRetryAction(
+    error: unknown,
+    wrappedError: Error,
+    attempt: number,
+    maxRetries: number
+  ): number | null {
+    if (this.isNonRetryableError(error)) {
+      throw wrappedError;
+    }
+
+    if (attempt === maxRetries - 1) {
+      return null;
+    }
+
+    return this.getRetryDelayMs(error, attempt);
+  }
+
   private async tryProvider<T>(
     provider: ethers.JsonRpcProvider,
     operation: (p: ethers.JsonRpcProvider) => Promise<T>,
@@ -318,13 +389,7 @@ export class RpcProviderManager {
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       try {
-        if (providerType === "primary") {
-          this.metrics.primaryAttempts += 1;
-          this.metricsCollector.recordPrimaryAttempt(this.config.chainName);
-        } else {
-          this.metrics.fallbackAttempts += 1;
-          this.metricsCollector.recordFallbackAttempt(this.config.chainName);
-        }
+        this.recordAttempt(providerType);
 
         const result = await this.withTimeout(
           operation(provider),
@@ -334,51 +399,19 @@ export class RpcProviderManager {
         return { success: true, result };
       } catch (error: unknown) {
         lastError = error instanceof Error ? error : new Error(String(error));
+        this.recordFailure(providerType);
 
-        if (providerType === "primary") {
-          this.metrics.primaryFailures += 1;
-          this.metricsCollector.recordPrimaryFailure(this.config.chainName);
-        } else {
-          this.metrics.fallbackFailures += 1;
-          this.metricsCollector.recordFallbackFailure(this.config.chainName);
-        }
-
-        // Non-retryable errors (contract revert, invalid args, etc.) will
-        // never succeed on any provider -- re-throw immediately to skip
-        // both remaining retries and failover to the other provider.
-        if (this.isNonRetryableError(error)) {
-          throw lastError;
-        }
-
-        if (attempt === maxRetries - 1) {
+        const delayMs = this.evaluateRetryAction(
+          error,
+          lastError,
+          attempt,
+          maxRetries
+        );
+        if (delayMs === null) {
           break;
         }
 
-        // On 429 rate limit: respect Retry-After if within cap,
-        // otherwise bail immediately and let executeWithFailover switch providers
-        if (
-          isError(error, "SERVER_ERROR") &&
-          error.response?.statusCode === 429
-        ) {
-          const retryAfterHeader = error.response.getHeader("retry-after");
-          const retryAfterSeconds = retryAfterHeader
-            ? Number.parseInt(retryAfterHeader, 10)
-            : Number.NaN;
-
-          if (
-            !Number.isNaN(retryAfterSeconds) &&
-            retryAfterSeconds > 0 &&
-            retryAfterSeconds <= RpcProviderManager.RETRY_AFTER_CAP_SECONDS
-          ) {
-            await this.delay(retryAfterSeconds * 1000);
-            continue;
-          }
-
-          // No usable Retry-After -- stop retrying this provider
-          break;
-        }
-
-        await this.delay(Math.min(1000 * 2 ** attempt, 5000));
+        await this.delay(delayMs);
       }
     }
 
@@ -408,9 +441,7 @@ export class RpcProviderManager {
     if (typeof error !== "object" || error === null || !("code" in error)) {
       return false;
     }
-    return NON_RETRYABLE_ERROR_CODES.has(
-      (error as EthersError).code as string
-    );
+    return NON_RETRYABLE_ERROR_CODES.has((error as EthersError).code as string);
   }
 
   getMetrics(): Readonly<RpcProviderMetrics> {

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers, isError } from "ethers";
 
 /**
  * Interface for metrics collection - allows dependency injection
@@ -96,6 +96,7 @@ export class RpcProviderManager {
 
   private static readonly DEFAULT_MAX_RETRIES = 3;
   private static readonly DEFAULT_TIMEOUT_MS = 30_000;
+  private static readonly RETRY_AFTER_CAP_SECONDS = 30;
 
   constructor(options: RpcProviderManagerOptions) {
     const {
@@ -304,6 +305,30 @@ export class RpcProviderManager {
         }
 
         if (attempt === maxRetries - 1) {
+          break;
+        }
+
+        // On 429 rate limit: respect Retry-After if within cap,
+        // otherwise bail immediately and let executeWithFailover switch providers
+        if (
+          isError(error, "SERVER_ERROR") &&
+          error.response?.statusCode === 429
+        ) {
+          const retryAfterHeader = error.response.getHeader("retry-after");
+          const retryAfterSeconds = retryAfterHeader
+            ? Number.parseInt(retryAfterHeader, 10)
+            : Number.NaN;
+
+          if (
+            !Number.isNaN(retryAfterSeconds) &&
+            retryAfterSeconds > 0 &&
+            retryAfterSeconds <= RpcProviderManager.RETRY_AFTER_CAP_SECONDS
+          ) {
+            await this.delay(retryAfterSeconds * 1000);
+            continue;
+          }
+
+          // No usable Retry-After -- stop retrying this provider
           break;
         }
 

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -1,4 +1,18 @@
-import { ethers, isError } from "ethers";
+import { type EthersError, ethers, isError } from "ethers";
+
+/**
+ * Ethers error codes that indicate a permanent failure -- retrying on the same
+ * or a different provider will never succeed. These are re-thrown immediately,
+ * bypassing both the retry loop and the failover logic.
+ */
+const NON_RETRYABLE_ERROR_CODES: ReadonlySet<string> = new Set([
+  "CALL_EXCEPTION", // contract revert, out-of-gas, function not found
+  "INVALID_ARGUMENT", // bad parameter types/values
+  "MISSING_ARGUMENT",
+  "UNEXPECTED_ARGUMENT",
+  "NUMERIC_FAULT", // overflow, division by zero
+  "BAD_DATA", // malformed ABI encoding that won't decode on any provider
+]);
 
 /**
  * Interface for metrics collection - allows dependency injection
@@ -329,6 +343,13 @@ export class RpcProviderManager {
           this.metricsCollector.recordFallbackFailure(this.config.chainName);
         }
 
+        // Non-retryable errors (contract revert, invalid args, etc.) will
+        // never succeed on any provider -- re-throw immediately to skip
+        // both remaining retries and failover to the other provider.
+        if (this.isNonRetryableError(error)) {
+          throw lastError;
+        }
+
         if (attempt === maxRetries - 1) {
           break;
         }
@@ -381,6 +402,15 @@ export class RpcProviderManager {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private isNonRetryableError(error: unknown): boolean {
+    if (typeof error !== "object" || error === null || !("code" in error)) {
+      return false;
+    }
+    return NON_RETRYABLE_ERROR_CODES.has(
+      (error as EthersError).code as string
+    );
   }
 
   getMetrics(): Readonly<RpcProviderMetrics> {

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -163,7 +163,7 @@ export class RpcProviderManager {
   ): Promise<T> {
     this.metrics.totalRequests += 1;
 
-    // If we've already switched to fallback, use it directly
+    // When in sticky fallback state, try fallback first, then primary as recovery
     if (this.isUsingFallback) {
       const fallbackProvider = this.getFallbackProvider();
       if (fallbackProvider) {
@@ -178,7 +178,7 @@ export class RpcProviderManager {
           return fallbackResult.result as T;
         }
 
-        // Fallback failed - try primary again in case it recovered
+        // Fallback failed - try primary in case it recovered
         console.warn(
           JSON.stringify({
             level: "warn",
@@ -188,9 +188,51 @@ export class RpcProviderManager {
             timestamp: new Date().toISOString(),
           })
         );
+
+        const primaryProvider = this.getPrimaryProvider();
+        const primaryResult = await this.tryProvider(
+          primaryProvider,
+          operation,
+          "primary",
+          this.config.maxRetries
+        );
+
+        if (primaryResult.success) {
+          console.info(
+            JSON.stringify({
+              level: "info",
+              event: "RPC_FAILOVER_RECOVERY",
+              message: `Primary RPC recovered for ${this.config.chainName}, switching back from fallback`,
+              chain: this.config.chainName,
+              previousState: "fallback",
+              newState: "primary",
+              timestamp: new Date().toISOString(),
+            })
+          );
+          this.isUsingFallback = false;
+          this.onFailoverStateChange?.(this.config.chainName, false, "recovery");
+          return primaryResult.result as T;
+        }
+
+        // Both failed -- throw without redundant retry
+        console.error(
+          JSON.stringify({
+            level: "error",
+            event: "RPC_BOTH_ENDPOINTS_FAILED",
+            message: `Both primary and fallback RPC failed for ${this.config.chainName}`,
+            chain: this.config.chainName,
+            fallbackError: fallbackResult.error,
+            primaryError: primaryResult.error,
+            timestamp: new Date().toISOString(),
+          })
+        );
+        throw new Error(
+          `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`
+        );
       }
     }
 
+    // Normal path: try primary first, then fallback
     const primaryProvider = this.getPrimaryProvider();
     const primaryResult = await this.tryProvider(
       primaryProvider,
@@ -200,21 +242,6 @@ export class RpcProviderManager {
     );
 
     if (primaryResult.success) {
-      if (this.isUsingFallback) {
-        console.info(
-          JSON.stringify({
-            level: "info",
-            event: "RPC_FAILOVER_RECOVERY",
-            message: `Primary RPC recovered for ${this.config.chainName}, switching back from fallback`,
-            chain: this.config.chainName,
-            previousState: "fallback",
-            newState: "primary",
-            timestamp: new Date().toISOString(),
-          })
-        );
-        this.isUsingFallback = false;
-        this.onFailoverStateChange?.(this.config.chainName, false, "recovery");
-      }
       return primaryResult.result as T;
     }
 
@@ -231,22 +258,20 @@ export class RpcProviderManager {
       );
 
       if (fallbackResult.success) {
-        if (!this.isUsingFallback) {
-          console.warn(
-            JSON.stringify({
-              level: "warn",
-              event: "RPC_FAILOVER_ACTIVATED",
-              message: `Primary RPC failed for ${this.config.chainName}, switching to fallback`,
-              chain: this.config.chainName,
-              previousState: "primary",
-              newState: "fallback",
-              primaryError: primaryResult.error,
-              timestamp: new Date().toISOString(),
-            })
-          );
-          this.isUsingFallback = true;
-          this.onFailoverStateChange?.(this.config.chainName, true, "failover");
-        }
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "RPC_FAILOVER_ACTIVATED",
+            message: `Primary RPC failed for ${this.config.chainName}, switching to fallback`,
+            chain: this.config.chainName,
+            previousState: "primary",
+            newState: "fallback",
+            primaryError: primaryResult.error,
+            timestamp: new Date().toISOString(),
+          })
+        );
+        this.isUsingFallback = true;
+        this.onFailoverStateChange?.(this.config.chainName, true, "failover");
         return fallbackResult.result as T;
       }
 

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -354,6 +354,16 @@ export class RpcProviderManager {
   }
 
   /**
+   * Get the currently-active RPC URL, respecting failover state.
+   * Use this for write operations that need a raw URL (e.g. signer initialization).
+   */
+  getCurrentRpcUrl(): string {
+    return this.isUsingFallback && this.config.fallbackRpcUrl
+      ? this.config.fallbackRpcUrl
+      : this.config.primaryRpcUrl;
+  }
+
+  /**
    * Get the chain name this manager is configured for
    */
   getChainName(): string {

--- a/tests/integration/query-transactions.test.ts
+++ b/tests/integration/query-transactions.test.ts
@@ -17,7 +17,7 @@ const {
   mockGetAddressUrl,
   mockGetTransactionUrl,
   mockGetChainIdFromNetwork,
-  mockResolveRpcConfig,
+  mockGetRpcProvider,
 } = vi.hoisted(() => ({
   mockParseResults: new Map<
     string,
@@ -35,7 +35,7 @@ const {
   mockGetAddressUrl: vi.fn(),
   mockGetTransactionUrl: vi.fn(),
   mockGetChainIdFromNetwork: vi.fn(),
-  mockResolveRpcConfig: vi.fn(),
+  mockGetRpcProvider: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -137,7 +137,7 @@ vi.mock("@/lib/explorer", () => ({
 // ---------------------------------------------------------------------------
 vi.mock("@/lib/rpc", () => ({
   getChainIdFromNetwork: mockGetChainIdFromNetwork,
-  resolveRpcConfig: mockResolveRpcConfig,
+  getRpcProvider: mockGetRpcProvider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -244,12 +244,9 @@ function registerParseResult(
 // ---------------------------------------------------------------------------
 function setupDefaultMocks(): void {
   mockGetChainIdFromNetwork.mockReturnValue(1);
-  mockResolveRpcConfig.mockResolvedValue({
-    chainId: 1,
-    chainName: "Ethereum Mainnet",
-    primaryRpcUrl: "https://eth.example.com",
-    fallbackRpcUrl: "https://eth-backup.example.com",
-    source: "default",
+  mockGetRpcProvider.mockResolvedValue({
+    executeWithFailover: (fn: (provider: unknown) => unknown) =>
+      fn({ getBlockNumber: mockGetBlockNumber }),
   });
   mockFindFirstExplorer.mockResolvedValue(MOCK_EXPLORER_CONFIG);
   mockGetAddressUrl.mockReturnValue(
@@ -507,7 +504,9 @@ describe("queryTransactionsCore", () => {
   });
 
   it("returns error when RPC config is not available (chain disabled)", async () => {
-    mockResolveRpcConfig.mockResolvedValue(null);
+    mockGetRpcProvider.mockRejectedValue(
+      new Error("Chain 1 not found or not enabled")
+    );
 
     const result = await queryTransactionsCore(defaultInput());
 

--- a/tests/integration/web3-steps.test.ts
+++ b/tests/integration/web3-steps.test.ts
@@ -63,13 +63,6 @@ vi.mock("@/lib/rpc", () => ({
       }
     ),
   }),
-  resolveRpcConfig: vi.fn().mockResolvedValue({
-    chainId: 1,
-    chainName: "Ethereum Mainnet",
-    primaryRpcUrl: "https://eth.example.com",
-    fallbackRpcUrl: "https://eth-backup.example.com",
-    source: "default",
-  }),
 }));
 
 // Mock database
@@ -125,7 +118,7 @@ vi.mock("@/lib/utils", () => ({
 
 // Now import the step functions after all mocks are set up
 import { checkBalanceStep } from "@/keeperhub/plugins/web3/steps/check-balance";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork, getRpcProvider } from "@/lib/rpc";
 
 // Helper to create test context
 const createTestContext = () => ({
@@ -159,9 +152,11 @@ describe("Web3 Plugin Steps Integration", () => {
         );
       }
 
-      // Verify resolveRpcConfig is called with userId for user RPC preferences
-      // The step uses resolveRpcConfig + new ethers.JsonRpcProvider(), not getRpcProvider
-      expect(resolveRpcConfig).toHaveBeenCalledWith(1, "user_123");
+      // Verify getRpcProvider is called with chainId and userId for user RPC preferences
+      expect(getRpcProvider).toHaveBeenCalledWith({
+        chainId: 1,
+        userId: "user_123",
+      });
     });
 
     it("should successfully check balance on sepolia", async () => {
@@ -212,8 +207,10 @@ describe("Web3 Plugin Steps Integration", () => {
     });
 
     it("should handle RPC provider errors", async () => {
-      // Mock resolveRpcConfig to return null (chain not found/disabled)
-      vi.mocked(resolveRpcConfig).mockResolvedValueOnce(null);
+      // Mock getRpcProvider to reject (chain not found/disabled)
+      vi.mocked(getRpcProvider).mockRejectedValueOnce(
+        new Error("Chain 1 not found or not enabled")
+      );
 
       const input = {
         network: "mainnet",
@@ -230,15 +227,6 @@ describe("Web3 Plugin Steps Integration", () => {
     });
 
     it("should use user RPC preferences when available", async () => {
-      // Mock resolveRpcConfig to return user-configured RPC
-      vi.mocked(resolveRpcConfig).mockResolvedValueOnce({
-        chainId: 1,
-        chainName: "Ethereum Mainnet",
-        primaryRpcUrl: "https://user-custom-rpc.example.com",
-        fallbackRpcUrl: "https://user-backup.example.com",
-        source: "user",
-      });
-
       const input = {
         network: "mainnet",
         address: "0x1234567890123456789012345678901234567890",
@@ -248,51 +236,73 @@ describe("Web3 Plugin Steps Integration", () => {
       const result = await checkBalanceStep(input);
 
       expect(result.success).toBe(true);
-      // Verify user preferences were used
-      expect(resolveRpcConfig).toHaveBeenCalledWith(1, "user_123");
+      // Verify getRpcProvider is called with userId so user preferences are resolved
+      expect(getRpcProvider).toHaveBeenCalledWith({
+        chainId: 1,
+        userId: "user_123",
+      });
     });
   });
 });
 
-describe("Web3 RPC Config Resolution", () => {
+describe("Web3 RPC Provider Resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should resolve config with user preferences", async () => {
-    vi.mocked(resolveRpcConfig).mockResolvedValueOnce({
-      chainId: 1,
-      chainName: "Ethereum Mainnet",
-      primaryRpcUrl: "https://user-custom-rpc.example.com",
-      fallbackRpcUrl: "https://user-custom-backup.example.com",
-      source: "user",
+  it("should pass userId to getRpcProvider for user preferences", async () => {
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: "0x1234567890123456789012345678901234567890",
+      _context: createTestContext(),
     });
 
-    const config = await resolveRpcConfig(1, "user_123");
-
-    expect(config?.source).toBe("user");
-    expect(config?.primaryRpcUrl).toBe("https://user-custom-rpc.example.com");
+    expect(result.success).toBe(true);
+    expect(getRpcProvider).toHaveBeenCalledWith({
+      chainId: 1,
+      userId: "user_123",
+    });
   });
 
-  it("should fall back to defaults when no user preference", async () => {
-    vi.mocked(resolveRpcConfig).mockResolvedValueOnce({
-      chainId: 1,
-      chainName: "Ethereum Mainnet",
-      primaryRpcUrl: "https://default-rpc.example.com",
-      fallbackRpcUrl: "https://default-backup.example.com",
-      source: "default",
+  it("should fail when getRpcProvider rejects for disabled chain", async () => {
+    vi.mocked(getRpcProvider).mockRejectedValueOnce(
+      new Error("Chain 999 not found or not enabled")
+    );
+
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: "0x1234567890123456789012345678901234567890",
+      _context: createTestContext(),
     });
 
-    const config = await resolveRpcConfig(1, "user_456");
-
-    expect(config?.source).toBe("default");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("not found or not enabled");
+    }
   });
 
-  it("should return null for disabled chain", async () => {
-    vi.mocked(resolveRpcConfig).mockResolvedValueOnce(null);
+  it("should use executeWithFailover for balance check", async () => {
+    const mockExecuteWithFailover = vi.fn(
+      async (operation: (provider: unknown) => Promise<unknown>) => {
+        const mockProvider = {
+          getBalance: vi
+            .fn()
+            .mockResolvedValue(BigInt(3_000_000_000_000_000_000)),
+        };
+        return await operation(mockProvider);
+      }
+    );
+    vi.mocked(getRpcProvider).mockResolvedValueOnce({
+      executeWithFailover: mockExecuteWithFailover,
+    } as unknown as Awaited<ReturnType<typeof getRpcProvider>>);
 
-    const config = await resolveRpcConfig(999);
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: "0x1234567890123456789012345678901234567890",
+      _context: createTestContext(),
+    });
 
-    expect(config).toBeNull();
+    expect(result.success).toBe(true);
+    expect(mockExecuteWithFailover).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -54,12 +54,12 @@ vi.mock("drizzle-orm", () => ({
 
 // Mock RPC resolution
 const mockGetChainIdFromNetwork = vi.fn();
-const mockResolveRpcConfig = vi.fn();
+const mockGetRpcProvider = vi.fn();
 
 vi.mock("@/lib/rpc", () => ({
   getChainIdFromNetwork: (...args: unknown[]) =>
     mockGetChainIdFromNetwork(...args),
-  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
 }));
 
 // Mock explorer
@@ -171,8 +171,8 @@ function makeInput(
 
 function setupMocks(): void {
   mockGetChainIdFromNetwork.mockReturnValue(1);
-  mockResolveRpcConfig.mockResolvedValue({
-    primaryRpcUrl: "https://rpc.example.com",
+  mockGetRpcProvider.mockResolvedValue({
+    getCurrentRpcUrl: () => "https://rpc.example.com",
   });
   mockResolveOrgContext.mockResolvedValue({
     success: true,

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -172,7 +172,7 @@ function makeInput(
 function setupMocks(): void {
   mockGetChainIdFromNetwork.mockReturnValue(1);
   mockGetRpcProvider.mockResolvedValue({
-    getCurrentRpcUrl: () => "https://rpc.example.com",
+    resolveActiveRpcUrl: () => Promise.resolve("https://rpc.example.com"),
   });
   mockResolveOrgContext.mockResolvedValue({
     success: true,

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -37,12 +37,12 @@ vi.mock("drizzle-orm", () => ({
 
 // Mock RPC resolution
 const mockGetChainIdFromNetwork = vi.fn();
-const mockResolveRpcConfig = vi.fn();
+const mockGetRpcProvider = vi.fn();
 
 vi.mock("@/lib/rpc", () => ({
   getChainIdFromNetwork: (...args: unknown[]) =>
     mockGetChainIdFromNetwork(...args),
-  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
 }));
 
 // Mock ethers with enough fidelity for encoding/decoding tests
@@ -197,8 +197,9 @@ beforeEach(() => {
 
 function setupRpcMocks(chainId = 1): void {
   mockGetChainIdFromNetwork.mockReturnValue(chainId);
-  mockResolveRpcConfig.mockResolvedValue({
-    primaryRpcUrl: "https://rpc.example.com",
+  mockGetRpcProvider.mockResolvedValue({
+    executeWithFailover: (fn: (provider: unknown) => unknown) =>
+      fn(new (class MockProvider {})()),
   });
 }
 
@@ -486,9 +487,11 @@ describe("batch-read-contract - uniform mode execution", () => {
     expect(result.error).toContain("Unknown network");
   });
 
-  it("fails when RPC config is not found", async () => {
+  it("fails when RPC provider resolution fails", async () => {
     mockGetChainIdFromNetwork.mockReturnValue(99_999);
-    mockResolveRpcConfig.mockResolvedValue(null);
+    mockGetRpcProvider.mockRejectedValue(
+      new Error("RPC config for chain 99999 not found or not enabled")
+    );
 
     const result = await expectFailure({
       inputMode: "uniform",
@@ -867,8 +870,9 @@ describe("batch-read-contract - mixed mode execution", () => {
       }
       throw new Error(`Unknown network: ${network}`);
     });
-    mockResolveRpcConfig.mockResolvedValue({
-      primaryRpcUrl: "https://rpc.example.com",
+    mockGetRpcProvider.mockResolvedValue({
+      executeWithFailover: (fn: (provider: unknown) => unknown) =>
+        fn(new (class MockProvider {})()),
     });
 
     // Ethereum batch (calls 0 and 2)

--- a/tests/unit/check-allowance.test.ts
+++ b/tests/unit/check-allowance.test.ts
@@ -43,12 +43,12 @@ vi.mock("drizzle-orm", () => ({
 
 // Mock RPC resolution
 const mockGetChainIdFromNetwork = vi.fn();
-const mockResolveRpcConfig = vi.fn();
+const mockGetRpcProvider = vi.fn();
 
 vi.mock("@/lib/rpc", () => ({
   getChainIdFromNetwork: (...args: unknown[]) =>
     mockGetChainIdFromNetwork(...args),
-  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
 }));
 
 // Mock ethers Contract methods
@@ -111,8 +111,9 @@ function makeInput(
 
 function setupMocks(): void {
   mockGetChainIdFromNetwork.mockReturnValue(1);
-  mockResolveRpcConfig.mockResolvedValue({
-    primaryRpcUrl: "https://rpc.example.com",
+  mockGetRpcProvider.mockResolvedValue({
+    executeWithFailover: (fn: (provider: unknown) => unknown) =>
+      fn(new (class MockProvider {})()),
   });
   mockDecimals.mockResolvedValue(BigInt(18));
   mockSymbol.mockResolvedValue("DAI");
@@ -234,9 +235,11 @@ describe("check-allowance - error handling", () => {
     }
   });
 
-  it("fails when RPC config is not found", async () => {
+  it("fails when RPC provider resolution fails", async () => {
     setupMocks();
-    mockResolveRpcConfig.mockResolvedValue(null);
+    mockGetRpcProvider.mockRejectedValue(
+      new Error("RPC config for chain 1 not found or not enabled")
+    );
 
     const result = (await checkAllowanceStep(
       makeInput({})

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -41,12 +41,12 @@ vi.mock("@/lib/explorer", () => ({
 }));
 
 const mockGetChainIdFromNetwork = vi.fn();
-const mockResolveRpcConfig = vi.fn();
+const mockGetRpcProvider = vi.fn();
 
 vi.mock("@/lib/rpc", () => ({
   getChainIdFromNetwork: (...args: unknown[]) =>
     mockGetChainIdFromNetwork(...args),
-  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
 }));
 
 const mockContractFunction = vi.fn();
@@ -138,8 +138,9 @@ function makeInput(
 
 function setupRpcMocks(): void {
   mockGetChainIdFromNetwork.mockReturnValue(1);
-  mockResolveRpcConfig.mockResolvedValue({
-    primaryRpcUrl: "https://rpc.example.com",
+  mockGetRpcProvider.mockResolvedValue({
+    executeWithFailover: (fn: (provider: unknown) => unknown) =>
+      fn(new (class MockProvider {})()),
   });
 }
 

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -323,6 +323,42 @@ describe("RpcProviderManager", () => {
       );
     });
 
+    it("should throw without redundant fallback retry when both fail in sticky fallback state", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      // First call: primary fails, fallback succeeds -> sticky fallback
+      const firstOp = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Primary failed"))
+        .mockResolvedValue("fallback ok");
+      await manager.executeWithFailover(firstOp);
+      expect(manager.isCurrentlyUsingFallback()).toBe(true);
+
+      vi.mocked(metricsCollector.recordFallbackAttempt).mockClear();
+      vi.mocked(metricsCollector.recordPrimaryAttempt).mockClear();
+
+      // Second call: both fail. Fallback should be tried once, primary once.
+      // No redundant third attempt on fallback.
+      const secondOp = vi.fn().mockRejectedValue(new Error("down"));
+
+      await expect(manager.executeWithFailover(secondOp)).rejects.toThrow(
+        "RPC failed on both endpoints"
+      );
+
+      // Fallback attempted once, primary attempted once -- no double fallback
+      expect(metricsCollector.recordFallbackAttempt).toHaveBeenCalledTimes(1);
+      expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+    });
+
     describe("Retry-After handling on 429", () => {
       it("should respect Retry-After header within cap and retry", async () => {
         const manager = new RpcProviderManager({

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -38,8 +38,38 @@ vi.mock("ethers", () => {
       JsonRpcProvider: MockJsonRpcProvider,
       FetchRequest: MockFetchRequest,
     },
+    isError: (error: unknown, code: string): boolean => {
+      return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        (error as { code: string }).code === code
+      );
+    },
   };
 });
+
+// ---------------------------------------------------------------------------
+// Helpers for 429 / Retry-After tests
+// ---------------------------------------------------------------------------
+
+function makeServerError(
+  statusCode: number,
+  headers: Record<string, string> = {}
+): Error & { code: string; response: { statusCode: number; getHeader: (key: string) => string } } {
+  const err = new Error(`server responded with ${statusCode}`) as Error & {
+    code: string;
+    response: { statusCode: number; getHeader: (key: string) => string };
+  };
+  err.code = "SERVER_ERROR";
+  err.response = {
+    statusCode,
+    getHeader(key: string): string {
+      return headers[key.toLowerCase()] ?? "";
+    },
+  };
+  return err;
+}
 
 describe("RpcProviderManager", () => {
   let metricsCollector: RpcMetricsCollector;
@@ -291,6 +321,129 @@ describe("RpcProviderManager", () => {
         false,
         "recovery"
       );
+    });
+
+    describe("Retry-After handling on 429", () => {
+      it("should respect Retry-After header within cap and retry", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let callCount = 0;
+        const result = await manager.executeWithFailover(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw makeServerError(429, { "retry-after": "1" });
+          }
+          return "ok";
+        });
+
+        expect(result).toBe("ok");
+        expect(callCount).toBe(2);
+      });
+
+      it("should bail immediately on 429 without Retry-After header", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let totalCalls = 0;
+        const result = await manager.executeWithFailover(async () => {
+          totalCalls++;
+          if (totalCalls === 1) {
+            throw makeServerError(429);
+          }
+          return "fallback-ok";
+        });
+
+        expect(result).toBe("fallback-ok");
+        // Primary called once (bailed on 429), fallback called once (success)
+        expect(totalCalls).toBe(2);
+        expect(metricsCollector.recordPrimaryFailure).toHaveBeenCalledTimes(1);
+      });
+
+      it("should bail immediately on 429 with Retry-After exceeding cap", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let totalCalls = 0;
+        const result = await manager.executeWithFailover(async () => {
+          totalCalls++;
+          if (totalCalls === 1) {
+            throw makeServerError(429, { "retry-after": "60" });
+          }
+          return "fallback-ok";
+        });
+
+        expect(result).toBe("fallback-ok");
+        expect(totalCalls).toBe(2);
+        expect(metricsCollector.recordPrimaryFailure).toHaveBeenCalledTimes(1);
+      });
+
+      it("should throw when both providers return 429 without Retry-After", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeServerError(429);
+          })
+        ).rejects.toThrow("RPC failed on both endpoints");
+      });
+
+      it("should use exponential backoff for non-429 errors", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            maxRetries: 2,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let callCount = 0;
+        const result = await manager.executeWithFailover(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error("connection reset");
+          }
+          return "ok";
+        });
+
+        expect(result).toBe("ok");
+        expect(callCount).toBe(2);
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -53,6 +53,12 @@ vi.mock("ethers", () => {
 // Helpers for 429 / Retry-After tests
 // ---------------------------------------------------------------------------
 
+function makeEthersError(code: string, message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
 function makeServerError(
   statusCode: number,
   headers: Record<string, string> = {}
@@ -472,6 +478,101 @@ describe("RpcProviderManager", () => {
           callCount++;
           if (callCount === 1) {
             throw new Error("connection reset");
+          }
+          return "ok";
+        });
+
+        expect(result).toBe("ok");
+        expect(callCount).toBe(2);
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("non-retryable error handling", () => {
+      it("should throw immediately on CALL_EXCEPTION without retrying or failing over", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeEthersError("CALL_EXCEPTION", "execution reverted");
+          })
+        ).rejects.toThrow("execution reverted");
+
+        // Called once on primary, no retries, no fallback attempt
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordPrimaryFailure).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordFallbackAttempt).not.toHaveBeenCalled();
+      });
+
+      it("should throw immediately on INVALID_ARGUMENT", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeEthersError("INVALID_ARGUMENT", "invalid address");
+          })
+        ).rejects.toThrow("invalid address");
+
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordFallbackAttempt).not.toHaveBeenCalled();
+      });
+
+      it("should throw immediately on NUMERIC_FAULT", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeEthersError("NUMERIC_FAULT", "overflow");
+          })
+        ).rejects.toThrow("overflow");
+
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordFallbackAttempt).not.toHaveBeenCalled();
+      });
+
+      it("should still retry transient SERVER_ERROR (non-429)", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            maxRetries: 2,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let callCount = 0;
+        const result = await manager.executeWithFailover(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw makeServerError(503);
           }
           return "ok";
         });

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -386,7 +386,7 @@ describe("RpcProviderManager", () => {
           if (callCount === 1) {
             throw makeServerError(429, { "retry-after": "1" });
           }
-          return "ok";
+          return Promise.resolve("ok");
         });
 
         expect(result).toBe("ok");
@@ -411,7 +411,7 @@ describe("RpcProviderManager", () => {
           if (totalCalls === 1) {
             throw makeServerError(429);
           }
-          return "fallback-ok";
+          return Promise.resolve("fallback-ok");
         });
 
         expect(result).toBe("fallback-ok");
@@ -438,7 +438,7 @@ describe("RpcProviderManager", () => {
           if (totalCalls === 1) {
             throw makeServerError(429, { "retry-after": "60" });
           }
-          return "fallback-ok";
+          return Promise.resolve("fallback-ok");
         });
 
         expect(result).toBe("fallback-ok");
@@ -482,7 +482,7 @@ describe("RpcProviderManager", () => {
           if (callCount === 1) {
             throw new Error("connection reset");
           }
-          return "ok";
+          return Promise.resolve("ok");
         });
 
         expect(result).toBe("ok");
@@ -577,7 +577,7 @@ describe("RpcProviderManager", () => {
           if (callCount === 1) {
             throw makeServerError(503);
           }
-          return "ok";
+          return Promise.resolve("ok");
         });
 
         expect(result).toBe("ok");

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -38,14 +38,11 @@ vi.mock("ethers", () => {
       JsonRpcProvider: MockJsonRpcProvider,
       FetchRequest: MockFetchRequest,
     },
-    isError: (error: unknown, code: string): boolean => {
-      return (
-        typeof error === "object" &&
-        error !== null &&
-        "code" in error &&
-        (error as { code: string }).code === code
-      );
-    },
+    isError: (error: unknown, code: string): boolean =>
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code: string }).code === code,
   };
 });
 
@@ -53,7 +50,10 @@ vi.mock("ethers", () => {
 // Helpers for 429 / Retry-After tests
 // ---------------------------------------------------------------------------
 
-function makeEthersError(code: string, message: string): Error & { code: string } {
+function makeEthersError(
+  code: string,
+  message: string
+): Error & { code: string } {
   const err = new Error(message) as Error & { code: string };
   err.code = code;
   return err;
@@ -62,7 +62,10 @@ function makeEthersError(code: string, message: string): Error & { code: string 
 function makeServerError(
   statusCode: number,
   headers: Record<string, string> = {}
-): Error & { code: string; response: { statusCode: number; getHeader: (key: string) => string } } {
+): Error & {
+  code: string;
+  response: { statusCode: number; getHeader: (key: string) => string };
+} {
   const err = new Error(`server responded with ${statusCode}`) as Error & {
     code: string;
     response: { statusCode: number; getHeader: (key: string) => string };
@@ -378,7 +381,7 @@ describe("RpcProviderManager", () => {
         });
 
         let callCount = 0;
-        const result = await manager.executeWithFailover(async () => {
+        const result = await manager.executeWithFailover(() => {
           callCount++;
           if (callCount === 1) {
             throw makeServerError(429, { "retry-after": "1" });
@@ -403,7 +406,7 @@ describe("RpcProviderManager", () => {
         });
 
         let totalCalls = 0;
-        const result = await manager.executeWithFailover(async () => {
+        const result = await manager.executeWithFailover(() => {
           totalCalls++;
           if (totalCalls === 1) {
             throw makeServerError(429);
@@ -430,7 +433,7 @@ describe("RpcProviderManager", () => {
         });
 
         let totalCalls = 0;
-        const result = await manager.executeWithFailover(async () => {
+        const result = await manager.executeWithFailover(() => {
           totalCalls++;
           if (totalCalls === 1) {
             throw makeServerError(429, { "retry-after": "60" });
@@ -456,7 +459,7 @@ describe("RpcProviderManager", () => {
         });
 
         await expect(
-          manager.executeWithFailover(async () => {
+          manager.executeWithFailover(() => {
             throw makeServerError(429);
           })
         ).rejects.toThrow("RPC failed on both endpoints");
@@ -474,7 +477,7 @@ describe("RpcProviderManager", () => {
         });
 
         let callCount = 0;
-        const result = await manager.executeWithFailover(async () => {
+        const result = await manager.executeWithFailover(() => {
           callCount++;
           if (callCount === 1) {
             throw new Error("connection reset");
@@ -502,7 +505,7 @@ describe("RpcProviderManager", () => {
         });
 
         await expect(
-          manager.executeWithFailover(async () => {
+          manager.executeWithFailover(() => {
             throw makeEthersError("CALL_EXCEPTION", "execution reverted");
           })
         ).rejects.toThrow("execution reverted");
@@ -526,7 +529,7 @@ describe("RpcProviderManager", () => {
         });
 
         await expect(
-          manager.executeWithFailover(async () => {
+          manager.executeWithFailover(() => {
             throw makeEthersError("INVALID_ARGUMENT", "invalid address");
           })
         ).rejects.toThrow("invalid address");
@@ -548,7 +551,7 @@ describe("RpcProviderManager", () => {
         });
 
         await expect(
-          manager.executeWithFailover(async () => {
+          manager.executeWithFailover(() => {
             throw makeEthersError("NUMERIC_FAULT", "overflow");
           })
         ).rejects.toThrow("overflow");
@@ -569,7 +572,7 @@ describe("RpcProviderManager", () => {
         });
 
         let callCount = 0;
-        const result = await manager.executeWithFailover(async () => {
+        const result = await manager.executeWithFailover(() => {
           callCount++;
           if (callCount === 1) {
             throw makeServerError(503);


### PR DESCRIPTION
## Summary
- Add `getCurrentRpcUrl()` to `RpcProviderManager` for failover-aware URL resolution
- Convert 8 read-operation steps to use `executeWithFailover()` for automatic retry + fallback on RPC rate limits
- Convert 4 write-operation steps to use `getCurrentRpcUrl()` to respect cached failover state
- Update unit test mocks for the new `getRpcProvider` pattern (77 tests passing)