### PR TITLE
hotfix: wrap BillingPage in Suspense boundary for static prerendering

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { BillingPage } from "@/keeperhub/components/billing/billing-page";
 import { isBillingEnabled } from "@/keeperhub/lib/billing/feature-flag";
@@ -7,5 +8,9 @@ export default function BillingRoute(): React.ReactElement {
     notFound();
   }
 
-  return <BillingPage />;
+  return (
+    <Suspense>
+      <BillingPage />
+    </Suspense>
+  );
 }

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,5 +1,5 @@
-import { Suspense } from "react";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { BillingPage } from "@/keeperhub/components/billing/billing-page";
 import { isBillingEnabled } from "@/keeperhub/lib/billing/feature-flag";
 


### PR DESCRIPTION
## Summary

- Wraps BillingPage component in a Suspense boundary to fix Next.js static prerendering failure
- BillingPage uses useSearchParams() which requires a Suspense boundary during build-time page generation
- This was surfaced after NEXT_PUBLIC_BILLING_ENABLED was properly passed as a Docker build arg