### PR TITLE
fix: credential fetcher fallback when plugin registry unavailable

### DIFF
--- a/lib/credential-fetcher.ts
+++ b/lib/credential-fetcher.ts
@@ -65,8 +65,18 @@ function mapIntegrationConfig(
     return getCredentialMapping(plugin, config);
   }
 
-  // Fallback for unknown integrations
-  return {};
+  // Fallback: return raw config as credentials when plugin registry is unavailable.
+  // This handles Workflow DevKit step contexts where ensurePluginsLoaded() silently
+  // fails because the dynamic require("@/plugins") is not in the step bundle.
+  // Safe because config is already decrypted and most plugins use identical
+  // configKey/envVar names (e.g. Discord: webhookUrl → webhookUrl).
+  const fallbackCreds: WorkflowCredentials = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (value !== undefined && value !== null) {
+      fallbackCreds[key] = String(value);
+    }
+  }
+  return fallbackCreds;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When `getIntegration()` returns `undefined` in `mapIntegrationConfig`, the fallback now returns the raw decrypted config as credentials instead of empty `{}`
- This handles cases where the Workflow DevKit step bundle context cannot populate the plugin registry via `ensurePluginsLoaded()` (the dynamic `require("@/plugins")` gets externalized by esbuild and silently fails)
- Safe because config is already decrypted at that point, and most plugins use identical `configKey`/`envVar` names

## Context

Discord send-message step fails with "Discord webhook URL is required" despite the integration being correctly configured. The credential fetch chain returns empty credentials because the plugin registry lookup falls through to `return {}`.

## Test plan

- [ ] Deploy to staging and trigger a Discord send-message workflow
- [ ] Verify SendGrid and Telegram steps also work