### PR TITLE
hotfix: use BIGINT cast for duration columns

### DIFF
--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -192,7 +192,7 @@ async function getWorkflowCounts(
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'error' THEN 1 ELSE 0 END)`,
       cancelled: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'cancelled' THEN 1 ELSE 0 END)`,
-      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS INTEGER)), 0)`,
+      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS BIGINT)), 0)`,
       durationCount: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} IS NOT NULL THEN 1 ELSE 0 END)`,
     })
     .from(workflowExecutions)

--- a/keeperhub/lib/metrics/db-metrics.ts
+++ b/keeperhub/lib/metrics/db-metrics.ts
@@ -103,16 +103,16 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS INTEGER)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS BIGINT)), 0)`,
         // Count executions in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 100 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 250 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 500 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 5000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 10000 THEN 1 ELSE 0 END)`,
-        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS INTEGER) <= 30000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 100 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 250 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 500 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 1000 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 2000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 10000 THEN 1 ELSE 0 END)`,
+        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 30000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutions)
       .where(
@@ -236,15 +236,15 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS INTEGER)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS BIGINT)), 0)`,
         // Count steps in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 50 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 100 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 250 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 500 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS INTEGER) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 50 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 100 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 250 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 500 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 1000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 2000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 5000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutionLogs)
       .where(


### PR DESCRIPTION
## Summary
- Changed all `CAST(duration AS INTEGER)` to `CAST(duration AS BIGINT)` in metrics and analytics queries
- Fixes PostgreSQL "out of range for type integer" error when duration values exceed 2^31 (~2.1B ms)
- Affected files: `keeperhub/lib/metrics/db-metrics.ts`, `keeperhub/lib/analytics/queries.ts`