### PR TITLE
ci: KEEP-1548 build Docker images once, reuse for e2e and deploy

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -1,0 +1,125 @@
+# Starts the application for e2e tests.
+# Docker path: pulls pre-built image from ECR (push events).
+# Bare-metal path: builds locally with pnpm (PRs, workflow_dispatch).
+name: Start Application
+description: Start application from Docker image or bare-metal build
+
+inputs:
+  image_tag:
+    description: 'ECR image tag. When provided, uses Docker path instead of bare-metal.'
+    required: false
+    default: ''
+  ecr_registry:
+    description: 'ECR registry URL'
+    required: false
+    default: ''
+  ecr_repo:
+    description: 'ECR repository name'
+    required: false
+    default: ''
+  ecr_region:
+    description: 'AWS region for ECR'
+    required: false
+    default: ''
+  aws_access_key_id:
+    description: 'AWS access key ID (for ECR login)'
+    required: false
+    default: ''
+  aws_secret_access_key:
+    description: 'AWS secret access key (for ECR login)'
+    required: false
+    default: ''
+  database_url:
+    description: 'Database connection URL'
+    required: true
+  better_auth_secret:
+    description: 'BetterAuth secret'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # --- Docker path ---
+    - name: Configure AWS credentials
+      if: inputs.image_tag != ''
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-access-key-id: ${{ inputs.aws_access_key_id }}
+        aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
+        aws-region: ${{ inputs.ecr_region }}
+
+    - name: Login to AWS ECR
+      if: inputs.image_tag != ''
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Start application (Docker)
+      if: inputs.image_tag != ''
+      shell: bash
+      env:
+        BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
+      run: |
+        IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
+        echo "Pulling ${IMAGE}..."
+        docker pull "${IMAGE}"
+
+        printf '%s\n' \
+          "DATABASE_URL=${{ inputs.database_url }}" \
+          "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
+          "NODE_ENV=production" \
+          > /tmp/keeperhub-app.env
+
+        docker run -d --name keeperhub-app --network host \
+          --env-file /tmp/keeperhub-app.env \
+          "${IMAGE}"
+
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+            echo "App is ready (Docker)"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "App did not start in 60s"
+            docker logs keeperhub-app
+            exit 1
+          fi
+          sleep 2
+        done
+
+    # --- Bare-metal path ---
+    - name: Cache Next.js build
+      if: inputs.image_tag == ''
+      uses: actions/cache@v4
+      with:
+        path: .next/cache
+        key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+        restore-keys: |
+          ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+          ${{ runner.os }}-nextjs-
+
+    - name: Build application
+      if: inputs.image_tag == ''
+      shell: bash
+      run: pnpm build
+      env:
+        DATABASE_URL: ${{ inputs.database_url }}
+        BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
+
+    - name: Start application
+      if: inputs.image_tag == ''
+      shell: bash
+      run: |
+        pnpm start &
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+            echo "App is ready"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "App did not start in 60s"
+            exit 1
+          fi
+          sleep 2
+        done
+      env:
+        DATABASE_URL: ${{ inputs.database_url }}
+        BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}

--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -57,13 +57,17 @@ runs:
       shell: bash
       env:
         BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
