### PR TITLE
feat: add project filter drawer to analytics

### DIFF
--- a/keeperhub/api/analytics/networks/route.ts
+++ b/keeperhub/api/analytics/networks/route.ts
@@ -20,12 +20,14 @@ export const GET = requireOrganization(
       const range = parseTimeRange(params.get("range"));
       const customStart = params.get("customStart") ?? undefined;
       const customEnd = params.get("customEnd") ?? undefined;
+      const projectId = params.get("projectId") ?? undefined;
 
       const networks = await getNetworkBreakdown(
         organizationId,
         range,
         customStart,
-        customEnd
+        customEnd,
+        projectId
       );
 
       return NextResponse.json({ networks });

--- a/keeperhub/api/analytics/runs/route.ts
+++ b/keeperhub/api/analytics/runs/route.ts
@@ -50,6 +50,8 @@ export const GET = requireOrganization(
           ? (sourceParam as RunSource)
           : undefined;
 
+      const projectId = params.get("projectId") ?? undefined;
+
       const result = await getUnifiedRuns(organizationId, range, {
         cursor,
         limit,
@@ -57,6 +59,7 @@ export const GET = requireOrganization(
         source,
         customStart,
         customEnd,
+        projectId,
       });
 
       return NextResponse.json(result);

--- a/keeperhub/api/analytics/stream/route.ts
+++ b/keeperhub/api/analytics/stream/route.ts
@@ -24,13 +24,15 @@ async function fetchAndEmit(
   organizationId: string,
   range: ReturnType<typeof parseTimeRange>,
   customStart: string | undefined,
-  customEnd: string | undefined
+  customEnd: string | undefined,
+  projectId: string | undefined
 ): Promise<void> {
   const summary = await getAnalyticsSummary(
     organizationId,
     range,
     customStart,
-    customEnd
+    customEnd,
+    projectId
   );
 
   const event: AnalyticsStreamEvent = {
@@ -56,6 +58,7 @@ export const GET = requireOrganization(
       const range = parseTimeRange(params.get("range"));
       const customStart = params.get("customStart") ?? undefined;
       const customEnd = params.get("customEnd") ?? undefined;
+      const projectId = params.get("projectId") ?? undefined;
 
       let lastChecksum = "";
       let lastEventTime = 0;
@@ -104,7 +107,8 @@ export const GET = requireOrganization(
                 organizationId,
                 range,
                 customStart,
-                customEnd
+                customEnd,
+                projectId
               );
             } catch {
               cleanup();

--- a/keeperhub/api/analytics/summary/route.ts
+++ b/keeperhub/api/analytics/summary/route.ts
@@ -20,12 +20,14 @@ export const GET = requireOrganization(
       const range = parseTimeRange(params.get("range"));
       const customStart = params.get("customStart") ?? undefined;
       const customEnd = params.get("customEnd") ?? undefined;
+      const projectId = params.get("projectId") ?? undefined;
 
       const summary = await getAnalyticsSummary(
         organizationId,
         range,
         customStart,
-        customEnd
+        customEnd,
+        projectId
       );
 
       return NextResponse.json(summary);

--- a/keeperhub/api/analytics/time-series/route.ts
+++ b/keeperhub/api/analytics/time-series/route.ts
@@ -20,12 +20,14 @@ export const GET = requireOrganization(
       const range = parseTimeRange(params.get("range"));
       const customStart = params.get("customStart") ?? undefined;
       const customEnd = params.get("customEnd") ?? undefined;
+      const projectId = params.get("projectId") ?? undefined;
 
       const buckets = await getTimeSeries(
         organizationId,
         range,
         customStart,
-        customEnd
+        customEnd,
+        projectId
       );
 
       return NextResponse.json({ buckets });

--- a/keeperhub/components/analytics/project-drawer.tsx
+++ b/keeperhub/components/analytics/project-drawer.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { ChevronLeft, ChevronRight, Layers } from "lucide-react";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { analyticsProjectIdAtom } from "@/keeperhub/lib/atoms/analytics";
+import { cn } from "@/lib/utils";
+
+const STORAGE_KEY = "keeperhub-analytics-drawer";
+const DRAWER_WIDTH = 220;
+const STRIP_WIDTH = 32;
+
+type DrawerState = "open" | "collapsed";
+
+type Project = {
+  id: string;
+  name: string;
+  color: string | null;
+};
+
+function useDrawerState(): [DrawerState, (s: DrawerState) => void] {
+  const [state, setState] = useState<DrawerState>("collapsed");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "open" || stored === "collapsed") {
+      setState(stored);
+    }
+  }, []);
+
+  const setAndPersist = useCallback((next: DrawerState): void => {
+    setState(next);
+    localStorage.setItem(STORAGE_KEY, next);
+  }, []);
+
+  return [state, setAndPersist];
+}
+
+function useProjects(): { projects: Project[]; loading: boolean } {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(): Promise<void> {
+      try {
+        const res = await fetch("/api/projects");
+        if (!res.ok) {
+          return;
+        }
+        const data = (await res.json()) as Project[];
+        if (!cancelled) {
+          setProjects(data);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load().catch(() => {
+      if (!cancelled) {
+        setLoading(false);
+      }
+    });
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { projects, loading };
+}
+
+export function ProjectDrawer(): ReactNode {
+  const [state, setState] = useDrawerState();
+  const [projectId, setProjectId] = useAtom(analyticsProjectIdAtom);
+  const { projects, loading } = useProjects();
+
+  if (state === "collapsed") {
+    return (
+      <button
+        className="flex shrink-0 items-start justify-center border-r bg-background pt-3 transition-colors hover:bg-muted"
+        onClick={() => setState("open")}
+        style={{ width: STRIP_WIDTH }}
+        type="button"
+      >
+        <div className="flex flex-col items-center gap-1">
+          <ChevronRight className="size-3.5 text-muted-foreground" />
+          <span
+            className="max-h-[120px] overflow-hidden text-muted-foreground text-xs"
+            style={{ writingMode: "vertical-lr" }}
+          >
+            Projects
+          </span>
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="flex shrink-0 flex-col border-r bg-background"
+      style={{ width: DRAWER_WIDTH }}
+    >
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <Layers className="size-3.5 text-muted-foreground" />
+          <span className="font-medium text-sm">Projects</span>
+        </div>
+        <button
+          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          onClick={() => setState("collapsed")}
+          title="Collapse"
+          type="button"
+        >
+          <ChevronLeft className="size-4" />
+        </button>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto p-1.5">
+        <button
+          className={cn(
+            "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors",
+            projectId === null
+              ? "bg-accent font-medium text-accent-foreground"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground"
+          )}
+          onClick={() => setProjectId(null)}
+          type="button"
+        >
+          All Runs
+        </button>
+
+        {loading ? (
+          <div className="px-2.5 py-3 text-xs text-muted-foreground">
+            Loading...
+          </div>
+        ) : (
+          projects.map((project) => (
+            <button
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors",
+                projectId === project.id
+                  ? "bg-accent font-medium text-accent-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+              key={project.id}
+              onClick={() => setProjectId(project.id)}
+              type="button"
+            >
+              <span
+                className="inline-block size-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: project.color ?? "#6b7280" }}
+              />
+              <span className="truncate">{project.name}</span>
+            </button>
+          ))
+        )}
+      </nav>
+    </div>
+  );
+}

--- a/keeperhub/components/analytics/runs-table.tsx
+++ b/keeperhub/components/analytics/runs-table.tsx
@@ -22,6 +22,7 @@ import {
   analyticsStatusFilterAtom,
 } from "@/keeperhub/lib/atoms/analytics";
 import { cn } from "@/lib/utils";
+import { ProjectDrawer } from "./project-drawer";
 
 function formatDuration(ms: number | null): string {
   if (ms === null) {
@@ -246,12 +247,6 @@ function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
           <ChevronIcon className="size-4 text-muted-foreground" />
         </td>
         <td className="py-3 pr-3">
-          <StatusBadge status={run.status} />
-        </td>
-        <td className="py-3 pr-3">
-          <SourceBadge source={run.source} />
-        </td>
-        <td className="py-3 pr-3">
           <div className="flex items-center gap-1.5">
             <span
               className={cn(
@@ -279,6 +274,12 @@ function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
               {run.completedSteps ?? 0}/{run.totalSteps} steps
             </span>
           ) : null}
+        </td>
+        <td className="py-3 pr-3">
+          <StatusBadge status={run.status} />
+        </td>
+        <td className="py-3 pr-3">
+          <SourceBadge source={run.source} />
         </td>
         <td className="whitespace-nowrap py-3 pr-3 text-sm text-muted-foreground">
           {formatDuration(run.durationMs)}
@@ -344,9 +345,9 @@ function RunsTableContent({
           <thead>
             <tr className="border-b text-xs text-muted-foreground">
               <th className="w-8 pb-2 pl-3" />
+              <th className="pb-2 pr-3 font-medium">Name</th>
               <th className="pb-2 pr-3 font-medium">Status</th>
               <th className="pb-2 pr-3 font-medium">Source</th>
-              <th className="pb-2 pr-3 font-medium">Name</th>
               <th className="pb-2 pr-3 font-medium">Duration</th>
               <th className="pb-2 pr-3 font-medium">Network</th>
               <th className="pb-2 pr-3 font-medium">Gas</th>
@@ -450,27 +451,30 @@ export function RunsTable(): ReactNode {
   const isEmpty = runs.length === 0;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center justify-between">
-          <span>Runs</span>
-          {runsData ? (
-            <span className="text-sm font-normal text-muted-foreground">
-              {runsData.total.toLocaleString()} total
-            </span>
-          ) : null}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <RunsTableContent
-          handleLoadMore={handleLoadMore}
-          isEmpty={isEmpty}
-          loading={loading}
-          loadingMore={loadingMore}
-          nextCursor={runsData?.nextCursor ?? null}
-          runs={runs}
-        />
-      </CardContent>
-    </Card>
+    <div className="flex gap-0 overflow-hidden rounded-xl border">
+      <ProjectDrawer />
+      <Card className="flex-1 rounded-none border-0">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Workflow Runs</span>
+            {runsData ? (
+              <span className="text-sm font-normal text-muted-foreground">
+                {runsData.total.toLocaleString()} total
+              </span>
+            ) : null}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <RunsTableContent
+            handleLoadMore={handleLoadMore}
+            isEmpty={isEmpty}
+            loading={loading}
+            loadingMore={loadingMore}
+            nextCursor={runsData?.nextCursor ?? null}
+            runs={runs}
+          />
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/keeperhub/components/analytics/use-analytics.ts
+++ b/keeperhub/components/analytics/use-analytics.ts
@@ -14,6 +14,7 @@ import {
   analyticsLiveAtom,
   analyticsLoadingAtom,
   analyticsNetworksAtom,
+  analyticsProjectIdAtom,
   analyticsRangeAtom,
   analyticsRunsAtom,
   analyticsSourceFilterAtom,
@@ -81,6 +82,7 @@ export function useAnalytics(): UseAnalyticsReturn {
   const range = useAtomValue(analyticsRangeAtom);
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
   const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
+  const projectId = useAtomValue(analyticsProjectIdAtom);
   const [live, setLive] = useAtom(analyticsLiveAtom);
   const [loading, setLoading] = useAtom(analyticsLoadingAtom);
   const [error, setError] = useAtom(analyticsErrorAtom);
@@ -103,11 +105,12 @@ export function useAnalytics(): UseAnalyticsReturn {
     setLoading(true);
     setError(null);
 
-    const baseQuery = buildQuery({ range });
+    const baseQuery = buildQuery({ range, projectId: projectId ?? undefined });
     const runsQuery = buildQuery({
       range,
       status: statusFilter,
       source: sourceFilter,
+      projectId: projectId ?? undefined,
     });
 
     const { signal } = controller;
@@ -208,6 +211,7 @@ export function useAnalytics(): UseAnalyticsReturn {
     range,
     statusFilter,
     sourceFilter,
+    projectId,
     setLoading,
     setError,
     setSummary,
@@ -243,7 +247,7 @@ export function useAnalytics(): UseAnalyticsReturn {
   const startSSE = useCallback((): void => {
     cleanupSSE();
 
-    const query = buildQuery({ range });
+    const query = buildQuery({ range, projectId: projectId ?? undefined });
     const source = new EventSource(`/api/analytics/stream?${query}`);
 
     source.onmessage = (event: MessageEvent): void => {
@@ -275,6 +279,7 @@ export function useAnalytics(): UseAnalyticsReturn {
     eventSourceRef.current = source;
   }, [
     range,
+    projectId,
     cleanupSSE,
     setSummary,
     setLastUpdated,

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -105,10 +105,13 @@ export async function getAnalyticsSummary(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
-  customEnd?: string
+  customEnd?: string,
+  projectId?: string
 ): Promise<AnalyticsSummary> {
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
+
+  const skipDirect = Boolean(projectId);
 
   const [
     workflowStats,
@@ -118,12 +121,27 @@ export async function getAnalyticsSummary(
     previousPeriod,
     workflowGasWei,
   ] = await Promise.all([
-    getWorkflowCounts(organizationId, rangeStart, rangeEnd),
-    getDirectCounts(organizationId, rangeStart, rangeEnd),
-    getActiveWorkflowCount(organizationId),
-    getActiveDirectCount(organizationId),
-    getPreviousPeriodSummary(organizationId, range, customStart, customEnd),
-    getWorkflowGasTotal(organizationId, rangeStart, rangeEnd),
+    getWorkflowCounts(organizationId, rangeStart, rangeEnd, projectId),
+    skipDirect
+      ? {
+          total: 0,
+          success: 0,
+          error: 0,
+          durationSum: 0,
+          durationCount: 0,
+          totalGasWei: "0",
+        }
+      : getDirectCounts(organizationId, rangeStart, rangeEnd),
+    getActiveWorkflowCount(organizationId, projectId),
+    skipDirect ? 0 : getActiveDirectCount(organizationId),
+    getPreviousPeriodSummary(
+      organizationId,
+      range,
+      customStart,
+      customEnd,
+      projectId
+    ),
+    getWorkflowGasTotal(organizationId, rangeStart, rangeEnd, projectId),
   ]);
 
   const totalRuns = workflowStats.total + directStats.total;
@@ -153,7 +171,8 @@ export async function getAnalyticsSummary(
 async function getWorkflowCounts(
   organizationId: string,
   rangeStart: Date,
-  rangeEnd: Date
+  rangeEnd: Date,
+  projectId?: string
 ): Promise<{
   total: number;
   success: number;
@@ -174,6 +193,7 @@ async function getWorkflowCounts(
     .where(
       and(
         eq(workflows.organizationId, organizationId),
+        projectId ? eq(workflows.projectId, projectId) : undefined,
         gte(workflowExecutions.startedAt, rangeStart),
         lt(workflowExecutions.startedAt, rangeEnd)
       )
@@ -230,7 +250,10 @@ async function getDirectCounts(
   };
 }
 
-function getActiveWorkflowCount(organizationId: string): Promise<number> {
+function getActiveWorkflowCount(
+  organizationId: string,
+  projectId?: string
+): Promise<number> {
   return db
     .select({ count: count() })
     .from(workflowExecutions)
@@ -238,6 +261,7 @@ function getActiveWorkflowCount(organizationId: string): Promise<number> {
     .where(
       and(
         eq(workflows.organizationId, organizationId),
+        projectId ? eq(workflows.projectId, projectId) : undefined,
         sql`${workflowExecutions.status} IN ('pending', 'running')`
       )
     )
@@ -261,14 +285,25 @@ async function getPreviousPeriodSummary(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
-  customEnd?: string
+  customEnd?: string,
+  projectId?: string
 ): Promise<AnalyticsSummary["previousPeriod"]> {
   const { start, end } = getPreviousPeriodStart(range, customStart, customEnd);
+  const skipDirect = Boolean(projectId);
 
   const [workflowStats, directStats, workflowGasWei] = await Promise.all([
-    getWorkflowCounts(organizationId, start, end),
-    getDirectCounts(organizationId, start, end),
-    getWorkflowGasTotal(organizationId, start, end),
+    getWorkflowCounts(organizationId, start, end, projectId),
+    skipDirect
+      ? {
+          total: 0,
+          success: 0,
+          error: 0,
+          durationSum: 0,
+          durationCount: 0,
+          totalGasWei: "0",
+        }
+      : getDirectCounts(organizationId, start, end),
+    getWorkflowGasTotal(organizationId, start, end, projectId),
   ]);
 
   return {
@@ -325,7 +360,8 @@ function logInputField(field: string): ReturnType<typeof sql> {
 async function getWorkflowGasTotal(
   organizationId: string,
   rangeStart: Date,
-  rangeEnd: Date
+  rangeEnd: Date,
+  projectId?: string
 ): Promise<string> {
   const result = await db
     .select({
@@ -340,6 +376,7 @@ async function getWorkflowGasTotal(
     .where(
       and(
         eq(workflows.organizationId, organizationId),
+        projectId ? eq(workflows.projectId, projectId) : undefined,
         gte(workflowExecutionLogs.startedAt, rangeStart),
         lt(workflowExecutionLogs.startedAt, rangeEnd),
         sql`${logOutputField("gasUsed")} IS NOT NULL`
@@ -356,7 +393,8 @@ export async function getTimeSeries(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
-  customEnd?: string
+  customEnd?: string,
+  projectId?: string
 ): Promise<TimeSeriesBucket[]> {
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
@@ -376,12 +414,17 @@ export async function getTimeSeries(
     .where(
       and(
         eq(workflows.organizationId, organizationId),
+        projectId ? eq(workflows.projectId, projectId) : undefined,
         gte(workflowExecutions.startedAt, rangeStart),
         lt(workflowExecutions.startedAt, rangeEnd)
       )
     )
     .groupBy(sql`${bucketExpr(workflowExecutions.startedAt)}`)
     .orderBy(sql`${bucketExpr(workflowExecutions.startedAt)} ASC`);
+
+  if (projectId) {
+    return mergeBuckets(workflowBuckets as BucketRow[], []);
+  }
 
   const directBuckets = await db
     .select({
@@ -465,29 +508,39 @@ export async function getNetworkBreakdown(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
-  customEnd?: string
+  customEnd?: string,
+  projectId?: string
 ): Promise<NetworkBreakdown[]> {
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
+  const skipDirect = Boolean(projectId);
 
   const [directResult, workflowResult] = await Promise.all([
-    db
-      .select({
-        network: directExecutions.network,
-        totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-        executionCount: count(),
-        successCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
-        errorCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
-      })
-      .from(directExecutions)
-      .where(
-        and(
-          eq(directExecutions.organizationId, organizationId),
-          gte(directExecutions.createdAt, rangeStart),
-          lt(directExecutions.createdAt, rangeEnd)
-        )
-      )
-      .groupBy(directExecutions.network),
+    skipDirect
+      ? ([] as {
+          network: string;
+          totalGasWei: string;
+          executionCount: number;
+          successCount: number;
+          errorCount: number;
+        }[])
+      : db
+          .select({
+            network: directExecutions.network,
+            totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+            executionCount: count(),
+            successCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
+            errorCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
+          })
+          .from(directExecutions)
+          .where(
+            and(
+              eq(directExecutions.organizationId, organizationId),
+              gte(directExecutions.createdAt, rangeStart),
+              lt(directExecutions.createdAt, rangeEnd)
+            )
+          )
+          .groupBy(directExecutions.network),
     db
       .select({
         network: sql<string>`${logInputField("network")}`,
@@ -505,6 +558,7 @@ export async function getNetworkBreakdown(
       .where(
         and(
           eq(workflows.organizationId, organizationId),
+          projectId ? eq(workflows.projectId, projectId) : undefined,
           gte(workflowExecutionLogs.startedAt, rangeStart),
           lt(workflowExecutionLogs.startedAt, rangeEnd),
           sql`${logOutputField("gasUsed")} IS NOT NULL`
@@ -576,6 +630,7 @@ export async function getUnifiedRuns(
     source?: RunSource;
     customStart?: string;
     customEnd?: string;
+    projectId?: string;
   } = {}
 ): Promise<{ runs: UnifiedRun[]; nextCursor: string | null; total: number }> {
   const {
@@ -585,10 +640,12 @@ export async function getUnifiedRuns(
     source,
     customStart,
     customEnd,
+    projectId,
   } = options;
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const pageLimit = Math.min(limit, 100);
+  const skipDirect = Boolean(projectId) || source === "direct";
 
   // Fire run fetches and count queries in parallel
   const [workflowRuns, directRuns, total] = await Promise.all([
@@ -600,9 +657,10 @@ export async function getUnifiedRuns(
           rangeEnd,
           status,
           cursor,
-          pageLimit + 1
+          pageLimit + 1,
+          projectId
         ),
-    source === "workflow"
+    skipDirect || source === "workflow"
       ? ([] as UnifiedRun[])
       : fetchDirectRuns(
           organizationId,
@@ -612,7 +670,14 @@ export async function getUnifiedRuns(
           cursor,
           pageLimit + 1
         ),
-    getUnifiedRunsTotal(organizationId, rangeStart, rangeEnd, status, source),
+    getUnifiedRunsTotal(
+      organizationId,
+      rangeStart,
+      rangeEnd,
+      status,
+      source,
+      projectId
+    ),
   ]);
 
   const allRuns = [...workflowRuns, ...directRuns].sort(
@@ -632,13 +697,19 @@ async function fetchWorkflowRuns(
   rangeEnd: Date,
   status: NormalizedStatus | undefined,
   cursor: string | undefined,
-  limit: number
+  limit: number,
+  projectId?: string
 ): Promise<UnifiedRun[]> {
   // Scope to org's workflows via subquery so leftJoin still enforces org isolation
   const orgWorkflowIds = db
     .select({ id: workflows.id })
     .from(workflows)
-    .where(eq(workflows.organizationId, organizationId));
+    .where(
+      and(
+        eq(workflows.organizationId, organizationId),
+        projectId ? eq(workflows.projectId, projectId) : undefined
+      )
+    );
 
   const conditions = [
     sql`${workflowExecutions.workflowId} IN (${orgWorkflowIds})`,
@@ -808,13 +879,17 @@ async function getWorkflowRunsTotal(
   organizationId: string,
   rangeStart: Date,
   rangeEnd: Date,
-  status: NormalizedStatus | undefined
+  status: NormalizedStatus | undefined,
+  projectId?: string
 ): Promise<number> {
   const conditions = [
     eq(workflows.organizationId, organizationId),
     gte(workflowExecutions.startedAt, rangeStart),
     lt(workflowExecutions.startedAt, rangeEnd),
   ];
+  if (projectId) {
+    conditions.push(eq(workflows.projectId, projectId));
+  }
   if (status) {
     const dbStatuses = status === "error" ? ["error", "cancelled"] : [status];
     conditions.push(
@@ -864,14 +939,23 @@ async function getUnifiedRunsTotal(
   rangeStart: Date,
   rangeEnd: Date,
   status: NormalizedStatus | undefined,
-  source: RunSource | undefined
+  source: RunSource | undefined,
+  projectId?: string
 ): Promise<number> {
+  const skipDirect = Boolean(projectId);
+
   // Run both count queries in parallel
   const [workflowTotal, directTotal] = await Promise.all([
     source === "direct"
       ? 0
-      : getWorkflowRunsTotal(organizationId, rangeStart, rangeEnd, status),
-    source === "workflow"
+      : getWorkflowRunsTotal(
+          organizationId,
+          rangeStart,
+          rangeEnd,
+          status,
+          projectId
+        ),
+    skipDirect || source === "workflow"
       ? 0
       : getDirectRunsTotal(organizationId, rangeStart, rangeEnd, status),
   ]);

--- a/keeperhub/lib/atoms/analytics.ts
+++ b/keeperhub/lib/atoms/analytics.ts
@@ -29,5 +29,7 @@ export const analyticsSourceFilterAtom = atom<RunSource | undefined>(undefined);
 
 export const analyticsSearchAtom = atom("");
 
+export const analyticsProjectIdAtom = atom<string | null>(null);
+
 export const analyticsLiveAtom = atom(true);
 export const analyticsLastUpdatedAtom = atom<Date | null>(null);

--- a/scripts/seed/seed-analytics-data.ts
+++ b/scripts/seed/seed-analytics-data.ts
@@ -22,7 +22,7 @@ expand(dotenv.config());
 import postgres from "postgres";
 import { getDatabaseUrl } from "../../lib/db/connection-utils";
 
-const TEST_USER_EMAIL = "test-analytics@techops.services";
+const TEST_USER_EMAIL = process.env.SEED_EMAIL ?? "dev@keeperhub.local";
 const SEED_PREFIX = "[Analytics Seed]";
 const FORCE_MODE = process.argv.includes("--force");
 
@@ -144,21 +144,59 @@ async function deleteSeedData(sql: Db, orgId: string): Promise<void> {
   console.log(`  Deleted ${directResult.length} direct executions`);
 }
 
-async function createSeedWorkflows(
+const SEED_PROJECTS = [
+  { name: "DeFi Monitoring", color: "#4A90D9" },
+  { name: "Trading Bots", color: "#7B61FF" },
+] as const;
+
+async function ensureSeedProjects(
   sql: Db,
   userId: string,
   orgId: string
 ): Promise<string[]> {
-  const workflowNames = [
-    `${SEED_PREFIX} USDC Monitor`,
-    `${SEED_PREFIX} ETH Price Alert`,
-    `${SEED_PREFIX} LP Rebalancer`,
+  const projectIds: string[] = [];
+  const now = new Date();
+
+  for (const project of SEED_PROJECTS) {
+    const existing = await sql`
+      SELECT id FROM projects
+      WHERE organization_id = ${orgId} AND name = ${project.name}
+      LIMIT 1
+    `;
+    if (existing.length > 0) {
+      projectIds.push(existing[0].id as string);
+      console.log(`  Project already exists: ${project.name} (${existing[0].id})`);
+    } else {
+      const id = generateId();
+      await sql.unsafe(
+        `INSERT INTO projects (id, name, color, organization_id, user_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [id, project.name, project.color, orgId, userId, now, now]
+      );
+      projectIds.push(id);
+      console.log(`  Created project: ${project.name} (${id})`);
+    }
+  }
+
+  return projectIds;
+}
+
+async function createSeedWorkflows(
+  sql: Db,
+  userId: string,
+  orgId: string,
+  projectIds: string[]
+): Promise<string[]> {
+  const seedWorkflows = [
+    { name: `${SEED_PREFIX} USDC Monitor`, projectId: projectIds[0] },
+    { name: `${SEED_PREFIX} ETH Price Alert`, projectId: projectIds[0] },
+    { name: `${SEED_PREFIX} LP Rebalancer`, projectId: projectIds[1] },
   ];
 
   const workflowIds: string[] = [];
   const now = new Date();
 
-  for (const name of workflowNames) {
+  for (const wf of seedWorkflows) {
     const id = generateId();
     const nodes = JSON.stringify([
       { id: "trigger-1", type: "trigger", position: { x: 0, y: 0 }, data: {} },
@@ -176,15 +214,15 @@ async function createSeedWorkflows(
     await sql.unsafe(
       `INSERT INTO workflows (
         id, name, description, user_id, organization_id, is_anonymous,
-        nodes, edges, visibility, enabled, created_at, updated_at
+        nodes, edges, visibility, enabled, created_at, updated_at, project_id
       ) VALUES (
-        $1, $2, $3, $4, $5, false, $6::jsonb, $7::jsonb, 'private', true, $8, $9
+        $1, $2, $3, $4, $5, false, $6::jsonb, $7::jsonb, 'private', true, $8, $9, $10
       )`,
-      [id, name, "Seeded for analytics testing", userId, orgId, nodes, edges, now, now]
+      [id, wf.name, "Seeded for analytics testing", userId, orgId, nodes, edges, now, now, wf.projectId ?? null]
     );
 
     workflowIds.push(id);
-    console.log(`  Created workflow: ${name} (${id})`);
+    console.log(`  Created workflow: ${wf.name} (${id})`);
   }
 
   return workflowIds;
@@ -497,7 +535,8 @@ async function seedAnalyticsData(): Promise<void> {
 
     console.log("Seeding analytics data...");
 
-    const workflowIds = await createSeedWorkflows(sql, userId, orgId);
+    const projectIds = await ensureSeedProjects(sql, userId, orgId);
+    const workflowIds = await createSeedWorkflows(sql, userId, orgId, projectIds);
     await createWorkflowExecutions(sql, userId, workflowIds);
     await createDirectExecutions(sql, orgId);
     await createSpendCap(sql, orgId);

--- a/scripts/seed/seed-test-workflow.ts
+++ b/scripts/seed/seed-test-workflow.ts
@@ -1,0 +1,514 @@
+/**
+ * Seed script for local testing of security workflow templates.
+ * Creates a test user, org, and multiple security workflows.
+ *
+ * Usage: pnpm tsx scripts/seed-test-workflow.ts
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+import {
+  member,
+  organization,
+  sessions,
+  users,
+  workflows,
+} from "../../lib/db/schema";
+import { generateId } from "../../lib/utils/id";
+
+const connectionString = getDatabaseUrl();
+const client = postgres(connectionString, { max: 1 });
+const db = drizzle(client);
+
+const USER_ID = "test-user-001";
+const ORG_ID = "test-org-001";
+const SESSION_TOKEN = "test-session-token";
+
+// Known mainnet transactions for testing
+const USDT_TRANSFER_CALLDATA =
+  "0xa9059cbb000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000000000000000000000000000000000000003d0900";
+
+// Unlimited approval: approve(spender, MAX_UINT256)
+const UNLIMITED_APPROVAL_CALLDATA =
+  "0x095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+// transferOwnership(newOwner) -- critical privileged op
+const TRANSFER_OWNERSHIP_CALLDATA =
+  "0xf2fde38b000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+type WorkflowDef = {
+  name: string;
+  description: string;
+  nodes: unknown[];
+  edges: unknown[];
+};
+
+function buildWorkflows(): WorkflowDef[] {
+  return [
+    // 1. Full security pipeline: Get Tx -> Decode -> Assess Risk
+    {
+      name: "Security: Transaction Risk Scanner",
+      description:
+        "Fetch a transaction by hash, decode its calldata, and run AI risk assessment. Tests the full Get Transaction -> Decode Calldata -> Assess Risk pipeline.",
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          position: { x: 100, y: 200 },
+          data: {
+            label: "Manual Trigger",
+            type: "trigger",
+            config: { triggerType: "Manual" },
+            status: "idle",
+          },
+        },
+        {
+          id: "get-tx-1",
+          type: "action",
+          position: { x: 350, y: 200 },
+          data: {
+            label: "Get Transaction",
+            description: "Fetch full transaction details from Ethereum mainnet",
+            type: "action",
+            config: {
+              actionType: "web3/get-transaction",
+              network: "1",
+              // DAI approve() call -- recent tx with meaningful calldata
+              transactionHash:
+                "0x135ade6349bd76094c4876baa3277d84229fe05f4ebe5e54fd12f8157e313e12",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "decode-1",
+          type: "action",
+          position: { x: 600, y: 200 },
+          data: {
+            label: "Decode Calldata",
+            description: "Decode the transaction input data",
+            type: "action",
+            config: {
+              actionType: "web3/decode-calldata",
+              calldata: "{{@get-tx-1:Get Transaction.input}}",
+              contractAddress: "{{@get-tx-1:Get Transaction.to}}",
+              network: "1",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "risk-1",
+          type: "action",
+          position: { x: 850, y: 200 },
+          data: {
+            label: "Assess Risk",
+            description: "AI-powered risk assessment",
+            type: "action",
+            config: {
+              actionType: "web3/assess-risk",
+              calldata: "{{@get-tx-1:Get Transaction.input}}",
+              contractAddress: "{{@get-tx-1:Get Transaction.to}}",
+              value: "{{@get-tx-1:Get Transaction.value}}",
+              chain: "1",
+              senderAddress: "{{@get-tx-1:Get Transaction.from}}",
+            },
+            status: "idle",
+          },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "trigger-1", target: "get-tx-1" },
+        { id: "e2", source: "get-tx-1", target: "decode-1" },
+        { id: "e3", source: "decode-1", target: "risk-1" },
+      ],
+    },
+
+    // 2. Unlimited approval detection
+    {
+      name: "Security: Unlimited Approval Detector",
+      description:
+        "Detects unlimited token approvals (approve with MAX_UINT256). Tests assess-risk catching high-risk approval patterns.",
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          position: { x: 100, y: 200 },
+          data: {
+            label: "Manual Trigger",
+            type: "trigger",
+            config: { triggerType: "Manual" },
+            status: "idle",
+          },
+        },
+        {
+          id: "decode-1",
+          type: "action",
+          position: { x: 350, y: 200 },
+          data: {
+            label: "Decode Approval",
+            description: "Decode the approve() calldata",
+            type: "action",
+            config: {
+              actionType: "web3/decode-calldata",
+              calldata: UNLIMITED_APPROVAL_CALLDATA,
+              contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+              network: "1",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "risk-1",
+          type: "action",
+          position: { x: 600, y: 200 },
+          data: {
+            label: "Assess Risk",
+            description: "Should flag as HIGH: unlimited approval",
+            type: "action",
+            config: {
+              actionType: "web3/assess-risk",
+              calldata: UNLIMITED_APPROVAL_CALLDATA,
+              contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+              chain: "1",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "condition-1",
+          type: "action",
+          position: { x: 850, y: 200 },
+          data: {
+            label: "Is High Risk?",
+            description: "Gate: only pass if risk is high or critical",
+            type: "action",
+            config: {
+              actionType: "Condition",
+              condition: "{{@risk-1:Assess Risk.riskScore}} >= 51",
+            },
+            status: "idle",
+          },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "trigger-1", target: "decode-1" },
+        { id: "e2", source: "decode-1", target: "risk-1" },
+        { id: "e3", source: "risk-1", target: "condition-1" },
+      ],
+    },
+
+    // 3. Ownership transfer detection (critical)
+    {
+      name: "Security: Ownership Transfer Alert",
+      description:
+        "Detects transferOwnership() calls. Tests assess-risk catching CRITICAL privileged operations.",
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          position: { x: 100, y: 200 },
+          data: {
+            label: "Manual Trigger",
+            type: "trigger",
+            config: { triggerType: "Manual" },
+            status: "idle",
+          },
+        },
+        {
+          id: "risk-1",
+          type: "action",
+          position: { x: 350, y: 200 },
+          data: {
+            label: "Assess Risk",
+            description:
+              "Should flag as CRITICAL: transferOwnership is a privileged op",
+            type: "action",
+            config: {
+              actionType: "web3/assess-risk",
+              calldata: TRANSFER_OWNERSHIP_CALLDATA,
+              contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+              value: "0",
+              chain: "1",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "condition-critical",
+          type: "action",
+          position: { x: 600, y: 100 },
+          data: {
+            label: "Is Critical?",
+            description: "Gate: critical risk only",
+            type: "action",
+            config: {
+              actionType: "Condition",
+              condition: "{{@risk-1:Assess Risk.riskScore}} >= 76",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "condition-elevated",
+          type: "action",
+          position: { x: 600, y: 300 },
+          data: {
+            label: "Is Elevated?",
+            description: "Gate: medium or high risk",
+            type: "action",
+            config: {
+              actionType: "Condition",
+              condition:
+                "{{@risk-1:Assess Risk.riskScore}} >= 26 && {{@risk-1:Assess Risk.riskScore}} < 76",
+            },
+            status: "idle",
+          },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "trigger-1", target: "risk-1" },
+        { id: "e2", source: "risk-1", target: "condition-critical" },
+        { id: "e3", source: "risk-1", target: "condition-elevated" },
+      ],
+    },
+
+    // 4. Treasury balance monitor
+    {
+      name: "Security: Treasury Balance Monitor",
+      description:
+        "Checks ETH balance of a treasury address on a schedule. Alerts if balance drops below threshold. No security plugins needed -- tests Condition gating.",
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          position: { x: 100, y: 200 },
+          data: {
+            label: "Every 15 Minutes",
+            type: "trigger",
+            config: {
+              triggerType: "Schedule",
+              scheduleCron: "*/15 * * * *",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "balance-1",
+          type: "action",
+          position: { x: 350, y: 200 },
+          data: {
+            label: "Check Treasury Balance",
+            description: "Check ETH balance of Ethereum Foundation",
+            type: "action",
+            config: {
+              actionType: "web3/check-balance",
+              network: "1",
+              address: "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "condition-low",
+          type: "action",
+          position: { x: 600, y: 200 },
+          data: {
+            label: "Balance Below 100 ETH?",
+            description: "Gate: alert if treasury is running low",
+            type: "action",
+            config: {
+              actionType: "Condition",
+              condition: "{{@balance-1:Check Treasury Balance.balance}} < 100",
+            },
+            status: "idle",
+          },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "trigger-1", target: "balance-1" },
+        { id: "e2", source: "balance-1", target: "condition-low" },
+      ],
+    },
+
+    // 5. Safe/low-risk baseline -- normal ERC-20 transfer
+    {
+      name: "Security: Low-Risk Baseline (ERC-20 Transfer)",
+      description:
+        "Decodes and assesses a normal ERC-20 transfer. Should produce LOW risk. Use as baseline to verify assess-risk calibration.",
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          position: { x: 100, y: 200 },
+          data: {
+            label: "Manual Trigger",
+            type: "trigger",
+            config: { triggerType: "Manual" },
+            status: "idle",
+          },
+        },
+        {
+          id: "decode-1",
+          type: "action",
+          position: { x: 350, y: 200 },
+          data: {
+            label: "Decode Transfer",
+            description: "Decode a standard ERC-20 transfer(address,uint256)",
+            type: "action",
+            config: {
+              actionType: "web3/decode-calldata",
+              calldata: USDT_TRANSFER_CALLDATA,
+              contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+              network: "1",
+            },
+            status: "idle",
+          },
+        },
+        {
+          id: "risk-1",
+          type: "action",
+          position: { x: 600, y: 200 },
+          data: {
+            label: "Assess Risk",
+            description: "Should produce LOW risk for a normal transfer",
+            type: "action",
+            config: {
+              actionType: "web3/assess-risk",
+              calldata: USDT_TRANSFER_CALLDATA,
+              contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+              value: "0",
+              chain: "1",
+            },
+            status: "idle",
+          },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "trigger-1", target: "decode-1" },
+        { id: "e2", source: "decode-1", target: "risk-1" },
+      ],
+    },
+  ];
+}
+
+async function seed(): Promise<void> {
+  console.log("Seeding security workflow test templates...\n");
+
+  const now = new Date();
+
+  // 1. User -- find existing or create
+  const existingUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, "test@keeperhub.local"))
+    .limit(1);
+
+  const userId = existingUser[0]?.id ?? USER_ID;
+
+  if (existingUser[0]) {
+    console.log(`  + User: test@keeperhub.local (exists as ${userId})`);
+  } else {
+    await db.insert(users).values({
+      id: userId,
+      name: "Test User",
+      email: "test@keeperhub.local",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    console.log("  + User: test@keeperhub.local (created)");
+  }
+
+  // 2. Session
+  await db
+    .insert(sessions)
+    .values({
+      id: generateId(),
+      token: SESSION_TOKEN,
+      userId,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+  console.log("  + Session created (30 day expiry)");
+
+  // 3. Organization -- find existing or create
+  const existingOrg = await db
+    .select({ id: organization.id })
+    .from(organization)
+    .where(eq(organization.slug, "test-org"))
+    .limit(1);
+
+  const orgId = existingOrg[0]?.id ?? ORG_ID;
+
+  if (existingOrg[0]) {
+    console.log(`  + Organization: Test Org (exists as ${orgId})`);
+  } else {
+    await db.insert(organization).values({
+      id: orgId,
+      name: "Test Org",
+      slug: "test-org",
+      createdAt: now,
+    });
+    console.log("  + Organization: Test Org (created)");
+  }
+
+  // 4. Membership
+  await db
+    .insert(member)
+    .values({
+      id: generateId(),
+      organizationId: orgId,
+      userId,
+      role: "owner",
+      createdAt: now,
+    })
+    .onConflictDoNothing();
+  console.log("  + Member: owner role\n");
+
+  // 5. Workflows
+  const workflowDefs = buildWorkflows();
+  const createdIds: string[] = [];
+
+  for (const def of workflowDefs) {
+    const id = generateId();
+    await db
+      .insert(workflows)
+      .values({
+        id,
+        name: def.name,
+        description: def.description,
+        userId,
+        organizationId: orgId,
+        nodes: def.nodes,
+        edges: def.edges,
+        visibility: "private",
+        enabled: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing();
+    createdIds.push(id);
+    console.log(`  + ${def.name}`);
+    console.log(`    http://localhost:3000/workflows/${id}`);
+  }
+
+  console.log(
+    `\nDone! Created ${createdIds.length} security workflow templates.`
+  );
+
+  await client.end();
+  process.exit(0);
+}
+
+seed().catch(async (err: unknown) => {
+  console.error("Seed failed:", err);
+  await client.end();
+  process.exit(1);
+});

--- a/scripts/seed/seed-user.ts
+++ b/scripts/seed/seed-user.ts
@@ -1,0 +1,101 @@
+/**
+ * Seed a local dev user with email/password auth.
+ * Uses Better Auth's hashPassword so the credentials work with sign-in.
+ *
+ * Usage: pnpm tsx scripts/seed-user.ts
+ *
+ * Default credentials:
+ *   Email:    dev@keeperhub.local
+ *   Password: Test1234!
+ *
+ * Override via env:
+ *   SEED_EMAIL=me@example.com SEED_PASSWORD=secret pnpm tsx scripts/seed-user.ts
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+import { accounts, users } from "../../lib/db/schema";
+import { generateId } from "../../lib/utils/id";
+
+const EMAIL = process.env.SEED_EMAIL ?? "dev@keeperhub.local";
+const PASSWORD = process.env.SEED_PASSWORD ?? "Test1234!";
+const NAME = process.env.SEED_NAME ?? "Dev User";
+
+async function hashPassword(password: string): Promise<string> {
+  const mod = await import(
+    // @ts-ignore -- better-auth internal module has no type declarations
+    "../node_modules/.ignored/better-auth/dist/crypto-DgVHxgLL.mjs"
+  );
+  return mod.i(password) as Promise<string>;
+}
+
+async function main(): Promise<void> {
+  const connectionString = getDatabaseUrl();
+  const client = postgres(connectionString, { max: 1 });
+  const db = drizzle(client);
+
+  try {
+    const existing = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, EMAIL))
+      .limit(1);
+
+    if (existing.length > 0) {
+      const userId = existing[0].id;
+      const hash = await hashPassword(PASSWORD);
+
+      await db
+        .update(accounts)
+        .set({ password: hash, updatedAt: new Date() })
+        .where(eq(accounts.userId, userId));
+
+      await db
+        .update(users)
+        .set({ emailVerified: true, updatedAt: new Date() })
+        .where(eq(users.id, userId));
+
+      console.log(`Updated existing user: ${EMAIL}`);
+      console.log(`  Password reset to: ${PASSWORD}`);
+    } else {
+      const userId = generateId();
+      const accountId = generateId();
+      const hash = await hashPassword(PASSWORD);
+      const now = new Date();
+
+      await db.insert(users).values({
+        id: userId,
+        name: NAME,
+        email: EMAIL,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+        isAnonymous: false,
+      });
+
+      await db.insert(accounts).values({
+        id: accountId,
+        accountId: userId,
+        providerId: "credential",
+        userId,
+        password: hash,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      console.log(`Created user: ${EMAIL}`);
+      console.log(`  Password: ${PASSWORD}`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error("Failed to seed user:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Enable per-project filtering of analytics data so users with multiple projects can isolate KPIs, charts, and runs for a single project instead of viewing everything org-wide
- Adds a collapsible inline drawer next to the Workflow Runs table with project list (color dots + names) and an "All Runs" option to reset
- When a project is selected, direct executions are excluded (they have no project association)
- Drawer state (open/collapsed) persists across page reloads via localStorage

## Test plan
- [ ] Open /analytics, verify collapsed "Projects" strip appears next to the Workflow Runs card
- [ ] Click the strip to expand -- project list loads with color dots
- [ ] Click a project -- KPIs, chart, and runs table update to show only that project's data
- [ ] Click "All Runs" -- everything returns to org-wide view
- [ ] Collapse the drawer -- runs table expands to fill space
- [ ] Refresh page -- drawer state persists
- [ ] Run `pnpm check` and `pnpm type-check` -- no new errors