### PR TITLE
feat: redesign setup guide with fold and dismiss controls

### DIFF
--- a/components/workflow/nodes/add-node.tsx
+++ b/components/workflow/nodes/add-node.tsx
@@ -28,7 +28,6 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
         <p className="text-muted-foreground">Automate anything onchain</p>
       </div>
       {/* start custom keeperhub code */}
-      <GettingStartedChecklist onCreateWorkflow={data.onClick} />
       <div className="flex gap-3">
         <Button
           className="gap-2 shadow-lg"
@@ -48,6 +47,7 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
           Browse Templates
         </Button>
       </div>
+      <GettingStartedChecklist onCreateWorkflow={data.onClick} />
       {/* end keeperhub code */}
     </div>
   );

--- a/keeperhub/components/onboarding/getting-started-checklist.tsx
+++ b/keeperhub/components/onboarding/getting-started-checklist.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { Check, Info, KeyRound, Wallet, Workflow } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Info,
+  KeyRound,
+  Wallet,
+  Workflow,
+  X,
+} from "lucide-react";
 import { useRef } from "react";
 import { AuthDialog } from "@/components/auth/dialog";
 import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
@@ -111,17 +120,37 @@ function SkeletonRows(): React.ReactElement {
   );
 }
 
+const ICON_BTN =
+  "rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+
+function DismissButton({
+  onClick,
+}: {
+  onClick: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      className={ICON_BTN}
+      onClick={onClick}
+      title="Dismiss"
+      type="button"
+    >
+      <X className="size-4" />
+    </button>
+  );
+}
+
 export function GettingStartedChecklist({
   onCreateWorkflow,
 }: GettingStartedChecklistProps): React.ReactElement | null {
   const {
     steps,
     isLoading,
-    allComplete,
     completedCount,
-    hidden,
-    hide,
-    show,
+    guideState,
+    collapse,
+    expand,
+    dismiss,
     refetch,
   } = useOnboardingStatus();
   const { open: openOverlay } = useOverlay();
@@ -130,8 +159,22 @@ export function GettingStartedChecklist({
 
   const isAnonymous = isAnonymousUser(session?.user);
 
-  if (allComplete) {
-    return null;
+  const docsLink = (
+    <p className="mt-1.5 text-center text-base tracking-wide text-muted-foreground/40">
+      Need help?{" "}
+      <a
+        className="underline decoration-muted-foreground/20 underline-offset-2 transition-colors hover:text-muted-foreground hover:decoration-muted-foreground/40"
+        href="https://docs.keeperhub.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        View docs
+      </a>
+    </p>
+  );
+
+  if (guideState === "dismissed") {
+    return <div className="w-full min-w-[14rem] max-w-[16rem]">{docsLink}</div>;
   }
 
   const promptSignIn = (): void => {
@@ -158,14 +201,14 @@ export function GettingStartedChecklist({
               <Info className="size-3.5 text-muted-foreground" />
             </TooltipTrigger>
             <TooltipContent className="text-xs" side="top">
-              See{" "}
+              Connect KeeperHub to your AI tools.{" "}
               <a
                 className="underline"
                 href="https://docs.keeperhub.com/ai-tools/mcp-server"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                MCP docs
+                Learn more
               </a>
             </TooltipContent>
           </Tooltip>
@@ -204,39 +247,56 @@ export function GettingStartedChecklist({
     },
   ];
 
-  return (
-    <div className="w-full min-w-[14rem] max-w-[16rem]">
-      {hidden ? (
-        <button
-          className="flex w-full items-center gap-2 px-3 py-1.5 transition-opacity hover:opacity-80"
-          onClick={show}
-          type="button"
-        >
-          <div className="h-px flex-1 bg-border/40" />
-          <span className="shrink-0 text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
-            Setup Guide
+  if (guideState === "collapsed") {
+    return (
+      <div className="w-full min-w-[14rem] max-w-[16rem]">
+        <div className="flex items-center rounded-md border bg-popover px-2 py-1.5 shadow-md">
+          <span className="font-medium text-sm">Setup Guide</span>
+          <span className="ml-2 text-xs text-muted-foreground">
+            {completedCount}/{steps.length}
           </span>
-          <div className="h-px flex-1 bg-border/40" />
-        </button>
-      ) : (
-        <div className="rounded-md border bg-popover p-1 shadow-md">
-          <AuthDialog>
-            <button className="hidden" ref={authTriggerRef} type="button" />
-          </AuthDialog>
-
-          <div className="flex items-center justify-between px-2 py-1.5">
-            <span className="font-medium text-sm">Setup Guide</span>
+          <div className="ml-auto flex items-center gap-0.5">
             <button
-              className="text-muted-foreground text-xs transition-colors hover:text-foreground"
-              onClick={hide}
+              className={ICON_BTN}
+              onClick={expand}
+              title="Expand"
               type="button"
             >
-              Hide
+              <ChevronDown className="size-4" />
             </button>
+            <DismissButton onClick={dismiss} />
           </div>
+        </div>
+        {docsLink}
+      </div>
+    );
+  }
 
-          <div className="-mx-1 my-1 h-px bg-border" />
+  return (
+    <div className="w-full min-w-[14rem] max-w-[16rem]">
+      <div className="rounded-md border bg-popover shadow-md">
+        <AuthDialog>
+          <button className="hidden" ref={authTriggerRef} type="button" />
+        </AuthDialog>
 
+        <div className="flex items-center px-2 py-1.5">
+          <span className="font-medium text-sm">Setup Guide</span>
+          <div className="ml-auto flex items-center gap-0.5">
+            <button
+              className={ICON_BTN}
+              onClick={collapse}
+              title="Collapse"
+              type="button"
+            >
+              <ChevronUp className="size-4" />
+            </button>
+            <DismissButton onClick={dismiss} />
+          </div>
+        </div>
+
+        <div className="my-1 h-px bg-border" />
+
+        <div className="px-1">
           {isLoading ? (
             <SkeletonRows />
           ) : (
@@ -260,30 +320,19 @@ export function GettingStartedChecklist({
               })}
             </div>
           )}
-
-          <div className="-mx-1 my-1 h-px bg-border" />
-
-          <div className="px-2 py-1.5">
-            {isLoading ? (
-              <div className="h-1 w-full animate-pulse rounded-full bg-muted" />
-            ) : (
-              <ProgressBar completed={completedCount} total={steps.length} />
-            )}
-          </div>
         </div>
-      )}
 
-      <p className="mt-1.5 text-center text-base tracking-wide text-muted-foreground/40">
-        Read{" "}
-        <a
-          className="underline decoration-muted-foreground/20 underline-offset-2 transition-colors hover:text-muted-foreground hover:decoration-muted-foreground/40"
-          href="https://docs.keeperhub.com/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          docs
-        </a>
-      </p>
+        <div className="my-1 h-px bg-border" />
+
+        <div className="px-2 py-1.5">
+          {isLoading ? (
+            <div className="h-1 w-full animate-pulse rounded-full bg-muted" />
+          ) : (
+            <ProgressBar completed={completedCount} total={steps.length} />
+          )}
+        </div>
+      </div>
+      {docsLink}
     </div>
   );
 }

--- a/keeperhub/lib/hooks/use-onboarding-status.ts
+++ b/keeperhub/lib/hooks/use-onboarding-status.ts
@@ -1,18 +1,45 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useSession } from "@/lib/auth-client";
+import { authClient, useSession } from "@/lib/auth-client";
 
-const DISMISSED_KEY = "keeperhub-onboarding-dismissed";
+type GuideState = "expanded" | "collapsed" | "dismissed";
 
-function isDismissed(): boolean {
+const GUIDE_KEY = "keeperhub-onboarding-guide";
+const OLD_DISMISSED_KEY = "keeperhub-onboarding-dismissed";
+
+function readGuideState(): GuideState {
   if (typeof window === "undefined") {
-    return false;
+    return "expanded";
   }
   try {
-    return localStorage.getItem(DISMISSED_KEY) === "true";
+    // Migrate old key if present
+    const oldValue = localStorage.getItem(OLD_DISMISSED_KEY);
+    if (oldValue === "true") {
+      localStorage.removeItem(OLD_DISMISSED_KEY);
+      localStorage.setItem(GUIDE_KEY, "collapsed");
+      return "collapsed";
+    }
+
+    const value = localStorage.getItem(GUIDE_KEY);
+    if (value === "collapsed" || value === "dismissed") {
+      return value;
+    }
+    return "expanded";
   } catch {
-    return false;
+    return "expanded";
+  }
+}
+
+function persistGuideState(state: GuideState): void {
+  try {
+    if (state === "expanded") {
+      localStorage.removeItem(GUIDE_KEY);
+    } else {
+      localStorage.setItem(GUIDE_KEY, state);
+    }
+  } catch {
+    // localStorage unavailable
   }
 }
 
@@ -27,9 +54,10 @@ type OnboardingStatus = {
   allComplete: boolean;
   completedCount: number;
   refetch: () => void;
-  hidden: boolean;
-  hide: () => void;
-  show: () => void;
+  guideState: GuideState;
+  collapse: () => void;
+  expand: () => void;
+  dismiss: () => void;
 };
 
 function isFulfilledArray(result: PromiseSettledResult<unknown>): boolean {
@@ -42,13 +70,15 @@ function isFulfilledArray(result: PromiseSettledResult<unknown>): boolean {
 
 export function useOnboardingStatus(): OnboardingStatus {
   const { data: session } = useSession();
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const activeOrgId = activeOrg?.id ?? null;
   const [steps, setSteps] = useState<OnboardingStep[]>([
     { id: "create-workflow", complete: false },
     { id: "generate-api-key", complete: false },
     { id: "create-wallet", complete: false },
   ]);
   const [isLoading, setIsLoading] = useState(true);
-  const [hidden, setHidden] = useState(isDismissed);
+  const [guideState, setGuideState] = useState<GuideState>(readGuideState);
   const [refetchKey, setRefetchKey] = useState(0);
 
   const refetch = useCallback(() => {
@@ -57,32 +87,35 @@ export function useOnboardingStatus(): OnboardingStatus {
 
   const isAuthenticated = Boolean(session?.user);
 
-  const hide = useCallback(() => {
-    setHidden(true);
-    try {
-      localStorage.setItem(DISMISSED_KEY, "true");
-    } catch {
-      // localStorage unavailable
-    }
+  const collapse = useCallback(() => {
+    setGuideState("collapsed");
+    persistGuideState("collapsed");
   }, []);
 
-  const show = useCallback(() => {
-    setHidden(false);
-    try {
-      localStorage.removeItem(DISMISSED_KEY);
-    } catch {
-      // localStorage unavailable
-    }
+  const expand = useCallback(() => {
+    setGuideState("expanded");
+    persistGuideState("expanded");
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setGuideState("dismissed");
+    persistGuideState("dismissed");
   }, []);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refetchKey intentionally triggers re-fetch
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isAuthenticated || guideState === "dismissed") {
       setIsLoading(false);
       return;
     }
 
     let cancelled = false;
+
+    setSteps([
+      { id: "create-workflow", complete: false },
+      { id: "generate-api-key", complete: false },
+      { id: "create-wallet", complete: false },
+    ]);
 
     async function fetchStatus(): Promise<void> {
       setIsLoading(true);
@@ -117,7 +150,7 @@ export function useOnboardingStatus(): OnboardingStatus {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, refetchKey]);
+  }, [isAuthenticated, activeOrgId, refetchKey, guideState]);
 
   const completedCount = steps.filter((s) => s.complete).length;
   const allComplete = completedCount === steps.length;
@@ -127,9 +160,10 @@ export function useOnboardingStatus(): OnboardingStatus {
     isLoading,
     allComplete,
     completedCount,
-    hidden,
-    hide,
-    show,
+    guideState,
+    collapse,
+    expand,
+    dismiss,
     refetch,
   };
 }


### PR DESCRIPTION
## Summary
- Replace auto-hide behavior with explicit fold/dismiss controls so users keep control over the setup guide instead of it vanishing when all steps complete
- Tri-state model (expanded, collapsed, dismissed) persisted in localStorage with migration from old key
- Dismissed state skips API fetches; collapsed shows compact progress bar without skeleton flash
- Icon buttons match the flyout panel drawer styling for visual consistency

## Test plan
- [ ] Fresh user: guide shows expanded with skeleton, then steps load
- [ ] Click collapse (chevron up): compact bar with count, persists on refresh without skeleton
- [ ] Click expand (chevron down): returns to full view
- [ ] Click dismiss (X) from either state: guide disappears, docs link remains, persists on refresh
- [ ] Switch org: steps refresh, fold/dismiss state unchanged
- [ ] Org with all steps complete: guide still shows (does not auto-hide)