### PR TITLE
ci: KEEP-1548 Fix ephemeral e2e test rate limiting 

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -35,6 +35,10 @@ inputs:
   better_auth_secret:
     description: 'BetterAuth secret'
     required: true
+  test_api_key:
+    description: 'TEST_API_KEY for rate limit bypass via X-Test-API-Key header'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -61,6 +65,7 @@ runs:
         ECR_REPO: ${{ inputs.ecr_repo }}
         IMAGE_TAG: ${{ inputs.image_tag }}
         DATABASE_URL: ${{ inputs.database_url }}
+        TEST_API_KEY: ${{ inputs.test_api_key }}
       run: |
         IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
@@ -71,6 +76,8 @@ runs:
           "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
           "NODE_ENV=production" \
           "HOSTNAME=0.0.0.0" \
+          "CI=true" \
+          "TEST_API_KEY=${TEST_API_KEY}" \
           > /tmp/keeperhub-app.env
 
         docker run -d --name keeperhub-app --network host \

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -117,6 +117,18 @@ jobs:
         with:
           install-playwright: "true"
 
+      - name: Fetch TEST_API_KEY from Parameter Store
+        run: |
+          TEST_API_KEY=$(aws ssm get-parameter \
+            --name "/eks/maker-staging/keeperhub/test-api-key" \
+            --with-decryption --query "Parameter.Value" --output text \
+            --region us-east-2)
+          echo "::add-mask::$TEST_API_KEY"
+          echo "TEST_API_KEY=$TEST_API_KEY" >> "$GITHUB_ENV"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Wait for deployment to be ready
         run: |
           echo "Waiting for ${{ env.BASE_URL }}/api/health to return 200..."
@@ -143,7 +155,7 @@ jobs:
         run: pnpm exec playwright test --grep-invert "happy-paths"
         env:
           BASE_URL: ${{ env.BASE_URL }}
-          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          TEST_API_KEY: ${{ env.TEST_API_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           CI: true

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -187,6 +187,18 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
+      - name: Fetch TEST_API_KEY from Parameter Store
+        run: |
+          TEST_API_KEY=$(aws ssm get-parameter \
+            --name "/eks/maker-staging/keeperhub/test-api-key" \
+            --with-decryption --query "Parameter.Value" --output text \
+            --region us-east-2)
+          echo "::add-mask::$TEST_API_KEY"
+          echo "TEST_API_KEY=$TEST_API_KEY" >> "$GITHUB_ENV"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Start application
         uses: ./.github/actions/start-app
         with:
@@ -198,7 +210,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
-          test_api_key: ${{ secrets.TEST_API_KEY }}
+          test_api_key: ${{ env.TEST_API_KEY }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -213,6 +225,7 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
+          TEST_API_KEY: ${{ env.TEST_API_KEY }}
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''
@@ -279,6 +292,18 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
+      - name: Fetch TEST_API_KEY from Parameter Store
+        run: |
+          TEST_API_KEY=$(aws ssm get-parameter \
+            --name "/eks/maker-staging/keeperhub/test-api-key" \
+            --with-decryption --query "Parameter.Value" --output text \
+            --region us-east-2)
+          echo "::add-mask::$TEST_API_KEY"
+          echo "TEST_API_KEY=$TEST_API_KEY" >> "$GITHUB_ENV"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Start application
         uses: ./.github/actions/start-app
         with:
@@ -290,7 +315,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
-          test_api_key: ${{ secrets.TEST_API_KEY }}
+          test_api_key: ${{ env.TEST_API_KEY }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e
@@ -306,6 +331,7 @@ jobs:
           PARA_PORTAL_KEY_ID: ${{ secrets.PARA_PORTAL_KEY_ID }}
           PARA_PORTAL_API_KEY: ${{ secrets.PARA_PORTAL_API_KEY }}
           CI: true
+          TEST_API_KEY: ${{ env.TEST_API_KEY }}
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -187,18 +187,6 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
-      - name: Fetch TEST_API_KEY from Parameter Store
-        run: |
-          TEST_API_KEY=$(aws ssm get-parameter \
-            --name "/eks/maker-staging/keeperhub/test-api-key" \
-            --with-decryption --query "Parameter.Value" --output text \
-            --region us-east-2)
-          echo "::add-mask::$TEST_API_KEY"
-          echo "TEST_API_KEY=$TEST_API_KEY" >> "$GITHUB_ENV"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
       - name: Start application
         uses: ./.github/actions/start-app
         with:
@@ -210,7 +198,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
-          test_api_key: ${{ env.TEST_API_KEY }}
+          test_api_key: ${{ secrets.TEST_API_KEY }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -225,7 +213,7 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
-          TEST_API_KEY: ${{ env.TEST_API_KEY }}
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''
@@ -292,18 +280,6 @@ jobs:
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
 
-      - name: Fetch TEST_API_KEY from Parameter Store
-        run: |
-          TEST_API_KEY=$(aws ssm get-parameter \
-            --name "/eks/maker-staging/keeperhub/test-api-key" \
-            --with-decryption --query "Parameter.Value" --output text \
-            --region us-east-2)
-          echo "::add-mask::$TEST_API_KEY"
-          echo "TEST_API_KEY=$TEST_API_KEY" >> "$GITHUB_ENV"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
       - name: Start application
         uses: ./.github/actions/start-app
         with:
@@ -315,7 +291,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
-          test_api_key: ${{ env.TEST_API_KEY }}
+          test_api_key: ${{ secrets.TEST_API_KEY }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e
@@ -331,7 +307,7 @@ jobs:
           PARA_PORTAL_KEY_ID: ${{ secrets.PARA_PORTAL_KEY_ID }}
           PARA_PORTAL_API_KEY: ${{ secrets.PARA_PORTAL_API_KEY }}
           CI: true
-          TEST_API_KEY: ${{ env.TEST_API_KEY }}
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -198,6 +198,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
+          test_api_key: ${{ secrets.TEST_API_KEY }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -289,6 +290,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
+          test_api_key: ${{ secrets.TEST_API_KEY }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e


### PR DESCRIPTION
## Summary

Fix ephemeral e2e test rate limiting and pass TEST_API_KEY to both ephemeral and remote e2e tests.

TEST_API_KEY is sourced from github secrets for ephemeral tests (pre-deploy check).
TEST_API_KEY is sourced from AWS Param Store for deployment tests (post-deploy verification).

## Commits

- `74ec2d5a` pass CI and TEST_API_KEY to ephemeral e2e app container
- `3b44c97b` fetch TEST_API_KEY from Parameter Store for ephemeral e2e tests
- `08a4c143` use GitHub secret for TEST_API_KEY in ephemeral e2e tests (CI IAM user lacks ssm:GetParameter)
- `02db8e27` fetch TEST_API_KEY from Parameter Store for remote e2e tests