### PR TITLE
feat: move sidebar collapse into menu header

### DIFF
--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -841,7 +841,7 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
       {/* Expand button when panel is collapsed - only show if trigger exists */}
       {!isMobile && hasTriggerNode && panelCollapsed && (
         <button
-          className="-translate-y-1/2 pointer-events-auto absolute top-1/2 right-0 z-20 flex size-6 items-center justify-center rounded-l-full border border-r-0 bg-background shadow-sm transition-colors hover:bg-muted"
+          className="pointer-events-auto absolute top-[calc(60px+0.75rem)] right-0 z-20 flex size-6 items-center justify-center rounded-l-full border border-r-0 bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
           onClick={() => {
             setIsPanelAnimating(true);
             setPanelCollapsed(false);
@@ -875,12 +875,10 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
             role="separator"
             tabIndex={0}
           >
-            {/* Hover indicator */}
-            <div className="absolute inset-y-0 left-0 w-1 bg-transparent transition-colors group-hover:bg-blue-500 group-active:bg-blue-600" />
-            {/* Collapse button - hidden while resizing */}
+            <div className="absolute inset-y-0 left-0 w-px bg-border" />
             {!(isDraggingResize || panelCollapsed) && (
               <button
-                className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-0 flex size-6 items-center justify-center rounded-full border bg-background opacity-0 shadow-sm transition-opacity hover:bg-muted group-hover:opacity-100"
+                className="-translate-x-1/2 absolute top-3 left-0 flex size-6 items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
                 onClick={(e) => {
                   e.stopPropagation();
                   setIsPanelAnimating(true);
@@ -890,7 +888,7 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
                 onMouseDown={(e) => e.stopPropagation()}
                 type="button"
               >
-                <ChevronRight className="size-4" />
+                <ChevronRight className="size-3.5" />
               </button>
             )}
           </div>

--- a/keeperhub/components/analytics/analytics-page.tsx
+++ b/keeperhub/components/analytics/analytics-page.tsx
@@ -7,7 +7,10 @@ import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { analyticsSummaryAtom } from "@/keeperhub/lib/atoms/analytics";
+import {
+  analyticsProjectIdAtom,
+  analyticsSummaryAtom,
+} from "@/keeperhub/lib/atoms/analytics";
 import { useSession } from "@/lib/auth-client";
 import { AnalyticsHeader } from "./analytics-header";
 import { EmptyState } from "./empty-state";
@@ -58,6 +61,7 @@ export function AnalyticsPage(): ReactNode {
   const { data: session } = useSession();
   const { loading, error, refetch } = useAnalytics();
   const summary = useAtomValue(analyticsSummaryAtom);
+  const projectId = useAtomValue(analyticsProjectIdAtom);
   const prevErrorRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -79,12 +83,20 @@ export function AnalyticsPage(): ReactNode {
     }
   }, [session, error, refetch]);
 
-  if (error === "AUTH_REQUIRED" || error === "ORG_REQUIRED") {
+  const isAnonymous = !session?.user || session.user.isAnonymous;
+  if (isAnonymous || error === "AUTH_REQUIRED") {
+    return <AuthGate error="AUTH_REQUIRED" />;
+  }
+
+  if (error === "ORG_REQUIRED") {
     return <AuthGate error={error} />;
   }
 
   const hasNoData =
-    summary !== null && summary.totalRuns === 0 && summary.activeRuns === 0;
+    projectId === null &&
+    summary !== null &&
+    summary.totalRuns === 0 &&
+    summary.activeRuns === 0;
 
   if (hasNoData && !loading) {
     return (

--- a/keeperhub/components/flyout-panel.tsx
+++ b/keeperhub/components/flyout-panel.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export const FLYOUT_WIDTH = 280;
@@ -11,6 +16,7 @@ type FlyoutPanelProps = {
   leftOffset: number;
   title: string;
   collapsedLabel?: string;
+  accentColor?: string;
   onCollapse: () => void;
   onExpand: () => void;
   children: React.ReactNode;
@@ -21,6 +27,7 @@ export function FlyoutPanel({
   leftOffset,
   title,
   collapsedLabel,
+  accentColor,
   onCollapse,
   onExpand,
   children,
@@ -30,24 +37,54 @@ export function FlyoutPanel({
   }
 
   if (state === "collapsed") {
+    const label = collapsedLabel ?? title;
+    const dashIndex = label.indexOf(" - ");
+    const category = dashIndex > -1 ? label.slice(0, dashIndex) : label;
+    const selection = dashIndex > -1 ? label.slice(dashIndex + 3) : null;
+
     return (
-      <button
-        className="pointer-events-auto fixed top-[60px] bottom-0 z-30 flex items-center justify-center border-r bg-background transition-[left] duration-200 ease-out hover:bg-muted"
-        data-flyout
-        onClick={onExpand}
-        style={{ left: leftOffset, width: STRIP_WIDTH }}
-        type="button"
-      >
-        <div className="flex flex-col items-center gap-1">
-          <ChevronRight className="size-3.5 text-muted-foreground" />
-          <span
-            className="max-h-[120px] overflow-hidden text-muted-foreground text-xs"
-            style={{ writingMode: "vertical-lr" }}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="pointer-events-auto fixed top-[60px] bottom-0 z-30 flex items-start justify-center border-r bg-background pt-3 transition-[left] duration-200 ease-out hover:bg-muted/50"
+            data-flyout
+            onClick={onExpand}
+            style={{ left: leftOffset, width: STRIP_WIDTH }}
+            type="button"
           >
-            {collapsedLabel ?? title}
-          </span>
-        </div>
-      </button>
+            {accentColor && (
+              <div
+                className="absolute top-0 left-0 h-1 w-full"
+                style={{ backgroundColor: accentColor }}
+              />
+            )}
+            <div className="flex flex-col items-center gap-1.5">
+              <ChevronRight className="size-3.5 text-muted-foreground" />
+              <div
+                className="flex items-start gap-0.5 whitespace-nowrap"
+                style={{ writingMode: "vertical-lr" }}
+              >
+                <span className="font-medium text-foreground/70 text-[10px] uppercase tracking-wider">
+                  {category}
+                </span>
+                {selection && (
+                  <>
+                    <span className="text-muted-foreground/40 text-[10px]">
+                      /
+                    </span>
+                    <span className="max-h-[100px] overflow-hidden text-muted-foreground text-[11px]">
+                      {selection}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">
+          <span className="text-xs">{label}</span>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/keeperhub/components/navigation-sidebar.tsx
+++ b/keeperhub/components/navigation-sidebar.tsx
@@ -250,6 +250,11 @@ function TagsPanel({
 
   return (
     <div className="flex flex-col gap-0.5">
+      {projectTags.length > 0 && (
+        <p className="px-2 pt-1 pb-1.5 font-medium text-muted-foreground text-xs uppercase tracking-wider">
+          Tags
+        </p>
+      )}
       {projectTags.map((tag) => {
         const isActive = tag.id === selectedTagId;
         return (
@@ -334,13 +339,131 @@ function WorkflowsPanel({
   );
 }
 
+function SidebarHeader({
+  expanded,
+  onToggle,
+  onNewWorkflow,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  onNewWorkflow: () => void;
+}): React.ReactNode {
+  return (
+    <div
+      className={cn(
+        "flex items-center overflow-hidden border-b",
+        expanded ? "px-3 py-2" : "relative justify-center pr-0.5 pt-3 pb-2"
+      )}
+    >
+      <button
+        aria-label="New Workflow"
+        className={cn(
+          expanded
+            ? "group/new flex items-center gap-1.5 whitespace-nowrap rounded-md border border-keeperhub-green/20 bg-keeperhub-green/10 px-2 py-1 text-keeperhub-green text-sm font-medium transition-all duration-200 hover:border-keeperhub-green/40 hover:bg-keeperhub-green/15 hover:shadow-[0_0_8px_rgba(0,255,100,0.08)] active:scale-[0.97]"
+            : "z-20 flex items-center justify-center text-keeperhub-green transition-colors hover:text-keeperhub-green-dark"
+        )}
+        data-testid="nav-new"
+        onClick={onNewWorkflow}
+        type="button"
+      >
+        <Plus
+          className={cn(
+            expanded
+              ? "size-3.5 transition-transform duration-150 group-hover/new:rotate-90"
+              : "size-4"
+          )}
+        />
+        {expanded && <span>New Workflow</span>}
+      </button>
+      <button
+        aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
+        className={cn(
+          "shrink-0 transition-colors",
+          expanded
+            ? "ml-auto rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            : "absolute right-0.5 z-20 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        )}
+        onClick={onToggle}
+        type="button"
+      >
+        {expanded ? (
+          <ChevronLeft className="size-4" />
+        ) : (
+          <ChevronRight className="size-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+function NavItem({
+  item,
+  active,
+  showLabels,
+  onClick,
+}: {
+  item: { id: string; icon: typeof Plus; label: string; href: string | null };
+  active: boolean;
+  showLabels: boolean;
+  onClick: () => void;
+}): React.ReactNode {
+  const disabled = item.href === null && item.id !== "workflows";
+  const layoutClass = showLabels ? "gap-3 px-2" : "justify-center";
+
+  if (disabled) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            aria-label={item.label}
+            className={cn(
+              "flex h-9 w-full cursor-default items-center rounded-md text-muted-foreground transition-colors",
+              layoutClass
+            )}
+            data-testid={`nav-${item.id}`}
+            type="button"
+          >
+            <item.icon className="size-4 shrink-0" />
+            {showLabels && (
+              <span className="truncate text-sm">{item.label}</span>
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">Coming Soon</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  const button = (
+    <button
+      aria-label={item.label}
+      className={cn(
+        "flex h-9 w-full items-center rounded-md transition-colors hover:bg-muted",
+        layoutClass,
+        active && "bg-muted"
+      )}
+      data-testid={`nav-${item.id}`}
+      onClick={onClick}
+      type="button"
+    >
+      <item.icon className="size-4 shrink-0" />
+      {showLabels && <span className="truncate text-sm">{item.label}</span>}
+    </button>
+  );
+
+  if (showLabels) {
+    return button;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side="right">{item.label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 const NAV_ITEMS = [
-  {
-    id: "new",
-    icon: Plus,
-    label: "New Workflow",
-    href: null as string | null,
-  },
   {
     id: "workflows",
     icon: List,
@@ -356,6 +479,7 @@ const NAV_ITEMS = [
   },
 ];
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large component with many panel interactions, further extraction would hurt readability
 export function NavigationSidebar(): React.ReactNode {
   const isMobile = useIsMobile();
   const { data: session } = useSession();
@@ -473,6 +597,11 @@ export function NavigationSidebar(): React.ReactNode {
     navState.state.panels.tags !== "closed" ||
     navState.state.panels.workflows !== "closed";
 
+  const anyPanelExpanded =
+    navState.state.panels.projects === "open" ||
+    navState.state.panels.tags === "open" ||
+    navState.state.panels.workflows === "open";
+
   useEffect(() => {
     if (!anyPanelOpen) {
       return;
@@ -500,7 +629,7 @@ export function NavigationSidebar(): React.ReactNode {
     );
   }, [currentWidth]);
 
-  if (isMobile) {
+  if (isMobile || !navState.hasMounted) {
     return null;
   }
 
@@ -534,9 +663,6 @@ export function NavigationSidebar(): React.ReactNode {
   const offsets = computePanelOffsets(currentWidth, navState.state.panels);
 
   function isActive(id: string): boolean {
-    if (id === "new") {
-      return false;
-    }
     if (id === "workflows") {
       return navState.state.panels.projects !== "closed";
     }
@@ -600,12 +726,6 @@ export function NavigationSidebar(): React.ReactNode {
       }
       return;
     }
-    if (id === "new") {
-      handleNewWorkflow().catch(() => {
-        router.push("/");
-      });
-      return;
-    }
     navState.closeAll();
     if (href) {
       router.push(href);
@@ -644,73 +764,6 @@ export function NavigationSidebar(): React.ReactNode {
     navState.setPanelState("workflows", "open");
   }
 
-  function renderNavItem(item: {
-    id: string;
-    icon: typeof Plus;
-    label: string;
-    href: string | null;
-  }): React.ReactNode {
-    const disabled =
-      item.href === null && item.id !== "workflows" && item.id !== "new";
-    const layoutClass = showLabels ? "gap-3 px-2" : "justify-center";
-
-    if (disabled) {
-      return (
-        <Tooltip key={item.id}>
-          <TooltipTrigger asChild>
-            <button
-              aria-label={item.label}
-              className={cn(
-                "flex h-9 w-full cursor-default items-center rounded-md text-muted-foreground transition-colors",
-                layoutClass
-              )}
-              data-testid={`nav-${item.id}`}
-              key={item.id}
-              type="button"
-            >
-              <item.icon className="size-4 shrink-0" />
-              {showLabels && (
-                <span className="truncate text-sm">{item.label}</span>
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">Coming Soon</TooltipContent>
-        </Tooltip>
-      );
-    }
-
-    const active = isActive(item.id);
-
-    const button = (
-      <button
-        aria-label={item.label}
-        className={cn(
-          "flex h-9 w-full items-center rounded-md transition-colors hover:bg-muted",
-          layoutClass,
-          active && "bg-muted"
-        )}
-        data-testid={`nav-${item.id}`}
-        key={item.id}
-        onClick={() => handleNavClick(item.id, item.href)}
-        type="button"
-      >
-        <item.icon className="size-4 shrink-0" />
-        {showLabels && <span className="truncate text-sm">{item.label}</span>}
-      </button>
-    );
-
-    if (showLabels) {
-      return button;
-    }
-
-    return (
-      <Tooltip key={item.id}>
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
-        <TooltipContent side="right">{item.label}</TooltipContent>
-      </Tooltip>
-    );
-  }
-
   const navItems = NAV_ITEMS.filter(
     (item) => item.id !== "analytics" || !isAnonymous
   );
@@ -725,12 +778,30 @@ export function NavigationSidebar(): React.ReactNode {
         ref={sidebarRef}
         style={{ width: currentWidth }}
       >
+        <SidebarHeader
+          expanded={expanded}
+          onNewWorkflow={() => {
+            handleNewWorkflow().catch(() => {
+              router.push("/");
+            });
+          }}
+          onToggle={() => setExpanded(!expanded)}
+        />
+
         <nav
           aria-label="Main navigation"
           className="flex flex-1 flex-col gap-1 overflow-hidden px-2.5 pt-3"
           data-testid="navigation-sidebar"
         >
-          {navItems.map(renderNavItem)}
+          {navItems.map((item) => (
+            <NavItem
+              active={isActive(item.id)}
+              item={item}
+              key={item.id}
+              onClick={() => handleNavClick(item.id, item.href)}
+              showLabels={showLabels}
+            />
+          ))}
         </nav>
 
         {/* Resize handle */}
@@ -743,31 +814,16 @@ export function NavigationSidebar(): React.ReactNode {
           role="separator"
           tabIndex={0}
         >
-          <div className="absolute inset-y-0 right-0 w-px bg-border transition-colors group-hover:w-1 group-hover:bg-blue-500 group-active:w-1 group-active:bg-blue-600" />
-          {dragWidth === null && (
-            <button
-              aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
-              className="-translate-y-1/2 absolute top-1/2 right-0 flex size-6 translate-x-1/2 items-center justify-center rounded-full border bg-background opacity-0 shadow-sm transition-opacity hover:bg-muted group-hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-                setExpanded(!expanded);
-              }}
-              onMouseDown={(e) => e.stopPropagation()}
-              type="button"
-            >
-              {expanded ? (
-                <ChevronLeft className="size-4" />
-              ) : (
-                <ChevronRight className="size-4" />
-              )}
-            </button>
-          )}
+          <div className="absolute inset-y-0 right-0 w-px bg-border" />
         </div>
       </div>
 
       {/* Panel 1: Projects */}
       <FlyoutPanel
-        collapsedLabel="Projects"
+        accentColor={selectedProject?.color ?? undefined}
+        collapsedLabel={
+          selectedProject ? `Projects - ${selectedProject.name}` : "Projects"
+        }
         leftOffset={offsets.projects}
         onCollapse={() => navState.setPanelState("projects", "collapsed")}
         onExpand={() => navState.setPanelState("projects", "open")}
@@ -788,7 +844,7 @@ export function NavigationSidebar(): React.ReactNode {
 
       {/* Panel 2: Tags */}
       <FlyoutPanel
-        collapsedLabel={selectedProject?.name}
+        collapsedLabel={selectedTag ? `Tags - ${selectedTag.name}` : "Tags"}
         leftOffset={offsets.tags}
         onCollapse={() => navState.setPanelState("tags", "collapsed")}
         onExpand={() => navState.setPanelState("tags", "open")}
@@ -807,7 +863,10 @@ export function NavigationSidebar(): React.ReactNode {
 
       {/* Panel 3: Workflows */}
       <FlyoutPanel
-        collapsedLabel={selectedTag?.name}
+        collapsedLabel={(() => {
+          const wf = tagWorkflows.find((w) => w.id === workflowId);
+          return wf ? `Workflows - ${wf.name}` : "Workflows";
+        })()}
         leftOffset={offsets.workflows}
         onCollapse={() => navState.setPanelState("workflows", "collapsed")}
         onExpand={() => navState.setPanelState("workflows", "open")}
@@ -821,21 +880,23 @@ export function NavigationSidebar(): React.ReactNode {
         />
       </FlyoutPanel>
 
-      {/* Close-all button outside the rightmost panel */}
+      {/* Fold/Close button outside the rightmost panel */}
       {anyPanelOpen && (
         <Tooltip>
           <TooltipTrigger asChild>
             <button
-              className="pointer-events-auto fixed top-[68px] z-40 flex size-6 items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-[left] duration-200 ease-out hover:bg-muted hover:text-foreground"
+              className="pointer-events-auto fixed top-[62px] z-40 rounded-md p-1.5 text-muted-foreground transition-[left,colors] duration-200 ease-out hover:bg-muted hover:text-foreground"
               data-flyout
-              onClick={navState.closeAll}
-              style={{ left: offsets.rightEdge + 6 }}
+              onClick={anyPanelExpanded ? navState.foldAll : navState.closeAll}
+              style={{ left: offsets.rightEdge + 4 }}
               type="button"
             >
-              <X className="size-3.5" />
+              <X className="size-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="right">Close menu</TooltipContent>
+          <TooltipContent side="right">
+            {anyPanelExpanded ? "Fold menu" : "Close menu"}
+          </TooltipContent>
         </Tooltip>
       )}
     </>

--- a/keeperhub/lib/hooks/use-persisted-nav-state.ts
+++ b/keeperhub/lib/hooks/use-persisted-nav-state.ts
@@ -99,6 +99,7 @@ type UsePersistedNavStateReturn = {
   setSelectedProject: (id: string | null) => void;
   setSelectedTag: (id: string | null) => void;
   closeAll: () => void;
+  foldAll: () => void;
   peelRightmost: () => void;
   validateSelections: (projectIds: string[], tagIds: string[]) => void;
 };
@@ -106,7 +107,7 @@ type UsePersistedNavStateReturn = {
 export function usePersistedNavState(): UsePersistedNavStateReturn {
   const [state, setState] = useState<PersistedNavState>(DEFAULT_STATE);
   const stateRef = useRef(state);
-  const mounted = useRef(false);
+  const [hasMounted, setHasMounted] = useState(false);
 
   // Keep ref in sync with state
   stateRef.current = state;
@@ -115,7 +116,7 @@ export function usePersistedNavState(): UsePersistedNavStateReturn {
     const loaded = loadState();
     stateRef.current = loaded;
     setState(loaded);
-    mounted.current = true;
+    setHasMounted(true);
   }, []);
 
   const commit = useCallback((next: PersistedNavState) => {
@@ -173,6 +174,17 @@ export function usePersistedNavState(): UsePersistedNavStateReturn {
       selectedProjectId: null,
       selectedTagId: null,
     });
+  }, [commit]);
+
+  const foldAll = useCallback(() => {
+    const current = stateRef.current;
+    const panels = { ...current.panels };
+    for (const key of Object.keys(panels) as (keyof NavPanelStates)[]) {
+      if (panels[key] === "open") {
+        panels[key] = "collapsed";
+      }
+    }
+    commit({ ...current, panels });
   }, [commit]);
 
   const peelRightmost = useCallback(() => {
@@ -233,12 +245,13 @@ export function usePersistedNavState(): UsePersistedNavStateReturn {
 
   return {
     state,
-    hasMounted: mounted.current,
+    hasMounted,
     setSidebar,
     setPanelState,
     setSelectedProject,
     setSelectedTag,
     closeAll,
+    foldAll,
     peelRightmost,
     validateSelections,
   };

--- a/scripts/seed/seed-analytics-data.ts
+++ b/scripts/seed/seed-analytics-data.ts
@@ -149,6 +149,12 @@ const SEED_PROJECTS = [
   { name: "Trading Bots", color: "#7B61FF" },
 ] as const;
 
+const SEED_TAGS = [
+  { name: "Production", color: "#22C55E" },
+  { name: "Alerts", color: "#F59E0B" },
+  { name: "DeFi", color: "#8B5CF6" },
+] as const;
+
 async function ensureSeedProjects(
   sql: Db,
   userId: string,
@@ -181,16 +187,49 @@ async function ensureSeedProjects(
   return projectIds;
 }
 
+async function ensureSeedTags(
+  sql: Db,
+  userId: string,
+  orgId: string
+): Promise<string[]> {
+  const tagIds: string[] = [];
+  const now = new Date();
+
+  for (const tag of SEED_TAGS) {
+    const existing = await sql`
+      SELECT id FROM tags
+      WHERE organization_id = ${orgId} AND name = ${tag.name}
+      LIMIT 1
+    `;
+    if (existing.length > 0) {
+      tagIds.push(existing[0].id as string);
+      console.log(`  Tag already exists: ${tag.name} (${existing[0].id})`);
+    } else {
+      const id = generateId();
+      await sql.unsafe(
+        `INSERT INTO tags (id, name, color, organization_id, user_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [id, tag.name, tag.color, orgId, userId, now, now]
+      );
+      tagIds.push(id);
+      console.log(`  Created tag: ${tag.name} (${id})`);
+    }
+  }
+
+  return tagIds;
+}
+
 async function createSeedWorkflows(
   sql: Db,
   userId: string,
   orgId: string,
-  projectIds: string[]
+  projectIds: string[],
+  tagIds: string[]
 ): Promise<string[]> {
   const seedWorkflows = [
-    { name: `${SEED_PREFIX} USDC Monitor`, projectId: projectIds[0] },
-    { name: `${SEED_PREFIX} ETH Price Alert`, projectId: projectIds[0] },
-    { name: `${SEED_PREFIX} LP Rebalancer`, projectId: projectIds[1] },
+    { name: `${SEED_PREFIX} USDC Monitor`, projectId: projectIds[0], tagId: tagIds[0] },
+    { name: `${SEED_PREFIX} ETH Price Alert`, projectId: projectIds[0], tagId: tagIds[1] },
+    { name: `${SEED_PREFIX} LP Rebalancer`, projectId: projectIds[1], tagId: tagIds[2] },
   ];
 
   const workflowIds: string[] = [];
@@ -233,11 +272,11 @@ async function createSeedWorkflows(
     await sql.unsafe(
       `INSERT INTO workflows (
         id, name, description, user_id, organization_id, is_anonymous,
-        nodes, edges, visibility, enabled, created_at, updated_at, project_id
+        nodes, edges, visibility, enabled, created_at, updated_at, project_id, tag_id
       ) VALUES (
-        $1, $2, $3, $4, $5, false, $6::jsonb, $7::jsonb, 'private', true, $8, $9, $10
+        $1, $2, $3, $4, $5, false, $6::jsonb, $7::jsonb, 'private', true, $8, $9, $10, $11
       )`,
-      [id, wf.name, "Seeded for analytics testing", userId, orgId, nodes, edges, now, now, wf.projectId ?? null]
+      [id, wf.name, "Seeded for analytics testing", userId, orgId, nodes, edges, now, now, wf.projectId ?? null, wf.tagId ?? null]
     );
 
     workflowIds.push(id);
@@ -555,7 +594,8 @@ async function seedAnalyticsData(): Promise<void> {
     console.log("Seeding analytics data...");
 
     const projectIds = await ensureSeedProjects(sql, userId, orgId);
-    const workflowIds = await createSeedWorkflows(sql, userId, orgId, projectIds);
+    const tagIds = await ensureSeedTags(sql, userId, orgId);
+    const workflowIds = await createSeedWorkflows(sql, userId, orgId, projectIds, tagIds);
     await createWorkflowExecutions(sql, userId, workflowIds);
     await createDirectExecutions(sql, orgId);
     await createSpendCap(sql, orgId);


### PR DESCRIPTION
## Summary
- Align the navigation sidebar fold/expand UX with the flyout panels so the entire left nav feels consistent and the collapse button lives inside the menu header instead of floating on the resize handle
- Adds a branded "New Workflow" CTA button to the sidebar header with keeperhub-green styling
- Persists sidebar collapsed/expanded state across page loads without hydration flash

## Test plan
- [ ] Expand and collapse the sidebar via the in-header chevron button
- [ ] Verify "New Workflow" button creates a workflow in both expanded and collapsed states
- [ ] Refresh the page with sidebar collapsed -- confirm it stays collapsed with no flash
- [ ] Verify flyout panels (Projects, Tags, Workflows) still fold/expand correctly
- [ ] Check collapsed state shows centered + icon and right-aligned > chevron