+        ECR_REGISTRY: ${{ inputs.ecr_registry }}
+        ECR_REPO: ${{ inputs.ecr_repo }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        DATABASE_URL: ${{ inputs.database_url }}
       run: |
-        IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
+        IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
         docker pull "${IMAGE}"
 
         printf '%s\n' \
-          "DATABASE_URL=${{ inputs.database_url }}" \
+          "DATABASE_URL=${DATABASE_URL}" \
           "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
           "NODE_ENV=production" \
           > /tmp/keeperhub-app.env

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -64,13 +64,13 @@ jobs:
         run: |
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
           if aws ecr describe-images \
-            --repository-name ${{ env.AWS_ECR_NAME }} \
-            --image-ids imageTag=app-${IMAGE_TAG} \
-            --region ${{ env.REGION }} >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            --repository-name "${{ env.AWS_ECR_NAME }}" \
+            --image-ids "imageTag=app-${IMAGE_TAG}" \
+            --region "${{ env.REGION }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Images already exist for app-${IMAGE_TAG}, skipping build"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Verify submodule token access

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -82,6 +82,12 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fail fast if build skipped but image missing
+        if: steps.skip.outputs.skip_build == 'true' && steps.check-image.outputs.exists != 'true'
+        run: |
+          echo "::error::Cannot skip build: image app-${{ steps.vars.outputs.sha_short }} does not exist in ECR. Remove [skip build] from the commit message or push a build first."
+          exit 1
+
       - name: Verify submodule token access
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         env:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -15,6 +15,9 @@ on:
       ecr_repo:
         description: "ECR repository name"
         value: ${{ jobs.build.outputs.ecr_repo }}
+      ecr_region:
+        description: "AWS region for ECR"
+        value: ${{ jobs.build.outputs.ecr_region }}
 
 jobs:
   build:
@@ -24,6 +27,7 @@ jobs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
       ecr_registry: ${{ steps.login-ecr.outputs.registry }}
       ecr_repo: ${{ env.AWS_ECR_NAME }}
+      ecr_region: ${{ env.REGION }}
     env:
       REGION: ${{ github.ref_name == 'prod' && 'us-east-1' || 'us-east-2' }}
       AWS_ECR_NAME: keeperhub-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,8 +62,13 @@ jobs:
       - name: Extract commit hash and ECR coordinates
         id: vars
         run: |
+          SHA=$(git rev-parse --short HEAD)
+          if [[ -z "$SHA" || ${#SHA} -lt 7 ]]; then
+            echo "::error::Failed to resolve commit SHA (got '${SHA}')"
+            exit 1
+          fi
           {
-            echo "sha_short=$(git rev-parse --short HEAD)"
+            echo "sha_short=${SHA}"
             echo "ecr_repo=${AWS_ECR_NAME}"
             echo "ecr_region=${REGION}"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -72,20 +72,24 @@ jobs:
         id: check-image
         run: |
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
-          if aws ecr describe-images \
-            --repository-name "${{ env.AWS_ECR_NAME }}" \
-            --image-ids "imageTag=app-${IMAGE_TAG}" \
-            --region "${{ env.REGION }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Images already exist for app-${IMAGE_TAG}, skipping build"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          ALL_EXIST=true
+          for prefix in app migrator; do
+            if aws ecr describe-images \
+              --repository-name "${{ env.AWS_ECR_NAME }}" \
+              --image-ids "imageTag=${prefix}-${IMAGE_TAG}" \
+              --region "${{ env.REGION }}" >/dev/null 2>&1; then
+              echo "${prefix}-${IMAGE_TAG} exists"
+            else
+              echo "${prefix}-${IMAGE_TAG} not found"
+              ALL_EXIST=false
+            fi
+          done
+          echo "exists=${ALL_EXIST}" >> "$GITHUB_OUTPUT"
 
       - name: Fail fast if build skipped but image missing
         if: steps.skip.outputs.skip_build == 'true' && steps.check-image.outputs.exists != 'true'
         run: |
-          echo "::error::Cannot skip build: image app-${{ steps.vars.outputs.sha_short }} does not exist in ECR. Remove [skip build] from the commit message or push a build first."
+          echo "::error::Cannot skip build: one or more images for ${{ steps.vars.outputs.sha_short }} do not exist in ECR. Remove [skip build] from the commit message or push a build first."
           exit 1
 
       - name: Verify submodule token access

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -26,8 +26,8 @@ jobs:
     outputs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
       ecr_registry: ${{ steps.login-ecr.outputs.registry }}
-      ecr_repo: ${{ env.AWS_ECR_NAME }}
-      ecr_region: ${{ env.REGION }}
+      ecr_repo: ${{ steps.vars.outputs.ecr_repo }}
+      ecr_region: ${{ steps.vars.outputs.ecr_region }}
     env:
       REGION: ${{ github.ref_name == 'prod' && 'us-east-1' || 'us-east-2' }}
       AWS_ECR_NAME: keeperhub-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
@@ -59,9 +59,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Extract commit hash
+      - name: Extract commit hash and ECR coordinates
         id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          {
+            echo "sha_short=$(git rev-parse --short HEAD)"
+            echo "ecr_repo=${AWS_ECR_NAME}"
+            echo "ecr_region=${REGION}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check if images already exist
         id: check-image

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,110 @@
+# Type: reusable | Called by ci-pipeline.yml
+# Builds Docker images via docker-bake.hcl and pushes to ECR.
+# Skips build if images already exist for the current commit SHA (rerun optimization).
+name: Build Images
+
+on:
+  workflow_call:
+    outputs:
+      image_tag:
+        description: "Short SHA used as image tag"
+        value: ${{ jobs.build.outputs.image_tag }}
+      ecr_registry:
+        description: "ECR registry URL"
+        value: ${{ jobs.build.outputs.ecr_registry }}
+      ecr_repo:
+        description: "ECR repository name"
+        value: ${{ jobs.build.outputs.ecr_repo }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+    outputs:
+      image_tag: ${{ steps.vars.outputs.sha_short }}
+      ecr_registry: ${{ steps.login-ecr.outputs.registry }}
+      ecr_repo: ${{ env.AWS_ECR_NAME }}
+    env:
+      REGION: ${{ github.ref_name == 'prod' && 'us-east-1' || 'us-east-2' }}
+      AWS_ECR_NAME: keeperhub-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      NEXT_PUBLIC_AUTH_PROVIDERS: ${{ github.ref_name == 'prod' && vars.NEXT_PUBLIC_AUTH_PROVIDERS_PROD || vars.NEXT_PUBLIC_AUTH_PROVIDERS_STAGING }}
+      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ github.ref_name == 'prod' && vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_STAGING }}
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ github.ref_name == 'prod' && vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_STAGING }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Check commit message for skip flags
+        id: skip
+        run: |
+          MSG=$(git log -1 --format=%B)
+          echo "skip_build=$([[ "$MSG" == *"[skip build]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if images already exist
+        id: check-image
+        run: |
+          IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
+          if aws ecr describe-images \
+            --repository-name ${{ env.AWS_ECR_NAME }} \
+            --image-ids imageTag=app-${IMAGE_TAG} \
+            --region ${{ env.REGION }} >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Images already exist for app-${IMAGE_TAG}, skipping build"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Verify submodule token access
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        env:
+          TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
+        run: |
+          for repo in keeperhub-events keeperhub-scheduler; do
+            status=$(curl -sf -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer $TOKEN" \
+              "https://api.github.com/repos/techops-services/$repo")
+            if [ "$status" != "200" ]; then
+              echo "::error::KEEPERHUB_SUBMODULE_TOKEN cannot access techops-services/$repo (HTTP $status). Token may be expired or revoked."
+              exit 1
+            fi
+            echo "Verified access to techops-services/$repo"
+          done
+
+      - name: Set up Docker Buildx
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push all images to ECR
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        uses: docker/bake-action@v6
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPO: ${{ env.AWS_ECR_NAME }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
+          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+          BUILDX_BAKE_GIT_AUTH_TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
+          ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
+        with:
+          files: docker-bake.hcl
+          push: true

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -36,6 +36,9 @@ jobs:
       ecr_region: ${{ needs.build-images.outputs.ecr_region || '' }}
     secrets: inherit
 
+  # Deploy runs after build-images and e2e-tests.
+  # On prod pushes, e2e-tests is skipped (not failed/cancelled),
+  # so !failure() && !cancelled() correctly allows deploy to proceed.
   deploy:
     needs: [build-images, e2e-tests]
     if: ${{ github.event_name == 'push' && !failure() && !cancelled() }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,4 +1,4 @@
-# Type: orchestrator | Coordinates e2e-tests-ephemeral -> deploy
+# Type: orchestrator | Coordinates build-images -> e2e-tests-ephemeral -> deploy
 name: CI Pipeline
 
 on:
@@ -8,17 +8,33 @@ on:
     types: [labeled, synchronize]
 
 jobs:
+  # Build Docker images once for push events (staging/prod).
+  # Outputs image tag and ECR coordinates for downstream jobs.
+  # Skipped for PRs -- e2e falls back to bare-metal build.
+  build-images:
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+
   e2e-tests:
+    needs: [build-images]
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}
       caller_action: ${{ github.event.action }}
       has_e2e_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-ephemeral') || false }}
       label_name: ${{ github.event.label.name || '' }}
+      image_tag: ${{ needs.build-images.outputs.image_tag || '' }}
+      ecr_registry: ${{ needs.build-images.outputs.ecr_registry || '' }}
+      ecr_repo: ${{ needs.build-images.outputs.ecr_repo || '' }}
     secrets: inherit
 
   deploy:
-    needs: e2e-tests
+    needs: [build-images, e2e-tests]
     if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-keeperhub.yaml
+    with:
+      skip_build: true
+      image_tag: ${{ needs.build-images.outputs.image_tag }}
     secrets: inherit

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -16,9 +16,14 @@ jobs:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
 
+  # Ephemeral e2e tests run on:
+  # - Push to staging (gate for staging-to-prod promotion PRs)
+  # - PRs with run-e2e-tests-ephemeral label
+  # Skipped on push to prod -- code already passed e2e on staging,
+  # and remote e2e tests post-deploy validate the actual prod environment.
   e2e-tests:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && !(github.event_name == 'push' && github.ref_name == 'prod') }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}
@@ -32,7 +37,7 @@ jobs:
 
   deploy:
     needs: [build-images, e2e-tests]
-    if: github.event_name == 'push'
+    if: ${{ github.event_name == 'push' && !failure() && !cancelled() }}
     uses: ./.github/workflows/deploy-keeperhub.yaml
     with:
       skip_build: true

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -6,24 +6,25 @@ on:
     branches: [staging, prod]
   pull_request:
     types: [labeled, synchronize]
+  workflow_dispatch: {}
 
 jobs:
-  # Build Docker images once for push events (staging/prod).
+  # Build Docker images once for push/dispatch events (staging/prod).
   # Outputs image tag and ECR coordinates for downstream jobs.
   # Skipped for PRs -- e2e falls back to bare-metal build.
   build-images:
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
 
   # Ephemeral e2e tests run on:
-  # - Push to staging (gate for staging-to-prod promotion PRs)
+  # - Push/dispatch to staging (gate for staging-to-prod promotion PRs)
   # - PRs with run-e2e-tests-ephemeral label
   # Skipped on push to prod -- code already passed e2e on staging,
   # and remote e2e tests post-deploy validate the actual prod environment.
   e2e-tests:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() && !(github.event_name == 'push' && github.ref_name == 'prod') }}
+    if: ${{ !failure() && !cancelled() && !(github.event_name != 'pull_request' && github.ref_name == 'prod') }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}
@@ -41,9 +42,8 @@ jobs:
   # so !failure() && !cancelled() correctly allows deploy to proceed.
   deploy:
     needs: [build-images, e2e-tests]
-    if: ${{ github.event_name == 'push' && !failure() && !cancelled() }}
+    if: ${{ github.event_name != 'pull_request' && !failure() && !cancelled() }}
     uses: ./.github/workflows/deploy-keeperhub.yaml
     with:
-      skip_build: true
       image_tag: ${{ needs.build-images.outputs.image_tag }}
     secrets: inherit

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -33,6 +33,7 @@ jobs:
       image_tag: ${{ needs.build-images.outputs.image_tag || '' }}
       ecr_registry: ${{ needs.build-images.outputs.ecr_registry || '' }}
       ecr_repo: ${{ needs.build-images.outputs.ecr_repo || '' }}
+      ecr_region: ${{ needs.build-images.outputs.ecr_region || '' }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -1,37 +1,26 @@
 # Type: reusable | Called by ci-pipeline.yml
+# Pure deployer: expects images to already exist in ECR (built by build-images.yml).
 on:
   workflow_call:
     inputs:
-      skip_build:
-        description: 'Skip Docker build (images already pushed to ECR by build-images job)'
-        type: boolean
-        required: false
-        default: false
       image_tag:
-        description: 'Pre-built image tag (short SHA). Overrides computed SHA when provided.'
+        description: 'Pre-built image tag (short SHA).'
         type: string
         required: false
         default: ''
-  workflow_dispatch: {}
 
 name: deploy-keeperhub
 jobs:
-  build-and-deploy:
+  deploy:
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     runs-on: ubuntu-latest
     env:
       HELM_FILE: deploy/keeperhub/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
       REGION: ${{ github.ref_name == 'prod' && 'us-east-1' || 'us-east-2' }}
       CLUSTER_NAME: ${{ github.ref_name == 'prod' && 'maker-prod' || 'maker-staging' }}
-      ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       NAMESPACE: keeperhub
       SERVICE_NAME: keeperhub
-      AWS_ECR_NAME: keeperhub-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.SERVICE_ACCOUNT_ROLE_ARN }}
-      # Auth provider build args (selected by deployment branch: prod vs staging)
-      NEXT_PUBLIC_AUTH_PROVIDERS: ${{ github.ref_name == 'prod' && vars.NEXT_PUBLIC_AUTH_PROVIDERS_PROD || vars.NEXT_PUBLIC_AUTH_PROVIDERS_STAGING }}
-      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ github.ref_name == 'prod' && vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GITHUB_CLIENT_ID_STAGING }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ github.ref_name == 'prod' && vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_PROD || vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID_STAGING }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -43,7 +32,6 @@ jobs:
         id: skip
         run: |
           MSG=$(git log -1 --format=%B)
