### PR TITLE
docs: rewrite FAQ, unhide API section, and fix API key docs

### DIFF
--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -25,7 +25,7 @@ export const metadata = {
 };
 
 // Hidden sections that should not appear in sidebar
-const HIDDEN_SECTIONS = ["api", "plans-features", "keeperhub"];
+const HIDDEN_SECTIONS = ["plans-features", "keeperhub"];
 
 // Filter and reorder page map items
 function filterPageMap(

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -149,6 +149,72 @@ Yes. The [MCP server](/ai-tools/mcp-server) exposes 19 tools that let AI agents 
 
 ---
 
+## MCP and AI agent setup
+
+### What is the MCP server?
+
+The KeeperHub [MCP server](/ai-tools/mcp-server) lets AI agents (Claude, custom agents, etc.) create, run, and monitor workflows over the [Model Context Protocol](https://modelcontextprotocol.io). It exposes 19 tools covering workflow CRUD, execution, plugin discovery, template deployment, and integration management.
+
+### How do I set up the MCP server?
+
+You need an organization-scoped API key (prefix `kh_`). Create one in Settings > API Keys > Organisation tab.
+
+Then pick a transport mode:
+
+**Docker (recommended):**
+```bash
+docker build -t keeperhub-mcp .
+docker run -i --rm -e KEEPERHUB_API_KEY=kh_your_key keeperhub-mcp
+```
+
+**Node.js:**
+```bash
+pnpm install && pnpm build
+KEEPERHUB_API_KEY=kh_your_key pnpm start
+```
+
+**Via Claude Code Plugin** -- if you install the [Claude Code plugin](/ai-tools/claude-code-plugin), the MCP server is set up automatically. No manual config needed.
+
+Source code and full docs: [github.com/techops-services/keeperhub-mcp](https://github.com/techops-services/keeperhub-mcp)
+
+### How do I connect Claude Code to KeeperHub?
+
+Add this to your MCP client config (e.g. `~/.claude.json`):
+
+```json
+{
+  "mcpServers": {
+    "keeperhub": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "KEEPERHUB_API_KEY", "keeperhub-mcp"],
+      "env": {
+        "KEEPERHUB_API_KEY": "kh_your_key_here"
+      }
+    }
+  }
+}
+```
+
+Or skip the manual config entirely -- install the Claude Code plugin and run `/keeperhub:login`:
+
+```bash
+/plugin marketplace add techops-services/claude-plugins
+/plugin install keeperhub@techops-plugins
+/keeperhub:login
+```
+
+Restart Claude Code after setup. You can verify with `/keeperhub:status`.
+
+### What's the difference between `kh_` and `wfb_` API keys?
+
+`kh_` keys are organization-scoped -- required for the MCP server and Claude Code plugin. `wfb_` keys are user-scoped and work with the REST API. The MCP server won't accept `wfb_` keys.
+
+### Can I run the MCP server for remote agents (not just local)?
+
+Yes. Set the `PORT` and `MCP_API_KEY` environment variables to enable HTTP/SSE mode. Remote agents connect via `GET /sse` for the event stream and `POST /message` for commands. All requests require `Authorization: Bearer <MCP_API_KEY>`.
+
+---
+
 ## API and integrations
 
 ### Is there an API?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -5,112 +5,111 @@ description: "Frequently asked questions about KeeperHub - getting started, secu
 
 # Frequently Asked Questions
 
-## Getting Started
+## Getting started
 
 ### What is KeeperHub?
 
 KeeperHub is a no-code blockchain automation platform. You build visual workflows that monitor onchain state, execute transactions, and send notifications -- without writing code or managing infrastructure. It works with Ethereum, Base, Arbitrum, Polygon, and other EVM-compatible chains.
 
-Common use cases include treasury monitoring, DeFi position management, event-driven alerting, and recurring onchain operations like reward distribution or collateral top-ups.
+People use it for things like treasury monitoring, DeFi position management, event-driven alerting, and recurring onchain operations (reward distribution, collateral top-ups, that sort of thing).
 
 ### How do I get started?
 
 1. Create an account at [app.keeperhub.com](https://app.keeperhub.com)
 2. Set up your Para wallet in the Web3 integration settings
-3. Fund your wallet with ETH on your target network (start with Sepolia testnet to experiment for free)
-4. Build a workflow using the visual builder or the AI assistant
-5. Test with a manual trigger before enabling automated scheduling
-6. Monitor execution through the run logs
+3. Fund your wallet with ETH on the network you want to use (start with Sepolia -- it's free)
+4. Build a workflow with the visual builder or the AI assistant
+5. Test with a manual trigger before turning on automated scheduling
+6. Watch the run logs to make sure everything behaves
 
-See the [Quick Start Guide](/getting-started/quickstart) for a full walkthrough.
+The [Quick Start Guide](/getting-started/quickstart) walks through this in detail.
 
 ### Do I need to know how to code?
 
-No. The visual builder handles most automation patterns through drag-and-drop nodes for triggers, actions, conditions, and loops. You can also describe what you want in plain English using the AI assistant.
+No. The visual builder covers most automation patterns with drag-and-drop nodes -- triggers, actions, conditions, loops. You can also just describe what you want in plain English and the AI assistant will generate a workflow for you.
 
-For cases that need custom logic, the [Code Plugin](/plugins/code) lets you write JavaScript in a sandboxed environment. For fully programmatic control, the [REST API](/api) and [MCP server](/ai-tools/mcp-server) let you manage workflows from code or AI agents.
+If you do need custom logic, the [Code Plugin](/plugins/code) runs JavaScript in a sandbox. And if you want full programmatic control, there's a [REST API](/api) and an [MCP server](/ai-tools/mcp-server) for managing workflows from code or AI agents.
 
 ### What blockchains does KeeperHub support?
 
-Ethereum Mainnet, Base, Arbitrum, Polygon, Optimism, and Sepolia (testnet). Gas defaults are applied automatically per chain, with L2 networks using lower gas multipliers since their estimates tend to be more accurate.
+Ethereum Mainnet, Base, Arbitrum, Polygon, Optimism, and Sepolia (testnet). Gas defaults are applied automatically per chain -- L2s like Base and Arbitrum use lower gas multipliers since their estimates tend to be tighter.
 
-Some protocol plugins have chain-specific restrictions -- for example, Ajna is Base-only, and Sky converters are Ethereum-only. Check each plugin's documentation for supported chains.
+Some protocol plugins only work on certain chains. Ajna is Base-only, Sky converters are Ethereum-only, and so on. Check each plugin's docs for specifics.
 
-Non-EVM chains (Solana, Cosmos, Bitcoin L2s) are not currently supported.
+Non-EVM chains (Solana, Cosmos, Bitcoin L2s) are not supported.
 
 ### What DeFi protocols does KeeperHub integrate with?
 
-KeeperHub has dedicated plugins for [Aave V3](/plugins/aave-v3) (lending/borrowing), [Morpho](/plugins/morpho) (lending), [Uniswap](/plugins/uniswap) (DEX/liquidity), [CoW Swap](/plugins/cowswap) (MEV-protected orders), [Pendle](/plugins/pendle) (yield tokenization), [Sky](/plugins/sky) (savings/converters), [Ajna](/plugins/ajna) (liquidation), and [Safe](/plugins/safe) (multisig monitoring).
+There are dedicated plugins for [Aave V3](/plugins/aave-v3) (lending/borrowing), [Morpho](/plugins/morpho) (lending), [Uniswap](/plugins/uniswap) (DEX/liquidity), [CoW Swap](/plugins/cowswap) (MEV-protected orders), [Pendle](/plugins/pendle) (yield tokenization), [Sky](/plugins/sky) (savings/converters), [Ajna](/plugins/ajna) (liquidation), and [Safe](/plugins/safe) (multisig monitoring).
 
-Beyond these, you can interact with any smart contract through the generic [Web3 plugin](/plugins/web3) by providing a contract address -- the ABI is fetched automatically, including for proxy contracts.
+You can also interact with any smart contract through the [Web3 plugin](/plugins/web3) -- just provide a contract address and the ABI is fetched automatically, including for proxy contracts.
 
 ---
 
-## Wallet and Funds
+## Wallet and funds
 
 ### How does the wallet work? Do I need to bring my own?
 
-When you create a KeeperHub account, you can set up a [Para wallet](/wallet-management/para) through the Web3 integration settings. It uses multi-party computation (MPC) -- the private key is split between you and Para so neither party can sign alone, but automated signing is seamless during workflow execution.
+You set up a [Para wallet](/wallet-management/para) through the Web3 integration settings after creating your account. It uses multi-party computation (MPC) -- the private key is split between you and Para so neither party can sign alone, but signing during workflow execution happens automatically.
 
-Read-only operations (checking balances, reading contracts, monitoring events) do not require any ETH. Write operations (transfers, contract calls) execute through your Para wallet and require ETH for gas on the target network.
+Read-only operations (checking balances, reading contracts, monitoring events) don't require any ETH. Write operations (transfers, contract calls) go through your Para wallet and need ETH for gas on the target network.
 
 ### Who controls my funds? Can KeeperHub or Para access my wallet without permission?
 
-Your Para wallet uses MPC where the private key is split into shares held by you and Para -- neither party can sign a transaction alone. This means:
+Your Para wallet uses MPC -- the private key is split into shares held by you and Para. Neither party can sign a transaction alone. KeeperHub employees can't move your funds, and Para can't either.
 
-- KeeperHub employees cannot move your funds unilaterally
-- Para cannot move your funds unilaterally
-
-The tradeoff: you get convenience and automated signing for workflows, but you are trusting Para's infrastructure to be available for signing operations.
+The tradeoff is that you're trusting Para's infrastructure to be available when your workflows need to sign transactions. If Para goes down, write operations won't execute until it recovers.
 
 ### How do I fund my wallet?
 
-Transfer ETH to your Para wallet address on the network you want to use. Your wallet address is the same across all EVM networks. You can find it in the Wallet tab of your account.
+Transfer ETH to your Para wallet address on the network you want to use. The address is the same across all EVM networks -- you can find it in the Wallet tab.
 
-We recommend starting on the Sepolia testnet, where you can get free test ETH from public faucets to experiment without risking real funds.
+Start on Sepolia. You can get free test ETH from public faucets and experiment without risking real money.
 
 ### Can I export my private key?
 
-Private key export is not currently supported but is planned for a future release. In the meantime, your funds remain accessible through your Para wallet in KeeperHub. We will announce when this feature becomes available.
+Not yet. Private key export is planned but not currently available. Your funds are accessible through your Para wallet in KeeperHub, and we'll announce when export ships.
 
 ---
 
-## Security and Trust
+## Security and trust
 
 ### Is KeeperHub safe for production use with real funds?
 
-KeeperHub is designed for production use. The platform provides automatic gas estimation with safety buffers, transaction retry logic, nonce management, and MPC wallet security. Several best practices help minimize risk:
+Yes, KeeperHub is built for production use -- automatic gas estimation with safety buffers, transaction retries, nonce management, MPC wallet security.
 
-- **Test on Sepolia first** before switching to mainnet
-- **Use condition nodes** to validate onchain state before write operations
-- **Monitor your wallet balance** and set spending caps
-- **Review run logs** regularly to catch unexpected behavior early
+That said, some things are worth doing:
+
+- Test on Sepolia before switching to mainnet
+- Use condition nodes to check onchain state before write operations
+- Keep an eye on your wallet balance and set spending caps
+- Check run logs regularly
 
 ### Can KeeperHub employees see my workflows or data?
 
-API keys are hashed with SHA256 before storage -- only the prefix is stored for identification. Wallet private keys are managed by Para, not stored by KeeperHub. Workflow configurations and execution logs are stored in KeeperHub's database as necessary for the platform to function (it needs your workflow configuration to execute it, and stores logs for debugging and analytics).
+API keys are hashed (SHA256) before storage -- only the prefix is kept for identification. Wallet private keys are managed by Para, not stored by KeeperHub.
+
+Workflow configurations and execution logs are stored in KeeperHub's database because the platform needs them to run your workflows and show you debugging info. So yes, that data exists on KeeperHub's infrastructure.
 
 ### What happens to pending transactions during a platform outage?
 
-Transactions that have already been submitted to the blockchain will continue to process regardless of KeeperHub's status -- blockchain transactions are independent of KeeperHub once submitted. Scheduled workflows that would have fired during an outage will not execute until the platform recovers. For time-critical automations like liquidation protection, consider running redundant monitoring through additional channels.
+Transactions already submitted to the blockchain keep processing -- they don't depend on KeeperHub once they're on the network. Scheduled workflows that would have fired during an outage won't run until the platform recovers. If you're running time-critical automations (liquidation protection, for instance), consider redundant monitoring through other channels.
 
 ### What data does KeeperHub collect?
 
-KeeperHub stores your account information, workflow configurations (node types, contract addresses, parameters, conditions), and execution logs (inputs, outputs, transaction hashes, gas usage). This data is necessary for the platform to execute your workflows and provide debugging and analytics. API keys are hashed before storage, and wallet private keys are managed by Para, not by KeeperHub.
+Account info, workflow configurations (node types, contract addresses, parameters, conditions), and execution logs (inputs, outputs, transaction hashes, gas usage). The platform needs this data to run workflows and provide analytics. API keys are hashed before storage, and wallet private keys are managed by Para.
 
 ---
 
-## Workflows and Execution
+## Workflows and execution
 
 ### What happens if a workflow fails mid-execution?
 
-Blockchain transactions are irreversible. If a workflow fails at step 4, any transactions confirmed in steps 1-3 cannot be rolled back. KeeperHub records the status of every step in the [Runs panel](/keeper-runs/overview) with full error context -- inputs, outputs, transaction hashes, and error messages -- so you can diagnose exactly what happened.
+Blockchain transactions are irreversible. If step 4 fails, whatever transactions steps 1-3 already confirmed on-chain can't be rolled back. KeeperHub records the status of every step in the [Runs panel](/keeper-runs/overview) with full context -- inputs, outputs, transaction hashes, error messages.
 
-KeeperHub's retry logic re-attempts failed steps with exponential backoff. To mitigate risk: test on Sepolia first, use condition nodes to validate state before write operations, and set up redundant notifications so failures are always reported.
+Failed steps are retried with exponential backoff. To reduce risk: test on Sepolia first, use condition nodes to validate state before write operations, and set up notifications so you always hear about failures.
 
 ### What are the execution limits?
-
-Known limits:
 
 | Limit | Value |
 |-------|-------|
@@ -123,81 +122,83 @@ Known limits:
 
 ### How does gas estimation work?
 
-KeeperHub calls `eth_estimateGas` and applies a chain-specific multiplier to prevent failed transactions:
+KeeperHub calls `eth_estimateGas` and applies a multiplier per chain:
 
-- **Ethereum and Polygon**: 2.0x standard, 2.5x for time-sensitive triggers (events, webhooks)
-- **Base and Arbitrum**: 1.5x standard, 2.0x for time-sensitive triggers
+- Ethereum and Polygon: 2.0x normally, 2.5x for time-sensitive triggers (events, webhooks)
+- Base and Arbitrum: 1.5x normally, 2.0x for time-sensitive triggers
 
-You can override the gas limit per action node in the Advanced section. Gas pricing (base fee, priority fee) is handled automatically by KeeperHub's adaptive fee strategy. See [Gas Management](/wallet-management/gas) for details.
+You can override the gas limit on any action node in its Advanced section. Gas pricing (base fee, priority fee) is handled automatically. See [Gas Management](/wallet-management/gas) for more.
 
 ### How does the AI workflow builder work?
 
-Click the "Ask AI" input at the bottom of the workflow canvas and describe your automation in plain language -- for example, "Monitor my vault health every 15 minutes and send a Telegram alert if collateral drops below 150%." The AI generates a workflow structure with appropriate triggers, actions, conditions, and node configurations. You review and customize the generated workflow before enabling it.
+Click "Ask AI" at the bottom of the workflow canvas and describe what you want -- for example, "Monitor my vault health every 15 minutes and send a Telegram alert if collateral drops below 150%." The AI generates a workflow with triggers, actions, and conditions that you can review and tweak before turning it on.
 
-The AI can also be accessed programmatically through the [MCP server's](/ai-tools/mcp-server) `ai_generate_workflow` tool.
+You can also use this programmatically through the [MCP server's](/ai-tools/mcp-server) `ai_generate_workflow` tool.
 
 ### How do I pass data between workflow steps?
 
-Each node's output is automatically available to downstream nodes through template references using the syntax `{{@nodeId:Label.field}}`. For example, if a "Check Balance" node outputs a balance value, a downstream condition node can reference it as `{{@checkBalance:Check Balance.balance}}`. You can include these references in notification messages, condition expressions, and action parameters. See [Core Concepts](/intro/concepts) for details.
+Each node's output is available to downstream nodes through template references: `{{@nodeId:Label.field}}`. So if a "Check Balance" node outputs a balance, a condition node downstream can reference `{{@checkBalance:Check Balance.balance}}`. These references work in notification messages, condition expressions, and action parameters. See [Core Concepts](/intro/concepts) for the full syntax.
 
 ### Does KeeperHub handle token approvals automatically?
 
-No. Approval flows are not automatic. You must add an explicit "Approve ERC20 Token" node before any write operation that requires a token allowance (swaps, lending deposits, etc.). You can also use the "Check ERC20 Allowance" node to verify existing approvals before proceeding.
+No. You need to add an "Approve ERC20 Token" node before any write operation that requires a token allowance -- swaps, lending deposits, etc. There's also a "Check ERC20 Allowance" node if you want to verify existing approvals first.
 
 ### Can AI agents use KeeperHub autonomously?
 
-Yes. KeeperHub provides an [MCP server](/ai-tools/mcp-server) with 19 tools that let AI agents create, trigger, execute, and monitor workflows programmatically. This makes KeeperHub an execution layer where autonomous agents can delegate their onchain actions. There is also a Claude Code plugin for developers who want to build workflows from the terminal.
+Yes. The [MCP server](/ai-tools/mcp-server) exposes 19 tools that let AI agents create, trigger, run, and monitor workflows programmatically. There's also a Claude Code plugin for building workflows from the terminal.
 
 ---
 
-## API and Integrations
+## API and integrations
 
 ### Is there an API?
 
-Yes. The REST API at `app.keeperhub.com/api` supports full workflow CRUD, execution, analytics, and integration management. Authenticate with API keys using a Bearer token. See the [API documentation](/api) for all endpoints.
+Yes. The REST API at `app.keeperhub.com/api` covers workflow CRUD, execution, analytics, and integration management. Authenticate with API keys (Bearer token). See the [API docs](/api) for endpoints.
 
 ### What notification channels are supported?
 
-[Discord](/plugins/discord) (via webhook URL), [Telegram](/plugins/telegram) (via bot token), [SendGrid email](/plugins/sendgrid), and generic [webhooks](/plugins/webhook). You set up connections once in your account settings and reuse them across all workflows.
+[Discord](/plugins/discord) (webhook URL), [Telegram](/plugins/telegram) (bot token), [SendGrid email](/plugins/sendgrid), and generic [webhooks](/plugins/webhook). Set up connections once in account settings and reuse them across workflows.
 
 ### Can I export or version-control my workflows?
 
-You can download any workflow as JSON using the Download button in the toolbar or `GET /api/workflows/{workflowId}/download`. SDK code can be generated via `GET /api/workflows/{workflowId}/code`. You can also duplicate workflows via the API or the Hub. There is no built-in version history or CI/CD integration yet, but the MCP server's `create_workflow` and `update_workflow` tools can be used to build a custom GitOps pipeline.
+You can download any workflow as JSON from the toolbar or via `GET /api/workflows/{workflowId}/download`. SDK code generation is available at `GET /api/workflows/{workflowId}/code`. Duplication works through the API or the Hub.
+
+There's no built-in version history or CI/CD integration yet. If you need that, the MCP server's `create_workflow` and `update_workflow` tools can be wired into a custom GitOps pipeline.
 
 ---
 
-## Account and Organization
+## Account and organization
 
 ### How do teams and organizations work?
 
-You can create organizations with unique slugs, invite team members via email, and share workflows within the organization. All organization members currently have equal permissions -- there are no admin, editor, or viewer roles yet. Role-based access control is planned. As a workaround, create separate organizations for different access needs and limit membership to trusted collaborators.
+You can create organizations, invite team members via email, and share workflows within the org. Right now all members have equal permissions -- there are no admin, editor, or viewer roles. Role-based access control is planned. In the meantime, use separate organizations if you need different access levels.
 
 See [Organizations](/users-teams-orgs/organizations) for details.
 
 ### What happens if I lose access to my account?
 
-You can reset your password via a one-time code sent to your email. If you use OAuth (Google, GitHub), you are directed to your provider for recovery.
+Reset your password with a one-time code sent to your email. OAuth users (Google, GitHub) go through their provider's recovery flow.
 
 ### What happens if I delete my account?
 
-Account deletion is a soft delete -- your data is preserved but your account is deactivated, and all sessions are invalidated. You can reactivate by contacting an administrator. Before deleting, export your workflow definitions if you want to retain them.
+Deletion is a soft delete -- your data is preserved but the account is deactivated and all sessions are invalidated. You can reactivate by contacting an administrator. Export your workflow definitions before deleting if you want to keep them.
 
 ---
 
-## Comparison and Migration
+## Comparison and migration
 
 ### How does KeeperHub compare to OpenZeppelin Defender, Gelato, or Chainlink Automation?
 
-KeeperHub differentiates with a no-code visual builder (vs YAML/code configuration), AI-assisted workflow generation, and managed MPC wallets (vs self-managed keys). Dedicated [Defender](/guides/defender-migration) and [Gelato](/guides/gelato-migration) migration guides include feature mapping tables and step-by-step transition plans.
+The main differences: KeeperHub has a visual no-code builder (vs YAML/code), AI-assisted workflow generation, and managed MPC wallets (vs self-managed keys). There are dedicated migration guides for [Defender](/guides/defender-migration) and [Gelato](/guides/gelato-migration) with feature mapping tables.
 
 OpenZeppelin Defender shuts down July 1, 2026. Gelato Web3 Functions shut down March 31, 2026.
 
-### When should I use a custom keeper bot instead of KeeperHub?
+### When should I use a custom keeper bot instead?
 
-A custom bot may be better when you need sub-second latency for MEV or arbitrage, complex stateful logic that does not fit a DAG of nodes, specific infrastructure requirements (custom RPC nodes, co-located servers), or zero third-party dependencies for security-critical operations.
+A custom bot makes more sense when you need sub-second latency (MEV, arbitrage), complex stateful logic that doesn't fit a DAG, specific infrastructure requirements (co-located servers, custom RPC nodes), or zero third-party dependencies.
 
-KeeperHub is the better choice when you want to avoid building and maintaining infrastructure, need to iterate quickly on automation logic without deploying code, want non-technical team members to create and modify automations, or need multi-chain support without managing separate deployments.
+KeeperHub makes more sense when you want to skip building infrastructure, need to iterate on automation logic quickly, want non-technical team members involved, or need multi-chain support without managing separate deployments.
 
 ### Can I use custom RPC endpoints?
 
-Yes. In Settings, you can set a primary and fallback RPC URL per chain. When set, your custom endpoints are used instead of the platform defaults. Deleting a preference reverts to the default RPC endpoints.
+Yes. In Settings, set a primary and fallback RPC URL per chain. Your custom endpoints replace the platform defaults. Delete the preference to revert.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,29 +1,205 @@
 ---
 title: "FAQ"
-description: "Frequently asked questions about KeeperHub - wallet management, account setup, and platform features."
+description: "Frequently asked questions about KeeperHub - getting started, security, workflows, pricing, and more."
 ---
 
 # Frequently Asked Questions
 
-## What is the Para wallet that was created for me?
+## Getting Started
 
-GetPara provides a fully self custodial embedded wallet for all attendees using **Multi-Party Computation (MPC)**.
+### What is KeeperHub?
 
-Your email is the unique identifier for your Para wallet, but you also have a wallet address.
+KeeperHub is a no-code blockchain automation platform. You build visual workflows that monitor onchain state, execute transactions, and send notifications -- without writing code or managing infrastructure. It works with Ethereum, Base, Arbitrum, Polygon, and other EVM-compatible chains.
 
-To learn more about Para, visit: https://blog.getpara.com/non-custodial-embedded-wallets/
+Common use cases include treasury monitoring, DeFi position management, event-driven alerting, and recurring onchain operations like reward distribution or collateral top-ups.
 
-# How do I export the Private Key from my Para wallet?
+### How do I get started?
 
-1. Navigate to the **Wallet** tab
-2. Tap on the **Settings** sub-tab
-3. Tap on **Export Private Key** within Wallet settings
-4. Follow the instructions provided by Para on their domain
+1. Create an account at [app.keeperhub.com](https://app.keeperhub.com) -- a Para wallet is provisioned automatically
+2. Fund your wallet with ETH on your target network (start with Sepolia testnet to experiment for free)
+3. Build a workflow using the visual builder or the AI assistant
+4. Test with a manual trigger before enabling automated scheduling
+5. Monitor execution through the run logs
 
-**IMPORTANT: PLEASE READ CAREFULLY**
+See the [Quick Start Guide](/getting-started/quickstart) for a full walkthrough.
 
-- **Never** share your private key or seed phrase with anyone
-- **Do not** store it in email, cloud drives, chat apps, screenshots, or unencrypted notes
-- Prefer storing the key/seed **offline**: encrypted password manager (with local vault), an air-gapped USB drive in a safe, or a hardware wallet
-- If you must write it down, use a physical copy kept in a secure place (e.g. safe)
-- After copying, **clear your clipboard** and close the export screen
+### Do I need to know how to code?
+
+No. The visual builder handles most automation patterns through drag-and-drop nodes for triggers, actions, conditions, and loops. You can also describe what you want in plain English using the AI assistant.
+
+For cases that need custom logic, the [Code Plugin](/plugins/code) lets you write JavaScript in a sandboxed environment. For fully programmatic control, the [REST API](/api) and [MCP server](/ai-tools/mcp-server) let you manage workflows from code or AI agents.
+
+### What blockchains does KeeperHub support?
+
+Ethereum Mainnet, Base, Arbitrum, Polygon, Optimism, and Sepolia (testnet). Gas defaults are applied automatically per chain, with L2 networks using lower gas multipliers since their estimates tend to be more accurate.
+
+Some protocol plugins have chain-specific restrictions -- for example, Ajna is Base-only, and Sky converters are Ethereum-only. Check each plugin's documentation for supported chains.
+
+Non-EVM chains (Solana, Cosmos, Bitcoin L2s) are not currently supported.
+
+### What DeFi protocols does KeeperHub integrate with?
+
+KeeperHub has dedicated plugins for [Aave V3](/plugins/aave-v3) (lending/borrowing), [Morpho](/plugins/morpho) (lending), [Uniswap](/plugins/uniswap) (DEX/liquidity), [CoW Swap](/plugins/cowswap) (MEV-protected orders), [Pendle](/plugins/pendle) (yield tokenization), [Sky](/plugins/sky) (savings/converters), [Ajna](/plugins/ajna) (liquidation), and [Safe](/plugins/safe) (multisig monitoring).
+
+Beyond these, you can interact with any smart contract through the generic [Web3 plugin](/plugins/web3) by providing a contract address -- the ABI is fetched automatically, including for proxy contracts.
+
+---
+
+## Wallet and Funds
+
+### How does the wallet work? Do I need to bring my own?
+
+When you create a KeeperHub account, a [Para wallet](/wallet-management/para) is automatically generated for you. It uses multi-party computation (MPC) -- the private key is split between you and Para so neither party can sign alone, but automated signing is seamless during workflow execution.
+
+Read-only operations (checking balances, reading contracts, monitoring events) do not require any ETH. Write operations (transfers, contract calls) execute through your Para wallet and require ETH for gas on the target network.
+
+### Who controls my funds? Can KeeperHub or Para access my wallet without permission?
+
+Your Para wallet uses MPC where the private key is split into shares held by you and Para -- neither party can sign a transaction alone. This means:
+
+- KeeperHub employees cannot move your funds unilaterally
+- Para cannot move your funds unilaterally
+- You can [export your private key](/wallet-management/para) at any time from the Wallet Settings tab for full independent control
+
+The tradeoff: you get convenience and automated signing for workflows, but you are trusting Para's infrastructure to be available for signing operations.
+
+### How do I fund my wallet?
+
+Transfer ETH to your Para wallet address on the network you want to use. Your wallet address is the same across all EVM networks. You can find it in the Wallet tab of your account.
+
+We recommend starting on the Sepolia testnet, where you can get free test ETH from public faucets to experiment without risking real funds.
+
+### Can I export my private key?
+
+Yes. Navigate to the **Wallet** tab, tap **Settings**, then **Export Private Key**. Follow the instructions provided by Para on their domain.
+
+**Important**: Never share your private key or seed phrase with anyone. Do not store it in email, cloud drives, chat apps, screenshots, or unencrypted notes. Prefer storing the key offline in an encrypted password manager, air-gapped USB drive, or hardware wallet. After copying, clear your clipboard and close the export screen.
+
+---
+
+## Security and Trust
+
+### Is KeeperHub safe for production use with real funds?
+
+KeeperHub is designed for production use. The platform provides automatic gas estimation with safety buffers, transaction retry logic, nonce management, and MPC wallet security. Several best practices help minimize risk:
+
+- **Test on Sepolia first** before switching to mainnet
+- **Use condition nodes** to validate onchain state before write operations
+- **Monitor your wallet balance** and set spending caps
+- **Review run logs** regularly to catch unexpected behavior early
+
+### Can KeeperHub employees see my workflows or data?
+
+API keys are hashed with SHA256 before storage -- only the prefix is stored for identification. Wallet private keys are managed by Para, not stored by KeeperHub. Workflow configurations and execution logs are stored in KeeperHub's database as necessary for the platform to function (it needs your workflow configuration to execute it, and stores logs for debugging and analytics).
+
+### What happens to pending transactions during a platform outage?
+
+Transactions that have already been submitted to the blockchain will continue to process regardless of KeeperHub's status -- blockchain transactions are independent of KeeperHub once submitted. Scheduled workflows that would have fired during an outage will not execute until the platform recovers. For time-critical automations like liquidation protection, consider running redundant monitoring through additional channels.
+
+### What data does KeeperHub collect?
+
+KeeperHub stores your account information, workflow configurations (node types, contract addresses, parameters, conditions), and execution logs (inputs, outputs, transaction hashes, gas usage). This data is necessary for the platform to execute your workflows and provide debugging and analytics. API keys are hashed before storage, and wallet private keys are managed by Para, not by KeeperHub.
+
+---
+
+## Workflows and Execution
+
+### What happens if a workflow fails mid-execution?
+
+Blockchain transactions are irreversible. If a workflow fails at step 4, any transactions confirmed in steps 1-3 cannot be rolled back. KeeperHub records the status of every step in the [Runs panel](/keeper-runs/overview) with full error context -- inputs, outputs, transaction hashes, and error messages -- so you can diagnose exactly what happened.
+
+KeeperHub's retry logic re-attempts failed steps with exponential backoff. To mitigate risk: test on Sepolia first, use condition nodes to validate state before write operations, and set up redundant notifications so failures are always reported.
+
+### What are the execution limits?
+
+Known limits:
+
+| Limit | Value |
+|-------|-------|
+| API rate limit (authenticated) | 100 requests/minute |
+| API rate limit (unauthenticated) | 10 requests/minute |
+| Direct Execution API | 60 requests/minute per API key |
+| Code Plugin timeout | 1-120 seconds (default 60) |
+| Batch Read Contract | 5,000 total calls per execution |
+| Batch size per RPC request | 1-500 (default 100) |
+
+### How does gas estimation work?
+
+KeeperHub calls `eth_estimateGas` and applies a chain-specific multiplier to prevent failed transactions:
+
+- **Ethereum and Polygon**: 2.0x standard, 2.5x for time-sensitive triggers (events, webhooks)
+- **Base and Arbitrum**: 1.5x standard, 2.0x for time-sensitive triggers
+
+You can override the gas limit per action node in the Advanced section. Gas pricing (base fee, priority fee) is handled automatically by KeeperHub's adaptive fee strategy. See [Gas Management](/wallet-management/gas) for details.
+
+### How does the AI workflow builder work?
+
+Click the "Ask AI" input at the bottom of the workflow canvas and describe your automation in plain language -- for example, "Monitor my vault health every 15 minutes and send a Telegram alert if collateral drops below 150%." The AI generates a workflow structure with appropriate triggers, actions, conditions, and node configurations. You review and customize the generated workflow before enabling it.
+
+The AI can also be accessed programmatically through the [MCP server's](/ai-tools/mcp-server) `ai_generate_workflow` tool.
+
+### How do I pass data between workflow steps?
+
+Each node's output is automatically available to downstream nodes through template references using the syntax `{{@nodeId:Label.field}}`. For example, if a "Check Balance" node outputs a balance value, a downstream condition node can reference it as `{{@checkBalance:Check Balance.balance}}`. You can include these references in notification messages, condition expressions, and action parameters. See [Core Concepts](/intro/concepts) for details.
+
+### Does KeeperHub handle token approvals automatically?
+
+No. Approval flows are not automatic. You must add an explicit "Approve ERC20 Token" node before any write operation that requires a token allowance (swaps, lending deposits, etc.). You can also use the "Check ERC20 Allowance" node to verify existing approvals before proceeding.
+
+### Can AI agents use KeeperHub autonomously?
+
+Yes. KeeperHub provides an [MCP server](/ai-tools/mcp-server) with 19 tools that let AI agents create, trigger, execute, and monitor workflows programmatically. This makes KeeperHub an execution layer where autonomous agents can delegate their onchain actions. There is also a Claude Code plugin for developers who want to build workflows from the terminal.
+
+---
+
+## API and Integrations
+
+### Is there an API?
+
+Yes. The REST API at `app.keeperhub.com/api` supports full workflow CRUD, execution, analytics, and integration management. Authenticate with API keys using a Bearer token. See the [API documentation](/api) for all endpoints.
+
+### What notification channels are supported?
+
+[Discord](/plugins/discord) (via webhook URL), [Telegram](/plugins/telegram) (via bot token), [SendGrid email](/plugins/sendgrid), and generic [webhooks](/plugins/webhook). You set up connections once in your account settings and reuse them across all workflows.
+
+### Can I export or version-control my workflows?
+
+You can download any workflow as JSON using the Download button in the toolbar or `GET /api/workflows/{workflowId}/download`. SDK code can be generated via `GET /api/workflows/{workflowId}/code`. You can also duplicate workflows via the API or the Hub. There is no built-in version history or CI/CD integration yet, but the MCP server's `create_workflow` and `update_workflow` tools can be used to build a custom GitOps pipeline.
+
+---
+
+## Account and Organization
+
+### How do teams and organizations work?
+
+You can create organizations with unique slugs, invite team members via email, and share workflows within the organization. All organization members currently have equal permissions -- there are no admin, editor, or viewer roles yet. Role-based access control is planned. As a workaround, create separate organizations for different access needs and limit membership to trusted collaborators.
+
+See [Organizations](/users-teams-orgs/organizations) for details.
+
+### What happens if I lose access to my account?
+
+You can reset your password via a one-time code sent to your email. If you use OAuth (Google, GitHub), you are directed to your provider for recovery. While you have account access, you can export your Para wallet private key at any time from the Wallet Settings tab to ensure you always have independent control of your funds.
+
+### What happens if I delete my account?
+
+Account deletion is a soft delete -- your data is preserved but your account is deactivated, and all sessions are invalidated. You can reactivate by contacting an administrator. Before deleting, export your workflow definitions and your Para wallet private key if you want to retain them.
+
+---
+
+## Comparison and Migration
+
+### How does KeeperHub compare to OpenZeppelin Defender, Gelato, or Chainlink Automation?
+
+KeeperHub differentiates with a no-code visual builder (vs YAML/code configuration), AI-assisted workflow generation, and managed MPC wallets (vs self-managed keys). Dedicated [Defender](/guides/defender-migration) and [Gelato](/guides/gelato-migration) migration guides include feature mapping tables and step-by-step transition plans.
+
+OpenZeppelin Defender shuts down July 1, 2026. Gelato Web3 Functions shut down March 31, 2026.
+
+### When should I use a custom keeper bot instead of KeeperHub?
+
+A custom bot may be better when you need sub-second latency for MEV or arbitrage, complex stateful logic that does not fit a DAG of nodes, specific infrastructure requirements (custom RPC nodes, co-located servers), or zero third-party dependencies for security-critical operations.
+
+KeeperHub is the better choice when you want to avoid building and maintaining infrastructure, need to iterate quickly on automation logic without deploying code, want non-technical team members to create and modify automations, or need multi-chain support without managing separate deployments.
+
+### Can I use custom RPC endpoints?
+
+Yes. In Settings, you can set a primary and fallback RPC URL per chain. When set, your custom endpoints are used instead of the platform defaults. Deleting a preference reverts to the default RPC endpoints.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -15,11 +15,12 @@ Common use cases include treasury monitoring, DeFi position management, event-dr
 
 ### How do I get started?
 
-1. Create an account at [app.keeperhub.com](https://app.keeperhub.com) -- a Para wallet is provisioned automatically
-2. Fund your wallet with ETH on your target network (start with Sepolia testnet to experiment for free)
-3. Build a workflow using the visual builder or the AI assistant
-4. Test with a manual trigger before enabling automated scheduling
-5. Monitor execution through the run logs
+1. Create an account at [app.keeperhub.com](https://app.keeperhub.com)
+2. Set up your Para wallet in the Web3 integration settings
+3. Fund your wallet with ETH on your target network (start with Sepolia testnet to experiment for free)
+4. Build a workflow using the visual builder or the AI assistant
+5. Test with a manual trigger before enabling automated scheduling
+6. Monitor execution through the run logs
 
 See the [Quick Start Guide](/getting-started/quickstart) for a full walkthrough.
 
@@ -49,7 +50,7 @@ Beyond these, you can interact with any smart contract through the generic [Web3
 
 ### How does the wallet work? Do I need to bring my own?
 
-When you create a KeeperHub account, a [Para wallet](/wallet-management/para) is automatically generated for you. It uses multi-party computation (MPC) -- the private key is split between you and Para so neither party can sign alone, but automated signing is seamless during workflow execution.
+When you create a KeeperHub account, you can set up a [Para wallet](/wallet-management/para) through the Web3 integration settings. It uses multi-party computation (MPC) -- the private key is split between you and Para so neither party can sign alone, but automated signing is seamless during workflow execution.
 
 Read-only operations (checking balances, reading contracts, monitoring events) do not require any ETH. Write operations (transfers, contract calls) execute through your Para wallet and require ETH for gas on the target network.
 
@@ -59,7 +60,6 @@ Your Para wallet uses MPC where the private key is split into shares held by you
 
 - KeeperHub employees cannot move your funds unilaterally
 - Para cannot move your funds unilaterally
-- You can [export your private key](/wallet-management/para) at any time from the Wallet Settings tab for full independent control
 
 The tradeoff: you get convenience and automated signing for workflows, but you are trusting Para's infrastructure to be available for signing operations.
 
@@ -71,9 +71,7 @@ We recommend starting on the Sepolia testnet, where you can get free test ETH fr
 
 ### Can I export my private key?
 
-Yes. Navigate to the **Wallet** tab, tap **Settings**, then **Export Private Key**. Follow the instructions provided by Para on their domain.
-
-**Important**: Never share your private key or seed phrase with anyone. Do not store it in email, cloud drives, chat apps, screenshots, or unencrypted notes. Prefer storing the key offline in an encrypted password manager, air-gapped USB drive, or hardware wallet. After copying, clear your clipboard and close the export screen.
+Private key export is not currently supported but is planned for a future release. In the meantime, your funds remain accessible through your Para wallet in KeeperHub. We will announce when this feature becomes available.
 
 ---
 
@@ -178,11 +176,11 @@ See [Organizations](/users-teams-orgs/organizations) for details.
 
 ### What happens if I lose access to my account?
 
-You can reset your password via a one-time code sent to your email. If you use OAuth (Google, GitHub), you are directed to your provider for recovery. While you have account access, you can export your Para wallet private key at any time from the Wallet Settings tab to ensure you always have independent control of your funds.
+You can reset your password via a one-time code sent to your email. If you use OAuth (Google, GitHub), you are directed to your provider for recovery.
 
 ### What happens if I delete my account?
 
-Account deletion is a soft delete -- your data is preserved but your account is deactivated, and all sessions are invalidated. You can reactivate by contacting an administrator. Before deleting, export your workflow definitions and your Para wallet private key if you want to retain them.
+Account deletion is a soft delete -- your data is preserved but your account is deactivated, and all sessions are invalidated. You can reactivate by contacting an administrator. Before deleting, export your workflow definitions if you want to retain them.
 
 ---
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -207,7 +207,7 @@ Restart Claude Code after setup. You can verify with `/keeperhub:status`.
 
 ### What's the difference between `kh_` and `wfb_` API keys?
 
-`kh_` keys are organization-scoped -- required for the MCP server and Claude Code plugin. `wfb_` keys are user-scoped and work with the REST API. The MCP server won't accept `wfb_` keys.
+`kh_` keys are organization-scoped -- used for the REST API, MCP server, and Claude Code plugin. Create them in Settings > API Keys > Organisation tab. `wfb_` keys are user-scoped and used for webhook triggers. Most of the time you want a `kh_` key.
 
 ### Can I run the MCP server for remote agents (not just local)?
 

--- a/docs/api/api-keys.md
+++ b/docs/api/api-keys.md
@@ -7,6 +7,13 @@ description: "KeeperHub API Keys - create and manage API keys for programmatic a
 
 Manage API keys for programmatic access to the KeeperHub API.
 
+## Key Types
+
+| Prefix | Scope | Used for |
+|--------|-------|----------|
+| `kh_` | Organization | REST API, MCP server, Claude Code plugin |
+| `wfb_` | User | Webhook triggers |
+
 ## List API Keys
 
 ```http
@@ -21,7 +28,7 @@ GET /api/api-keys
     {
       "id": "key_123",
       "name": "Production Key",
-      "keyPrefix": "wfb_abc",
+      "keyPrefix": "kh_abc",
       "createdAt": "2024-01-01T00:00:00Z",
       "lastUsedAt": "2024-01-15T12:00:00Z"
     }
@@ -51,8 +58,8 @@ POST /api/api-keys
 {
   "id": "key_123",
   "name": "My API Key",
-  "key": "wfb_full_api_key_here",
-  "keyPrefix": "wfb_ful",
+  "key": "kh_full_api_key_here",
+  "keyPrefix": "kh_full_",
   "createdAt": "2024-01-01T00:00:00Z"
 }
 ```
@@ -74,14 +81,6 @@ Revokes the API key. This action cannot be undone.
   "success": true
 }
 ```
-
-## Key Format
-
-API keys follow the format:
-- Prefix: `wfb_`
-- Random string: 32 characters
-
-Example: `wfb_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`
 
 ## Security Notes
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -16,20 +16,26 @@ For browser-based applications, authentication is handled via Better Auth sessio
 For programmatic access, use API keys in the `Authorization` header:
 
 ```bash
-curl -H "Authorization: Bearer wfb_your_api_key" \
+curl -H "Authorization: Bearer kh_your_api_key" \
   https://app.keeperhub.com/api/workflows
 ```
+
+### Key Types
+
+KeeperHub has two types of API keys:
+
+| Prefix | Scope | Created in | Used for |
+|--------|-------|------------|----------|
+| `kh_` | Organization | Settings > API Keys > Organisation | REST API, MCP server, Claude Code plugin |
+| `wfb_` | User | Settings > API Keys | Webhook triggers |
 
 ### Creating API Keys
 
 1. Navigate to Settings in the KeeperHub dashboard
 2. Select "API Keys"
-3. Click "Create New Key"
-4. Copy the key immediately - it will only be shown once
-
-### Key Format
-
-API keys follow the format: `wfb_` followed by a random string.
+3. For organization keys (`kh_`), switch to the Organisation tab
+4. Click "Create New Key"
+5. Copy the key immediately -- it will only be shown once
 
 ### Key Security
 
@@ -39,7 +45,7 @@ API keys follow the format: `wfb_` followed by a random string.
 
 ## Webhook Authentication
 
-For webhook triggers, use the workflow-specific webhook URL with your API key:
+For webhook triggers, use a user-scoped key (`wfb_`) with the workflow-specific webhook URL:
 
 ```bash
 POST /api/workflows/{workflowId}/webhook


### PR DESCRIPTION
## Summary
- The existing FAQ had only 2 questions about Para wallets and the API section
  was hidden from the docs sidebar -- rewrite the FAQ into a comprehensive
  resource and make the API reference visible on docs.keeperhub.com
- FAQ now covers 30+ questions across getting started, wallet/funds, security,
  workflows, MCP/AI agent setup, API, account management, and migration
- Correct inaccuracies: wallet is not auto-created (users set it up in Web3
  integration settings), private key export is not yet available
- Document both API key types (kh_ org-scoped, wfb_ user-scoped for webhooks)
  in authentication docs, API keys docs, and FAQ

## Test plan
- [ ] Start docs-site locally (`cd docs-site && pnpm dev`) and verify:
  - [ ] API section appears in the sidebar
  - [ ] FAQ page renders all sections with correct formatting
  - [ ] Internal links from FAQ to other docs pages resolve
- [ ] Verify no broken links in API key docs (`/api/authentication`, `/api/api-keys`)
- [ ] Deploy to docs.keeperhub.com and confirm API section is visible