### PR TITLE
KEEP-1188 - Add TechOps deploy for keeperhub-docs

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -40,6 +40,24 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Configure TechOps AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.TECHOPS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TECHOPS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to TechOps ECR
+        id: login-techops-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Restore AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -59,6 +77,8 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ steps.vars.outputs.sha_short }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:latest
+            ${{ steps.login-techops-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ steps.vars.outputs.sha_short }}
+            ${{ steps.login-techops-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:latest
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache,mode=max
 
@@ -85,6 +105,50 @@ jobs:
           namespace: ${{ env.NAMESPACE }}
           timeout: 5m0s
           name: ${{ env.SERVICE_NAME }}
+          chart-repository: https://techops-services.github.io/helm-charts
+          version: 0.2.1
+          atomic: true
+
+      # ── TechOps cluster deploy (staging only) ──
+      - name: Configure TechOps AWS credentials for deploy
+        if: ${{ env.ENVIRONMENT_TAG == 'staging' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.TECHOPS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TECHOPS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to TechOps ECR for deploy
+        if: ${{ env.ENVIRONMENT_TAG == 'staging' }}
+        id: login-techops-ecr-deploy
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Replace variables in TechOps Helm values
+        if: ${{ env.ENVIRONMENT_TAG == 'staging' }}
+        env:
+          ECR_REGISTRY: ${{ steps.login-techops-ecr-deploy.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          sed -i 's|${ECR_REGISTRY}|'"$ECR_REGISTRY"'|g' deploy/helm/staging/docs-site/values.yaml
+          sed -i 's|${IMAGE_TAG}|'"$IMAGE_TAG"'|g' deploy/helm/staging/docs-site/values.yaml
+
+      - name: Configure kubectl for TechOps
+        if: ${{ env.ENVIRONMENT_TAG == 'staging' }}
+        run: |
+          aws eks update-kubeconfig --name techops-prod --region us-east-2
+
+      - name: Deploy Docs to TechOps with Helm
+        if: ${{ env.ENVIRONMENT_TAG == 'staging' }}
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
+        env:
+          CLUSTER_NAME: techops-prod
+        with:
+          cluster-name: techops-prod
+          config-files: deploy/helm/staging/docs-site/values.yaml
+          chart-path: techops-services/common
+          namespace: keeperhub-staging
+          timeout: 5m0s
+          name: keeperhub-docs
           chart-repository: https://techops-services.github.io/helm-charts
           version: 0.2.1
           atomic: true

--- a/deploy/helm/staging/docs-site/values.yaml
+++ b/deploy/helm/staging/docs-site/values.yaml
@@ -13,7 +13,7 @@ service:
 ingress:
   enabled: true
   hosts:
-    - docs-staging.keeperhub.com
+    - migration-docs-staging.keeperhub.com
   annotations:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: websecure


### PR DESCRIPTION
## Summary
- Push docs image to TechOps ECR during build step
- Add TechOps cluster deploy steps (staging only) to deploy-docs workflow
- Use migration hostname (`migration-docs-staging.keeperhub.com`) for TechOps ingress

## Test plan
- [ ] Merge to staging and verify docs deploy succeeds on both Sky and TechOps
- [ ] Verify `keeperhub-docs-common` pod running in `keeperhub-staging` namespace on TechOps