### PR TITLE
refactor: KEEP-1560 remove upstream boundary comment markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,27 +129,6 @@ Exits with code 1 if errors are found. Errors are hardcoded colors in CSS and ar
 
 ---
 
-## 🚨 CRITICAL: KeeperHub Custom Code Policy
-
-**This is a fork of vercel-labs/workflow-builder-template. ALL custom changes MUST follow these rules:**
-
-1. **ALL new features/changes go in `/keeperhub` directory**
-   - Prevents merge conflicts when syncing from upstream
-   - Mirror the project structure inside `/keeperhub` (e.g., `keeperhub/components/`, `keeperhub/plugins/`)
-
-2. **When modifying core files outside `/keeperhub`, use markers:**
-
-   ```typescript
-   // start custom keeperhub code //
-   ... your custom code here ...
-   // end keeperhub code //
-   ```
-
-3. **Git remote structure:**
-   - `upstream` → vercel-labs/workflow-builder-template (original template)
-   - `origin` → techops-services/keeperhub (our fork)
-   - Merge from: `upstream/main`
-
 ## Tech Stack
 
 - **Framework**: Next.js 16 (App Router)

--- a/app/accept-invite/[inviteId]/page.tsx
+++ b/app/accept-invite/[inviteId]/page.tsx
@@ -814,9 +814,7 @@ export default function AcceptInvitePage() {
   // unmount the form and reset its local state (OTP field, submitting flag).
   if (verificationData.showVerification && invitation) {
     return (
-      // start custom keeperhub code //
       <div data-page-state={pageState}>
-        {/* end keeperhub code */}
         <VerificationFormState
           invitation={invitation}
           onBack={() =>
@@ -825,40 +823,32 @@ export default function AcceptInvitePage() {
           onSuccess={handleSuccess}
           storedPassword={verificationData.storedPassword}
         />
-        {/* start custom keeperhub code */}
       </div>
-      // end keeperhub code //
     );
   }
 
   if (pageState === "loading") {
-    // start custom keeperhub code //
     return (
       <div data-page-state={pageState}>
         <LoadingState />
       </div>
     );
-    // end keeperhub code //
   }
 
   if (pageState === "error" && inviteError) {
-    // start custom keeperhub code //
     return (
       <div data-page-state={pageState}>
         <ErrorState inviteError={inviteError} />
       </div>
     );
-    // end keeperhub code //
   }
 
   if (pageState === "not-found" || !invitation) {
-    // start custom keeperhub code //
     return (
       <div data-page-state={pageState}>
         <NotFoundState />
       </div>
     );
-    // end keeperhub code //
   }
 
   if (pageState === "logged-in-match") {
@@ -868,9 +858,7 @@ export default function AcceptInvitePage() {
     // button that would flash and auto-resolve.
     if (isAcceptingViaAuth) {
       return (
-        // start custom keeperhub code //
         <div data-page-state={pageState}>
-          {/* end keeperhub code */}
           <div className="flex min-h-screen items-center justify-center p-4">
             <div className="w-full max-w-md space-y-6 rounded-lg border bg-card p-8 text-center">
               <Spinner className="mx-auto size-8" />
@@ -884,42 +872,30 @@ export default function AcceptInvitePage() {
               </div>
             </div>
           </div>
-          {/* start custom keeperhub code */}
         </div>
-        // end keeperhub code //
       );
     }
 
     return (
-      // start custom keeperhub code //
       <div data-page-state={pageState}>
-        {/* end keeperhub code */}
         <AcceptDirectState invitation={invitation} onSuccess={handleSuccess} />
-        {/* start custom keeperhub code */}
       </div>
-      // end keeperhub code //
     );
   }
 
   if (pageState === "logged-in-mismatch" && session?.user?.email) {
     return (
-      // start custom keeperhub code //
       <div data-page-state={pageState}>
-        {/* end keeperhub code */}
         <EmailMismatchState
           currentEmail={session.user.email}
           invitation={invitation}
         />
-        {/* start custom keeperhub code */}
       </div>
-      // end keeperhub code //
     );
   }
 
   return (
-    // start custom keeperhub code //
     <div data-page-state={pageState}>
-      {/* end keeperhub code */}
       <AuthFormState
         invitation={invitation}
         onAccepting={() => setIsAcceptingViaAuth(true)}
@@ -931,8 +907,6 @@ export default function AcceptInvitePage() {
         }
         onSuccess={handleSuccess}
       />
-      {/* start custom keeperhub code */}
     </div>
-    // end keeperhub code //
   );
 }

--- a/app/api/admin/test/invitation/route.ts
+++ b/app/api/admin/test/invitation/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/admin/test/invitation/route";
-// end keeperhub code //

--- a/app/api/admin/test/otp/route.ts
+++ b/app/api/admin/test/otp/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/admin/test/otp/route";
-// end keeperhub code //

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -3,11 +3,9 @@ import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModelV2 } from "@ai-sdk/provider";
 import { streamText } from "ai";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { createTimer, getMetricsCollector } from "@/keeperhub/lib/metrics";
 import { MetricNames } from "@/keeperhub/lib/metrics/types";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { generateAIActionPrompts } from "@/plugins/registry";
 
@@ -316,13 +314,10 @@ function getAIModel(
 }
 
 export async function POST(request: Request) {
-  // start custom keeperhub code //
   const timer = createTimer();
   const metrics = getMetricsCollector();
-  // end keeperhub code //
 
   try {
-    // start custom keeperhub code //
     // Try API key authentication first
     const apiKeyAuth = await authenticateApiKey(request);
 
@@ -339,17 +334,14 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
       }
     }
-    // end keeperhub code //
 
     const body = await request.json();
     const { prompt, existingWorkflow } = body;
 
     if (!prompt) {
-      // start custom keeperhub code //
       metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
         status: "failure",
       });
-      // end keeperhub code //
       return NextResponse.json(
         { error: "Prompt is required" },
         { status: 400 }
@@ -366,11 +358,9 @@ export async function POST(request: Request) {
     );
 
     if (!modelResult.success) {
-      // start custom keeperhub code //
       metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
         status: "failure",
       });
-      // end keeperhub code //
       return NextResponse.json({ error: modelResult.error }, { status: 500 });
     }
 
@@ -435,18 +425,14 @@ Example: If user says "connect node A to node B", output:
       async start(controller) {
         try {
           await processOperationStream(result.textStream, encoder, controller);
-          // start custom keeperhub code //
           metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
             status: "success",
           });
-          // end keeperhub code //
           controller.close();
         } catch (error) {
-          // start custom keeperhub code //
           metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
             status: "failure",
           });
-          // end keeperhub code //
           controller.enqueue(
             encodeMessage(encoder, {
               type: "error",
@@ -470,11 +456,9 @@ Example: If user says "connect node A to node B", output:
     });
   } catch (error) {
     console.error("Failed to generate workflow:", error);
-    // start custom keeperhub code //
     metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
       status: "failure",
     });
