### PR TITLE
chore: add design system token layer and migrate hardcoded values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@
 - **No co-authored with Claude in PR descriptions and git commits**
 - **Do not git push or create Github PRs without user's confirmation**
 - **Do not leave code comments with summaries of user's prompt**
-- **Do not include task codes in branch/PR names**
 - **PR titles must follow conventional commit format**: `<type>: <description>` or `<type>(scope): <description>`. Allowed types: `feat`, `fix`, `hotfix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `breaking`. This is enforced by the `pr-title-check` workflow on PRs targeting `staging`.
 
 ## Code Quality: Lint and Type Checking
@@ -98,6 +97,37 @@ When you must use an ignore comment:
    // biome-ignore lint/suspicious/noExplicitAny: third-party SDK types are incomplete
    const result = externalLib.call() as any;
    ```
+
+## Design System
+
+Before writing or modifying any UI code, read the relevant spec file in `specs/design-system/`. Use only tokens from `specs/design-system/tokens.css`. Run `node scripts/token-audit.js` before committing UI changes. Zero errors required.
+
+### Key Rules
+
+1. **Read the spec first**: Check `specs/design-system/foundations/` for color, spacing, typography, radius, elevation, and motion tokens. Check `specs/design-system/components/` for component-specific specs.
+2. **Use tokens, not raw values**: Never use hardcoded hex colors, rgb/rgba values, or arbitrary pixel values. Reference semantic tokens from `tokens.css`.
+3. **Tailwind classes over arbitrary values**: Use `bg-primary`, `text-muted-foreground`, `border-border` instead of `bg-[#xxx]`, `text-[#xxx]`.
+4. **Hub-specific dark surfaces**: Use `--color-hub-card`, `--color-hub-icon-bg`, etc. for protocol/hub pages.
+5. **Layout constants**: Use `--header-height`, `--flyout-width`, `--sidebar-strip-width` instead of `top-[60px]`, `w-[280px]`, `w-[32px]`.
+6. **Token reference**: See `specs/design-system/tokens/token-reference.md` for the complete token map with usage guidance.
+
+### Audit Script
+
+```bash
+node scripts/token-audit.js         # Full scan (errors + warnings)
+node scripts/token-audit.js --quiet # Errors only
+```
+
+Exits with code 1 if errors are found. Errors are hardcoded colors in CSS and arbitrary Tailwind color classes. Warnings are hardcoded spacing, font sizes, z-index, and shadows.
+
+### Exempt Files
+
+- `keeperhub/api/og/generate-og.tsx` -- server-rendered OG images, not interactive UI
+- `lib/monaco-theme.ts` -- editor syntax highlighting, uses Monaco's theming API
+- `lib/next-boilerplate/` -- upstream template code
+- `docs-site/` -- separate documentation site
+
+---
 
 ## 🚨 CRITICAL: KeeperHub Custom Code Policy
 
@@ -263,6 +293,7 @@ pnpm discover / --auth --steps "click:button:has-text('New Workflow')" "probe:af
 ```
 
 Output goes to `tests/e2e/playwright/.probes/<label>-<timestamp>/`:
+
 - `screenshot.png` - full page screenshot
 - `screenshot-highlighted.png` - elements with numbered overlays (if --highlight)
 - `elements.md` - interactive elements table grouped by region (optimized for Claude)
@@ -278,10 +309,10 @@ import { probe, highlightElements } from "./utils/discover";
 
 test("my test", async ({ page }) => {
   await page.goto("/");
-  await probe(page, "initial");        // captures screenshot + element map
+  await probe(page, "initial"); // captures screenshot + element map
 
   await page.click('button:has-text("Sign In")');
-  await probe(page, "dialog-open");    // captures new state after click
+  await probe(page, "dialog-open"); // captures new state after click
 
   // Read .probes/ output to understand what's on screen
 });
@@ -290,6 +321,7 @@ test("my test", async ({ page }) => {
 ### Tool 3: Playwright MCP (direct browser control)
 
 The Playwright MCP server (`.mcp.json`) gives Claude direct browser access. Use it for interactive exploration when the CLI isn't enough:
+
 - Navigate pages, click elements, fill forms
 - Take screenshots and read them
 - Evaluate JavaScript in the page
@@ -316,31 +348,31 @@ Combine with the discovery utilities: use MCP to navigate, then call `getInterac
 
 ### Key Selectors Reference
 
-| Element | Selector |
-|---|---|
-| Sign In button | `button:has-text("Sign In")` (first) |
-| Auth dialog | `[role="dialog"]` |
-| Signup email | `#signup-email` |
-| Signup password | `#signup-password` |
-| OTP input | `#otp` |
-| User menu | `[data-testid="user-menu"]` |
-| Workflow canvas | `[data-testid="workflow-canvas"]` |
-| Trigger node | `.react-flow__node-trigger` |
-| Action grid | `[data-testid="action-grid"]` |
-| Add Step button | `button[name="Add Step"]` |
-| Toasts | `[data-sonner-toast]` |
-| Org switcher | `button[role="combobox"]` |
+| Element         | Selector                             |
+| --------------- | ------------------------------------ |
+| Sign In button  | `button:has-text("Sign In")` (first) |
+| Auth dialog     | `[role="dialog"]`                    |
+| Signup email    | `#signup-email`                      |
+| Signup password | `#signup-password`                   |
+| OTP input       | `#otp`                               |
+| User menu       | `[data-testid="user-menu"]`          |
+| Workflow canvas | `[data-testid="workflow-canvas"]`    |
+| Trigger node    | `.react-flow__node-trigger`          |
+| Action grid     | `[data-testid="action-grid"]`        |
+| Add Step button | `button[name="Add Step"]`            |
+| Toasts          | `[data-sonner-toast]`                |
+| Org switcher    | `button[role="combobox"]`            |
 
 ### Existing Test Utilities
 
-| Utility | Import | Purpose |
-|---|---|---|
-| `signUpAndVerify(page)` | `./utils/auth` | Full signup + OTP verification flow |
-| `signIn(page, email, pw)` | `./utils/auth` | Sign in with credentials |
-| `createWorkflow(page)` | `./utils/workflow` | Navigate + create new workflow |
-| `addActionNode(page, label)` | `./utils/workflow` | Add action to canvas |
-| `probe(page, label)` | `./utils/discover` | Capture page state for analysis |
-| `highlightElements(page)` | `./utils/discover` | Add numbered overlays |
-| `getInteractiveElements(page)` | `./utils/discover` | Get structured element list |
-| `getPageStructure(page)` | `./utils/discover` | Get page headings, landmarks, forms |
-| `createTestWorkflow(email)` | `./utils/db` | Inject workflow directly into DB |
+| Utility                        | Import             | Purpose                             |
+| ------------------------------ | ------------------ | ----------------------------------- |
+| `signUpAndVerify(page)`        | `./utils/auth`     | Full signup + OTP verification flow |
+| `signIn(page, email, pw)`      | `./utils/auth`     | Sign in with credentials            |
+| `createWorkflow(page)`         | `./utils/workflow` | Navigate + create new workflow      |
+| `addActionNode(page, label)`   | `./utils/workflow` | Add action to canvas                |
+| `probe(page, label)`           | `./utils/discover` | Capture page state for analysis     |
+| `highlightElements(page)`      | `./utils/discover` | Add numbered overlays               |
+| `getInteractiveElements(page)` | `./utils/discover` | Get structured element list         |
+| `getPageStructure(page)`       | `./utils/discover` | Get page headings, landmarks, forms |
+| `createTestWorkflow(email)`    | `./utils/db`       | Inject workflow directly into DB    |

--- a/app/globals.css
+++ b/app/globals.css
@@ -189,11 +189,11 @@
 
 .dark .react-flow__attribution {
   background: transparent !important;
-  color: rgba(255, 255, 255, 0.4) !important;
+  color: var(--muted-foreground) !important;
 }
 
 .dark .react-flow__attribution a {
-  color: rgba(255, 255, 255, 0.5) !important;
+  color: var(--muted-foreground) !important;
 }
 
 /* React Flow pane cursor */
@@ -261,15 +261,15 @@
 }
 
 .template-badge {
-  background-color: rgba(59, 130, 246, 0.1);
-  color: rgb(37, 99, 235) !important;
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  background-color: var(--color-badge-blue-bg);
+  color: var(--color-badge-blue-text) !important;
+  border: 1px solid var(--color-badge-blue-border);
   border-radius: 3px;
   padding: 1px 4px;
 }
 
 .dark .template-badge {
-  color: rgb(96, 165, 250) !important;
+  color: var(--color-badge-blue-text-dark) !important;
 }
 /* end keeperhub code */
 

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -246,7 +246,7 @@ function HubPageContent(): React.ReactElement {
               </div>
             </div>
             <div className="bg-white/[0.03] py-6 relative">
-              <div className="absolute top-0 h-full bg-[#171f2e] w-full" />
+              <div className="absolute top-0 h-full bg-[var(--color-hub-overlay)] w-full" />
               <div className="container mx-auto px-4">
                 <FeaturedCarousel workflows={featuredWorkflows} />
               </div>
@@ -265,7 +265,7 @@ function HubPageContent(): React.ReactElement {
             )}
 
             <div className="relative pt-6 pb-8">
-              <div className="absolute inset-0 bg-[#171f2e]" />
+              <div className="absolute inset-0 bg-[var(--color-hub-overlay)]" />
               <div className="relative container mx-auto px-4">
                 <h2 className="mb-4 font-bold text-2xl">Community Workflows</h2>
                 <div className="grid grid-cols-[1fr_3fr] items-start gap-8">

