### PR TITLE
docs: sync CLI reference from manual

### DIFF
--- a/docs/cli/concepts.md
+++ b/docs/cli/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: "Concepts"
-description: "Core concepts for the KeeperHub CLI including authentication, output formats, configuration, and MCP server mode."
+description: "KeeperHub CLI Concepts"
 ---
 
 # Concepts

--- a/docs/cli/quickstart.md
+++ b/docs/cli/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Install the KeeperHub CLI, authenticate, and run your first commands."
+description: "KeeperHub CLI Quickstart"
 ---
 
 # Quickstart


### PR DESCRIPTION
Auto-synced CLI command reference from cli@manual. Changes generated by go generate ./docs/... and copied to docs/cli/.