-          echo "skip_build=$([[ "$MSG" == *"[skip build]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "skip_deploy=$([[ "$MSG" == *"[skip deploy]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials
@@ -68,46 +56,6 @@ jobs:
           else
             echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
-
-      # Build steps are skipped when:
-      # - inputs.skip_build=true: ci-pipeline.yml already built images via build-images.yml
-      # - [skip build] in commit message: manual escape hatch for workflow_dispatch reruns
-      #   where images already exist in ECR from a previous run
-      - name: Set up Docker Buildx
-        if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Verify submodule token access
-        if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
-        env:
-          TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
-        run: |
-          for repo in keeperhub-events keeperhub-scheduler; do
-            status=$(curl -sf -o /dev/null -w "%{http_code}" \
-              -H "Authorization: Bearer $TOKEN" \
-              "https://api.github.com/repos/techops-services/$repo")
-            if [ "$status" != "200" ]; then
-              echo "::error::KEEPERHUB_SUBMODULE_TOKEN cannot access techops-services/$repo (HTTP $status). Token may be expired or revoked."
-              exit 1
-            fi
-            echo "Verified access to techops-services/$repo"
-          done
-
-      - name: Build and push all images to ECR
-        if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
-        uses: docker/bake-action@v6
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPO: ${{ env.AWS_ECR_NAME }}
-          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
-          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
-          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
-          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-          BUILDX_BAKE_GIT_AUTH_TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
-          ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
-        with:
-          files: docker-bake.hcl
-          push: true
 
       - name: Replace variables in the Helm values file
         id: replace-vars
