### PR TITLE
feat: fix device authorization flow for CLI auth

### DIFF
--- a/drizzle/0034_device-code-table.sql
+++ b/drizzle/0034_device-code-table.sql
@@ -1,0 +1,133 @@
+-- Device code table for Better Auth device authorization plugin (CLI auth flow)
+CREATE TABLE IF NOT EXISTS "device_code" (
+	"id" text PRIMARY KEY NOT NULL,
+	"device_code" text NOT NULL,
+	"user_code" text NOT NULL,
+	"user_id" text,
+	"expires_at" timestamp NOT NULL,
+	"status" text NOT NULL,
+	"last_polled_at" timestamp,
+	"polling_interval" integer,
+	"client_id" text,
+	"scope" text,
+	"created_at" timestamp,
+	"updated_at" timestamp
+);
+--> statement-breakpoint
+-- Billing tables (previously added via db:push, included here for fresh DB compatibility)
+CREATE TABLE IF NOT EXISTS "billing_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"provider_event_id" text NOT NULL,
+	"type" text NOT NULL,
+	"data" jsonb,
+	"processed" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "billing_events_provider_event_id_unique" UNIQUE("provider_event_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "execution_debt" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"overage_record_id" text NOT NULL,
+	"provider_invoice_id" text,
+	"debt_executions" integer NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"enforced_at" timestamp NOT NULL,
+	"cleared_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "execution_debt_overage_record_id_unique" UNIQUE("overage_record_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "organization_subscriptions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"provider_customer_id" text,
+	"provider_subscription_id" text,
+	"provider_price_id" text,
+	"plan" text DEFAULT 'free' NOT NULL,
+	"tier" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"current_period_start" timestamp,
+	"current_period_end" timestamp,
+	"cancel_at_period_end" boolean DEFAULT false NOT NULL,
+	"billing_alert" text,
+	"billing_alert_url" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_subscriptions_organization_id_unique" UNIQUE("organization_id"),
+	CONSTRAINT "organization_subscriptions_provider_customer_id_unique" UNIQUE("provider_customer_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "overage_billing_records" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"period_start" timestamp NOT NULL,
+	"period_end" timestamp NOT NULL,
+	"execution_limit" integer NOT NULL,
+	"total_executions" integer NOT NULL,
+	"overage_count" integer NOT NULL,
+	"overage_rate_cents" integer NOT NULL,
+	"total_charge_cents" integer NOT NULL,
+	"provider_invoice_item_id" text,
+	"provider_invoice_id" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "overage_billing_org_period" UNIQUE("organization_id","period_start","period_end")
+);
+--> statement-breakpoint
+-- Duration column type changes (previously applied via db:push)
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'workflow_execution_logs' AND column_name = 'duration' AND data_type = 'text'
+  ) THEN
+    ALTER TABLE "workflow_execution_logs" ALTER COLUMN "duration" SET DATA TYPE numeric USING "duration"::numeric;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'workflow_executions' AND column_name = 'duration' AND data_type = 'text'
+  ) THEN
+    ALTER TABLE "workflow_executions" ALTER COLUMN "duration" SET DATA TYPE numeric USING "duration"::numeric;
+  END IF;
+END $$;
+--> statement-breakpoint
+-- Foreign keys (using DO blocks for idempotency)
+DO $$ BEGIN
+  ALTER TABLE "device_code" ADD CONSTRAINT "device_code_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "execution_debt" ADD CONSTRAINT "execution_debt_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "execution_debt" ADD CONSTRAINT "execution_debt_overage_record_id_overage_billing_records_id_fk" FOREIGN KEY ("overage_record_id") REFERENCES "public"."overage_billing_records"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "organization_subscriptions" ADD CONSTRAINT "organization_subscriptions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "overage_billing_records" ADD CONSTRAINT "overage_billing_records_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_execution_debt_org_status" ON "execution_debt" USING btree ("organization_id","status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_execution_debt_invoice" ON "execution_debt" USING btree ("provider_invoice_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_org_subscriptions_org" ON "organization_subscriptions" USING btree ("organization_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_org_subscriptions_provider_sub" ON "organization_subscriptions" USING btree ("provider_subscription_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_overage_billing_org" ON "overage_billing_records" USING btree ("organization_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_overage_billing_status" ON "overage_billing_records" USING btree ("status");

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "51c4602b-a908-4419-9667-9470346b85ea",
-  "prevId": "27c909ed-9aa1-4426-be8e-96290034ed00",
+  "id": "88cfbfb8-f93d-4c14-8eca-b50c3fb0caa4",
+  "prevId": "51c4602b-a908-4419-9667-9470346b85ea",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -311,6 +311,65 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_provider_event_id_unique": {
+          "name": "billing_events_provider_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.chains": {
       "name": "chains",
       "schema": "",
@@ -434,6 +493,105 @@
           ]
         }
       },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_code_user_id_users_id_fk": {
