### PR TITLE
fix: KEEP-1539 improve RPC failover error handling

### DIFF
--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers, isError } from "ethers";
 
 /**
  * Interface for metrics collection - allows dependency injection
@@ -96,6 +96,7 @@ export class RpcProviderManager {
 
   private static readonly DEFAULT_MAX_RETRIES = 3;
   private static readonly DEFAULT_TIMEOUT_MS = 30_000;
+  private static readonly RETRY_AFTER_CAP_SECONDS = 30;
 
   constructor(options: RpcProviderManagerOptions) {
     const {
@@ -304,6 +305,30 @@ export class RpcProviderManager {
         }
 
         if (attempt === maxRetries - 1) {
+          break;
+        }
+
+        // On 429 rate limit: respect Retry-After if within cap,
+        // otherwise bail immediately and let executeWithFailover switch providers
+        if (
+          isError(error, "SERVER_ERROR") &&
+          error.response?.statusCode === 429
+        ) {
+          const retryAfterHeader = error.response.getHeader("retry-after");
+          const retryAfterSeconds = retryAfterHeader
+            ? Number.parseInt(retryAfterHeader, 10)
+            : Number.NaN;
+
+          if (
+            !Number.isNaN(retryAfterSeconds) &&
+            retryAfterSeconds > 0 &&
+            retryAfterSeconds <= RpcProviderManager.RETRY_AFTER_CAP_SECONDS
+          ) {
+            await this.delay(retryAfterSeconds * 1000);
+            continue;
+          }
+
+          // No usable Retry-After -- stop retrying this provider
           break;
         }
 

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -1,4 +1,18 @@
-import { ethers, isError } from "ethers";
+import { type EthersError, ethers, isError } from "ethers";
+
+/**
+ * Ethers error codes that indicate a permanent failure -- retrying on the same
+ * or a different provider will never succeed. These are re-thrown immediately,
+ * bypassing both the retry loop and the failover logic.
+ */
+const NON_RETRYABLE_ERROR_CODES: ReadonlySet<string> = new Set([
+  "CALL_EXCEPTION", // contract revert, out-of-gas, function not found
+  "INVALID_ARGUMENT", // bad parameter types/values
+  "MISSING_ARGUMENT",
+  "UNEXPECTED_ARGUMENT",
+  "NUMERIC_FAULT", // overflow, division by zero
+  "BAD_DATA", // malformed ABI encoding that won't decode on any provider
+]);
 
 /**
  * Interface for metrics collection - allows dependency injection
@@ -329,6 +343,13 @@ export class RpcProviderManager {
           this.metricsCollector.recordFallbackFailure(this.config.chainName);
         }
 
+        // Non-retryable errors (contract revert, invalid args, etc.) will
+        // never succeed on any provider -- re-throw immediately to skip
+        // both remaining retries and failover to the other provider.
+        if (this.isNonRetryableError(error)) {
+          throw lastError;
+        }
+
         if (attempt === maxRetries - 1) {
           break;
         }
@@ -381,6 +402,15 @@ export class RpcProviderManager {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private isNonRetryableError(error: unknown): boolean {
+    if (typeof error !== "object" || error === null || !("code" in error)) {
+      return false;
+    }
+    return NON_RETRYABLE_ERROR_CODES.has(
+      (error as EthersError).code as string
+    );
   }
 
   getMetrics(): Readonly<RpcProviderMetrics> {

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -163,7 +163,7 @@ export class RpcProviderManager {
   ): Promise<T> {
     this.metrics.totalRequests += 1;
 
-    // If we've already switched to fallback, use it directly
+    // When in sticky fallback state, try fallback first, then primary as recovery
     if (this.isUsingFallback) {
       const fallbackProvider = this.getFallbackProvider();
       if (fallbackProvider) {
@@ -178,7 +178,7 @@ export class RpcProviderManager {
           return fallbackResult.result as T;
         }
 
-        // Fallback failed - try primary again in case it recovered
+        // Fallback failed - try primary in case it recovered
         console.warn(
           JSON.stringify({
             level: "warn",
@@ -188,9 +188,51 @@ export class RpcProviderManager {
             timestamp: new Date().toISOString(),
           })
         );
+
+        const primaryProvider = this.getPrimaryProvider();
+        const primaryResult = await this.tryProvider(
+          primaryProvider,
+          operation,
+          "primary",
+          this.config.maxRetries
+        );
+
+        if (primaryResult.success) {
+          console.info(
+            JSON.stringify({
+              level: "info",
+              event: "RPC_FAILOVER_RECOVERY",
+              message: `Primary RPC recovered for ${this.config.chainName}, switching back from fallback`,
+              chain: this.config.chainName,
+              previousState: "fallback",
+              newState: "primary",
+              timestamp: new Date().toISOString(),
+            })
+          );
+          this.isUsingFallback = false;
+          this.onFailoverStateChange?.(this.config.chainName, false, "recovery");
+          return primaryResult.result as T;
+        }
+
+        // Both failed -- throw without redundant retry
+        console.error(
+          JSON.stringify({
+            level: "error",
+            event: "RPC_BOTH_ENDPOINTS_FAILED",
+            message: `Both primary and fallback RPC failed for ${this.config.chainName}`,
+            chain: this.config.chainName,
+            fallbackError: fallbackResult.error,
+            primaryError: primaryResult.error,
+            timestamp: new Date().toISOString(),
+          })
+        );
+        throw new Error(
+          `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`
+        );
       }
     }
 
+    // Normal path: try primary first, then fallback
     const primaryProvider = this.getPrimaryProvider();
     const primaryResult = await this.tryProvider(
       primaryProvider,
@@ -200,21 +242,6 @@ export class RpcProviderManager {
     );
 
     if (primaryResult.success) {
-      if (this.isUsingFallback) {
-        console.info(
-          JSON.stringify({
-            level: "info",
-            event: "RPC_FAILOVER_RECOVERY",
-            message: `Primary RPC recovered for ${this.config.chainName}, switching back from fallback`,
-            chain: this.config.chainName,
-            previousState: "fallback",
-            newState: "primary",
-            timestamp: new Date().toISOString(),
-          })
-        );
-        this.isUsingFallback = false;
-        this.onFailoverStateChange?.(this.config.chainName, false, "recovery");
-      }
       return primaryResult.result as T;
     }
 
@@ -231,22 +258,20 @@ export class RpcProviderManager {
       );
 
       if (fallbackResult.success) {
-        if (!this.isUsingFallback) {
-          console.warn(
-            JSON.stringify({
-              level: "warn",
-              event: "RPC_FAILOVER_ACTIVATED",
-              message: `Primary RPC failed for ${this.config.chainName}, switching to fallback`,
-              chain: this.config.chainName,
-              previousState: "primary",
-              newState: "fallback",
-              primaryError: primaryResult.error,
-              timestamp: new Date().toISOString(),
-            })
-          );
-          this.isUsingFallback = true;
-          this.onFailoverStateChange?.(this.config.chainName, true, "failover");
-        }
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "RPC_FAILOVER_ACTIVATED",
+            message: `Primary RPC failed for ${this.config.chainName}, switching to fallback`,
+            chain: this.config.chainName,
+            previousState: "primary",
+            newState: "fallback",
+            primaryError: primaryResult.error,
+            timestamp: new Date().toISOString(),
+          })
+        );
+        this.isUsingFallback = true;
+        this.onFailoverStateChange?.(this.config.chainName, true, "failover");
         return fallbackResult.result as T;
       }
 

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -323,6 +323,42 @@ describe("RpcProviderManager", () => {
       );
     });
 
+    it("should throw without redundant fallback retry when both fail in sticky fallback state", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      // First call: primary fails, fallback succeeds -> sticky fallback
+      const firstOp = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Primary failed"))
+        .mockResolvedValue("fallback ok");
+      await manager.executeWithFailover(firstOp);
+      expect(manager.isCurrentlyUsingFallback()).toBe(true);
+
+      vi.mocked(metricsCollector.recordFallbackAttempt).mockClear();
+      vi.mocked(metricsCollector.recordPrimaryAttempt).mockClear();
+
+      // Second call: both fail. Fallback should be tried once, primary once.
+      // No redundant third attempt on fallback.
+      const secondOp = vi.fn().mockRejectedValue(new Error("down"));
+
+      await expect(manager.executeWithFailover(secondOp)).rejects.toThrow(
+        "RPC failed on both endpoints"
+      );
+
+      // Fallback attempted once, primary attempted once -- no double fallback
+      expect(metricsCollector.recordFallbackAttempt).toHaveBeenCalledTimes(1);
+      expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+    });
+
     describe("Retry-After handling on 429", () => {
       it("should respect Retry-After header within cap and retry", async () => {
         const manager = new RpcProviderManager({

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -38,8 +38,38 @@ vi.mock("ethers", () => {
       JsonRpcProvider: MockJsonRpcProvider,
       FetchRequest: MockFetchRequest,
     },
+    isError: (error: unknown, code: string): boolean => {
+      return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        (error as { code: string }).code === code
+      );
+    },
   };
 });
+
+// ---------------------------------------------------------------------------
+// Helpers for 429 / Retry-After tests
+// ---------------------------------------------------------------------------
+
+function makeServerError(
+  statusCode: number,
+  headers: Record<string, string> = {}
+): Error & { code: string; response: { statusCode: number; getHeader: (key: string) => string } } {
+  const err = new Error(`server responded with ${statusCode}`) as Error & {
+    code: string;
+    response: { statusCode: number; getHeader: (key: string) => string };
+  };
+  err.code = "SERVER_ERROR";
+  err.response = {
+    statusCode,
+    getHeader(key: string): string {
+      return headers[key.toLowerCase()] ?? "";
+    },
+  };
+  return err;
+}
 
 describe("RpcProviderManager", () => {
   let metricsCollector: RpcMetricsCollector;
@@ -291,6 +321,129 @@ describe("RpcProviderManager", () => {
         false,
         "recovery"
       );
+    });
+
+    describe("Retry-After handling on 429", () => {
+      it("should respect Retry-After header within cap and retry", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let callCount = 0;
+        const result = await manager.executeWithFailover(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw makeServerError(429, { "retry-after": "1" });
+          }
+          return "ok";
+        });
+
+        expect(result).toBe("ok");
+        expect(callCount).toBe(2);
+      });
+
+      it("should bail immediately on 429 without Retry-After header", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let totalCalls = 0;
+        const result = await manager.executeWithFailover(async () => {
+          totalCalls++;
+          if (totalCalls === 1) {
+            throw makeServerError(429);
+          }
+          return "fallback-ok";
+        });
+
+        expect(result).toBe("fallback-ok");
+        // Primary called once (bailed on 429), fallback called once (success)
+        expect(totalCalls).toBe(2);
+        expect(metricsCollector.recordPrimaryFailure).toHaveBeenCalledTimes(1);
+      });
+
+      it("should bail immediately on 429 with Retry-After exceeding cap", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let totalCalls = 0;
+        const result = await manager.executeWithFailover(async () => {
+          totalCalls++;
+          if (totalCalls === 1) {
+            throw makeServerError(429, { "retry-after": "60" });
+          }
+          return "fallback-ok";
+        });
+
+        expect(result).toBe("fallback-ok");
+        expect(totalCalls).toBe(2);
+        expect(metricsCollector.recordPrimaryFailure).toHaveBeenCalledTimes(1);
+      });
+
+      it("should throw when both providers return 429 without Retry-After", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeServerError(429);
+          })
+        ).rejects.toThrow("RPC failed on both endpoints");
+      });
+
+      it("should use exponential backoff for non-429 errors", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            maxRetries: 2,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let callCount = 0;
+        const result = await manager.executeWithFailover(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error("connection reset");
+          }
+          return "ok";
+        });
+
+        expect(result).toBe("ok");
+        expect(callCount).toBe(2);
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -53,6 +53,12 @@ vi.mock("ethers", () => {
 // Helpers for 429 / Retry-After tests
 // ---------------------------------------------------------------------------
 
+function makeEthersError(code: string, message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
 function makeServerError(
   statusCode: number,
   headers: Record<string, string> = {}
@@ -472,6 +478,101 @@ describe("RpcProviderManager", () => {
           callCount++;
           if (callCount === 1) {
             throw new Error("connection reset");
+          }
+          return "ok";
+        });
+
+        expect(result).toBe("ok");
+        expect(callCount).toBe(2);
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("non-retryable error handling", () => {
+      it("should throw immediately on CALL_EXCEPTION without retrying or failing over", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeEthersError("CALL_EXCEPTION", "execution reverted");
+          })
+        ).rejects.toThrow("execution reverted");
+
+        // Called once on primary, no retries, no fallback attempt
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordPrimaryFailure).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordFallbackAttempt).not.toHaveBeenCalled();
+      });
+
+      it("should throw immediately on INVALID_ARGUMENT", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeEthersError("INVALID_ARGUMENT", "invalid address");
+          })
+        ).rejects.toThrow("invalid address");
+
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordFallbackAttempt).not.toHaveBeenCalled();
+      });
+
+      it("should throw immediately on NUMERIC_FAULT", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            fallbackRpcUrl: "https://fallback.example.com",
+            maxRetries: 3,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        await expect(
+          manager.executeWithFailover(async () => {
+            throw makeEthersError("NUMERIC_FAULT", "overflow");
+          })
+        ).rejects.toThrow("overflow");
+
+        expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledTimes(1);
+        expect(metricsCollector.recordFallbackAttempt).not.toHaveBeenCalled();
+      });
+
+      it("should still retry transient SERVER_ERROR (non-429)", async () => {
+        const manager = new RpcProviderManager({
+          config: {
+            primaryRpcUrl: "https://primary.example.com",
+            maxRetries: 2,
+            timeoutMs: 100,
+            chainName: "Ethereum",
+          },
+          metricsCollector,
+        });
+
+        let callCount = 0;
+        const result = await manager.executeWithFailover(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw makeServerError(503);
           }
           return "ok";
         });


### PR DESCRIPTION
## Summary
- Respect Retry-After header on HTTP 429 rate limits -- use server-specified delay when within 30s cap, otherwise bail immediately and switch providers
- Eliminate redundant fallback retry when in sticky failover state -- each provider tried exactly once before throwing
- Skip retry and failover entirely for non-retryable errors (CALL_EXCEPTION, INVALID_ARGUMENT, NUMERIC_FAULT, etc.) -- a contract revert will never succeed on a different provider

## Test plan
- [x] `pnpm vitest run tests/unit/rpc-provider.test.ts` -- 29 tests covering all new behavior
- [x] `pnpm vitest run tests/unit/approve-token.test.ts tests/integration/web3-steps.test.ts tests/integration/query-transactions.test.ts` -- regression suite
- [x] `pnpm type-check` -- no new type errors