@@ -150,7 +98,7 @@ jobs:
 
   # DISABLED: remote E2E tests temporarily disabled while KEEP-1351 stabilises auth/rate-limit infrastructure
   e2e-playwright-remote:
-    needs: build-and-deploy
+    needs: deploy
     if: ${{ vars.ENABLE_E2E_REMOTE_TESTS == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -60,14 +60,19 @@ jobs:
       - name: Extract commit hash
         id: vars
         shell: bash
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          if [[ -n "${{ inputs.image_tag }}" ]]; then
-            echo "sha_short=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          if [[ -n "${INPUT_IMAGE_TAG}" ]]; then
+            echo "sha_short=${INPUT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
-      # Build steps only run when not using pre-built images
+      # Build steps are skipped when:
+      # - inputs.skip_build=true: ci-pipeline.yml already built images via build-images.yml
+      # - [skip build] in commit message: manual escape hatch for workflow_dispatch reruns
+      #   where images already exist in ECR from a previous run
       - name: Set up Docker Buildx
         if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -1,6 +1,17 @@
 # Type: reusable | Called by ci-pipeline.yml
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      skip_build:
+        description: 'Skip Docker build (images already pushed to ECR by build-images job)'
+        type: boolean
+        required: false
+        default: false
+      image_tag:
+        description: 'Pre-built image tag (short SHA). Overrides computed SHA when provided.'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch: {}
 
 name: deploy-keeperhub
@@ -46,19 +57,23 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Set up Docker Buildx
-        if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/setup-buildx-action@v3
-
       - name: Extract commit hash
         id: vars
-        if: steps.skip.outputs.skip_build != 'true'
         shell: bash
         run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          if [[ -n "${{ inputs.image_tag }}" ]]; then
+            echo "sha_short=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Build steps only run when not using pre-built images
+      - name: Set up Docker Buildx
+        if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
+        uses: docker/setup-buildx-action@v3
 
       - name: Verify submodule token access
-        if: steps.skip.outputs.skip_build != 'true'
+        if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
         env:
           TOKEN: ${{ secrets.KEEPERHUB_SUBMODULE_TOKEN }}
         run: |
@@ -74,7 +89,7 @@ jobs:
           done
 
       - name: Build and push all images to ECR
-        if: steps.skip.outputs.skip_build != 'true'
+        if: ${{ !inputs.skip_build && steps.skip.outputs.skip_build != 'true' }}
         uses: docker/bake-action@v6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -113,10 +113,10 @@ jobs:
           SERVICE_ACCOUNT_ROLE_ARN: ${{ env.SERVICE_ACCOUNT_ROLE_ARN }}
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: |
-          sed -i 's|${ECR_REGISTRY}|'"$ECR_REGISTRY"'|g' $HELM_FILE
-          sed -i 's|${IMAGE_TAG}|'"$IMAGE_TAG"'|g' $HELM_FILE
-          sed -i 's|${SERVICE_ACCOUNT_ROLE_ARN}|'"$SERVICE_ACCOUNT_ROLE_ARN"'|g' $HELM_FILE
-          sed -i 's|${AWS_ACCOUNT_ID}|'"$AWS_ACCOUNT_ID"'|g' $HELM_FILE
+          sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$HELM_FILE"
+          sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$HELM_FILE"
+          sed -i "s|\${SERVICE_ACCOUNT_ROLE_ARN}|${SERVICE_ACCOUNT_ROLE_ARN}|g" "$HELM_FILE"
+          sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$HELM_FILE"
 
       - name: Configure kubectl
         if: steps.skip.outputs.skip_deploy != 'true'

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -58,9 +58,11 @@ jobs:
         env:
           EFFECTIVE_EVENT: ${{ inputs.caller_event || github.event_name }}
         run: |
-          echo "run-e2e=false" >> $GITHUB_OUTPUT
-          echo "run-deployed=false" >> $GITHUB_OUTPUT
-          echo "pr-number=" >> $GITHUB_OUTPUT
+          {
+            echo "run-e2e=false"
+            echo "run-deployed=false"
+            echo "pr-number="
+          } >> "$GITHUB_OUTPUT"
 
           # Check for [skip e2e] flag in commit message (push events only)
           if [[ "$EFFECTIVE_EVENT" == "push" ]]; then
@@ -72,17 +74,17 @@ jobs:
           fi
 
           if [[ "$EFFECTIVE_EVENT" == "push" || "$EFFECTIVE_EVENT" == "workflow_dispatch" ]]; then
-            echo "run-e2e=true" >> $GITHUB_OUTPUT
+            echo "run-e2e=true" >> "$GITHUB_OUTPUT"
           elif [[ "$EFFECTIVE_EVENT" == "pull_request" ]]; then
             if [[ "${{ inputs.caller_action }}" == "labeled" ]]; then
               # Only run when the run-e2e-tests-ephemeral label was the one just added
               if [[ "${{ inputs.label_name }}" == "run-e2e-tests-ephemeral" ]]; then
-                echo "run-e2e=true" >> $GITHUB_OUTPUT
+                echo "run-e2e=true" >> "$GITHUB_OUTPUT"
               fi
             elif [[ "${{ inputs.caller_action }}" == "synchronize" ]]; then
               # On new commits, re-run if the label is already present
               if [[ "${{ inputs.has_e2e_label }}" == "true" ]]; then
-                echo "run-e2e=true" >> $GITHUB_OUTPUT
+                echo "run-e2e=true" >> "$GITHUB_OUTPUT"
               fi
             fi
           fi

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -202,15 +202,21 @@ jobs:
 
       - name: Start application (Docker)
         if: inputs.image_tag != ''
+        env:
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
         run: |
           IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
           echo "Pulling ${IMAGE}..."
           docker pull "${IMAGE}"
 
+          printf '%s\n' \
+            "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test" \
+            "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
+            "NODE_ENV=production" \
+            > /tmp/keeperhub-app.env
+
           docker run -d --name keeperhub-app --network host \
-            -e DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test \
-            -e BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }} \
-            -e NODE_ENV=production \
+            --env-file /tmp/keeperhub-app.env \
             "${IMAGE}"
 
           for i in $(seq 1 30); do
