### PR TITLE
hotfix: use BETTER_AUTH_URL as fallback for billing redirect URLs

### DIFF
--- a/keeperhub/api/billing/checkout/route.ts
+++ b/keeperhub/api/billing/checkout/route.ts
@@ -195,7 +195,10 @@ export async function POST(request: Request): Promise<NextResponse> {
       sub
     );
 
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const appUrl =
+      process.env.NEXT_PUBLIC_APP_URL ??
+      process.env.BETTER_AUTH_URL ??
+      "http://localhost:3000";
 
     const { url } = await provider.createCheckoutSession({
       customerId: providerCustomerId,

--- a/keeperhub/api/billing/portal/route.ts
+++ b/keeperhub/api/billing/portal/route.ts
@@ -26,7 +26,10 @@ export async function POST(_request: Request): Promise<NextResponse> {
       );
     }
 
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const appUrl =
+      process.env.NEXT_PUBLIC_APP_URL ??
+      process.env.BETTER_AUTH_URL ??
+      "http://localhost:3000";
     const provider = getBillingProvider();
 
     const { url } = await provider.createPortalSession(


### PR DESCRIPTION
## Summary

- Billing checkout and portal routes were falling back to localhost:3000 when NEXT_PUBLIC_APP_URL is not set
- Added BETTER_AUTH_URL as intermediate fallback since it is already configured in K8s deployments (https://app-staging.keeperhub.com)
- Affects checkout success/cancel redirects and portal return URL