### PR TITLE
fix: KEEP-1549 reduce spurious error status on workflow executions

### DIFF
--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -20,7 +20,7 @@ export async function PATCH(
 
   const { executionId } = await context.params;
   const body = await request.json();
-  const { status, error } = body;
+  const { status, error, duration } = body;
 
   type ExecutionStatus = "running" | "success" | "error";
   const validStatuses: ExecutionStatus[] = ["running", "success", "error"];
@@ -51,10 +51,14 @@ export async function PATCH(
   }
 
   // Build update payload
+  const isTerminal = status === "success" || status === "error";
   const updateData: {
     status: ExecutionStatus;
     error?: string | null;
     completedAt?: Date;
+    duration?: string;
+    currentNodeId?: null;
+    currentNodeName?: null;
   } = { status: typedStatus };
 
   if (status === "error") {
@@ -62,6 +66,14 @@ export async function PATCH(
     updateData.completedAt = new Date();
   } else if (status === "success") {
     updateData.completedAt = new Date();
+  }
+
+  if (isTerminal) {
+    updateData.currentNodeId = null;
+    updateData.currentNodeName = null;
+    if (typeof duration === "string") {
+      updateData.duration = duration;
+    }
   }
 
   await db

--- a/keeperhub/lib/execution-fallback.ts
+++ b/keeperhub/lib/execution-fallback.ts
@@ -4,6 +4,7 @@ type FallbackCompleteParams = {
   executionId: string;
   status: "success" | "error";
   error?: string;
+  startTime?: number;
 };
 
 /**
@@ -48,6 +49,9 @@ export async function fallbackCompleteExecution(
         body: JSON.stringify({
           status: params.status,
           error: params.error,
+          ...(params.startTime !== undefined && {
+            duration: (Date.now() - params.startTime).toString(),
+          }),
         }),
       }
     );

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1200,6 +1200,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
     return processedConfig;
   }
+  // end keeperhub code //
 
   // -------------------------------------------------------------------
   // For Each: body-node executor (scoped outputs, body-only edges)

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -27,7 +27,6 @@ import {
   detectTriggerType,
   recordWorkflowComplete,
 } from "@/keeperhub/lib/metrics/instrumentation/workflow";
-import { fallbackCompleteExecution } from "@/keeperhub/lib/execution-fallback";
 import {
   getFailedMaxRetriesNodeIds,
   reconcileMaxRetriesFailures,
@@ -1636,6 +1635,24 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     };
   }
 
+  // start custom keeperhub code //
+  function processSettledResults(
+    settled: PromiseSettledResult<void>[],
+    nodeIds: string[]
+  ): void {
+    for (const [i, outcome] of settled.entries()) {
+      if (outcome.status === "rejected") {
+        const nodeId = nodeIds[i];
+        if (!(nodeId in results)) {
+          const errorMessage =
+            outcome.reason instanceof Error
+              ? outcome.reason.message
+              : String(outcome.reason);
+          results[nodeId] = { success: false, error: errorMessage };
+        }
+      }
+    }
+  }
   // end keeperhub code //
 
   // Helper to execute a single node
@@ -1667,9 +1684,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       };
 
       const nextNodes = edgesBySource.get(nodeId) || [];
-      await Promise.all(
+      const settled = await Promise.allSettled(
         nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
       );
+      processSettledResults(settled, nextNodes);
       return;
     }
 
@@ -1910,9 +1928,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             currentEdgesBySource: edgesBySource,
             continueAfterCollect: async (collectId) => {
               const nextNodes = edgesBySource.get(collectId) ?? [];
-              await Promise.all(
+              const settled = await Promise.allSettled(
                 nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
               );
+              processSettledResults(settled, nextNodes);
             },
           });
 
@@ -1946,20 +1965,22 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 edgesBySourceHandle
               ),
             });
-            await Promise.all(
+            const handleSettled = await Promise.allSettled(
               handleTargets.map((nextNodeId) =>
                 executeNode(nextNodeId, visited)
               )
             );
+            processSettledResults(handleSettled, handleTargets);
           } else {
             // Legacy fallback: no sourceHandle on edges, use old gate behavior
             if (conditionResult === true) {
               const nextNodes = edgesBySource.get(nodeId) ?? [];
-              await Promise.all(
+              const legacySettled = await Promise.allSettled(
                 nextNodes.map((nextNodeId) =>
                   executeNode(nextNodeId, visited)
                 )
               );
+              processSettledResults(legacySettled, nextNodes);
             }
           }
           // end keeperhub code //
@@ -1971,9 +1992,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             nextNodes.length,
             "next nodes in parallel"
           );
-          await Promise.all(
+          const nextSettled = await Promise.allSettled(
             nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
           );
+          processSettledResults(nextSettled, nextNodes);
         }
       }
     } catch (error) {
@@ -2013,7 +2035,11 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     incrementConcurrentExecutions();
     // end keeperhub code //
 
-    await Promise.all(triggerNodes.map((trigger) => executeNode(trigger.id)));
+    const triggerNodeIds = triggerNodes.map((trigger) => trigger.id);
+    const triggerSettled = await Promise.allSettled(
+      triggerNodeIds.map((id) => executeNode(id))
+    );
+    processSettledResults(triggerSettled, triggerNodeIds);
 
     // start custom keeperhub code //
     // KEEP-1541: Reconcile spurious SDK failures.
@@ -2116,28 +2142,22 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             executionId,
             status: finalSuccess ? "success" : "error",
             output: Object.values(results).at(-1)?.data,
-            error: Object.values(results).find((r) => !r.success)?.error,
+            error: finalSuccess
+              ? undefined
+              : Object.values(results).find((r) => !r.success)?.error,
             startTime: workflowStartTime,
           },
         });
-        console.log("[Workflow Executor] Updated execution record");
-      } catch (error) {
+      } catch (completeError) {
         logSystemError(
-          ErrorCategory.DATABASE,
+          ErrorCategory.WORKFLOW_ENGINE,
           "[Workflow Executor] Failed to update execution record:",
-          error,
+          completeError,
           {
             ...(workflowId ? { workflow_id: workflowId } : {}),
             ...(executionId ? { execution_id: executionId } : {}),
           }
         );
-        // start custom keeperhub code //
-        await fallbackCompleteExecution({
-          executionId,
-          status: finalSuccess ? "success" : "error",
-          error: Object.values(results).find((r) => !r.success)?.error,
-        });
-        // end keeperhub code //
       }
     }
 
@@ -2193,13 +2213,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             ...(executionId ? { execution_id: executionId } : {}),
           }
         );
-        // start custom keeperhub code //
-        await fallbackCompleteExecution({
-          executionId,
-          status: "error",
-          error: errorMessage,
-        });
-        // end keeperhub code //
       }
     }
 

--- a/lib/workflow-logging.ts
+++ b/lib/workflow-logging.ts
@@ -9,7 +9,7 @@ import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 
 // start custom keeperhub code //
-const TERMINAL_STATUSES = new Set(["cancelled", "success", "error"]);
+const TERMINAL_STATUSES = new Set(["cancelled"]);
 
 /**
  * Check if an execution has been cancelled (or otherwise terminated).


### PR DESCRIPTION
## Summary

- Narrow `TERMINAL_STATUSES` guard in `workflow-logging.ts` to only block writes for `cancelled` executions. Previously, nodes completing while the execution was in `error` state had their completion writes silently dropped, causing Discord nodes to appear stuck as `running`.
- Switch all 6 `Promise.all` calls in the workflow executor to `Promise.allSettled` with a `processSettledResults` helper. One node's SDK error no longer short-circuits parallel siblings.
- Remove unreachable `fallbackCompleteExecution` calls from workflow executor catch blocks (`fetch` is sandboxed inside `"use workflow"` context).
- Add `duration` support to execution fallback and internal executions route. Clear `currentNodeId`/`currentNodeName` when writing terminal status.