### PR TITLE
fix: KEEP-1549 use DB-backed reconciler instead of in-memory step tracker

### DIFF
--- a/keeperhub/lib/steps/fetch-successful-steps.ts
+++ b/keeperhub/lib/steps/fetch-successful-steps.ts
@@ -1,0 +1,37 @@
+/**
+ * KEEP-1549: "use step" function to query workflow_execution_logs for
+ * successfully completed node IDs. Used by the reconciler inside
+ * "use workflow" context where direct DB imports are unavailable.
+ */
+import "server-only";
+
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { workflowExecutionLogs } from "@/lib/db/schema";
+
+type FetchSuccessfulStepsInput = {
+  executionId: string;
+};
+
+type FetchSuccessfulStepsResult = {
+  successfulNodeIds: string[];
+};
+
+export async function fetchSuccessfulStepsStep(
+  input: FetchSuccessfulStepsInput
+): Promise<FetchSuccessfulStepsResult> {
+  "use step";
+
+  const logs = await db.query.workflowExecutionLogs.findMany({
+    where: and(
+      eq(workflowExecutionLogs.executionId, input.executionId),
+      eq(workflowExecutionLogs.status, "success")
+    ),
+    columns: { nodeId: true },
+  });
+
+  return {
+    successfulNodeIds: logs.map((log) => log.nodeId),
+  };
+}
+fetchSuccessfulStepsStep.maxRetries = 0;

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -32,10 +32,8 @@ import {
   reconcileMaxRetriesFailures,
   reconcileSdkFailures,
 } from "@/keeperhub/lib/max-retries-reconciler";
-import {
-  clearExecution,
-  getSuccessfulSteps,
-} from "@/keeperhub/lib/step-success-tracker";
+import { clearExecution } from "@/keeperhub/lib/step-success-tracker";
+import { fetchSuccessfulStepsStep } from "@/keeperhub/lib/steps/fetch-successful-steps";
 import { ARRAY_SOURCE_RE } from "@/keeperhub/lib/for-each-utils";
 import {
   buildEdgesBySourceHandle,
@@ -2051,7 +2049,27 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     //   2. reconcileSdkFailures - catches any remaining SDK-induced failures
     // See max-retries-reconciler.ts for details.
     if (executionId) {
-      const successfulSteps = getSuccessfulSteps(executionId);
+      // Query DB for successful steps via a "use step" function.
+      // The in-memory tracker (step-success-tracker.ts) is not shared
+      // across SDK isolates in production, so we use the DB as the
+      // source of truth for reconciliation.
+      let successfulSteps: Map<string, unknown> | undefined;
+      try {
+        const { successfulNodeIds } = await fetchSuccessfulStepsStep({
+          executionId,
+        });
+        if (successfulNodeIds.length > 0) {
+          successfulSteps = new Map<string, unknown>();
+          for (const nodeId of successfulNodeIds) {
+            successfulSteps.set(nodeId, undefined);
+          }
+        }
+      } catch (fetchError) {
+        console.warn(
+          "[Workflow Executor] Failed to fetch successful steps for reconciliation:",
+          fetchError
+        );
+      }
 
       if (successfulSteps) {
         // Pass 1: targeted max-retries reconciliation


### PR DESCRIPTION
## Summary

The in-memory step-success-tracker `Map` used by the KEEP-1541 reconciler is not shared across SDK isolates in production. `recordStepSuccess` writes to one `Map` inside `"use step"` context, while `getSuccessfulSteps` reads from a different empty `Map` in `"use workflow"` context -- so the reconciler never finds any successful steps to override spurious SDK errors.

- Add `fetchSuccessfulStepsStep`, a `"use step"` function that queries `workflow_execution_logs` for nodes with `status='success'`. This uses the DB (which `withStepLogging` already writes to) as the source of truth for reconciliation.
- Replace the in-memory `getSuccessfulSteps()` call in the executor with the new DB-backed step.