@@ -356,15 +362,21 @@ jobs:
 
       - name: Start application (Docker)
         if: inputs.image_tag != ''
+        env:
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
         run: |
           IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
           echo "Pulling ${IMAGE}..."
           docker pull "${IMAGE}"
 
+          printf '%s\n' \
+            "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test" \
+            "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
+            "NODE_ENV=production" \
+            > /tmp/keeperhub-app.env
+
           docker run -d --name keeperhub-app --network host \
-            -e DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test \
-            -e BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }} \
-            -e NODE_ENV=production \
+            --env-file /tmp/keeperhub-app.env \
             "${IMAGE}"
 
           for i in $(seq 1 30); do

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -24,6 +24,21 @@ on:
         type: string
         required: false
         default: ''
+      image_tag:
+        description: 'ECR image tag (short SHA). When provided, runs app from Docker instead of bare-metal build.'
+        type: string
+        required: false
+        default: ''
+      ecr_registry:
+        description: 'ECR registry URL'
+        type: string
+        required: false
+        default: ''
+      ecr_repo:
+        description: 'ECR repository name'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch: {}
 
 jobs:
@@ -118,15 +133,6 @@ jobs:
         with:
           discover-plugins: "true"
 
-      - name: Cache Next.js build
-        uses: actions/cache@v4
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-
-
       - name: Wait for services
         run: |
           # Wait for PostgreSQL (max 60s)
