### PR TITLE
refactor: KEEP-1564 unify workflow cards across hub and protocol overlay

### DIFF
--- a/keeperhub/components/hub/protocol-detail.tsx
+++ b/keeperhub/components/hub/protocol-detail.tsx
@@ -4,32 +4,17 @@ import {
   ArrowLeft,
   ArrowUpRight,
   Box,
-  ChevronLeft,
-  ChevronRight,
   ExternalLink,
-  Eye,
   Headphones,
 } from "lucide-react";
 import { nanoid } from "nanoid";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { getChainName, getExplorerUrl } from "@/keeperhub/lib/chain-utils";
 import {
   buildEventAbiFragment,
@@ -40,8 +25,7 @@ import {
 import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api, type SavedWorkflow } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
-import { WorkflowMiniMap } from "./workflow-mini-map";
-import { WorkflowNodeIcons } from "./workflow-node-icons";
+import { WorkflowTemplateCard } from "./workflow-template-card";
 
 type ProtocolDetailProps = {
   protocol: ProtocolDefinition;
@@ -53,38 +37,6 @@ type ProtocolDetailProps = {
 
 const TAB_TRIGGER_CLASS =
   "h-auto flex-none border-0 border-b-2 border-transparent rounded-none px-0 pb-2 data-[state=active]:border-b-[var(--color-text-accent)] data-[state=active]:bg-transparent data-[state=active]:shadow-none dark:data-[state=active]:border-b-[var(--color-text-accent)] dark:data-[state=active]:bg-transparent";
-
-type WorkflowNodeShape = {
-  data?: {
-    type?: string;
-    label?: string;
-    config?: { actionType?: string };
-  };
-};
-
-const NON_PROTOCOL_ACTIONS = new Set([
-  "discord/send-message",
-  "sendgrid/send-email",
-]);
-
-function getProtocolActionLabels(nodes: unknown): string[] {
-  const typedNodes = nodes as WorkflowNodeShape[];
-  return typedNodes
-    .filter((node) => {
-      const actionType = node.data?.config?.actionType;
-      return (
-        node.data?.type === "action" &&
-        actionType !== undefined &&
-        actionType.includes("/") &&
-        !NON_PROTOCOL_ACTIONS.has(actionType)
-      );
-    })
-    .map((node) => {
-      const label = node.data?.label ?? "";
-      const colonIndex = label.indexOf(": ");
-      return colonIndex >= 0 ? label.slice(colonIndex + 2) : label;
-    });
-}
 
 function ActionTypeBadge({
   type,
@@ -103,73 +55,6 @@ function ActionTypeBadge({
     <span className="rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5 font-medium text-[var(--color-text-accent)] text-[10px] uppercase tracking-wider">
       WRITE
     </span>
-  );
-}
-
-function WorkflowTemplateCard({
-  workflow,
-  isDuplicating,
-  onDuplicate,
-  onView,
-}: {
-  workflow: SavedWorkflow;
-  isDuplicating: boolean;
-  onDuplicate: () => void;
-  onView: () => void;
-}): React.ReactElement {
-  const actionLabels = getProtocolActionLabels(workflow.nodes);
-
-  return (
-    <Card className="flex w-[260px] shrink-0 flex-col gap-0 overflow-hidden border border-border/30 bg-sidebar py-0">
-      <div className="relative flex h-[130px] w-full items-center justify-center overflow-hidden px-8">
-        <WorkflowMiniMap
-          edges={workflow.edges}
-          height={120}
-          nodes={workflow.nodes}
-          width={220}
-        />
-      </div>
-      <CardHeader className="pt-0 pb-2">
-        <CardTitle className="line-clamp-2">{workflow.name}</CardTitle>
-        {workflow.description && (
-          <CardDescription className="line-clamp-2">
-            {workflow.description}
-          </CardDescription>
-        )}
-        {actionLabels.length > 0 && (
-          <div className="flex flex-wrap gap-1 pt-1">
-            {actionLabels.map((label) => (
-              <span
-                className="rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5 font-medium text-[var(--color-text-accent)] text-[10px]"
-                key={label}
-              >
-                {label}
-              </span>
-            ))}
-          </div>
-        )}
-        <WorkflowNodeIcons nodes={workflow.nodes} />
-      </CardHeader>
-      <div className="flex-1" />
-      <CardFooter className="gap-2 pt-1 pb-3">
-        <Button
-          className="flex-1"
-          disabled={isDuplicating}
-          onClick={onDuplicate}
-          variant="default"
-        >
-          {isDuplicating ? "Duplicating..." : "Use Template"}
-        </Button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button onClick={onView} variant="outline">
-              <Eye className="size-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="top">View Template</TooltipContent>
-        </Tooltip>
-      </CardFooter>
-    </Card>
   );
 }
 
@@ -314,36 +199,7 @@ export function ProtocolDetail({
     []
   );
   const [duplicatingIds, setDuplicatingIds] = useState<Set<string>>(new Set());
-  const scrollRef = useRef<HTMLDivElement>(null);
   const allChains = collectAllChains(protocol.contracts);
-
-  const arrowVisibility = useMemo((): string => {
-    const count = featuredWorkflows.length;
-    if (count > 3) {
-      return "flex";
-    }
-    if (count > 2) {
-      return "flex md:hidden";
-    }
-    if (count > 1) {
-      return "flex sm:hidden";
-    }
-    return "hidden";
-  }, [featuredWorkflows.length]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const container = scrollRef.current;
-    if (!container) {
-      return;
-    }
-    const cardWidth = 260;
-    const gap = 16;
-    const scrollAmount = cardWidth + gap;
-    container.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -644,43 +500,23 @@ export function ProtocolDetail({
 
         <TabsContent value="workflows">
           {featuredWorkflows.length > 0 ? (
-            <>
-              <div className="mb-3 flex items-center justify-between">
-                <h3 className="font-bold text-lg">Automate {protocol.name}</h3>
-                <div className={`gap-2 ${arrowVisibility}`}>
-                  <Button
-                    aria-label="Scroll left"
-                    onClick={() => scroll("left")}
-                    size="icon"
-                    variant="outline"
-                  >
-                    <ChevronLeft className="size-4" />
-                  </Button>
-                  <Button
-                    aria-label="Scroll right"
-                    onClick={() => scroll("right")}
-                    size="icon"
-                    variant="outline"
-                  >
-                    <ChevronRight className="size-4" />
-                  </Button>
-                </div>
-              </div>
-              <div
-                className="flex gap-4 overflow-x-auto scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                ref={scrollRef}
-              >
-                {featuredWorkflows.map((workflow) => (
-                  <WorkflowTemplateCard
-                    isDuplicating={duplicatingIds.has(workflow.id)}
-                    key={workflow.id}
-                    onDuplicate={() => handleDuplicate(workflow.id)}
-                    onView={() => router.push(`/workflows/${workflow.id}`)}
-                    workflow={workflow}
-                  />
-                ))}
-              </div>
-            </>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {featuredWorkflows.map((workflow) => (
+                <WorkflowTemplateCard
+                  isDuplicating={duplicatingIds.has(workflow.id)}
+                  key={workflow.id}
+                  onDuplicate={(e) => {
+                    e.stopPropagation();
+                    handleDuplicate(workflow.id);
+                  }}
+                  onPreview={(e) => {
+                    e.stopPropagation();
+                    router.push(`/workflows/${workflow.id}`);
+                  }}
+                  workflow={workflow}
+                />
+              ))}
+            </div>
           ) : (
             <p className="py-8 text-center text-muted-foreground text-sm">
               No workflows available for this protocol yet.

--- a/keeperhub/components/hub/workflow-template-card.tsx
+++ b/keeperhub/components/hub/workflow-template-card.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Copy, Eye, Star } from "lucide-react";
+import type { MouseEvent } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { SavedWorkflow } from "@/lib/api-client";
+import { WorkflowMiniMap } from "./workflow-mini-map";
+import { WorkflowNodeIcons } from "./workflow-node-icons";
+
+type WorkflowTemplateCardProps = {
+  workflow: SavedWorkflow;
+  isDuplicating: boolean;
+  isFeatured?: boolean;
+  className?: string;
+  onDuplicate: (e: MouseEvent) => void;
+  onPreview: (e: MouseEvent) => void;
+};
+
+export function WorkflowTemplateCard({
+  workflow,
+  isDuplicating,
+  isFeatured = false,
+  className,
+  onDuplicate,
+  onPreview,
+}: WorkflowTemplateCardProps): React.ReactElement {
+  return (
+    <article
+      className={`group relative flex flex-col overflow-hidden rounded-xl border border-border/20 bg-[var(--color-hub-card)] transition-all duration-200 hover:border-border/50 hover:shadow-[0_0_20px_rgba(9,253,103,0.03)] motion-reduce:transition-none ${className ?? "aspect-square"}`}
+    >
+      <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-1/2 opacity-35">
+        <WorkflowMiniMap
+          edges={workflow.edges}
+          height={120}
+          nodes={workflow.nodes}
+          width={200}
+        />
+      </div>
+
+      {isFeatured && (
+        <div className="absolute top-3 right-3 z-10 flex items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5">
+          <Star className="size-2.5 fill-[var(--color-text-accent)] text-[var(--color-text-accent)]" />
+          <span className="font-medium text-[var(--color-text-accent)] text-[10px]">
+            Featured
+          </span>
+        </div>
+      )}
+
+      <div className="flex flex-1 flex-col justify-between p-4">
+        <div className="flex flex-col gap-3">
+          <WorkflowNodeIcons nodes={workflow.nodes} />
+
+          <div>
+            <h3 className="line-clamp-2 font-semibold text-sm leading-snug">
+              {workflow.name}
+            </h3>
+            {workflow.description && (
+              <p className="mt-1.5 line-clamp-4 text-muted-foreground/80 text-xs leading-relaxed">
+                {workflow.description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {workflow.publicTags && workflow.publicTags.length > 0 && (
+          <div className="flex flex-wrap gap-1 pt-3">
+            {workflow.publicTags.slice(0, 3).map((tag) => (
+              <span
+                className="rounded-full bg-[var(--color-hub-icon-bg)] px-2 py-0.5 text-muted-foreground text-[10px]"
+                key={tag.slug}
+              >
+                {tag.name}
+              </span>
+            ))}
+            {workflow.publicTags.length > 3 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="cursor-default rounded-full bg-[var(--color-hub-icon-bg)] px-1.5 py-0.5 text-muted-foreground text-[10px]">
+                    +{workflow.publicTags.length - 3}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="flex flex-col gap-0.5" side="bottom">
+                  {workflow.publicTags.map((tag) => (
+                    <span className="text-xs" key={tag.slug}>
+                      {tag.name}
+                    </span>
+                  ))}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-[var(--color-hub-card)] via-[var(--color-hub-card)]/80 via-30% to-transparent opacity-0 transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100 motion-reduce:transition-none">
+        <div className="flex w-full gap-2 p-4 pt-8">
+          <button
+            className="flex h-8 flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--color-text-accent)] font-medium text-[#0a0f14] text-xs transition-colors hover:bg-[var(--color-text-accent)]/90 disabled:opacity-50"
+            disabled={isDuplicating}
+            onClick={onDuplicate}
+            type="button"
+          >
+            <Copy className="size-3" />
+            {isDuplicating ? "Duplicating..." : "Use Template"}
+          </button>
+          <button
+            className="flex h-8 items-center gap-1.5 rounded-lg border border-border/50 bg-[var(--color-hub-icon-bg)] px-3 text-muted-foreground text-xs transition-colors hover:border-border hover:text-foreground"
+            onClick={onPreview}
+            type="button"
+          >
+            <Eye className="size-3" />
+            Preview
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/keeperhub/components/hub/workflow-template-grid.tsx
+++ b/keeperhub/components/hub/workflow-template-grid.tsx
@@ -1,19 +1,12 @@
 "use client";
 
-import { Copy, Eye, Star } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { type MouseEvent, useState } from "react";
 import { toast } from "sonner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { refetchSidebar } from "@/keeperhub/lib/refetch-sidebar";
 import { api, type SavedWorkflow } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
-import { WorkflowMiniMap } from "./workflow-mini-map";
-import { WorkflowNodeIcons } from "./workflow-node-icons";
+import { WorkflowTemplateCard } from "./workflow-template-card";
 
 type WorkflowTemplateGridProps = {
   workflows: SavedWorkflow[];
@@ -74,108 +67,16 @@ export function WorkflowTemplateGrid({
 
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {workflows.map((workflow) => {
-        const isDuplicating = duplicatingIds.has(workflow.id);
-        const isFeatured = featuredIds?.has(workflow.id) ?? false;
-
-        return (
-          <article
-            className="group relative flex aspect-square flex-col overflow-hidden rounded-xl border border-border/20 bg-[var(--color-hub-card)] transition-all duration-200 hover:border-border/50 hover:shadow-[0_0_20px_rgba(9,253,103,0.03)] motion-reduce:transition-none"
-            key={workflow.id}
-          >
-            {/* Subtle workflow preview */}
-            <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-1/2 opacity-35">
-              <WorkflowMiniMap
-                edges={workflow.edges}
-                height={120}
-                nodes={workflow.nodes}
-                width={200}
-              />
-            </div>
-
-            {isFeatured && (
-              <div className="absolute top-3 right-3 z-10 flex items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5">
-                <Star className="size-2.5 fill-[var(--color-text-accent)] text-[var(--color-text-accent)]" />
-                <span className="font-medium text-[var(--color-text-accent)] text-[10px]">
-                  Featured
-                </span>
-              </div>
-            )}
-
-            <div className="flex flex-1 flex-col justify-between p-4">
-              <div className="flex flex-col gap-3">
-                <WorkflowNodeIcons nodes={workflow.nodes} />
-
-                <div>
-                  <h3 className="line-clamp-2 font-semibold text-sm leading-snug">
-                    {workflow.name}
-                  </h3>
-                  {workflow.description && (
-                    <p className="mt-1.5 line-clamp-4 text-muted-foreground/80 text-xs leading-relaxed">
-                      {workflow.description}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {workflow.publicTags && workflow.publicTags.length > 0 && (
-                <div className="flex flex-wrap gap-1 pt-3">
-                  {workflow.publicTags.slice(0, 3).map((tag) => (
-                    <span
-                      className="rounded-full bg-[var(--color-hub-icon-bg)] px-2 py-0.5 text-muted-foreground text-[10px]"
-                      key={tag.slug}
-                    >
-                      {tag.name}
-                    </span>
-                  ))}
-                  {workflow.publicTags.length > 3 && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="cursor-default rounded-full bg-[var(--color-hub-icon-bg)] px-1.5 py-0.5 text-muted-foreground text-[10px]">
-                          +{workflow.publicTags.length - 3}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent
-                        className="flex flex-col gap-0.5"
-                        side="bottom"
-                      >
-                        {workflow.publicTags.map((tag) => (
-                          <span className="text-xs" key={tag.slug}>
-                            {tag.name}
-                          </span>
-                        ))}
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Hover overlay */}
-            <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-[var(--color-hub-card)] via-[var(--color-hub-card)]/80 via-30% to-transparent opacity-0 transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100 motion-reduce:transition-none">
-              <div className="flex w-full gap-2 p-4 pt-8">
-                <button
-                  className="flex h-8 flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--color-text-accent)] font-medium text-[#0a0f14] text-xs transition-colors hover:bg-[var(--color-text-accent)]/90 disabled:opacity-50"
-                  disabled={isDuplicating}
-                  onClick={(e) => handleDuplicate(e, workflow.id)}
-                  type="button"
-                >
-                  <Copy className="size-3" />
-                  {isDuplicating ? "Duplicating..." : "Use Template"}
-                </button>
-                <button
-                  className="flex h-8 items-center gap-1.5 rounded-lg border border-border/50 bg-[var(--color-hub-icon-bg)] px-3 text-muted-foreground text-xs transition-colors hover:border-border hover:text-foreground"
-                  onClick={(e) => handlePreview(e, workflow.id)}
-                  type="button"
-                >
-                  <Eye className="size-3" />
-                  Preview
-                </button>
-              </div>
-            </div>
-          </article>
-        );
-      })}
+      {workflows.map((workflow) => (
+        <WorkflowTemplateCard
+          isDuplicating={duplicatingIds.has(workflow.id)}
+          isFeatured={featuredIds?.has(workflow.id) ?? false}
+          key={workflow.id}
+          onDuplicate={(e) => handleDuplicate(e, workflow.id)}
+          onPreview={(e) => handlePreview(e, workflow.id)}
+          workflow={workflow}
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Extracted hub-style workflow card into a shared `WorkflowTemplateCard` component
- Protocol overlay workflows tab now uses the same card design as the main hub grid
- Removed old shadcn Card-based `WorkflowTemplateCard` and horizontal scroll layout from protocol detail
- Protocol overlay workflows tab now uses a responsive grid (`1 / 2 / 3 cols`) instead of horizontal scrolling