### PR TITLE
ci: KEEP-1548 Fix

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -70,6 +70,7 @@ runs:
           "DATABASE_URL=${DATABASE_URL}" \
           "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
           "NODE_ENV=production" \
+          "HOSTNAME=0.0.0.0" \
           > /tmp/keeperhub-app.env
 
         docker run -d --name keeperhub-app --network host \


### PR DESCRIPTION
## Summary

Follow-up to #505. Hardens the CI pipeline and refactors deploy into a pure deployer.

### Fixes

- Fix Next.js container binding: set `HOSTNAME=0.0.0.0` so the standalone server listens on all interfaces instead of the runner hostname, which caused the health check to fail in e2e
