### PR TITLE
fix: KEEP-1564 prevent hub page reload on protocol overlay interaction

### DIFF
--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { HubHero } from "@/keeperhub/components/hub/hub-hero";
 import { HubResults } from "@/keeperhub/components/hub/hub-results";
@@ -20,7 +20,6 @@ export default function HubPage(): React.ReactElement {
 }
 
 function HubPageContent(): React.ReactElement {
-  const router = useRouter();
   const [featuredWorkflows, setFeaturedWorkflows] = useState<SavedWorkflow[]>(
     []
   );
@@ -49,9 +48,9 @@ function HubPageContent(): React.ReactElement {
       setSelectedProtocolSlug(slug);
       const params = new URLSearchParams(searchParams.toString());
       params.set("protocol", slug);
-      router.replace(`/hub?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, "", `/hub?${params.toString()}`);
     },
-    [router, searchParams]
+    [searchParams]
   );
 
   const clearProtocolSelection = useCallback((): void => {
@@ -59,8 +58,8 @@ function HubPageContent(): React.ReactElement {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("protocol");
     const qs = params.toString();
-    router.replace(qs ? `/hub?${qs}` : "/hub", { scroll: false });
-  }, [router, searchParams]);
+    window.history.replaceState(null, "", qs ? `/hub?${qs}` : "/hub");
+  }, [searchParams]);
 
   /** Merge featured + community, featured first, deduplicated */
   const allWorkflows = useMemo((): SavedWorkflow[] => {

--- a/keeperhub/components/hub/protocol-detail-modal.tsx
+++ b/keeperhub/components/hub/protocol-detail-modal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -20,16 +21,52 @@ export function ProtocolDetailModal({
   open,
   onOpenChange,
 }: ProtocolDetailModalProps): React.ReactElement {
+  const [lockedHeight, setLockedHeight] = useState<number | undefined>(
+    undefined
+  );
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const captureHeight = useCallback((): void => {
+    const el = contentRef.current;
+    if (el && lockedHeight === undefined) {
+      const maxAllowed = window.innerHeight * 0.8;
+      setLockedHeight(Math.min(el.scrollHeight, maxAllowed));
+    }
+  }, [lockedHeight]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean): void => {
+      if (!nextOpen) {
+        setLockedHeight(undefined);
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange]
+  );
+
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-h-[80vh] overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-w-4xl">
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent
+        className="overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-w-4xl"
+        ref={contentRef}
+        style={{
+          maxHeight: "80vh",
+          minHeight: lockedHeight ? `${lockedHeight}px` : undefined,
+        }}
+      >
         <DialogTitle className="sr-only">
           {protocol?.name ?? "Protocol Details"}
         </DialogTitle>
         <DialogDescription className="sr-only">
           {protocol?.description ?? "Protocol actions and details"}
         </DialogDescription>
-        {protocol && <ProtocolDetail hideBackButton protocol={protocol} />}
+        {protocol && (
+          <ProtocolDetail
+            hideBackButton
+            onTabChange={captureHeight}
+            protocol={protocol}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/keeperhub/components/hub/protocol-detail.tsx
+++ b/keeperhub/components/hub/protocol-detail.tsx
@@ -319,11 +319,8 @@ export function ProtocolDetail({
 
   const arrowVisibility = useMemo((): string => {
     const count = featuredWorkflows.length;
-    if (count > 4) {
-      return "flex";
-    }
     if (count > 3) {
-      return "flex lg:hidden";
+      return "flex";
     }
     if (count > 2) {
       return "flex md:hidden";

--- a/keeperhub/components/hub/protocol-detail.tsx
+++ b/keeperhub/components/hub/protocol-detail.tsx
@@ -48,6 +48,7 @@ type ProtocolDetailProps = {
   onBack?: () => void;
   hideBackButton?: boolean;
   modalUrl?: string;
+  onTabChange?: () => void;
 };
 
 const TAB_TRIGGER_CLASS =
@@ -299,6 +300,7 @@ export function ProtocolDetail({
   onBack,
   hideBackButton,
   modalUrl,
+  onTabChange,
 }: ProtocolDetailProps): React.ReactElement {
   const router = useRouter();
   const { data: session } = useSession();
@@ -598,7 +600,7 @@ export function ProtocolDetail({
         </div>
       </div>
 
-      <Tabs className="mt-6" defaultValue="actions">
+      <Tabs className="mt-6" defaultValue="actions" onValueChange={onTabChange}>
         <TabsList className="mb-4 h-auto w-full justify-start gap-4 rounded-none border-b border-border/30 bg-transparent p-0">
           <TabsTrigger className={TAB_TRIGGER_CLASS} value="actions">
             Actions ({protocol.actions.length})


### PR DESCRIPTION
## Summary

- Replace `router.replace()` with `window.history.replaceState()` when toggling the protocol query param, preventing Next.js from re-fetching page data and causing a visible reload
- Lock the protocol detail modal `minHeight` on first tab switch so switching between actions/events/workflows tabs does not cause the dialog to resize and jump
- Reset locked height when modal closes so each protocol gets a fresh measurement