### PR TITLE
fix: support dynamic port in CLI auth callback trusted origin

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -464,7 +464,7 @@ export const auth = betterAuth({
   trustedOrigins: [
     "http://localhost:3000",
     // start custom keeperhub code //
-    "http://127.0.0.1", // CLI browser auth callback
+    "http://127.0.0.1:*", // CLI browser auth callback (dynamic port)
     // end keeperhub code //
     "https://app-staging.keeperhub.com",
     "https://*.keeperhub.com",


### PR DESCRIPTION
## Summary
- CLI `kh auth login` starts a local callback server on a random port
- Better Auth's origin check requires port-specific matching (`http://127.0.0.1:50121` does not match `http://127.0.0.1`)
- Changes `http://127.0.0.1` to `http://127.0.0.1:*` which Better Auth's `matchesOriginPattern` supports (verified locally)

## Test plan
- [x] Verified `matchesOriginPattern('http://127.0.0.1:50121/callback', 'http://127.0.0.1:*')` returns `true`
- [ ] Deploy to staging, run `kh auth login`, confirm OAuth redirect works