### PR TITLE
fix: KEEP-1554 follow up on #535 with correct fix for duration col datatype and faulting casting

### DIFF
--- a/drizzle/0032_duration_text_to_numeric.sql
+++ b/drizzle/0032_duration_text_to_numeric.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "workflow_executions"
+  ALTER COLUMN "duration" TYPE numeric USING "duration"::numeric;
+
+ALTER TABLE "workflow_execution_logs"
+  ALTER COLUMN "duration" TYPE numeric USING "duration"::numeric;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1772595598240,
       "tag": "0031_heavy_overlord",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1773292800000,
+      "tag": "0032_duration_text_to_numeric",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub/api/internal/reaper/route.ts
+++ b/keeperhub/api/internal/reaper/route.ts
@@ -64,7 +64,7 @@ export async function GET(request: Request): Promise<NextResponse> {
         status: "error",
         error: `Execution timed out: no activity for ${thresholdMinutes} minutes`,
         completedAt: new Date(),
-        duration: sql`EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000`,
+        duration: sql`ROUND(EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000)`,
       })
       .where(staleConditions)
       .returning({ id: workflowExecutions.id });

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -192,7 +192,7 @@ async function getWorkflowCounts(
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'error' THEN 1 ELSE 0 END)`,
       cancelled: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'cancelled' THEN 1 ELSE 0 END)`,
-      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS BIGINT)), 0)`,
+      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS NUMERIC)), 0)`,
       durationCount: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} IS NOT NULL THEN 1 ELSE 0 END)`,
     })
     .from(workflowExecutions)

--- a/keeperhub/lib/analytics/queries.ts
+++ b/keeperhub/lib/analytics/queries.ts
@@ -192,7 +192,7 @@ async function getWorkflowCounts(
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'error' THEN 1 ELSE 0 END)`,
       cancelled: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'cancelled' THEN 1 ELSE 0 END)`,
-      durationSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS NUMERIC)), 0)`,
+      durationSum: sql<number>`COALESCE(SUM(${workflowExecutions.duration}), 0)`,
       durationCount: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} IS NOT NULL THEN 1 ELSE 0 END)`,
     })
     .from(workflowExecutions)

--- a/keeperhub/lib/metrics/db-metrics.ts
+++ b/keeperhub/lib/metrics/db-metrics.ts
@@ -103,16 +103,16 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS NUMERIC)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(${workflowExecutions.duration}), 0)`,
         // Count executions in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 100 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 250 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 500 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 5000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 10000 THEN 1 ELSE 0 END)`,
-        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 30000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 100 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 250 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 500 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 1000 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 2000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 5000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 10000 THEN 1 ELSE 0 END)`,
+        bucket7: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} <= 30000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutions)
       .where(
@@ -236,15 +236,15 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS NUMERIC)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(${workflowExecutionLogs.duration}), 0)`,
         // Count steps in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 50 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 100 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 250 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 500 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 50 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 100 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 250 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 500 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 1000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 2000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.duration} <= 5000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutionLogs)
       .where(

--- a/keeperhub/lib/metrics/db-metrics.ts
+++ b/keeperhub/lib/metrics/db-metrics.ts
@@ -103,16 +103,16 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS BIGINT)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutions.duration} AS NUMERIC)), 0)`,
         // Count executions in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 100 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 250 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 500 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 5000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 10000 THEN 1 ELSE 0 END)`,
-        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS BIGINT) <= 30000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 100 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 250 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 500 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 1000 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 2000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 10000 THEN 1 ELSE 0 END)`,
+        bucket7: sql<number>`SUM(CASE WHEN CAST(${workflowExecutions.duration} AS NUMERIC) <= 30000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutions)
       .where(
@@ -236,15 +236,15 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
     const durationQuery = await db
       .select({
         totalCount: count(),
-        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS BIGINT)), 0)`,
+        totalSum: sql<number>`COALESCE(SUM(CAST(${workflowExecutionLogs.duration} AS NUMERIC)), 0)`,
         // Count steps in each bucket (cumulative)
-        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 50 THEN 1 ELSE 0 END)`,
-        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 100 THEN 1 ELSE 0 END)`,
-        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 250 THEN 1 ELSE 0 END)`,
-        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 500 THEN 1 ELSE 0 END)`,
-        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 1000 THEN 1 ELSE 0 END)`,
-        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 2000 THEN 1 ELSE 0 END)`,
-        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS BIGINT) <= 5000 THEN 1 ELSE 0 END)`,
+        bucket0: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 50 THEN 1 ELSE 0 END)`,
+        bucket1: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 100 THEN 1 ELSE 0 END)`,
+        bucket2: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 250 THEN 1 ELSE 0 END)`,
+        bucket3: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 500 THEN 1 ELSE 0 END)`,
+        bucket4: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 1000 THEN 1 ELSE 0 END)`,
+        bucket5: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 2000 THEN 1 ELSE 0 END)`,
+        bucket6: sql<number>`SUM(CASE WHEN CAST(${workflowExecutionLogs.duration} AS NUMERIC) <= 5000 THEN 1 ELSE 0 END)`,
       })
       .from(workflowExecutionLogs)
       .where(

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
   index,
   integer,
   jsonb,
+  numeric,
   pgEnum,
   pgTable,
   text,
@@ -281,7 +282,7 @@ export const workflowExecutions = pgTable(
     error: text("error"),
     startedAt: timestamp("started_at").notNull().defaultNow(),
     completedAt: timestamp("completed_at"),
-    duration: text("duration"), // Duration in milliseconds
+    duration: numeric("duration"), // Duration in milliseconds
     // Progress tracking
     totalSteps: text("total_steps"),
     completedSteps: text("completed_steps").default("0"),
@@ -318,7 +319,7 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
   error: text("error"),
   startedAt: timestamp("started_at").notNull().defaultNow(),
   completedAt: timestamp("completed_at"),
-  duration: text("duration"), // Duration in milliseconds
+  duration: numeric("duration"), // Duration in milliseconds
   timestamp: timestamp("timestamp").notNull().defaultNow(),
   // start custom keeperhub code //
   iterationIndex: integer("iteration_index"), // 0-based loop iteration (null for non-loop nodes)


### PR DESCRIPTION
## Summary

- Replace `CAST(duration AS BIGINT)` with `CAST(duration AS NUMERIC)` in analytics queries and metrics DB queries
- BIGINT rejects decimal strings (e.g. `587694809.273000`), NUMERIC handles both decimals and large values exceeding 2^31
- Fixes repeated `[API] Failed to fetch analytics summary` and `[Metrics] Failed to query workflow stats from DB` errors firing every ~10s in production

## Context

- `44ed9d34` (Mar 3, Simon) correctly changed INTEGER to NUMERIC to handle decimal duration strings
- `fcc0b55a` (Mar 10, Joel) changed NUMERIC to BIGINT to handle overflow past 2^31, but reintroduced the decimal parsing failure #535 
- This commit restores NUMERIC which handles both cases

## Test plan

- [x] Verify analytics dashboard loads without 500 errors (local)
- [x] Verify `/api/metrics` endpoint returns duration histogram data (local)
- [ ] Check pod logs for absence of `Failed to query workflow stats` errors (staging)