### PR TITLE
fix: refresh sidebar after hub template duplication

### DIFF
--- a/keeperhub/components/hub/featured-carousel.tsx
+++ b/keeperhub/components/hub/featured-carousel.tsx
@@ -17,6 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api, type SavedWorkflow } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import { WorkflowMiniMap } from "./workflow-mini-map";
@@ -77,6 +78,7 @@ export function FeaturedCarousel({ workflows }: FeaturedCarouselProps) {
       }
 
       const duplicated = await api.workflow.duplicate(workflowId);
+      refetchSidebar();
       toast.success("Workflow duplicated successfully");
       router.push(`/workflows/${duplicated.id}`);
     } catch (error) {

--- a/keeperhub/components/hub/protocol-detail.tsx
+++ b/keeperhub/components/hub/protocol-detail.tsx
@@ -36,6 +36,7 @@ import {
   type ProtocolDefinition,
   type ProtocolEvent,
 } from "@/keeperhub/lib/protocol-registry";
+import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api, type SavedWorkflow } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import { WorkflowMiniMap } from "./workflow-mini-map";
@@ -165,6 +166,7 @@ export function ProtocolDetail({
       }
 
       const duplicated = await api.workflow.duplicate(workflowId);
+      refetchSidebar();
       toast.success("Workflow duplicated successfully");
       router.push(`/workflows/${duplicated.id}`);
     } catch (error) {
@@ -248,6 +250,7 @@ export function ProtocolDetail({
         edges,
       });
 
+      refetchSidebar();
       sessionStorage.setItem("animate-sidebar", "true");
       router.push(`/workflows/${newWorkflow.id}`);
     } catch {
@@ -299,6 +302,7 @@ export function ProtocolDetail({
         edges: [],
       });
 
+      refetchSidebar();
       sessionStorage.setItem("animate-sidebar", "true");
       router.push(`/workflows/${newWorkflow.id}`);
     } catch {

--- a/keeperhub/components/hub/workflow-template-grid.tsx
+++ b/keeperhub/components/hub/workflow-template-grid.tsx
@@ -17,6 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api, type SavedWorkflow } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import { WorkflowMiniMap } from "./workflow-mini-map";
@@ -47,6 +48,7 @@ export function WorkflowTemplateGrid({ workflows }: WorkflowTemplateGridProps) {
       }
 
       const duplicated = await api.workflow.duplicate(workflowId);
+      refetchSidebar();
       toast.success("Workflow duplicated successfully");
       router.push(`/workflows/${duplicated.id}`);
     } catch (error) {

--- a/keeperhub/components/overlays/featured-overlay.tsx
+++ b/keeperhub/components/overlays/featured-overlay.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/card";
 import { WorkflowMiniMap } from "@/keeperhub/components/hub/workflow-mini-map";
 import { useDebounce } from "@/keeperhub/lib/hooks/use-debounce";
+import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api, type SavedWorkflow } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 
@@ -78,6 +79,7 @@ export function FeaturedOverlay({ overlayId }: FeaturedOverlayProps) {
       }
 
       const duplicated = await api.workflow.duplicate(workflowId);
+      refetchSidebar();
       toast.success("Template applied successfully");
       closeAll();
       router.push(`/workflows/${duplicated.id}`);


### PR DESCRIPTION
## Summary
- Duplicating a workflow from the hub never refreshed the left nav sidebar, so the new workflow only appeared after an unrelated mutation (like renaming) triggered a refetch
- Add `refetchSidebar()` after workflow creation/duplication in all hub components: template grid, featured carousel, protocol detail, and featured overlay

## Test plan
- [ ] Go to `/hub` and click "Use Template" on any template -- verify the new workflow appears in the left nav immediately
- [ ] From a protocol detail page, click "Use in Workflow" -- verify sidebar updates
- [ ] From a protocol detail page, click "Listen to Event" -- verify sidebar updates
- [ ] Verify existing sidebar behavior (creating a new workflow from the sidebar itself) still works