--- a/components/ai-elements/connection.tsx
+++ b/components/ai-elements/connection.tsx
@@ -19,7 +19,7 @@ export const Connection: ConnectionLineComponent = ({
     <circle
       cx={toX}
       cy={toY}
-      fill="#fff"
+      fill="var(--background)"
       r={3}
       stroke="var(--color-ring)"
       strokeWidth={1}

--- a/components/ui/animated-border.tsx
+++ b/components/ui/animated-border.tsx
@@ -47,9 +47,9 @@ export const AnimatedBorder = ({ className }: AnimatedBorderProps) => {
         >
           <defs>
             <linearGradient id="gradient-glow" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stopColor="#60a5fa" />
-              <stop offset="50%" stopColor="#3b82f6" />
-              <stop offset="100%" stopColor="#60a5fa" />
+              <stop offset="0%" stopColor="var(--ds-blue-400)" />
+              <stop offset="50%" stopColor="var(--ds-blue-500)" />
+              <stop offset="100%" stopColor="var(--ds-blue-400)" />
             </linearGradient>
           </defs>
           <rect
@@ -62,7 +62,7 @@ export const AnimatedBorder = ({ className }: AnimatedBorderProps) => {
             stroke="url(#gradient-glow)"
             strokeWidth="2"
             style={{
-              filter: "drop-shadow(0 0 4px #3b82f6)",
+              filter: "drop-shadow(0 0 4px var(--ds-blue-500))",
             }}
           />
         </svg>

--- a/keeperhub/api/projects/route.ts
+++ b/keeperhub/api/projects/route.ts
@@ -3,20 +3,10 @@ import { NextResponse } from "next/server";
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { resolveCreatorContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
+import { COLOR_PALETTE } from "@/keeperhub/lib/palette";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { projects, workflows } from "@/lib/db/schema";
-
-const DEFAULT_COLORS = [
-  "#4A90D9",
-  "#7B61FF",
-  "#E06C75",
-  "#98C379",
-  "#E5C07B",
-  "#56B6C2",
-  "#C678DD",
-  "#D19A66",
-];
 
 export async function GET(request: Request) {
   try {
@@ -104,8 +94,8 @@ export async function POST(request: Request) {
       .from(projects)
       .where(eq(projects.organizationId, organizationId));
 
-    const colorIndex = (existingCount[0]?.value ?? 0) % DEFAULT_COLORS.length;
-    const color = body.color || DEFAULT_COLORS[colorIndex];
+    const colorIndex = (existingCount[0]?.value ?? 0) % COLOR_PALETTE.length;
+    const color = body.color || COLOR_PALETTE[colorIndex];
 
     const [newProject] = await db
       .insert(projects)

--- a/keeperhub/components/analytics/project-drawer.tsx
+++ b/keeperhub/components/analytics/project-drawer.tsx
@@ -154,7 +154,9 @@ export function ProjectDrawer(): ReactNode {
             >
               <span
                 className="inline-block size-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: project.color ?? "#6b7280" }}
+                style={{
+                  backgroundColor: project.color ?? "var(--color-text-muted)",
+                }}
               />
               <span className="truncate">{project.name}</span>
             </button>

--- a/keeperhub/components/hub/protocol-card.tsx
+++ b/keeperhub/components/hub/protocol-card.tsx
@@ -66,7 +66,7 @@ function ChainBadges({
     <div className="flex flex-wrap gap-1">
       {visible.map((chain) => (
         <span
-          className="rounded-full bg-[#09fd671a] px-2 py-0.5 font-medium text-[#09fd67] text-[10px]"
+          className="rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5 font-medium text-[var(--color-text-accent)] text-[10px]"
           key={chain}
         >
           {getChainName(chain)}
@@ -126,7 +126,7 @@ export function ProtocolCard({
       <CardHeader className="pb-2 pt-3">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex size-10 items-center justify-center rounded-lg bg-[#2a3342]">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--color-hub-icon-bg)]">
               {protocol.icon ? (
                 <Image
                   alt={protocol.name}
@@ -136,7 +136,7 @@ export function ProtocolCard({
                   width={24}
                 />
               ) : (
-                <Box className="size-4 text-[#09fd67]" />
+                <Box className="size-4 text-[var(--color-text-accent)]" />
               )}
             </div>
             <div className="flex items-center gap-2">

--- a/keeperhub/components/hub/protocol-detail.tsx
+++ b/keeperhub/components/hub/protocol-detail.tsx
@@ -63,7 +63,7 @@ function ActionTypeBadge({
   }
 
   return (
-    <span className="rounded-full bg-[#09fd671a] px-2 py-0.5 font-medium text-[#09fd67] text-[10px] uppercase tracking-wider">
+    <span className="rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5 font-medium text-[var(--color-text-accent)] text-[10px] uppercase tracking-wider">
       WRITE
     </span>
   );
@@ -330,7 +330,7 @@ export function ProtocolDetail({
       )}
 
       <div className="flex items-start gap-4">
-        <div className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-[#2a3342]">
+        <div className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-[var(--color-hub-icon-bg)]">
           {protocol.icon ? (
             <Image
               alt={protocol.name}
@@ -340,7 +340,7 @@ export function ProtocolDetail({
               width={32}
             />
           ) : (
-            <Box className="size-5 text-[#09fd67]" />
+            <Box className="size-5 text-[var(--color-text-accent)]" />
           )}
         </div>
         <div>
@@ -382,7 +382,7 @@ export function ProtocolDetail({
           <div className="mt-3 flex flex-wrap gap-1">
             {allChains.map((chain) => (
               <span
-                className="rounded-full bg-[#09fd671a] px-2 py-0.5 font-medium text-[#09fd67] text-[10px]"
+                className="rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5 font-medium text-[var(--color-text-accent)] text-[10px]"
                 key={chain}
               >
                 {getChainName(chain)}

--- a/keeperhub/components/hub/protocol-strip.tsx
+++ b/keeperhub/components/hub/protocol-strip.tsx
@@ -122,7 +122,7 @@ export function ProtocolStrip({
 
           return (
             <button
-              className="relative flex w-[340px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-[#1a2230] text-left transition-colors hover:border-border hover:brightness-110"
+              className="relative flex w-[340px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-[var(--color-hub-card)] text-left transition-colors hover:border-border hover:brightness-110"
               key={protocol.slug}
               onClick={() => onSelect(protocol.slug)}
               type="button"
@@ -130,7 +130,7 @@ export function ProtocolStrip({
               <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_120%_70%_at_top_left,#243548_0%,transparent_70%)]" />
               <div className="relative flex flex-1 flex-col gap-3 p-5">
                 <div className="flex items-center gap-3">
-                  <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[#2a3342]">
+                  <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-hub-icon-bg)]">
                     {protocol.icon ? (
                       <Image
                         alt={protocol.name}
@@ -140,7 +140,7 @@ export function ProtocolStrip({
                         width={24}
                       />
                     ) : (
-                      <Box className="size-5 text-[#09fd67]" />
+                      <Box className="size-5 text-[var(--color-text-accent)]" />
                     )}
                   </div>
                   <h3 className="font-semibold text-base">{protocol.name}</h3>
@@ -154,7 +154,7 @@ export function ProtocolStrip({
                 <div className="flex flex-wrap gap-1.5">
                   {chains.slice(0, MAX_VISIBLE_CHAINS).map((chain) => (
                     <span
-                      className="rounded-full bg-[#09fd671a] px-2.5 py-0.5 font-medium text-[#09fd67] text-[11px]"
+                      className="rounded-full bg-[var(--color-bg-accent)] px-2.5 py-0.5 font-medium text-[var(--color-text-accent)] text-[11px]"
                       key={chain}
                     >
                       {getChainName(chain)}

--- a/keeperhub/components/hub/workflow-mini-map.tsx
+++ b/keeperhub/components/hub/workflow-mini-map.tsx
@@ -68,7 +68,11 @@ function MiniNode({
 
   return (
     <rect
-      className={isTrigger ? "fill-[#09fd67]/60" : "fill-[#3d4f63]"}
+      className={
+        isTrigger
+          ? "fill-[var(--color-text-accent)]/60"
+          : "fill-[var(--color-hub-node-bg)]"
+      }
       height={FIXED_NODE_SIZE}
       rx={FIXED_NODE_SIZE * 0.15}
       ry={FIXED_NODE_SIZE * 0.15}
@@ -121,7 +125,7 @@ function MiniEdge({
 
   return (
     <path
-      className="fill-none stroke-[#2a3342]"
+      className="fill-none stroke-[var(--color-hub-icon-bg)]"
       d={`M ${sourceX} ${sourceY} C ${midX} ${sourceY}, ${midX} ${targetY}, ${targetX} ${targetY}`}
       strokeWidth={0.4}
     />

--- a/keeperhub/components/hub/workflow-node-icons.tsx
+++ b/keeperhub/components/hub/workflow-node-icons.tsx
@@ -171,7 +171,7 @@ export function WorkflowNodeIcons({ nodes }: WorkflowNodeIconsProps) {
       {visible.map(({ key, label, Icon }) => (
         <Tooltip key={key}>
           <TooltipTrigger asChild>
-            <div className="flex size-10 items-center justify-center rounded-lg bg-[#2a3342] transition-colors hover:bg-[#354155]">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--color-hub-icon-bg)] transition-colors hover:bg-[var(--color-hub-icon-bg-hover)]">
               <Icon className="size-5 text-slate-400" />
             </div>
           </TooltipTrigger>
@@ -181,7 +181,7 @@ export function WorkflowNodeIcons({ nodes }: WorkflowNodeIconsProps) {
       {overflow > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="flex size-10 items-center justify-center rounded-lg bg-[#2a3342] transition-colors hover:bg-[#354155]">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--color-hub-icon-bg)] transition-colors hover:bg-[var(--color-hub-icon-bg-hover)]">
               <span className="font-medium text-slate-400 text-sm">
                 +{overflow}
               </span>

--- a/keeperhub/components/hub/workflow-template-grid.tsx
+++ b/keeperhub/components/hub/workflow-template-grid.tsx
@@ -92,7 +92,7 @@ export function WorkflowTemplateGrid({ workflows }: WorkflowTemplateGridProps) {
                 <div className="absolute top-3 right-3 flex flex-wrap justify-end gap-1">
                   {workflow.publicTags.slice(0, 2).map((tag) => (
                     <span
-                      className="rounded-full bg-[#09fd671a] px-3 py-1 font-medium text-[#09fd67] text-[10px]"
+                      className="rounded-full bg-[var(--color-bg-accent)] px-3 py-1 font-medium text-[var(--color-text-accent)] text-[10px]"
                       key={tag.slug}
                     >
                       {tag.name}
@@ -101,7 +101,7 @@ export function WorkflowTemplateGrid({ workflows }: WorkflowTemplateGridProps) {
                   {workflow.publicTags.length > 2 && (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="cursor-default rounded-full bg-[#09fd671a] px-2 py-1 font-medium text-[#09fd67] text-[10px]">
+                        <span className="cursor-default rounded-full bg-[var(--color-bg-accent)] px-2 py-1 font-medium text-[var(--color-text-accent)] text-[10px]">
                           +{workflow.publicTags.length - 2}
                         </span>
                       </TooltipTrigger>

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -176,7 +176,9 @@ function ProjectsPanel({
           >
             <span
               className="inline-block size-2.5 shrink-0 rounded-full"
-              style={{ backgroundColor: project.color ?? "#888" }}
+              style={{
+                backgroundColor: project.color ?? "var(--color-text-muted)",
+              }}
             />
             <span className="truncate">{project.name}</span>
             <span className="ml-auto flex items-center gap-1 text-muted-foreground text-xs">

--- a/keeperhub/components/overlays/projects-overlay.tsx
+++ b/keeperhub/components/overlays/projects-overlay.tsx
@@ -98,7 +98,10 @@ export function ProjectsOverlay({ overlayId }: ProjectsOverlayProps) {
                   <div className="flex items-center gap-3">
                     <span
                       className="inline-block size-3 shrink-0 rounded-full"
-                      style={{ backgroundColor: project.color ?? "#888" }}
+                      style={{
+                        backgroundColor:
+                          project.color ?? "var(--color-text-muted)",
+                      }}
                     />
                     <div>
                       <p className="font-medium text-sm">{project.name}</p>

--- a/keeperhub/components/projects/project-form-dialog.tsx
+++ b/keeperhub/components/projects/project-form-dialog.tsx
@@ -13,19 +13,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { COLOR_PALETTE } from "@/keeperhub/lib/palette";
 import { api, type Project } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
-
-const COLOR_PALETTE = [
-  "#4A90D9",
-  "#7B61FF",
-  "#E06C75",
-  "#98C379",
-  "#E5C07B",
-  "#56B6C2",
-  "#C678DD",
-  "#D19A66",
-];
 
 type ProjectFormDialogProps = {
   open: boolean;

--- a/keeperhub/components/projects/project-select.tsx
+++ b/keeperhub/components/projects/project-select.tsx
@@ -73,7 +73,9 @@ export function ProjectSelect({
               <span className="flex items-center gap-2">
                 <span
                   className="inline-block size-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: project.color ?? "#888" }}
+                  style={{
+                    backgroundColor: project.color ?? "var(--color-text-muted)",
+                  }}
                 />
                 {project.name}
               </span>

--- a/keeperhub/components/tags/tag-form-dialog.tsx
+++ b/keeperhub/components/tags/tag-form-dialog.tsx
@@ -12,19 +12,9 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { COLOR_PALETTE } from "@/keeperhub/lib/palette";
 import { api, type Tag } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
-
-const COLOR_PALETTE = [
-  "#4A90D9",
-  "#7B61FF",
-  "#E06C75",
-  "#98C379",
-  "#E5C07B",
-  "#56B6C2",
-  "#C678DD",
-  "#D19A66",
-];
 
 type TagFormDialogProps = {
   open: boolean;

--- a/keeperhub/lib/palette.ts
+++ b/keeperhub/lib/palette.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared color palette for projects and tags.
+ * These are stored as hex values in the database.
+ * The corresponding design tokens are defined in specs/design-system/tokens.css
+ * under the --ds-palette-* variables.
+ */
+export const COLOR_PALETTE: string[] = [
+  "#4A90D9",
+  "#7B61FF",
+  "#E06C75",
+  "#98C379",
+  "#E5C07B",
+  "#56B6C2",
+  "#C678DD",
+  "#D19A66",
+];
+
+/**
+ * Default fallback color for projects/tags without an assigned color.
+ * Maps to --color-text-muted in the design system.
+ */
+export const DEFAULT_PROJECT_COLOR = "var(--color-text-muted)";

--- a/scripts/token-audit.js
+++ b/scripts/token-audit.js
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+
+/**
+ * Token Audit Script
+ *
+ * Scans CSS and component files for hardcoded visual values that should
+ * use design tokens instead. CI-ready: exits with code 1 if errors found.
+ *
+ * Usage:
+ *   node scripts/token-audit.js           # scan all files
+ *   node scripts/token-audit.js --quiet   # errors only, no warnings
+ *
+ * Exit codes:
+ *   0 = no errors (warnings may exist)
+ *   1 = errors found (hardcoded colors, spacing in CSS)
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, extname, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const quietMode = process.argv.includes("--quiet");
+
+// ----------------------------------------------------------------
+// Directories to scan
+// ----------------------------------------------------------------
+const SCAN_DIRS = [
+  "app",
+  "components",
+  "keeperhub/components",
+  "keeperhub/app",
+  "keeperhub/api",
+];
+
+// Files/directories to skip
+const SKIP_PATTERNS = [
+  "node_modules",
+  ".next",
+  "docs-site",
+  "lib/next-boilerplate",
+  // OG image generation is exempt (server-rendered images, not UI)
+  "generate-og.tsx",
+  // Monaco theme uses editor-specific theming API
+  "monaco-theme.ts",
+  // Palette constants are DB-stored hex values, not UI styling
+  "keeperhub/lib/palette.ts",
+  // Logo uses brand color directly in SVG paths
+  "keeperhub/components/icons/keeperhub-logo.tsx",
+  // MCP schemas route has hex examples in documentation strings
+  "keeperhub/api/mcp/schemas/route.ts",
+];
+
+// File extensions to scan
+const SCAN_EXTENSIONS = new Set([".css", ".scss", ".tsx", ".ts", ".jsx"]);
+
+// ----------------------------------------------------------------
+// Token suggestions: maps detected patterns to recommended tokens
+// ----------------------------------------------------------------
+
+const COLOR_HEX_SUGGESTIONS = {
+  "#09fd67": "--color-text-accent / --ds-green-accent",
+  "#09fd671a": "--color-bg-accent / --ds-green-accent-10",
+  "#00ff4f": "--ds-green-logo (logo only)",
+  "#1a2230": "--color-hub-card / --ds-hub-surface-1",
+  "#2a3342": "--color-hub-icon-bg / --ds-hub-surface-2",
+  "#243548": "--color-hub-gradient-center / --ds-hub-surface-3",
+  "#354155": "--color-hub-icon-bg-hover / --ds-hub-surface-hover",
+  "#171f2e": "--color-hub-overlay / --ds-hub-overlay",
+  "#4a90d9": "--ds-palette-blue",
+  "#7b61ff": "--ds-palette-violet",
+  "#e06c75": "--ds-palette-rose",
+  "#98c379": "--ds-palette-green",
+  "#e5c07b": "--ds-palette-amber",
+  "#56b6c2": "--ds-palette-cyan",
+  "#c678dd": "--ds-palette-purple",
+  "#d19a66": "--ds-palette-orange",
+  "#3b82f6": "--ds-blue-500 or Tailwind blue-500",
+  "#60a5fa": "--ds-blue-400 or Tailwind blue-400",
+  "#3d4f63": "--color-hub-node-bg / --ds-hub-surface-muted",
+  "#888": "--color-text-muted / --ds-neutral-400",
+  "#888888": "--color-text-muted / --ds-neutral-400",
+  "#6b7280": "--color-text-muted / --ds-neutral-400",
+  "#fff": "var(--background) or --color-text-inverse",
+  "#ffffff": "var(--background) or --color-text-inverse",
+};
+
+const SPACING_SUGGESTIONS = {
+  "60px": "--header-height (var(--ds-header-height))",
+  "280px": "--flyout-width (var(--ds-flyout-width))",
+  "32px": "--sidebar-strip-width (var(--ds-sidebar-strip-width))",
+  "220px": "--drawer-width (var(--ds-drawer-width))",
+};
+
+// ----------------------------------------------------------------
+// Detection patterns
+// ----------------------------------------------------------------
+
+function isCommentOrVarDef(line) {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("--") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("//")
+  );
+}
+
+function isJsComment(line) {
+  const trimmed = line.trim();
+  return trimmed.startsWith("//") || trimmed.startsWith("*");
+}
+
+function suggestHexToken(match) {
+  const lower = match.toLowerCase();
+  return COLOR_HEX_SUGGESTIONS[lower] ?? "Define as token in tokens.css";
+}
+
+function suggestRgbToken() {
+  return "Use a semantic color token from tokens.css";
+}
+
+function suggestArbitraryColor(match) {
+  const hex = match.match(/#[0-9a-fA-F]+/)?.[0]?.toLowerCase();
+  if (hex && COLOR_HEX_SUGGESTIONS[hex]) {
+    const tokenName = COLOR_HEX_SUGGESTIONS[hex].split(" /")[0].split(" or")[0].trim();
+    return `Use var(${tokenName})`;
+  }
+  return "Use a semantic Tailwind color class or var(--token)";
+}
+
+function suggestSpacing(match) {
+  const px = match.match(/(\d+)px/)?.[1];
+  if (px && SPACING_SUGGESTIONS[`${px}px`]) {
+    return SPACING_SUGGESTIONS[`${px}px`];
+  }
+  return "Use a spacing token (--space-*) or Tailwind class";
+}
+
+function suggestFontSize(match) {
+  const sizeMap = {
+    "text-[10px]": "--ds-text-2xs (use text-[0.625rem])",
+    "text-[11px]": "--ds-text-xs (use text-[0.6875rem])",
+    "text-[12px]": "text-xs (Tailwind built-in)",
+    "text-[13px]": "--ds-text-sm or text-xs",
+    "text-[14px]": "text-sm (Tailwind built-in)",
+  };
+  return sizeMap[match] ?? "Use a Tailwind text size class";
+}
+
+function suggestZIndex(match) {
+  const z = match.match(/\[(\d+)\]/)?.[1];
+  const zMap = {
+    "10": "--z-raised",
+    "20": "--z-controls",
+    "30": "--z-flyout",
+    "40": "--z-sidebar",
+    "50": "--z-modal",
+    "60": "--z-toast",
+  };
+  return zMap[z] ?? "Use a z-index token from the scale";
+}
+
+function suggestShadow() {
+  return "Use --shadow-sm/md/lg/xl/overlay/focus token";
+}
+
+const PATTERNS = [
+  // ERRORS: These must be fixed
+  {
+    name: "hardcoded-hex-color",
+    severity: "error",
+    category: "color",
+    regex: /#(?:[0-9a-fA-F]{3,4}){1,2}\b/g,
+    description: "Hardcoded hex color",
+    cssOnly: false,
+    suggest: suggestHexToken,
+    skipLine: isCommentOrVarDef,
+  },
+  {
+    name: "hardcoded-rgb-color",
+    severity: "error",
+    category: "color",
+    regex: /(?<!var\()rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+/g,
+    description: "Hardcoded rgb/rgba color",
+    cssOnly: true,
+    suggest: suggestRgbToken,
+    skipLine: isCommentOrVarDef,
+  },
+  {
+    name: "arbitrary-tailwind-color",
+    severity: "error",
+    category: "color",
+    regex: /(?:bg|text|border|ring|outline|fill|stroke|from|to|via)-\[#[0-9a-fA-F]{3,8}\]/g,
+    description: "Arbitrary Tailwind color class",
+    cssOnly: false,
+    suggest: suggestArbitraryColor,
+    skipLine: isJsComment,
+  },
+
+  // WARNINGS: Should be fixed but not blocking
+  {
+    name: "hardcoded-px-in-css",
+    severity: "warning",
+    category: "spacing",
+    regex: /(?:padding|margin|gap|top|left|right|bottom|width|height)\s*:\s*\d+px/g,
+    description: "Hardcoded pixel spacing in CSS",
+    cssOnly: true,
+    suggest: suggestSpacing,
+    skipLine: isCommentOrVarDef,
+  },
+  {
+    name: "arbitrary-tailwind-spacing",
+    severity: "warning",
+    category: "spacing",
+    regex: /(?:top|left|right|bottom|w|h|min-w|min-h|max-w|max-h|gap|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr)-\[\d+px\]/g,
+    description: "Arbitrary Tailwind spacing",
+    cssOnly: false,
+    suggest: suggestSpacing,
+    skipLine: isJsComment,
+  },
+  {
+    name: "hardcoded-font-size",
+    severity: "warning",
+    category: "typography",
+    regex: /text-\[\d+px\]/g,
+    description: "Arbitrary Tailwind font size",
+    cssOnly: false,
+    suggest: suggestFontSize,
+    skipLine: isJsComment,
+  },
+  {
+    name: "hardcoded-z-index",
+    severity: "warning",
+    category: "z-index",
+    regex: /z-\[\d+\]/g,
+    description: "Arbitrary z-index value",
+    cssOnly: false,
+    suggest: suggestZIndex,
+    skipLine: isJsComment,
+  },
+  {
+    name: "hardcoded-box-shadow",
+    severity: "warning",
+    category: "shadow",
+    regex: /box-shadow\s*:\s*[^;]+/g,
+    description: "Hardcoded box-shadow in CSS",
+    cssOnly: true,
+    suggest: suggestShadow,
+    skipLine: isCommentOrVarDef,
+  },
+];
+
+// ----------------------------------------------------------------
+// File scanning
+// ----------------------------------------------------------------
+
+function getAllFiles(dir) {
+  const results = [];
+  try {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      if (SKIP_PATTERNS.some((p) => fullPath.includes(p))) {
+        continue;
+      }
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        results.push(...getAllFiles(fullPath));
+      } else if (SCAN_EXTENSIONS.has(extname(entry))) {
+        results.push(fullPath);
+      }
+    }
+  } catch {
+    // Directory doesn't exist, skip
+  }
+  return results;
+}
+
+function scanFile(filePath) {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const relPath = relative(ROOT, filePath);
+  const isCss = filePath.endsWith(".css") || filePath.endsWith(".scss");
+  const violations = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+
+    for (const pattern of PATTERNS) {
+      if (pattern.cssOnly && !isCss) {
+        continue;
+      }
+
+      if (pattern.skipLine(line)) {
+        continue;
+      }
+
+      // Reset regex lastIndex for global patterns
+      pattern.regex.lastIndex = 0;
+
+      let match = pattern.regex.exec(line);
+      while (match !== null) {
+        violations.push({
+          file: relPath,
+          line: lineNum,
+          column: match.index + 1,
+          match: match[0],
+          severity: pattern.severity,
+          category: pattern.category,
+          description: pattern.description,
+          suggestion: pattern.suggest(match[0]),
+        });
+        match = pattern.regex.exec(line);
+      }
+    }
+  }
+
+  return violations;
+}
+
+// ----------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------
+
+function main() {
+  const allFiles = [];
+  for (const dir of SCAN_DIRS) {
+    allFiles.push(...getAllFiles(join(ROOT, dir)));
+  }
+
+  // Also scan app/globals.css directly
+  const globalsCss = join(ROOT, "app", "globals.css");
+  if (!allFiles.includes(globalsCss)) {
+    allFiles.push(globalsCss);
+  }
+
+  let errorCount = 0;
+  let warningCount = 0;
+  const allViolations = [];
+
+  for (const file of allFiles) {
+    const violations = scanFile(file);
+    allViolations.push(...violations);
+    for (const v of violations) {
+      if (v.severity === "error") {
+        errorCount++;
+      } else {
+        warningCount++;
+      }
+    }
+  }
+
+  // Sort by file, then line number
+  allViolations.sort((a, b) => {
+    if (a.file !== b.file) {
+      return a.file.localeCompare(b.file);
+    }
+    return a.line - b.line;
+  });
+
+  // Print results
+  for (const v of allViolations) {
+    if (quietMode && v.severity === "warning") {
+      continue;
+    }
+
+    const icon = v.severity === "error" ? "ERROR" : "WARN";
+    process.stdout.write(
+      `${icon}  ${v.file}:${v.line}:${v.column}  ${v.description}: ${v.match}\n`,
+    );
+    process.stdout.write(`       Suggestion: ${v.suggestion}\n\n`);
+  }
+
+  // Summary
+  process.stdout.write("---\n");
+  process.stdout.write(
+    `Token audit: ${allFiles.length} files scanned, ${errorCount} errors, ${warningCount} warnings\n`,
+  );
+
+  if (errorCount > 0) {
+    process.stdout.write(
+      "\nFix errors before committing. See specs/design-system/tokens.css for available tokens.\n",
+    );
+    process.exit(1);
+  }
+
+  if (warningCount > 0 && !quietMode) {
+    process.stdout.write(
+      "\nWarnings found. Consider migrating to design tokens for consistency.\n",
+    );
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/specs/design-system/AUDIT.md
+++ b/specs/design-system/AUDIT.md
@@ -1,0 +1,186 @@
+# Design System Audit
+
+Audited: 2026-03-04
+Scope: All project-owned CSS files and component files (excluding node_modules, .next, docs-site)
+
+## Summary
+
+| Category | Count | Severity |
+|---|---|---|
+| Colors (hardcoded hex/rgb/rgba) | 47 | Error |
+| Spacing (hardcoded px in CSS) | 18 | Error |
+| Typography (hardcoded font-size/weight) | 12 | Warning |
+| Border radius (hardcoded px) | 5 | Error |
+| Z-index (raw values) | 7 | Warning |
+| Box shadows (hardcoded) | 4 | Warning |
+| Transitions (hardcoded durations) | 3 | Warning |
+| **Total** | **96** | |
+
+## Files with Most Hardcoded Values
+
+| File | Count | Categories |
+|---|---|---|
+| `keeperhub/api/og/generate-og.tsx` | 25+ | colors, shadows (OG image -- exempt) |
+| `keeperhub/components/hub/protocol-strip.tsx` | 8 | colors, spacing |
+| `keeperhub/components/hub/protocol-detail.tsx` | 7 | colors, spacing, typography |
+| `keeperhub/components/hub/protocol-card.tsx` | 5 | colors |
+| `keeperhub/components/hub/hub-hero.tsx` | 4 | colors, gradients |
+| `keeperhub/components/hub/workflow-template-grid.tsx` | 4 | colors |
+| `keeperhub/components/hub/workflow-node-icons.tsx` | 4 | colors |
+| `app/globals.css` | 6 | colors (template-badge, React Flow) |
+| `keeperhub/components/projects/project-form-dialog.tsx` | 8 | color palette array |
+| `keeperhub/components/tags/tag-form-dialog.tsx` | 8 | color palette array (duplicate) |
+
+## Detailed Findings
+
+### Colors
+
+#### Hardcoded in CSS (`app/globals.css`)
+
+| Line | Value | Context |
+|---|---|---|
+| 192 | `rgba(255, 255, 255, 0.4)` | React Flow attribution text |
+| 196 | `rgba(255, 255, 255, 0.5)` | React Flow attribution link |
+| 264 | `rgba(59, 130, 246, 0.1)` | Template badge bg |
+| 265 | `rgb(37, 99, 235)` | Template badge text |
+| 266 | `rgba(59, 130, 246, 0.2)` | Template badge border |
+| 272 | `rgb(96, 165, 250)` | Template badge text (dark) |
+
+#### Hardcoded in Components (Tailwind arbitrary values)
+
+| File | Value | Usage |
+|---|---|---|
+| hub/protocol-detail.tsx | `bg-[#09fd671a]` | Green accent bg (10% opacity) |
+| hub/protocol-detail.tsx | `text-[#09fd67]` | Green accent text |
+| hub/protocol-card.tsx | `bg-[#09fd671a]`, `text-[#09fd67]` | Green badges |
+| hub/protocol-card.tsx | `bg-[#2a3342]` | Dark icon background |
+| hub/protocol-strip.tsx | `bg-[#1a2230]` | Card background |
+| hub/protocol-strip.tsx | `bg-[#2a3342]` | Icon container |
+| hub/protocol-strip.tsx | `text-[#09fd67]` | Icon color |
+| hub/workflow-template-grid.tsx | `bg-[#09fd671a]`, `text-[#09fd67]` | Tags |
+| hub/workflow-node-icons.tsx | `bg-[#2a3342]`, `hover:bg-[#354155]` | Icon backgrounds |
+| hub/hub-hero.tsx | `bg-[radial-gradient(circle,#243548...)]` | Backdrop gradient |
+| hub/hub-hero.tsx | `bg-[linear-gradient(...oklch(0.2101...))]` | Bottom fade |
+| app/hub/page.tsx | `bg-[#171f2e]` | Dark overlay (2x) |
+
+#### Duplicated Color Palette Arrays
+
+| File | Values |
+|---|---|
+| projects/project-form-dialog.tsx:19-27 | `#4A90D9, #7B61FF, #E06C75, #98C379, #E5C07B, #56B6C2, #C678DD, #D19A66` |
+| tags/tag-form-dialog.tsx:18-26 | Identical 8-color array |
+
+#### SVG/Icon Colors
+
+| File | Value | Usage |
+|---|---|---|
+| icons/keeperhub-logo.tsx | `#00FF4F` | Logo green fill |
+| ui/animated-border.tsx | `#60a5fa`, `#3b82f6` | Blue gradient stops |
+| ui/animated-border.tsx | `drop-shadow(0 0 4px #3b82f6)` | Blue glow |
+
+#### OG Image Colors (exempt -- server-rendered image, not UI)
+
+File: `keeperhub/api/og/generate-og.tsx`
+Well-organized as constants at top of file. 25+ color values for image generation.
+These are intentionally hardcoded for OG image rendering and are exempt from token requirements.
+
+### Spacing
+
+#### Hardcoded Width/Height Constants
+
+| File | Value | Usage |
+|---|---|---|
+| flyout-panel.tsx | `280` (px) | Flyout width |
+| flyout-panel.tsx | `32` (px) | Strip width |
+| analytics/project-drawer.tsx | `220` (px) | Drawer width |
+| analytics/project-drawer.tsx | `32` (px) | Strip width |
+
+#### Arbitrary Tailwind Spacing
+
+| File | Class | Notes |
+|---|---|---|
+| hub/featured-carousel.tsx | `w-[280px]`, `h-[140px]` | Card dimensions |
+| hub/protocol-strip.tsx | `w-[340px]` | Strip card width |
+| hub/protocol-detail.tsx | `w-[260px]`, `h-[130px]` | Detail card dimensions |
+| organization/org-switcher.tsx | `w-[200px]` (3x) | Switcher width |
+| organization/manage-orgs-modal.tsx | `w-[120px]`, `w-[130px]` | Column widths |
+| onboarding/organization-setup.tsx | `w-[400px]` (3x) | Setup form width |
+| workflow/condition-query-builder.tsx | `w-[120px]` (2x) | Field widths |
+| address-book/save-address-button.tsx | `h-[38px]` | Button height |
+
+#### Hardcoded Spacing in CSS
+
+| File | Line | Value | Context |
+|---|---|---|---|
+| app/globals.css | 163 | `translateX(-6px)` | Flyout animation |
+| app/globals.css | 184 | `2px 4px` | React Flow attribution padding |
+| app/globals.css | 224-225 | `12px` | React Flow handle size |
+| app/globals.css | 240-241 | `44px` | Mobile touch target |
+| app/globals.css | 246 | `-0.5px` | Handle position |
+| app/globals.css | 267-268 | `1px 4px`, `3px` | Template badge padding/radius |
+
+### Typography
+
+| File | Value | Context |
+|---|---|---|
+| app/globals.css:187 | `10px` | React Flow attribution font-size |
+| hub/protocol-detail.tsx | `text-[10px]` | Badge text (multiple) |
+| hub/protocol-strip.tsx | `text-[11px]` | Strip badge text |
+| hub/protocol-card.tsx | `text-[10px]` | Card badge text |
+| onboarding/getting-started-checklist.tsx | `text-[10px]` | Checklist label |
+| overlays/wallet-overlay.tsx | `text-[10px]` | Address label |
+
+### Border Radius
+
+| File | Line | Value |
+|---|---|---|
+| app/globals.css | 267 | `3px` (template badge) |
+| app/globals.css (React Flow) | - | Inherits from `--radius` system |
+
+All other radius values use Tailwind classes (`rounded-md`, `rounded-lg`, `rounded-xl`, `rounded-full`).
+
+### Z-Index
+
+| File | Value | Context |
+|---|---|---|
+| navigation-sidebar.tsx | `z-40` | Sidebar overlay (2x) |
+| flyout-panel.tsx | `z-30` | Flyout panel (2x) |
+| mobile-warning-dialog.tsx | `z-50` | Mobile dialog |
+| hub/hub-hero.tsx | `-z-10` | Background layer |
+| workflows/page.tsx | `z-20` | Workflow controls |
+
+### Box Shadows
+
+| File | Value |
+|---|---|
+| docs-site globals.css | `0 8px 24px rgba(0,0,0,0.3)` |
+| docs-site globals.css | `0 0 0 2px rgba(6,177,113,0.15)` |
+| generate-og.tsx | `0 4px 16px rgba(0,0,0,0.5)` (exempt) |
+
+Components use Tailwind shadow classes (`shadow-sm`, `shadow-lg`) which is correct.
+
+### Transitions
+
+| File | Value |
+|---|---|
+| app/globals.css:256 | `150ms` (stroke transition) |
+| docs-site globals.css | `0.2s ease` (multiple) |
+| docs-site globals.css | `color 0.2s ease` |
+
+## Exemptions
+
+These files are intentionally exempt from token requirements:
+
+1. **`keeperhub/api/og/generate-og.tsx`** -- Server-rendered OG images, not interactive UI
+2. **`lib/monaco-theme.ts`** -- Editor syntax highlighting, uses Monaco's own theming API
+3. **`lib/next-boilerplate/app/globals.css`** -- Upstream template, do not modify
+4. **`docs-site/`** -- Separate documentation site with its own design system
+
+## Recurring Patterns
+
+1. **`#09fd67` green accent** appears 12+ times across hub components -- needs a token
+2. **`#2a3342` dark surface** appears 5+ times -- needs a token
+3. **`#1a2230` dark card bg** appears 3+ times -- needs a token
+4. **`text-[10px]`/`text-[11px]`** badge sizes appear 8+ times -- needs typography token
+5. **Duplicated color palette** in project-form-dialog and tag-form-dialog
+6. **`top-[60px]`** header offset used in sidebar and flyout -- needs a layout token

--- a/specs/design-system/components/action-grid.md
+++ b/specs/design-system/components/action-grid.md
@@ -1,0 +1,72 @@
+# Action Grid
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | ActionGrid |
+| Category | Workflow |
+| Status | Active |
+| File | `keeperhub/components/workflow/config/action-grid.tsx` |
+
+## Overview
+
+Searchable grid of available workflow actions (plugin steps). Displayed when adding a new node to the workflow canvas. Groups actions by integration category with collapsible sections.
+
+**When to use**: When user clicks "Add Step" or the add-node placeholder on the workflow canvas.
+
+**When not to use**: Not used outside the workflow editor context.
+
+## Anatomy
+
+1. **Search Input** -- filters actions by name
+2. **View Toggle** -- grid vs list layout switch
+3. **Category Sections** -- collapsible groups (Web3, Notifications, System, etc.)
+4. **Action Cards** -- individual action items with icon, name, description
+5. **Integration Icon** -- plugin icon for each action
+
+## Tokens Used
+
+| Token | Usage |
+|---|---|
+| `--background` | Grid background |
+| `--border` | Section dividers |
+| `--muted` | Category header background |
+| `--muted-foreground` | Description text |
+| `--foreground` | Action name text |
+| `--accent` | Hover state background |
+| `--primary` | Selected/active action |
+| `text-sm` | Action name size |
+| `text-xs` | Description size |
+
+## Props/API
+
+```typescript
+interface ActionGridProps {
+  onSelectAction: (action: IntegrationAction) => void;
+  currentNodeType?: string;
+}
+```
+
+## States
+
+| State | Appearance |
+|---|---|
+| Default | All categories shown, first collapsed by default |
+| Search active | Only matching actions visible, categories auto-expanded |
+| Hover (action) | `accent` background |
+| Empty search | "No actions found" message |
+| Loading | Skeleton cards |
+
+## Code Example
+
+```tsx
+<ActionGrid
+  onSelectAction={(action) => addNodeToCanvas(action)}
+/>
+```
+
+## Cross-references
+
+- [Workflow Canvas](./workflow-canvas.md) -- parent context
+- [Node Config Panel](./node-config-panel.md) -- shown after action selection

--- a/specs/design-system/components/flyout-panel.md
+++ b/specs/design-system/components/flyout-panel.md
@@ -1,0 +1,75 @@
+# Flyout Panel
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | FlyoutPanel |
+| Category | Navigation |
+| Status | Active |
+| File | `keeperhub/components/flyout-panel.tsx` |
+
+## Overview
+
+Expandable side panel that slides out from the navigation sidebar. Used for project lists, tag management, and workflow filtering.
+
+**When to use**: As a sub-navigation panel within the sidebar.
+
+**When not to use**: For modal-like overlays or full-page panels.
+
+## Anatomy
+
+1. **Strip** -- narrow collapsed state (32px) showing section icon
+2. **Expanded Panel** -- full-width panel (280px) with content
+3. **Header** -- section title and collapse button
+4. **Content Area** -- scrollable list of items (projects, tags, etc.)
+
+## Tokens Used
+
+| Token | Should Use | Currently Uses |
+|---|---|---|
+| `--flyout-width` | Panel width | `280` (JS constant, should reference token) |
+| `--sidebar-strip-width` | Strip width | `32` (JS constant, should reference token) |
+| `--z-flyout` | Z-index layer | `z-30` (correct value, should use token) |
+| `--header-height` | Top offset | `top-[60px]` (should use `top-[var(--header-height)]`) |
+| `--shadow-lg` | Panel shadow | `shadow-lg` (correct) |
+| `--background` | Panel background | `bg-background` (correct) |
+| `--border` | Panel border | `border-border` (correct) |
+
+## Props/API
+
+```typescript
+interface FlyoutPanelProps {
+  title: string;
+  icon: ReactNode;
+  children: ReactNode;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+```
+
+## States
+
+| State | Appearance |
+|---|---|
+| Collapsed | 32px strip with icon only |
+| Expanded | 280px panel with full content, shadow-lg |
+| Animating | flyout-in keyframe (translateX -6px to 0) |
+
+## Code Example
+
+```tsx
+<FlyoutPanel
+  title="Projects"
+  icon={<FolderIcon />}
+  isOpen={isProjectsPanelOpen}
+  onToggle={() => toggleProjectsPanel()}
+>
+  <ProjectList />
+</FlyoutPanel>
+```
+
+## Cross-references
+
+- [Navigation Sidebar](./navigation-sidebar.md) -- parent container
+- [Project Drawer](./project-drawer.md) -- similar pattern in analytics

--- a/specs/design-system/components/getting-started-checklist.md
+++ b/specs/design-system/components/getting-started-checklist.md
@@ -1,0 +1,62 @@
+# Getting Started Checklist
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | GettingStartedChecklist |
+| Category | Onboarding |
+| Status | Active |
+| File | `keeperhub/components/onboarding/getting-started-checklist.tsx` |
+
+## Overview
+
+Onboarding progress checklist shown to new users on the workflow canvas. Tracks 4 setup steps: sign in, connect wallet, set API key, create first workflow.
+
+**When to use**: On the AddNode placeholder when user has incomplete onboarding steps.
+
+**When not to use**: After all steps are completed and user dismisses it.
+
+## Anatomy
+
+1. **Header** -- "Get Started" title with progress count (e.g., "0/4")
+2. **Checklist Items** -- 4 step rows with checkbox, label, and action
+3. **Step Checkbox** -- green check when completed, empty circle when pending
+4. **Step Action** -- button or link for incomplete steps (e.g., "Sign In", "Connect")
+5. **Hide/Show Toggle** -- collapses checklist to a minimal bar
+6. **Collapsed Bar** -- shows "Get Started 0/4" when hidden
+
+## Tokens Used
+
+| Token | Should Use | Currently Uses |
+|---|---|---|
+| `--keeperhub-green` | Completed checkmarks | `text-keeperhub-green` (correct) |
+| `--muted-foreground` | Pending step text | `text-muted-foreground` (correct) |
+| `--border` | Section borders | `border-border` (correct) |
+| `--background` | Card background | `bg-background` (correct) |
+| `text-[10px]` | Small label text | Should use `--ds-text-2xs` |
+| `min-w-[14rem]` | Min width constraint | Arbitrary value |
+| `max-w-[16rem]` | Max width constraint | Arbitrary value |
+
+## Props/API
+
+No external props. Uses the `useOnboardingStatus` hook:
+
+```typescript
+const { steps, completedCount, isHidden, hide, show } = useOnboardingStatus();
+```
+
+## States
+
+| State | Appearance |
+|---|---|
+| All pending | 4 empty circles, action buttons visible |
+| Partially complete | Mix of green checks and empty circles |
+| All complete | All green checks, auto-hides after delay |
+| Hidden | Collapsed bar showing "Get Started X/4" |
+| Anonymous user | Auth-required steps show "Sign In" action |
+
+## Cross-references
+
+- [Workflow Node (AddNode)](./workflow-node.md) -- parent container
+- Onboarding hook: `keeperhub/lib/hooks/use-onboarding-status.ts`

--- a/specs/design-system/components/navigation-sidebar.md
+++ b/specs/design-system/components/navigation-sidebar.md
@@ -1,0 +1,69 @@
+# Navigation Sidebar
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | NavigationSidebar |
+| Category | Navigation |
+| Status | Active |
+| File | `keeperhub/components/navigation-sidebar.tsx` |
+
+## Overview
+
+Primary left-side navigation for the application. Contains org switcher, workflow list, project/tag filters, and a collapsible flyout panel.
+
+**When to use**: Always present on authenticated pages. Renders as full sidebar on desktop, sheet overlay on mobile.
+
+**When not to use**: Unauthenticated/landing pages, onboarding flows.
+
+## Anatomy
+
+1. **Org Switcher** -- top section, switches active organization
+2. **Navigation Links** -- main nav items (Workflows, Analytics, Hub, Settings)
+3. **Workflow List** -- scrollable list of user's workflows
+4. **Project/Tag Filters** -- collapsible filter sections
+5. **User Menu** -- bottom section with user avatar and settings
+6. **Mobile Overlay** -- sheet variant for small screens
+
+## Tokens Used
+
+| Token | Usage |
+|---|---|
+| `--sidebar` | Background color |
+| `--sidebar-foreground` | Text color |
+| `--sidebar-primary` | Active item text |
+| `--sidebar-accent` | Hover background |
+| `--sidebar-border` | Divider borders |
+| `--sidebar-ring` | Focus indicator |
+| `z-40` | Overlay z-index (should use `--z-sidebar`) |
+| `top-[60px]` | Header offset (should use `--header-height`) |
+
+## Props/API
+
+Rendered as part of the app layout. No external props -- reads state from:
+- Organization context (active org)
+- Router (active route for highlighting)
+- Workflow list query
+
+## States
+
+| State | Appearance |
+|---|---|
+| Default | Full sidebar visible, nav links with muted text |
+| Active link | `sidebar-primary` text color, `sidebar-accent` background |
+| Hover | `sidebar-accent` background |
+| Mobile | Hidden by default, slides in as sheet overlay |
+| Collapsed | Strip-width (32px) showing only icons |
+
+## Code Example
+
+```tsx
+// Used in layout.tsx -- no direct instantiation needed
+<NavigationSidebar />
+```
+
+## Cross-references
+
+- [Flyout Panel](./flyout-panel.md) -- nested inside sidebar
+- [Organization Switcher](./org-switcher.md) -- rendered at top of sidebar

--- a/specs/design-system/components/org-switcher.md
+++ b/specs/design-system/components/org-switcher.md
@@ -1,0 +1,66 @@
+# Organization Switcher
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | OrgSwitcher |
+| Category | Navigation |
+| Status | Active |
+| File | `keeperhub/components/organization/org-switcher.tsx` |
+
+## Overview
+
+Dropdown control for switching between organizations. Shows current org name and allows selecting a different org or creating a new one.
+
+**When to use**: At the top of the navigation sidebar.
+
+**When not to use**: In settings pages (use full org management UI instead).
+
+## Anatomy
+
+1. **Trigger Button** -- displays current org name with chevron, combobox role
+2. **Dropdown Menu** -- popover with org list
+3. **Org Item** -- individual org with name and optional avatar
+4. **Divider** -- separator between org list and actions
+5. **Create Org** -- action button to create new organization
+6. **Manage Orgs** -- action button to open org settings
+
+## Tokens Used
+
+| Token | Usage |
+|---|---|
+| `--popover` | Dropdown background |
+| `--popover-foreground` | Dropdown text |
+| `--border` | Dropdown border |
+| `--accent` | Hover state on items |
+| `--accent-foreground` | Hover text |
+| `--muted-foreground` | Secondary text |
+| `w-[200px]` | Fixed width (should use spacing token) |
+
+## Props/API
+
+No external props. Reads from organization context and auth state.
+
+## States
+
+| State | Appearance |
+|---|---|
+| Closed | Button showing current org name |
+| Open | Dropdown with org list, focused item highlighted |
+| Hover (item) | `accent` background |
+| Active (item) | Checkmark indicator |
+| Loading | Skeleton text in button |
+| Single org | Dropdown still shown but with only one item |
+
+## Code Example
+
+```tsx
+// Used in sidebar layout
+<OrgSwitcher />
+```
+
+## Cross-references
+
+- [Navigation Sidebar](./navigation-sidebar.md) -- parent container
+- Manage Orgs Modal -- opened from "Manage" action

--- a/specs/design-system/components/protocol-card.md
+++ b/specs/design-system/components/protocol-card.md
@@ -1,0 +1,68 @@
+# Protocol Card
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | ProtocolCard |
+| Category | Hub |
+| Status | Active |
+| File | `keeperhub/components/hub/protocol-card.tsx` |
+
+## Overview
+
+Displays a blockchain protocol integration in the Hub. Shows protocol name, icon, supported chains, and available actions count.
+
+**When to use**: Inside ProtocolGrid on the Hub page.
+
+**When not to use**: Not for workflow nodes or action grid items.
+
+## Anatomy
+
+1. **Icon Container** -- protocol logo in a dark rounded container
+2. **Protocol Name** -- bold text label
+3. **Chain Badges** -- small green badges showing supported networks
+4. **Action Count** -- number of available actions
+5. **Card Container** -- bordered dark surface with hover effect
+
+## Tokens Used
+
+| Token | Should Use | Currently Uses |
+|---|---|---|
+| `--color-hub-card` | Card background | `bg-[#1a2230]` (hardcoded) |
+| `--color-hub-icon-bg` | Icon container | `bg-[#2a3342]` (hardcoded) |
+| `--color-text-accent` | Chain badge text | `text-[#09fd67]` (hardcoded) |
+| `--color-bg-accent` | Chain badge bg | `bg-[#09fd671a]` (hardcoded) |
+| `--border` | Card border | `border-border/50` (correct) |
+| `text-[10px]` | Badge font size | Should use `--ds-text-2xs` |
+
+## Props/API
+
+```typescript
+interface ProtocolCardProps {
+  protocol: Protocol;
+  onClick: (protocol: Protocol) => void;
+}
+```
+
+## States
+
+| State | Appearance |
+|---|---|
+| Default | Dark card with protocol info, subtle border |
+| Hover | Border brightens, slight scale or brightness change |
+| Active/Selected | Opens ProtocolDetailModal |
+
+## Code Example
+
+```tsx
+<ProtocolCard
+  protocol={aaveV3}
+  onClick={(p) => openDetail(p)}
+/>
+```
+
+## Cross-references
+
+- [Protocol Detail](./protocol-detail.md) -- opened on click
+- [Protocol Strip](./protocol-strip.md) -- alternative compact layout

--- a/specs/design-system/components/workflow-node.md
+++ b/specs/design-system/components/workflow-node.md
@@ -1,0 +1,111 @@
+# Workflow Node
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | TriggerNode / ActionNode / AddNode |
+| Category | Workflow |
+| Status | Active |
+| Files | `components/workflow/nodes/trigger-node.tsx`, `action-node.tsx`, `add-node.tsx` |
+
+## Overview
+
+Visual nodes on the React Flow workflow canvas. Three types exist:
+- **TriggerNode** -- the starting point of a workflow (manual, schedule, webhook, event)
+- **ActionNode** -- an action step in the workflow (plugin actions, conditions, HTTP)
+- **AddNode** -- placeholder node prompting user to add their first step
+
+**When to use**: Inside the WorkflowCanvas React Flow instance.
+
+**When not to use**: Outside of the workflow editor. These are React Flow custom nodes.
+
+## Anatomy
+
+### TriggerNode / ActionNode
+
+1. **Node Container** -- rounded card with border, status indicator
+2. **Integration Icon** -- plugin icon (left side)
+3. **Node Label** -- action name / step description
+4. **Status Badge** -- execution status (idle, running, success, error)
+5. **Source Handle** -- right-side connection point
+6. **Target Handle** -- left-side connection point (ActionNode only)
+
+### AddNode
+
+1. **Prompt Text** -- "Add your first step"
+2. **Action Buttons** -- "Browse Actions" and "Browse Templates"
+3. **Onboarding Checklist** -- getting started checklist (for new users)
+
+## Tokens Used
+
+| Token | Usage |
+|---|---|
+| `--card` | Node background |
+| `--card-foreground` | Node text |
+| `--border` | Node border, handle border |
+| `--primary` | Handle fill color |
+| `--muted-foreground` | Secondary text |
+| `--destructive` | Error status border |
+| `--keeperhub-green` | Success status indicator |
+| `--ring` | Focus/selection ring |
+| `z-20` | Handle z-index (should use `--z-controls`) |
+
+### React Flow Handle Styling (globals.css)
+
+| Property | Value | Notes |
+|---|---|---|
+| Width/Height | `12px` | Hardcoded in CSS with `!important` |
+| Border | `2px solid var(--border)` | Uses token (correct) |
+| Background | `var(--primary)` | Uses token (correct) |
+| Mobile hit area | `44px` | Touch target expansion |
+
+## Props/API
+
+```typescript
+// React Flow NodeProps
+interface TriggerNodeData {
+  type: 'manual' | 'schedule' | 'webhook' | 'event';
+  config: TriggerConfig;
+}
+
+interface ActionNodeData {
+  integrationId: string;
+  actionId: string;
+  label: string;
+  config: Record<string, unknown>;
+  status?: 'idle' | 'running' | 'success' | 'error' | 'cancelled';
+}
+```
+
+## States
+
+| State | Appearance |
+|---|---|
+| Default | Card with muted border, idle status |
+| Selected | Ring highlight, config panel opens |
+| Hover | Cursor pointer |
+| Dragging | Cursor grabbing, slight elevation |
+| Running | Blue/pulsing border indicator |
+| Success | Green border/badge |
+| Error | Red/destructive border, error icon |
+| Cancelled | Gray border, cancelled badge |
+
+## Code Example
+
+```tsx
+// Registered as custom React Flow node types
+const nodeTypes = {
+  trigger: TriggerNode,
+  action: ActionNode,
+  add: AddNode,
+};
+
+<ReactFlow nodeTypes={nodeTypes} nodes={nodes} edges={edges} />
+```
+
+## Cross-references
+
+- [Action Grid](./action-grid.md) -- selects action type for new nodes
+- [Node Config Panel](./node-config-panel.md) -- configures selected node
+- [Workflow Runs](./workflow-runs.md) -- shows execution results per node

--- a/specs/design-system/components/workflow-runs.md
+++ b/specs/design-system/components/workflow-runs.md
@@ -1,0 +1,60 @@
+# Workflow Runs
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Name | WorkflowRuns |
+| Category | Workflow |
+| Status | Active |
+| File | `components/workflow/workflow-runs.tsx` |
+
+## Overview
+
+Panel showing workflow execution history and real-time logs. Displays a list of past runs with their status, duration, and step-by-step results.
+
+**When to use**: Inside the workflow editor, toggled via the toolbar.
+
+**When not to use**: For analytics-level run data, use the RunsTable in analytics instead.
+
+## Anatomy
+
+1. **Runs List** -- scrollable list of execution runs
+2. **Run Item** -- individual run with timestamp, status badge, duration
+3. **Step Results** -- expandable section showing each step's outcome
+4. **Log Output** -- raw log text for each step
+5. **Status Badge** -- success/error/running/cancelled indicator
+6. **Auto-refresh Indicator** -- polling state for active runs
+
+## Tokens Used
+
+| Token | Usage |
+|---|---|
+| `--background` | Panel background |
+| `--card` | Run item background |
+| `--border` | Dividers between runs |
+| `--foreground` | Primary text |
+| `--muted-foreground` | Timestamps, metadata |
+| `--keeperhub-green` | Success status |
+| `--destructive` | Error status |
+| `--accent` | Running/active state |
+| `text-sm` | Body text |
+| `text-xs` | Metadata/timestamps |
+| `font-mono` | Log output text |
+
+## States
+
+| State | Appearance |
+|---|---|
+| Empty | "No runs yet" placeholder |
+| Loading | Skeleton items |
+| Run idle | Neutral border, timestamp shown |
+| Run active | Blue/pulsing indicator, auto-polling |
+| Run success | Green badge, all steps green |
+| Run error | Red badge, failed step highlighted |
+| Run cancelled | Gray badge, "Cancelled" label |
+
+## Cross-references
+
+- [Workflow Node](./workflow-node.md) -- nodes update status based on run data
+- [Analytics Runs Table](./runs-table.md) -- analytics-level run view

--- a/specs/design-system/foundations/color.md
+++ b/specs/design-system/foundations/color.md
@@ -1,0 +1,118 @@
+# Color
+
+Category: Foundation
+Status: Active
+Source: `app/globals.css`, `specs/design-system/tokens.css`
+
+## Color Space
+
+All theme colors use **OKLCh** (Oklch Lightness, Chroma, Hue). OKLCh provides perceptually uniform color manipulation -- adjusting lightness by the same amount across colors produces visually consistent results.
+
+Format: `oklch(L C H)` where L = 0-1, C = 0-0.4, H = 0-360.
+
+## Semantic Color Roles
+
+### Text
+
+| Token | Light Mode | Dark Mode | Usage |
+|---|---|---|---|
+| `--foreground` | `oklch(0.2101 0.0318 264.66)` | `oklch(0.9288 0.0126 255.51)` | Primary text |
+| `--muted-foreground` | `oklch(0.5544 0.0407 257.42)` | `oklch(0.5544 0.0407 257.42)` | Secondary/helper text |
+| `--primary-foreground` | `oklch(0.9842 0.0034 247.86)` | `oklch(0.2101 0.0318 264.66)` | Text on primary surfaces |
+| `--accent-foreground` | `oklch(0.2101 0.0318 264.66)` | `oklch(0.9288 0.0126 255.51)` | Text on accent surfaces |
+| `--keeperhub-green` | `oklch(0.8671 0.2514 147.76)` | same | Brand accent text |
+
+### Background
+
+| Token | Light Mode | Dark Mode | Usage |
+|---|---|---|---|
+| `--background` | `oklch(0.9842 0.0034 247.86)` | `oklch(0.2101 0.0318 264.66)` | Page background |
+| `--card` | `oklch(0.9683 0.0069 247.9)` | `oklch(0.2795 0.0368 260.03)` | Card/elevated surfaces |
+| `--popover` | `oklch(0.9683 0.0069 247.9)` | `oklch(0.2795 0.0368 260.03)` | Popovers, dropdowns |
+| `--muted` | `oklch(0.9288 0.0126 255.51)` | `oklch(0.3717 0.0392 257.29)` | Subdued surfaces |
+| `--accent` | `oklch(0.9288 0.0126 255.51)` | `oklch(0.3717 0.0392 257.29)` | Highlighted surfaces |
+| `--secondary` | `oklch(0.9842 0.0034 247.86)` | `oklch(0.2101 0.0318 264.66)` | Secondary button bg |
+| `--destructive` | `oklch(0.577 0.245 27.325)` | `oklch(0.65 0.25 29)` | Error/danger states |
+
+### Border
+
+| Token | Light Mode | Dark Mode | Usage |
+|---|---|---|---|
+| `--border` | `oklch(0.9288 0.0126 255.51)` | `oklch(0.3717 0.0392 257.29)` | Default borders |
+| `--input` | `oklch(0.9288 0.0126 255.51)` | `oklch(0.3717 0.0392 257.29)` | Input field borders |
+| `--ring` | `oklch(0.7107 0.0351 256.79)` | `oklch(0.4455 0.0374 257.28)` | Focus rings |
+
+### Charts
+
+| Token | Light Mode | Dark Mode |
+|---|---|---|
+| `--chart-1` | `oklch(0.646 0.222 41.116)` | `oklch(0.488 0.243 264.376)` |
+| `--chart-2` | `oklch(0.6 0.118 184.704)` | `oklch(0.696 0.17 162.48)` |
+| `--chart-3` | `oklch(0.398 0.07 227.392)` | `oklch(0.769 0.188 70.08)` |
+| `--chart-4` | `oklch(0.828 0.189 84.429)` | `oklch(0.627 0.265 303.9)` |
+| `--chart-5` | `oklch(0.769 0.188 70.08)` | `oklch(0.645 0.246 16.439)` |
+
+### Sidebar
+
+| Token | Light Mode | Dark Mode |
+|---|---|---|
+| `--sidebar` | `oklch(0.9842 ...)` | `oklch(0.2101 ...)` |
+| `--sidebar-foreground` | `oklch(0.5544 ...)` | `oklch(0.5544 ...)` |
+| `--sidebar-primary` | `oklch(0.2101 ...)` | `oklch(0.9288 ...)` |
+| `--sidebar-accent` | `oklch(0.9683 ...)` | `oklch(0.2101 ...)` |
+| `--sidebar-border` | `oklch(0.9288 ...)` | `oklch(0.3717 ...)` |
+| `--sidebar-ring` | `oklch(0.7107 ...)` | `oklch(0.4455 ...)` |
+
+### Brand
+
+| Token | Value | Usage |
+|---|---|---|
+| `--keeperhub-green` | `oklch(0.8671 0.2514 147.76)` | Primary brand green |
+| `--keeperhub-green-dark` | `oklch(0.7402 0.2136 147.89)` | Darker brand green |
+| `--ds-green-accent` | `#09fd67` | Bright accent (hub badges, active states) |
+| `--ds-green-accent-10` | `#09fd671a` | Accent at 10% opacity (backgrounds) |
+
+### Hub Surfaces (dark-only)
+
+| Token | Value | Usage |
+|---|---|---|
+| `--ds-hub-surface-1` | `#1a2230` | Card backgrounds |
+| `--ds-hub-surface-2` | `#2a3342` | Icon containers |
+| `--ds-hub-surface-3` | `#243548` | Gradient centers |
+| `--ds-hub-surface-hover` | `#354155` | Hover states |
+| `--ds-hub-overlay` | `#171f2e` | Dark overlays |
+
+### Palette (project/tag colors)
+
+| Token | Value |
+|---|---|
+| `--ds-palette-blue` | `#4A90D9` |
+| `--ds-palette-violet` | `#7B61FF` |
+| `--ds-palette-rose` | `#E06C75` |
+| `--ds-palette-green` | `#98C379` |
+| `--ds-palette-amber` | `#E5C07B` |
+| `--ds-palette-cyan` | `#56B6C2` |
+| `--ds-palette-purple` | `#C678DD` |
+| `--ds-palette-orange` | `#D19A66` |
+
+## Tailwind Usage
+
+Colors are mapped to Tailwind via `@theme inline` in `app/globals.css`:
+
+```
+bg-background       -> var(--background)
+text-foreground      -> var(--foreground)
+bg-primary           -> var(--primary)
+text-muted-foreground -> var(--muted-foreground)
+border-border        -> var(--border)
+bg-destructive       -> var(--destructive)
+bg-keeperhub-green   -> var(--keeperhub-green)
+```
+
+## Rules
+
+1. Never use raw hex/rgb/oklch values in component code
+2. Always reference semantic tokens (`--foreground`, `--border`, etc.)
+3. For hub-specific dark surfaces, use `--color-hub-*` tokens
+4. For badge colors, use `--color-badge-*` tokens
+5. The project/tag palette array should import from a shared constant, not be duplicated

--- a/specs/design-system/foundations/elevation.md
+++ b/specs/design-system/foundations/elevation.md
@@ -1,0 +1,41 @@
+# Elevation / Shadows
+
+Category: Foundation
+Status: Active
+Source: `specs/design-system/tokens.css`
+
+## Shadow Scale
+
+| Token | Value | Tailwind | Usage |
+|---|---|---|---|
+| `--shadow-sm` | `0 1px 2px 0 rgba(0,0,0,0.05)` | `shadow-sm` | Subtle lift (buttons, cards at rest) |
+| `--shadow-md` | `0 4px 6px -1px rgba(0,0,0,0.1), ...` | `shadow-md` | Moderate elevation (dropdowns) |
+| `--shadow-lg` | `0 10px 15px -3px rgba(0,0,0,0.1), ...` | `shadow-lg` | High elevation (flyout panels, modals) |
+| `--shadow-xl` | `0 20px 25px -5px rgba(0,0,0,0.1), ...` | `shadow-xl` | Maximum elevation |
+| `--shadow-overlay` | `0 8px 24px rgba(0,0,0,0.3)` | -- | Overlay/dropdown menus |
+| `--shadow-focus` | `0 0 0 2px rgba(6,177,113,0.15)` | -- | Focus ring shadow (green tint) |
+
+## Elevation Hierarchy
+
+From lowest to highest:
+
+1. **Base** (no shadow) -- Page background, inline elements
+2. **Raised** (`shadow-sm`) -- Cards, sidebar items on hover
+3. **Floating** (`shadow-md`) -- Tooltips, small dropdowns
+4. **Overlay** (`shadow-lg` or `shadow-overlay`) -- Flyout panels, command menus
+5. **Modal** (`shadow-xl`) -- Modal dialogs, full-screen overlays
+
+## Focus Rings
+
+Interactive elements use a two-part focus indicator:
+
+1. **Outline**: `outline-ring/50` (set globally via `@layer base`)
+2. **Shadow**: `--shadow-focus` for inputs with green-tinted glow on `:focus`
+
+## Rules
+
+1. Never use hardcoded `box-shadow` values in components
+2. Use Tailwind shadow classes (`shadow-sm`, `shadow-lg`) for standard elevation
+3. For focus states, use `--shadow-focus` or the global outline from `@layer base`
+4. Dark mode shadows should be darker -- the existing Tailwind shadows handle this automatically
+5. The `!important` shadows in React Flow overrides are exempt (third-party library constraints)

--- a/specs/design-system/foundations/motion.md
+++ b/specs/design-system/foundations/motion.md
@@ -1,0 +1,88 @@
+# Motion / Transitions
+
+Category: Foundation
+Status: Active
+Source: `specs/design-system/tokens.css`, `app/globals.css`
+
+## Duration Scale
+
+| Token | Value | Usage |
+|---|---|---|
+| `--duration-fast` | `100ms` | Micro-interactions (opacity, color) |
+| `--duration-normal` | `150ms` | Default transitions (borders, strokes) |
+| `--duration-slow` | `200ms` | Standard UI transitions (slides, fades) |
+| `--duration-slower` | `300ms` | Complex animations (modals, drawers) |
+
+## Easing Functions
+
+| Token | Value | Usage |
+|---|---|---|
+| `--easing-default` | `ease` | General-purpose |
+| `--easing-in-out` | `cubic-bezier(0.4, 0, 0.2, 1)` | Enter/exit transitions |
+| `--easing-spring` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Playful/bouncy interactions |
+
+## Custom Animations
+
+Defined in `app/globals.css`:
+
+### flyout-in
+
+Slide-in from the left with fade. Used for flyout panel entry.
+
+```css
+@keyframes flyout-in {
+  from { opacity: 0; transform: translateX(-6px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+```
+
+### dashdraw
+
+Animated dashed line drawing. Used for workflow edge connections.
+
+```css
+@keyframes dashdraw {
+  from { stroke-dashoffset: 10; }
+  to   { stroke-dashoffset: 0; }
+}
+```
+
+## Transition Patterns
+
+### Color transitions
+
+```css
+transition: color var(--duration-slow) var(--easing-default);
+/* equivalent to: transition: color 0.2s ease; */
+```
+
+### Stroke transitions (workflow connectors)
+
+```css
+transition: stroke var(--duration-normal);
+/* equivalent to: transition: stroke 150ms; */
+```
+
+### Interactive element transitions
+
+The docs-site applies a global transition to all interactive elements:
+
+```css
+a, button, input, [role="button"] {
+  transition: all 0.2s ease;
+}
+```
+
+This should use tokens: `transition: all var(--duration-slow) var(--easing-default)`.
+
+## tw-animate-css
+
+The project imports `tw-animate-css` for Tailwind animation utilities. This provides classes like `animate-in`, `animate-out`, `fade-in`, `slide-in-from-left`, etc. Use these for component mount/unmount animations.
+
+## Rules
+
+1. Never hardcode durations (`150ms`, `0.2s`) -- use duration tokens
+2. Never hardcode easing (`ease`, `ease-in-out`) -- use easing tokens
+3. Prefer Tailwind animation classes from `tw-animate-css` for enter/exit
+4. Custom `@keyframes` should be defined in `app/globals.css`, not inline
+5. Use `prefers-reduced-motion` media query for accessibility when adding new animations

--- a/specs/design-system/foundations/radius.md
+++ b/specs/design-system/foundations/radius.md
@@ -1,0 +1,43 @@
+# Border Radius
+
+Category: Foundation
+Status: Active
+Source: `specs/design-system/tokens.css`, `app/globals.css`
+
+## Scale
+
+Base radius: **0.625rem** (10px), defined as `--radius` in globals.css.
+
+| Token | Value | px | Tailwind | Usage |
+|---|---|---|---|---|
+| `--radius-sm` | `calc(var(--radius) - 4px)` | ~6 | `rounded-sm` | Small elements (badges, chips) |
+| `--radius-md` | `calc(var(--radius) - 2px)` | ~8 | `rounded-md` | Inputs, buttons |
+| `--radius-lg` | `var(--radius)` | 10 | `rounded-lg` | Cards, modals, panels |
+| `--radius-xl` | `calc(var(--radius) + 4px)` | ~14 | `rounded-xl` | Large cards, hero elements |
+| `--radius-full` | `9999px` | - | `rounded-full` | Circles, pills, avatars |
+
+## How It Works
+
+The `--radius` CSS variable is the single source of truth. All other radius values are computed from it. Changing `--radius` globally adjusts the entire rounding feel:
+
+```css
+:root {
+  --radius: 0.625rem;  /* 10px -- current value */
+}
+```
+
+The Tailwind theme maps these in `@theme inline`:
+
+```css
+--radius-sm: calc(var(--radius) - 4px);
+--radius-md: calc(var(--radius) - 2px);
+--radius-lg: var(--radius);
+--radius-xl: calc(var(--radius) + 4px);
+```
+
+## Rules
+
+1. Never use hardcoded border-radius values (`3px`, `4px`, `10px`, `20px`)
+2. Always use Tailwind classes: `rounded-sm`, `rounded-md`, `rounded-lg`, `rounded-xl`, `rounded-full`
+3. For elements that need `rounded-none`, that is also acceptable
+4. The search input in docs-site uses `border-radius: 20px` -- this should be `rounded-full` instead

--- a/specs/design-system/foundations/spacing.md
+++ b/specs/design-system/foundations/spacing.md
@@ -1,0 +1,57 @@
+# Spacing
+
+Category: Foundation
+Status: Active
+Source: `specs/design-system/tokens.css`
+
+## Scale
+
+Base unit: **4px** (0.25rem). All spacing derives from multiples of 4px.
+
+| Token | Value | px | Usage |
+|---|---|---|---|
+| `--space-0` | `0` | 0 | Reset |
+| `--space-px` | `1px` | 1 | Hairline offsets |
+| `--space-0-5` | `0.125rem` | 2 | Micro spacing (badge padding) |
+| `--space-1` | `0.25rem` | 4 | Tight inner padding |
+| `--space-1-5` | `0.375rem` | 6 | Small padding |
+| `--space-2` | `0.5rem` | 8 | Default inner padding |
+| `--space-3` | `0.75rem` | 12 | Medium padding |
+| `--space-4` | `1rem` | 16 | Standard padding/gap |
+| `--space-5` | `1.25rem` | 20 | Comfortable padding |
+| `--space-6` | `1.5rem` | 24 | Section padding |
+| `--space-8` | `2rem` | 32 | Large section gaps |
+| `--space-10` | `2.5rem` | 40 | Extra large gaps |
+| `--space-12` | `3rem` | 48 | Page-level spacing |
+| `--space-16` | `4rem` | 64 | Major layout gaps |
+
+## Layout Constants
+
+| Token | Value | Usage |
+|---|---|---|
+| `--header-height` | `60px` | Main header bar height |
+| `--sidebar-strip-width` | `32px` | Collapsed sidebar strip |
+| `--flyout-width` | `280px` | Flyout panel width |
+| `--drawer-width` | `220px` | Analytics drawer width |
+
+## Tailwind Mapping
+
+Use standard Tailwind spacing classes which map to the 4px scale:
+
+```
+p-1  -> 4px      m-1  -> 4px
+p-2  -> 8px      m-2  -> 8px
+p-3  -> 12px     m-3  -> 12px
+p-4  -> 16px     m-4  -> 16px
+p-6  -> 24px     m-6  -> 24px
+p-8  -> 32px     m-8  -> 32px
+gap-4 -> 16px    gap-6 -> 24px
+```
+
+## Rules
+
+1. Never use arbitrary pixel values in Tailwind (e.g., `p-[13px]`). Map to the nearest scale step.
+2. Layout constants (`--header-height`, `--flyout-width`, etc.) must use tokens, not hardcoded numbers.
+3. Use `top-[var(--header-height)]` instead of `top-[60px]`.
+4. For component-specific fixed dimensions (card widths, chart heights), use the spacing scale or define a layout constant in tokens.css.
+5. Viewport-relative values (`80vh`, `100dvh`) are acceptable and do not need tokens.

--- a/specs/design-system/foundations/typography.md
+++ b/specs/design-system/foundations/typography.md
@@ -1,0 +1,72 @@
+# Typography
+
+Category: Foundation
+Status: Active
+Source: `specs/design-system/tokens.css`, `app/globals.css`
+
+## Font Families
+
+| Token | Stack | Usage |
+|---|---|---|
+| `--font-sans` / `--ds-font-sans` | Anek Latin, system-ui, sans-serif | All UI text |
+| `--font-mono` / `--ds-font-mono` | Geist Mono, ui-monospace, monospace | Code, addresses, data |
+
+Fonts are loaded via `next/font` in the layout and applied via CSS variables `--font-anek-latin` and `--font-geist-mono`.
+
+## Type Scale
+
+| Token | Size | px | Tailwind | Usage |
+|---|---|---|---|---|
+| `--ds-text-2xs` | `0.625rem` | 10 | `text-[0.625rem]` | Badges, tiny labels |
+| `--ds-text-xs` | `0.6875rem` | 11 | `text-[0.6875rem]` | Small badges |
+| `--ds-text-sm` | `0.75rem` | 12 | `text-xs` | Table headers, captions |
+| `--ds-text-base` | `0.875rem` | 14 | `text-sm` | Body text, table cells |
+| `--ds-text-md` | `1rem` | 16 | `text-base` | Default/base size |
+| `--ds-text-lg` | `1.125rem` | 18 | `text-lg` | Small headings |
+| `--ds-text-xl` | `1.25rem` | 20 | `text-xl` | Section headings |
+| `--ds-text-2xl` | `1.5rem` | 24 | `text-2xl` | Page headings |
+| `--ds-text-3xl` | `1.875rem` | 30 | `text-3xl` | Hero headings |
+
+## Font Weights
+
+| Token | Value | Tailwind | Usage |
+|---|---|---|---|
+| `--ds-weight-normal` | 400 | `font-normal` | Body text |
+| `--ds-weight-medium` | 500 | `font-medium` | Labels, badge text |
+| `--ds-weight-semibold` | 600 | `font-semibold` | Subheadings, strong emphasis |
+| `--ds-weight-bold` | 700 | `font-bold` | Main headings |
+
+## Line Heights
+
+| Token | Value | Tailwind | Usage |
+|---|---|---|---|
+| `--ds-leading-tight` | 1.15 | `leading-tight` | Large headings |
+| `--ds-leading-snug` | 1.4 | `leading-snug` | Subheadings |
+| `--ds-leading-normal` | 1.5 | `leading-normal` | Default |
+| `--ds-leading-relaxed` | 1.6 | `leading-relaxed` | Body text |
+| `--ds-leading-loose` | 1.7 | `leading-loose` | Long-form content |
+
+## Letter Spacing
+
+| Token | Value | Usage |
+|---|---|---|
+| `--ds-tracking-tight` | -1.5px | Hero headings |
+| `--ds-tracking-snug` | -0.75px | Section headings |
+| `--ds-tracking-normal` | 0 | Default |
+| `--ds-tracking-wide` | 0.5px | Uppercase labels, table headers |
+
+## Heading Hierarchy
+
+| Level | Size | Weight | Tracking | Leading |
+|---|---|---|---|---|
+| h1 | `text-3xl` | `font-bold` | `tracking-tight` | `leading-tight` |
+| h2 | `text-2xl` | `font-bold` | `tracking-snug` | `leading-snug` |
+| h3 | `text-xl` | `font-semibold` | `tracking-normal` | `leading-snug` |
+| h4 | `text-lg` | `font-semibold` | `tracking-normal` | `leading-normal` |
+
+## Rules
+
+1. Never use `text-[10px]` or `text-[11px]` -- use `text-[0.625rem]` or `text-[0.6875rem]` with a comment referencing the token name
+2. Prefer Tailwind type classes (`text-sm`, `font-medium`) over inline styles
+3. Body text should use `text-sm` (14px), not `text-base` (16px) -- the app is information-dense
+4. Monospace font is for code, blockchain addresses, and numeric data only

--- a/specs/design-system/prompt.txt
+++ b/specs/design-system/prompt.txt
@@ -1,0 +1,71 @@
+Audit this project and make the design system LLM-readable.
+
+Step 1: Audit
+Scan every CSS/SCSS file. List every hardcoded visual value:
+hex colors, rgb/rgba colors, pixel spacing, raw font sizes,
+font weights, border radii, z-index values, box shadows,
+and transition durations. Group them by category. Count totals.
+Report which files have the most hardcoded values.
+
+Step 2: Token layer
+Create a tokens.css file with three layers:
+
+- Layer 1: upstream design system tokens (use existing ones
+  if the project already uses a design system, otherwise
+  derive sensible primitives from the audit)
+- Layer 2: project aliases that reference Layer 1 with
+  fallbacks, e.g. --color-text: var(--ds-text, #292A2E)
+- Layer 3 is the components themselves — they only ever
+  reference Layer 2 aliases, never raw values
+
+Include tokens for: colors (text, background, link, border,
+interactive states), spacing (at least 8 steps), typography
+(font families, sizes, weights, line heights), border radius,
+elevation/shadow, z-index, and motion/transitions.
+
+Step 3: Spec files
+Create a specs/design-system/ directory. Write structured markdown specs:
+
+- specs/design-system/foundations/ — color.md, spacing.md, typography.md,
+  radius.md, elevation.md, motion.md
+- specs/design-system/tokens/ — token-reference.md (master map of every
+  CSS variable, its value, and when to use it)
+- specs/design-system/components/ — one file per major component in the
+  project. Each spec follows this template:
+  1. Metadata (name, category, status)
+  2. Overview (when to use, when not to use)
+  3. Anatomy (parts of the component)
+  4. Tokens used (which CSS variables it references)
+  5. Props/API (if applicable)
+  6. States (default, hover, active, focus, disabled, error)
+  7. Code example
+  8. Cross-references (related components)
+
+Only spec components that actually exist in this project.
+
+Step 4: Audit script
+Create scripts/token-audit.js (or .sh) that:
+
+- Scans all CSS files for hardcoded values
+- Suggests the correct token for each violation
+- Prints file, line number, violation, and suggestion
+- Returns exit code 1 if any errors found (CI-ready)
+- Distinguishes errors (hardcoded colors, spacing) from
+  warnings (raw durations, uncommon values)
+
+SKIP THIS STEP - ONLY RUN IF USER EXPLICITELY ASKS
+Step 5: Replace hardcoded values
+Go through every CSS file and replace hardcoded values with
+the tokens from Step 2. Every color:, background:, padding:,
+margin:, gap:, border-radius:, font-size:, font-weight:,
+box-shadow:, z-index:, and transition: should reference a
+var(--token). No raw values should remain.
+
+Step 6: Project instructions
+Add a section to the project's AI instruction file (CLAUDE.md,
+.cursorrules, or equivalent) that says:
+"Before writing or modifying any UI code, read the relevant
+spec file in specs/design-system/. Use only tokens from tokens.css. Run the
+token audit script before committing. Zero errors required."
+
+Run the audit script at the end and confirm zero violations.

--- a/specs/design-system/tokens.css
+++ b/specs/design-system/tokens.css
@@ -1,0 +1,324 @@
+/*
+ * KeeperHub Design Tokens
+ * =======================
+ * Three-layer token architecture for the KeeperHub design system.
+ *
+ * Layer 1: Primitive tokens   -- raw values (oklch colors, px sizes, scales)
+ * Layer 2: Semantic aliases   -- project-level tokens referencing Layer 1
+ * Layer 3: Components         -- components only reference Layer 2 aliases
+ *
+ * This file defines Layer 1 and Layer 2.
+ * Components (Layer 3) consume these via Tailwind classes or var() references.
+ *
+ * Color space: OKLCh (used by the existing theme in app/globals.css)
+ * Spacing base: 4px (0.25rem)
+ * Border radius base: 0.625rem (10px)
+ */
+
+/* ================================================================
+   LAYER 1: PRIMITIVE TOKENS
+   Raw design values. Never reference these directly in components.
+   ================================================================ */
+
+:root {
+  /* --- Colors: Neutrals (light mode base) --- */
+  --ds-neutral-50: oklch(0.9842 0.0034 247.86);
+  --ds-neutral-100: oklch(0.9683 0.0069 247.9);
+  --ds-neutral-200: oklch(0.9288 0.0126 255.51);
+  --ds-neutral-300: oklch(0.7107 0.0351 256.79);
+  --ds-neutral-400: oklch(0.5544 0.0407 257.42);
+  --ds-neutral-500: oklch(0.4455 0.0374 257.28);
+  --ds-neutral-600: oklch(0.3717 0.0392 257.29);
+  --ds-neutral-700: oklch(0.2795 0.0368 260.03);
+  --ds-neutral-800: oklch(0.2101 0.0318 264.66);
+
+  /* --- Colors: Brand Green --- */
+  --ds-green-400: oklch(0.8671 0.2514 147.76);
+  --ds-green-500: oklch(0.7402 0.2136 147.89);
+  --ds-green-accent: #09fd67;
+  --ds-green-accent-10: #09fd671a;
+  --ds-green-logo: #00ff4f;
+
+  /* --- Colors: Semantic States --- */
+  --ds-red-500: oklch(0.577 0.245 27.325);
+  --ds-red-500-dark: oklch(0.65 0.25 29);
+
+  /* --- Colors: Charts --- */
+  --ds-chart-orange: oklch(0.646 0.222 41.116);
+  --ds-chart-teal: oklch(0.6 0.118 184.704);
+  --ds-chart-slate: oklch(0.398 0.07 227.392);
+  --ds-chart-yellow: oklch(0.828 0.189 84.429);
+  --ds-chart-gold: oklch(0.769 0.188 70.08);
+  --ds-chart-purple-dark: oklch(0.488 0.243 264.376);
+  --ds-chart-green-dark: oklch(0.696 0.17 162.48);
+  --ds-chart-violet-dark: oklch(0.627 0.265 303.9);
+  --ds-chart-coral-dark: oklch(0.645 0.246 16.439);
+
+  /* --- Colors: Hub Surfaces (dark-only components) --- */
+  --ds-hub-surface-1: #1a2230;
+  --ds-hub-surface-2: #2a3342;
+  --ds-hub-surface-3: #243548;
+  --ds-hub-surface-hover: #354155;
+  --ds-hub-overlay: #171f2e;
+  --ds-hub-surface-muted: #3d4f63;
+
+  /* --- Colors: Template Badge (blue) --- */
+  --ds-blue-500: rgb(37, 99, 235);
+  --ds-blue-400: rgb(96, 165, 250);
+  --ds-blue-500-10: rgba(59, 130, 246, 0.1);
+  --ds-blue-500-20: rgba(59, 130, 246, 0.2);
+
+  /* --- Colors: Palette (projects/tags) --- */
+  --ds-palette-blue: #4a90d9;
+  --ds-palette-violet: #7b61ff;
+  --ds-palette-rose: #e06c75;
+  --ds-palette-green: #98c379;
+  --ds-palette-amber: #e5c07b;
+  --ds-palette-cyan: #56b6c2;
+  --ds-palette-purple: #c678dd;
+  --ds-palette-orange: #d19a66;
+
+  /* --- Spacing Scale (4px base) --- */
+  --ds-space-0: 0;
+  --ds-space-px: 1px;
+  --ds-space-0-5: 0.125rem; /* 2px */
+  --ds-space-1: 0.25rem; /* 4px */
+  --ds-space-1-5: 0.375rem; /* 6px */
+  --ds-space-2: 0.5rem; /* 8px */
+  --ds-space-3: 0.75rem; /* 12px */
+  --ds-space-4: 1rem; /* 16px */
+  --ds-space-5: 1.25rem; /* 20px */
+  --ds-space-6: 1.5rem; /* 24px */
+  --ds-space-8: 2rem; /* 32px */
+  --ds-space-10: 2.5rem; /* 40px */
+  --ds-space-12: 3rem; /* 48px */
+  --ds-space-16: 4rem; /* 64px */
+
+  /* --- Typography: Font Families --- */
+  --ds-font-sans: var(--font-anek-latin), "Anek Latin", system-ui, sans-serif;
+  --ds-font-mono: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
+
+  /* --- Typography: Font Sizes --- */
+  --ds-text-2xs: 0.625rem; /* 10px -- badges, labels */
+  --ds-text-xs: 0.6875rem; /* 11px -- small badges */
+  --ds-text-sm: 0.75rem; /* 12px -- table headers */
+  --ds-text-base: 0.875rem; /* 14px -- body text */
+  --ds-text-md: 1rem; /* 16px -- default */
+  --ds-text-lg: 1.125rem; /* 18px */
+  --ds-text-xl: 1.25rem; /* 20px */
+  --ds-text-2xl: 1.5rem; /* 24px */
+  --ds-text-3xl: 1.875rem; /* 30px */
+
+  /* --- Typography: Font Weights --- */
+  --ds-weight-normal: 400;
+  --ds-weight-medium: 500;
+  --ds-weight-semibold: 600;
+  --ds-weight-bold: 700;
+
+  /* --- Typography: Line Heights --- */
+  --ds-leading-tight: 1.15;
+  --ds-leading-snug: 1.4;
+  --ds-leading-normal: 1.5;
+  --ds-leading-relaxed: 1.6;
+  --ds-leading-loose: 1.7;
+
+  /* --- Typography: Letter Spacing --- */
+  --ds-tracking-tight: -1.5px;
+  --ds-tracking-snug: -0.75px;
+  --ds-tracking-normal: 0;
+  --ds-tracking-wide: 0.5px;
+
+  /* --- Border Radius --- */
+  --ds-radius-none: 0;
+  --ds-radius-sm: 0.375rem; /* 6px */
+  --ds-radius-md: 0.5rem; /* 8px */
+  --ds-radius-lg: 0.625rem; /* 10px -- base */
+  --ds-radius-xl: 1.025rem; /* ~16px */
+  --ds-radius-full: 9999px;
+
+  /* --- Elevation / Shadows --- */
+  --ds-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --ds-shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --ds-shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --ds-shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  --ds-shadow-overlay: 0 8px 24px rgba(0, 0, 0, 0.3);
+  --ds-shadow-focus: 0 0 0 2px rgba(6, 177, 113, 0.15);
+
+  /* --- Z-Index Scale --- */
+  --ds-z-base: 0;
+  --ds-z-below: -10;
+  --ds-z-raised: 10;
+  --ds-z-controls: 20;
+  --ds-z-flyout: 30;
+  --ds-z-sidebar: 40;
+  --ds-z-modal: 50;
+  --ds-z-toast: 60;
+
+  /* --- Motion / Transitions --- */
+  --ds-duration-fast: 100ms;
+  --ds-duration-normal: 150ms;
+  --ds-duration-slow: 200ms;
+  --ds-duration-slower: 300ms;
+  --ds-easing-default: ease;
+  --ds-easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-easing-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* --- Layout Constants --- */
+  --ds-header-height: 60px;
+  --ds-sidebar-strip-width: 32px;
+  --ds-flyout-width: 280px;
+  --ds-drawer-width: 220px;
+}
+
+/* ================================================================
+   LAYER 2: SEMANTIC ALIASES
+   Project-level tokens. Components reference ONLY these.
+   Each alias maps to a Layer 1 primitive with a hardcoded fallback.
+   ================================================================ */
+
+:root {
+  /* --- Color: Text --- */
+  --color-text: var(--ds-neutral-800, oklch(0.2101 0.0318 264.66));
+  --color-text-muted: var(--ds-neutral-400, oklch(0.5544 0.0407 257.42));
+  --color-text-inverse: var(--ds-neutral-50, oklch(0.9842 0.0034 247.86));
+  --color-text-link: var(--ds-green-500, oklch(0.7402 0.2136 147.89));
+  --color-text-link-hover: var(--ds-green-400, oklch(0.8671 0.2514 147.76));
+  --color-text-accent: var(--ds-green-accent, #09fd67);
+  --color-text-error: var(--ds-red-500, oklch(0.577 0.245 27.325));
+
+  /* --- Color: Background --- */
+  --color-bg: var(--ds-neutral-50, oklch(0.9842 0.0034 247.86));
+  --color-bg-surface: var(--ds-neutral-100, oklch(0.9683 0.0069 247.9));
+  --color-bg-muted: var(--ds-neutral-200, oklch(0.9288 0.0126 255.51));
+  --color-bg-inverse: var(--ds-neutral-800, oklch(0.2101 0.0318 264.66));
+  --color-bg-accent: var(--ds-green-accent-10, #09fd671a);
+  --color-bg-error: oklch(0.577 0.245 27.325 / 0.1);
+
+  /* --- Color: Border --- */
+  --color-border: var(--ds-neutral-200, oklch(0.9288 0.0126 255.51));
+  --color-border-muted: oklch(0.9288 0.0126 255.51 / 0.5);
+  --color-border-accent: var(--ds-green-accent, #09fd67);
+  --color-border-error: var(--ds-red-500, oklch(0.577 0.245 27.325));
+
+  /* --- Color: Interactive --- */
+  --color-interactive-primary: var(
+    --ds-neutral-800,
+    oklch(0.2101 0.0318 264.66)
+  );
+  --color-interactive-primary-hover: var(
+    --ds-neutral-700,
+    oklch(0.2795 0.0368 260.03)
+  );
+  --color-interactive-accent: var(--ds-green-400, oklch(0.8671 0.2514 147.76));
+  --color-interactive-accent-hover: var(
+    --ds-green-500,
+    oklch(0.7402 0.2136 147.89)
+  );
+  --color-interactive-destructive: var(--ds-red-500, oklch(0.577 0.245 27.325));
+
+  /* --- Color: Hub (dark surfaces for hub/protocol pages) --- */
+  --color-hub-card: var(--ds-hub-surface-1, #1a2230);
+  --color-hub-icon-bg: var(--ds-hub-surface-2, #2a3342);
+  --color-hub-icon-bg-hover: var(--ds-hub-surface-hover, #354155);
+  --color-hub-gradient-center: var(--ds-hub-surface-3, #243548);
+  --color-hub-overlay: var(--ds-hub-overlay, #171f2e);
+  --color-hub-node-bg: var(--ds-hub-surface-muted, #3d4f63);
+
+  /* --- Color: Badge (template) --- */
+  --color-badge-blue-bg: var(--ds-blue-500-10, rgba(59, 130, 246, 0.1));
+  --color-badge-blue-text: var(--ds-blue-500, rgb(37, 99, 235));
+  --color-badge-blue-text-dark: var(--ds-blue-400, rgb(96, 165, 250));
+  --color-badge-blue-border: var(--ds-blue-500-20, rgba(59, 130, 246, 0.2));
+
+  /* --- Spacing --- */
+  --space-0: var(--ds-space-0, 0);
+  --space-px: var(--ds-space-px, 1px);
+  --space-0-5: var(--ds-space-0-5, 0.125rem);
+  --space-1: var(--ds-space-1, 0.25rem);
+  --space-1-5: var(--ds-space-1-5, 0.375rem);
+  --space-2: var(--ds-space-2, 0.5rem);
+  --space-3: var(--ds-space-3, 0.75rem);
+  --space-4: var(--ds-space-4, 1rem);
+  --space-5: var(--ds-space-5, 1.25rem);
+  --space-6: var(--ds-space-6, 1.5rem);
+  --space-8: var(--ds-space-8, 2rem);
+  --space-10: var(--ds-space-10, 2.5rem);
+  --space-12: var(--ds-space-12, 3rem);
+  --space-16: var(--ds-space-16, 4rem);
+
+  /* --- Typography --- */
+  --font-sans: var(--ds-font-sans);
+  --font-mono: var(--ds-font-mono);
+  --text-size-badge: var(--ds-text-2xs, 0.625rem);
+  --text-size-label: var(--ds-text-xs, 0.6875rem);
+  --text-size-caption: var(--ds-text-sm, 0.75rem);
+  --text-size-body: var(--ds-text-base, 0.875rem);
+  --text-size-default: var(--ds-text-md, 1rem);
+  --text-size-heading-sm: var(--ds-text-lg, 1.125rem);
+  --text-size-heading-md: var(--ds-text-xl, 1.25rem);
+  --text-size-heading-lg: var(--ds-text-2xl, 1.5rem);
+  --text-size-heading-xl: var(--ds-text-3xl, 1.875rem);
+
+  /* --- Border Radius --- */
+  --radius-sm: var(--ds-radius-sm, 0.375rem);
+  --radius-md: var(--ds-radius-md, 0.5rem);
+  --radius-lg: var(--ds-radius-lg, 0.625rem);
+  --radius-xl: var(--ds-radius-xl, 1.025rem);
+  --radius-full: var(--ds-radius-full, 9999px);
+
+  /* --- Elevation --- */
+  --shadow-sm: var(--ds-shadow-sm);
+  --shadow-md: var(--ds-shadow-md);
+  --shadow-lg: var(--ds-shadow-lg);
+  --shadow-xl: var(--ds-shadow-xl);
+  --shadow-overlay: var(--ds-shadow-overlay);
+  --shadow-focus: var(--ds-shadow-focus);
+
+  /* --- Z-Index --- */
+  --z-below: var(--ds-z-below, -10);
+  --z-base: var(--ds-z-base, 0);
+  --z-raised: var(--ds-z-raised, 10);
+  --z-controls: var(--ds-z-controls, 20);
+  --z-flyout: var(--ds-z-flyout, 30);
+  --z-sidebar: var(--ds-z-sidebar, 40);
+  --z-modal: var(--ds-z-modal, 50);
+  --z-toast: var(--ds-z-toast, 60);
+
+  /* --- Motion --- */
+  --duration-fast: var(--ds-duration-fast, 100ms);
+  --duration-normal: var(--ds-duration-normal, 150ms);
+  --duration-slow: var(--ds-duration-slow, 200ms);
+  --duration-slower: var(--ds-duration-slower, 300ms);
+  --easing-default: var(--ds-easing-default, ease);
+  --easing-in-out: var(--ds-easing-in-out);
+  --easing-spring: var(--ds-easing-spring);
+
+  /* --- Layout --- */
+  --header-height: var(--ds-header-height, 60px);
+  --sidebar-strip-width: var(--ds-sidebar-strip-width, 32px);
+  --flyout-width: var(--ds-flyout-width, 280px);
+  --drawer-width: var(--ds-drawer-width, 220px);
+}
+
+/* ================================================================
+   LAYER 3: COMPONENT USAGE (reference only -- not defined here)
+   ================================================================
+
+   Components consume Layer 2 aliases via Tailwind classes or var():
+
+   CORRECT:
+     .my-card { background: var(--color-bg-surface); }
+     <div className="bg-[var(--color-hub-card)]">
+     <span className="text-keeperhub-green">  // Tailwind theme alias
+
+   INCORRECT:
+     .my-card { background: #1a2230; }
+     <div className="bg-[#2a3342]">
+     <span style={{ color: '#09fd67' }}>
+
+   See specs/design-system/AUDIT.md for current violations.
+   See specs/design-system/tokens/token-reference.md for the full token map.
+   ================================================================ */

--- a/specs/design-system/tokens/token-reference.md
+++ b/specs/design-system/tokens/token-reference.md
@@ -1,0 +1,233 @@
+# Token Reference
+
+Master map of all CSS variables in the KeeperHub design system.
+Source: `specs/design-system/tokens.css`, `app/globals.css`
+
+## Layer 1: Primitive Tokens (--ds-*)
+
+Never reference directly in components. These are raw values.
+
+### Neutral Colors
+
+| Variable | Value |
+|---|---|
+| `--ds-neutral-50` | `oklch(0.9842 0.0034 247.86)` |
+| `--ds-neutral-100` | `oklch(0.9683 0.0069 247.9)` |
+| `--ds-neutral-200` | `oklch(0.9288 0.0126 255.51)` |
+| `--ds-neutral-300` | `oklch(0.7107 0.0351 256.79)` |
+| `--ds-neutral-400` | `oklch(0.5544 0.0407 257.42)` |
+| `--ds-neutral-500` | `oklch(0.4455 0.0374 257.28)` |
+| `--ds-neutral-600` | `oklch(0.3717 0.0392 257.29)` |
+| `--ds-neutral-700` | `oklch(0.2795 0.0368 260.03)` |
+| `--ds-neutral-800` | `oklch(0.2101 0.0318 264.66)` |
+
+### Brand Colors
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-green-400` | `oklch(0.8671 0.2514 147.76)` | Brand green (light variant) |
+| `--ds-green-500` | `oklch(0.7402 0.2136 147.89)` | Brand green (dark variant) |
+| `--ds-green-accent` | `#09fd67` | Bright accent green |
+| `--ds-green-accent-10` | `#09fd671a` | Accent at 10% opacity |
+| `--ds-green-logo` | `#00FF4F` | Logo only |
+
+### State Colors
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-red-500` | `oklch(0.577 0.245 27.325)` | Error/destructive (light) |
+| `--ds-red-500-dark` | `oklch(0.65 0.25 29)` | Error/destructive (dark) |
+
+### Chart Colors
+
+| Variable | Value |
+|---|---|
+| `--ds-chart-orange` | `oklch(0.646 0.222 41.116)` |
+| `--ds-chart-teal` | `oklch(0.6 0.118 184.704)` |
+| `--ds-chart-slate` | `oklch(0.398 0.07 227.392)` |
+| `--ds-chart-yellow` | `oklch(0.828 0.189 84.429)` |
+| `--ds-chart-gold` | `oklch(0.769 0.188 70.08)` |
+| `--ds-chart-purple-dark` | `oklch(0.488 0.243 264.376)` |
+| `--ds-chart-green-dark` | `oklch(0.696 0.17 162.48)` |
+| `--ds-chart-violet-dark` | `oklch(0.627 0.265 303.9)` |
+| `--ds-chart-coral-dark` | `oklch(0.645 0.246 16.439)` |
+
+### Hub Surface Colors
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-hub-surface-1` | `#1a2230` | Dark card backgrounds |
+| `--ds-hub-surface-2` | `#2a3342` | Dark icon containers |
+| `--ds-hub-surface-3` | `#243548` | Gradient centers |
+| `--ds-hub-surface-hover` | `#354155` | Dark hover states |
+| `--ds-hub-overlay` | `#171f2e` | Dark overlays |
+
+### Blue (Template Badge)
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-blue-500` | `rgb(37, 99, 235)` | Badge text (light) |
+| `--ds-blue-400` | `rgb(96, 165, 250)` | Badge text (dark) |
+| `--ds-blue-500-10` | `rgba(59, 130, 246, 0.1)` | Badge background |
+| `--ds-blue-500-20` | `rgba(59, 130, 246, 0.2)` | Badge border |
+
+### Palette (Project/Tag Colors)
+
+| Variable | Value |
+|---|---|
+| `--ds-palette-blue` | `#4A90D9` |
+| `--ds-palette-violet` | `#7B61FF` |
+| `--ds-palette-rose` | `#E06C75` |
+| `--ds-palette-green` | `#98C379` |
+| `--ds-palette-amber` | `#E5C07B` |
+| `--ds-palette-cyan` | `#56B6C2` |
+| `--ds-palette-purple` | `#C678DD` |
+| `--ds-palette-orange` | `#D19A66` |
+
+### Spacing
+
+| Variable | Value | px |
+|---|---|---|
+| `--ds-space-0` | `0` | 0 |
+| `--ds-space-px` | `1px` | 1 |
+| `--ds-space-0-5` | `0.125rem` | 2 |
+| `--ds-space-1` | `0.25rem` | 4 |
+| `--ds-space-1-5` | `0.375rem` | 6 |
+| `--ds-space-2` | `0.5rem` | 8 |
+| `--ds-space-3` | `0.75rem` | 12 |
+| `--ds-space-4` | `1rem` | 16 |
+| `--ds-space-5` | `1.25rem` | 20 |
+| `--ds-space-6` | `1.5rem` | 24 |
+| `--ds-space-8` | `2rem` | 32 |
+| `--ds-space-10` | `2.5rem` | 40 |
+| `--ds-space-12` | `3rem` | 48 |
+| `--ds-space-16` | `4rem` | 64 |
+
+### Typography
+
+| Variable | Value |
+|---|---|
+| `--ds-font-sans` | Anek Latin, system-ui, sans-serif |
+| `--ds-font-mono` | Geist Mono, ui-monospace, monospace |
+| `--ds-text-2xs` | `0.625rem` (10px) |
+| `--ds-text-xs` | `0.6875rem` (11px) |
+| `--ds-text-sm` | `0.75rem` (12px) |
+| `--ds-text-base` | `0.875rem` (14px) |
+| `--ds-text-md` | `1rem` (16px) |
+| `--ds-text-lg` | `1.125rem` (18px) |
+| `--ds-text-xl` | `1.25rem` (20px) |
+| `--ds-text-2xl` | `1.5rem` (24px) |
+| `--ds-text-3xl` | `1.875rem` (30px) |
+| `--ds-weight-normal` | 400 |
+| `--ds-weight-medium` | 500 |
+| `--ds-weight-semibold` | 600 |
+| `--ds-weight-bold` | 700 |
+| `--ds-leading-tight` | 1.15 |
+| `--ds-leading-snug` | 1.4 |
+| `--ds-leading-normal` | 1.5 |
+| `--ds-leading-relaxed` | 1.6 |
+| `--ds-leading-loose` | 1.7 |
+| `--ds-tracking-tight` | -1.5px |
+| `--ds-tracking-snug` | -0.75px |
+| `--ds-tracking-normal` | 0 |
+| `--ds-tracking-wide` | 0.5px |
+
+### Border Radius
+
+| Variable | Value |
+|---|---|
+| `--ds-radius-none` | 0 |
+| `--ds-radius-sm` | `0.375rem` (6px) |
+| `--ds-radius-md` | `0.5rem` (8px) |
+| `--ds-radius-lg` | `0.625rem` (10px) |
+| `--ds-radius-xl` | `1.025rem` (~16px) |
+| `--ds-radius-full` | 9999px |
+
+### Elevation
+
+| Variable | Value |
+|---|---|
+| `--ds-shadow-sm` | `0 1px 2px 0 rgba(0,0,0,0.05)` |
+| `--ds-shadow-md` | `0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)` |
+| `--ds-shadow-lg` | `0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1)` |
+| `--ds-shadow-xl` | `0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1)` |
+| `--ds-shadow-overlay` | `0 8px 24px rgba(0,0,0,0.3)` |
+| `--ds-shadow-focus` | `0 0 0 2px rgba(6,177,113,0.15)` |
+
+### Z-Index
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-z-below` | -10 | Background decorations |
+| `--ds-z-base` | 0 | Default layer |
+| `--ds-z-raised` | 10 | Slightly elevated (handles) |
+| `--ds-z-controls` | 20 | Workflow controls, React Flow handles |
+| `--ds-z-flyout` | 30 | Flyout panels |
+| `--ds-z-sidebar` | 40 | Navigation sidebar overlay |
+| `--ds-z-modal` | 50 | Modals, dialogs |
+| `--ds-z-toast` | 60 | Toast notifications |
+
+### Motion
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-duration-fast` | 100ms | Opacity, color micro-changes |
+| `--ds-duration-normal` | 150ms | Default transitions |
+| `--ds-duration-slow` | 200ms | Standard UI animations |
+| `--ds-duration-slower` | 300ms | Complex enter/exit |
+| `--ds-easing-default` | ease | General purpose |
+| `--ds-easing-in-out` | `cubic-bezier(0.4, 0, 0.2, 1)` | Enter/exit |
+| `--ds-easing-spring` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Bouncy/playful |
+
+### Layout
+
+| Variable | Value | When to use |
+|---|---|---|
+| `--ds-header-height` | 60px | Header offset calculations |
+| `--ds-sidebar-strip-width` | 32px | Collapsed sidebar strip |
+| `--ds-flyout-width` | 280px | Flyout panel width |
+| `--ds-drawer-width` | 220px | Analytics drawer width |
+
+---
+
+## Layer 2: Semantic Aliases
+
+These are what components should reference. See `specs/design-system/tokens.css` for the full list with fallback values.
+
+### Quick Reference by Use Case
+
+| I need... | Use this token | Tailwind class |
+|---|---|---|
+| Page background | `--background` | `bg-background` |
+| Primary text | `--foreground` | `text-foreground` |
+| Muted text | `--muted-foreground` | `text-muted-foreground` |
+| Card surface | `--card` | `bg-card` |
+| Default border | `--border` | `border-border` |
+| Focus ring | `--ring` | `ring-ring` |
+| Primary button bg | `--primary` | `bg-primary` |
+| Primary button text | `--primary-foreground` | `text-primary-foreground` |
+| Destructive action | `--destructive` | `bg-destructive` |
+| Brand green | `--keeperhub-green` | `bg-keeperhub-green` / `text-keeperhub-green` |
+| Brand green (darker) | `--keeperhub-green-dark` | `bg-keeperhub-green-dark` |
+| Green accent text | `--color-text-accent` | -- (use var()) |
+| Green accent bg | `--color-bg-accent` | -- (use var()) |
+| Hub dark card | `--color-hub-card` | -- (use var()) |
+| Hub icon container | `--color-hub-icon-bg` | -- (use var()) |
+| Template badge bg | `--color-badge-blue-bg` | -- (use var()) |
+| Template badge text | `--color-badge-blue-text` | -- (use var()) |
+| Header offset | `--header-height` | `top-[var(--header-height)]` |
+| Flyout width | `--flyout-width` | `w-[var(--flyout-width)]` |
+
+### Tokens Not Yet in Tailwind Theme
+
+These tokens from `tokens.css` are not yet mapped in `@theme inline`. Use `var()` directly until they are added:
+
+- All `--color-hub-*` tokens
+- All `--color-badge-*` tokens
+- All `--color-text-*` semantic tokens
+- All `--color-bg-*` semantic tokens
+- All `--space-*` tokens (use Tailwind spacing classes instead)
+- All `--shadow-*` tokens (use Tailwind shadow classes instead)
+- All `--z-*` tokens (use Tailwind z-index classes instead)
+- All `--duration-*` and `--easing-*` tokens
+- All `--ds-*` layout tokens


### PR DESCRIPTION
## Summary
- Establish a three-layer token architecture so all UI code references semantic CSS variables instead of raw hex/rgb values, preventing visual drift and making theme changes propagate automatically
- Adds a CI-ready audit script (`scripts/token-audit.js`) that scans for hardcoded visual values, suggests the correct token, and exits non-zero on errors -- 98 errors resolved to reach zero across 18 files
- Centralizes the project/tag color palette into a shared module to eliminate three duplicate arrays

## Test plan
- [ ] Run `node scripts/token-audit.js` -- should report 0 errors (74 warnings expected)
- [ ] Hub pages render correctly: protocol cards, detail view, strip, minimap all use correct colors
- [ ] Template badges show correct blue styling in both light and dark mode
- [ ] Project and tag color pickers still function with the shared palette
- [ ] SVG connection dots and animated borders render correctly
- [ ] Project dot fallback color (when no color assigned) renders as muted text color
- [ ] `pnpm build` succeeds with no type errors