### PR TITLE
fix: add API key auth support to workflow executions route

### DIFF
--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -1,6 +1,7 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 // start custom keeperhub code //
+import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 // end keeperhub code //
@@ -14,15 +15,29 @@ export async function GET(
 ) {
   try {
     const { workflowId } = await context.params;
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     // start custom keeperhub code //
+    // Try API key authentication first, then fall back to session
+    let userId: string | null = null;
+    let organizationId: string | null = null;
+
+    const apiKeyAuth = await authenticateApiKey(request);
+    if (apiKeyAuth.authenticated) {
+      organizationId = apiKeyAuth.organizationId || null;
+    } else {
+      const session = await auth.api.getSession({
+        headers: request.headers,
+      });
+
+      if (!session?.user) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+
+      userId = session.user.id;
+      const orgContext = await getOrgContext();
+      organizationId = orgContext.organization?.id || null;
+    }
+
     // Verify workflow access (owner or org member)
     const workflow = await db.query.workflows.findFirst({
       where: eq(workflows.id, workflowId),
@@ -35,12 +50,11 @@ export async function GET(
       );
     }
 
-    const isOwner = session.user.id === workflow.userId;
-    const orgContext = await getOrgContext();
+    const isOwner = userId !== null && userId === workflow.userId;
     const isSameOrg =
       !workflow.isAnonymous &&
       workflow.organizationId &&
-      orgContext.organization?.id === workflow.organizationId;
+      organizationId === workflow.organizationId;
 
     if (!(isOwner || isSameOrg)) {
       return NextResponse.json(
@@ -79,15 +93,29 @@ export async function DELETE(
 ) {
   try {
     const { workflowId } = await context.params;
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     // start custom keeperhub code //
+    // Try API key authentication first, then fall back to session
+    let userId: string | null = null;
+    let organizationId: string | null = null;
+
+    const apiKeyAuth = await authenticateApiKey(request);
+    if (apiKeyAuth.authenticated) {
+      organizationId = apiKeyAuth.organizationId || null;
+    } else {
+      const session = await auth.api.getSession({
+        headers: request.headers,
+      });
+
+      if (!session?.user) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+
+      userId = session.user.id;
+      const orgContext = await getOrgContext();
+      organizationId = orgContext.organization?.id || null;
+    }
+
     // Verify workflow access (owner or org member)
     const workflow = await db.query.workflows.findFirst({
       where: eq(workflows.id, workflowId),
@@ -100,12 +128,11 @@ export async function DELETE(
       );
     }
 
-    const isOwner = session.user.id === workflow.userId;
-    const orgContext = await getOrgContext();
+    const isOwner = userId !== null && userId === workflow.userId;
     const isSameOrg =
       !workflow.isAnonymous &&
       workflow.organizationId &&
-      orgContext.organization?.id === workflow.organizationId;
+      organizationId === workflow.organizationId;
 
     if (!(isOwner || isSameOrg)) {
       return NextResponse.json(

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -1,11 +1,9 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 // start custom keeperhub code //
-import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
-import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
+import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
 // end keeperhub code //
-import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 
@@ -17,26 +15,14 @@ export async function GET(
     const { workflowId } = await context.params;
 
     // start custom keeperhub code //
-    // Try API key authentication first, then fall back to session
-    let userId: string | null = null;
-    let organizationId: string | null = null;
-
-    const apiKeyAuth = await authenticateApiKey(request);
-    if (apiKeyAuth.authenticated) {
-      organizationId = apiKeyAuth.organizationId || null;
-    } else {
-      const session = await auth.api.getSession({
-        headers: request.headers,
-      });
-
-      if (!session?.user) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-      }
-
-      userId = session.user.id;
-      const orgContext = await getOrgContext();
-      organizationId = orgContext.organization?.id || null;
+    const authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
     }
+    const { userId, organizationId } = authContext;
 
     // Verify workflow access (owner or org member)
     const workflow = await db.query.workflows.findFirst({
@@ -95,26 +81,14 @@ export async function DELETE(
     const { workflowId } = await context.params;
 
     // start custom keeperhub code //
-    // Try API key authentication first, then fall back to session
-    let userId: string | null = null;
-    let organizationId: string | null = null;
-
-    const apiKeyAuth = await authenticateApiKey(request);
-    if (apiKeyAuth.authenticated) {
-      organizationId = apiKeyAuth.organizationId || null;
-    } else {
-      const session = await auth.api.getSession({
-        headers: request.headers,
-      });
-
-      if (!session?.user) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-      }
-
-      userId = session.user.id;
-      const orgContext = await getOrgContext();
-      organizationId = orgContext.organization?.id || null;
+    const authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
     }
+    const { userId, organizationId } = authContext;
 
     // Verify workflow access (owner or org member)
     const workflow = await db.query.workflows.findFirst({

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1,10 +1,8 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 // start custom keeperhub code //
-import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
-import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-import { auth } from "@/lib/auth";
+import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, publicTags, tags, workflowPublicTags, workflows } from "@/lib/db/schema";
@@ -57,37 +55,6 @@ function sanitizeNodesForPublicView(
   });
 }
 
-// Helper to get authenticated user context for PATCH
-async function getAuthContextForPatch(
-  request: Request
-): Promise<
-  | { userId: string | null; organizationId: string | null }
-  | { error: string; status: number }
-> {
-  const apiKeyAuth = await authenticateApiKey(request);
-
-  if (apiKeyAuth.authenticated) {
-    return {
-      userId: null,
-      organizationId: apiKeyAuth.organizationId || null,
-    };
-  }
-
-  const session = await auth.api.getSession({
-    headers: request.headers,
-  });
-
-  if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
-  }
-
-  const orgContext = await getOrgContext();
-  return {
-    userId: session.user.id,
-    organizationId: orgContext.organization?.id || null,
-  };
-}
-
 export async function GET(
   request: Request,
   context: { params: Promise<{ workflowId: string }> }
@@ -96,28 +63,14 @@ export async function GET(
     const { workflowId } = await context.params;
 
     // start custom keeperhub code //
-    // Try API key authentication first
-    const apiKeyAuth = await authenticateApiKey(request);
-    let userId: string | null = null;
-    let organizationId: string | null = null;
-
-    if (apiKeyAuth.authenticated) {
-      // API key authentication successful
-      organizationId = apiKeyAuth.organizationId || null;
-    } else {
-      // Fall back to session authentication
-      const session = await auth.api.getSession({
-        headers: request.headers,
-      });
-
-      if (session?.user) {
-        userId = session.user.id;
-
-        // Get organization context from session
-        const orgContext = await getOrgContext();
-        organizationId = orgContext.organization?.id || null;
-      }
+    const authContext = await getDualAuthContext(request, { required: false });
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
     }
+    const { userId, organizationId } = authContext;
     // end keeperhub code //
 
     // First, try to find the workflow
@@ -289,7 +242,7 @@ export async function PATCH(
     const { workflowId } = await context.params;
 
     // start custom keeperhub code //
-    const authContext = await getAuthContextForPatch(request);
+    const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
       return NextResponse.json(
         { error: authContext.error },
@@ -422,30 +375,14 @@ export async function DELETE(
     const { workflowId } = await context.params;
 
     // start custom keeperhub code //
-    // Try API key authentication first
-    const apiKeyAuth = await authenticateApiKey(request);
-    let userId: string | null = null;
-    let organizationId: string | null = null;
-
-    if (apiKeyAuth.authenticated) {
-      // API key authentication successful
-      organizationId = apiKeyAuth.organizationId || null;
-    } else {
-      // Fall back to session authentication
-      const session = await auth.api.getSession({
-        headers: request.headers,
-      });
-
-      if (!session?.user) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-      }
-
-      userId = session.user.id;
-
-      // Get organization context from session
-      const orgContext = await getOrgContext();
-      organizationId = orgContext.organization?.id || null;
+    const authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
     }
+    const { userId, organizationId } = authContext;
 
     const { hasAccess } = await validateWorkflowAccess(
       workflowId,

--- a/keeperhub/lib/middleware/auth-helpers.ts
+++ b/keeperhub/lib/middleware/auth-helpers.ts
@@ -8,7 +8,7 @@ export type DualAuthContext =
 
 /**
  * Resolves user and organization context from either API key or session auth.
- * API key auth sets userId to null (org-level access only).
+ * For API key auth, userId is the key creator (if available).
  *
  * @param required - If true (default), returns 401 when neither auth method succeeds.
  *   Set to false for routes that allow unauthenticated access (e.g. public workflows).
@@ -22,7 +22,7 @@ export async function getDualAuthContext(
   const apiKeyAuth = await authenticateApiKey(request);
   if (apiKeyAuth.authenticated) {
     return {
-      userId: null,
+      userId: apiKeyAuth.userId || null,
       organizationId: apiKeyAuth.organizationId || null,
     };
   }

--- a/keeperhub/lib/middleware/auth-helpers.ts
+++ b/keeperhub/lib/middleware/auth-helpers.ts
@@ -2,6 +2,46 @@ import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 
+export type DualAuthContext =
+  | { userId: string | null; organizationId: string | null }
+  | { error: string; status: number };
+
+/**
+ * Resolves user and organization context from either API key or session auth.
+ * API key auth sets userId to null (org-level access only).
+ *
+ * @param required - If true (default), returns 401 when neither auth method succeeds.
+ *   Set to false for routes that allow unauthenticated access (e.g. public workflows).
+ */
+export async function getDualAuthContext(
+  request: Request,
+  options?: { required?: boolean }
+): Promise<DualAuthContext> {
+  const required = options?.required ?? true;
+
+  const apiKeyAuth = await authenticateApiKey(request);
+  if (apiKeyAuth.authenticated) {
+    return {
+      userId: null,
+      organizationId: apiKeyAuth.organizationId || null,
+    };
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    if (required) {
+      return { error: "Unauthorized", status: 401 };
+    }
+    return { userId: null, organizationId: null };
+  }
+
+  const orgContext = await getOrgContext();
+  return {
+    userId: session.user.id,
+    organizationId: orgContext.organization?.id || null,
+  };
+}
+
 /**
  * Resolves the organization ID from either an API key or session.
  * Used by PATCH/DELETE routes that only need org-level authorization.

--- a/tests/unit/dual-auth-context.test.ts
+++ b/tests/unit/dual-auth-context.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuthenticateApiKey, mockGetSession, mockGetOrgContext } =
+  vi.hoisted(() => ({
+    mockAuthenticateApiKey: vi.fn(),
+    mockGetSession: vi.fn(),
+    mockGetOrgContext: vi.fn(),
+  }));
+
+vi.mock("@/keeperhub/lib/api-key-auth", () => ({
+  authenticateApiKey: mockAuthenticateApiKey,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: mockGetSession,
+    },
+  },
+}));
+
+vi.mock("@/keeperhub/lib/middleware/org-context", () => ({
+  getOrgContext: mockGetOrgContext,
+}));
+
+import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/test", {
+    headers: new Headers(headers),
+  });
+}
+
+describe("getDualAuthContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("API key authentication", () => {
+    it("returns userId and organizationId from API key", async () => {
+      mockAuthenticateApiKey.mockResolvedValue({
+        authenticated: true,
+        organizationId: "org_123",
+        userId: "user_creator",
+      });
+
+      const result = await getDualAuthContext(
+        makeRequest({ Authorization: "Bearer kh_test" })
+      );
+
+      expect(result).toEqual({
+        userId: "user_creator",
+        organizationId: "org_123",
+      });
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+
+    it("returns null userId when API key has no creator", async () => {
+      mockAuthenticateApiKey.mockResolvedValue({
+        authenticated: true,
+        organizationId: "org_123",
+      });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({
+        userId: null,
+        organizationId: "org_123",
+      });
+    });
+  });
+
+  describe("session authentication", () => {
+    beforeEach(() => {
+      mockAuthenticateApiKey.mockResolvedValue({ authenticated: false });
+    });
+
+    it("returns userId and organizationId from session", async () => {
+      mockGetSession.mockResolvedValue({
+        user: { id: "user_session" },
+      });
+      mockGetOrgContext.mockResolvedValue({
+        organization: { id: "org_session" },
+      });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({
+        userId: "user_session",
+        organizationId: "org_session",
+      });
+    });
+
+    it("returns null organizationId when user has no org", async () => {
+      mockGetSession.mockResolvedValue({
+        user: { id: "user_no_org" },
+      });
+      mockGetOrgContext.mockResolvedValue({ organization: null });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({
+        userId: "user_no_org",
+        organizationId: null,
+      });
+    });
+  });
+
+  describe("no authentication", () => {
+    beforeEach(() => {
+      mockAuthenticateApiKey.mockResolvedValue({ authenticated: false });
+      mockGetSession.mockResolvedValue(null);
+    });
+
+    it("returns 401 error when required (default)", async () => {
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({ error: "Unauthorized", status: 401 });
+    });
+
+    it("returns null values when not required", async () => {
+      const result = await getDualAuthContext(makeRequest(), {
+        required: false,
+      });
+
+      expect(result).toEqual({
+        userId: null,
+        organizationId: null,
+      });
+    });
+  });
+
+  describe("auth priority", () => {
+    it("prefers API key over session when both present", async () => {
+      mockAuthenticateApiKey.mockResolvedValue({
+        authenticated: true,
+        organizationId: "org_apikey",
+        userId: "user_apikey",
+      });
+      mockGetSession.mockResolvedValue({
+        user: { id: "user_session" },
+      });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({
+        userId: "user_apikey",
+        organizationId: "org_apikey",
+      });
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Problem
GET /api/workflows/:id/executions (used by MCP's list_executions tool) returned 401 Unauthorized for all API key requests. The route only accepted session-based auth (browser cookies), so MCP requests with Bearer kh_ tokens were always rejected at the first auth check.

Root Cause
The executions route was missing the dual-auth pattern used by every other workflow route. app/api/workflows/[workflowId]/route.ts (GET/PATCH/DELETE) all call authenticateApiKey() first and fall back to session auth. The executions route skipped this entirely.

Fix
Applied the same dual-auth pattern to both GET and DELETE handlers in app/api/workflows/[workflowId]/executions/route.ts:

1. Try authenticateApiKey(request) first — if valid, use organizationId from the key
2. Fall back to auth.api.getSession() + getOrgContext() for session-based auth
3. Access check unchanged: isOwner || isSameOrg

Impact
- MCP list_executions now works for org API key holders
- No change to session-based auth behavior
- DELETE handler gets the same fix for consistency
