### PR TITLE
hotfix: KEEP-1541 reconcile spurious max-retries failures in workflow executor

### DIFF
--- a/app/api/internal/execution-logs/route.ts
+++ b/app/api/internal/execution-logs/route.ts
@@ -1,0 +1,3 @@
+// start custom keeperhub code //
+export { POST } from "@/keeperhub/api/internal/execution-logs/route";
+// end keeperhub code //

--- a/keeperhub/api/internal/execution-logs/route.ts
+++ b/keeperhub/api/internal/execution-logs/route.ts
@@ -1,0 +1,48 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
+import { db } from "@/lib/db";
+import { workflowExecutionLogs } from "@/lib/db/schema";
+
+/**
+ * KEEP-1541: Internal endpoint to fetch execution logs for reconciling
+ * spurious max-retries failures. Called via HTTP loopback from the workflow
+ * executor to avoid importing DB modules in the workflow bundle.
+ */
+export async function POST(request: Request): Promise<Response> {
+  const authResult = authenticateInternalService(request);
+  if (!authResult.authenticated) {
+    return NextResponse.json({ error: authResult.error }, { status: 401 });
+  }
+
+  const body = (await request.json()) as {
+    executionId?: string;
+    nodeIds?: string[];
+  };
+
+  const { executionId, nodeIds } = body;
+
+  if (!(executionId && Array.isArray(nodeIds)) || nodeIds.length === 0) {
+    return NextResponse.json(
+      { error: "executionId and nodeIds[] are required" },
+      { status: 400 }
+    );
+  }
+
+  const logs = await db
+    .select({
+      nodeId: workflowExecutionLogs.nodeId,
+      status: workflowExecutionLogs.status,
+      output: workflowExecutionLogs.output,
+    })
+    .from(workflowExecutionLogs)
+    .where(
+      and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        inArray(workflowExecutionLogs.nodeId, nodeIds)
+      )
+    );
+
+  return NextResponse.json({ logs });
+}

--- a/keeperhub/lib/fetch-execution-logs.ts
+++ b/keeperhub/lib/fetch-execution-logs.ts
@@ -1,0 +1,54 @@
+import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
+
+type ExecutionLog = {
+  nodeId: string;
+  status: string;
+  output: unknown;
+};
+
+/**
+ * KEEP-1541: Fetch execution logs via HTTP loopback to avoid importing DB
+ * modules in the workflow bundle. Same pattern as execution-fallback.ts.
+ *
+ * Returns the logs on success, or undefined if the request fails or config
+ * is missing (caller should skip reconciliation in that case).
+ */
+export async function fetchExecutionLogs(
+  executionId: string,
+  nodeIds: string[]
+): Promise<ExecutionLog[] | undefined> {
+  const serviceKey = process.env.EVENTS_SERVICE_API_KEY;
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
+
+  if (!(baseUrl && serviceKey)) {
+    return undefined;
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/api/internal/execution-logs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Service-Key": serviceKey,
+      },
+      body: JSON.stringify({ executionId, nodeIds }),
+    });
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const { logs } = (await response.json()) as { logs: ExecutionLog[] };
+    return logs;
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[Workflow Executor] Failed to fetch execution logs for reconciliation:",
+      error,
+      { execution_id: executionId }
+    );
+    return undefined;
+  }
+}