@@ -178,16 +184,67 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
+      # --- Docker path: pull pre-built image from ECR (push to staging/prod) ---
+      - name: Configure AWS credentials
+        if: inputs.image_tag != ''
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to AWS ECR
+        if: inputs.image_tag != ''
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Start application (Docker)
+        if: inputs.image_tag != ''
+        run: |
+          IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
+          echo "Pulling ${IMAGE}..."
+          docker pull "${IMAGE}"
+
+          docker run -d --name keeperhub-app --network host \
+            -e DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test \
+            -e BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }} \
+            -e NODE_ENV=production \
+            "${IMAGE}"
+
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "App is ready (Docker)"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "App did not start in 60s"
+              docker logs keeperhub-app
+              exit 1
+            fi
+            sleep 2
+          done
+
+      # --- Bare-metal path: build locally (PRs, workflow_dispatch) ---
+      - name: Cache Next.js build
+        if: inputs.image_tag == ''
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
       - name: Build application
+        if: inputs.image_tag == ''
         run: pnpm build
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
       - name: Start application
+        if: inputs.image_tag == ''
         run: |
           pnpm start &
-          # Wait for app to be ready (max 60s)
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000 > /dev/null 2>&1; then
               echo "App is ready"
@@ -203,6 +260,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
+      # --- Tests (same for both paths) ---
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
         env:
@@ -216,6 +274,14 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
+
+      - name: Dump app container logs
+        if: failure() && inputs.image_tag != ''
+        run: docker logs keeperhub-app 2>&1 | tail -200
+
+      - name: Stop app container
+        if: always() && inputs.image_tag != ''
+        run: docker rm -f keeperhub-app || true
 
       - name: Upload test results
         if: failure()
@@ -272,7 +338,48 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
+      # --- Docker path: pull pre-built image from ECR (push to staging/prod) ---
+      - name: Configure AWS credentials
+        if: inputs.image_tag != ''
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to AWS ECR
+        if: inputs.image_tag != ''
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Start application (Docker)
+        if: inputs.image_tag != ''
+        run: |
+          IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
+          echo "Pulling ${IMAGE}..."
+          docker pull "${IMAGE}"
+
+          docker run -d --name keeperhub-app --network host \
+            -e DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test \
+            -e BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }} \
+            -e NODE_ENV=production \
+            "${IMAGE}"
+
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "App is ready (Docker)"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "App did not start in 60s"
+              docker logs keeperhub-app
+              exit 1
+            fi
+            sleep 2
+          done
+
+      # --- Bare-metal path: build locally (PRs, workflow_dispatch) ---
       - name: Cache Next.js build
