### PR TITLE
fix: CLI docs returning 404 due to missing middleware route

### DIFF
--- a/docs-site/middleware.ts
+++ b/docs-site/middleware.ts
@@ -6,6 +6,7 @@ const VALID_ROUTES = new Set([
   "",
   "faq",
   "api",
+  "cli",
   "getting-started",
   "intro",
   "keeper-runs",

--- a/docs-site/postcss.config.mjs
+++ b/docs-site/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: {},
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- The middleware route allowlist was not updated when the CLI section was added in #572, so all `/cli/*` pages were rewritten to `/404` before reaching Nextra's page component
- Adds a local `postcss.config.mjs` so the docs-site dev server stops inheriting the root project's Tailwind-based PostCSS config (which requires `@tailwindcss/postcss` the docs-site doesn't have)

## Test Plan
- [ ] Visit `/cli` -- should render CLI overview page
- [ ] Visit `/cli/commands/kh_auth_login` -- should render command reference
- [ ] Visit `/cli/quickstart` and `/cli/concepts` -- should render
- [ ] Run `pnpm dev` inside `docs-site/` -- no `@tailwindcss/postcss` error
- [ ] Existing docs sections (API, Plugins, etc.) still load normally