### PR TITLE
chore: exclude .worktrees from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ dist
 # Development files
 .git
 .gitignore
+.worktrees
 README.md
 Dockerfile
 .dockerignore


### PR DESCRIPTION
## Summary
- Adds `.worktrees` to `.dockerignore` to prevent git worktree directories from being copied into Docker build context when building locally