+        if: inputs.image_tag == ''
         uses: actions/cache@v4
         with:
           path: .next/cache
@@ -282,15 +389,16 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Build application
+        if: inputs.image_tag == ''
         run: pnpm build
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
       - name: Start application
+        if: inputs.image_tag == ''
         run: |
           pnpm start &
-          # Wait for app to be ready (max 60s)
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000 > /dev/null 2>&1; then
               echo "App is ready"
@@ -306,6 +414,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
+      # --- Tests (same for both paths) ---
       - name: Run Playwright tests
         run: pnpm test:e2e
         env:
@@ -320,6 +429,14 @@ jobs:
           PARA_PORTAL_KEY_ID: ${{ secrets.PARA_PORTAL_KEY_ID }}
           PARA_PORTAL_API_KEY: ${{ secrets.PARA_PORTAL_API_KEY }}
           CI: true
+
+      - name: Dump app container logs
+        if: failure() && inputs.image_tag != ''
+        run: docker logs keeperhub-app 2>&1 | tail -200
+
+      - name: Stop app container
+        if: always() && inputs.image_tag != ''
+        run: docker rm -f keeperhub-app || true
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -290,7 +290,9 @@ jobs:
 
       - name: Stop app container
         if: always() && inputs.image_tag != ''
-        run: docker rm -f keeperhub-app || true
+        run: |
+          docker rm -f keeperhub-app || true
+          rm -f /tmp/keeperhub-app.env
 
       - name: Upload test results
         if: failure()
@@ -451,7 +453,9 @@ jobs:
 
       - name: Stop app container
         if: always() && inputs.image_tag != ''
-        run: docker rm -f keeperhub-app || true
+        run: |
+          docker rm -f keeperhub-app || true
+          rm -f /tmp/keeperhub-app.env
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -39,6 +39,11 @@ on:
         type: string
         required: false
         default: ''
+      ecr_region:
+        description: 'AWS region for ECR'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch: {}
 
 jobs:
@@ -189,7 +194,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: ${{ inputs.ecr_region }}
 
       - name: Login to AWS ECR
         if: inputs.image_tag != ''
@@ -343,7 +348,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: ${{ inputs.ecr_region }}
 
       - name: Login to AWS ECR
         if: inputs.image_tag != ''

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -58,11 +58,7 @@ jobs:
         env:
           EFFECTIVE_EVENT: ${{ inputs.caller_event || github.event_name }}
         run: |
-          {
-            echo "run-e2e=false"
-            echo "run-deployed=false"
-            echo "pr-number="
-          } >> "$GITHUB_OUTPUT"
+          echo "run-e2e=false" >> "$GITHUB_OUTPUT"
 
           # Check for [skip e2e] flag in commit message (push events only)
           if [[ "$EFFECTIVE_EVENT" == "push" ]]; then

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -187,89 +187,18 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
-      # --- Docker path: pull pre-built image from ECR (push to staging/prod) ---
-      - name: Configure AWS credentials
-        if: inputs.image_tag != ''
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.ecr_region }}
-
-      - name: Login to AWS ECR
-        if: inputs.image_tag != ''
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Start application (Docker)
-        if: inputs.image_tag != ''
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-        run: |
-          IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
-          echo "Pulling ${IMAGE}..."
-          docker pull "${IMAGE}"
-
-          printf '%s\n' \
-            "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test" \
-            "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
-            "NODE_ENV=production" \
-            > /tmp/keeperhub-app.env
-
-          docker run -d --name keeperhub-app --network host \
-            --env-file /tmp/keeperhub-app.env \
-            "${IMAGE}"
-
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "App is ready (Docker)"
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "App did not start in 60s"
-              docker logs keeperhub-app
-              exit 1
-            fi
-            sleep 2
-          done
-
-      # --- Bare-metal path: build locally (PRs, workflow_dispatch) ---
-      - name: Cache Next.js build
-        if: inputs.image_tag == ''
-        uses: actions/cache@v4
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-
-
-      - name: Build application
-        if: inputs.image_tag == ''
-        run: pnpm build
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-
       - name: Start application
-        if: inputs.image_tag == ''
-        run: |
-          pnpm start &
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "App is ready"
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "App did not start in 60s"
-              exit 1
-            fi
-            sleep 2
-          done
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+        uses: ./.github/actions/start-app
+        with:
+          image_tag: ${{ inputs.image_tag }}
+          ecr_registry: ${{ inputs.ecr_registry }}
+          ecr_repo: ${{ inputs.ecr_repo }}
+          ecr_region: ${{ inputs.ecr_region }}
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
+          better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
 
-      # --- Tests (same for both paths) ---
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
         env:
