### PR TITLE
fix: add missing hub CSS custom properties to globals.css

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -80,6 +80,18 @@
   --sidebar-ring: oklch(0.7107 0.0351 256.79);
   --keeperhub-green: oklch(0.8671 0.2514 147.76);
   --keeperhub-green-dark: oklch(0.7402 0.2136 147.89);
+
+  /* --- Hub surfaces (dark-only, used on /hub and protocol pages) --- */
+  --color-hub-card: #1a2230;
+  --color-hub-icon-bg: #2a3342;
+  --color-hub-icon-bg-hover: #354155;
+  --color-hub-gradient-center: #243548;
+  --color-hub-overlay: #171f2e;
+  --color-hub-node-bg: #3d4f63;
+
+  /* --- Accent (green brand) --- */
+  --color-text-accent: #09fd67;
+  --color-bg-accent: #09fd671a;
 }
 
 .dark {


### PR DESCRIPTION
## Summary
- Hub workflow cards render with black mini-map nodes and unstyled icon badges after the design system merge (PR #485) because the hub-specific CSS variables were defined in the spec (`tokens.css`) but never wired into `globals.css`
- Adds the 8 missing custom properties to `:root`: hub surface colors, node/icon backgrounds, overlay, and green accent tokens

## Test plan
- [ ] Visit `/hub` and verify featured workflow cards show green trigger nodes and gray action nodes in the mini-map (not black squares)
- [ ] Verify integration icon badges have dark surface backgrounds (not unstyled)
- [ ] Verify tag badges on community workflow cards show green text on green-tinted background
- [ ] Verify protocol strip cards render with proper dark surface backgrounds
- [ ] Compare against the expected design (images 3-4 in the issue)