### PR TITLE
ci: disable staging deployments to maker-staging cluster

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -3,7 +3,7 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [staging, prod]
+    branches: [prod]
   pull_request:
     types: [labeled, synchronize]
   workflow_dispatch: {}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - staging
       - prod
     paths:
       - 'docs/**'


### PR DESCRIPTION
Staging is now fully served from the techops-staging EKS cluster. Remove staging branch trigger from ci-pipeline.yml and deploy-docs.yaml so that pushes to staging no longer deploy to the old maker-staging cluster. Prod deployments to maker-prod are unchanged.