### PR TITLE
fix: complete ERC-4626 standard and fix stale seed slugs

### DIFF
--- a/.claude/agents/protocol-domain.md
+++ b/.claude/agents/protocol-domain.md
@@ -88,7 +88,7 @@ Supported chains with their numeric string keys:
 ERC-4626 is the tokenized vault standard. Many DeFi protocols implement ERC-4626 for savings/staking vaults (e.g., sUSDS, sDAI). A shared module at `keeperhub/lib/standards/erc4626.ts` provides standardized vault actions.
 
 How to detect ERC-4626 compliance:
-- The contract implements `deposit(uint256,address)`, `withdraw(uint256,address,address)`, `redeem(uint256,address,address)`, `asset()`, `totalAssets()`, `convertToAssets(uint256)`, `convertToShares(uint256)`, `previewDeposit(uint256)`, `previewRedeem(uint256)`, `maxDeposit(address)`, `maxWithdraw(address)`, `balanceOf(address)`, `totalSupply()`
+- The contract implements `deposit(uint256,address)`, `mint(uint256,address)`, `withdraw(uint256,address,address)`, `redeem(uint256,address,address)`, `asset()`, `totalAssets()`, `convertToAssets(uint256)`, `convertToShares(uint256)`, `previewDeposit(uint256)`, `previewMint(uint256)`, `previewWithdraw(uint256)`, `previewRedeem(uint256)`, `maxDeposit(address)`, `maxMint(address)`, `maxWithdraw(address)`, `maxRedeem(address)`, `balanceOf(address)`, `totalSupply()`
 - The protocol documentation or contract source explicitly states ERC-4626 compliance
 - The contract inherits from OpenZeppelin's ERC4626 or a similar implementation
 
