### PR TITLE
fix: KEEP-1554 add set -e to init containers and fix migration journal ordering

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -57,6 +57,7 @@ deployment:
         - -c
       args:
         - |
+          set -e
           echo "Setting up workflow postgres tables..."
           export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
           pnpm exec workflow-postgres-setup

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -57,6 +57,7 @@ deployment:
         - -c
       args:
         - |
+          set -e
           echo "Setting up workflow postgres tables..."
           export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
           pnpm exec workflow-postgres-setup

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -58,6 +58,7 @@ deployment:
         - -c
       args:
         - |
+          set -e
           echo "Setting up workflow postgres tables..."
           export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
           pnpm exec workflow-postgres-setup

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -208,21 +208,21 @@
     {
       "idx": 29,
       "version": "7",
-      "when": 1772577375583,
+      "when": 1772579200001,
       "tag": "0029_opposite_human_cannonball",
       "breakpoints": true
     },
     {
       "idx": 30,
       "version": "7",
-      "when": 1772656435595,
+      "when": 1772579200002,
       "tag": "0030_lucky_praxagora",
       "breakpoints": true
     },
     {
       "idx": 31,
       "version": "7",
-      "when": 1772595598240,
+      "when": 1772579200003,
       "tag": "0031_heavy_overlord",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary

- Add `set -e` to all init container migration scripts (staging, prod, PR environments) so migration failures block deploys instead of silently continuing
- Fix Drizzle migration journal timestamps for 0029-0031 which were out of order, causing Drizzle to skip migrations with timestamps lower than the last applied one

## Context

Migrations 0029-0032 were never applied on staging or prod because:

1. Migration 0031 was deployed before 0029/0030, and had a `when` timestamp between them
2. Drizzle only runs migrations with timestamps greater than the last applied one, so 0029 was permanently skipped
3. When 0030 tried to ALTER a table created by 0029, it failed
4. The init container script had no `set -e`, so it reported "Migrations and seeding completed successfully" despite `pnpm db:migrate` exiting with code 1

Migrations were manually applied to both staging and prod databases. This PR fixes the code to prevent recurrence.

## Test plan

- [x] Dropped and recreated local database, ran `pnpm db:migrate` from scratch -- all 33 migrations applied successfully
  - [x] Verified `duration` column is `numeric`, `overage_billing_records` and `execution_debt` tables exist
  - [x] Verified journal timestamps are monotonically increasing
- [x] Verify staging and production