-    // end keeperhub code //
     return NextResponse.json(
       {
         error:

--- a/app/api/integrations/[integrationId]/route.ts
+++ b/app/api/integrations/[integrationId]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
@@ -10,7 +9,6 @@ import {
   updateIntegration,
 } from "@/lib/db/integrations";
 import type { IntegrationConfig } from "@/lib/types/integration";
-// end keeperhub code //
 
 export type GetIntegrationResponse = {
   id: string;
@@ -44,17 +42,13 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     const orgContext = await getOrgContext();
     const organizationId = orgContext.organization?.id || null;
-    // end keeperhub code //
 
     const integration = await getIntegration(
       integrationId,
       session.user.id,
-      // start custom keeperhub code //
       organizationId
-      // end keeperhub code //
     );
 
     if (!integration) {
@@ -64,7 +58,6 @@ export async function GET(
       );
     }
 
-    // start custom keeperhub code //
     const response: GetIntegrationResponse = {
       id: integration.id,
       name: integration.name,
@@ -73,7 +66,6 @@ export async function GET(
       createdAt: integration.createdAt.toISOString(),
       updatedAt: integration.updatedAt.toISOString(),
     };
-    // end keeperhub code //
 
     return NextResponse.json(response);
   } catch (error) {
@@ -109,14 +101,11 @@ export async function PUT(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     const orgContext = await getOrgContext();
     const organizationId = orgContext.organization?.id || null;
-    // end keeperhub code //
 
     const body: UpdateIntegrationRequest = await request.json();
 
-    // start custom keeperhub code //
     // Fetch existing integration so updateIntegration can merge database
     // secrets without an extra DB round-trip.
     const existing =
@@ -130,16 +119,13 @@ export async function PUT(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     const integration = await updateIntegration(
       integrationId,
       session.user.id,
       body,
-      // start custom keeperhub code //
       organizationId,
       existing
-      // end keeperhub code //
     );
 
     if (!integration) {
@@ -149,7 +135,6 @@ export async function PUT(
       );
     }
 
-    // start custom keeperhub code //
     const response: GetIntegrationResponse = {
       id: integration.id,
       name: integration.name,
@@ -158,7 +143,6 @@ export async function PUT(
       createdAt: integration.createdAt.toISOString(),
       updatedAt: integration.updatedAt.toISOString(),
     };
-    // end keeperhub code //
 
     return NextResponse.json(response);
   } catch (error) {
@@ -201,17 +185,13 @@ export async function DELETE(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     const orgContext = await getOrgContext();
     const organizationId = orgContext.organization?.id || null;
-    // end keeperhub code //
 
     const success = await deleteIntegration(
       integrationId,
       session.user.id,
-      // start custom keeperhub code //
       organizationId
-      // end keeperhub code //
     );
 
     if (!success) {

--- a/app/api/integrations/[integrationId]/test/route.ts
+++ b/app/api/integrations/[integrationId]/test/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import {
@@ -9,11 +8,8 @@ import {
 import { handleDatabaseTest, handlePluginTest } from "@/lib/db/test-connection";
 import type { IntegrationConfig } from "@/lib/types/integration";
 
-// end keeperhub code //
-
 export type { TestConnectionResult } from "@/lib/db/test-connection";
 
-// start custom keeperhub code //
 type TestRequestBody = { configOverrides?: IntegrationConfig };
 
 async function parseJsonBody(
@@ -32,7 +28,6 @@ async function parseJsonBody(
     );
   }
 }
-// end keeperhub code //
 
 export async function POST(
   request: Request,
@@ -47,10 +42,8 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     const orgContext = await getOrgContext();
     const organizationId = orgContext.organization?.id ?? null;
-    // end keeperhub code //
 
     const { integrationId } = await params;
 
@@ -64,9 +57,7 @@ export async function POST(
     const integration = await getIntegrationFromDb(
       integrationId,
       session.user.id,
-      // start custom keeperhub code //
       organizationId
-      // end keeperhub code //
     );
 
     if (!integration) {
@@ -76,7 +67,6 @@ export async function POST(
       );
     }
 
-    // start custom keeperhub code //
     // Parse optional config overrides from the request body.
     // For database integrations, overrides are merged with stored config so the
     // server can test with updated non-secret fields (e.g. host) without
@@ -86,14 +76,11 @@ export async function POST(
       return bodyOrError;
     }
     const body = bodyOrError;
-    // end keeperhub code //
 
     if (integration.type === "database") {
-      // start custom keeperhub code //
       const testConfig = body.configOverrides
         ? mergeDatabaseConfig(integration.config, body.configOverrides)
         : integration.config;
-      // end keeperhub code //
       const result = await handleDatabaseTest(testConfig);
       return NextResponse.json(result);
     }

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
@@ -8,7 +7,6 @@ import type {
   IntegrationConfig,
   IntegrationType,
 } from "@/lib/types/integration";
-// end keeperhub code //
 
 export type GetIntegrationsResponse = {
   id: string;
@@ -48,10 +46,8 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     const context = await getOrgContext();
     const organizationId = context.organization?.id || null;
-    // end keeperhub code //
 
     // Get optional type filter from query params
     const { searchParams } = new URL(request.url);
@@ -60,9 +56,7 @@ export async function GET(request: Request) {
     const integrations = await getIntegrations(
       session.user.id,
       typeFilter || undefined,
-      // start custom keeperhub code //
       organizationId
-      // end keeperhub code //
     );
 
     // Return integrations without config for security
@@ -112,10 +106,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     const context = await getOrgContext();
     const organizationId = context.organization?.id || null;
-    // end keeperhub code //
 
     const body: CreateIntegrationRequest = await request.json();
 
@@ -131,9 +123,7 @@ export async function POST(request: Request) {
       name: body.name || "",
       type: body.type,
       config: body.config,
-      // start custom keeperhub code //
       organizationId,
-      // end keeperhub code //
     });
 
     const response: CreateIntegrationResponse = {

--- a/app/api/internal/block-workflows/route.ts
+++ b/app/api/internal/block-workflows/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/internal/block-workflows/route";
-// end keeperhub code //

--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { and, eq, ne } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -88,4 +87,3 @@ export async function PATCH(
 
   return NextResponse.json({ success: true });
 }
-// end keeperhub code //

--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -52,4 +51,3 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   return NextResponse.json({ executionId: execution.id }, { status: 201 });
 }
-// end keeperhub code //

--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/internal/reaper/route";
-// end keeperhub code //

--- a/app/api/internal/schedules/[scheduleId]/route.ts
+++ b/app/api/internal/schedules/[scheduleId]/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { CronExpressionParser } from "cron-parser";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -101,4 +100,3 @@ export async function PATCH(request: Request, context: RouteContext) {
 
   return NextResponse.json({ success: true });
 }
-// end keeperhub code //

--- a/app/api/internal/schedules/route.ts
+++ b/app/api/internal/schedules/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -30,4 +29,3 @@ export async function GET(request: Request) {
 
   return NextResponse.json({ schedules });
 }
-// end keeperhub code //

--- a/app/api/internal/workflows/[workflowId]/route.ts
+++ b/app/api/internal/workflows/[workflowId]/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -37,4 +36,3 @@ export async function GET(
 
   return NextResponse.json({ workflow });
 }
-// end keeperhub code //

--- a/app/api/og/default/route.tsx
+++ b/app/api/og/default/route.tsx
@@ -1,7 +1,5 @@
-// start custom keeperhub code //
 import { generateDefaultOGImage } from "@/keeperhub/api/og/generate-og";
 
 export async function GET(): Promise<Response> {
   return await generateDefaultOGImage();
 }
-// end keeperhub code //

--- a/app/api/og/hub/route.tsx
+++ b/app/api/og/hub/route.tsx
@@ -1,7 +1,5 @@
-// start custom keeperhub code //
 import { generateHubOGImage } from "@/keeperhub/api/og/generate-og";
 
 export async function GET(): Promise<Response> {
   return await generateHubOGImage();
 }
-// end keeperhub code //

--- a/app/api/og/protocol/[slug]/route.tsx
+++ b/app/api/og/protocol/[slug]/route.tsx
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { generateProtocolOGImage } from "@/keeperhub/api/og/generate-og";
 
 export async function GET(
@@ -8,4 +7,3 @@ export async function GET(
   const { slug } = await context.params;
   return await generateProtocolOGImage(slug);
 }
-// end keeperhub code //

--- a/app/api/og/workflow/[workflowId]/route.tsx
+++ b/app/api/og/workflow/[workflowId]/route.tsx
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { generateWorkflowOGImage } from "@/keeperhub/api/og/generate-og";
 
 export async function GET(
@@ -8,4 +7,3 @@ export async function GET(
   const { workflowId } = await context.params;
   return generateWorkflowOGImage(workflowId);
 }
-// end keeperhub code //

--- a/app/api/organizations/route.ts
+++ b/app/api/organizations/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/organizations/route";
-// end keeperhub code //

--- a/app/api/protocols/[slug]/route.ts
+++ b/app/api/protocols/[slug]/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/protocols/[slug]/route";
-// end keeperhub code //

--- a/app/api/protocols/route.ts
+++ b/app/api/protocols/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { GET } from "@/keeperhub/api/protocols/route";
-// end keeperhub code //

--- a/app/api/user/delete/route.ts
+++ b/app/api/user/delete/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
@@ -88,4 +87,3 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 }
-// end keeperhub code //

--- a/app/api/user/forgot-password/route.ts
+++ b/app/api/user/forgot-password/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { randomInt } from "node:crypto";
 import { and, eq, gt } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -224,4 +223,3 @@ async function handleReset(
     message: "Password has been reset successfully",
   });
 }
-// end keeperhub code //

--- a/app/api/user/password/route.ts
+++ b/app/api/user/password/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
@@ -119,4 +118,3 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 }
-// end keeperhub code //

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -1,7 +1,6 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { start } from "workflow/api";
-// start custom keeperhub code //
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { enforceExecutionLimit } from "@/keeperhub/lib/billing/execution-guard";
 import { authenticateInternalService } from "@/keeperhub/lib/internal-service-auth";
@@ -9,7 +8,6 @@ import { getMetricsCollector } from "@/keeperhub/lib/metrics";
 import { LabelKeys, MetricNames } from "@/keeperhub/lib/metrics/types";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { checkConcurrencyLimit } from "@/keeperhub/api/execute/_lib/concurrency-limit";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
@@ -50,12 +48,10 @@ async function executeWorkflowBackground(
 
     console.log("[Workflow Execute] Workflow started, runId:", run.runId);
 
-    // start custom keeperhub code //
     await db
       .update(workflowExecutions)
       .set({ runId: run.runId })
       .where(eq(workflowExecutions.id, executionId));
-    // end keeperhub code //
   } catch (error) {
     console.error("[Workflow Execute] Error during execution:", error);
     console.error(
@@ -83,11 +79,9 @@ export async function POST(
   try {
     const { workflowId } = await context.params;
 
-    // start custom keeperhub code //
     // Check for internal service authentication (MCP, Events, Scheduler)
     const internalAuth = authenticateInternalService(request);
     const isInternalExecution = internalAuth.authenticated;
-    // end keeperhub code //
 
     let userId: string;
     let workflow: typeof workflows.$inferSelect | undefined;
@@ -111,7 +105,6 @@ export async function POST(
 
       userId = workflow.userId;
     } else {
-      // start custom keeperhub code //
       // Try API key authentication first
       const apiKeyAuth = await authenticateApiKey(request);
       let organizationId: string | null = null;
@@ -179,17 +172,14 @@ export async function POST(
 
         userId = session.user.id;
       }
-      // end keeperhub code //
     }
 
-    // start custom keeperhub code //
     // Validate that all integrationIds in workflow nodes belong to the user or org
     const validation = await validateWorkflowIntegrations(
       workflow.nodes as WorkflowNode[],
       userId,
       workflow.organizationId
     );
-    // end keeperhub code //
     if (!validation.valid) {
       console.error(
         "[Workflow Execute] Invalid integration references:",
@@ -201,7 +191,6 @@ export async function POST(
       );
     }
 
-    // start custom keeperhub code //
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
       return executionGuard.response;
@@ -218,7 +207,6 @@ export async function POST(
         { status: 429, headers: { "Retry-After": "30" } }
       );
     }
-    // end keeperhub code //
 
     // Parse request body
     const body = await request.json().catch(() => ({}));
@@ -264,7 +252,6 @@ export async function POST(
       console.log("[API] Created execution:", executionId);
     }
 
-    // start custom keeperhub code //
     // Record workflow execution metric in API process (workflow runs in separate context)
     const triggerType = isInternalExecution ? "scheduled" : "manual";
     const metrics = getMetricsCollector();
@@ -272,7 +259,6 @@ export async function POST(
       [LabelKeys.TRIGGER_TYPE]: triggerType,
       [LabelKeys.WORKFLOW_ID]: workflowId,
     });
-    // end keeperhub code //
 
     // Execute the workflow in the background (don't await)
     executeWorkflowBackground(

--- a/app/api/workflows/[workflowId]/claim/route.ts
+++ b/app/api/workflows/[workflowId]/claim/route.ts
@@ -1,3 +1,1 @@
-// start custom keeperhub code //
 export { POST } from "@/keeperhub/api/workflows/[workflowId]/claim/route";
-// end keeperhub code //

--- a/app/api/workflows/[workflowId]/code/route.ts
+++ b/app/api/workflows/[workflowId]/code/route.ts
@@ -1,9 +1,7 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
@@ -23,7 +21,6 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     // Verify workflow access (owner or org member)
     const workflow = await db.query.workflows.findFirst({
       where: eq(workflows.id, workflowId),
@@ -49,7 +46,6 @@ export async function GET(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     // Generate code
     const code = generateWorkflowSDKCode(

--- a/app/api/workflows/[workflowId]/download/route.ts
+++ b/app/api/workflows/[workflowId]/download/route.ts
@@ -2,10 +2,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
@@ -221,7 +219,6 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // start custom keeperhub code //
     // Verify workflow access (owner or org member)
     const workflow = await db.query.workflows.findFirst({
       where: eq(workflows.id, workflowId),
@@ -247,7 +244,6 @@ export async function GET(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     // Read boilerplate files
     const boilerplateFiles = await readDirectoryRecursive(BOILERPLATE_PATH);

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -1,19 +1,13 @@
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
-// start custom keeperhub code //
 import { remapTemplateRefsInString } from "@/lib/utils/template";
-
-// end keeperhub code //
-
 // Node type for type-safe node manipulation
 type WorkflowNodeLike = {
   id: string;
@@ -28,7 +22,6 @@ type WorkflowNodeLike = {
   [key: string]: unknown;
 };
 
-// start custom keeperhub code //
 /** Recursively rewrite a single value (string, object, or array) using old->new node ID map */
 function remapTemplateRefsInValue(
   value: unknown,
@@ -84,7 +77,6 @@ function duplicateNodes(
     return newNode;
   });
 }
-// end keeperhub code //
 
 // Edge type for type-safe edge manipulation
 type WorkflowEdgeLike = {
@@ -151,29 +143,24 @@ export async function POST(
       );
     }
 
-    // start custom keeperhub code //
     // Get organization context for the new workflow
     const orgContext = await getOrgContext();
     const organizationId = orgContext.organization?.id || null;
     const isAnonymous = orgContext.isAnonymous || !orgContext.organization;
-    // end keeperhub code //
 
     // Generate new IDs for nodes
     const oldNodes = sourceWorkflow.nodes as WorkflowNodeLike[];
-    // start custom keeperhub code //
     const idMap = new Map<string, string>();
     for (const n of oldNodes) {
       idMap.set(n.id, nanoid());
     }
     const newNodes = duplicateNodes(oldNodes, idMap);
-    // end keeperhub code //
     const newEdges = updateEdgeReferences(
       sourceWorkflow.edges as WorkflowEdgeLike[],
       oldNodes,
       newNodes
     );
 
-    // start custom keeperhub code //
     // Count workflows in current context (org or anonymous) to generate unique name
     const existingWorkflows = isAnonymous
       ? await db.query.workflows.findMany({
@@ -188,7 +175,6 @@ export async function POST(
             eq(workflows.isAnonymous, false)
           ),
         });
-    // end keeperhub code //
 
     // Generate a unique name
     const baseName = `${sourceWorkflow.name} (Copy)`;
@@ -214,21 +200,17 @@ export async function POST(
         nodes: newNodes,
         edges: newEdges,
         userId: session.user.id,
-        // start custom keeperhub code //
         organizationId,
         isAnonymous,
-        // end keeperhub code //
         visibility: "private", // Duplicated workflows are always private
       })
       .returning();
 
-    // start custom keeperhub code //
     // If moving an anonymous workflow to an org, delete the original
     // This prevents the old anonymous workflow from being accessible after sign out
     if (sourceWorkflow.isAnonymous && isOwner && !isAnonymous) {
       await db.delete(workflows).where(eq(workflows.id, workflowId));
     }
-    // end keeperhub code //
 
     return NextResponse.json({
       ...newWorkflow,

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -1,9 +1,7 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
-// end keeperhub code //
 import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 
@@ -14,7 +12,6 @@ export async function GET(
   try {
     const { workflowId } = await context.params;
 
-    // start custom keeperhub code //
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
       return NextResponse.json(
@@ -48,7 +45,6 @@ export async function GET(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     // Fetch executions
     const executions = await db.query.workflowExecutions.findMany({
@@ -80,7 +76,6 @@ export async function DELETE(
   try {
     const { workflowId } = await context.params;
 
-    // start custom keeperhub code //
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
       return NextResponse.json(
@@ -114,7 +109,6 @@ export async function DELETE(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     // Get all execution IDs for this workflow
     const executions = await db.query.workflowExecutions.findMany({

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1,16 +1,11 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, publicTags, tags, workflowPublicTags, workflows } from "@/lib/db/schema";
 import { syncWorkflowSchedule } from "@/lib/schedule-service";
-
-// end keeperhub code //
-
-// start custom keeperhub code //
 async function fetchWorkflowPublicTags(
   workflowId: string
 ): Promise<Array<{ id: string; name: string; slug: string }>> {
@@ -25,7 +20,6 @@ async function fetchWorkflowPublicTags(
     .where(eq(workflowPublicTags.workflowId, workflowId));
   return rows;
 }
-// end keeperhub code //
 
 // Helper to strip sensitive data from nodes for public viewing
 function sanitizeNodesForPublicView(
@@ -62,7 +56,6 @@ export async function GET(
   try {
     const { workflowId } = await context.params;
 
-    // start custom keeperhub code //
     const authContext = await getDualAuthContext(request, { required: false });
     if ("error" in authContext) {
       return NextResponse.json(
@@ -71,7 +64,6 @@ export async function GET(
       );
     }
     const { userId, organizationId } = authContext;
-    // end keeperhub code //
 
     // First, try to find the workflow
     const workflow = await db.query.workflows.findFirst({
@@ -87,7 +79,6 @@ export async function GET(
 
     const isOwner = userId === workflow.userId;
 
-    // start custom keeperhub code //
     // Check organization membership for private workflows
     const isSameOrg =
       !workflow.isAnonymous &&
@@ -108,7 +99,6 @@ export async function GET(
     const hasFullAccess = isOwner || isSameOrg;
 
     const workflowTags = await fetchWorkflowPublicTags(workflowId);
-    // end keeperhub code //
 
     // For public workflows viewed by non-owners, sanitize sensitive data
     const responseData = {
@@ -208,7 +198,6 @@ async function validateWorkflowAccess(
   };
 }
 
-// start custom keeperhub code //
 async function handlePostUpdateSideEffects(
   workflowId: string,
   body: Record<string, unknown>
@@ -232,7 +221,6 @@ async function handlePostUpdateSideEffects(
     }
   }
 }
-// end keeperhub code //
 
 export async function PATCH(
   request: Request,
@@ -241,7 +229,6 @@ export async function PATCH(
   try {
     const { workflowId } = await context.params;
 
-    // start custom keeperhub code //
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
       return NextResponse.json(
@@ -260,7 +247,6 @@ export async function PATCH(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     const body = await request.json();
 
@@ -287,7 +273,6 @@ export async function PATCH(
       );
     }
 
-    // start custom keeperhub code //
     // Validate projectId/tagId ownership when provided
     if (body.projectId !== undefined || body.tagId !== undefined) {
       const targetOrgId = existingWorkflow.organizationId || organizationId;
@@ -326,7 +311,6 @@ export async function PATCH(
         }
       }
     }
-    // end keeperhub code //
 
     const updateData = buildUpdateData(body);
 
@@ -343,9 +327,7 @@ export async function PATCH(
       );
     }
 
-    // start custom keeperhub code //
     await handlePostUpdateSideEffects(workflowId, body);
-    // end keeperhub code //
 
     return NextResponse.json({
       ...updatedWorkflow,
@@ -374,7 +356,6 @@ export async function DELETE(
   try {
     const { workflowId } = await context.params;
 
-    // start custom keeperhub code //
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
       return NextResponse.json(
@@ -396,7 +377,6 @@ export async function DELETE(
         { status: 404 }
       );
     }
-    // end keeperhub code //
 
     await db.delete(workflows).where(eq(workflows.id, workflowId));
 

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -7,7 +7,6 @@ import {
   getMetricsCollector,
 } from "@/keeperhub/lib/metrics";
 import { LabelKeys, MetricNames } from "@/keeperhub/lib/metrics/types";
-// start custom keeperhub code //
 import {
   EXECUTION_LIMIT_ERROR,
   enforceExecutionLimit,
@@ -19,9 +18,6 @@ import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
 import { executeWorkflow } from "@/lib/workflow-executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow-store";
-
-// end keeperhub code //
-
 // Validate API key and return the user ID if valid
 async function validateApiKey(
   authHeader: string | null,
@@ -111,12 +107,10 @@ async function executeWorkflowBackground(
 
     console.log("[Webhook] Workflow started, runId:", run.runId);
 
-    // start custom keeperhub code //
     await db
       .update(workflowExecutions)
       .set({ runId: run.runId })
       .where(eq(workflowExecutions.id, executionId));
-    // end keeperhub code //
   } catch (error) {
     console.error("[Webhook] Error during execution:", error);
     console.error(
@@ -143,9 +137,7 @@ export async function POST(
   request: Request,
   context: { params: Promise<{ workflowId: string }> }
 ) {
-  // start custom keeperhub code //
   const timer = createTimer();
-  // end keeperhub code //
 
   try {
     const { workflowId } = await context.params;
@@ -156,14 +148,12 @@ export async function POST(
     });
 
     if (!workflow) {
-      // start custom keeperhub code //
       recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 404,
         error: "Workflow not found",
       });
-      // end keeperhub code //
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404, headers: corsHeaders }
@@ -176,14 +166,12 @@ export async function POST(
 
     if (!apiKeyValidation.valid) {
       const statusCode = apiKeyValidation.statusCode || 401;
-      // start custom keeperhub code //
       recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode,
         error: apiKeyValidation.error,
       });
-      // end keeperhub code //
       return NextResponse.json(
         { error: apiKeyValidation.error },
         { status: statusCode, headers: corsHeaders }
@@ -196,14 +184,12 @@ export async function POST(
     );
 
     if (!triggerNode || triggerNode.data.config?.triggerType !== "Webhook") {
-      // start custom keeperhub code //
       recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 400,
         error: "This workflow is not configured for webhook triggers",
       });
-      // end keeperhub code //
       return NextResponse.json(
         { error: "This workflow is not configured for webhook triggers" },
         { status: 400, headers: corsHeaders }
@@ -220,21 +206,18 @@ export async function POST(
         "[Webhook] Invalid integration references:",
         validation.invalidIds
       );
-      // start custom keeperhub code //
       recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 403,
         error: "Workflow contains invalid integration references",
       });
-      // end keeperhub code //
       return NextResponse.json(
         { error: "Workflow contains invalid integration references" },
         { status: 403, headers: corsHeaders }
       );
     }
 
-    // start custom keeperhub code //
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
       recordWebhookMetrics({
@@ -267,7 +250,6 @@ export async function POST(
         { status: 429, headers: { ...corsHeaders, "Retry-After": "30" } }
       );
     }
-    // end keeperhub code //
 
     // Parse request body
     const body = await request.json().catch(() => ({}));
@@ -285,14 +267,12 @@ export async function POST(
 
     console.log("[Webhook] Created execution:", execution.id);
 
-    // start custom keeperhub code //
     // Record workflow execution metric in API process (workflow runs in separate context)
     const metrics = getMetricsCollector();
     metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_TOTAL, {
       [LabelKeys.TRIGGER_TYPE]: "webhook",
       [LabelKeys.WORKFLOW_ID]: workflowId,
     });
-    // end keeperhub code //
 
     // Execute the workflow in the background (don't await)
     executeWorkflowBackground(
@@ -303,14 +283,12 @@ export async function POST(
       body
     );
 
-    // start custom keeperhub code //
     recordWebhookMetrics({
       workflowId,
       executionId: execution.id,
       durationMs: timer(),
       statusCode: 200,
     });
-    // end keeperhub code //
 
     // Return immediately with the execution ID
     return NextResponse.json(
@@ -323,7 +301,6 @@ export async function POST(
   } catch (error) {
     console.error("[Webhook] Failed to start workflow execution:", error);
 
-    // start custom keeperhub code //
     const { workflowId } = await context.params;
     recordWebhookMetrics({
       workflowId,
@@ -332,7 +309,6 @@ export async function POST(
       error:
         error instanceof Error ? error.message : "Failed to execute workflow",
     });
-    // end keeperhub code //
 
     return NextResponse.json(
       {

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -1,7 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
@@ -10,10 +9,6 @@ import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, tags, workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
-
-// end keeperhub code //
-
-// start custom keeperhub code //
 function createDefaultNodes() {
   const triggerId = nanoid();
   const actionId = nanoid();
@@ -55,9 +50,7 @@ function createDefaultNodes() {
 
   return { nodes: [triggerNode, actionNode], edges: [edge] };
 }
-// end keeperhub code //
 
-// start custom keeperhub code //
 // Helper to authenticate and get user context
 async function getUserContext(request: Request) {
   // Try API key authentication first
@@ -121,11 +114,9 @@ async function generateWorkflowName(
   const count = userWorkflows.length + 1;
   return `Untitled ${count}`;
 }
-// end keeperhub code //
 
 export async function POST(request: Request) {
   try {
-    // start custom keeperhub code //
     const userContext = await getUserContext(request);
     if ("error" in userContext) {
       const status = userContext.error === "Unauthorized" ? 401 : 400;
@@ -133,7 +124,6 @@ export async function POST(request: Request) {
     }
 
     const { userId, organizationId } = userContext;
-    // end keeperhub code //
 
     const body = await request.json();
 
@@ -157,7 +147,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // start custom keeperhub code //
     // Ensure there are always default nodes (trigger + action) if nodes array is empty
     let nodes = body.nodes;
     let edges = body.edges;
@@ -166,9 +155,7 @@ export async function POST(request: Request) {
       nodes = defaults.nodes;
       edges = defaults.edges;
     }
-    // end keeperhub code //
 
-    // start custom keeperhub code //
     const isAnonymous = !organizationId;
     const workflowName = await generateWorkflowName(
       body.name,
@@ -221,7 +208,6 @@ export async function POST(request: Request) {
         }
       }
     }
-    // end keeperhub code //
 
     // Generate workflow ID first
     const workflowId = generateId();
@@ -235,12 +221,10 @@ export async function POST(request: Request) {
         nodes,
         edges,
         userId,
-        // start custom keeperhub code //
         organizationId,
         isAnonymous,
         projectId: body.projectId || null,
         tagId: body.tagId || null,
-        // end keeperhub code //
       })
       .returning();
 

--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
@@ -171,4 +170,3 @@ export async function GET(request: Request) {
   }
 }
 
-// end keeperhub code //

--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -1,8 +1,6 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
@@ -37,7 +35,6 @@ export async function GET(
       );
     }
 
-    // start custom keeperhub code //
     // Verify access: owner or org member
     const isOwner = execution.workflow.userId === session.user.id;
     const orgContext = await getOrgContext();
@@ -49,7 +46,6 @@ export async function GET(
     if (!(isOwner || isSameOrg)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    // end keeperhub code //
 
     // Get logs
     const logs = await db.query.workflowExecutionLogs.findMany({

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -1,11 +1,9 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { createTimer } from "@/keeperhub/lib/metrics";
 import { recordStatusPollMetrics } from "@/keeperhub/lib/metrics/instrumentation/api";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-// end keeperhub code //
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
@@ -19,9 +17,7 @@ export async function GET(
   request: Request,
   context: { params: Promise<{ executionId: string }> }
 ) {
-  // start custom keeperhub code //
   const timer = createTimer();
-  // end keeperhub code //
 
   try {
     const { executionId } = await context.params;
@@ -30,13 +26,11 @@ export async function GET(
     });
 
     if (!session?.user) {
-      // start custom keeperhub code //
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),
         statusCode: 401,
       });
-      // end keeperhub code //
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -49,20 +43,17 @@ export async function GET(
     });
 
     if (!execution) {
-      // start custom keeperhub code //
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),
         statusCode: 404,
       });
-      // end keeperhub code //
       return NextResponse.json(
         { error: "Execution not found" },
         { status: 404 }
       );
     }
 
-    // start custom keeperhub code //
     // Verify access: owner or org member
     const isOwner = execution.workflow.userId === session.user.id;
     const orgContext = await getOrgContext();
@@ -79,7 +70,6 @@ export async function GET(
       });
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    // end keeperhub code //
 
     // Get logs for all nodes
     const logs = await db.query.workflowExecutionLogs.findMany({
@@ -122,14 +112,12 @@ export async function GET(
           }
         : null;
 
-    // start custom keeperhub code //
     recordStatusPollMetrics({
       executionId,
       durationMs: timer(),
       statusCode: 200,
       executionStatus: execution.status,
     });
-    // end keeperhub code //
 
     return NextResponse.json({
       status: execution.status,
@@ -138,7 +126,6 @@ export async function GET(
       errorContext,
     });
   } catch (error) {
-    // start custom keeperhub code //
     const { executionId } = await context.params;
     logSystemError(
       ErrorCategory.DATABASE,
@@ -154,7 +141,6 @@ export async function GET(
       durationMs: timer(),
       statusCode: 500,
     });
-    // end keeperhub code //
 
     return NextResponse.json(
       {

--- a/app/api/workflows/public/route.ts
+++ b/app/api/workflows/public/route.ts
@@ -3,9 +3,6 @@ import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { db } from "@/lib/db";
 import { publicTags, workflowPublicTags, workflows } from "@/lib/db/schema";
-
-// start custom KeeperHub code
-
 type TagInfo = { id: string; name: string; slug: string };
 
 async function resolveTagFilter(tagSlug: string): Promise<string[] | "empty"> {
@@ -155,4 +152,3 @@ export async function GET(request: Request): Promise<NextResponse> {
     );
   }
 }
-// end custom KeeperHub code

--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -1,17 +1,14 @@
 import { and, asc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-// start custom keeperhub code //
 import { authenticateApiKey } from "@/keeperhub/lib/api-key-auth";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
-// end keeperhub code //
 
 export async function GET(request: Request) {
   try {
-    // start custom keeperhub code //
     // Try API key authentication first
     const apiKeyAuth = await authenticateApiKey(request);
     let organizationId: string | null;
@@ -62,7 +59,6 @@ export async function GET(request: Request) {
       .from(workflows)
       .where(and(...conditions))
       .orderBy(asc(workflows.createdAt));
-    // end keeperhub code //
 
     const mappedWorkflows = userWorkflows.map((workflow) => ({
       ...workflow,

--- a/app/hub/layout.tsx
+++ b/app/hub/layout.tsx
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
@@ -40,4 +39,3 @@ type HubLayoutProps = {
 export default function HubLayout({ children }: HubLayoutProps) {
   return children;
 }
-// end keeperhub code //

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -29,7 +29,6 @@ export default function HubPage(): React.ReactElement {
 }
 
 function HubPageContent(): React.ReactElement {
-  // start custom KeeperHub code
   const router = useRouter();
   const [featuredWorkflows, setFeaturedWorkflows] = useState<SavedWorkflow[]>(
     []
@@ -171,7 +170,6 @@ function HubPageContent(): React.ReactElement {
 
     fetchProtocols();
   }, []);
-  // end custom KeeperHub code
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const gradientRef = useRef<HTMLDivElement>(null);
@@ -199,7 +197,6 @@ function HubPageContent(): React.ReactElement {
       className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       ref={scrollContainerRef}
     >
-      {/* start custom KeeperHub code */}
       <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
         {isLoading ? (
           <div className="container mx-auto px-4 pt-20 pb-8 animate-pulse">
@@ -252,7 +249,6 @@ function HubPageContent(): React.ReactElement {
               </div>
             </div>
 
-            {/* start custom keeperhub code */}
             {protocols.length > 0 && (
               <div className="bg-sidebar py-6">
                 <div className="container mx-auto px-4">
@@ -300,11 +296,9 @@ function HubPageContent(): React.ReactElement {
               open={selectedProtocolSlug !== null}
               protocol={selectedProtocol}
             />
-            {/* end keeperhub code */}
           </>
         )}
       </div>
-      {/* end custom KeeperHub code */}
     </div>
   );
 }

--- a/app/hub/protocol/[slug]/page.tsx
+++ b/app/hub/protocol/[slug]/page.tsx
@@ -1,6 +1,4 @@
-// start custom keeperhub code //
 export {
   default,
   generateMetadata,
 } from "@/keeperhub/app/hub/protocol/[slug]/page";
-// end keeperhub code //

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,13 +13,10 @@ import { OverlayProvider } from "@/components/overlays/overlay-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { KeeperHubExtensionLoader } from "@/keeperhub/components/extension-loader";
-// start custom keeperhub code //
 import { MobileWarningDialog } from "@/keeperhub/components/mobile-warning-dialog";
-// end keeperhub code //
 import { mono, sans } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 
-// start custom keeperhub code //
 export const metadata: Metadata = {
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_APP_URL ?? "https://app.keeperhub.com"
@@ -50,7 +47,6 @@ export const metadata: Metadata = {
     images: ["/api/og/default"],
   },
 };
-// end keeperhub code //
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -90,9 +86,7 @@ const RootLayout = ({ children }: RootLayoutProps) => (
               </Suspense>
               <Toaster />
               <GlobalModals />
-              {/* start custom keeperhub code */}
               <MobileWarningDialog />
-              {/* end keeperhub code */}
             </OverlayProvider>
           </AuthProvider>
         </Provider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,12 +5,10 @@ import { nanoid } from "nanoid";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
-// start custom keeperhub code //
 import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
-// end keeperhub code //
 import {
   currentWorkflowIdAtom,
   currentWorkflowNameAtom,
@@ -21,7 +19,6 @@ import {
   type WorkflowNode,
 } from "@/lib/workflow-store";
 
-// start custom keeperhub code //
 function createDefaultNodes() {
   const triggerId = nanoid();
   const actionId = nanoid();
@@ -63,7 +60,6 @@ function createDefaultNodes() {
 
   return { nodes: [triggerNode, actionNode], edges: [edge] };
 }
-// end keeperhub code //
 
 const Home = () => {
   const router = useRouter();
@@ -97,7 +93,6 @@ const Home = () => {
     }
   }, [session]);
 
-  // start custom keeperhub code //
   // Handler to add initial nodes and create the workflow.
   // If the user already has workflows, navigate to the most recent one instead
   // of creating a new one. Anonymous users are limited to a single workflow.
@@ -151,7 +146,6 @@ const Home = () => {
     router,
     setIsTransitioningFromHomepage,
   ]);
-  // end keeperhub code //
 
   // Initialize with a temporary "add" node on mount
   useEffect(() => {

--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -8,12 +8,10 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { NodeConfigPanel } from "@/components/workflow/node-config-panel";
 import { useIsMobile } from "@/hooks/use-mobile";
-// start custom keeperhub code //
 import {
   getPendingClaim,
   useClaimWorkflow,
 } from "@/keeperhub/lib/hooks/use-claim-workflow";
-// end keeperhub code //
 import { api } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import {
@@ -39,18 +37,12 @@ import {
   isSidebarCollapsedAtom,
   isWorkflowEnabled,
   isWorkflowOwnerAtom,
-  // start custom keeperhub code //
   newlyCreatedNodeIdAtom,
-  // end keeperhub code //
   nodesAtom,
-  // start custom keeperhub code //
   propertiesPanelActiveTabAtom,
-  // end keeperhub code //
   rightPanelWidthAtom,
   selectedExecutionIdAtom,
-  // start custom keeperhub code //
   selectedNodeAtom,
-  // end keeperhub code //
   triggerExecuteAtom,
   updateNodeDataAtom,
   type WorkflowNode,
@@ -166,11 +158,9 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
   const setCurrentWorkflowPublicTags = useSetAtom(
     currentWorkflowPublicTagsAtom
   );
-  // start custom keeperhub code //
   const setSelectedNode = useSetAtom(selectedNodeAtom);
   const setActiveTab = useSetAtom(propertiesPanelActiveTabAtom);
   const setNewlyCreatedNodeId = useSetAtom(newlyCreatedNodeIdAtom);
-  // end keeperhub code //
   const setGlobalIntegrations = useSetAtom(integrationsAtom);
   const setIntegrationsLoaded = useSetAtom(integrationsLoadedAtom);
   const integrationsVersion = useAtomValue(integrationsVersionAtom);
@@ -420,7 +410,6 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
       setHasUnsavedChanges(false);
       setWorkflowNotFound(false);
 
-      // start custom keeperhub code //
       // Auto-select an unconfigured action node (fresh workflow from homepage)
       const emptyAction = nodesWithIdleStatus.find(
         (n: WorkflowNode) =>
@@ -437,7 +426,6 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
         setActiveTab("properties");
         setNewlyCreatedNodeId(emptyAction.id);
       }
-      // end keeperhub code //
     } catch (error) {
       console.error("Failed to load workflow:", error);
       setWorkflowNotFound(true);
@@ -457,18 +445,12 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
     setHasUnsavedChanges,
     setWorkflowNotFound,
     setCurrentWorkflowDescription,
-    // start custom keeperhub code //
     setSelectedNode,
     setActiveTab,
     setNewlyCreatedNodeId,
-    // end keeperhub code //
   ]);
 
-  // start custom keeperhub code //
   const { claimPending } = useClaimWorkflow(workflowId, loadExistingWorkflow);
-
-  // end keeperhub code //
-
   // Track if we've already auto-fixed integrations for this workflow+version
   const lastAutoFixRef = useRef<{ workflowId: string; version: number } | null>(
     null
@@ -476,12 +458,10 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
 
   useEffect(() => {
     const loadWorkflowData = async () => {
-      // start custom keeperhub code //
       const pendingClaim = getPendingClaim();
       if (pendingClaim?.workflowId === workflowId) {
         return;
       }
-      // end keeperhub code //
 
       const isGeneratingParam = searchParams?.get("generating") === "true";
       const storedPrompt = sessionStorage.getItem("ai-prompt");
@@ -774,7 +754,6 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
                 className="gap-2"
                 onClick={async () => {
                   try {
-                    // start custom keeperhub code //
                     await ensureSession();
                     const triggerId = `trigger-${Date.now()}`;
                     const actionId = `action-${Date.now()}`;
@@ -814,7 +793,6 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
                         },
                       ],
                     });
-                    // end keeperhub code //
                     router.replace(`/workflows/${newWorkflow.id}`);
                   } catch (error) {
                     console.error("Failed to create workflow:", error);

--- a/components/ai-elements/edge.tsx
+++ b/components/ai-elements/edge.tsx
@@ -49,13 +49,11 @@ const getHandleCoordsByPosition = (
   // Choose the handle type based on position - Left is for target, Right is for source
   const handleType = handlePosition === Position.Left ? "target" : "source";
 
-  // start custom keeperhub code //
   // When a handle ID is provided (multi-handle nodes), find by ID; otherwise by position
   const handles = node.internals.handleBounds?.[handleType];
   const handle = handleId
     ? handles?.find((h) => h.id === handleId)
     : handles?.find((h) => h.position === handlePosition);
-  // end keeperhub code //
 
   if (!handle) {
     return [0, 0] as const;
@@ -90,7 +88,6 @@ const getHandleCoordsByPosition = (
   return [x, y] as const;
 };
 
-// start custom keeperhub code //
 const getEdgeParams = (
   source: InternalNode<Node>,
   target: InternalNode<Node>,
@@ -111,7 +108,6 @@ const getEdgeParams = (
     targetPos,
   };
 };
-// end keeperhub code //
 
 const Animated = ({ id, source, target, sourceHandleId, targetHandleId, style, selected }: EdgeProps) => {
   const sourceNode = useInternalNode(source);

--- a/components/ai-elements/node.tsx
+++ b/components/ai-elements/node.tsx
@@ -11,30 +11,22 @@ import { cn } from "@/lib/utils";
 import { Handle, Position } from "@xyflow/react";
 import type { ComponentProps } from "react";
 import { AnimatedBorder } from "@/components/ui/animated-border";
-// start custom keeperhub code //
 import { AddStepButton } from "@/keeperhub/components/workflow/add-step-button";
-// end keeperhub code //
 
-// start custom keeperhub code //
 export type SourceHandleConfig = {
   id: string;
   label: string;
   topPercent: number;
 };
-// end keeperhub code //
 
 export type NodeProps = ComponentProps<typeof Card> & {
   handles: {
     target: boolean;
     source: boolean;
-    // start custom keeperhub code //
     sourceHandles?: SourceHandleConfig[];
-    // end keeperhub code //
   };
   status?: "idle" | "running" | "success" | "error";
-  // start custom keeperhub code //
   nodeId?: string;
-  // end keeperhub code //
 };
 
 export const Node = ({ handles, className, status, nodeId, ...props }: NodeProps) => (
@@ -49,7 +41,6 @@ export const Node = ({ handles, className, status, nodeId, ...props }: NodeProps
   >
     {status === "running" && <AnimatedBorder />}
     {handles.target && <Handle position={Position.Left} type="target" />}
-    {/* start custom keeperhub code */}
     {handles.sourceHandles ? (
       <>
         {handles.sourceHandles.map((h) => (
@@ -90,7 +81,6 @@ export const Node = ({ handles, className, status, nodeId, ...props }: NodeProps
         {handles.source && nodeId && <AddStepButton sourceNodeId={nodeId} />}
       </>
     )}
-    {/* end keeperhub code */}
     {props.children}
   </Card>
 );

--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -15,9 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
-// start custom keeperhub code //
 import { setPendingClaim } from "@/keeperhub/lib/hooks/use-claim-workflow";
-// end keeperhub code //
 import { refetchOrganizations } from "@/keeperhub/lib/refetch-organizations";
 import { authClient, signIn, signUp } from "@/lib/auth-client";
 import {
@@ -25,22 +23,18 @@ import {
   getSingleProvider,
 } from "@/lib/auth-providers";
 
-// start custom keeperhub code //
 const WORKFLOW_PATH_REGEX = /^\/workflows\/([^/]+)$/;
-// end keeperhub code //
 
 type AuthDialogProps = {
   children?: ReactNode;
 };
 
-// start custom keeperhub code //
 type ModalView =
   | "signin"
   | "signup"
   | "verify"
   | "forgot-password"
   | "reset-password";
-// end keeperhub code //
 
 const VercelIcon = ({ className = "mr-2 h-3 w-3" }: { className?: string }) => (
   <svg
@@ -186,9 +180,7 @@ type SignInFormProps = {
   onPasswordChange: (v: string) => void;
   onSubmit: (e: React.FormEvent) => void;
   onCreateAccount: () => void;
-  // start custom keeperhub code //
   onForgotPassword: () => void;
-  // end keeperhub code //
 };
 
 const SignInForm = ({
@@ -200,9 +192,7 @@ const SignInForm = ({
   onPasswordChange,
   onSubmit,
   onCreateAccount,
-  // start custom keeperhub code //
   onForgotPassword,
-  // end keeperhub code //
 }: SignInFormProps) => (
   <div className="space-y-4">
     <form className="space-y-4" onSubmit={onSubmit}>
@@ -220,7 +210,6 @@ const SignInForm = ({
         />
       </div>
       <div className="space-y-2">
-        {/* start custom keeperhub code */}
         <div className="flex items-center justify-between">
           <Label className="ml-1" htmlFor="password">
             Password
@@ -234,7 +223,6 @@ const SignInForm = ({
             Forgot password?
           </button>
         </div>
-        {/* end keeperhub code */}
         <Input
           id="password"
           onChange={(e) => onPasswordChange(e.target.value)}
@@ -319,12 +307,10 @@ const getViewTitle = (view: ModalView) => {
       return "Create account";
     case "verify":
       return "Verify your email";
-    // start custom keeperhub code //
     case "forgot-password":
       return "Reset password";
     case "reset-password":
       return "Set new password";
-    // end keeperhub code //
     default:
       return "Sign in";
   }
@@ -340,14 +326,12 @@ const getViewDescription = (view: ModalView, email?: string) => {
       return email
         ? `Enter the 6-digit code sent to ${email}`
         : "Enter the verification code sent to your email.";
-    // start custom keeperhub code //
     case "forgot-password":
       return "Enter your email to receive a password reset code.";
     case "reset-password":
       return email
         ? `Enter the 6-digit code sent to ${email} and your new password.`
         : "Enter the reset code and your new password.";
-    // end keeperhub code //
     default:
       return null;
   }
@@ -371,11 +355,9 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
   const [otp, setOtp] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  // start custom keeperhub code //
   const [forgotEmail, setForgotEmail] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
-  // end keeperhub code //
   const [loadingProvider, setLoadingProvider] = useState<
     "github" | "google" | "vercel" | null
   >(null);
@@ -408,14 +390,11 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
     setVerifyPassword("");
     setOtp("");
     setError("");
-    // start custom keeperhub code //
     setForgotEmail("");
     setNewPassword("");
     setConfirmNewPassword("");
-    // end keeperhub code //
   };
 
-  // start custom keeperhub code //
   const getClaimContext = async () => {
     const workflowMatch = window.location.pathname.match(WORKFLOW_PATH_REGEX);
     if (!workflowMatch) {
@@ -436,7 +415,6 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
       setPendingClaim(claimContext);
     }
   };
-  // end keeperhub code //
 
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
@@ -453,10 +431,8 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
   ) => {
     try {
       setLoadingProvider(provider);
-      // start custom keeperhub code //
       const claimContext = await getClaimContext();
       storeClaimIfNeeded(claimContext);
-      // end keeperhub code //
       await signIn.social({ provider, callbackURL: window.location.pathname });
     } catch {
       toast.error(`Failed to sign in with ${getProviderLabel(provider)}`);
@@ -470,9 +446,7 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
     setError("");
     setLoading(true);
 
-    // start custom keeperhub code //
     const claimContext = await getClaimContext();
-    // end keeperhub code //
 
     try {
       const response = await signIn.email({ email, password });
@@ -529,9 +503,7 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
         return;
       }
 
-      // start custom keeperhub code //
       storeClaimIfNeeded(claimContext);
-      // end keeperhub code //
 
       await new Promise((resolve) => setTimeout(resolve, 300));
       await authClient.getSession();
@@ -654,10 +626,8 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
     setError("");
     setLoading(true);
 
-    // start custom keeperhub code //
     // Capture claim context BEFORE verification (while still anonymous)
     const claimContext = await getClaimContext();
-    // end keeperhub code //
 
     try {
       const response = await authClient.emailOtp.verifyEmail({
@@ -694,10 +664,8 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
         }
       }
 
-      // start custom keeperhub code //
       // Store claim context after successful sign-in
       storeClaimIfNeeded(claimContext);
-      // end keeperhub code //
 
       // Refresh session
       await authClient.getSession();
@@ -741,7 +709,6 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
     }
   };
 
-  // start custom keeperhub code //
   const handleForgotPasswordRequest = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -851,7 +818,6 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
       setLoading(false);
     }
   };
-  // end keeperhub code //
 
   if (singleProvider && singleProvider !== "email") {
     return (
@@ -921,13 +887,11 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
                     setError("");
                   }}
                   onEmailChange={setEmail}
-                  // start custom keeperhub code //
                   onForgotPassword={() => {
                     setForgotEmail(email);
                     setView("forgot-password");
                     setError("");
                   }}
-                  // end keeperhub code //
                   onPasswordChange={setPassword}
                   onSubmit={handleSignIn}
                   password={password}
@@ -1056,7 +1020,6 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
             </div>
           )}
 
-          {/* start custom keeperhub code */}
           {view === "forgot-password" && (
             <div className="space-y-4">
               <form
@@ -1198,7 +1161,6 @@ export const AuthDialog = ({ children }: AuthDialogProps) => {
               </div>
             </div>
           )}
-          {/* end keeperhub code */}
         </div>
       </DialogContent>
     </Dialog>

--- a/components/layout-content.tsx
+++ b/components/layout-content.tsx
@@ -4,9 +4,7 @@ import { ReactFlowProvider } from "@xyflow/react";
 import type { ReactNode } from "react";
 import { PersistentCanvas } from "@/components/workflow/persistent-canvas";
 import { WorkflowToolbar } from "@/components/workflow/workflow-toolbar";
-// start custom keeperhub code //
 import { NavigationSidebar } from "@/keeperhub/components/navigation-sidebar";
-// end keeperhub code //
 
 export function LayoutContent({ children }: { children: ReactNode }) {
   return (
@@ -14,9 +12,7 @@ export function LayoutContent({ children }: { children: ReactNode }) {
       <WorkflowToolbar persistent />
       <PersistentCanvas />
       <div className="pointer-events-none relative z-10">{children}</div>
-      {/* start custom keeperhub code */}
       <NavigationSidebar />
-      {/* end keeperhub code */}
     </ReactFlowProvider>
   );
 }

--- a/components/overlays/add-connection-overlay.tsx
+++ b/components/overlays/add-connection-overlay.tsx
@@ -16,7 +16,6 @@ import {
   aiGatewayTeamsLoadingAtom,
 } from "@/lib/ai-gateway/state";
 import { api } from "@/lib/api-client";
-// start keeperhub
 import { useSession } from "@/lib/auth-client";
 import {
   DatabaseConnectionForm,
@@ -25,7 +24,6 @@ import {
 } from "@/keeperhub/components/database-connection-form";
 import { getCustomIntegrationFormHandler } from "@/lib/extension-registry";
 import { integrationsAtom } from "@/lib/integrations-store";
-// end keeperhub
 import type { IntegrationType } from "@/lib/types/integration";
 import {
   getIntegration,
@@ -90,13 +88,11 @@ export function AddConnectionOverlay({
   const shouldUseManagedKeys =
     aiGatewayStatus?.enabled && aiGatewayStatus?.isVercelUser;
 
-  // start keeperhub - filter out singleConnection types that already exist
   const existingIntegrations = useAtomValue(integrationsAtom);
   const existingIntegrationTypes = useMemo(
     () => new Set(existingIntegrations.map((i) => i.type)),
     [existingIntegrations]
   );
-  // end keeperhub
 
   const integrationTypes = getIntegrationTypes();
 
@@ -110,7 +106,6 @@ export function AddConnectionOverlay({
     );
   }, [integrationTypes, searchQuery]);
 
-  // start keeperhub - check if a singleConnection type is already configured
   const isAlreadyConfigured = (type: IntegrationType) => {
     const plugin = getIntegration(type);
     return plugin?.singleConnection && existingIntegrationTypes.has(type);
@@ -121,7 +116,6 @@ export function AddConnectionOverlay({
     const plugin = getIntegration(type);
     return plugin?.requiresCredentials === false;
   };
-  // end keeperhub
 
   const showConsentModalWithCallbacks = useCallback(() => {
     push(AiGatewayConsentOverlay, {
@@ -199,12 +193,10 @@ export function AddConnectionOverlay({
           ) : (
             filteredTypes.map((type) => {
               const description = getDescription(type);
-              // start keeperhub - grey out singleConnection types that are already configured
               // or integrations that don't require credentials
               const configured = isAlreadyConfigured(type);
               const noCredentials = noCredentialsRequired(type);
               const isDisabled = configured || noCredentials;
-              // end keeperhub
               return (
                 <button
                   className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors ${
@@ -322,7 +314,6 @@ export function ConfigureConnectionOverlay({
   const [name, setName] = useState("");
   const [config, setConfig] = useState<Record<string, string>>({});
   const [dbTab, setDbTab] = useState<DatabaseTab>("url");
-  // start keeperhub - derive anonymous state from session reactively
   const { data: session } = useSession();
   const isAnonymous =
     type === "web3" &&
@@ -331,7 +322,6 @@ export function ConfigureConnectionOverlay({
       session.user.email?.includes("@http://") ||
       session.user.email?.includes("@https://") ||
       session.user.email?.startsWith("temp-"));
-  // end keeperhub
 
   const updateConfig = (key: string, value: string) => {
     setConfig((prev) => ({ ...prev, [key]: value }));
@@ -448,7 +438,6 @@ export function ConfigureConnectionOverlay({
 
   // Render config fields
   const renderConfigFields = () => {
-    // start keeperhub - check for custom form handlers (e.g., web3 wallet)
     const customHandler = getCustomIntegrationFormHandler(type);
     if (customHandler) {
       return customHandler({
@@ -460,7 +449,6 @@ export function ConfigureConnectionOverlay({
         closeAll,
       });
     }
-    // end keeperhub
 
     if (type === "database") {
       return (
@@ -523,11 +511,9 @@ export function ConfigureConnectionOverlay({
     });
   };
 
-  // start keeperhub - for web3 + anonymous, show Sign In button with AuthDialog
   const showSignInButton = type === "web3" && isAnonymous;
   // Web3 uses custom form handler with its own Create Wallet button
   const hideOverlayActions = type === "web3";
-  // end keeperhub
 
   return (
     <Overlay
@@ -566,7 +552,6 @@ export function ConfigureConnectionOverlay({
         </div>
       </div>
 
-      {/* start keeperhub - Sign In button for anonymous web3 users */}
       {showSignInButton && (
         <OverlayFooter>
           <AuthDialog>
@@ -574,7 +559,6 @@ export function ConfigureConnectionOverlay({
           </AuthDialog>
         </OverlayFooter>
       )}
-      {/* end keeperhub */}
     </Overlay>
   );
 }

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -7,9 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-// start custom keeperhub code //
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-// end keeperhub code //
 import { ConfirmOverlay } from "./confirm-overlay";
 import { Overlay } from "./overlay";
 import { useOverlay } from "./overlay-provider";
@@ -20,9 +18,7 @@ type ApiKey = {
   keyPrefix: string;
   createdAt: string;
   lastUsedAt: string | null;
-  // start custom keeperhub code //
   createdByName?: string | null;
-  // end keeperhub code //
   key?: string;
 };
 
@@ -37,17 +33,13 @@ type ApiKeysOverlayProps = {
 function CreateApiKeyOverlay({
   overlayId,
   onCreated,
-  // start custom keeperhub code //
   endpoint,
   keyType,
-  // end keeperhub code //
 }: {
   overlayId: string;
   onCreated: (key: ApiKey) => void;
-  // start custom keeperhub code //
   endpoint: string;
   keyType: "webhook" | "organisation";
-  // end keeperhub code //
 }) {
   const { pop } = useOverlay();
   const [keyName, setKeyName] = useState("");
@@ -81,12 +73,10 @@ function CreateApiKeyOverlay({
     }
   };
 
-  // start custom keeperhub code //
   const description =
     keyType === "webhook"
       ? "Create a new API key for webhook authentication"
       : "Create a new API key for MCP server and external integrations";
-  // end keeperhub code //
 
   return (
     <Overlay
@@ -115,7 +105,6 @@ function CreateApiKeyOverlay({
   );
 }
 
-// start custom keeperhub code //
 /**
  * Shared component for displaying and managing API keys list
  */
@@ -241,7 +230,6 @@ function ApiKeysList({
     </div>
   );
 }
-// end keeperhub code //
 
 /**
  * Hook for managing API keys state and operations
@@ -313,7 +301,6 @@ function useApiKeys(
   };
 }
 
-// start custom keeperhub code //
 /**
  * Main API Keys management overlay with tabs for Webhook and Organisation keys.
  */
@@ -410,4 +397,3 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
     </Overlay>
   );
 }
-// end keeperhub code //

--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -163,10 +163,8 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
     }
   }, [selectedNode, globalIntegrations, isOwner, updateNodeData]);
 
-  // start custom keeperhub code //
   const handleUpdateConfig = useCallback(
     (key: string, value: string | Record<string, unknown> | undefined) => {
-    // end keeperhub code //
       if (!selectedNode) {
         return;
       }

--- a/components/overlays/edit-connection-overlay.tsx
+++ b/components/overlays/edit-connection-overlay.tsx
@@ -6,7 +6,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api, type Integration } from "@/lib/api-client";
-// start keeperhub
 import {
   DatabaseConnectionForm,
   detectDefaultTab,
@@ -16,7 +15,6 @@ import {
 import { getCustomIntegrationFormHandler } from "@/lib/extension-registry";
 import type { IntegrationConfig } from "@/lib/types/integration";
 import { getIntegration, getIntegrationLabels } from "@/plugins/registry";
-// end keeperhub
 import { ConfirmOverlay } from "./confirm-overlay";
 import { Overlay } from "./overlay";
 import { useOverlay } from "./overlay-provider";
@@ -131,7 +129,6 @@ export function EditConnectionOverlay({
     setConfig((prev) => ({ ...prev, [key]: value }));
   };
 
-  // start custom keeperhub code //
   // For database integrations, secret fields (password, url) are stripped from
   // the server response. We check if the user entered new secret values to
   // decide whether to test client-side or use the server-side test endpoint.
@@ -166,19 +163,16 @@ export function EditConnectionOverlay({
     }
     return result;
   };
-  // end keeperhub code //
 
   const doSave = async () => {
     try {
       setSaving(true);
-      // start custom keeperhub code //
       const nonEmptyConfig = getNonEmptyConfig();
       const hasNewConfig = Object.keys(nonEmptyConfig).length > 0;
       await api.integration.update(integration.id, {
         name: name.trim(),
         ...(hasNewConfig ? { config: nonEmptyConfig } : {}),
       });
-      // end keeperhub code //
       toast.success("Connection updated");
       onSuccess?.();
       closeAll();
@@ -189,7 +183,6 @@ export function EditConnectionOverlay({
     }
   };
 
-  // start custom keeperhub code //
   const runConnectionTest = (): Promise<{
     status: "success" | "error";
     message: string;
@@ -224,7 +217,6 @@ export function EditConnectionOverlay({
     const hasNewConfig = Object.values(config).some((v) => v && v.length > 0);
     return !hasNewConfig;
   };
-  // end keeperhub code //
 
   const handleSave = async () => {
     if (saving) {
@@ -318,7 +310,6 @@ export function EditConnectionOverlay({
 
   // Render config fields
   const renderConfigFields = () => {
-    // start keeperhub - check for custom form handlers (e.g., web3 wallet display)
     const customHandler = getCustomIntegrationFormHandler(integration.type);
     if (customHandler) {
       return customHandler({
@@ -328,7 +319,6 @@ export function EditConnectionOverlay({
         updateConfig,
       });
     }
-    // end keeperhub
 
     if (integration.type === "database") {
       return (

--- a/components/overlays/overlay-container.tsx
+++ b/components/overlays/overlay-container.tsx
@@ -13,7 +13,6 @@ import { Dialog, DialogPortal } from "@/components/ui/dialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import { useOverlay } from "./overlay-provider";
-// start custom keeperhub code //
 import type { OverlaySize } from "./types";
 
 const sizeClasses: Record<OverlaySize, string> = {
@@ -25,7 +24,6 @@ const sizeClasses: Record<OverlaySize, string> = {
   "4xl": "max-w-4xl",
   full: "max-w-[90vw]",
 };
-// end keeperhub code //
 
 // iOS-like spring configuration
 const iosSpring = {
@@ -241,7 +239,6 @@ function DesktopOverlayContainer() {
             />
 
             {/* Dialog container */}
-            {/* start custom keeperhub code */}
             <motion.div
               animate="visible"
               className={cn(
@@ -252,7 +249,6 @@ function DesktopOverlayContainer() {
               initial="hidden"
               variants={containerVariants}
             >
-              {/* end keeperhub code */}
               <LayoutGroup>
                 <motion.div
                   className="relative max-h-[85vh] overflow-hidden rounded-xl border bg-background shadow-2xl ring-1 ring-black/5"

--- a/components/overlays/settings-overlay.tsx
+++ b/components/overlays/settings-overlay.tsx
@@ -4,12 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { AccountSettings } from "@/components/settings/account-settings";
 import { Spinner } from "@/components/ui/spinner";
-// start custom keeperhub code //
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AppearanceSection } from "@/keeperhub/components/settings/appearance-section";
 import { ChangePasswordSection } from "@/keeperhub/components/settings/change-password-section";
 import { DeactivateAccountSection } from "@/keeperhub/components/settings/delete-account-section";
-// end keeperhub code //
 import { api } from "@/lib/api-client";
 import { Overlay } from "./overlay";
 import { useOverlay } from "./overlay-provider";
@@ -26,18 +24,14 @@ export function SettingsOverlay({ overlayId }: SettingsOverlayProps) {
   // Account state
   const [accountName, setAccountName] = useState("");
   const [accountEmail, setAccountEmail] = useState("");
-  // start custom keeperhub code //
   const [providerId, setProviderId] = useState<string | null>(null);
-  // end keeperhub code //
 
   const loadAccount = useCallback(async () => {
     try {
       const data = await api.user.get();
       setAccountName(data.name || "");
       setAccountEmail(data.email || "");
-      // start custom keeperhub code //
       setProviderId(data.providerId ?? null);
-      // end keeperhub code //
     } catch (error) {
       console.error("Failed to load account:", error);
     }
@@ -94,7 +88,6 @@ export function SettingsOverlay({ overlayId }: SettingsOverlayProps) {
           <Spinner />
         </div>
       ) : (
-        // start custom keeperhub code //
         <Tabs className="w-full" defaultValue="account">
           <TabsList className="mb-4 w-full">
             <TabsTrigger value="account">Account</TabsTrigger>
@@ -120,7 +113,6 @@ export function SettingsOverlay({ overlayId }: SettingsOverlayProps) {
             <AppearanceSection />
           </TabsContent>
         </Tabs>
-        // end keeperhub code //
       )}
     </Overlay>
   );

--- a/components/overlays/types.ts
+++ b/components/overlays/types.ts
@@ -22,12 +22,10 @@ export type OverlayAction = {
   loading?: boolean;
 };
 
-// start custom keeperhub code //
 /**
  * Size options for overlays
  */
 export type OverlaySize = "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "full";
-// end keeperhub code //
 
 /**
  * Configuration options when opening an overlay
@@ -45,10 +43,8 @@ export type OverlayOptions = {
   closeOnEscape?: boolean;
   /** Callback when overlay is closed */
   onClose?: () => void;
-  // start custom keeperhub code //
   /** Size of the overlay (default: "lg") */
   size?: OverlaySize;
-  // end keeperhub code //
 };
 
 /**

--- a/components/settings/integrations-manager.tsx
+++ b/components/settings/integrations-manager.tsx
@@ -13,9 +13,7 @@ import { Button } from "@/components/ui/button";
 import { IntegrationIcon } from "@/components/ui/integration-icon";
 import { Spinner } from "@/components/ui/spinner";
 import { api, type Integration } from "@/lib/api-client";
-// start keeperhub - sync to global atom for singleConnection filtering
 import { integrationsAtom } from "@/lib/integrations-store";
-// end keeperhub
 import { getIntegrationLabels } from "@/plugins/registry";
 
 // System integrations that don't have plugins
@@ -36,18 +34,14 @@ export function IntegrationsManager({
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
   const [_testingId, setTestingId] = useState<string | null>(null);
-  // start keeperhub - sync to global atom for singleConnection filtering
   const setGlobalIntegrations = useSetAtom(integrationsAtom);
-  // end keeperhub
 
   const loadIntegrations = useCallback(async () => {
     try {
       setLoading(true);
       const data = await api.integration.getAll();
       setIntegrations(data);
-      // start keeperhub - sync to global atom for singleConnection filtering
       setGlobalIntegrations(data);
-      // end keeperhub
     } catch (error) {
       console.error("Failed to load integrations:", error);
       toast.error("Failed to load integrations");
@@ -187,7 +181,6 @@ export function IntegrationsManager({
               </span>
             </div>
             <div className="flex items-center gap-1">
-              {/* start custom keeperhub code */}
               {/* Test button hidden - unreliable functionality */}
               {/* <Button
                 className="h-7 px-2"
@@ -202,7 +195,6 @@ export function IntegrationsManager({
                   <span className="text-xs">Test</span>
                 )}
               </Button> */}
-              {/* end keeperhub code */}
               <Button
                 className="size-7"
                 onClick={() => handleEdit(integration)}

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -22,7 +22,6 @@ import {
   type WorkflowNode,
 } from "@/lib/workflow-store";
 import { findActionById } from "@/plugins/registry";
-// start custom keeperhub code //
 import { getReadContractOutputFields } from "@/keeperhub/lib/action-output-fields";
 import { resolveForEachSyntheticOutput } from "@/keeperhub/lib/for-each-utils";
 import {
@@ -35,7 +34,6 @@ import {
   schemaToFields,
 } from "@/keeperhub/lib/template-helpers";
 import { getTriggerOutputFields } from "@/keeperhub/lib/trigger-output-fields";
-// end keeperhub code //
 
 type TemplateAutocompleteProps = {
   isOpen: boolean;
@@ -45,8 +43,6 @@ type TemplateAutocompleteProps = {
   currentNodeId?: string;
   filter?: string;
 };
-
-
 // Get common fields based on node action type
 const getCommonFields = (node: WorkflowNode) => {
   const actionType = node.data.config?.actionType as string | undefined;
@@ -95,7 +91,6 @@ const getCommonFields = (node: WorkflowNode) => {
     return [{ field: "text", description: "Generated text" }];
   }
 
-  // start custom keeperhub code //
   // Check for Read Contract action with dynamic outputs based on ABI
   // This must be BEFORE the plugin outputFields check to override static fields
   if (isActionType(actionType, "Read Contract", "web3/read-contract")) {
@@ -130,7 +125,6 @@ const getCommonFields = (node: WorkflowNode) => {
       { field: "count", description: "Number of completed iterations" },
     ];
   }
-  // end keeperhub code //
 
   // Check if the plugin defines output fields
   if (actionType) {
@@ -145,7 +139,6 @@ const getCommonFields = (node: WorkflowNode) => {
     const triggerType = node.data.config?.triggerType as string | undefined;
     const webhookSchema = node.data.config?.webhookSchema as string | undefined;
 
-    // start custom keeperhub code //
     // Use keeperhub trigger output fields function for Event triggers
     if (triggerType === WorkflowTriggerEnum.EVENT) {
       const outputFields = getTriggerOutputFields(
@@ -156,7 +149,6 @@ const getCommonFields = (node: WorkflowNode) => {
         return outputFields;
       }
     }
-    // end keeperhub code //
 
     if (triggerType === "Webhook" && webhookSchema) {
       try {
@@ -169,7 +161,6 @@ const getCommonFields = (node: WorkflowNode) => {
       }
     }
 
-    // start custom keeperhub code //
     // Use keeperhub trigger output fields function for other trigger types
     if (triggerType) {
       const outputFields = getTriggerOutputFields(
@@ -180,7 +171,6 @@ const getCommonFields = (node: WorkflowNode) => {
         return outputFields;
       }
     }
-    // end keeperhub code //
 
     return [
       { field: "triggered", description: "Trigger status" },
@@ -191,8 +181,6 @@ const getCommonFields = (node: WorkflowNode) => {
 
   return [{ field: "data", description: "Output data" }];
 };
-
-
 export function TemplateAutocomplete({
   isOpen,
   position,
@@ -203,7 +191,6 @@ export function TemplateAutocomplete({
 }: TemplateAutocompleteProps) {
   const [nodes] = useAtom(nodesAtom);
   const [edges] = useAtom(edgesAtom);
-  // start custom keeperhub code //
   const executionLogs = useAtomValue(executionLogsAtom);
   const currentWorkflowId = useAtomValue(currentWorkflowIdAtom);
   const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
@@ -211,7 +198,6 @@ export function TemplateAutocomplete({
   const currentWorkflowIdRef = useRef<string | null>(null);
   const lastFetchWorkflowIdRef = useRef<string | null>(null);
   currentWorkflowIdRef.current = currentWorkflowId;
-  // end keeperhub code //
   const [selectedIndex, setSelectedIndex] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -223,7 +209,6 @@ export function TemplateAutocomplete({
     return () => setMounted(false);
   }, []);
 
-  // start custom keeperhub code //
   // Lazy-load last execution logs when autocomplete opens and we have no logs for this workflow.
   // Race guards: (1) lastFetchWorkflowIdRef prevents double-fetch for same workflow;
   // (2) only set state when currentWorkflowIdRef.current === workflowId so we never apply stale data after navigation.
@@ -290,7 +275,6 @@ export function TemplateAutocomplete({
     lastExecutionLogs.workflowId,
     setLastExecutionLogs,
   ]);
-  // end keeperhub code //
 
   // Find all nodes that come before the current node
   const getUpstreamNodes = () => {
@@ -333,7 +317,6 @@ export function TemplateAutocomplete({
 
   for (const node of upstreamNodes) {
     const nodeName = getNodeDisplayName(node);
-    // start custom keeperhub code //
     // 1) Prefer current execution in runtime; 2) else last execution output; 3) else getCommonFields
     const runtimeOutput = executionLogs[node.id]?.output;
     const hasRuntimeOutput =
@@ -445,7 +428,6 @@ export function TemplateAutocomplete({
           template: `{{@${node.id}:${nodeName}.${fieldPath}}}`,
         });
       }
-      // end keeperhub code //
     } else {
       const fields = getCommonFields(node);
 
@@ -471,7 +453,6 @@ export function TemplateAutocomplete({
     }
   }
 
-  // start custom keeperhub code //
   // Built-in system variables (available to all nodes, evaluated at execution time)
   for (const field of BUILTIN_VARIABLE_FIELDS) {
     options.push({
@@ -483,7 +464,6 @@ export function TemplateAutocomplete({
       template: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.${field.field}}}`,
     });
   }
-  // end keeperhub code //
 
   // Filter options based on search term
   const filteredOptions = filter

--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -2,9 +2,7 @@
 
 import { useAtom } from "jotai";
 import { useEffect, useRef, useState } from "react";
-// start custom keeperhub code //
 import { doesNodeExist, getDisplayTextForTemplate } from "@/keeperhub/lib/template-utils";
-// end keeperhub code //
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { TemplateAutocomplete } from "./template-autocomplete";
@@ -18,7 +16,6 @@ export interface TemplateBadgeInputProps {
   id?: string;
 }
 
-// start keeperhub custom code //
 // Helper to find all template pattern ranges in text
 function findTemplateRanges(text: string): Array<{ start: number; end: number }> {
   const templatePattern = /\{\{@[^}]+\}\}/g;
@@ -88,7 +85,6 @@ function findActiveAtSign(text: string, cursorOffset?: number): number {
   // No cursor info, return the last @
   return activeAtSigns[activeAtSigns.length - 1];
 }
-// end keeperhub custom code //
 
 /**
  * An input component that renders template variables as styled badges
@@ -395,7 +391,6 @@ export function TemplateBadgeInput({
       onChange?.(newValue);
       // Don't trigger display update - this prevents cursor reset!
       
-      // start keeperhub custom code //
 
       // Check for @ sign to show autocomplete (moved here so it works with existing badges)
       // Get cursor position first to find the closest @
@@ -448,7 +443,6 @@ export function TemplateBadgeInput({
       } else {
         setShowAutocomplete(false);
       }
-      // end keeperhub custom code //
       
       return;
     }
@@ -466,7 +460,6 @@ export function TemplateBadgeInput({
     setInternalValue(newValue);
     onChange?.(newValue);
     
-    // start keeperhub custom code //
 
     // Check for @ sign to show autocomplete
     // Get cursor position first to find the closest @
@@ -519,7 +512,6 @@ export function TemplateBadgeInput({
     } else {
       setShowAutocomplete(false);
     }
-    // end keeperhub custom code //
   };
 
   const handleAutocompleteSelect = (template: string) => {
@@ -575,7 +567,6 @@ export function TemplateBadgeInput({
     document.execCommand("insertText", false, text);
   };
 
-  // start custom keeperhub code //
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && showAutocomplete) {
       e.preventDefault();
@@ -673,7 +664,6 @@ export function TemplateBadgeInput({
       }
     }
   };
-  // end keeperhub code //
 
   // Update display only when needed (not while typing)
   useEffect(() => {

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -1,13 +1,9 @@
 "use client";
 
 import { useAtom } from "jotai";
-// start keeperhub custom code //
 import type { CSSProperties } from "react";
-// end keeperhub custom code //
 import { useEffect, useRef, useState } from "react";
-// start custom keeperhub code //
 import { doesNodeExist, getDisplayTextForTemplate } from "@/keeperhub/lib/template-utils";
-// end keeperhub code //
 import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { TemplateAutocomplete } from "./template-autocomplete";
@@ -20,13 +16,10 @@ export interface TemplateBadgeTextareaProps {
   className?: string;
   id?: string;
   rows?: number;
-  // start keeperhub custom code //
   /** When set, limits visible height to this many rows and makes content scrollable */
   maxRows?: number;
-  // end keeperhub custom code //
 }
 
-// start keeperhub custom code //
 // Helper to find all template pattern ranges in text
 function findTemplateRanges(text: string): Array<{ start: number; end: number }> {
   const templatePattern = /\{\{@[^}]+\}\}/g;
@@ -96,7 +89,6 @@ function findActiveAtSign(text: string, cursorOffset?: number): number {
   // No cursor info, return the last @
   return activeAtSigns[activeAtSigns.length - 1];
 }
-// end keeperhub custom code //
 
 /**
  * A textarea component that renders template variables as styled badges
@@ -110,9 +102,7 @@ export function TemplateBadgeTextarea({
   className,
   id,
   rows = 3,
-  // start keeperhub custom code //
   maxRows,
-  // end keeperhub custom code //
 }: TemplateBadgeTextareaProps) {
   const [isFocused, setIsFocused] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -459,7 +449,6 @@ export function TemplateBadgeTextarea({
       onChange?.(newValue);
       // Don't trigger display update - this prevents cursor reset!
       
-      // start keeperhub custom code //
 
       // Check for @ sign to show autocomplete (moved here so it works with existing badges)
       // Get cursor position first to find the closest @
@@ -512,7 +501,6 @@ export function TemplateBadgeTextarea({
       } else {
         setShowAutocomplete(false);
       }
-      // end keeperhub custom code //
       
       return;
     }
@@ -532,7 +520,6 @@ export function TemplateBadgeTextarea({
     setInternalValue(newValue);
     onChange?.(newValue);
     
-    // start keeperhub custom code //
 
     // Check for @ sign to show autocomplete
     // Get cursor position first to find the closest @
@@ -585,7 +572,6 @@ export function TemplateBadgeTextarea({
     } else {
       setShowAutocomplete(false);
     }
-    // end keeperhub custom code //
   };
 
   const handleAutocompleteSelect = (template: string) => {
@@ -655,13 +641,11 @@ export function TemplateBadgeTextarea({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // Handle Enter key to insert line breaks
     if (e.key === "Enter") {
-      // start custom keeperhub code //
       // prevent Enter key from inserting line breaks if autocomplete is open
       if (showAutocomplete) {
         e.preventDefault();
         return;
       }
-      // end keeperhub code //
       e.preventDefault();
       document.execCommand("insertLineBreak");
     }
@@ -674,7 +658,6 @@ export function TemplateBadgeTextarea({
     }
   }, [internalValue, isFocused]);
 
-  // start keeperhub custom code //
   // Calculate min height based on rows; max height when maxRows is set (truncates display, scrollable)
   const minHeight = `${rows * 1.5}rem`;
   const style: CSSProperties = { minHeight };
@@ -682,7 +665,6 @@ export function TemplateBadgeTextarea({
     style.maxHeight = `${maxRows * 1.5}rem`;
     style.overflowY = "auto";
   }
-  // end keeperhub custom code //
 
   return (
     <>

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -4,13 +4,11 @@ import { ChevronDown, Info } from "lucide-react";
 import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-// start custom keeperhub code //
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-// end keeperhub code //
 import {
   Select,
   SelectContent,
@@ -20,12 +18,10 @@ import {
 } from "@/components/ui/select";
 import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
-// start custom keeperhub code //
 import { SaveAddressBookmark } from "@/keeperhub/components/address-book/save-address-bookmark";
 import { computeSelector } from "@/keeperhub/lib/abi-utils";
 import { parseAddressBookSelection } from "@/keeperhub/lib/address-book-selection";
 import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
-// end keeperhub code //
 import { getCustomFieldRenderer } from "@/lib/extension-registry";
 import {
   type ActionConfigField,
@@ -39,11 +35,9 @@ type FieldProps = {
   value: string;
   onChange: (value: unknown) => void;
   disabled?: boolean;
-  // start custom keeperhub code //
   config?: Record<string, unknown>;
   nodeId?: string;
 };
-// end keeperhub code //
 
 function TemplateInputField({
   field,
@@ -53,7 +47,6 @@ function TemplateInputField({
   config,
   nodeId,
 }: FieldProps) {
-  // start custom keeperhub code //
   const isAddressField =
     field.isAddressField === true ||
     field.key === "contractAddress" ||
@@ -90,7 +83,6 @@ function TemplateInputField({
   }
 
   return input;
-  // end keeperhub code //
 }
 
 function TemplateTextareaField({
@@ -132,9 +124,7 @@ function NumberInputField({ field, value, onChange, disabled }: FieldProps) {
       min={field.min}
       onChange={(e) => onChange(e.target.value)}
       placeholder={field.placeholder}
-      // start custom keeperhub code //
       step={field.step}
-      // end keeperhub code //
       type="number"
       value={value}
     />
@@ -217,10 +207,8 @@ export function AbiFunctionSelectField({
               `${input.type} ${input.name}`
           )
           .join(", ");
-        // start custom keeperhub code //
         const inputTypes = inputs.map((input: { type: string }) => input.type);
         const selector = computeSelector(func.name, inputTypes);
-        // end keeperhub code //
         return {
           name: func.name,
           label: `${func.name}(${params})`,
@@ -252,14 +240,12 @@ export function AbiFunctionSelectField({
         {functions.map((func) => (
           <SelectItem key={func.label} value={func.name}>
             <div className="flex flex-col items-start">
-              {/* start custom keeperhub code // */}
               <span>
                 {func.label}{" "}
                 <code className="text-muted-foreground text-xs">
                   ({func.selector})
                 </code>
               </span>
-              {/* end keeperhub code // */}
               <span className="text-muted-foreground text-xs">
                 {func.stateMutability}
               </span>
@@ -494,14 +480,11 @@ function renderField(
   config: Record<string, unknown>,
   onUpdateConfig: (key: string, value: unknown) => void,
   disabled?: boolean,
-  // start custom keeperhub code //
   nodeId?: string
-  // end keeperhub code //
 ) {
   // Check conditional rendering
   if (field.showWhen) {
     const dependentValue = config[field.showWhen.field];
-    // start custom keeperhub code //
     if ("oneOf" in field.showWhen) {
       if (!field.showWhen.oneOf.includes(dependentValue as string)) {
         return null;
@@ -509,7 +492,6 @@ function renderField(
     } else if (dependentValue !== field.showWhen.equals) {
       return null;
     }
-    // end keeperhub code //
   }
 
   const value =
@@ -547,7 +529,6 @@ function renderField(
       <Label className="ml-1 flex items-center gap-1.5" htmlFor={field.key}>
         {field.label}
         {field.required && <span className="text-red-500">*</span>}
-        {/* start custom keeperhub code // */}
         {field.helpTip && (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -558,17 +539,12 @@ function renderField(
             </TooltipContent>
           </Tooltip>
         )}
-        {/* end keeperhub code // */}
       </Label>
       <FieldRenderer
-        // start custom keeperhub code //
         config={config}
-        // end keeperhub code //
         disabled={disabled}
         field={field}
-        // start custom keeperhub code //
         nodeId={nodeId}
-        // end keeperhub code //
         onChange={(val: unknown) => onUpdateConfig(field.key, val)}
         value={value}
       />
@@ -586,7 +562,6 @@ function FieldGroup({
   onUpdateConfig,
   disabled,
   defaultExpanded = false,
-  // start custom keeperhub code //
   nodeId,
 }: {
   label: string;
@@ -597,7 +572,6 @@ function FieldGroup({
   defaultExpanded?: boolean;
   nodeId?: string;
 }) {
-  // end keeperhub code //
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   return (
@@ -630,9 +604,7 @@ type ActionConfigRendererProps = {
   config: Record<string, unknown>;
   onUpdateConfig: (key: string, value: unknown) => void;
   disabled?: boolean;
-  // start custom keeperhub code //
   nodeId?: string;
-  // end keeperhub code //
 };
 
 /**
@@ -644,9 +616,7 @@ export function ActionConfigRenderer({
   config,
   onUpdateConfig,
   disabled,
-  // start custom keeperhub code //
   nodeId,
-  // end keeperhub code //
 }: ActionConfigRendererProps) {
   return (
     <>
@@ -660,9 +630,7 @@ export function ActionConfigRenderer({
               fields={field.fields}
               key={`group-${field.label}`}
               label={field.label}
-              // start custom keeperhub code //
               nodeId={nodeId}
-              // end keeperhub code //
               onUpdateConfig={onUpdateConfig}
             />
           );
@@ -673,9 +641,7 @@ export function ActionConfigRenderer({
           config,
           onUpdateConfig,
           disabled,
-          // start custom keeperhub code //
           nodeId
-          // end keeperhub code //
         );
       })}
     </>

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/components/ui/tooltip";
 import { SqlTemplateEditor } from "@/keeperhub/components/ui/sql-template-editor";
 import { TemplateCodeEditor } from "@/keeperhub/components/ui/template-code-editor";
-// start keeperhub
 import { actionRequiresCredentials } from "@/keeperhub/lib/integration-helpers";
 import { ConditionQueryBuilder } from "@/keeperhub/components/workflow/condition-query-builder";
 import type { ConditionGroup } from "@/keeperhub/lib/condition-builder-types";
@@ -38,7 +37,6 @@ import {
   visualConditionToExpression,
 } from "@/keeperhub/lib/condition-builder-utils";
 import { resolveConditionExpression } from "@/keeperhub/lib/condition-resolver";
-// end keeperhub
 import { aiGatewayStatusAtom } from "@/lib/ai-gateway/state";
 import { validateConditionExpressionUI } from "@/lib/condition-validator";
 import {
@@ -46,7 +44,6 @@ import {
   integrationsVersionAtom,
 } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
-// start custom keeperhub code //
 import {
   ARRAY_SOURCE_RE,
   extractObjectPaths,
@@ -58,7 +55,6 @@ import {
   lastExecutionLogsAtom,
   nodesAtom,
 } from "@/lib/workflow-store";
-// end keeperhub code //
 import {
   findActionById,
   getActionsByCategory,
@@ -68,20 +64,14 @@ import {
 import { ActionConfigRenderer } from "./action-config-renderer";
 import { SchemaBuilder, type SchemaField } from "./schema-builder";
 
-// start custom keeperhub code //
 type ConfigValue = string | Record<string, unknown> | undefined;
-// end keeperhub code //
 
 type ActionConfigProps = {
   config: Record<string, unknown>;
-  // start custom keeperhub code //
   onUpdateConfig: (key: string, value: ConfigValue) => void;
-  // end keeperhub code //
   disabled: boolean;
   isOwner?: boolean;
-  // start custom keeperhub code //
   nodeId?: string;
-  // end keeperhub code //
 };
 
 // Database Query fields component
@@ -96,7 +86,6 @@ function DatabaseQueryFields({
 }) {
   return (
     <>
-      {/* start custom keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="dbQuery">SQL Query</Label>
         <SqlTemplateEditor
@@ -110,7 +99,6 @@ function DatabaseQueryFields({
           query. Use @ to insert values from previous nodes.
         </p>
       </div>
-      {/* end keeperhub code */}
       <div className="space-y-2">
         <Label>Schema (Optional)</Label>
         <SchemaBuilder
@@ -170,7 +158,6 @@ function HttpRequestFields({
           value={(config?.endpoint as string) || ""}
         />
       </div>
-      {/* start custom keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="httpHeaders">Headers (JSON)</Label>
         <TemplateCodeEditor
@@ -194,7 +181,6 @@ function HttpRequestFields({
             value={(config?.httpBody as string) || "{}"}
           />
         </div>
-      {/* end keeperhub code */}
         {config?.httpMethod === "GET" && (
           <p className="text-muted-foreground text-xs">
             Body is disabled for GET requests
@@ -205,7 +191,6 @@ function HttpRequestFields({
   );
 }
 
-// start custom keeperhub code //
 // Condition fields component with visual builder + expression mode toggle
 function ConditionFields({
   config,
@@ -363,10 +348,6 @@ function ConditionFields({
     </div>
   );
 }
-// end keeperhub code //
-
-// start custom keeperhub code //
-
 /**
  * Extract dot-paths from the first element of the array referenced by arraySource.
  */
@@ -395,7 +376,6 @@ export function useArrayItemFields(arraySource: string | undefined): string[] {
     return paths;
   }, [arraySource, executionLogs, lastExecutionLogs, nodes]);
 }
-// end keeperhub code //
 
 /** Sentinel value for the "Full element (no mapping)" select option. */
 const FULL_ELEMENT_VALUE = "__full__";
@@ -410,11 +390,9 @@ function ForEachFields({
   onUpdateConfig: (key: string, value: string) => void;
   disabled: boolean;
 }) {
-  // start custom keeperhub code //
   const itemFields = useArrayItemFields(
     config?.arraySource as string | undefined
   );
-  // end keeperhub code //
   return (
     <>
       <div className="space-y-2">
@@ -430,7 +408,6 @@ function ForEachFields({
           Reference an array from a previous node. Use @ to select a field.
         </p>
       </div>
-      {/* start custom keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="mapExpression">Extract Field (optional)</Label>
         {itemFields.length > 0 ? (
@@ -471,7 +448,6 @@ function ForEachFields({
             : "Run the workflow once to see available fields, or type a dot-path manually."}
         </p>
       </div>
-      {/* end keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="maxIterations">Max Items (optional)</Label>
         <Input
@@ -491,7 +467,6 @@ function ForEachFields({
           allowed.
         </p>
       </div>
-      {/* start custom keeperhub code */}
       <div className="space-y-2">
         <Label htmlFor="concurrency">Concurrency</Label>
         <Select
@@ -532,7 +507,6 @@ function ForEachFields({
           Custom limit runs up to N iterations concurrently.
         </p>
       </div>
-      {/* end keeperhub code */}
       <div className="rounded-lg border bg-muted/30 p-3">
         <p className="text-muted-foreground text-sm">
           Connect action nodes after this For Each to define the loop body.
@@ -590,9 +564,7 @@ function SystemActionFields({
 }: {
   actionType: string;
   config: Record<string, unknown>;
-  // start custom keeperhub code //
   onUpdateConfig: (key: string, value: ConfigValue) => void;
-  // end keeperhub code //
   disabled: boolean;
 }) {
   switch (actionType) {
@@ -620,7 +592,6 @@ function SystemActionFields({
           onUpdateConfig={onUpdateConfig}
         />
       );
-    // start custom keeperhub code //
     case "For Each":
       return (
         <ForEachFields
@@ -631,7 +602,6 @@ function SystemActionFields({
       );
     case "Collect":
       return <CollectFields />;
-    // end keeperhub code //
     default:
       return null;
   }
@@ -642,10 +612,8 @@ const SYSTEM_ACTIONS: Array<{ id: string; label: string }> = [
   { id: "HTTP Request", label: "HTTP Request" },
   { id: "Database Query", label: "Database Query" },
   { id: "Condition", label: "Condition" },
-  // start custom keeperhub code //
   { id: "For Each", label: "For Each" },
   { id: "Collect", label: "Collect" },
-  // end keeperhub code //
 ];
 
 const SYSTEM_ACTION_IDS = SYSTEM_ACTIONS.map((a) => a.id);
@@ -657,21 +625,17 @@ const SYSTEM_ACTION_INTEGRATIONS: Record<string, IntegrationType> = {
 
 // Build category mapping dynamically from plugins + System
 function useCategoryData() {
-  // start custom keeperhub code //
   const nodes = useAtomValue(nodesAtom);
   const hasForEach = nodes.some(
     (n) => n.data?.config?.actionType === "For Each"
   );
-  // end keeperhub code //
 
   return useMemo(() => {
     const pluginCategories = getActionsByCategory();
 
-    // start custom keeperhub code //
     const systemActions = hasForEach
       ? SYSTEM_ACTIONS
       : SYSTEM_ACTIONS.filter((a) => a.id !== "Collect");
-    // end keeperhub code //
 
     // Build category map including System with both id and label
     const allCategories: Record<
@@ -682,7 +646,6 @@ function useCategoryData() {
     };
 
     for (const [category, actions] of Object.entries(pluginCategories)) {
-      // start custom keeperhub code //
       // Deduplicate by slug within each category. When the same action is
       // registered under two integrations, keep the first occurrence.
       const seen = new Set<string>();
@@ -698,7 +661,6 @@ function useCategoryData() {
           id: a.id,
           label: a.label,
         }));
-      // end keeperhub code //
     }
 
     return allCategories;
@@ -743,13 +705,10 @@ export function ActionConfig({
   onUpdateConfig,
   disabled,
   isOwner = true,
-  // start custom keeperhub code //
   nodeId,
-  // end keeperhub code //
 }: ActionConfigProps) {
   const actionType = (config?.actionType as string) || "";
   const categories = useCategoryData();
-  // start custom keeperhub code //
   // Deduplicate integrations by label for the Service dropdown.
   // When two integrations share a label, keep the one with more actions
   // to avoid Radix Select duplicate-value collisions.
@@ -764,7 +723,6 @@ export function ActionConfig({
     }
     return Array.from(byLabel.values());
   }, []);
-  // end keeperhub code //
 
   const selectedCategory = actionType ? getCategoryForAction(actionType) : null;
   const [category, setCategory] = useState<string>(selectedCategory || "");
@@ -772,7 +730,6 @@ export function ActionConfig({
   const globalIntegrations = useAtomValue(integrationsAtom);
   const { push } = useOverlay();
 
-  // start keeperhub - anonymous check for action restrictions
   const [isAnonymous, setIsAnonymous] = useState(false);
   useEffect(() => {
     let cancelled = false;
@@ -796,7 +753,6 @@ export function ActionConfig({
       cancelled = true;
     };
   }, []);
-  // end keeperhub
 
   // AI Gateway managed keys state
   const aiGatewayStatus = useAtomValue(aiGatewayStatusAtom);
@@ -844,13 +800,11 @@ export function ActionConfig({
     return (action?.credentialIntegrationType ?? action?.integration) as IntegrationType | undefined;
   }, [actionType]);
 
-  // start keeperhub
   // Check if action requires credentials (some like web3 read-only actions don't)
   const requiresCredentials = useMemo(
     () => actionRequiresCredentials(actionType),
     [actionType]
   );
-  // end keeperhub
 
   // Check if AI Gateway managed keys should be offered (user can have multiple for different teams)
   const shouldUseManagedKeys =
@@ -955,7 +909,6 @@ export function ActionConfig({
         </div>
       </div>
 
-      {/* start keeperhub - show Connection for plugin actions that require credentials or system actions that use an integration (e.g. Database Query) */}
       {integrationType &&
         isOwner &&
         (requiresCredentials || SYSTEM_ACTION_INTEGRATIONS[actionType]) &&
@@ -981,7 +934,6 @@ export function ActionConfig({
                   </Tooltip>
                 </TooltipProvider>
               </div>
-              {/* start keeperhub - hide + button for singleConnection integrations */}
               {hasExistingConnections &&
                 !getIntegration(integrationType)?.singleConnection && (
                   <Button
@@ -994,7 +946,6 @@ export function ActionConfig({
                     <Plus className="size-4" />
                   </Button>
                 )}
-              {/* end keeperhub */}
             </div>
             <IntegrationSelector
               disabled={disabled}
@@ -1004,7 +955,6 @@ export function ActionConfig({
             />
           </div>
         ))}
-      {/* end keeperhub */}
 
       {/* System actions - hardcoded config fields */}
       <SystemActionFields
@@ -1022,9 +972,7 @@ export function ActionConfig({
             config={config}
             disabled={disabled}
             fields={pluginAction.configFields}
-            // start custom keeperhub code //
             nodeId={nodeId}
-            // end keeperhub code //
             onUpdateConfig={handlePluginUpdateConfig}
           />
         )}

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -30,9 +30,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsTouch } from "@/hooks/use-touch";
 import { cn } from "@/lib/utils";
-// start custom keeperhub code //
 import { nodesAtom } from "@/lib/workflow-store";
-// end keeperhub code //
 import { getAllActions } from "@/plugins/registry";
 
 type ActionType = {
@@ -63,7 +61,6 @@ const SYSTEM_ACTIONS: ActionType[] = [
     description: "Branch based on a condition",
     category: "System",
   },
-  // start custom keeperhub code //
   {
     id: "For Each",
     label: "For Each",
@@ -76,17 +73,14 @@ const SYSTEM_ACTIONS: ActionType[] = [
     description: "Gather results from a For Each loop",
     category: "System",
   },
-  // end keeperhub code //
 ];
 
 // Combine System actions with plugin actions
 function useAllActions(): ActionType[] {
-  // start custom keeperhub code //
   const nodes = useAtomValue(nodesAtom);
   const hasForEach = nodes.some(
     (n) => n.data?.config?.actionType === "For Each"
   );
-  // end keeperhub code //
 
   return useMemo(() => {
     const pluginActions = getAllActions();
@@ -99,11 +93,9 @@ function useAllActions(): ActionType[] {
       integration: action.integration,
     }));
 
-    // start custom keeperhub code //
     const systemActions = hasForEach
       ? SYSTEM_ACTIONS
       : SYSTEM_ACTIONS.filter((a) => a.id !== "Collect");
-    // end keeperhub code //
 
     return [...systemActions, ...mappedPluginActions];
   }, [hasForEach]);
@@ -181,7 +173,6 @@ function getInitialViewMode(): ViewMode {
   }
 }
 
-// start custom keeperhub code //
 // Super-category definitions for the action panel
 const SUPER_CATEGORY_ORDER = ["Web3", "Messaging", "System"] as const;
 type SuperCategory = (typeof SUPER_CATEGORY_ORDER)[number];
@@ -214,7 +205,6 @@ type SuperCategoryGroup = {
   superCategory: SuperCategory;
   pluginGroups: PluginGroup[];
 };
-// end keeperhub code //
 
 export function ActionGrid({
   onSelectAction,
@@ -298,7 +288,6 @@ export function ActionGrid({
     );
   });
 
-  // start custom keeperhub code //
   // Group actions by super-category, then by plugin category within each
   const superCategoryGroups = useMemo((): SuperCategoryGroup[] => {
     const categoryMap: Record<string, ActionType[]> = {};
@@ -347,7 +336,6 @@ export function ActionGrid({
       }))
       .filter((sg) => sg.pluginGroups.length > 0);
   }, [superCategoryGroups, hiddenGroups, showHidden]);
-  // end keeperhub code //
 
   const hiddenCount = hiddenGroups.size;
 
@@ -463,7 +451,6 @@ export function ActionGrid({
           </div>
         )}
 
-        {/* start custom keeperhub code */}
         {/* List View - Flat search results (no category headers) */}
         {viewMode === "list" &&
           filter &&
@@ -608,7 +595,6 @@ export function ActionGrid({
               })}
             </div>
           ))}
-        {/* end keeperhub code */}
       </div>
     </div>
   );

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -42,7 +42,6 @@ export function TriggerConfig({
     ? `${typeof window !== "undefined" ? window.location.origin : ""}/api/workflows/${workflowId}/webhook`
     : "";
 
-  // start custom keeperhub code //
   const handleConfigValue = (key: string, value: unknown): void => {
     let stringValue: string;
     if (typeof value === "string") {
@@ -54,7 +53,6 @@ export function TriggerConfig({
     }
     onUpdateConfig(key, stringValue);
   };
-  // end keeperhub code //
 
   const handleCopyWebhookUrl = () => {
     if (webhookUrl) {
@@ -96,7 +94,6 @@ export function TriggerConfig({
                 Webhook
               </div>
             </SelectItem>
-            {/* start custom keeperhub code // */}
             <SelectItem value="Event">
               <div className="flex items-center gap-2">
                 <Boxes className="h-4 w-4" />
@@ -109,7 +106,6 @@ export function TriggerConfig({
                 Block
               </div>
             </SelectItem>
-            {/* end keeperhub code // */}
           </SelectContent>
         </Select>
       </div>
@@ -217,7 +213,6 @@ export function TriggerConfig({
         </>
       )}
 
-      {/* start custom keeperhub code // */}
       {/* Event fields */}
       {config?.triggerType === "Event" && (
         <EventTriggerFields
@@ -278,12 +273,10 @@ export function TriggerConfig({
             </>
           );
         })()}
-      {/* end keeperhub code // */}
     </>
   );
 }
 
-// start custom keeperhub code //
 const CUSTOM_PROTOCOL_VALUE = "__custom__";
 
 type EventTriggerFieldsProps = {
@@ -531,4 +524,3 @@ function ProtocolSelector({
     </div>
   );
 }
-// end keeperhub code //

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -59,9 +59,7 @@ import {
   updateNodeDataAtom,
   workflowNotFoundAtom,
 } from "@/lib/workflow-store";
-// start custom keeperhub code //
 import { findActionById, flattenConfigFields } from "@/plugins/registry";
-// end keeperhub code //
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { ActionConfig } from "./config/action-config";
 import { ActionGrid } from "./config/action-grid";
@@ -307,7 +305,6 @@ export const PanelInner = () => {
   const autoSelectAbortControllersRef = useRef<Record<string, AbortController>>(
     {}
   );
-  // start custom keeperhub code //
   // Tracks in-flight config so multiple synchronous onUpdateConfig calls
   // within the same event (e.g. toggling manual ABI + clearing the field)
   // don't overwrite each other due to stale selectedNode closure.
@@ -315,7 +312,6 @@ export const PanelInner = () => {
   const sidebarRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
-  // end keeperhub code //
   const selectedNode = nodes.find((node) => node.id === selectedNodeId);
   const selectedEdge = edges.find((edge) => edge.id === selectedEdgeId);
 
@@ -335,11 +331,9 @@ export const PanelInner = () => {
     const isManualTrigger =
       selectedNode.data.type === "trigger" &&
       selectedNode.data.config?.triggerType === "Manual";
-    // start custom keeperhub code //
     const isForEachOrCollect =
       selectedNode.data.config?.actionType === "For Each" ||
       selectedNode.data.config?.actionType === "Collect";
-    // end keeperhub code //
 
     if (isConditionAction || isManualTrigger || isForEachOrCollect) {
       setActiveTab("properties");
@@ -548,22 +542,17 @@ export const PanelInner = () => {
     [updateNodeData, setPendingIntegrationNodes]
   );
 
-  // start custom keeperhub code //
   // Widened value type to support structured config objects (e.g. conditionConfig)
   const handleUpdateConfig = (key: string, value: string | Record<string, unknown> | undefined) => {
-  // end keeperhub code //
     if (selectedNode) {
-      // start custom keeperhub code //
       const baseConfig = pendingConfigRef.current ?? selectedNode.data.config;
       let newConfig = { ...baseConfig, [key]: value };
-      // end keeperhub code //
 
       // When action type changes, clear the integrationId since it may not be valid for the new action
       if (key === "actionType" && baseConfig?.integrationId) {
         newConfig = { ...newConfig, integrationId: undefined };
       }
 
-      // start custom keeperhub code //
       // When action type is selected, persist defaultValues from configFields
       // into config so that showWhen conditions and validation work immediately.
       // For _protocolMeta: always overwrite with the new action's value since
@@ -582,14 +571,11 @@ export const PanelInner = () => {
           }
         }
       }
-      // end keeperhub code //
 
-      // start custom keeperhub code //
       pendingConfigRef.current = newConfig;
       queueMicrotask(() => {
         pendingConfigRef.current = null;
       });
-      // end keeperhub code //
       updateNodeData({ id: selectedNode.id, data: { config: newConfig } });
 
       // When action type changes, auto-select integration if only one exists
@@ -659,7 +645,6 @@ export const PanelInner = () => {
     }
   };
 
-  // start custom keeperhub code //
   const handleUpdateWorkflowProject = async (
     newProjectId: string | null
   ): Promise<void> => {
@@ -693,7 +678,6 @@ export const PanelInner = () => {
       }
     }
   };
-  // end keeperhub code //
 
   const handleRefreshRuns = async () => {
     setIsRefreshing(true);
@@ -851,7 +835,6 @@ export const PanelInner = () => {
                   value={currentWorkflowDescription}
                 />
               </div>
-              {/* start custom keeperhub code */}
               <div className="space-y-2">
                 <Label className="ml-1">Project</Label>
                 <ProjectSelect
@@ -871,7 +854,6 @@ export const PanelInner = () => {
                   value={currentWorkflowTagId}
                 />
               </div>
-              {/* end keeperhub code */}
               <div className="space-y-2">
                 <Label className="ml-1" htmlFor="workflow-id">
                   Workflow ID
@@ -1043,10 +1025,8 @@ export const PanelInner = () => {
           {(selectedNode.data.type !== "trigger" ||
             (selectedNode.data.config?.triggerType as string) !== "Manual") &&
           selectedNode.data.config?.actionType !== "Condition" &&
-          // start custom keeperhub code //
           selectedNode.data.config?.actionType !== "For Each" &&
           selectedNode.data.config?.actionType !== "Collect" ? (
-            // end keeperhub code //
             <TabsTrigger
               className="bg-transparent text-muted-foreground data-[state=active]:text-foreground data-[state=active]:shadow-none"
               value="code"
@@ -1118,9 +1098,7 @@ export const PanelInner = () => {
                   config={selectedNode.data.config || {}}
                   disabled={isGenerating || !isOwner}
                   isOwner={isOwner}
-                  // start custom keeperhub code //
                   nodeId={selectedNode.id}
-                  // end keeperhub code //
                   onUpdateConfig={handleUpdateConfig}
                 />
               ) : null}

--- a/components/workflow/nodes/action-node.tsx
+++ b/components/workflow/nodes/action-node.tsx
@@ -73,7 +73,6 @@ const getModelDisplayName = (modelId: string): string => {
   return modelNames[modelId] || modelId;
 };
 
-// start custom keeperhub code //
 const FOR_EACH_SOURCE_HANDLES: SourceHandleConfig[] = [
   { id: "done", label: "done", topPercent: 30 },
   { id: "loop", label: "loop", topPercent: 70 },
@@ -83,7 +82,6 @@ const CONDITION_SOURCE_HANDLES: SourceHandleConfig[] = [
   { id: "true", label: "true", topPercent: 30 },
   { id: "false", label: "false", topPercent: 70 },
 ];
-// end keeperhub code //
 
 // System action labels (non-plugin actions)
 const SYSTEM_ACTION_LABELS: Record<string, string> = {
@@ -91,10 +89,8 @@ const SYSTEM_ACTION_LABELS: Record<string, string> = {
   "Database Query": "Database",
   Condition: "Condition",
   "Execute Code": "System",
-  // start custom keeperhub code //
   "For Each": "Loop",
   Collect: "Loop",
-  // end keeperhub code //
 };
 
 // Helper to get integration name from action type
@@ -156,12 +152,10 @@ const getProviderLogo = (actionType: string) => {
       return <Code className="size-12 text-green-300" strokeWidth={1.5} />;
     case "Condition":
       return <GitBranch className="size-12 text-pink-300" strokeWidth={1.5} />;
-    // start custom keeperhub code //
     case "For Each":
       return <Repeat className="size-12 text-purple-300" strokeWidth={1.5} />;
     case "Collect":
       return <ListEnd className="size-12 text-purple-300" strokeWidth={1.5} />;
-    // end keeperhub code //
     default:
       // Not a system action, continue to check plugin registry
       break;
@@ -368,7 +362,6 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
   const aiModel = getAiModel();
   const isDisabled = data.enabled === false;
 
-  // start custom keeperhub code //
   const isForEach = actionType === "For Each";
   const isCondition = actionType === "Condition";
   const handles = isForEach
@@ -376,7 +369,6 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
     : isCondition
       ? { target: true, source: false, sourceHandles: CONDITION_SOURCE_HANDLES }
       : { target: true, source: true };
-  // end keeperhub code //
 
   return (
     <Node

--- a/components/workflow/nodes/add-node.tsx
+++ b/components/workflow/nodes/add-node.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import type { NodeProps } from "@xyflow/react";
-// start custom keeperhub code //
 import { Globe, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { GettingStartedChecklist } from "@/keeperhub/components/onboarding/getting-started-checklist";
-// end keeperhub code //
 import { getAppName, getCustomLogo } from "@/lib/extension-registry";
 
 type AddNodeData = {
@@ -16,9 +14,7 @@ type AddNodeData = {
 export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
   const CustomLogo = getCustomLogo();
   const appName = getAppName();
-  // start custom keeperhub code //
   const router = useRouter();
-  // end keeperhub code //
 
   return (
     <div className="flex flex-col items-center justify-center gap-8 rounded-lg border border-border border-dashed bg-background/50 p-8 backdrop-blur-sm">
@@ -27,7 +23,6 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
         <h1 className="mb-1 font-bold text-3xl">{appName}</h1>
         <p className="text-muted-foreground">Automate anything onchain</p>
       </div>
-      {/* start custom keeperhub code */}
       <div className="flex gap-3">
         <Button
           className="gap-2 shadow-lg"
@@ -48,7 +43,6 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
         </Button>
       </div>
       <GettingStartedChecklist onCreateWorkflow={data.onClick} />
-      {/* end keeperhub code */}
     </div>
   );
 }

--- a/components/workflow/nodes/trigger-node.tsx
+++ b/components/workflow/nodes/trigger-node.tsx
@@ -41,13 +41,11 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
 
   const TriggerIcon = triggerIcons[triggerType as WorkflowTriggerType] || Play;
 
-  // start custom keeperhub code //
   const protocolIconPath = data.config?._eventProtocolIconPath as
     | string
     | undefined;
   const hasProtocolIcon =
     triggerType === "Event" && protocolIconPath && protocolIconPath.length > 0;
-  // end keeperhub code //
 
   return (
     <Node
@@ -78,7 +76,6 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
       )}
 
       <div className="flex flex-col items-center justify-center gap-3 p-6">
-        {/* start custom keeperhub code // */}
         {hasProtocolIcon ? (
           <Image
             alt="Protocol"
@@ -90,7 +87,6 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
         ) : (
           <TriggerIcon className="size-12 text-blue-500" strokeWidth={1.5} />
         )}
-        {/* end keeperhub code // */}
         <div className="flex flex-col items-center gap-1 text-center">
           <NodeTitle className="text-base">{displayTitle}</NodeTitle>
           {displayDescription && (

--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -77,14 +77,12 @@ const edgeTypes = {
   temporary: Edge.Temporary,
 };
 
-// start custom keeperhub code //
 /** Extract actionType from a workflow node's data. */
 function getActionType(node: { data?: unknown }): string | undefined {
   const config = (node.data as Record<string, unknown> | undefined)
     ?.config as Record<string, unknown> | undefined;
   return config?.actionType as string | undefined;
 }
-// end keeperhub code //
 
 export function WorkflowCanvas() {
   const [nodes, setNodes] = useAtom(nodesAtom);
@@ -236,7 +234,6 @@ export function WorkflowCanvas() {
     []
   );
 
-  // start custom keeperhub code //
   // Auto-assign sourceHandle on For Each and Condition edges that lack one.
   // Runs once when edges load and whenever nodes change type.
   // Uses functional setEdges to avoid overwriting concurrent edge additions.
@@ -313,7 +310,6 @@ export function WorkflowCanvas() {
       return changed ? updated : currentEdges;
     });
   }, [nodes, setEdges]);
-  // end keeperhub code //
 
   const isValidConnection = useCallback(
     (connection: XYFlowConnection | XYFlowEdge) => {
@@ -327,7 +323,6 @@ export function WorkflowCanvas() {
         return false;
       }
 
-      // start custom keeperhub code //
       const sourceHandle = "sourceHandle" in connection
         ? (connection.sourceHandle as string | undefined)
         : undefined;
@@ -350,7 +345,6 @@ export function WorkflowCanvas() {
       if (sourceHandle === "loop" && targetIsCollect) {
         return false;
       }
-      // end keeperhub code //
 
       return true;
     },
@@ -359,7 +353,6 @@ export function WorkflowCanvas() {
 
   const onConnect: OnConnect = useCallback(
     (connection: XYFlowConnection) => {
-      // start custom keeperhub code //
       // Auto-assign sourceHandle for For Each and Condition connections.
       // Uses functional updater to read current edges and avoid stale closures.
       setEdges((currentEdges) => {
@@ -391,7 +384,6 @@ export function WorkflowCanvas() {
             sourceHandle = hasTrueEdge ? "false" : "true";
           }
         }
-        // end keeperhub code //
 
         const newEdge = {
           id: nanoid(),
@@ -415,16 +407,12 @@ export function WorkflowCanvas() {
     [setSelectedNode]
   );
 
-  // start custom keeperhub code //
   const connectingHandleId = useRef<string | null>(null);
-  // end keeperhub code //
 
   const onConnectStart = useCallback(
     (_event: MouseEvent | TouchEvent, params: OnConnectStartParams) => {
       connectingNodeId.current = params.nodeId;
-      // start custom keeperhub code //
       connectingHandleId.current = params.handleId ?? null;
-      // end keeperhub code //
     },
     []
   );
@@ -538,7 +526,6 @@ export function WorkflowCanvas() {
           );
         }, 50);
 
-        // start custom keeperhub code //
         // Create connection from the source node to the new node.
         // Defer edge creation: addNode deselects the source node (new object
         // reference), which makes React Flow re-measure its handles via
@@ -566,7 +553,6 @@ export function WorkflowCanvas() {
           setHasUnsavedChanges(true);
           triggerAutosave({ immediate: true });
         });
-        // end keeperhub code //
 
         // Set flag to prevent immediate deselection
         justCreatedNodeFromConnection.current = true;
@@ -576,9 +562,7 @@ export function WorkflowCanvas() {
       }
 
       connectingNodeId.current = null;
-      // start custom keeperhub code //
       connectingHandleId.current = null;
-      // end keeperhub code //
     },
     [
       getClientPosition,
@@ -625,9 +609,7 @@ export function WorkflowCanvas() {
     <div
       className="relative h-full bg-background"
       data-testid="workflow-canvas"
-      // start custom keeperhub code //
       data-ready={isCanvasReady}
-      // end keeperhub code //
       style={{
         opacity: isCanvasReady ? 1 : 0,
         width: rightPanelWidth ? `calc(100% - ${rightPanelWidth})` : "100%",

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -17,7 +17,6 @@ import Image from "next/image";
 import type { JSX } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toChecksumAddress } from "@/keeperhub/lib/address-utils";
-// start custom keeperhub code //
 import {
   FOR_EACH_GROUP_TYPE,
   buildChildLogsLookup,
@@ -25,7 +24,6 @@ import {
   type ChildLogsLookup,
   type IterationGroup,
 } from "@/keeperhub/lib/iteration-grouping";
-// end keeperhub code //
 import { api } from "@/lib/api-client";
 import {
   OUTPUT_DISPLAY_CONFIGS,
@@ -54,10 +52,8 @@ type ExecutionLog = {
   input?: unknown;
   output?: unknown;
   error: string | null;
-  // start custom keeperhub code //
   iterationIndex: number | null;
   forEachNodeId: string | null;
-  // end keeperhub code //
 };
 
 type WorkflowExecution = {
@@ -587,7 +583,6 @@ function ExecutionProgress({ execution }: { execution: WorkflowExecution }) {
   );
 }
 
-// start custom keeperhub code //
 // Types and functions (ExecutionLog, IterationGroup, GroupedLogEntry,
 // buildIterationGroups, groupLogsByIteration) imported from
 // @/keeperhub/lib/iteration-grouping
@@ -788,9 +783,6 @@ function ForEachLogGroup({
     </div>
   );
 }
-
-// end keeperhub code //
-
 // Component for rendering individual execution log entries
 function ExecutionLogEntry({
   log,
@@ -907,9 +899,7 @@ export function WorkflowRuns({
     selectedExecutionIdAtom
   );
   const [, setExecutionLogs] = useAtom(executionLogsAtom);
-  // start custom keeperhub code //
   const runsRefreshTrigger = useAtomValue(runsRefreshTriggerAtom);
-  // end keeperhub code //
   const [executions, setExecutions] = useState<WorkflowExecution[]>([]);
   const [logs, setLogs] = useState<Record<string, ExecutionLog[]>>({});
   const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
@@ -919,10 +909,8 @@ export function WorkflowRuns({
   // Track which execution we've already auto-expanded to prevent loops
   const autoExpandedExecutionRef = useRef<string | null>(null);
 
-  // start custom keeperhub code //
   // Track terminal executions that have had their final log refresh
   const finalizedExecutionsRef = useRef<Set<string>>(new Set());
-  // end keeperhub code //
 
   const loadExecutions = useCallback(
     async (showLoading = true) => {
@@ -960,14 +948,12 @@ export function WorkflowRuns({
     loadExecutions();
   }, [loadExecutions]);
 
-  // start custom keeperhub code //
   // Immediate refresh when toolbar signals a new execution started
   useEffect(() => {
     if (runsRefreshTrigger > 0) {
       loadExecutions(false);
     }
   }, [runsRefreshTrigger, loadExecutions]);
-  // end keeperhub code //
 
   // Clear expanded runs when workflow changes to prevent stale state
   useEffect(() => {
@@ -991,10 +977,8 @@ export function WorkflowRuns({
         startedAt: Date;
         completedAt: Date | null;
         duration: string | null;
-        // start custom keeperhub code //
         iterationIndex?: number | null;
         forEachNodeId?: string | null;
-        // end keeperhub code //
       }>,
       _workflow?: {
         nodes: unknown;
@@ -1012,10 +996,8 @@ export function WorkflowRuns({
         input: log.input,
         output: log.output,
         error: log.error,
-        // start custom keeperhub code //
         iterationIndex: log.iterationIndex ?? null,
         forEachNodeId: log.forEachNodeId ?? null,
-        // end keeperhub code //
       })),
     []
   );
@@ -1114,7 +1096,6 @@ export function WorkflowRuns({
         const data = await api.workflow.getExecutions(currentWorkflowId);
         setExecutions(data as WorkflowExecution[]);
 
-        // start custom keeperhub code //
         // Refresh logs for expanded runs: always for running, once more for newly-terminal
         const terminalStatuses = new Set(["cancelled", "success", "error"]);
         const executionMap = new Map(data.map((e) => [e.id, e]));
@@ -1135,7 +1116,6 @@ export function WorkflowRuns({
             finalizedExecutionsRef.current.add(executionId);
           }
         }
-        // end keeperhub code //
       } catch (error) {
         console.error("Failed to poll executions:", error);
       }
@@ -1274,12 +1254,10 @@ export function WorkflowRuns({
 
               <button
                 className="min-w-0 flex-1 text-left transition-colors hover:opacity-80"
-                // start custom keeperhub code //
                 onClick={() => {
                   selectRun(execution.id);
                   toggleRun(execution.id);
                 }}
-                // end keeperhub code //
                 type="button"
               >
                 <div className="mb-1 flex items-center gap-2">
@@ -1340,7 +1318,6 @@ export function WorkflowRuns({
                   </div>
                 ) : (
                   <div className="p-4">
-                    {/* start custom keeperhub code */}
                     {(() => {
                       const lookup = buildChildLogsLookup(executionLogs);
                       const grouped = groupLogsByIteration(executionLogs, lookup);
@@ -1378,7 +1355,6 @@ export function WorkflowRuns({
                         }
                       );
                     })()}
-                    {/* end keeperhub code */}
                   </div>
                 )}
               </div>

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -19,9 +19,7 @@ import {
   Undo2,
 } from "lucide-react";
 import { nanoid } from "nanoid";
-// start custom KeeperHub code
 import { usePathname, useRouter } from "next/navigation";
-// end custom KeeperHub code
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
@@ -36,7 +34,6 @@ import {
 import { OrgSwitcher } from "@/keeperhub/components/organization/org-switcher";
 import { GoLiveOverlay } from "@/keeperhub/components/overlays/go-live-overlay";
 import { Switch } from "@/keeperhub/components/ui/switch";
-// start custom keeperhub code //
 import { BUILTIN_NODE_ID } from "@/keeperhub/lib/builtin-variables";
 import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 import { api, type Project, type Tag } from "@/lib/api-client";
@@ -98,9 +95,6 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip";
 import { UserMenu } from "../workflows/user-menu";
-
-// end keeperhub code //
-
 type WorkflowToolbarProps = {
   workflowId?: string;
   persistent?: boolean;
@@ -217,11 +211,9 @@ function getBrokenTemplateReferences(
     }
 
     const allRefs = extractAllTemplateReferences(config);
-    // start custom keeperhub code //
     const brokenRefs = allRefs.filter(
       (ref) => ref.nodeId !== BUILTIN_NODE_ID && !nodeIds.has(ref.nodeId)
     );
-    // end keeperhub code //
 
     if (brokenRefs.length > 0) {
       // Get action for label lookups
@@ -272,25 +264,21 @@ function isFieldEmpty(value: unknown): boolean {
 
 // Check if a conditional field should be shown based on current config
 function shouldShowField(
-  // start custom keeperhub code //
   field: {
     showWhen?:
       | { field: string; equals: string }
       | { field: string; oneOf: string[] };
   },
-  // end keeperhub code //
   config: Record<string, unknown>
 ): boolean {
   if (!field.showWhen) {
     return true;
   }
-  // start custom keeperhub code //
   const dependentValue = config[field.showWhen.field];
   if ("oneOf" in field.showWhen) {
     return field.showWhen.oneOf.includes(dependentValue as string);
   }
   return dependentValue === field.showWhen.equals;
-  // end keeperhub code //
 }
 
 // Get missing required fields for a single node
@@ -432,9 +420,7 @@ type ExecuteTestWorkflowParams = {
   setIsExecuting: (value: boolean) => void;
   setSelectedExecutionId: (value: string | null) => void;
   setCurrentExecutionId: (value: string | null) => void;
-  // start custom keeperhub code //
   onExecutionStarted?: () => void;
-  // end keeperhub code //
 };
 
 async function executeTestWorkflow({
@@ -445,9 +431,7 @@ async function executeTestWorkflow({
   setIsExecuting,
   setSelectedExecutionId,
   setCurrentExecutionId,
-  // start custom keeperhub code //
   onExecutionStarted,
-  // end keeperhub code //
 }: ExecuteTestWorkflowParams) {
   // Set all nodes to idle first
   updateNodesStatus(nodes, updateNodeData, "idle");
@@ -470,14 +454,12 @@ async function executeTestWorkflow({
     });
 
     if (!response.ok) {
-      // start custom keeperhub code //
       const body = await response.json().catch(() => null);
       const message =
         typeof body?.error === "string"
           ? body.error
           : "Failed to execute workflow";
       throw new Error(message);
-      // end keeperhub code //
     }
 
     const result = await response.json();
@@ -486,10 +468,8 @@ async function executeTestWorkflow({
     setSelectedExecutionId(result.executionId);
     setCurrentExecutionId(result.executionId);
 
-    // start custom keeperhub code //
     // Signal the Runs panel to refresh immediately
     onExecutionStarted?.();
-    // end keeperhub code //
 
     // Poll for execution status updates
     const pollInterval = setInterval(async () => {
@@ -532,12 +512,10 @@ async function executeTestWorkflow({
           setIsExecuting(false);
           setCurrentExecutionId(null);
 
-          // start custom keeperhub code //
           // Reset nodes to idle when cancelled (steps may show stale "success" from runtime)
           if (statusData.status === "cancelled") {
             updateNodesStatus(nodes, updateNodeData, "idle");
           }
-          // end keeperhub code //
         }
       } catch (error) {
         console.error("Failed to poll execution status:", error);
@@ -599,9 +577,7 @@ function useWorkflowHandlers({
 }: WorkflowHandlerParams) {
   const { open: openOverlay } = useOverlay();
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  // start custom keeperhub code //
   const setRunsRefreshTrigger = useSetAtom(runsRefreshTriggerAtom);
-  // end keeperhub code //
 
   // Cleanup polling interval on unmount
   useEffect(
@@ -653,9 +629,7 @@ function useWorkflowHandlers({
       setIsExecuting,
       setSelectedExecutionId,
       setCurrentExecutionId,
-      // start custom keeperhub code //
       onExecutionStarted: () => setRunsRefreshTrigger((c) => c + 1),
-      // end keeperhub code //
     });
     // Don't set executing to false here - let polling handle it
   };
@@ -819,17 +793,14 @@ function useWorkflowState() {
       tagId?: string | null;
     }>
   >([]);
-  // start custom keeperhub code //
   const [allProjects, setAllProjects] = useState<Project[]>([]);
   const [allTags, setAllTags] = useState<Tag[]>([]);
-  // end keeperhub code //
   const [isEnabled, setIsEnabled] = useAtom(isWorkflowEnabled);
 
   // Load all workflows and projects on mount
   useEffect(() => {
     const loadAllWorkflows = async () => {
       try {
-        // start custom keeperhub code //
         const [workflows, projects, tags] = await Promise.all([
           api.workflow.getAll(),
           api.project.getAll().catch(() => [] as Project[]),
@@ -838,7 +809,6 @@ function useWorkflowState() {
         setAllWorkflows(workflows);
         setAllProjects(projects);
         setAllTags(tags);
-        // end keeperhub code //
       } catch (error) {
         console.error("Failed to load workflows:", error);
       }
@@ -1053,7 +1023,6 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
 
   const loadWorkflows = async () => {
     try {
-      // start custom keeperhub code //
       const [workflows, projects, tags] = await Promise.all([
         api.workflow.getAll(),
         api.project.getAll().catch(() => [] as Project[]),
@@ -1062,7 +1031,6 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       setAllWorkflows(workflows);
       setAllProjects(projects);
       setAllTags(tags);
-      // end keeperhub code //
     } catch (error) {
       console.error("Failed to load workflows:", error);
     }
@@ -1073,7 +1041,6 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       return;
     }
 
-    // start custom keeperhub code //
     // Show Go Live overlay when making public
     if (newVisibility === "public") {
       openOverlay(GoLiveOverlay, {
@@ -1091,7 +1058,6 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       });
       return;
     }
-    // end keeperhub code //
 
     // Switch to private immediately (no risks)
     try {
@@ -1107,7 +1073,6 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
     }
   };
 
-  // start custom keeperhub code //
   const handleEditPublicSettings = (): void => {
     if (!currentWorkflowId) {
       return;
@@ -1127,9 +1092,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       },
     });
   };
-  // end keeperhub code //
 
-  // start custom keeperhub code //
   const updateWorkflowEnabled = async (enabled: boolean) => {
     if (!currentWorkflowId) {
       return;
@@ -1171,7 +1134,6 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       await updateWorkflowEnabled(true);
     }
   };
-  // end keeperhub code //
 
   const handleDuplicate = async () => {
     if (!currentWorkflowId) {
@@ -1386,7 +1348,6 @@ function ToolbarActions({
       {/* Visibility Toggle */}
       <VisibilityButton actions={actions} state={state} />
 
-      {/* start custom keeperhub code // */}
       {shouldDisplayEnableWorkflowSwitch && (
         <>
           {/* Enable Workflow Switch - Desktop Horizontal */}
@@ -1405,7 +1366,6 @@ function ToolbarActions({
           </div>
         </>
       )}
-      {/* end keeperhub code // */}
 
       <RunButtonGroup actions={actions} state={state} />
     </>
@@ -1420,14 +1380,12 @@ function SaveButton({
   state: ReturnType<typeof useWorkflowState>;
   handleSave: () => Promise<void>;
 }) {
-  // start custom keeperhub code //
   const isAnonymous = isAnonymousUser(state.session?.user);
   const disabled =
     isAnonymous ||
     !state.currentWorkflowId ||
     state.isGenerating ||
     state.isSaving;
-  // end keeperhub code //
 
   const button = (
     <Button
@@ -1451,7 +1409,6 @@ function SaveButton({
     </Button>
   );
 
-  // start custom keeperhub code //
   if (isAnonymous) {
     return (
       <Tooltip>
@@ -1462,7 +1419,6 @@ function SaveButton({
       </Tooltip>
     );
   }
-  // end keeperhub code //
 
   return button;
 }
@@ -1577,7 +1533,6 @@ function RunButtonGroup({
   state: ReturnType<typeof useWorkflowState>;
   actions: ReturnType<typeof useWorkflowActions>;
 }) {
-  // start custom keeperhub code //
   const triggerType = state.nodes.find((node) => node.data.type === "trigger")
     ?.data.config?.triggerType;
 
@@ -1590,7 +1545,6 @@ function RunButtonGroup({
     state.nodes.length === 0 ||
     state.isGenerating ||
     isNonManualTrigger;
-  // end keeperhub code //
 
   // Show Stop button while executing
   if (state.isExecuting) {
@@ -1620,7 +1574,6 @@ function RunButtonGroup({
     </Button>
   );
 
-  // start custom keeperhub code //
   if (isNonManualTrigger) {
     return (
       <TooltipProvider>
@@ -1638,7 +1591,6 @@ function RunButtonGroup({
   }
 
   return button;
-  // end keeperhub code //
 }
 
 // Read-only badge - pill with a live green accent on the toolbar
@@ -1692,10 +1644,8 @@ function WorkflowMenuComponent({
   state: ReturnType<typeof useWorkflowState>;
   actions: ReturnType<typeof useWorkflowActions>;
 }) {
-  // start custom KeeperHub code
   const pathname = usePathname();
   const isWorkflowRoute = pathname.startsWith("/workflows/");
-  // end custom KeeperHub code
 
   return (
     <div className="flex flex-col gap-1">
@@ -1777,11 +1727,9 @@ export const WorkflowToolbar = ({
                   onDuplicate={actions.handleDuplicate}
                 />
               )}
-              {/* start custom keeperhub code // */}
               <div className="hidden lg:block">
                 <OrgSwitcher />
               </div>
-              {/* end keeperhub code // */}
               <UserMenu />
             </div>
           </div>
@@ -1833,11 +1781,9 @@ export const WorkflowToolbar = ({
                 onDuplicate={actions.handleDuplicate}
               />
             )}
-            {/* start custom keeperhub code // */}
             <div className="hidden lg:block">
               <OrgSwitcher />
             </div>
-            {/* end keeperhub code // */}
             <UserMenu />
           </div>
         </div>

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -31,7 +31,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-// start custom keeperhub code //
 import { ManageOrgsModal } from "@/keeperhub/components/organization/manage-orgs-modal";
 import { AddressBookOverlay } from "@/keeperhub/components/overlays/address-book-overlay";
 import { FeedbackOverlay } from "@/keeperhub/components/overlays/feedback-overlay";
@@ -39,16 +38,13 @@ import { ProjectsOverlay } from "@/keeperhub/components/overlays/projects-overla
 import { TagsOverlay } from "@/keeperhub/components/overlays/tags-overlay";
 import { WalletOverlay } from "@/keeperhub/components/overlays/wallet-overlay";
 import { useOrganization } from "@/keeperhub/lib/hooks/use-organization";
-// end keeperhub code //
 import { signOut, useSession } from "@/lib/auth-client";
 
 export const UserMenu = () => {
   const { data: session, isPending } = useSession();
   const { open: openOverlay } = useOverlay();
   const [orgModalOpen, setOrgModalOpen] = useState(false);
-  // start custom keeperhub code //
   const { organization } = useOrganization();
-  // end keeperhub code //
 
   const handleLogout = async () => {
     await signOut();
@@ -139,7 +135,6 @@ export const UserMenu = () => {
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {/* start custom keeperhub code */}
           <div className="lg:hidden">
             <DropdownMenuItem onClick={() => setOrgModalOpen(true)}>
               <Users className="size-4" />
@@ -153,7 +148,6 @@ export const UserMenu = () => {
             <Github className="size-4" />
             <span>Report an issue</span>
           </DropdownMenuItem>
-          {/* end keeperhub code */}
           <DropdownMenuItem onClick={() => openOverlay(SettingsOverlay)}>
             <Settings className="size-4" />
             <span>Settings</span>
@@ -162,7 +156,6 @@ export const UserMenu = () => {
             <Plug className="size-4" />
             <span>Connections</span>
           </DropdownMenuItem>
-          {/* start custom keeperhub code */}
           <DropdownMenuItem onClick={() => openOverlay(ApiKeysOverlay)}>
             <Key className="size-4" />
             <span>API Keys</span>
@@ -175,8 +168,6 @@ export const UserMenu = () => {
             <Bookmark className="size-4" />
             <span>Address Book</span>
           </DropdownMenuItem>
-          {/* end keeperhub code */}
-          {/* start custom keeperhub code */}
           <DropdownMenuItem onClick={() => openOverlay(ProjectsOverlay)}>
             <FolderOpen className="size-4" />
             <span>Projects</span>
@@ -185,7 +176,6 @@ export const UserMenu = () => {
             <Tag className="size-4" />
             <span>Tags</span>
           </DropdownMenuItem>
-          {/* end keeperhub code */}
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleLogout}>
             <LogOut className="size-4" />

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,8 +1,6 @@
 import { pgTable, foreignKey, unique, text, timestamp, jsonb, boolean, index, uniqueIndex, integer, serial, primaryKey } from "drizzle-orm/pg-core"
 import { sql } from "drizzle-orm"
 
-
-
 export const sessions = pgTable("sessions", {
 	id: text().primaryKey().notNull(),
 	expiresAt: timestamp("expires_at", { mode: 'string' }).notNull(),

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -4,7 +4,6 @@
  * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
  */
 
-// start custom keeperhub code //
 /**
  * Ensure special characters in postgres URL passwords are percent-encoded.
  * postgres.js parses connection strings via new URL() which requires encoding.
@@ -37,7 +36,6 @@ function encodePostgresPassword(url: string): string {
     return url;
   }
 }
-// end keeperhub code //
 
 export async function register() {
   // Patch console with LOG_LEVEL support
@@ -67,7 +65,6 @@ export async function register() {
       console.log("[Metrics] Prometheus dual-write collector initialized");
     }
 
-    // start custom keeperhub code //
     // Initialize Workflow Postgres World (pg-boss queue polling)
     if (process.env.WORKFLOW_TARGET_WORLD === "@workflow/world-postgres") {
       const rawUrl =
@@ -88,7 +85,6 @@ export async function register() {
         console.log("[Workflow] Postgres World initialized");
       }
     }
-    // end keeperhub code //
 
     // Catch unhandled promise rejections (would otherwise be silent)
     process.on("unhandledRejection", (reason) => {

--- a/keeperhub/api/internal/block-workflows/route.ts
+++ b/keeperhub/api/internal/block-workflows/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { and, eq, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -78,4 +77,3 @@ export async function GET(request: Request): Promise<NextResponse> {
     );
   }
 }
-// end keeperhub code //

--- a/keeperhub/api/internal/reaper/route.ts
+++ b/keeperhub/api/internal/reaper/route.ts
@@ -1,4 +1,3 @@
-// start custom keeperhub code //
 import { and, eq, gt, lt, notInArray, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -88,4 +87,3 @@ export async function GET(request: Request): Promise<NextResponse> {
     );
   }
 }
-// end keeperhub code //

--- a/keeperhub/api/mcp/schemas/route.ts
+++ b/keeperhub/api/mcp/schemas/route.ts
@@ -499,7 +499,6 @@ export async function GET(request: Request) {
     // Template syntax documentation
     templateSyntax: TEMPLATE_SYNTAX,
 
-    // start custom keeperhub code //
     // Built-in system variables (evaluated at runtime)
     builtinVariables: {
       description: `Built-in variables evaluated at runtime. Reference using {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.fieldName}} syntax.`,
@@ -525,7 +524,6 @@ export async function GET(request: Request) {
         },
       },
     },
-    // end keeperhub code //
 
     // Workflow structure hints for AI
     workflowStructure: {

--- a/keeperhub/components/settings/web3-wallet-section.tsx
+++ b/keeperhub/components/settings/web3-wallet-section.tsx
@@ -71,22 +71,18 @@ export function Web3WalletSection({
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Sequential wallet creation with error handling
   async function handleCreateWallet() {
-    // start keeperhub - validate email before creating
     if (!userEmail) {
       toast.error("Unable to get your email. Please refresh and try again.");
       return;
     }
-    // end keeperhub
 
     setCreating(true);
     try {
-      // start keeperhub - send email in request body
       const response = await fetch("/api/user/wallet", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: userEmail }),
       });
-      // end keeperhub
 
       const data = await response.json();
 

--- a/keeperhub/components/workflow/config/abi-event-select-field.tsx
+++ b/keeperhub/components/workflow/config/abi-event-select-field.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-// start custom keeperhub code //
 import React from "react";
 import {
   Select,
@@ -89,4 +88,3 @@ export function AbiEventSelectField({
     </Select>
   );
 }
-// end keeperhub code //

--- a/keeperhub/lib/metrics/collectors/prometheus.ts
+++ b/keeperhub/lib/metrics/collectors/prometheus.ts
@@ -88,7 +88,6 @@ function getOrCreateGauge(
   return new Gauge({ name, help, labelNames, registers: [registry] });
 }
 
-// start custom keeperhub code //
 // DB-sourced workflow metrics → dbRegistry (identical across pods, scrape one)
 // Workflow runner jobs exit before Prometheus can scrape - data must come from DB.
 //
@@ -382,7 +381,6 @@ const sessionActive = getOrCreateGauge(
   "Active (non-expired) sessions",
   []
 );
-// end keeperhub code //
 
 // API-process metrics → apiRegistry (per-pod in-memory, scrape all pods)
 const webhookLatency = getOrCreateHistogram(
@@ -709,7 +707,6 @@ export const prometheusMetricsCollector: MetricsCollector = {
   },
 };
 
-// start custom keeperhub code //
 // Duration histogram bucket boundaries in milliseconds
 const WORKFLOW_DURATION_BUCKETS = [
   100, 250, 500, 1000, 2000, 5000, 10_000, 30_000,
@@ -919,7 +916,6 @@ export async function updateDbMetrics(): Promise<void> {
     // Don't throw - allow other metrics to still be returned
   }
 }
-// end keeperhub code //
 
 /**
  * Get all metrics in Prometheus format (backward compat: /api/metrics)

--- a/keeperhub/lib/metrics/db-metrics.ts
+++ b/keeperhub/lib/metrics/db-metrics.ts
@@ -305,7 +305,6 @@ export async function getDailyActiveUsersFromDb(): Promise<number> {
   }
 }
 
-// start custom keeperhub code //
 export type UserStats = {
   total: number;
   verified: number;
@@ -695,4 +694,3 @@ export async function getInfraStatsFromDb(): Promise<InfraStats> {
     };
   }
 }
-// end keeperhub code //

--- a/keeperhub/lib/metrics/prometheus-api.ts
+++ b/keeperhub/lib/metrics/prometheus-api.ts
@@ -9,14 +9,10 @@
 import "server-only";
 
 export {
-  // start custom keeperhub code //
   getApiProcessMetrics,
   getDbMetrics,
-  // end keeperhub code //
   getPrometheusContentType,
   getPrometheusMetrics,
   prometheusMetricsCollector,
-  // start custom keeperhub code //
   updateDbMetrics,
-  // end keeperhub code //
 } from "./collectors/prometheus";

--- a/keeperhub/plugins/discord/index.ts
+++ b/keeperhub/plugins/discord/index.ts
@@ -10,7 +10,6 @@ const discordPlugin: IntegrationPlugin = {
   icon: DiscordIcon,
 
   // Webhook URL is stored in the integration for centralized management
-  // start keeperhub - type is 'password' so it shows "Configured" state when editing (upstream: 'url')
   formFields: [
     {
       id: "webhookUrl",
@@ -27,7 +26,6 @@ const discordPlugin: IntegrationPlugin = {
       },
     },
   ],
-  // end keeperhub
 
   testConfig: {
     getTestFunction: async () => {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -17,13 +17,10 @@ export type WorkflowData = {
   edges: WorkflowEdge[];
   visibility?: WorkflowVisibility;
   enabled?: boolean;
-  // start custom keeperhub code //
   projectId?: string | null;
   tagId?: string | null;
-  // end keeperhub code //
 };
 
-// start custom keeperhub code //
 export type PublicTag = {
   id: string;
   name: string;
@@ -31,7 +28,6 @@ export type PublicTag = {
   workflowCount?: number;
   createdAt?: string;
 };
-// end keeperhub code //
 
 export type SavedWorkflow = WorkflowData & {
   id: string;
@@ -41,7 +37,6 @@ export type SavedWorkflow = WorkflowData & {
   createdAt: string;
   updatedAt: string;
   isOwner?: boolean;
-  // start custom KeeperHub code
   featured?: boolean;
   projectId?: string | null;
   tagId?: string | null;
@@ -49,7 +44,6 @@ export type SavedWorkflow = WorkflowData & {
   featuredProtocol?: string | null;
   featuredProtocolOrder?: number;
   publicTags?: PublicTag[];
-  // end custom KeeperHub code
 };
 
 // API error class
@@ -421,7 +415,6 @@ export const integrationApi = {
       method: "DELETE",
     }),
 
-  // start custom keeperhub code //
   // Test existing integration connection, optionally with config overrides
   // that are merged server-side with stored secrets before testing
   testConnection: (
@@ -437,7 +430,6 @@ export const integrationApi = {
           : {}),
       }
     ),
-  // end keeperhub code //
 
   // Test credentials without saving
   testCredentials: (data: {
@@ -524,7 +516,6 @@ export const userApi = {
 export const workflowApi = {
   // Get all workflows
   getAll: () => apiCall<SavedWorkflow[]>("/api/workflows"),
-  // start custom KeeperHub code
   // Get public workflows (non-featured)
   getPublic: () => apiCall<SavedWorkflow[]>("/api/workflows/public"),
   // Get featured workflows
@@ -535,7 +526,6 @@ export const workflowApi = {
     apiCall<SavedWorkflow[]>(
       `/api/workflows/public?featuredProtocol=${encodeURIComponent(slug)}`
     ),
-  // end custom KeeperHub code
 
   // Get a specific workflow
   getById: (id: string) => apiCall<SavedWorkflow>(`/api/workflows/${id}`),
@@ -566,7 +556,6 @@ export const workflowApi = {
       method: "POST",
     }),
 
-  // start custom keeperhub code //
   claim: (id: string) =>
     apiCall<SavedWorkflow>(`/api/workflows/${id}/claim`, {
       method: "POST",
@@ -578,7 +567,6 @@ export const workflowApi = {
       method: "PUT",
       body: JSON.stringify(data),
     }),
-  // end keeperhub code //
 
   // Get current workflow state
   getCurrent: () => apiCall<WorkflowData>("/api/workflows/current"),
@@ -687,10 +675,8 @@ export const workflowApi = {
         startedAt: Date;
         completedAt: Date | null;
         duration: string | null;
-        // start custom keeperhub code //
         iterationIndex: number | null;
         forEachNodeId: string | null;
-        // end keeperhub code //
       }>;
     }>(`/api/workflows/executions/${executionId}/logs`),
 
@@ -785,7 +771,6 @@ export const aiGatewayApi = {
     }),
 };
 
-// start custom keeperhub code //
 export type Tag = {
   id: string;
   name: string;
@@ -862,20 +847,15 @@ export const projectApi = {
       method: "DELETE",
     }),
 };
-
-// end keeperhub code //
-
 // Export all APIs as a single object
 export const api = {
   ai: aiApi,
   aiGateway: aiGatewayApi,
   integration: integrationApi,
   organization: organizationApi,
-  // start custom keeperhub code //
   project: projectApi,
   publicTag: publicTagApi,
   tag: tagApi,
-  // end keeperhub code //
   user: userApi,
   workflow: workflowApi,
 };

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -6,7 +6,6 @@ import {
 import { createAccessControl } from "better-auth/plugins/access";
 import { createAuthClient } from "better-auth/react";
 
-// start custom keeperhub code //
 // Import the same access control definition (shared type safety)
 const statement = {
   workflow: ["create", "read", "update", "delete"],
@@ -44,7 +43,6 @@ const ownerRole = ac.newRole({
   member: ["create", "update", "delete"],
   invitation: ["create", "cancel"],
 });
-// end keeperhub code //
 
 export const authClient = createAuthClient({
   baseURL:
@@ -54,7 +52,6 @@ export const authClient = createAuthClient({
   plugins: [
     anonymousClient(),
     emailOTPClient(),
-    // start custom keeperhub code //
     organizationClient({
       ac,
       roles: {
@@ -63,7 +60,6 @@ export const authClient = createAuthClient({
         member: memberRole,
       },
     }),
-    // end keeperhub code //
   ],
 });
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -25,7 +25,6 @@ import {
   member as memberTable,
   organizationRelations,
   organizationSubscriptions,
-  // start custom keeperhub code //
   organization as organizationTable,
   sessions,
   users,
@@ -34,10 +33,8 @@ import {
   workflowExecutions,
   workflowExecutionsRelations,
   workflows,
-  // end keeperhub code //
 } from "./db/schema";
 
-// start custom keeperhub code //
 // Define custom access control for organization resources
 const statement = {
   workflow: ["create", "read", "update", "delete"],
@@ -76,7 +73,6 @@ const ownerRole = ac.newRole({
   member: ["create", "update", "delete"],
   invitation: ["create", "cancel"],
 });
-// end keeperhub code //
 
 // Construct schema object for drizzle adapter
 const schema = {
@@ -88,14 +84,12 @@ const schema = {
   workflowExecutions,
   workflowExecutionLogs,
   workflowExecutionsRelations,
-  // start custom keeperhub code //
   organization: organizationTable,
   member: memberTable,
   invitation: invitationTable,
   organizationRelations,
   memberRelations,
   invitationRelations,
-  // end keeperhub code //
 };
 
 // Determine the base URL for authentication
@@ -185,7 +179,6 @@ const plugins = [
       //   throw error;
       // }
 
-      // start custom keeperhub code //
       // When anonymous user links account, transfer ownership to the new user.
       // Workflows stay as isAnonymous=true with no org - the client-side claim
       // dialog will offer to move them into the user's organization.
@@ -211,10 +204,8 @@ const plugins = [
         console.error("[Anonymous Migration] Error:", error);
         throw error;
       }
-      // end keeperhub code //
     },
   }),
-  // start custom keeperhub code //
   organization({
     // Access control with custom roles
     ac,
@@ -280,7 +271,6 @@ const plugins = [
       },
     },
   }),
-  // end keeperhub code //
   ...(process.env.VERCEL_CLIENT_ID
     ? [
         genericOAuth({
@@ -334,7 +324,6 @@ export const auth = betterAuth({
     level: "debug",
     disabled: false,
   },
-  // start custom keeperhub code //
   databaseHooks: {
     user: {
       create: {
@@ -410,7 +399,6 @@ export const auth = betterAuth({
       },
     },
   },
-  // end keeperhub code //
   onAPIError: {
     onError: (error, ctx) => {
       console.error("[Better Auth API Error]", {
@@ -442,7 +430,6 @@ export const auth = betterAuth({
       enabled: !!process.env.GOOGLE_CLIENT_ID,
     },
   },
-  // start custom keeperhub code //
   rateLimit: {
     enabled: !(process.env.CI || process.env.NODE_ENV === "test"),
     customRules: {
@@ -459,7 +446,6 @@ export const auth = betterAuth({
       },
     },
   },
-  // end keeperhub code //
   advanced: {
     // Use secure cookies in production (HTTPS only)
     useSecureCookies: process.env.NODE_ENV === "production",

--- a/lib/condition-validator.ts
+++ b/lib/condition-validator.ts
@@ -99,7 +99,6 @@ const OPERATOR_TOKEN_PATTERN =
   /^(===|!==|==|!=|>=|<=|>|<|&&|\|\||\*\*|!|\(|\))$/;
 const IDENTIFIER_TOKEN_PATTERN = /^[a-zA-Z_]\w*$/;
 
-// start custom keeperhub code
 // Regex patterns for UI validation
 const EXTRA_SPACES_PATTERN = /\s{2,}/;
 const WHITESPACE_CHAR_PATTERN = /\s/;
@@ -114,7 +113,6 @@ const OPERATOR_AFTER_PATTERN =
 const OPERATOR_PATTERN = /(===|!==|==|!=|>=|<=|>|<|&&|\|\||\*\*|\+|-|\*|\/|%)/g;
 const OPERATOR_CHAR_PATTERN = /[=!<>&|+\-*/%]/;
 const WHITESPACE_TEST_PATTERN = /\s/;
-// end keeperhub code
 
 export type ValidationResult =
   | { valid: true }
@@ -360,11 +358,9 @@ export function preValidateConditionExpression(
     "prototype",
   ];
 
-  // start custom keeperhub code //
   // Strip template variables before keyword check — node IDs like @process
   // are safe and should not trigger false positives
   const expressionWithoutTemplates = expression.replace(/\{\{@[^}]+\}\}/g, "");
-  // end keeperhub code //
 
   const lowerExpression = expressionWithoutTemplates.toLowerCase();
   for (const keyword of dangerousKeywords) {
@@ -391,7 +387,6 @@ export function sanitizeForDisplay(expression: string): string {
     .replace(/'/g, "&#39;");
 }
 
-// start custom keeperhub code
 type Token = { type: string; value: string; start: number };
 
 const VALID_OPERATORS_UI = new Set([
@@ -994,4 +989,3 @@ export function validateConditionExpressionUI(
   // Validate operators
   return validateOperators(tokens);
 }
-// end keeperhub code

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -51,7 +51,6 @@ export function ensureEncodedConnectionString(
   return `${protocol}${encodeURIComponent(username)}:${encodeURIComponent(password)}@${hostAndDb}`;
 }
 
-// start custom keeperhub code //
 interface PgQueryError extends Error {
   severity: string;
   code?: string;
@@ -92,7 +91,6 @@ function formatPgQueryError(error: PgQueryError): string {
   }
   return message;
 }
-// end keeperhub code //
 
 /**
  * Returns a safe, user-facing message for database errors.
@@ -108,7 +106,6 @@ export function getDatabaseErrorMessage(error: unknown): string {
     return "Unknown database error";
   }
 
-  // start custom keeperhub code //
   // PostgreSQL query errors (syntax errors, constraint violations, etc.)
   // are safe to show -- they describe the SQL problem, not credentials.
   // Drizzle ORM wraps PostgresError in error.cause, so check both levels.
@@ -119,7 +116,6 @@ export function getDatabaseErrorMessage(error: unknown): string {
   if (cause instanceof Error && isPgQueryError(cause)) {
     return formatPgQueryError(cause);
   }
-  // end keeperhub code //
 
   // Connection-level errors -- sanitize to avoid leaking credentials
   const errorMessage = error.message;

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -4,7 +4,6 @@ import postgres from "postgres";
 import { getDatabaseUrl } from "./connection-utils";
 import {
   accounts,
-  // start custom keeperhub code //
   addressBookEntry,
   addressBookEntryRelations,
   apiKeys,
@@ -19,7 +18,6 @@ import {
   overageBillingRecords,
   pendingTransactions,
   publicTags,
-  // end keeperhub code //
   sessions,
   tags,
   tagsRelations,
@@ -50,7 +48,6 @@ const schema = {
   workflowSchedules,
   workflowSchedulesRelations,
   apiKeys,
-  // start custom keeperhub code //
   executionDebt,
   organizationApiKeys,
   organizationSubscriptions,
@@ -63,7 +60,6 @@ const schema = {
   addressBookEntryRelations,
   tags,
   tagsRelations,
-  // end keeperhub code //
   integrations,
   chains,
   chainsRelations,

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -99,7 +99,6 @@ function decryptConfig(encryptedConfig: string): Record<string, unknown> {
   }
 }
 
-// start custom keeperhub code //
 const DB_SECRET_KEYS = new Set(["password", "url"]);
 
 /**
@@ -143,7 +142,6 @@ export function mergeDatabaseConfig(
   }
   return merged;
 }
-// end keeperhub code //
 
 export type DecryptedIntegration = {
   id: string;
@@ -158,22 +156,16 @@ export type DecryptedIntegration = {
 
 /**
  * Get all integrations for a user, optionally filtered by type
- * // start custom keeperhub code //
  * Updated to support organization context
- * // end keeperhub code //
  */
 export async function getIntegrations(
   userId: string,
   type?: IntegrationType,
-  // start custom keeperhub code //
   organizationId?: string | null
-  // end keeperhub code //
 ): Promise<DecryptedIntegration[]> {
-  // start custom keeperhub code //
   const conditions = organizationId
     ? [eq(integrations.organizationId, organizationId)]
     : [eq(integrations.userId, userId)];
-  // end keeperhub code //
 
   if (type) {
     conditions.push(eq(integrations.type, type));
@@ -192,25 +184,19 @@ export async function getIntegrations(
 
 /**
  * Get a single integration by ID
- * // start custom keeperhub code //
  * Updated to support organization context
- * // end keeperhub code //
  */
 export async function getIntegration(
   integrationId: string,
   userId: string,
-  // start custom keeperhub code //
   organizationId?: string | null
-  // end keeperhub code //
 ): Promise<DecryptedIntegration | null> {
-  // start custom keeperhub code //
   const conditions = organizationId
     ? [
         eq(integrations.id, integrationId),
         eq(integrations.organizationId, organizationId),
       ]
     : [eq(integrations.id, integrationId), eq(integrations.userId, userId)];
-  // end keeperhub code //
 
   const result = await db
     .select()
@@ -252,18 +238,14 @@ export async function getIntegrationById(
 
 /**
  * Create a new integration
- * // start custom keeperhub code //
  * Updated to support organization context
- * // end keeperhub code //
  */
 type CreateIntegrationOptions = {
   userId: string;
   name: string;
   type: IntegrationType;
   config: IntegrationConfig;
-  // start custom keeperhub code //
   organizationId?: string | null;
-  // end keeperhub code //
 };
 
 export async function createIntegration(
@@ -279,9 +261,7 @@ export async function createIntegration(
       name,
       type,
       config: encryptedConfig,
-      // start custom keeperhub code //
       organizationId,
-      // end keeperhub code //
     })
     .returning();
 
@@ -293,9 +273,7 @@ export async function createIntegration(
 
 /**
  * Update an integration
- * // start custom keeperhub code //
  * Updated to support organization context
- * // end keeperhub code //
  */
 export async function updateIntegration(
   integrationId: string,
@@ -304,10 +282,8 @@ export async function updateIntegration(
     name?: string;
     config?: IntegrationConfig;
   },
-  // start custom keeperhub code //
   organizationId?: string | null,
   existingIntegration?: DecryptedIntegration | null
-  // end keeperhub code //
 ): Promise<DecryptedIntegration | null> {
   const updateData: Partial<NewIntegration> = {
     updatedAt: new Date(),
@@ -317,7 +293,6 @@ export async function updateIntegration(
     updateData.name = updates.name;
   }
 
-  // start custom keeperhub code //
   if (updates.config !== undefined) {
     if (existingIntegration?.type === "database") {
       updateData.config = encryptConfig(
@@ -327,16 +302,13 @@ export async function updateIntegration(
       updateData.config = encryptConfig(updates.config);
     }
   }
-  // end keeperhub code //
 
-  // start custom keeperhub code //
   const conditions = organizationId
     ? [
         eq(integrations.id, integrationId),
         eq(integrations.organizationId, organizationId),
       ]
     : [eq(integrations.id, integrationId), eq(integrations.userId, userId)];
-  // end keeperhub code //
 
   const [result] = await db
     .update(integrations)
@@ -356,25 +328,19 @@ export async function updateIntegration(
 
 /**
  * Delete an integration
- * // start custom keeperhub code //
  * Updated to support organization context
- * // end keeperhub code //
  */
 export async function deleteIntegration(
   integrationId: string,
   userId: string,
-  // start custom keeperhub code //
   organizationId?: string | null
-  // end keeperhub code //
 ): Promise<boolean> {
-  // start custom keeperhub code //
   const conditions = organizationId
     ? [
         eq(integrations.id, integrationId),
         eq(integrations.organizationId, organizationId),
       ]
     : [eq(integrations.id, integrationId), eq(integrations.userId, userId)];
-  // end keeperhub code //
 
   const result = await db
     .delete(integrations)
@@ -452,18 +418,14 @@ export function extractIntegrationIds(
  * foreign integration IDs in their workflows, while allowing workflows
  * with references to deleted integrations to still be saved.
  *
- * // start custom keeperhub code //
  * Updated to support organization context
- * // end keeperhub code //
  *
  * @returns Object with `valid` boolean and optional `invalidIds` array
  */
 export async function validateWorkflowIntegrations(
   nodes: WorkflowNodeForValidation[],
   userId: string,
-  // start custom keeperhub code //
   organizationId?: string | null
-  // end keeperhub code //
 ): Promise<{ valid: boolean; invalidIds?: string[] }> {
   const integrationIds = extractIntegrationIds(nodes);
 
@@ -471,7 +433,6 @@ export async function validateWorkflowIntegrations(
     return { valid: true };
   }
 
-  // start custom keeperhub code //
   // Query for ALL integrations with these IDs (regardless of user/org)
   // to check if any belong to other users/orgs
   const existingIntegrations = await db
@@ -495,7 +456,6 @@ export async function validateWorkflowIntegrations(
       return i.userId !== userId;
     })
     .map((i) => i.id);
-  // end keeperhub code //
 
   if (invalidIds.length > 0) {
     return { valid: false, invalidIds };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -14,7 +14,6 @@ import {
 import type { IntegrationType } from "../types/integration";
 import { generateId } from "../utils/id";
 
-// start custom keeperhub code //
 // These enums are created by @workflow/world-postgres migrations in the public
 // schema and referenced by workflow.workflow_runs / workflow.workflow_steps.
 // Declaring them here prevents drizzle-kit from trying to drop them.
@@ -32,7 +31,6 @@ export const workflowStepStatus = pgEnum("step_status", [
   "failed",
   "cancelled",
 ]);
-// end keeperhub code //
 
 // Better Auth tables
 export const users = pgTable("users", {
@@ -45,9 +43,7 @@ export const users = pgTable("users", {
   updatedAt: timestamp("updated_at").notNull(),
   // Anonymous user tracking
   isAnonymous: boolean("is_anonymous").default(false),
-  // start custom keeperhub code //
   deactivatedAt: timestamp("deactivated_at"),
-  // end keeperhub code //
 });
 
 export const sessions = pgTable("sessions", {
@@ -61,9 +57,7 @@ export const sessions = pgTable("sessions", {
   userId: text("user_id")
     .notNull()
     .references(() => users.id),
-  // start custom keeperhub code //
   activeOrganizationId: text("active_organization_id"),
-  // end keeperhub code //
 });
 
 export const accounts = pgTable("accounts", {
@@ -93,7 +87,6 @@ export const verifications = pgTable("verifications", {
   updatedAt: timestamp("updated_at"),
 });
 
-// start custom keeperhub code //
 // Organization tables
 export const organization = pgTable("organization", {
   id: text("id").primaryKey(),
@@ -191,9 +184,6 @@ export const tags = pgTable(
   },
   (table) => [index("idx_tags_org").on(table.organizationId)]
 );
-
-// end keeperhub code //
-
 // Workflow visibility type
 export type WorkflowVisibility = "private" | "public";
 
@@ -207,7 +197,6 @@ export const workflows = pgTable("workflows", {
   userId: text("user_id")
     .notNull()
     .references(() => users.id),
-  // start custom keeperhub code //
   organizationId: text("organization_id").references(() => organization.id, {
     onDelete: "cascade",
   }),
@@ -222,7 +211,6 @@ export const workflows = pgTable("workflows", {
   tagId: text("tag_id").references(() => tags.id, {
     onDelete: "set null",
   }),
-  // end keeperhub code //
   // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
   nodes: jsonb("nodes").notNull().$type<any[]>(),
   // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
@@ -244,11 +232,9 @@ export const integrations = pgTable("integrations", {
   userId: text("user_id")
     .notNull()
     .references(() => users.id),
-  // start custom keeperhub code //
   organizationId: text("organization_id").references(() => organization.id, {
     onDelete: "cascade",
   }),
-  // end keeperhub code //
   name: text("name").notNull(),
   type: text("type").notNull().$type<IntegrationType>(),
   // biome-ignore lint/suspicious/noExplicitAny: JSONB type - encrypted credentials stored as JSON
@@ -291,9 +277,7 @@ export const workflowExecutions = pgTable(
     lastSuccessfulNodeId: text("last_successful_node_id"),
     lastSuccessfulNodeName: text("last_successful_node_name"),
     executionTrace: jsonb("execution_trace").$type<string[]>(),
-    // start custom keeperhub code //
     runId: text("run_id"),
-    // end keeperhub code //
   },
   (table) => [index("idx_workflow_executions_status").on(table.status)]
 );
@@ -321,10 +305,8 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
   completedAt: timestamp("completed_at"),
   duration: numeric("duration"), // Duration in milliseconds
   timestamp: timestamp("timestamp").notNull().defaultNow(),
-  // start custom keeperhub code //
   iterationIndex: integer("iteration_index"), // 0-based loop iteration (null for non-loop nodes)
   forEachNodeId: text("for_each_node_id"), // parent For Each node ID (null for non-loop nodes)
-  // end keeperhub code //
 });
 
 // KeeperHub: Para Wallets, Organization API Keys, and Organization Tokens (imported from KeeperHub schema extensions)
@@ -523,7 +505,6 @@ export const workflowSchedulesRelations = relations(
   })
 );
 
-// start custom keeperhub code //
 // Organization relations
 export const organizationRelations = relations(organization, ({ many }) => ({
   members: many(member),
@@ -598,9 +579,6 @@ export const tagsRelations = relations(tags, ({ one }) => ({
     references: [users.id],
   }),
 }));
-
-// end keeperhub code //
-
 export const chainsRelations = relations(chains, ({ one, many }) => ({
   explorerConfig: one(explorerConfigs, {
     fields: [chains.chainId],
@@ -646,7 +624,6 @@ export type BetaAccessRequest = typeof betaAccessRequests.$inferSelect;
 export type NewBetaAccessRequest = typeof betaAccessRequests.$inferInsert;
 export type WorkflowSchedule = typeof workflowSchedules.$inferSelect;
 export type NewWorkflowSchedule = typeof workflowSchedules.$inferInsert;
-// start custom keeperhub code //
 export type Organization = typeof organization.$inferSelect;
 export type NewOrganization = typeof organization.$inferInsert;
 export type Member = typeof member.$inferSelect;
@@ -659,7 +636,6 @@ export type Project = typeof projects.$inferSelect;
 export type NewProject = typeof projects.$inferInsert;
 export type Tag = typeof tags.$inferSelect;
 export type NewTag = typeof tags.$inferInsert;
-// end keeperhub code //
 export type Chain = typeof chains.$inferSelect;
 export type NewChain = typeof chains.$inferInsert;
 export type ExplorerConfig = typeof explorerConfigs.$inferSelect;

--- a/lib/explorer/proxy-detection.ts
+++ b/lib/explorer/proxy-detection.ts
@@ -10,9 +10,7 @@
  */
 
 import { ethers } from "ethers";
-// start custom keeperhub code //
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-// end keeperhub code //
 
 export type ProxyDetectionResult = {
   isProxy: boolean;
@@ -240,7 +238,6 @@ export async function detectProxyViaRpc(
     `[Proxy Detection] Starting RPC-based proxy detection for ${contractAddress} on chain ${chainId}`
   );
 
-  // start custom keeperhub code //
   let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
     rpcManager = await getRpcProvider({ chainId });
@@ -259,7 +256,6 @@ export async function detectProxyViaRpc(
         checkEip1167Proxy(provider, contractAddress),
       ])
   );
-  // end keeperhub code //
 
   // Check EIP-1967/OpenZeppelin result first (most common)
   if (eip1967Result.implementation) {
@@ -279,7 +275,6 @@ export async function detectProxyViaRpc(
     };
   }
 
-  // start custom keeperhub code //
   // Check EIP-1822 (UUPS) - less common, separate call
   const eip1822Impl = await rpcManager.executeWithFailover((provider) =>
     checkEip1822Proxy(provider, contractAddress)
@@ -303,7 +298,6 @@ export async function detectProxyViaRpc(
       proxyType: "gnosis-safe",
     };
   }
-  // end keeperhub code //
 
   console.log(
     `[Proxy Detection] No proxy pattern detected for ${contractAddress}`

--- a/lib/extension-registry.ts
+++ b/lib/extension-registry.ts
@@ -62,10 +62,8 @@ type IntegrationFormContext = {
   isEditMode: boolean;
   config: Record<string, unknown>;
   updateConfig: (key: string, value: string) => void;
-  // start keeperhub - callbacks for closing overlay after success
   onSuccess?: (integrationId: string) => void;
   closeAll?: () => void;
-  // end keeperhub
 };
 
 type CustomIntegrationFormHandler = (

--- a/lib/steps/database-query.ts
+++ b/lib/steps/database-query.ts
@@ -21,7 +21,6 @@ type DatabaseQueryResult =
   | { success: true; rows: unknown; count: number }
   | { success: false; error: string };
 
-// start custom keeperhub code //
 /** Primitive types accepted by postgres.js, plus objects/arrays that get JSON-stringified */
 export type SqlParam =
   | null
@@ -33,15 +32,12 @@ export type SqlParam =
   | Uint8Array
   | Record<string, unknown>
   | readonly SqlParam[];
-// end keeperhub code //
 
 export type DatabaseQueryInput = StepInput & {
   integrationId?: string;
   dbQuery?: string;
   query?: string;
-  // start custom keeperhub code //
   _dbParams?: SqlParam[];
-  // end keeperhub code //
 };
 
 function validateInput(input: DatabaseQueryInput): string | null {
@@ -66,7 +62,6 @@ function createDatabaseClient(
   });
 }
 
-// start custom keeperhub code //
 /** Serialize template-resolved values into types postgres.js can bind directly */
 export function serializeSqlParams(
   params: SqlParam[]
@@ -84,16 +79,12 @@ export function serializeSqlParams(
     return p;
   });
 }
-// end keeperhub code //
 
 async function executeQuery(
   client: postgres.Sql,
   queryString: string,
-  // start custom keeperhub code //
   params?: SqlParam[]
-  // end keeperhub code //
 ): Promise<unknown> {
-  // start custom keeperhub code //
   if (params && params.length > 0) {
     const serialized = serializeSqlParams(params);
     return await client.unsafe(
@@ -101,7 +92,6 @@ async function executeQuery(
       serialized as postgres.ParameterOrJSON<never>[]
     );
   }
-  // end keeperhub code //
   const db = drizzle(client);
   return await db.execute(sql.raw(queryString));
 }
@@ -151,9 +141,7 @@ async function databaseQuery(
 
   try {
     client = createDatabaseClient(normalizedUrl, ssl);
-    // start custom keeperhub code //
     const result = await executeQuery(client, queryString, input._dbParams);
-    // end keeperhub code //
     return {
       success: true,
       rows: result,

--- a/lib/steps/step-handler.ts
+++ b/lib/steps/step-handler.ts
@@ -5,7 +5,6 @@
  */
 import "server-only";
 
-// start custom keeperhub code //
 import { recordStepMetrics } from "@/keeperhub/lib/metrics/instrumentation/workflow";
 import { recordStepSuccess } from "@/keeperhub/lib/step-success-tracker";
 import { redactSensitiveData } from "../utils/redact";
@@ -16,18 +15,15 @@ import {
   logWorkflowCompleteDb,
   updateCurrentStep,
 } from "../workflow-logging";
-// end keeperhub code //
 
 export type StepContext = {
   executionId?: string;
   nodeId: string;
   nodeName: string;
   nodeType: string;
-  // start custom keeperhub code //
   triggerType?: string;
   iterationIndex?: number;
   forEachNodeId?: string;
-  // end keeperhub code //
 };
 
 /**
@@ -63,10 +59,8 @@ async function logStepStart(
       nodeName: context.nodeName,
       nodeType: context.nodeType,
       input: redactedInput,
-      // start custom keeperhub code //
       iterationIndex: context.iterationIndex,
       forEachNodeId: context.forEachNodeId,
-      // end keeperhub code //
     });
 
     return result;
@@ -84,9 +78,7 @@ async function logStepComplete(
   status: "success" | "error",
   output?: unknown,
   error?: string,
-  // start custom keeperhub code //
   executionId?: string
-  // end keeperhub code //
 ): Promise<void> {
   if (!logInfo.logId) {
     return;
@@ -101,9 +93,7 @@ async function logStepComplete(
       status,
       output: redactedOutput,
       error,
-      // start custom keeperhub code //
       executionId,
-      // end keeperhub code //
     });
   } catch (err) {
     console.error("[stepHandler] Failed to log completion:", err);
@@ -221,7 +211,6 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
         context?.executionId
       );
 
-      // start custom keeperhub code //
       recordStepMetrics({
         executionId: context?.executionId,
         nodeId: context?.nodeId || "",
@@ -231,7 +220,6 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
         success: false,
         error: errorResult.error,
       });
-      // end keeperhub code //
     } else {
       await logStepComplete(
         logInfo,
@@ -241,7 +229,6 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
         context?.executionId
       );
 
-      // start custom keeperhub code //
       if (context?.executionId && context.nodeId) {
         recordStepSuccess(context.executionId, context.nodeId, result);
       }
@@ -254,7 +241,6 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
         durationMs: Date.now() - logInfo.startTime,
         success: true,
       });
-      // end keeperhub code //
     }
 
     // Update progress: increment completed steps
@@ -294,7 +280,6 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
       context?.executionId
     );
 
-    // start custom keeperhub code //
     recordStepMetrics({
       executionId: context?.executionId,
       nodeId: context?.nodeId || "",
@@ -304,7 +289,6 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
       success: false,
       error: errorMessage,
     });
-    // end keeperhub code //
 
     // Update progress on error too
     if (context?.executionId && context.nodeId) {

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -8,7 +8,6 @@
 const TEMPLATE_PATTERN = /\{\{([^}]+)\}\}/g;
 const ARRAY_ACCESS_PATTERN = /^([^[]+)\[(\d+)\]$/;
 
-// start custom keeperhub code //
 /** Pattern for {{@nodeId:DisplayName.field}} template references */
 const TEMPLATE_REF_PATTERN = /\{\{@([^:]+):([^}]+)\}\}/g;
 
@@ -25,7 +24,6 @@ export function remapTemplateRefsInString(
     return `{{@${newId}:${rest}}}`;
   });
 }
-// end keeperhub code //
 
 export type NodeOutputs = {
   [nodeId: string]: {

--- a/lib/workflow-codegen.ts
+++ b/lib/workflow-codegen.ts
@@ -1,8 +1,5 @@
-// start custom keeperhub code //
-
 import { resolveConditionExpression } from "@/keeperhub/lib/condition-resolver";
 import { buildEdgesBySourceHandle } from "@/keeperhub/lib/edge-handle-utils";
-// end keeperhub code //
 import { findActionById, flattenConfigFields } from "@/plugins/registry";
 import {
   analyzeNodeUsage,
@@ -54,9 +51,7 @@ export function generateWorkflowCode(
   // Build a map of node connections
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const edgesBySource = new Map<string, string[]>();
-  // start custom keeperhub code //
   const edgesBySourceHandle = buildEdgesBySourceHandle(edges);
-  // end keeperhub code //
   for (const edge of edges) {
     const targets = edgesBySource.get(edge.source) || [];
     targets.push(edge.target);
@@ -846,7 +841,6 @@ export function generateWorkflowCode(
     return lines;
   }
 
-  // start custom keeperhub code //
   /** Resolve true/false targets for a condition node, using handle edges with positional fallback. */
   function resolveConditionTargets(nodeId: string): {
     trueTargets: string[];
@@ -872,7 +866,6 @@ export function generateWorkflowCode(
       falseTargets: nextNodes.slice(1, 2),
     };
   }
-  // end keeperhub code //
 
   function generateConditionNodeCode(
     node: WorkflowNode,
@@ -887,12 +880,10 @@ export function generateWorkflowCode(
 
     const condition = resolveConditionExpression(node.data.config);
 
-    // start custom keeperhub code //
     const {
       trueTargets: effectiveTrueTargets,
       falseTargets: effectiveFalseTargets,
     } = resolveConditionTargets(nodeId);
-    // end keeperhub code //
 
     if (effectiveTrueTargets.length > 0 || effectiveFalseTargets.length > 0) {
       let convertedCondition: string;
@@ -1010,12 +1001,10 @@ export function generateWorkflowCode(
     const lines: string[] = [`${indent}// Condition: ${node.data.label}`];
     const condition = resolveConditionExpression(node.data.config);
 
-    // start custom keeperhub code //
     const {
       trueTargets: effectiveTrueTargets,
       falseTargets: effectiveFalseTargets,
     } = resolveConditionTargets(nodeId);
-    // end keeperhub code //
 
     if (effectiveTrueTargets.length > 0 || effectiveFalseTargets.length > 0) {
       let convertedCondition: string;

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -3,7 +3,6 @@
  * This executor captures step executions through the workflow SDK for better observability
  */
 
-// start custom keeperhub code //
 import {
   BUILTIN_NODE_ID,
   BUILTIN_NODE_LABEL,
@@ -54,7 +53,6 @@ import type { StepContext } from "./steps/step-handler";
 import { triggerStep } from "./steps/trigger";
 import { deserializeEventTriggerData, getErrorMessageAsync } from "./utils";
 import type { WorkflowEdge, WorkflowNode } from "./workflow-store";
-// end keeperhub code //
 
 // System actions that don't have plugins - maps to module import functions
 const SYSTEM_ACTIONS: Record<string, StepImporter> = {
@@ -73,7 +71,6 @@ const SYSTEM_ACTIONS: Record<string, StepImporter> = {
     importer: () => import("./steps/condition") as Promise<any>,
     stepFunction: "conditionStep",
   },
-  // start custom keeperhub code //
   "For Each": {
     importer: () =>
       // biome-ignore lint/suspicious/noExplicitAny: Dynamic module import matches existing pattern
@@ -86,7 +83,6 @@ const SYSTEM_ACTIONS: Record<string, StepImporter> = {
       import("@/keeperhub/lib/steps/collect") as Promise<any>,
     stepFunction: "collectStep",
   },
-  // end keeperhub code //
 };
 
 type ExecutionResult = {
@@ -119,17 +115,14 @@ function replaceTemplateVariable(
   outputs: NodeOutputs,
   evalContext: Record<string, unknown>,
   varCounter: { value: number },
-  // start custom keeperhub code //
   nodeMap?: ReadonlyMap<string, unknown>,
   executionResults?: Record<string, ExecutionResult>
-  // end keeperhub code //
 ): string {
   const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
   const output = outputs[sanitizedNodeId];
 
   // KEEP-1284: Throw error when referenced node output doesn't exist
   if (!output) {
-    // start custom keeperhub code //
     // Dead-branch grace: if the node exists in the workflow graph but was never
     // executed (it sits on a branch that a condition did not take), return
     // undefined instead of throwing so the condition evaluates gracefully.
@@ -139,7 +132,6 @@ function replaceTemplateVariable(
       evalContext[varName] = undefined;
       return varName;
     }
-    // end keeperhub code //
     throw new Error(
       `Condition references node "${nodeId}" but no output was found. The referenced node may not have executed or produced output.`
     );
@@ -229,10 +221,8 @@ type ConditionEvalResult = {
 export function evaluateConditionExpression(
   conditionExpression: unknown,
   outputs: NodeOutputs,
-  // start custom keeperhub code //
   nodeMap?: ReadonlyMap<string, unknown>,
   executionResults?: Record<string, ExecutionResult>
-  // end keeperhub code //
 ): ConditionEvalResult {
   console.log("[Condition] Original expression:", conditionExpression);
 
@@ -274,10 +264,8 @@ export function evaluateConditionExpression(
             outputs,
             evalContext,
             varCounter,
-            // start custom keeperhub code //
             nodeMap,
             executionResults
-            // end keeperhub code //
           );
           // Store the resolved value with a readable key (the display text from the template)
           resolvedValues[rest] = evalContext[varName];
@@ -294,7 +282,6 @@ export function evaluateConditionExpression(
         );
       }
 
-      // start custom keeperhub code //
       // BigInt-safe conversion for large Web3 values (e.g. token balances in wei)
       if (needsBigIntMode(transformedExpression, evalContext)) {
         const converted = applyBigIntConversion(
@@ -304,7 +291,6 @@ export function evaluateConditionExpression(
         transformedExpression = converted.expression;
         evalContext = converted.evalContext;
       }
-      // end keeperhub code //
 
       const varNames = Object.keys(evalContext);
       const varValues = Object.values(evalContext);
@@ -356,10 +342,8 @@ async function executeActionStep(input: {
   config: Record<string, unknown>;
   outputs: NodeOutputs;
   context: StepContext;
-  // start custom keeperhub code //
   nodeMap?: ReadonlyMap<string, unknown>;
   executionResults?: Record<string, ExecutionResult>;
-  // end keeperhub code //
 }) {
   const { actionType, config, outputs, context } = input;
 
@@ -383,14 +367,12 @@ async function executeActionStep(input: {
     let evaluationError: string | undefined;
 
     try {
-      // start custom keeperhub code //
       const result = evaluateConditionExpression(
         originalExpression,
         outputs,
         input.nodeMap,
         input.executionResults
       );
-      // end keeperhub code //
       evaluatedCondition = result.result;
       resolvedValues = result.resolvedValues;
     } catch (error) {
@@ -452,7 +434,6 @@ async function executeActionStep(input: {
   };
 }
 
-// start custom keeperhub code //
 /**
  * Resolve a field path (e.g. "data.recipes[0].tags[0]") into a value.
  * Supports bracket notation for array indices.
@@ -604,18 +585,15 @@ function processTemplates(
 ): Record<string, unknown> {
   const processed: Record<string, unknown> = {};
   const storedPattern = /\{\{@([^:]+):([^}]+)\}\}/g;
-  // start custom keeperhub code //
   // Fallback: resolve display-format templates {{Label.field}} that were not
   // converted to stored format by the editor (mirrors extractTemplateParameters).
   const displayPattern = /\{\{([^@}][^}]*)\}\}/g;
-  // end keeperhub code //
 
   for (const [key, value] of Object.entries(config)) {
     if (typeof value === "string") {
       let result = value.replace(storedPattern, (m, nodeId, rest) =>
         replaceConfigTemplate(m, nodeId, rest, outputs)
       );
-      // start custom keeperhub code //
       result = result.replace(displayPattern, (full, displayRef) => {
         const resolved = resolveDisplayTemplate(displayRef, outputs);
         if (resolved === null || resolved === undefined) {
@@ -623,7 +601,6 @@ function processTemplates(
         }
         return formatConfigValue(resolved);
       });
-      // end keeperhub code //
       processed[key] = result;
     } else if (
       typeof value === "object" &&
@@ -642,7 +619,6 @@ function processTemplates(
   return processed;
 }
 
-// start custom keeperhub code //
 /**
  * Format a resolved value as a valid JavaScript expression for code context.
  * Strings are JSON-quoted so they stay valid when inlined into user code.
@@ -699,7 +675,6 @@ function processCodeTemplates(code: string, outputs: NodeOutputs): string {
 
   return result;
 }
-// end keeperhub code //
 
 /**
  * Resolve a display-format template (e.g. "Label.field") by searching outputs
@@ -846,9 +821,7 @@ export type LoopBodyInfo = {
   bodyNodeIds: string[];
   collectNodeId: string | undefined;
   bodyEdgesBySource: Map<string, string[]>;
-  // start custom keeperhub code //
   bodyEdgesBySourceHandle: EdgesBySourceHandle;
-  // end keeperhub code //
 };
 
 /**
@@ -879,15 +852,11 @@ export function identifyLoopBody(
   forEachNodeId: string,
   edgesBySource: Map<string, string[]>,
   nodeMap: Map<string, WorkflowNode>,
-  // start custom keeperhub code //
   edgesBySourceHandle?: EdgesBySourceHandle
-  // end keeperhub code //
 ): LoopBodyInfo {
   const bodyNodeIds: string[] = [];
   const bodyEdgesBySource = new Map<string, string[]>();
-  // start custom keeperhub code //
   const bodyEdgesBySourceHandle: EdgesBySourceHandle = new Map();
-  // end keeperhub code //
   let collectNodeId: string | undefined;
   const visited = new Set<string>();
 
@@ -950,7 +919,6 @@ export function identifyLoopBody(
     }
   }
 
-  // start custom keeperhub code //
   // Copy handle-aware edges, filtering targets to body-only nodes so
   // condition handles cannot accidentally route outside the loop body.
   const bodyNodeSet = new Set(bodyNodeIds);
@@ -970,7 +938,6 @@ export function identifyLoopBody(
       bodyEdgesBySourceHandle.set(bodyNodeId, filteredHandleMap);
     }
   }
-  // end keeperhub code //
 
   return { bodyNodeIds, collectNodeId, bodyEdgesBySource, bodyEdgesBySourceHandle };
 }
@@ -1034,9 +1001,6 @@ export function resolveArraySource(
 
   return raw;
 }
-
-// end keeperhub code //
-
 /**
  * Main workflow executor function
  */
@@ -1061,10 +1025,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   // Build node and edge maps
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const edgesBySource = new Map<string, string[]>();
-  // start custom keeperhub code //
   const edgesBySourceHandle = buildEdgesBySourceHandle(edges);
   const conditionDecisions = new Map<string, ConditionDecision>();
-  // end keeperhub code //
   for (const edge of edges) {
     const targets = edgesBySource.get(edge.source) || [];
     targets.push(edge.target);
@@ -1083,7 +1045,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     "trigger nodes"
   );
 
-  // start custom keeperhub code //
   // Detect trigger type for step context (gas strategy uses this for multiplier selection)
   const workflowTriggerType: string = (() => {
     const triggerNode = nodes.find((n) => n.data.type === "trigger");
@@ -1102,7 +1063,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
     return "manual";
   })();
-  // end keeperhub code //
 
   // Helper to get a meaningful node name
   function getNodeName(node: WorkflowNode): string {
@@ -1124,9 +1084,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
     return node.data.type;
   }
-
-  // start custom keeperhub code //
-
   /**
    * Process a node's config by resolving templates and handling special fields
    * (condition, dbQuery). Shared by executeNode and executeBodyNode.
@@ -1145,12 +1102,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     if (actionType === "Database Query") {
       configWithoutSpecial.dbQuery = undefined;
     }
-    // start custom keeperhub code //
     const originalCode = config.code;
     if (actionType === "code/run-code") {
       configWithoutSpecial.code = undefined;
     }
-    // end keeperhub code //
 
     const processedConfig = processTemplates(
       configWithoutSpecial,
@@ -1181,15 +1136,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       processedConfig.dbQuery = originalDbQuery;
     }
 
-    // start custom keeperhub code //
     if (actionType === "code/run-code" && typeof originalCode === "string") {
       processedConfig.code = processCodeTemplates(originalCode, currentOutputs);
     }
-    // end keeperhub code //
 
     return processedConfig;
   }
-  // end keeperhub code //
 
   // -------------------------------------------------------------------
   // For Each: body-node executor (scoped outputs, body-only edges)
@@ -1209,9 +1161,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     bodyEdgesBySource: Map<string, string[]>,
     collectNodeId: string | undefined,
     iterationMeta?: { iterationIndex: number; forEachNodeId: string },
-    // start custom keeperhub code //
     bodyHandleMap?: EdgesBySourceHandle
-    // end keeperhub code //
   ): Promise<void> {
     if (bodyVisited.has(nodeId)) {
       return;
@@ -1243,9 +1193,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           bodyEdgesBySource,
           collectNodeId,
           iterationMeta,
-          // start custom keeperhub code //
           bodyHandleMap
-          // end keeperhub code //
         );
       }
       return;
@@ -1339,15 +1287,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 bodyEdgesBySource,
                 collectNodeId,
                 iterationMeta,
-                // start custom keeperhub code //
                 bodyHandleMap
-                // end keeperhub code //
               );
             }
           },
         });
       } else if (actionType === "Condition") {
-        // start custom keeperhub code //
         const conditionValue = (result.data as { condition?: boolean })
           ?.condition;
         const nodeHandles = bodyHandleMap?.get(nodeId);
@@ -1372,10 +1317,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           // Legacy fallback: gate behavior
           return;
         }
-        // end keeperhub code //
       }
 
-      // start custom keeperhub code //
       // Continue to downstream body nodes.
       // Skip only when condition routed via handles AND the chosen handle had targets.
       const conditionRoutedViaHandles =
@@ -1403,7 +1346,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           );
         }
       }
-      // end keeperhub code //
     } catch (error) {
       const errorMessage = await getErrorMessageAsync(error);
       bodyResults[nodeId] = { success: false, error: errorMessage };
@@ -1450,14 +1392,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     const itemsToProcess = resolvedArray.slice(0, maxIterations);
 
     // 2. Identify body subgraph
-    // start custom keeperhub code //
     const { bodyNodeIds, collectNodeId, bodyEdgesBySource, bodyEdgesBySourceHandle } = identifyLoopBody(
       forEachNodeId,
       currentEdgesBySource,
       nodeMap,
       edgesBySourceHandle
     );
-    // end keeperhub code //
 
     const sanitizedForEachId = forEachNodeId.replace(/[^a-zA-Z0-9]/g, "_");
 
@@ -1502,9 +1442,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           bodyEdgesBySource,
           collectNodeId,
           iterationMeta,
-          // start custom keeperhub code //
           bodyEdgesBySourceHandle
-          // end keeperhub code //
         );
       }
 
@@ -1558,7 +1496,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       return iterationOutput;
     }
 
-    // start custom keeperhub code //
     // 4. Run iterations with configurable concurrency
     const { runIterations } = await import(
       "@/keeperhub/lib/for-each-concurrency"
@@ -1573,7 +1510,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       concurrencyMode as "sequential" | "parallel" | "custom",
       concurrencyLimit
     );
-    // end keeperhub code //
 
     // 5. Mark body nodes as visited in the parent scope
     for (const bodyNodeId of bodyNodeIds) {
@@ -1625,7 +1561,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     };
   }
 
-  // start custom keeperhub code //
   function processSettledResults(
     settled: PromiseSettledResult<void>[],
     nodeIds: string[]
@@ -1643,7 +1578,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       }
     }
   }
-  // end keeperhub code //
 
   // Helper to execute a single node
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Node execution requires type checking and error handling
@@ -1681,7 +1615,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       return;
     }
 
-    // start custom keeperhub code //
     // Inject fresh built-in system variables before each node executes.
     // Intentionally per-node (not per-workflow) so long-running sequential
     // workflows get an up-to-date timestamp at each step.
@@ -1690,7 +1623,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       label: BUILTIN_NODE_LABEL,
       data: getBuiltinVariables(),
     };
-    // end keeperhub code //
 
     try {
       let result: ExecutionResult;
@@ -1732,7 +1664,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           }
         } else if (triggerInput && Object.keys(triggerInput).length > 0) {
           // Use provided trigger input
-          // start custom keeperhub code //
           // For Event triggers, deserialize { value: string, type: string } objects
           // back to appropriate types (BigInt for uint/int, boolean for bool, etc.)
           if (triggerType === "Event") {
@@ -1771,7 +1702,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               triggerData.triggeredAt = triggerInput.triggerTime;
             }
           }
-          // end keeperhub code //
         }
 
         // Build context for logging
@@ -1814,9 +1744,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           return;
         }
 
-        // start custom keeperhub code //
         const processedConfig = processActionConfig(config, actionType, outputs);
-        // end keeperhub code //
 
         // Build step context for logging (stepHandler will handle the logging)
         const stepContext: StepContext = {
@@ -1824,9 +1752,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           nodeId: node.id,
           nodeName: getNodeName(node),
           nodeType: actionType,
-          // start custom keeperhub code //
           triggerType: workflowTriggerType,
-          // end keeperhub code //
         };
 
         // Execute the action step with stepHandler (logging is handled inside)
@@ -1838,10 +1764,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           config: processedConfig,
           outputs,
           context: stepContext,
-          // start custom keeperhub code //
           nodeMap,
           executionResults: results,
-          // end keeperhub code //
         });
 
         console.log("[Workflow Executor] Step result received:", {
@@ -1900,7 +1824,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             ? (node.data.config?.actionType as string | undefined)
             : undefined;
 
-        // start custom keeperhub code //
         if (currentActionType === "For Each") {
           // For Each: iterate over array, execute body subgraph per element,
           // store results on Collect, then continue from Collect downstream.
@@ -1933,12 +1856,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           };
           results[nodeId] = { success: true, data: iterationSummary };
         } else if (currentActionType === "Condition") {
-          // end keeperhub code //
           // For condition nodes, route to true/false handle targets
           const conditionResult = (result.data as { condition?: boolean })
             ?.condition;
 
-          // start custom keeperhub code //
           const handleMap = edgesBySourceHandle.get(nodeId);
           if (handleMap) {
             // Handle-aware routing: use sourceHandle to determine targets
@@ -1973,7 +1894,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               processSettledResults(legacySettled, nextNodes);
             }
           }
-          // end keeperhub code //
         } else {
           // For non-condition nodes, execute all next nodes in parallel
           const nextNodes = edgesBySource.get(nodeId) || [];
@@ -2015,7 +1935,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     console.log("[Workflow Executor] Starting execution from trigger nodes");
     const workflowStartTime = Date.now();
 
-    // start custom keeperhub code //
     const triggerType = detectTriggerType(nodes);
     const metrics = getMetricsCollector();
     metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_TOTAL, {
@@ -2023,7 +1942,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       ...(workflowId && { [LabelKeys.WORKFLOW_ID]: workflowId }),
     });
     incrementConcurrentExecutions();
-    // end keeperhub code //
 
     const triggerNodeIds = triggerNodes.map((trigger) => trigger.id);
     const triggerSettled = await Promise.allSettled(
@@ -2031,16 +1949,13 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     );
     processSettledResults(triggerSettled, triggerNodeIds);
 
-    // start custom keeperhub code //
     // Branch-aware finalSuccess: exclude nodes on dead (not-taken) condition branches
     const allSkippedTargets = collectAllSkippedTargets(conditionDecisions);
     const finalSuccess = Object.entries(results).every(
       ([nodeId, r]) => r.success || allSkippedTargets.has(nodeId)
     );
-    // end keeperhub code //
     const duration = Date.now() - workflowStartTime;
 
-    // start custom keeperhub code //
     // Diagnostic logging for branching workflow failures
     if (!finalSuccess && conditionDecisions.size > 0) {
       const failedNodes = Object.entries(results)
@@ -2068,7 +1983,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       error: Object.values(results).find((r) => !r.success)?.error,
     });
     decrementConcurrentExecutions();
-    // end keeperhub code //
 
     console.log("[Workflow Executor] Workflow execution completed:", {
       success: finalSuccess,
@@ -2122,7 +2036,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
     const errorMessage = await getErrorMessageAsync(error);
 
-    // start custom keeperhub code //
     recordWorkflowComplete({
       workflowId,
       executionId,
@@ -2132,7 +2045,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       error: errorMessage,
     });
     decrementConcurrentExecutions();
-    // end keeperhub code //
 
     // Update execution record with error if we have an executionId
     if (executionId) {
@@ -2166,10 +2078,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       error: errorMessage,
     };
   } finally {
-    // start custom keeperhub code //
     if (executionId) {
       clearExecution(executionId);
     }
-    // end keeperhub code //
   }
 }

--- a/lib/workflow-logging.ts
+++ b/lib/workflow-logging.ts
@@ -8,7 +8,6 @@ import { and, eq, ne } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 
-// start custom keeperhub code //
 const TERMINAL_STATUSES = new Set(["cancelled"]);
 
 /**
@@ -22,7 +21,6 @@ async function isExecutionTerminal(executionId: string): Promise<boolean> {
   });
   return !execution || TERMINAL_STATUSES.has(execution.status);
 }
-// end keeperhub code //
 
 export type LogStepStartParams = {
   executionId: string;
@@ -30,10 +28,8 @@ export type LogStepStartParams = {
   nodeName: string;
   nodeType: string;
   input?: unknown;
-  // start custom keeperhub code //
   iterationIndex?: number;
   forEachNodeId?: string;
-  // end keeperhub code //
 };
 
 export type LogStepStartResult = {
@@ -47,12 +43,10 @@ export type LogStepStartResult = {
 export async function logStepStartDb(
   params: LogStepStartParams
 ): Promise<LogStepStartResult> {
-  // start custom keeperhub code //
   // Guard: skip if execution was cancelled (runtime continues after cancel)
   if (await isExecutionTerminal(params.executionId)) {
     return { logId: "", startTime: Date.now() };
   }
-  // end keeperhub code //
 
   const [log] = await db
     .insert(workflowExecutionLogs)
@@ -64,10 +58,8 @@ export async function logStepStartDb(
       status: "running",
       input: params.input,
       startedAt: new Date(),
-      // start custom keeperhub code //
       iterationIndex: params.iterationIndex ?? null,
       forEachNodeId: params.forEachNodeId ?? null,
-      // end keeperhub code //
     })
     .returning();
 
@@ -83,9 +75,7 @@ export type LogStepCompleteParams = {
   status: "success" | "error";
   output?: unknown;
   error?: string;
-  // start custom keeperhub code //
   executionId?: string;
-  // end keeperhub code //
 };
 
 /**
@@ -94,12 +84,10 @@ export type LogStepCompleteParams = {
 export async function logStepCompleteDb(
   params: LogStepCompleteParams
 ): Promise<void> {
-  // start custom keeperhub code //
   // Guard: skip if execution was cancelled (runtime continues after cancel)
   if (params.executionId && (await isExecutionTerminal(params.executionId))) {
     return;
   }
-  // end keeperhub code //
 
   const duration = Date.now() - params.startTime;
 
@@ -131,7 +119,6 @@ export async function logWorkflowCompleteDb(
 ): Promise<void> {
   const duration = Date.now() - params.startTime;
 
-  // start custom keeperhub code //
   // KEEP-1549: Reconcile spurious SDK errors.
   // The Workflow DevKit can throw "exceeded max retries" AFTER all steps
   // succeed. If we're about to write status='error', check whether any
@@ -183,7 +170,6 @@ export async function logWorkflowCompleteDb(
       );
     }
   }
-  // end keeperhub code //
 
   await db
     .update(workflowExecutions)
@@ -255,12 +241,10 @@ export async function updateCurrentStep(
       currentNodeName: params.currentNodeName,
     })
     .where(
-      // start custom keeperhub code //
       and(
         eq(workflowExecutions.id, params.executionId),
         ne(workflowExecutions.status, "cancelled")
       )
-      // end keeperhub code //
     );
 }
 
@@ -287,12 +271,10 @@ export async function incrementCompletedSteps(
     return;
   }
 
-  // start custom keeperhub code //
   // Guard: skip if execution was cancelled (runtime continues after cancel)
   if (TERMINAL_STATUSES.has(execution.status)) {
     return;
   }
-  // end keeperhub code //
 
   const completedSteps =
     Number.parseInt(execution.completedSteps || "0", 10) + 1;

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -4,7 +4,6 @@ import { atom } from "jotai";
 import { buildExecutionLogsMap } from "@/keeperhub/lib/template-helpers";
 import { api } from "./api-client";
 
-// start custom keeperhub code //
 export type WorkflowNodeType = "trigger" | "action" | "add";
 
 // biome-ignore lint/style/noEnum: Prefer to use enums as make it easier to maintain and read.
@@ -15,7 +14,6 @@ export enum WorkflowTriggerEnum {
   EVENT = "Event", // keeperhub custom field //
   BLOCK = "Block", // keeperhub custom field //
 }
-// end keeperhub code //
 
 export type WorkflowTriggerType = `${WorkflowTriggerEnum}`;
 
@@ -45,11 +43,9 @@ export const isLoadingAtom = atom(false);
 export const isGeneratingAtom = atom(false);
 export const currentWorkflowIdAtom = atom<string | null>(null);
 export const currentWorkflowNameAtom = atom<string>("");
-// start custom keeperhub code //
 export const currentWorkflowDescriptionAtom = atom<string>("");
 export const currentWorkflowProjectIdAtom = atom<string | null>(null);
 export const currentWorkflowTagIdAtom = atom<string | null>(null);
-// end keeperhub code //
 export const currentWorkflowVisibilityAtom =
   atom<WorkflowVisibility>("private");
 export const currentWorkflowPublicTagsAtom = atom<
@@ -60,10 +56,8 @@ export const isWorkflowEnabled = atom<boolean>(false);
 
 // UI state atoms
 export const propertiesPanelActiveTabAtom = atom<string>("properties");
-// start custom keeperhub code //
 // Increment to trigger an immediate Runs panel refresh (e.g. after execute)
 export const runsRefreshTriggerAtom = atom<number>(0);
-// end keeperhub code //
 export const showMinimapAtom = atom(false);
 export const selectedExecutionIdAtom = atom<string | null>(null);
 export const rightPanelWidthAtom = atom<string | null>(null);
@@ -255,7 +249,6 @@ export const addNodeAtom = atom(null, (get, set, node: WorkflowNode) => {
   set(historyAtom, [...history, { nodes: currentNodes, edges: currentEdges }]);
   set(futureAtom, []);
 
-  // start custom keeperhub code //
   // Deselect all existing nodes and add new node as selected.
   // Only spread nodes whose selected state actually changes to preserve
   // object references -- React Flow re-measures handle bounds when node
@@ -264,7 +257,6 @@ export const addNodeAtom = atom(null, (get, set, node: WorkflowNode) => {
   const updatedNodes = currentNodes.map((n) =>
     n.selected ? { ...n, selected: false } : n
   );
-  // end keeperhub code //
   const newNode = { ...node, selected: true };
   const newNodes = [...updatedNodes, newNode];
   set(nodesAtom, newNodes);
@@ -503,7 +495,6 @@ export const clearWorkflowAtom = atom(null, (get, set) => {
   set(hasUnsavedChangesAtom, true);
 });
 
-// start custom keeperhub code //
 // Reset all workflow state for org switch (no history push; used by use-organization)
 export const resetWorkflowStateForOrgSwitchAtom = atom(null, (_get, set) => {
   set(nodesAtom, []);
@@ -528,7 +519,6 @@ export const resetWorkflowStateForOrgSwitchAtom = atom(null, (_get, set) => {
   set(historyAtom, []);
   set(futureAtom, []);
 });
-// end keeperhub code //
 
 // Load workflow from database
 export const loadWorkflowAtom = atom(null, async (get, set) => {
@@ -540,7 +530,6 @@ export const loadWorkflowAtom = atom(null, async (get, set) => {
     if (workflow.id) {
       set(currentWorkflowIdAtom, workflow.id);
 
-      // start custom keeperhub code //
       // Pre-fetch last execution logs so template autocomplete has runtime
       // output data available immediately instead of lazy-fetching on first @.
       // Guard: only apply if the workflow hasn't changed by the time data arrives.
@@ -573,7 +562,6 @@ export const loadWorkflowAtom = atom(null, async (get, set) => {
             error
           );
         });
-      // end keeperhub code //
     }
   } catch (error) {
     console.error("Failed to load workflow:", error);

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,6 @@ import { withWorkflow } from "workflow/next";
 
 const nextConfig = {
   output: "standalone",
-  // start custom keeperhub code //
   // The SDK loads @workflow/world-postgres via dynamic
   // require(process.env.WORKFLOW_TARGET_WORLD) which the standalone output
   // tracer cannot follow. serverExternalPackages keeps it out of the bundle
@@ -210,7 +209,6 @@ const nextConfig = {
       "./node_modules/next/dist/compiled/@vercel/og/**/*",
     ],
   },
-  // end keeperhub code //
   logging: {
     fetches: {
       fullUrl: true,

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -35,13 +35,11 @@ export type ActionConfigFieldBase = {
     | "abi-with-auto-fetch" // ABI textarea with automatic fetch from Etherscan
     | "token-select" // Token selector with supported/custom toggle
     | "abi-event-select" // Dynamic dropdown that parses ABI and shows events
-    // start custom keeperhub code //
     | "gas-limit-multiplier" // Gas limit multiplier with chain default display
     | "code-editor" // Monaco-based JavaScript code editor
     | "json-editor" // Monaco-based JSON editor
     | "call-list-builder" // Dynamic list of contract calls for batch operations
     | "args-list-builder"; // Dynamic list of argument sets for batch uniform mode
-  // end keeperhub code //
 
   // For chain-select: filter by chain type (e.g., "evm" or "solana")
   chainTypeFilter?: string;
@@ -64,22 +62,18 @@ export type ActionConfigFieldBase = {
   // Min value (for number fields)
   min?: number;
 
-  // start custom keeperhub code //
   max?: number;
   step?: number;
   actionSlug?: string;
-  // end keeperhub code //
 
   // Whether this field is required (defaults to false)
   required?: boolean;
 
   // Conditional rendering: only show if another field has a specific value
-  // start custom keeperhub code //
   // Use `equals` for single value match, `oneOf` for multiple value match
   showWhen?:
     | { field: string; equals: string }
     | { field: string; oneOf: string[] };
-  // end keeperhub code //
 
   // For abi-function-select and abi-event-select: which field contains the ABI JSON
   abiField?: string;
@@ -99,13 +93,11 @@ export type ActionConfigFieldBase = {
   // For abi-with-auto-fetch: "read" or "write" so the node shows the right proxy option label (Read as Proxy / Write as Proxy)
   contractInteractionType?: "read" | "write";
 
-  // start custom keeperhub code //
   // Tooltip text shown next to the label via an info icon
   helpTip?: string;
 
   // Whether this field represents an Ethereum address (enables address book support)
   isAddressField?: boolean;
-  // end keeperhub code //
 };
 
 /**

--- a/tests/integration/workflow-duplicate.test.ts
+++ b/tests/integration/workflow-duplicate.test.ts
@@ -80,14 +80,12 @@ vi.mock("@/lib/auth", () => ({
   },
 }));
 
-// start custom keeperhub code //
 vi.mock("@/keeperhub/lib/middleware/org-context", () => ({
   getOrgContext: vi.fn().mockResolvedValue({
     organization: { id: "org-1" },
     isAnonymous: false,
   }),
 }));
-// end keeperhub code //
 
 const workflowWithArrayConfig = {
   ...sourceWorkflow,


### PR DESCRIPTION
## Summary

- Removes all `// start custom keeperhub code //` and `// end keeperhub code //` boundary markers (940+ lines across 103 files)
- Drops the "Custom Code Policy" section from CLAUDE.md
- No functional changes -- purely comment deletion and blank line cleanup

## Context

Phase 2 of the keeperhub repo refactor. Upstream (vercel-labs/workflow-builder-template) is no longer being synced, so the boundary markers serve no purpose. Removing them now clears the way for the next phase: consolidating `app/` + `keeperhub/` and `lib/` + `keeperhub/lib/`.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm type-check` passes
- [x] CI pipeline passes