--- a/keeperhub/lib/max-retries-reconciler.ts
+++ b/keeperhub/lib/max-retries-reconciler.ts
@@ -1,0 +1,92 @@
+/**
+ * KEEP-1541: The Workflow DevKit's "use step" durability layer can throw
+ * "exceeded max retries" even when the step itself succeeded. This happens
+ * because the SDK's internal state tracking encounters a conflict (e.g.,
+ * step already completed, state replay mismatch) AFTER withStepLogging has
+ * already recorded a success log in workflow_execution_logs. The error is
+ * caught by executeNode's catch block and stored as a failed result, which
+ * then causes finalSuccess to be false -- marking the entire workflow as
+ * "error" despite all steps completing successfully.
+ *
+ * Fix: after all nodes finish, cross-reference failed results that have
+ * "max retries exceeded" errors against the actual execution logs in the DB.
+ * If every log entry for that node is status: "success" (no error logs at
+ * all), the SDK error was spurious and we override the result to success.
+ * If there is ANY error log for the node, we keep the failure -- this
+ * prevents masking real failures where a retry legitimately failed.
+ *
+ * Architecture: the workflow executor (.workflow.ts) cannot import DB modules
+ * (the bundler rejects Node.js modules like nanoid). It fetches logs via HTTP
+ * loopback to /api/internal/execution-logs (same pattern as execution-fallback.ts).
+ * This module contains only pure reconciliation logic used by tests.
+ */
+
+export type ExecutionLog = {
+  nodeId: string;
+  status: string;
+  output: unknown;
+};
+
+type ExecutionResult = {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+};
+
+type ReconcileInput = {
+  results: Record<string, ExecutionResult>;
+  executionLogs: ExecutionLog[];
+  workflowId: string | undefined;
+  executionId: string | undefined;
+};
+
+type ReconcileOutput = {
+  overriddenNodeIds: string[];
+};
+
+export function getFailedMaxRetriesNodeIds(
+  results: Record<string, ExecutionResult>
+): string[] {
+  return Object.entries(results)
+    .filter(([, r]) => !r.success && r.error?.includes("exceeded max retries"))
+    .map(([nodeId]) => nodeId);
+}
+
+export function reconcileMaxRetriesFailures(
+  input: ReconcileInput
+): ReconcileOutput {
+  const { results, executionLogs, workflowId, executionId } = input;
+
+  const failedNodeIds = getFailedMaxRetriesNodeIds(results);
+
+  if (failedNodeIds.length === 0) {
+    return { overriddenNodeIds: [] };
+  }
+
+  const overriddenNodeIds: string[] = [];
+
+  for (const failedNodeId of failedNodeIds) {
+    const nodeLogs = executionLogs.filter((l) => l.nodeId === failedNodeId);
+    const hasAnyErrorLog = nodeLogs.some((l) => l.status === "error");
+    const successLog = nodeLogs.find((l) => l.status === "success");
+
+    if (successLog && !hasAnyErrorLog) {
+      console.warn(
+        "[Workflow Executor] Overriding spurious max-retries failure for node with all-success logs:",
+        {
+          error: results[failedNodeId]?.error,
+          ...(workflowId ? { workflow_id: workflowId } : {}),
+          ...(executionId ? { execution_id: executionId } : {}),
+          node_id: failedNodeId,
+        }
+      );
+      results[failedNodeId] = {
+        success: true,
+        data: successLog.output,
+      };
+      overriddenNodeIds.push(failedNodeId);
+    }
+  }
+
+  return { overriddenNodeIds };
+}

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -28,6 +28,7 @@ import {
   recordWorkflowComplete,
 } from "@/keeperhub/lib/metrics/instrumentation/workflow";
 import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
+import { fetchExecutionLogs } from "@/keeperhub/lib/fetch-execution-logs";
 import { ARRAY_SOURCE_RE } from "@/keeperhub/lib/for-each-utils";
 import {
   buildEdgesBySourceHandle,
@@ -1913,6 +1914,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         }
       }
     } catch (error) {
+      const errorMessage = await getErrorMessageAsync(error);
       logSystemError(
         ErrorCategory.WORKFLOW_ENGINE,
         "[Workflow Executor] Error executing node:",
@@ -1923,7 +1925,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           node_id: nodeId,
         }
       );