+          "name": "device_code_user_id_users_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -572,6 +730,147 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_debt": {
+      "name": "execution_debt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_record_id": {
+          "name": "overage_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debt_executions": {
+          "name": "debt_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_debt_org_status": {
+          "name": "idx_execution_debt_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_execution_debt_invoice": {
+          "name": "idx_execution_debt_invoice",
+          "columns": [
+            {
+              "expression": "provider_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_debt_organization_id_organization_id_fk": {
+          "name": "execution_debt_organization_id_organization_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "execution_debt_overage_record_id_overage_billing_records_id_fk": {
+          "name": "execution_debt_overage_record_id_overage_billing_records_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "overage_billing_records",
+          "columnsFrom": [
+            "overage_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_debt_overage_record_id_unique": {
+          "name": "execution_debt_overage_record_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "overage_record_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -1189,6 +1488,174 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.organization_subscriptions": {
+      "name": "organization_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_price_id": {
+          "name": "provider_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_alert": {
+          "name": "billing_alert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_alert_url": {
+          "name": "billing_alert_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_subscriptions_org": {
+          "name": "idx_org_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_subscriptions_provider_sub": {
+          "name": "idx_org_subscriptions_provider_sub",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_subscriptions_organization_id_organization_id_fk": {
+          "name": "organization_subscriptions_organization_id_organization_id_fk",
+          "tableFrom": "organization_subscriptions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_subscriptions_organization_id_unique": {
+          "name": "organization_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        },
+        "organization_subscriptions_provider_customer_id_unique": {
+          "name": "organization_subscriptions_provider_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.organization_tokens": {
       "name": "organization_tokens",
       "schema": "",
@@ -1289,6 +1756,154 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overage_billing_records": {
+      "name": "overage_billing_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_limit": {
+          "name": "execution_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_executions": {
+          "name": "total_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_count": {
+          "name": "overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_rate_cents": {
+          "name": "overage_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_charge_cents": {
+          "name": "total_charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_item_id": {
+          "name": "provider_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overage_billing_org": {
+          "name": "idx_overage_billing_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overage_billing_status": {
+          "name": "idx_overage_billing_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overage_billing_records_organization_id_organization_id_fk": {
+          "name": "overage_billing_records_organization_id_organization_id_fk",
+          "tableFrom": "overage_billing_records",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overage_billing_org_period": {
+          "name": "overage_billing_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start",
+            "period_end"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -2337,7 +2952,7 @@
         },
         "duration": {
           "name": "duration",
-          "type": "text",
+          "type": "numeric",
           "primaryKey": false,
           "notNull": false
         },
@@ -2444,7 +3059,7 @@
         },
         "duration": {
           "name": "duration",
-          "type": "text",
+          "type": "numeric",
           "primaryKey": false,
           "notNull": false
         },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1773552000000,
       "tag": "0033_backfill-billing-tables",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1773402305543,
+      "tag": "0034_device-code-table",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub/app/device/page.tsx
+++ b/keeperhub/app/device/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { AuthDialog } from "@/components/auth/dialog";
 
 function SuccessState(): React.JSX.Element {
   return (
@@ -29,6 +30,18 @@ function ErrorState({
         Try Again
       </button>
     </div>
+  );
+}
+
+function LoadingState(): React.JSX.Element {
+  return (
+    <button
+      className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground opacity-50"
+      disabled
+      type="button"
+    >
+      Confirming...
+    </button>
   );
 }
 
@@ -62,13 +75,51 @@ export default function DevicePage(): React.JSX.Element {
 function DevicePageContent(): React.JSX.Element {
   const searchParams = useSearchParams();
   const userCode = searchParams.get("user_code") ?? "";
-  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
   const [errorMessage, setErrorMessage] = useState("");
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    async function checkSession(): Promise<void> {
+      const res = await fetch("/api/auth/get-session", {
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = (await res.json().catch(() => null)) as {
+          session?: unknown;
+          user?: { isAnonymous?: boolean; email?: string };
+        } | null;
+        const hasSession = Boolean(data?.session);
+        const isAnonymous =
+          data?.user?.isAnonymous || data?.user?.email?.startsWith("temp-");
+        setIsAuthenticated(hasSession && !isAnonymous);
+      } else {
+        setIsAuthenticated(false);
+      }
+    }
+    checkSession();
+
+    const onFocus = (): void => {
+      checkSession();
+    };
+    window.addEventListener("focus", onFocus);
+
+    const interval = setInterval(checkSession, 2000);
+
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      clearInterval(interval);
+    };
+  }, []);
 
   const handleConfirm = async (): Promise<void> => {
-    const response = await fetch("/api/auth/device/verify", {
+    setStatus("loading");
+    const response = await fetch("/api/auth/device/approve", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      credentials: "include",
       body: JSON.stringify({ userCode }),
     });
 
@@ -78,13 +129,40 @@ function DevicePageContent(): React.JSX.Element {
     }
 
     const data = (await response.json().catch(() => ({}))) as {
+      error?: string;
+      error_description?: string;
       message?: string;
     };
-    setErrorMessage(data.message ?? "Verification failed. Please try again.");
+    setErrorMessage(
+      data.error_description ?? data.message ?? "Verification failed."
+    );
     setStatus("error");
   };
 
   const renderAction = (): React.JSX.Element => {
+    if (isAuthenticated === null) {
+      return (
+        <button
+          className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground opacity-50"
+          disabled
+          type="button"
+        >
+          Checking session...
+        </button>
+      );
+    }
+    if (isAuthenticated === false) {
+      return (
+        <AuthDialog>
+          <button
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            type="button"
+          >
+            Sign in to authorize
+          </button>
+        </AuthDialog>
+      );
+    }
     if (status === "success") {
       return <SuccessState />;
     }
@@ -93,11 +171,14 @@ function DevicePageContent(): React.JSX.Element {
         <ErrorState message={errorMessage} onRetry={() => setStatus("idle")} />
       );
     }
+    if (status === "loading") {
+      return <LoadingState />;
+    }
     return <IdleState onConfirm={handleConfirm} userCode={userCode} />;
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+    <main className="pointer-events-auto flex min-h-screen flex-col items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm space-y-6 rounded-lg border border-border bg-card p-8 shadow-sm">
         <div className="space-y-1">
           <h1 className="text-xl font-semibold text-foreground">

--- a/keeperhub/app/device/page.tsx
+++ b/keeperhub/app/device/page.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { AuthDialog } from "@/components/auth/dialog";
+import { isAnonymousUser } from "@/keeperhub/lib/is-anonymous";
 
 function SuccessState(): React.JSX.Element {
   return (
@@ -89,12 +90,10 @@ function DevicePageContent(): React.JSX.Element {
       if (res.ok) {
         const data = (await res.json().catch(() => null)) as {
           session?: unknown;
-          user?: { isAnonymous?: boolean; email?: string };
+          user?: { name?: string | null; email?: string | null } | null;
         } | null;
         const hasSession = Boolean(data?.session);
-        const isAnonymous =
-          data?.user?.isAnonymous || data?.user?.email?.startsWith("temp-");
-        setIsAuthenticated(hasSession && !isAnonymous);
+        setIsAuthenticated(hasSession && !isAnonymousUser(data?.user));
       } else {
         setIsAuthenticated(false);
       }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -22,6 +22,7 @@ import { isAiGatewayManagedKeysEnabled } from "./ai-gateway/config";
 import { db } from "./db";
 import {
   accounts,
+  deviceCode,
   integrations,
   invitationRelations,
   invitation as invitationTable,
@@ -84,6 +85,7 @@ const schema = {
   session: sessions,
   account: accounts,
   verification: verifications,
+  deviceCode,
   workflows,
   workflowExecutions,
   workflowExecutionLogs,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -353,6 +353,22 @@ export {
   workflowPublicTags,
 } from "../../keeperhub/db/schema-extensions";
 
+// Better Auth: Device Authorization table (for CLI device flow)
+export const deviceCode = pgTable("device_code", {
+  id: text("id").primaryKey(),
+  deviceCode: text("device_code").notNull(),
+  userCode: text("user_code").notNull(),
+  userId: text("user_id").references(() => users.id),
+  expiresAt: timestamp("expires_at").notNull(),
+  status: text("status").notNull(),
+  lastPolledAt: timestamp("last_polled_at"),
+  pollingInterval: integer("polling_interval"),
+  clientId: text("client_id"),
+  scope: text("scope"),
+  createdAt: timestamp("created_at"),
+  updatedAt: timestamp("updated_at"),
+});
+
 // API Keys table for webhook authentication
 export const apiKeys = pgTable("api_keys", {
   id: text("id")


### PR DESCRIPTION
## Summary
- Adds `device_code` table to Drizzle schema and wires it into Better Auth's `drizzleAdapter` schema map (root cause of 500 on `/api/auth/device/code`)
- Fixes device page (`/device`): calls correct endpoint (`/api/auth/device/approve`), sends cookies, adds `pointer-events-auto` to fix unclickable button under layout's `pointer-events-none` wrapper
- Gates Confirm button on authenticated non-anonymous session; unauthenticated users see AuthDialog sign-in modal
- Polls session every 2s so the page updates after signing in via the dialog
- Fixes drizzle snapshot chain collision (0031 prevId pointed to 0026 instead of 0030)
- Migration 0034 uses `IF NOT EXISTS` / `EXCEPTION WHEN duplicate_object` guards for safe application on both fresh and existing DBs

## Test plan
- [ ] `curl -X POST localhost:3000/api/auth/device/code` returns device code
- [ ] Navigate to `/device?user_code=XXX` while logged in, click Confirm, see success
- [ ] Navigate to `/device?user_code=XXX` while logged out, see "Sign in to authorize" with auth dialog
- [ ] After signing in via dialog, Confirm button appears automatically
- [ ] `pnpm drizzle-kit migrate` applies cleanly on fresh DB