### PR TITLE
fix: KEEP-1555 route all RPC calls through RpcProviderManager

### DIFF
--- a/keeperhub/api/gas/estimate/route.ts
+++ b/keeperhub/api/gas/estimate/route.ts
@@ -6,7 +6,7 @@ import { getOrganizationWalletAddress } from "@/keeperhub/lib/para/wallet-helper
 import { getChainGasDefaults } from "@/keeperhub/lib/web3/gas-defaults";
 import { auth } from "@/lib/auth";
 import { ERC20_ABI } from "@/lib/contracts";
-import { resolveRpcConfig } from "@/lib/rpc";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
 type EstimateConfig = {
   contractAddress?: string;
@@ -241,13 +241,6 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     const { chainId, actionSlug, config, activeOrgId } = validated;
 
-    const rpcConfig = await resolveRpcConfig(chainId);
-    if (!rpcConfig) {
-      return badRequest(`Chain ${chainId} not found or not enabled`);
-    }
-
-    const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-
     let walletAddress: string;
     try {
       walletAddress = await getOrganizationWalletAddress(activeOrgId);
@@ -255,21 +248,20 @@ export async function POST(request: Request): Promise<NextResponse> {
       return badRequest("No wallet configured. Create a wallet first.");
     }
 
-    let result: NextResponse | bigint;
+    const rpcManager = await getRpcProvider({ chainId });
 
-    switch (actionSlug) {
-      case "transfer-funds":
-        result = await estimateTransferFunds(config, provider, walletAddress);
-        break;
-      case "transfer-token":
-        result = await estimateTransferToken(config, provider, walletAddress);
-        break;
-      case "write-contract":
-        result = await estimateWriteContract(config, provider, walletAddress);
-        break;
-      default:
-        return badRequest(`Unsupported action: ${actionSlug as string}`);
-    }
+    const result = await rpcManager.executeWithFailover(async (provider) => {
+      switch (actionSlug) {
+        case "transfer-funds":
+          return await estimateTransferFunds(config, provider, walletAddress);
+        case "transfer-token":
+          return await estimateTransferToken(config, provider, walletAddress);
+        case "write-contract":
+          return await estimateWriteContract(config, provider, walletAddress);
+        default:
+          return badRequest(`Unsupported action: ${actionSlug as string}`);
+      }
+    });
 
     // If the estimator returned a NextResponse, it's an error
     if (result instanceof NextResponse) {

--- a/keeperhub/api/user/wallet/balances/route.ts
+++ b/keeperhub/api/user/wallet/balances/route.ts
@@ -8,6 +8,7 @@ import { auth } from "@/lib/auth";
 import { ERC20_ABI } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { chains, organizationTokens } from "@/lib/db/schema";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
 type TokenBalance = {
   address: string;
@@ -93,10 +94,14 @@ export async function GET(request: Request) {
         const isTestnet = chain.isTestnet === true;
 
         try {
-          const provider = new ethers.JsonRpcProvider(chain.defaultPrimaryRpc);
+          const rpcManager = await getRpcProvider({
+            chainId: chain.chainId,
+          });
 
-          // Fetch native balance
-          const nativeBalanceRaw = await provider.getBalance(walletAddress);
+          // Fetch native balance with retry/failover
+          const nativeBalanceRaw = await rpcManager.executeWithFailover(
+            (provider) => provider.getBalance(walletAddress)
+          );
           const nativeBalance = ethers.formatEther(nativeBalanceRaw);
 
           // Fetch ERC20 token balances for this chain
@@ -105,14 +110,16 @@ export async function GET(request: Request) {
 
           for (const token of chainTokens) {
             try {
-              const contract = new ethers.Contract(
-                token.tokenAddress,
-                ERC20_ABI,
-                provider
+              const balanceRaw = await rpcManager.executeWithFailover(
+                async (provider) => {
+                  const contract = new ethers.Contract(
+                    token.tokenAddress,
+                    ERC20_ABI,
+                    provider
+                  );
+                  return (await contract.balanceOf(walletAddress)) as bigint;
+                }
               );
-              const balanceRaw = (await contract.balanceOf(
-                walletAddress
-              )) as bigint;
               const balance = ethers.formatUnits(balanceRaw, token.decimals);
 
               tokenBalances.push({
@@ -129,7 +136,6 @@ export async function GET(request: Request) {
                 `[Balances] Failed to fetch balance for token ${token.symbol}:`,
                 tokenError
               );
-              // Include token with error state
               tokenBalances.push({
                 address: token.tokenAddress,
                 symbol: token.symbol,

--- a/keeperhub/api/user/wallet/tokens/route.ts
+++ b/keeperhub/api/user/wallet/tokens/route.ts
@@ -10,6 +10,7 @@ import { auth } from "@/lib/auth";
 import { ERC20_ABI } from "@/lib/contracts";
 import { db } from "@/lib/db";
 import { chains, organizationTokens, supportedTokens } from "@/lib/db/schema";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
 /**
  * GET /api/user/wallet/tokens
@@ -175,20 +176,28 @@ export async function POST(request: Request) {
       );
     }
 
-    // Fetch token metadata from the contract
-    const provider = new ethers.JsonRpcProvider(chain[0].defaultPrimaryRpc);
-    const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+    // Fetch token metadata from the contract with retry/failover
+    const rpcManager = await getRpcProvider({ chainId });
 
     let symbol: string;
     let name: string;
     let decimals: number;
 
     try {
-      [symbol, name, decimals] = await Promise.all([
-        contract.symbol() as Promise<string>,
-        contract.name() as Promise<string>,
-        contract.decimals().then((d: bigint) => Number(d)),
-      ]);
+      [symbol, name, decimals] = await rpcManager.executeWithFailover(
+        (provider) => {
+          const contract = new ethers.Contract(
+            tokenAddress,
+            ERC20_ABI,
+            provider
+          );
+          return Promise.all([
+            contract.symbol() as Promise<string>,
+            contract.name() as Promise<string>,
+            contract.decimals().then((d: bigint) => Number(d)),
+          ]);
+        }
+      );
     } catch (error) {
       console.error("[Tokens] Failed to fetch token metadata:", error);
       return NextResponse.json(

--- a/keeperhub/api/validate-token/route.ts
+++ b/keeperhub/api/validate-token/route.ts
@@ -2,7 +2,8 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { normalizeAddressForStorage } from "@/keeperhub/lib/address-utils";
 import { ERC20_ABI } from "@/lib/contracts";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork } from "@/lib/rpc";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
 /**
  * Validate Token API
@@ -41,27 +42,30 @@ export async function GET(request: Request) {
   }
 
   try {
-    // Get chain ID and RPC URL
+    // Get chain ID and RPC provider
     const chainId = getChainIdFromNetwork(network);
-    const rpcConfig = await resolveRpcConfig(chainId);
 
-    if (!rpcConfig) {
+    let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+    try {
+      rpcManager = await getRpcProvider({ chainId });
+    } catch {
       return NextResponse.json(
         { valid: false, error: "Network not supported" },
         { status: 200 }
       );
     }
 
-    // Create provider and contract
-    const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-    const contract = new ethers.Contract(address, ERC20_ABI, provider);
-
-    // Try to fetch ERC20 metadata - if this fails, it's not a valid ERC20
-    const [symbol, name, decimals] = await Promise.all([
-      contract.symbol() as Promise<string>,
-      contract.name() as Promise<string>,
-      contract.decimals() as Promise<bigint>,
-    ]);
+    // Fetch ERC20 metadata with retry/failover
+    const [symbol, name, decimals] = await rpcManager.executeWithFailover(
+      (provider) => {
+        const contract = new ethers.Contract(address, ERC20_ABI, provider);
+        return Promise.all([
+          contract.symbol() as Promise<string>,
+          contract.name() as Promise<string>,
+          contract.decimals() as Promise<bigint>,
+        ]);
+      }
+    );
 
     return NextResponse.json({
       valid: true,

--- a/keeperhub/api/web3/fetch-abi/route.ts
+++ b/keeperhub/api/web3/fetch-abi/route.ts
@@ -9,7 +9,8 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { fetchEtherscanSourceCode } from "@/lib/explorer/etherscan";
 import { detectProxyViaRpc } from "@/lib/explorer/proxy-detection";
-import { getChainIdFromNetwork, resolveRpcConfig } from "@/lib/rpc";
+import { getChainIdFromNetwork } from "@/lib/rpc";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY || "";
 
@@ -253,60 +254,58 @@ async function getDiamondFacets(
   contractAddress: string,
   chainId: number
 ): Promise<string[]> {
-  // Get RPC config (using default, no user preferences needed for this)
-  const rpcConfig = await resolveRpcConfig(chainId);
-  if (!rpcConfig) {
-    throw new Error(`No RPC config found for chain ${chainId}`);
-  }
+  const rpcManager = await getRpcProvider({ chainId });
 
-  const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-  const diamondContract = new ethers.Contract(
-    contractAddress,
-    DIAMOND_LOUPE_ABI,
-    provider
-  );
-
-  // Try to get facet addresses using the loupe interface
-  try {
-    const facetAddresses = (await diamondContract.facetAddresses()) as string[];
-    const validAddresses = facetAddresses.filter((addr) =>
-      ethers.isAddress(addr)
+  return rpcManager.executeWithFailover(async (provider) => {
+    const diamondContract = new ethers.Contract(
+      contractAddress,
+      DIAMOND_LOUPE_ABI,
+      provider
     );
-    if (validAddresses.length > 0) {
-      console.log(
-        "[Diamond] Found facets via facetAddresses():",
-        validAddresses
+
+    // Try to get facet addresses using the loupe interface
+    try {
+      const facetAddresses =
+        (await diamondContract.facetAddresses()) as string[];
+      const validAddresses = facetAddresses.filter((addr) =>
+        ethers.isAddress(addr)
       );
-      return validAddresses;
+      if (validAddresses.length > 0) {
+        console.log(
+          "[Diamond] Found facets via facetAddresses():",
+          validAddresses
+        );
+        return validAddresses;
+      }
+    } catch (error) {
+      console.log(
+        "[Diamond] facetAddresses() not available, trying facets():",
+        error instanceof Error ? error.message : "Unknown error"
+      );
     }
-  } catch (error) {
-    console.log(
-      "[Diamond] facetAddresses() not available, trying facets():",
-      error instanceof Error ? error.message : "Unknown error"
-    );
-  }
 
-  // Fallback: try facets() which returns more detailed info
-  try {
-    const facets = (await diamondContract.facets()) as Array<{
-      facetAddress: string;
-      functionSelectors: string[];
-    }>;
-    const addresses = facets.map((f) => f.facetAddress);
-    const validAddresses = addresses.filter((addr) => ethers.isAddress(addr));
-    if (validAddresses.length > 0) {
-      console.log("[Diamond] Found facets via facets():", validAddresses);
-      return validAddresses;
+    // Fallback: try facets() which returns more detailed info
+    try {
+      const facets = (await diamondContract.facets()) as Array<{
+        facetAddress: string;
+        functionSelectors: string[];
+      }>;
+      const addresses = facets.map((f) => f.facetAddress);
+      const validAddresses = addresses.filter((addr) => ethers.isAddress(addr));
+      if (validAddresses.length > 0) {
+        console.log("[Diamond] Found facets via facets():", validAddresses);
+        return validAddresses;
+      }
+    } catch (facetsError) {
+      console.log(
+        "[Diamond] Both loupe methods failed:",
+        facetsError instanceof Error ? facetsError.message : "Unknown error"
+      );
     }
-  } catch (facetsError) {
-    console.log(
-      "[Diamond] Both loupe methods failed:",
-      facetsError instanceof Error ? facetsError.message : "Unknown error"
-    );
-  }
 
-  // If we get here, it's not a Diamond or doesn't implement the loupe interface
-  throw new Error("Not a Diamond contract or loupe interface not available");
+    // If we get here, it's not a Diamond or doesn't implement the loupe interface
+    throw new Error("Not a Diamond contract or loupe interface not available");
+  });
 }
 
 /**
@@ -1337,10 +1336,11 @@ export async function POST(request: Request) {
     const checksummedAddress = toChecksumAddress(contractAddress);
 
     const chainId = getChainIdFromNetwork(network);
-    const rpcConfig = await resolveRpcConfig(chainId);
-    if (rpcConfig) {
-      const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-      const code = await provider.getCode(checksummedAddress);
+    try {
+      const rpcManager = await getRpcProvider({ chainId });
+      const code = await rpcManager.executeWithFailover((provider) =>
+        provider.getCode(checksummedAddress)
+      );
       if (!code || code === "0x") {
         return NextResponse.json(
           {
@@ -1350,6 +1350,8 @@ export async function POST(request: Request) {
           { status: 400 }
         );
       }
+    } catch {
+      // Chain not found/enabled — skip code check, proceed to Etherscan
     }
 
     console.log("[Etherscan] Fetching ABI for:", {

--- a/keeperhub/lib/para/wallet-helpers.ts
+++ b/keeperhub/lib/para/wallet-helpers.ts
@@ -2,11 +2,11 @@ import "server-only";
 import { ParaEthersSigner } from "@getpara/ethers-v6-integration";
 import { Environment, Para as ParaServer } from "@getpara/server-sdk";
 import { eq } from "drizzle-orm";
-import { ethers } from "ethers";
 import { decryptUserShare } from "@/keeperhub/lib/encryption";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { db } from "@/lib/db";
 import { paraWallets } from "@/lib/db/schema";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 
 /**
  * Get organization's Para wallet from database
@@ -85,9 +85,9 @@ export async function initializeParaSigner(
   const decryptedShare = decryptUserShare(wallet.userShare);
   await paraClient.setUserShare(decryptedShare);
 
-  // Create blockchain provider and signer
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
-  const signer = new ParaEthersSigner(paraClient, provider);
+  // Create blockchain provider (with batching disabled) and signer
+  const rpcManager = getRpcProviderFromUrls(rpcUrl);
+  const signer = new ParaEthersSigner(paraClient, rpcManager.getProvider());
 
   return signer;
 }

--- a/keeperhub/lib/web3/transaction-manager.ts
+++ b/keeperhub/lib/web3/transaction-manager.ts
@@ -10,9 +10,10 @@
  * @see docs/keeperhub/KEEP-1240/gas.md for gas strategy specification
  */
 
-import { ethers } from "ethers";
+import type { ethers } from "ethers";
 import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
 import { initializeParaSigner } from "@/keeperhub/lib/para/wallet-helpers";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import {
   type TriggerType as GasTriggerType,
   getGasStrategy,
@@ -271,7 +272,8 @@ export async function withNonceSession<T>(
   fn: (session: NonceSession) => Promise<T>
 ): Promise<T> {
   const nonceManager = getNonceManager();
-  const provider = new ethers.JsonRpcProvider(context.rpcUrl);
+  const rpcManager = getRpcProviderFromUrls(context.rpcUrl);
+  const provider = rpcManager.getProvider();
 
   // Start session (acquires lock, fetches nonce, validates)
   const { session, validation } = await nonceManager.startSession(
@@ -309,6 +311,8 @@ export async function getCurrentNonce(
   walletAddress: string,
   rpcUrl: string
 ): Promise<number> {
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
-  return await provider.getTransactionCount(walletAddress, "pending");
+  const rpcManager = getRpcProviderFromUrls(rpcUrl);
+  return await rpcManager.executeWithFailover((provider) =>
+    provider.getTransactionCount(walletAddress, "pending")
+  );
 }

--- a/lib/explorer/proxy-detection.ts
+++ b/lib/explorer/proxy-detection.ts
@@ -10,7 +10,9 @@
  */
 
 import { ethers } from "ethers";
-import { resolveRpcConfig } from "@/lib/rpc";
+// start custom keeperhub code //
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+// end keeperhub code //
 
 export type ProxyDetectionResult = {
   isProxy: boolean;
@@ -238,24 +240,26 @@ export async function detectProxyViaRpc(
     `[Proxy Detection] Starting RPC-based proxy detection for ${contractAddress} on chain ${chainId}`
   );
 
-  // Get RPC config
-  const rpcConfig = await resolveRpcConfig(chainId);
-  if (!rpcConfig) {
+  // start custom keeperhub code //
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  try {
+    rpcManager = await getRpcProvider({ chainId });
+  } catch {
     console.warn(
       `[Proxy Detection] No RPC config found for chain ${chainId}, skipping detection`
     );
     return { isProxy: false };
   }
 
-  const provider = new ethers.JsonRpcProvider(rpcConfig.primaryRpcUrl);
-
-  // Run common checks in parallel:
-  // - EIP-1967 with admin (covers both EIP-1967 and OpenZeppelin)
-  // - EIP-1167 (uses getCode, independent of storage checks)
-  const [eip1967Result, eip1167Impl] = await Promise.all([
-    checkEip1967WithAdmin(provider, contractAddress),
-    checkEip1167Proxy(provider, contractAddress),
-  ]);
+  // Run common checks in parallel with retry/failover
+  const [eip1967Result, eip1167Impl] = await rpcManager.executeWithFailover(
+    async (provider) =>
+      Promise.all([
+        checkEip1967WithAdmin(provider, contractAddress),
+        checkEip1167Proxy(provider, contractAddress),
+      ])
+  );
+  // end keeperhub code //
 
   // Check EIP-1967/OpenZeppelin result first (most common)
   if (eip1967Result.implementation) {
@@ -275,8 +279,11 @@ export async function detectProxyViaRpc(
     };
   }
 
+  // start custom keeperhub code //
   // Check EIP-1822 (UUPS) - less common, separate call
-  const eip1822Impl = await checkEip1822Proxy(provider, contractAddress);
+  const eip1822Impl = await rpcManager.executeWithFailover((provider) =>
+    checkEip1822Proxy(provider, contractAddress)
+  );
   if (eip1822Impl) {
     return {
       isProxy: true,
@@ -286,7 +293,9 @@ export async function detectProxyViaRpc(
   }
 
   // Check Gnosis Safe (least common, requires contract call to verify)
-  const gnosisImpl = await checkGnosisSafeProxy(provider, contractAddress);
+  const gnosisImpl = await rpcManager.executeWithFailover((provider) =>
+    checkGnosisSafeProxy(provider, contractAddress)
+  );
   if (gnosisImpl) {
     return {
       isProxy: true,
@@ -294,6 +303,7 @@ export async function detectProxyViaRpc(
       proxyType: "gnosis-safe",
     };
   }
+  // end keeperhub code //
 
   console.log(
     `[Proxy Detection] No proxy pattern detected for ${contractAddress}`


### PR DESCRIPTION
## Summary

Fixes `BAD_DATA: missing response for request` errors occurring in staging and production during write-contract execution (specifically `poke()` on `0x1b3359D8e087c02D56b22765Ca0C53C9f3f64F5e`).

## Root Cause

Ethers v6 `JsonRpcProvider` batches concurrent JSON-RPC requests by default (`batchMaxCount: 100`, `batchStallTime: 10ms` -- see `defaultOptions` in `provider-jsonrpc.ts:201-211`). When multiple RPC calls are queued within the 10ms stall window (e.g. `eth_blockNumber`, `eth_getTransactionCount`, `eth_estimateGas` during transaction execution), ethers aggregates them into a single HTTP batch request per the JSON-RPC 2.0 batch spec (`provider-jsonrpc.ts:524-536`).

After receiving the batch response, ethers iterates each original request and filters the response array for a matching `id` (`provider-jsonrpc.ts:557`):

```js
const resp = result.filter((r) => (r.id === payload.id))[0];
```

When the RPC endpoint returns fewer responses than requests sent (incomplete batch), `resp == null` and ethers throws at `provider-jsonrpc.ts:561`:

```
BAD_DATA: missing response for request
  value: [{ id: 20, result: "0x177d86c" }, { id: 8, result: "0xf4b6..." }, { id: 9, result: "0x1" }]
  info: { payload: { id: 7, method: "eth_blockNumber" } }
```

Request id 7 was sent in the batch but its response was dropped by the RPC proxy.

We already had `RpcProviderManager` with `batchMaxCount: 1` (disabling batching) and retry/failover logic, but 8 production code paths were creating bare `new ethers.JsonRpcProvider(url)` with default batching enabled (`batchMaxCount: 100`).

## Changes

Replace all bare `new ethers.JsonRpcProvider(url)` calls in production code with `RpcProviderManager` via the existing `getRpcProvider()` / `getRpcProviderFromUrls()` factory functions. This gives every call site:

- `batchMaxCount: 1` -- each RPC call is its own HTTP request, eliminating batch response mismatches
- Retry with exponential backoff (up to 3 attempts)
- Primary/fallback provider failover

| File | Change |
|------|--------|
| `keeperhub/api/gas/estimate/route.ts` | `getRpcProvider` + `executeWithFailover` |
| `keeperhub/api/validate-token/route.ts` | `getRpcProvider` + `executeWithFailover` |
| `keeperhub/api/web3/fetch-abi/route.ts` | `getRpcProvider` + `executeWithFailover` (2 sites) |
| `keeperhub/api/user/wallet/balances/route.ts` | `getRpcProvider` + `executeWithFailover` |
| `keeperhub/api/user/wallet/tokens/route.ts` | `getRpcProvider` + `executeWithFailover` |
| `keeperhub/lib/para/wallet-helpers.ts` | `getRpcProviderFromUrls().getProvider()` (signer needs raw provider) |
| `keeperhub/lib/web3/transaction-manager.ts` | `getRpcProviderFromUrls` for nonce session, `executeWithFailover` for getCurrentNonce |
| `lib/explorer/proxy-detection.ts` | `getRpcProvider` + `executeWithFailover` (with keeperhub markers) |

## Test plan

- [x] Verify `pnpm check` and `pnpm type-check` pass (confirmed locally, zero new errors)
- [x] Deploy to staging and trigger the write-contract workflow calling `poke()` on `0x1b3359D8e087c02D56b22765Ca0C53C9f3f64F5e`
- [x] Verify gas estimation API (`/api/gas/estimate`) works for transfer-funds, transfer-token, write-contract
- [x] Verify token validation API (`/api/validate-token`) resolves ERC20 metadata
- [x] Verify wallet balances API (`/api/user/wallet/balances`) fetches native + token balances
- [x] Monitor logs for absence of `missing response for request` errors