-      const errorMessage = await getErrorMessageAsync(error);
       const errorResult = {
         success: false,
         error: errorMessage,
@@ -1950,6 +1951,65 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     // end keeperhub code //
 
     await Promise.all(triggerNodes.map((trigger) => executeNode(trigger.id)));
+
+    // start custom keeperhub code //
+    // KEEP-1541: Reconcile spurious "max retries exceeded" failures.
+    // See max-retries-reconciler.ts for details. Uses HTTP loopback
+    // (same pattern as execution-fallback.ts) to avoid DB imports in
+    // the workflow bundle.
+    if (executionId) {
+      const failedNodeIds = Object.entries(results)
+        .filter(
+          ([, r]) => !r.success && r.error?.includes("exceeded max retries")
+        )
+        .map(([nodeId]) => nodeId);
+
+      if (failedNodeIds.length > 0) {
+        const executionLogs = await fetchExecutionLogs(
+          executionId,
+          failedNodeIds
+        );
+
+        if (executionLogs) {
+          const overriddenNodeIds: string[] = [];
+
+          for (const failedNodeId of failedNodeIds) {
+            const nodeLogs = executionLogs.filter(
+              (l) => l.nodeId === failedNodeId
+            );
+            const hasAnyErrorLog = nodeLogs.some(
+              (l) => l.status === "error"
+            );
+            const successLog = nodeLogs.find((l) => l.status === "success");
+
+            if (successLog && !hasAnyErrorLog) {
+              console.warn(
+                "[Workflow Executor] Overriding spurious max-retries failure:",
+                {
+                  error: results[failedNodeId]?.error,
+                  ...(workflowId ? { workflow_id: workflowId } : {}),
+                  execution_id: executionId,
+                  node_id: failedNodeId,
+                }
+              );
+              results[failedNodeId] = {
+                success: true,
+                data: successLog.output,
+              };
+              overriddenNodeIds.push(failedNodeId);
+            }
+          }
+
+          if (overriddenNodeIds.length > 0) {
+            console.warn(
+              "[Workflow Executor] Reconciled spurious max-retries failures:",
+              overriddenNodeIds
+            );
+          }
+        }
+      }
+    }
+    // end keeperhub code //
 
     const finalSuccess = Object.values(results).every((r) => r.success);
     const duration = Date.now() - workflowStartTime;

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -29,6 +29,10 @@ import {
 } from "@/keeperhub/lib/metrics/instrumentation/workflow";
 import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
 import { fetchExecutionLogs } from "@/keeperhub/lib/fetch-execution-logs";
+import {
+  getFailedMaxRetriesNodeIds,
+  reconcileMaxRetriesFailures,
+} from "@/keeperhub/lib/max-retries-reconciler";
 import { ARRAY_SOURCE_RE } from "@/keeperhub/lib/for-each-utils";
 import {
   buildEdgesBySourceHandle,
@@ -1958,11 +1962,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     // (same pattern as execution-fallback.ts) to avoid DB imports in
     // the workflow bundle.
     if (executionId) {
-      const failedNodeIds = Object.entries(results)
-        .filter(
-          ([, r]) => !r.success && r.error?.includes("exceeded max retries")
-        )
-        .map(([nodeId]) => nodeId);
+      const failedNodeIds = getFailedMaxRetriesNodeIds(results);
 
       if (failedNodeIds.length > 0) {
         const executionLogs = await fetchExecutionLogs(
@@ -1971,34 +1971,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         );
 
         if (executionLogs) {
-          const overriddenNodeIds: string[] = [];
-
-          for (const failedNodeId of failedNodeIds) {
-            const nodeLogs = executionLogs.filter(
-              (l) => l.nodeId === failedNodeId
-            );
-            const hasAnyErrorLog = nodeLogs.some(
-              (l) => l.status === "error"
-            );
-            const successLog = nodeLogs.find((l) => l.status === "success");
-
-            if (successLog && !hasAnyErrorLog) {
-              console.warn(
-                "[Workflow Executor] Overriding spurious max-retries failure:",
-                {
-                  error: results[failedNodeId]?.error,
-                  ...(workflowId ? { workflow_id: workflowId } : {}),
-                  execution_id: executionId,
-                  node_id: failedNodeId,
-                }
-              );
-              results[failedNodeId] = {
-                success: true,
-                data: successLog.output,
-              };
-              overriddenNodeIds.push(failedNodeId);
-            }
-          }
+          const { overriddenNodeIds } = reconcileMaxRetriesFailures({
+            results,
+            executionLogs,
+            workflowId,
+            executionId,
+          });
 
           if (overriddenNodeIds.length > 0) {
             console.warn(

--- a/tests/unit/max-retries-reconciler.test.ts
+++ b/tests/unit/max-retries-reconciler.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ExecutionLog,
+  getFailedMaxRetriesNodeIds,
+  reconcileMaxRetriesFailures,
+} from "@/keeperhub/lib/max-retries-reconciler";
+
+describe("getFailedMaxRetriesNodeIds", () => {
+  it("should return node IDs with max-retries errors", () => {
+    const results = {
+      "node-1": { success: true },
+      "node-2": {
+        success: false,
+        error: 'Step "step//abc//sendWebhook" exceeded max retries (0 retries)',
+      },
+      "node-3": { success: false, error: "HTTP 500 Internal Server Error" },
+    };
+
+    expect(getFailedMaxRetriesNodeIds(results)).toEqual(["node-2"]);
+  });
+
+  it("should return empty array when no max-retries errors", () => {
+    const results = {
+      "node-1": { success: true },
+      "node-2": { success: false, error: "Connection refused" },
+    };
+
+    expect(getFailedMaxRetriesNodeIds(results)).toEqual([]);
+  });
+});
+
+describe("reconcileMaxRetriesFailures", () => {
+  it("should return empty when no max-retries failures exist", () => {
+    const results: Record<string, { success: boolean; error?: string }> = {
+      "node-1": { success: true },
+      "node-2": { success: false, error: "HTTP 500 Internal Server Error" },
+    };
+
+    const output = reconcileMaxRetriesFailures({
+      results,
+      executionLogs: [],
+      executionId: "exec-1",
+      workflowId: "wf-1",
+    });
+
+    expect(output.overriddenNodeIds).toEqual([]);
+    expect(results["node-2"]?.success).toBe(false);
+  });
+
+  it("should override to success when all logs for the node are success", () => {
+    const results: Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    > = {
+      "node-1": { success: true },
+      "node-2": {
+        success: false,
+        error: 'Step "step//abc//sendWebhook" exceeded max retries (0 retries)',
+      },
+    };
+
+    const executionLogs: ExecutionLog[] = [
+      {
+        nodeId: "node-2",
+        status: "success",
+        output: { statusCode: 200, body: "ok" },
+      },
+    ];
+
+    const output = reconcileMaxRetriesFailures({
+      results,
+      executionLogs,
+      executionId: "exec-1",
+      workflowId: "wf-1",
+    });
+
+    expect(output.overriddenNodeIds).toEqual(["node-2"]);
+    expect(results["node-2"]).toEqual({
+      success: true,
+      data: { statusCode: 200, body: "ok" },
+    });
+  });
+
+  it("should NOT override when there is an error log for the node", () => {
+    const results: Record<string, { success: boolean; error?: string }> = {
+      "node-1": {
+        success: false,
+        error: 'Step "step//abc//sendWebhook" exceeded max retries (1 retry)',
+      },
+    };
+
+    const executionLogs: ExecutionLog[] = [
+      { nodeId: "node-1", status: "success", output: { statusCode: 200 } },
+      { nodeId: "node-1", status: "error", output: null },
+    ];
+
+    const output = reconcileMaxRetriesFailures({
+      results,
+      executionLogs,
+      executionId: "exec-1",
+      workflowId: "wf-1",
+    });
+
+    expect(output.overriddenNodeIds).toEqual([]);
+    expect(results["node-1"]?.success).toBe(false);
+  });
+
+  it("should NOT override when there are no logs at all for the node", () => {
+    const results: Record<string, { success: boolean; error?: string }> = {
+      "node-1": {
+        success: false,
+        error: 'Step "step//abc//condition" exceeded max retries (0 retries)',
+      },
+    };
+
+    const output = reconcileMaxRetriesFailures({
+      results,
+      executionLogs: [],
+      executionId: "exec-1",
+      workflowId: "wf-1",
+    });
+
+    expect(output.overriddenNodeIds).toEqual([]);
+    expect(results["node-1"]?.success).toBe(false);
+  });
+
+  it("should handle multiple failed nodes independently", () => {
+    const results: Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    > = {
+      "node-1": {
+        success: false,
+        error: 'Step "step//a//webhook" exceeded max retries (0 retries)',
+      },
+      "node-2": {
+        success: false,
+        error: 'Step "step//b//condition" exceeded max retries (0 retries)',
+      },
+      "node-3": { success: true },
+    };
+
+    const executionLogs: ExecutionLog[] = [
+      { nodeId: "node-1", status: "success", output: { sent: true } },
+      { nodeId: "node-2", status: "success", output: { result: true } },
+      { nodeId: "node-2", status: "error", output: null },
+    ];
+
+    const output = reconcileMaxRetriesFailures({
+      results,
+      executionLogs,
+      executionId: "exec-1",
+      workflowId: "wf-1",
+    });
+
+    expect(output.overriddenNodeIds).toEqual(["node-1"]);
+    expect(results["node-1"]).toEqual({ success: true, data: { sent: true } });
+    expect(results["node-2"]?.success).toBe(false);
+    expect(results["node-3"]?.success).toBe(true);
+  });
+
+  it("should not touch results for non-max-retries failures", () => {
+    const results: Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    > = {
+      "node-1": {
+        success: false,
+        error: 'Step "step//a//webhook" exceeded max retries (0 retries)',
+      },
+      "node-2": {
+        success: false,
+        error: "Connection refused",
+      },
+    };
+
+    const executionLogs: ExecutionLog[] = [
+      { nodeId: "node-1", status: "success", output: { ok: true } },
+    ];
+
+    const output = reconcileMaxRetriesFailures({
+      results,
+      executionLogs,
+      executionId: "exec-1",
+      workflowId: "wf-1",
+    });
+
+    expect(output.overriddenNodeIds).toEqual(["node-1"]);
+    expect(results["node-2"]?.success).toBe(false);
+    expect(results["node-2"]?.error).toBe("Connection refused");
+  });
+});


### PR DESCRIPTION
## Summary

Workflows are being incorrectly marked as `error` in `workflow_executions` even though all step logs show `status: success` and the SDK run shows `status: completed`. The error message is always: `Step "step//...//stepName" exceeded max retries (X retries)`.

This affects `sendWebhookStep` and `conditionStep` most frequently.

## Root Cause

The Workflow DevKit's `"use step"` durability layer tracks step completion through an internal event-sourcing mechanism. When the SDK's state tracking encounters a conflict (e.g., step already completed, state replay mismatch), it throws "exceeded max retries" even though:

1. The step function itself returned a success result
2. `withStepLogging` already recorded a `status: success` log in `workflow_execution_logs`
3. The actual side effect (webhook call, condition evaluation) completed correctly

The error is caught by `executeNode()`'s catch block and stored as `results[nodeId] = { success: false, error: ... }`, which causes `finalSuccess` to be `false` -- marking the entire workflow as `error`.

## Fix

After all nodes finish execution but before computing `finalSuccess`, cross-reference any failed results that contain "exceeded max retries" errors against the actual execution logs in `workflow_execution_logs`:

- If **every** log entry for that node has `status: success` (no error logs at all), the SDK error was spurious -- override the in-memory `results` to success using the logged output
- If there is **any** error log for the node, keep the failure -- this prevents masking real failures where a retry legitimately failed

The in-memory `results` mutation happens before `finalSuccess` is computed, so `triggerStep({ _workflowComplete: { status } })` writes the correct status to DB. No separate DB update is needed.

### Architecture: HTTP Loopback Pattern

The workflow bundler rejects Node.js modules (like `nanoid` pulled in via `db/schema`), so `.workflow.ts` files cannot import DB modules -- not even dynamically (the bundler traces `import()` calls), and functions cannot be passed as parameters (the SDK serializes workflow arguments for durability). To work around this:

1. `keeperhub/api/internal/execution-logs/route.ts` -- internal API endpoint that queries `workflow_execution_logs` for a given execution + node IDs
2. `keeperhub/lib/fetch-execution-logs.ts` -- HTTP loopback helper (same pattern as `execution-fallback.ts`) that calls the internal endpoint via `fetch()`. No DB imports, safe for the workflow bundle
3. `lib/workflow-executor.workflow.ts` -- imports `fetchExecutionLogs` and calls it after node execution, before `finalSuccess` computation

This approach:
- **Does not change `maxRetries`** -- keeping it at 0 means no duplicate step executions (no double webhook calls)
- **Does not modify the catch block** -- the error is still caught and recorded normally
- **Only reconciles at the end** -- no interference with step execution flow
- **Is conservative** -- only overrides when there is zero evidence of actual failure in the logs
- **Does not change `WorkflowExecutionInput`** -- no caller modifications needed

## Changes

- `lib/workflow-executor.workflow.ts` -- reconciles after node execution, before `finalSuccess` computation
- `keeperhub/lib/fetch-execution-logs.ts` -- HTTP loopback helper to fetch execution logs without DB imports
- `keeperhub/api/internal/execution-logs/route.ts` -- internal API endpoint for execution log queries
- `app/api/internal/execution-logs/route.ts` -- thin wrapper (re-exports from keeperhub)
- `keeperhub/lib/max-retries-reconciler.ts` -- pure reconciliation logic (used by tests)
- `tests/unit/max-retries-reconciler.test.ts` -- 8 unit tests covering all reconciliation scenarios

## Scenarios Tested

| Scenario | Logs in DB | Result | Behavior |
|---|---|---|---|
| Step genuinely fails (HTTP 500) | error log | `success: false` | Unchanged -- no max-retries error |
| Step fails + SDK throws max retries | success + error logs | `success: false` | Kept as failure (error log exists) |
| Step succeeds + SDK throws spurious max retries | success log only | `success: true` | Overridden to success |
| No logs exist for node | none | `success: false` | Kept as failure (no evidence of success) |
| Multiple nodes, mixed outcomes | varies per node | per-node | Each node reconciled independently |
