### PR TITLE
fix: KEEP-1542 start building button now creates new workflow for authenticated users

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 // start custom keeperhub code //
+import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
@@ -109,15 +110,17 @@ const Home = () => {
     try {
       await ensureSession();
 
-      const existing = await api.workflow.getAll();
-      if (existing.length > 0) {
-        const latest = existing.sort(
-          (a, b) =>
-            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-        )[0];
-        setIsTransitioningFromHomepage(true);
-        router.replace(`/workflows/${latest.id}`);
-        return;
+      if (isAnonymousUser(session?.user)) {
+        const existing = await api.workflow.getAll();
+        if (existing.length > 0) {
+          const latest = existing.sort(
+            (a, b) =>
+              new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+          )[0];
+          setIsTransitioningFromHomepage(true);
+          router.replace(`/workflows/${latest.id}`);
+          return;
+        }
       }
 
       const { nodes: defaultNodes, edges: defaultEdges } = createDefaultNodes();
@@ -141,6 +144,7 @@ const Home = () => {
       hasCreatedWorkflowRef.current = false;
     }
   }, [
+    session,
     setNodes,
     setEdges,
     ensureSession,


### PR DESCRIPTION
## Summary
- The "Start building" button was redirecting authenticated users to their most recent existing workflow instead of creating a new one
- Scoped the redirect-to-existing logic to anonymous users only, since they are limited to a single workflow
- Authenticated users now always get a fresh workflow when clicking "Start building"