@@ -349,89 +278,18 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
-      # --- Docker path: pull pre-built image from ECR (push to staging/prod) ---
-      - name: Configure AWS credentials
-        if: inputs.image_tag != ''
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.ecr_region }}
-
-      - name: Login to AWS ECR
-        if: inputs.image_tag != ''
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Start application (Docker)
-        if: inputs.image_tag != ''
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-        run: |
-          IMAGE="${{ inputs.ecr_registry }}/${{ inputs.ecr_repo }}:app-${{ inputs.image_tag }}"
-          echo "Pulling ${IMAGE}..."
-          docker pull "${IMAGE}"
-
-          printf '%s\n' \
-            "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/keeperhub_test" \
-            "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
-            "NODE_ENV=production" \
-            > /tmp/keeperhub-app.env
-
-          docker run -d --name keeperhub-app --network host \
-            --env-file /tmp/keeperhub-app.env \
-            "${IMAGE}"
-
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "App is ready (Docker)"
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "App did not start in 60s"
-              docker logs keeperhub-app
-              exit 1
-            fi
-            sleep 2
-          done
-
-      # --- Bare-metal path: build locally (PRs, workflow_dispatch) ---
-      - name: Cache Next.js build
-        if: inputs.image_tag == ''
-        uses: actions/cache@v4
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-
-
-      - name: Build application
-        if: inputs.image_tag == ''
-        run: pnpm build
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-
       - name: Start application
-        if: inputs.image_tag == ''
-        run: |
-          pnpm start &
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "App is ready"
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "App did not start in 60s"
-              exit 1
-            fi
-            sleep 2
-          done
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+        uses: ./.github/actions/start-app
+        with:
+          image_tag: ${{ inputs.image_tag }}
+          ecr_registry: ${{ inputs.ecr_registry }}
+          ecr_repo: ${{ inputs.ecr_repo }}
+          ecr_region: ${{ inputs.ecr_region }}
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
+          better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
 
-      # --- Tests (same for both paths) ---
       - name: Run Playwright tests
         run: pnpm test:e2e
         env:


### PR DESCRIPTION
## Summary

Build Docker images once per SHA and reuse across e2e tests and deploy.

Previously the pipeline built the app twice per push: once bare-metal for e2e testing, once as Docker for deploy. The artifact tested was not the artifact deployed.

Now: build Docker images once -> e2e pulls that image and tests it -> deploy uses the same image tag for Helm.

### Changes

- Add `build-images.yml` reusable workflow that builds via `docker-bake.hcl`, pushes to ECR, and skips if images already exist for the commit SHA (checks both `app` and `migrator` targets)
- Refactor `ci-pipeline.yml`: `build-images` -> `e2e-tests` -> `deploy`, passing image coordinates between jobs
- Move `workflow_dispatch` from deploy to `ci-pipeline.yml` so manual triggers go through the full pipeline
- Make `deploy-keeperhub.yaml` a pure deployer (212 -> 130 lines): removed all Docker build steps, build-only env vars, and `skip_build` input
- Extract `start-app` composite action to deduplicate app startup logic across e2e test jobs (Docker path for push events, bare-metal fallback for PRs)
- Skip ephemeral e2e on push to prod (already passed on staging, remote e2e validates prod post-deploy)

### Hardening

- Pass secrets via env file instead of docker run args to avoid leaking in `ps` output
- Fix expression injection: use env blocks instead of inline `${{ }}` in run scripts
- Validate commit SHA output to prevent empty/malformed image tags
- Check both `app` and `migrator` images exist before skipping build (prevents partial push causing deploy failure)
- Fix all shellcheck warnings (SC2086/SC2016/SC2129)

### Impact

| Area | Before | After |
|------|--------|-------|
| Builds per push | 2 (bare-metal e2e + Docker deploy) | 1 (Docker, reused) |
| E2e tests the deployed artifact | No | Yes (same image) |
| Failed e2e rerun | Rebuilds everything | Skips build (ECR existence check) |
| Secrets in `ps` output | Visible via `docker run -e` | Hidden via `--env-file` |
| Deploy workflow | 212 lines, builds + deploys | 130 lines, deploys only |
| Build config locations | 2 (could drift) | 1 (build-images.yml only) |
| Manual dispatch | Separate path with own build logic | Same pipeline as push |

### Known limitations

- Images are per-environment (staging/prod) because `NEXT_PUBLIC_*` vars are baked at build time by Next.js. A staging image cannot be promoted to prod without rebuilding.
- E2e only tests the `app` image, not the `migrator` image. A broken migration would pass e2e and fail at deploy.

## Test plan

- [ ] Push to staging: verify build-images builds once, e2e pulls from ECR, deploy uses same tag
- [ ] Re-run e2e job: verify image exists check skips Docker build (both app + migrator checked)
- [ ] PR with `run-e2e-tests-ephemeral` label: verify bare-metal build path still works
- [ ] Push to prod: verify ephemeral e2e is skipped, deploy runs directly
- [ ] `workflow_dispatch` on ci-pipeline: verify full pipeline runs (build -> e2e -> deploy)