@@ -100,15 +100,17 @@ import { erc4626VaultActions } from "@/keeperhub/lib/standards/erc4626";
 export default defineProtocol({
   // ...
   actions: [
-    ...erc4626VaultActions("vaultContractKey"),  // Spread 13 standard vault actions
+    ...erc4626VaultActions("vaultContractKey"),  // Spread 18 standard vault actions
     // Protocol-specific non-vault actions below
   ],
 });
 ```
 
-The `erc4626VaultActions(contract)` function returns 13 `ProtocolAction[]` items:
-- 3 write: vault-deposit, vault-withdraw, vault-redeem
-- 10 read: vault-asset, vault-total-assets, vault-total-supply, vault-balance, vault-convert-to-assets, vault-convert-to-shares, vault-preview-deposit, vault-preview-redeem, vault-max-deposit, vault-max-withdraw
+The `erc4626VaultActions(contract, options?)` function returns 18 `ProtocolAction[]` items:
+- 4 write: vault-deposit, vault-mint, vault-withdraw, vault-redeem
+- 14 read: vault-asset, vault-total-assets, vault-total-supply, vault-balance, vault-convert-to-assets, vault-convert-to-shares, vault-preview-deposit, vault-preview-mint, vault-preview-withdraw, vault-preview-redeem, vault-max-deposit, vault-max-mint, vault-max-withdraw, vault-max-redeem
+
+Options: `{ slugPrefix?, labelPrefix?, decimals? }`. Use `decimals` for non-18-decimal vaults (e.g., USDC = 6).
 
 All slugs are prefixed with `vault-` to avoid collisions with protocol-specific actions.
 

--- a/keeperhub/lib/standards/erc4626.ts
+++ b/keeperhub/lib/standards/erc4626.ts
@@ -1,23 +1,28 @@
 import type { ProtocolAction } from "@/keeperhub/lib/protocol-registry";
 
 /**
- * Returns the 13 standard ERC-4626 vault actions for a given contract key.
+ * Returns the 18 standard ERC-4626 vault actions for a given contract key.
  * Use this in protocol definitions to avoid duplicating vault action boilerplate.
  *
- * 3 write actions: deposit, withdraw, redeem
- * 10 read actions: asset, totalAssets, totalSupply, balanceOf, convertToAssets,
- *   convertToShares, previewDeposit, previewRedeem, maxDeposit, maxWithdraw
+ * 4 write actions: deposit, mint, withdraw, redeem
+ * 14 read actions: asset, totalAssets, totalSupply, balanceOf, convertToAssets,
+ *   convertToShares, previewDeposit, previewMint, previewWithdraw, previewRedeem,
+ *   maxDeposit, maxMint, maxWithdraw, maxRedeem
  *
  * When a protocol has multiple ERC-4626 vaults, pass a slugPrefix to
  * disambiguate (e.g., "st-usds" produces "st-usds-vault-deposit").
  * The default (no prefix) produces "vault-deposit" for backwards compatibility.
+ *
+ * Pass `decimals` to override the default of 18 for vaults wrapping non-18-decimal
+ * assets (e.g., USDC = 6, WBTC = 8).
  */
 export function erc4626VaultActions(
   contract: string,
-  options?: { slugPrefix?: string; labelPrefix?: string }
+  options?: { slugPrefix?: string; labelPrefix?: string; decimals?: number }
 ): ProtocolAction[] {
   const p = options?.slugPrefix ? `${options.slugPrefix}-` : "";
   const lp = options?.labelPrefix ? `${options.labelPrefix} ` : "";
+  const d = options?.decimals ?? 18;
 
   return [
     // Write actions
@@ -31,6 +36,19 @@ export function erc4626VaultActions(
       function: "deposit",
       inputs: [
         { name: "assets", type: "uint256", label: "Asset Amount (wei)" },
+        { name: "receiver", type: "address", label: "Receiver Address" },
+      ],
+    },
+    {
+      slug: `${p}vault-mint`,
+      label: `${lp}Vault Mint`,
+      description:
+        "Mint exact vault shares by depositing the required amount of assets",
+      type: "write",
+      contract,
+      function: "mint",
+      inputs: [
+        { name: "shares", type: "uint256", label: "Shares Amount (wei)" },
         { name: "receiver", type: "address", label: "Receiver Address" },
       ],
     },
@@ -92,7 +110,7 @@ export function erc4626VaultActions(
           name: "totalAssets",
           type: "uint256",
           label: "Total Assets (wei)",
-          decimals: 18,
+          decimals: d,
         },
       ],
     },
@@ -109,7 +127,7 @@ export function erc4626VaultActions(
           name: "totalSupply",
           type: "uint256",
           label: "Total Shares (wei)",
-          decimals: 18,
+          decimals: d,
         },
       ],
     },
@@ -126,7 +144,7 @@ export function erc4626VaultActions(
           name: "balance",
           type: "uint256",
           label: "Share Balance (wei)",
-          decimals: 18,
+          decimals: d,
         },
       ],
     },
@@ -146,7 +164,7 @@ export function erc4626VaultActions(
           name: "assets",
           type: "uint256",
           label: "Asset Value (wei)",
-          decimals: 18,
+          decimals: d,
         },
       ],
     },
@@ -166,7 +184,7 @@ export function erc4626VaultActions(
           name: "shares",
           type: "uint256",
           label: "Shares Amount (wei)",
-          decimals: 18,
+          decimals: d,
         },
       ],
     },
@@ -185,7 +203,47 @@ export function erc4626VaultActions(
           name: "shares",
           type: "uint256",
           label: "Shares Received (wei)",
-          decimals: 18,
+          decimals: d,
+        },
+      ],
+    },
+    {
+      slug: `${p}vault-preview-mint`,
+      label: `${lp}Preview Vault Mint`,
+      description:
+        "Preview how many assets are needed to mint a given number of shares",
+      type: "read",
+      contract,
+      function: "previewMint",
+      inputs: [
+        { name: "shares", type: "uint256", label: "Shares Amount (wei)" },
+      ],
+      outputs: [
+        {
+          name: "assets",
+          type: "uint256",
+          label: "Assets Required (wei)",
+          decimals: d,
+        },
+      ],
+    },
+    {
+      slug: `${p}vault-preview-withdraw`,
+      label: `${lp}Preview Vault Withdraw`,
+      description:
+        "Preview how many shares must be burned to withdraw a given asset amount",
+      type: "read",
+      contract,
+      function: "previewWithdraw",
+      inputs: [
+        { name: "assets", type: "uint256", label: "Asset Amount (wei)" },
+      ],
+      outputs: [
+        {
+          name: "shares",
+          type: "uint256",
+          label: "Shares Burned (wei)",
+          decimals: d,
         },
       ],
     },
@@ -205,7 +263,7 @@ export function erc4626VaultActions(
           name: "assets",
           type: "uint256",
           label: "Assets Received (wei)",
-          decimals: 18,
+          decimals: d,
         },
       ],
     },
@@ -225,7 +283,27 @@ export function erc4626VaultActions(
           name: "maxAssets",
           type: "uint256",
           label: "Max Deposit (wei)",
-          decimals: 18,
+          decimals: d,
+        },
+      ],
+    },
+    {
+      slug: `${p}vault-max-mint`,
+      label: `${lp}Max Vault Mint`,
+      description:
+        "Get the maximum number of shares that can be minted for a receiver",
+      type: "read",
+      contract,
+      function: "maxMint",
+      inputs: [
+        { name: "receiver", type: "address", label: "Receiver Address" },
+      ],
+      outputs: [
+        {
+          name: "maxShares",
+          type: "uint256",
+          label: "Max Mint (wei)",
+          decimals: d,
         },
       ],
     },
@@ -243,7 +321,25 @@ export function erc4626VaultActions(
           name: "maxAssets",
           type: "uint256",
           label: "Max Withdraw (wei)",
-          decimals: 18,
+          decimals: d,
+        },
+      ],
+    },
+    {
+      slug: `${p}vault-max-redeem`,
+      label: `${lp}Max Vault Redeem`,
+      description:
+        "Get the maximum number of shares that can be redeemed by an owner",
+      type: "read",
+      contract,
+      function: "maxRedeem",
+      inputs: [{ name: "owner", type: "address", label: "Owner Address" }],
+      outputs: [
+        {
+          name: "maxShares",
+          type: "uint256",
+          label: "Max Redeem (wei)",
+          decimals: d,
         },
       ],
     },

--- a/scripts/seed/workflows/sky/read-actions.json
+++ b/scripts/seed/workflows/sky/read-actions.json
@@ -18,7 +18,7 @@
       }
     },
     {
-      "id": "sky-susds-balance",
+      "id": "sky-vault-balance",
       "type": "action",
       "position": { "x": 450, "y": 0 },
       "data": {
@@ -26,7 +26,7 @@
         "description": "Check sUSDS balance of a known holder",
         "type": "action",
         "config": {
-          "actionType": "sky/get-susds-balance",
+          "actionType": "sky/vault-balance",
           "network": "1",
           "account": "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD"
         },
@@ -34,7 +34,7 @@
       }
     },
     {
-      "id": "sky-preview-deposit",
+      "id": "sky-vault-preview-deposit",
       "type": "action",
       "position": { "x": 450, "y": 150 },
       "data": {
@@ -42,7 +42,7 @@
         "description": "Preview sUSDS shares for depositing 1 USDS",
         "type": "action",
         "config": {
-          "actionType": "sky/preview-deposit",
+          "actionType": "sky/vault-preview-deposit",
           "network": "1",
           "assets": "1000000000000000000"
         },
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "sky-susds-value",
+      "id": "sky-vault-convert-to-assets",
       "type": "action",
       "position": { "x": 450, "y": 300 },
       "data": {
@@ -58,7 +58,7 @@
         "description": "Convert 1 sUSDS share to USDS asset value",
         "type": "action",
         "config": {
-          "actionType": "sky/get-susds-value",
+          "actionType": "sky/vault-convert-to-assets",
           "network": "1",
           "shares": "1000000000000000000"
         },
@@ -116,21 +116,21 @@
   ],
   "edges": [
     {
-      "id": "e-trigger-to-sky-susds-balance",
+      "id": "e-trigger-to-sky-vault-balance",
       "source": "node-1",
-      "target": "sky-susds-balance",
+      "target": "sky-vault-balance",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-sky-preview-deposit",
+      "id": "e-trigger-to-sky-vault-preview-deposit",
       "source": "node-1",
-      "target": "sky-preview-deposit",
+      "target": "sky-vault-preview-deposit",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-sky-susds-value",
+      "id": "e-trigger-to-sky-vault-convert-to-assets",
       "source": "node-1",
-      "target": "sky-susds-value",
+      "target": "sky-vault-convert-to-assets",
       "type": "animated"
     },
     {

--- a/scripts/seed/workflows/sky/write-actions.json
+++ b/scripts/seed/workflows/sky/write-actions.json
@@ -18,15 +18,15 @@
       }
     },
     {
-      "id": "sky-deposit-ssr",
+      "id": "sky-vault-deposit",
       "type": "action",
       "position": { "x": 450, "y": 0 },
       "data": {
-        "label": "Deposit SSR",
+        "label": "Vault Deposit",
         "description": "Deposit USDS into sUSDS vault",
         "type": "action",
         "config": {
-          "actionType": "sky/deposit-ssr",
+          "actionType": "sky/vault-deposit",
           "network": "1",
           "assets": "1000000000000000000",
           "receiver": "0x0000000000000000000000000000000000000001"
@@ -35,15 +35,15 @@
       }
     },
     {
-      "id": "sky-withdraw-ssr",
+      "id": "sky-vault-withdraw",
       "type": "action",
       "position": { "x": 450, "y": 150 },
       "data": {
-        "label": "Withdraw SSR",
+        "label": "Vault Withdraw",
         "description": "Withdraw USDS from sUSDS vault",
         "type": "action",
         "config": {
-          "actionType": "sky/withdraw-ssr",
+          "actionType": "sky/vault-withdraw",
           "network": "1",
           "assets": "1000000000000000000",
           "receiver": "0x0000000000000000000000000000000000000001",
@@ -53,15 +53,15 @@
       }
     },
     {
-      "id": "sky-redeem-ssr",
+      "id": "sky-vault-redeem",
       "type": "action",
       "position": { "x": 450, "y": 300 },
       "data": {
-        "label": "Redeem SSR",
+        "label": "Vault Redeem",
         "description": "Redeem sUSDS shares for USDS",
         "type": "action",
         "config": {
-          "actionType": "sky/redeem-ssr",
+          "actionType": "sky/vault-redeem",
           "network": "1",
           "shares": "1000000000000000000",
           "receiver": "0x0000000000000000000000000000000000000001",
@@ -158,21 +158,21 @@
   ],
   "edges": [
     {
-      "id": "e-trigger-to-sky-deposit-ssr",
+      "id": "e-trigger-to-sky-vault-deposit",
       "source": "node-1",
-      "target": "sky-deposit-ssr",
+      "target": "sky-vault-deposit",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-sky-withdraw-ssr",
+      "id": "e-trigger-to-sky-vault-withdraw",
       "source": "node-1",
-      "target": "sky-withdraw-ssr",
+      "target": "sky-vault-withdraw",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-sky-redeem-ssr",
+      "id": "e-trigger-to-sky-vault-redeem",
       "source": "node-1",
-      "target": "sky-redeem-ssr",
+      "target": "sky-vault-redeem",
       "type": "animated"
     },
     {

--- a/scripts/seed/workflows/spark/read-actions.json
+++ b/scripts/seed/workflows/spark/read-actions.json
@@ -51,7 +51,7 @@
       }
     },
     {
-      "id": "spark-sdai-balance",
+      "id": "spark-vault-balance",
       "type": "action",
       "position": { "x": 450, "y": 300 },
       "data": {
@@ -59,7 +59,7 @@
         "description": "Check sDAI balance of the sDAI contract",
         "type": "action",
         "config": {
-          "actionType": "spark/get-sdai-balance",
+          "actionType": "spark/vault-balance",
           "network": "1",
           "account": "0x83F20F44975D03b1b09e64809B757c47f942BEeA"
         },
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "spark-sdai-total-assets",
+      "id": "spark-vault-total-assets",
       "type": "action",
       "position": { "x": 450, "y": 450 },
       "data": {
@@ -75,14 +75,14 @@
         "description": "Fetch total DAI assets held by sDAI vault",
         "type": "action",
         "config": {
-          "actionType": "spark/get-sdai-total-assets",
+          "actionType": "spark/vault-total-assets",
           "network": "1"
         },
         "status": "idle"
       }
     },
     {
-      "id": "spark-sdai-convert-to-assets",
+      "id": "spark-vault-convert-to-assets",
       "type": "action",
       "position": { "x": 450, "y": 600 },
       "data": {
@@ -90,7 +90,7 @@
         "description": "Convert 1 sDAI share to DAI asset value",
         "type": "action",
         "config": {
-          "actionType": "spark/get-sdai-convert-to-assets",
+          "actionType": "spark/vault-convert-to-assets",
           "network": "1",
           "shares": "1000000000000000000"
         },
@@ -112,21 +112,21 @@
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-spark-sdai-balance",
+      "id": "e-trigger-to-spark-vault-balance",
       "source": "node-1",
-      "target": "spark-sdai-balance",
+      "target": "spark-vault-balance",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-spark-sdai-total-assets",
+      "id": "e-trigger-to-spark-vault-total-assets",
       "source": "node-1",
-      "target": "spark-sdai-total-assets",
+      "target": "spark-vault-total-assets",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-spark-sdai-convert-to-assets",
+      "id": "e-trigger-to-spark-vault-convert-to-assets",
       "source": "node-1",
-      "target": "spark-sdai-convert-to-assets",
+      "target": "spark-vault-convert-to-assets",
       "type": "animated"
     }
   ]

--- a/scripts/seed/workflows/spark/write-actions.json
+++ b/scripts/seed/workflows/spark/write-actions.json
@@ -111,15 +111,15 @@
       }
     },
     {
-      "id": "spark-deposit-sdai",
+      "id": "spark-vault-deposit",
       "type": "action",
       "position": { "x": 450, "y": 750 },
       "data": {
-        "label": "Deposit sDAI",
+        "label": "Vault Deposit",
         "description": "Deposit DAI into sDAI vault",
         "type": "action",
         "config": {
-          "actionType": "spark/deposit-sdai",
+          "actionType": "spark/vault-deposit",
           "network": "1",
           "assets": "1000000000000000000",
           "receiver": "0x0000000000000000000000000000000000000001"
@@ -128,15 +128,15 @@
       }
     },
     {
-      "id": "spark-redeem-sdai",
+      "id": "spark-vault-redeem",
       "type": "action",
       "position": { "x": 450, "y": 900 },
       "data": {
-        "label": "Redeem sDAI",
+        "label": "Vault Redeem",
         "description": "Redeem sDAI shares for DAI",
         "type": "action",
         "config": {
-          "actionType": "spark/redeem-sdai",
+          "actionType": "spark/vault-redeem",
           "network": "1",
           "shares": "1000000000000000000",
           "receiver": "0x0000000000000000000000000000000000000001",
@@ -178,15 +178,15 @@
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-spark-deposit-sdai",
+      "id": "e-trigger-to-spark-vault-deposit",
       "source": "node-1",
-      "target": "spark-deposit-sdai",
+      "target": "spark-vault-deposit",
       "type": "animated"
     },
     {
-      "id": "e-trigger-to-spark-redeem-sdai",
+      "id": "e-trigger-to-spark-vault-redeem",
       "source": "node-1",
-      "target": "spark-redeem-sdai",
+      "target": "spark-vault-redeem",
       "type": "animated"
     }
   ]

--- a/tests/unit/protocol-sky.test.ts
+++ b/tests/unit/protocol-sky.test.ts
@@ -79,8 +79,8 @@ describe("Sky Protocol Definition", () => {
     }
   });
 
-  it("has exactly 34 actions", () => {
-    expect(skyDef.actions).toHaveLength(34);
+  it("has exactly 44 actions", () => {
+    expect(skyDef.actions).toHaveLength(44);
   });
 
   it("registers in the protocol registry and is retrievable", () => {
@@ -91,11 +91,11 @@ describe("Sky Protocol Definition", () => {
     expect(retrieved?.name).toBe("Sky");
   });
 
-  it("has 23 read actions and 11 write actions", () => {
+  it("has 31 read actions and 13 write actions", () => {
     const readActions = skyDef.actions.filter((a) => a.type === "read");
     const writeActions = skyDef.actions.filter((a) => a.type === "write");
-    expect(readActions).toHaveLength(23);
-    expect(writeActions).toHaveLength(11);
+    expect(readActions).toHaveLength(31);
+    expect(writeActions).toHaveLength(13);
   });
 
   it("has 7 contracts", () => {

--- a/tests/unit/protocol-spark.test.ts
+++ b/tests/unit/protocol-spark.test.ts
@@ -77,15 +77,15 @@ describe("Spark Protocol Definition", () => {
     }
   });
 
-  it("has exactly 20 actions", () => {
-    expect(sparkDef.actions).toHaveLength(20);
+  it("has exactly 25 actions", () => {
+    expect(sparkDef.actions).toHaveLength(25);
   });
 
-  it("has 8 write actions and 12 read actions", () => {
+  it("has 9 write actions and 16 read actions", () => {
     const readActions = sparkDef.actions.filter((a) => a.type === "read");
     const writeActions = sparkDef.actions.filter((a) => a.type === "write");
-    expect(writeActions).toHaveLength(8);
-    expect(readActions).toHaveLength(12);
+    expect(writeActions).toHaveLength(9);
+    expect(readActions).toHaveLength(16);
   });
 
   it("has 3 contracts", () => {


### PR DESCRIPTION
## Summary

- Complete ERC-4626 vault standard coverage: add missing `mint` write action and 4 missing read actions (`previewMint`, `previewWithdraw`, `maxMint`, `maxRedeem`) -- 13 to 18 actions per vault
- Add `decimals` option to `erc4626VaultActions()` for non-18-decimal vault assets (e.g. USDC = 6, WBTC = 8)
- Fix all seed workflow JSONs that still referenced pre-refactor slugs (`deposit-ssr`, `get-susds-balance`, `deposit-sdai`, etc.)
- Update Sky and Spark protocol tests for new action counts

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm vitest run tests/unit/protocol-sky.test.ts tests/unit/protocol-spark.test.ts` -- 33/33 pass