### PR TITLE
ci: KEEP-1351 fix ephemeral e2e test failures

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -115,6 +115,8 @@ runs:
       env:
         DATABASE_URL: ${{ inputs.database_url }}
         BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
+        CI: true
+        TEST_API_KEY: ${{ inputs.test_api_key }}
 
     - name: Start application
       if: inputs.image_tag == ''
@@ -135,3 +137,5 @@ runs:
       env:
         DATABASE_URL: ${{ inputs.database_url }}
         BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
+        CI: true
+        TEST_API_KEY: ${{ inputs.test_api_key }}


### PR DESCRIPTION
## Summary

- Pass `CI` and `TEST_API_KEY` env vars to the bare-metal start-app path so the auth rate-limit bypass works for PR e2e tests
- Remove `webhook-workflow.test.ts` from Playwright suite -- all three tests were pure API + DB polling with zero browser interaction, belongs in vitest e2e

## Root cause

The bare-metal path in `.github/actions/start-app/action.yml` (used by all PRs) was missing `CI` and `TEST_API_KEY` env vars. The Docker path had them. Without `CI=true`, BetterAuth rate limiting stayed enabled. Without `TEST_API_KEY`, the `X-Test-API-Key` header bypass had nothing to compare against. Result: every auth request from Playwright tests got 429'd.

## Test plan

- [x] PR CI passes with e2e label applied
- [x] Auth tests no longer hit "Too many requests" errors
- [x] Webhook workflow execution test removed from Playwright results