### PR TITLE
fix: analytics org-switch, nav, and toolbar UX issues

### DIFF
--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -228,6 +228,7 @@ const SignInForm = ({
           <button
             className="text-muted-foreground text-xs hover:text-foreground"
             onClick={onForgotPassword}
+            tabIndex={-1}
             type="button"
           >
             Forgot password?

--- a/components/overlays/overlay-provider.tsx
+++ b/components/overlays/overlay-provider.tsx
@@ -86,18 +86,16 @@ export function OverlayProvider({ children }: OverlayProviderProps) {
   );
 
   const pop = useCallback(() => {
+    let closedItem: OverlayStackItem | undefined;
     setStack((prev) => {
       if (prev.length <= 1) {
-        // If only one item, close it and call onClose
-        const item = prev[0];
-        item?.options.onClose?.();
+        closedItem = prev[0];
         return [];
       }
-      // Pop the top item and call its onClose
-      const poppedItem = prev.at(-1);
-      poppedItem?.options.onClose?.();
+      closedItem = prev.at(-1);
       return prev.slice(0, -1);
     });
+    queueMicrotask(() => closedItem?.options.onClose?.());
   }, []);
 
   const replace = useCallback(
@@ -113,42 +111,47 @@ export function OverlayProvider({ children }: OverlayProviderProps) {
         props: (props ?? {}) as Record<string, unknown>,
         options: options ?? {},
       };
+      let replacedItem: OverlayStackItem | undefined;
       setStack((prev) => {
         if (prev.length === 0) {
           return [item];
         }
-        // Replace the top item
-        const poppedItem = prev.at(-1);
-        poppedItem?.options.onClose?.();
+        replacedItem = prev.at(-1);
         return [...prev.slice(0, -1), item];
       });
+      queueMicrotask(() => replacedItem?.options.onClose?.());
       return id;
     },
     []
   );
 
   const closeAll = useCallback(() => {
+    let closedItems: OverlayStackItem[] = [];
     setStack((prev) => {
-      // Call onClose for all items
-      for (const item of prev) {
+      closedItems = prev;
+      return [];
+    });
+    queueMicrotask(() => {
+      for (const item of closedItems) {
         item.options.onClose?.();
       }
-      return [];
     });
   }, []);
 
   const close = useCallback((id: string) => {
+    let closedItems: OverlayStackItem[] = [];
     setStack((prev) => {
       const index = prev.findIndex((item) => item.id === id);
       if (index === -1) {
         return prev;
       }
-
-      // Call onClose for all items from this index onwards
-      for (let i = index; i < prev.length; i++) {
-        prev[i].options.onClose?.();
-      }
+      closedItems = prev.slice(index);
       return prev.slice(0, index);
+    });
+    queueMicrotask(() => {
+      for (const item of closedItems) {
+        item.options.onClose?.();
+      }
     });
   }, []);
 

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1254,20 +1254,6 @@ function ToolbarActions({
 
   return (
     <>
-      {/* Add Step - Mobile Vertical */}
-      <ButtonGroup className="flex lg:hidden" orientation="vertical">
-        <Button
-          className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-          disabled={state.isGenerating}
-          onClick={handleAddStep}
-          size="icon"
-          title="Add Step"
-          variant="secondary"
-        >
-          <Plus className="size-4" />
-        </Button>
-      </ButtonGroup>
-
       {/* Properties - Mobile Vertical (always visible) */}
       <ButtonGroup className="flex lg:hidden" orientation="vertical">
         <Button
@@ -1293,68 +1279,6 @@ function ToolbarActions({
         )}
       </ButtonGroup>
 
-      {/* Add Step - Desktop Horizontal */}
-      <ButtonGroup className="hidden lg:flex" orientation="horizontal">
-        <Button
-          className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-          disabled={state.isGenerating}
-          onClick={handleAddStep}
-          size="icon"
-          title="Add Step"
-          variant="secondary"
-        >
-          <Plus className="size-4" />
-        </Button>
-      </ButtonGroup>
-
-      {/* Undo/Redo - Mobile Vertical */}
-      <ButtonGroup className="flex lg:hidden" orientation="vertical">
-        <Button
-          className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-          disabled={!state.canUndo || state.isGenerating}
-          onClick={() => state.undo()}
-          size="icon"
-          title="Undo"
-          variant="secondary"
-        >
-          <Undo2 className="size-4" />
-        </Button>
-        <Button
-          className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-          disabled={!state.canRedo || state.isGenerating}
-          onClick={() => state.redo()}
-          size="icon"
-          title="Redo"
-          variant="secondary"
-        >
-          <Redo2 className="size-4" />
-        </Button>
-      </ButtonGroup>
-
-      {/* Undo/Redo - Desktop Horizontal */}
-      <ButtonGroup className="hidden lg:flex" orientation="horizontal">
-        <Button
-          className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-          disabled={!state.canUndo || state.isGenerating}
-          onClick={() => state.undo()}
-          size="icon"
-          title="Undo"
-          variant="secondary"
-        >
-          <Undo2 className="size-4" />
-        </Button>
-        <Button
-          className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
-          disabled={!state.canRedo || state.isGenerating}
-          onClick={() => state.redo()}
-          size="icon"
-          title="Redo"
-          variant="secondary"
-        >
-          <Redo2 className="size-4" />
-        </Button>
-      </ButtonGroup>
-
       {/* Save/Download - Mobile Vertical */}
       <div className="flex flex-col gap-1 lg:hidden">
         <SaveButton handleSave={actions.handleSave} state={state} />
@@ -1362,7 +1286,13 @@ function ToolbarActions({
       </div>
 
       {/* Save/Download - Desktop Horizontal */}
-      <div className="hidden gap-1 lg:flex">
+      <div className="hidden items-center gap-1 lg:flex">
+        {state.isSaving && !isAnonymousUser(state.session?.user) && (
+          <span className="flex items-center gap-1 text-muted-foreground text-xs">
+            <Loader2 className="size-3 animate-spin" />
+            Saving...
+          </span>
+        )}
         <SaveButton handleSave={actions.handleSave} state={state} />
         <DownloadButton actions={actions} state={state} />
       </div>
@@ -1428,11 +1358,7 @@ function SaveButton({
       }
       variant="secondary"
     >
-      {state.isSaving ? (
-        <Loader2 className="size-4 animate-spin" />
-      ) : (
-        <Save className="size-4" />
-      )}
+      <Save className="size-4" />
       {state.hasUnsavedChanges && !state.isSaving && !isAnonymous && (
         <div className="absolute top-1.5 right-1.5 size-2 rounded-full bg-primary" />
       )}

--- a/keeperhub/components/analytics/use-analytics.ts
+++ b/keeperhub/components/analytics/use-analytics.ts
@@ -22,6 +22,7 @@ import {
   analyticsSummaryAtom,
   analyticsTimeSeriesAtom,
 } from "@/keeperhub/lib/atoms/analytics";
+import { authClient } from "@/lib/auth-client";
 
 const POLL_INTERVAL_MS = 10_000;
 
@@ -79,6 +80,9 @@ async function processSection<T>(
 }
 
 export function useAnalytics(): UseAnalyticsReturn {
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const activeOrgId = activeOrg?.id ?? null;
+
   const range = useAtomValue(analyticsRangeAtom);
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
   const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
@@ -98,6 +102,10 @@ export function useAnalytics(): UseAnalyticsReturn {
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const fetchData = useCallback(async (): Promise<void> => {
+    if (!activeOrgId) {
+      return;
+    }
+
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
@@ -208,6 +216,7 @@ export function useAnalytics(): UseAnalyticsReturn {
       ),
     ]);
   }, [
+    activeOrgId,
     range,
     statusFilter,
     sourceFilter,

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -23,7 +23,7 @@ import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { registerSidebarRefetch } from "@/keeperhub/lib/refetch-sidebar";
 import type { Project, SavedWorkflow, Tag } from "@/lib/api-client";
 import { api } from "@/lib/api-client";
-import { useSession } from "@/lib/auth-client";
+import { authClient, useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import type { NavPanelStates } from "../lib/hooks/use-persisted-nav-state";
 import { usePersistedNavState } from "../lib/hooks/use-persisted-nav-state";
@@ -206,6 +206,11 @@ function ProjectsPanel({
           ))}
         </>
       )}
+      {isAnonymous && hasAny && (
+        <p className="mt-2 border-t px-2 pt-2 text-center text-muted-foreground/70 text-xs">
+          Sign in to create more
+        </p>
+      )}
     </div>
   );
 }
@@ -334,7 +339,7 @@ const NAV_ITEMS = [
     id: "new",
     icon: Plus,
     label: "New Workflow",
-    href: "/" as string | null,
+    href: null as string | null,
   },
   {
     id: "workflows",
@@ -530,7 +535,7 @@ export function NavigationSidebar(): React.ReactNode {
 
   function isActive(id: string): boolean {
     if (id === "new") {
-      return !(workflowId || isHubPage || isAnalyticsPage);
+      return false;
     }
     if (id === "workflows") {
       return navState.state.panels.projects !== "closed";
@@ -544,6 +549,48 @@ export function NavigationSidebar(): React.ReactNode {
     return false;
   }
 
+  async function handleNewWorkflow(): Promise<void> {
+    if (isAnonymous) {
+      if (!session) {
+        await authClient.signIn.anonymous();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      const existing = await api.workflow
+        .getAll()
+        .catch(() => [] as SavedWorkflow[]);
+      const visible = existing.filter((w) => w.name !== "__current__");
+      if (visible.length > 0) {
+        const latest = visible.sort(
+          (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+        )[0];
+        router.push(`/workflows/${latest.id}`);
+        return;
+      }
+      const newWorkflow = await api.workflow.create({
+        name: "Untitled Workflow",
+        description: "",
+        nodes: [],
+        edges: [],
+      });
+      await fetchData();
+      navState.setPanelState("projects", "open");
+      sessionStorage.setItem("animate-sidebar", "true");
+      router.push(`/workflows/${newWorkflow.id}`);
+      return;
+    }
+    const newWorkflow = await api.workflow.create({
+      name: "Untitled Workflow",
+      description: "",
+      nodes: [],
+      edges: [],
+    });
+    await fetchData();
+    navState.setPanelState("projects", "open");
+    sessionStorage.setItem("animate-sidebar", "true");
+    router.push(`/workflows/${newWorkflow.id}`);
+  }
+
   function handleNavClick(id: string, href: string | null): void {
     if (id === "workflows") {
       if (navState.state.panels.projects !== "closed") {
@@ -551,6 +598,12 @@ export function NavigationSidebar(): React.ReactNode {
       } else {
         navState.setPanelState("projects", "open");
       }
+      return;
+    }
+    if (id === "new") {
+      handleNewWorkflow().catch(() => {
+        router.push("/");
+      });
       return;
     }
     navState.closeAll();
@@ -597,7 +650,8 @@ export function NavigationSidebar(): React.ReactNode {
     label: string;
     href: string | null;
   }): React.ReactNode {
-    const disabled = item.href === null && item.id !== "workflows";
+    const disabled =
+      item.href === null && item.id !== "workflows" && item.id !== "new";
     const layoutClass = showLabels ? "gap-3 px-2" : "justify-center";
 
     if (disabled) {
@@ -658,7 +712,7 @@ export function NavigationSidebar(): React.ReactNode {
   }
 
   const navItems = NAV_ITEMS.filter(
-    (item) => item.id !== "analytics" || session
+    (item) => item.id !== "analytics" || !isAnonymous
   );
 
   return (

--- a/keeperhub/lib/hooks/use-claim-workflow.ts
+++ b/keeperhub/lib/hooks/use-claim-workflow.ts
@@ -1,10 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
-import { ConfirmOverlay } from "@/components/overlays/confirm-overlay";
-import { useOverlay } from "@/components/overlays/overlay-provider";
 import { api } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
 
@@ -30,29 +26,27 @@ export function getPendingClaim(): PendingClaim | null {
   }
 }
 
-export function setPendingClaim(claim: PendingClaim) {
+export function setPendingClaim(claim: PendingClaim): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(claim));
 }
 
-export function clearPendingClaim() {
+export function clearPendingClaim(): void {
   localStorage.removeItem(STORAGE_KEY);
 }
 
 export function useClaimWorkflow(
   workflowId: string,
   loadExistingWorkflow: () => Promise<void>
-) {
+): { claimPending: boolean } {
   const { data: session } = useSession();
-  const { open } = useOverlay();
-  const router = useRouter();
   const [claimPending, setClaimPending] = useState(() => {
     const claim = getPendingClaim();
     return claim?.workflowId === workflowId;
   });
-  const hasShownRef = useRef(false);
+  const hasClaimedRef = useRef(false);
 
   useEffect(() => {
-    if (hasShownRef.current) {
+    if (hasClaimedRef.current) {
       return;
     }
 
@@ -73,35 +67,25 @@ export function useClaimWorkflow(
       return;
     }
 
-    hasShownRef.current = true;
+    hasClaimedRef.current = true;
 
-    open(ConfirmOverlay, {
-      title: "Move workflow to your organization?",
-      message:
-        "This workflow was created before you signed in. Would you like to save it to your organization?",
-      confirmLabel: "Yes, move it",
-      cancelLabel: "No thanks",
-      onConfirm: async () => {
-        try {
-          await api.workflow.claim(workflowId);
-          clearPendingClaim();
-          setClaimPending(false);
-          toast.success("Workflow moved to your organization");
-          await loadExistingWorkflow();
-        } catch (error) {
-          console.error("Failed to claim workflow:", error);
-          toast.error("Failed to move workflow");
-          clearPendingClaim();
-          setClaimPending(false);
-        }
-      },
-      onCancel: () => {
+    async function claimAutomatically(): Promise<void> {
+      try {
+        await api.workflow.claim(workflowId);
         clearPendingClaim();
         setClaimPending(false);
-        router.push("/");
-      },
+        await loadExistingWorkflow();
+      } catch {
+        clearPendingClaim();
+        setClaimPending(false);
+      }
+    }
+
+    claimAutomatically().catch(() => {
+      clearPendingClaim();
+      setClaimPending(false);
     });
-  }, [session, workflowId, open, loadExistingWorkflow, router]);
+  }, [session, workflowId, loadExistingWorkflow]);
 
   return { claimPending };
 }

--- a/keeperhub/lib/hooks/use-persisted-nav-state.ts
+++ b/keeperhub/lib/hooks/use-persisted-nav-state.ts
@@ -21,7 +21,7 @@ const STORAGE_KEY = "keeperhub-nav-state";
 const LEGACY_KEY = "keeperhub-sidebar-expanded";
 
 const DEFAULT_STATE: PersistedNavState = {
-  sidebar: false,
+  sidebar: true,
   panels: { projects: "closed", tags: "closed", workflows: "closed" },
   selectedProjectId: null,
   selectedTagId: null,

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -122,11 +122,15 @@ export const autosaveAtom = atom(
 
     const saveFunc = async () => {
       try {
+        set(isSavingAtom, true);
         await api.workflow.update(workflowId, { nodes, edges });
         // Clear the unsaved changes indicator after successful save
         set(hasUnsavedChangesAtom, false);
       } catch (error) {
         console.warn("Autosave failed:", error);
+      } finally {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+        set(isSavingAtom, false);
       }
     };
 


### PR DESCRIPTION
## Summary
- Analytics page did not refresh when switching organizations because the fetch hook had no dependency on the active org, so switching orgs left stale data on screen
- Bundles several related UX fixes: overlay callbacks deferred to avoid React setState warnings, toolbar simplified (duplicate mobile/desktop buttons removed, inline save indicator added), New Workflow button creates directly instead of routing to landing page, anonymous workflows auto-claimed on sign-in, sidebar defaults expanded

## Test plan
- [ ] Sign in with a user belonging to multiple orgs
- [ ] Navigate to /analytics, switch orgs from dropdown -- data should refresh
- [ ] Create a new workflow from the sidebar nav button -- should create and navigate directly
- [ ] Sign in after creating an anonymous workflow -- should auto-claim without dialog
- [ ] Check toolbar on mobile and desktop -- no duplicate buttons, "Saving..." appears during autosave
- [ ] Open/close overlays -- no React warnings about setState in console