### PR TITLE
feat: add CLI auth relay for browser-based OAuth login

### DIFF
--- a/app/api/cli-auth/relay/route.ts
+++ b/app/api/cli-auth/relay/route.ts
@@ -1,0 +1,3 @@
+// start custom keeperhub code //
+export { GET } from "@/keeperhub/api/cli-auth/relay/route";
+// end keeperhub code //

--- a/app/cli-auth/page.tsx
+++ b/app/cli-auth/page.tsx
@@ -1,0 +1,3 @@
+// start custom keeperhub code //
+export { default } from "@/keeperhub/app/cli-auth/page";
+// end keeperhub code //

--- a/keeperhub/api/cli-auth/relay/route.ts
+++ b/keeperhub/api/cli-auth/relay/route.ts
@@ -1,0 +1,44 @@
+import { cookies } from "next/headers";
+import { type NextRequest, NextResponse } from "next/server";
+
+const PORT_PATTERN = /^\d+$/;
+const NONCE_PATTERN = /^[a-f0-9]{32}$/;
+
+/**
+ * GET /api/cli-auth/relay?port=PORT
+ *
+ * Server-side relay for CLI OAuth login. Better Auth redirects here after
+ * successful social sign-in (callbackURL). This route reads the session
+ * token from the HttpOnly cookie (same domain) and redirects to the CLI's
+ * local callback server with the token as a query parameter.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const port = req.nextUrl.searchParams.get("port") ?? "";
+  const nonce = req.nextUrl.searchParams.get("nonce") ?? "";
+  if (!(PORT_PATTERN.test(port) && NONCE_PATTERN.test(nonce))) {
+    return NextResponse.json(
+      { error: "Missing or invalid parameters" },
+      { status: 400 }
+    );
+  }
+
+  const cookieStore = await cookies();
+  const useSecure = process.env.NODE_ENV === "production";
+  const cookieName = useSecure
+    ? "__Secure-better-auth.session_token"
+    : "better-auth.session_token";
+  const sessionToken = cookieStore.get(cookieName)?.value;
+
+  if (!sessionToken) {
+    return NextResponse.json(
+      { error: "No session token found" },
+      { status: 401 }
+    );
+  }
+
+  const callbackURL = new URL(`http://127.0.0.1:${port}/callback`);
+  callbackURL.searchParams.set("token", sessionToken);
+  callbackURL.searchParams.set("nonce", nonce);
+
+  return NextResponse.redirect(callbackURL.toString());
+}

--- a/keeperhub/app/cli-auth/page.tsx
+++ b/keeperhub/app/cli-auth/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+async function fetchSignInURL(
+  provider: string,
+  callbackURL: string
+): Promise<string> {
+  const resp = await fetch("/api/auth/sign-in/social", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider, callbackURL }),
+    credentials: "include",
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Server error ${resp.status}: ${body}`);
+  }
+
+  const data = (await resp.json()) as { url?: string };
+  if (!data.url) {
+    throw new Error("Server returned no redirect URL.");
+  }
+
+  return data.url;
+}
+
+function CLIAuthContent(): React.JSX.Element {
+  const searchParams = useSearchParams();
+  const provider = searchParams.get("provider") ?? "github";
+  const port = searchParams.get("port") ?? "";
+  const nonce = searchParams.get("nonce") ?? "";
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!(port && nonce)) {
+      setError("Missing required parameters.");
+      return;
+    }
+
+    // Use the server-side relay as the OAuth callbackURL so that
+    // Better Auth's session cookie (HttpOnly, same domain) can be
+    // read and forwarded to the CLI's local callback server.
+    // The nonce prevents an attacker from constructing a valid relay URL.
+    const relayURL = `${window.location.origin}/api/cli-auth/relay?port=${port}&nonce=${nonce}`;
+    let cancelled = false;
+
+    fetchSignInURL(provider, relayURL)
+      .then((url) => {
+        if (!cancelled) {
+          window.location.href = url;
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : String(err);
+          setError(`Failed to connect: ${message}`);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [provider, port, nonce]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm space-y-6 rounded-lg border border-border bg-card p-8 shadow-sm">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold text-foreground">
+            CLI Authentication
+          </h1>
+          {error ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Redirecting to authentication provider...
+            </p>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default function CLIAuthPage(): React.JSX.Element {
+  return (
+    <Suspense>
+      <CLIAuthContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/cli-auth` page and `/api/cli-auth/relay` API route to support CLI OAuth login
- The `/cli-auth` page POSTs to Better Auth's social sign-in from the same origin, avoiding CORS and Cloudflare Access issues
- The relay reads the HttpOnly session cookie (same domain) and redirects to the CLI's local callback server with the token
- A one-time cryptographic nonce is threaded through the flow to prevent relay URL forgery

## Test plan
- [x] Lint and type-check pass
- [x] Local dev server returns 200 for `/cli-auth` page
- [x] Same-origin POST to `/api/auth/sign-in/social` succeeds (verified locally, "Provider not found" expected without GitHub OAuth creds)
- [ ] Deploy to staging and test full `kh auth login` flow end-to-end