### PR TITLE
fix: add API key auth to execution status/logs and guard workflow delete

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -4,7 +4,7 @@ import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
-import { projects, publicTags, tags, workflowPublicTags, workflows } from "@/lib/db/schema";
+import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflows } from "@/lib/db/schema";
 import { syncWorkflowSchedule } from "@/lib/schedule-service";
 async function fetchWorkflowPublicTags(
   workflowId: string
@@ -375,6 +375,23 @@ export async function DELETE(
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
+      );
+    }
+
+    // Check for existing executions before deleting
+    const executions = await db.query.workflowExecutions.findMany({
+      where: eq(workflowExecutions.workflowId, workflowId),
+      columns: { id: true },
+      limit: 1,
+    });
+
+    if (executions.length > 0) {
+      return NextResponse.json(
+        {
+          error:
+            "Workflow has execution history. Delete executions first before deleting the workflow.",
+        },
+        { status: 409 }
       );
     }
 

--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -1,7 +1,6 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-import { auth } from "@/lib/auth";
+import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { redactSensitiveData } from "@/lib/utils/redact";
@@ -12,13 +11,15 @@ export async function GET(
 ) {
   try {
     const { executionId } = await context.params;
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
 
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
     }
+    const { userId, organizationId } = authContext;
 
     // Get the execution and verify ownership
     const execution = await db.query.workflowExecutions.findFirst({
@@ -36,12 +37,11 @@ export async function GET(
     }
 
     // Verify access: owner or org member
-    const isOwner = execution.workflow.userId === session.user.id;
-    const orgContext = await getOrgContext();
+    const isOwner = userId !== null && execution.workflow.userId === userId;
     const isSameOrg =
       !execution.workflow.isAnonymous &&
       execution.workflow.organizationId &&
-      orgContext.organization?.id === execution.workflow.organizationId;
+      organizationId === execution.workflow.organizationId;
 
     if (!(isOwner || isSameOrg)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -3,8 +3,7 @@ import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/keeperhub/lib/logging";
 import { createTimer } from "@/keeperhub/lib/metrics";
 import { recordStatusPollMetrics } from "@/keeperhub/lib/metrics/instrumentation/api";
-import { getOrgContext } from "@/keeperhub/lib/middleware/org-context";
-import { auth } from "@/lib/auth";
+import { getDualAuthContext } from "@/keeperhub/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 
@@ -21,18 +20,20 @@ export async function GET(
 
   try {
     const { executionId } = await context.params;
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
 
-    if (!session?.user) {
+    const authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),
-        statusCode: 401,
+        statusCode: authContext.status,
       });
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
     }
+    const { userId, organizationId } = authContext;
 
     // Get the execution and verify ownership
     const execution = await db.query.workflowExecutions.findFirst({
@@ -55,12 +56,11 @@ export async function GET(
     }
 
     // Verify access: owner or org member
-    const isOwner = execution.workflow.userId === session.user.id;
-    const orgContext = await getOrgContext();
+    const isOwner = userId !== null && execution.workflow.userId === userId;
     const isSameOrg =
       !execution.workflow.isAnonymous &&
       execution.workflow.organizationId &&
-      orgContext.organization?.id === execution.workflow.organizationId;
+      organizationId === execution.workflow.organizationId;
 
     if (!(isOwner || isSameOrg)) {
       recordStatusPollMetrics({


### PR DESCRIPTION
## Summary
- Execution status and logs API routes only supported session-based auth, returning 401 for MCP server and CLI requests using API keys. Both routes now use `getDualAuthContext` to support API key + session auth.
- Workflow DELETE crashed with a 500 FK constraint error when the workflow had execution history. Now checks for executions first and returns a 409 with a clear message matching the CLI behavior.

## Changes
- `app/api/workflows/executions/[executionId]/status/route.ts` -- replace `auth.api.getSession` with `getDualAuthContext`
- `app/api/workflows/executions/[executionId]/logs/route.ts` -- same
- `app/api/workflows/[workflowId]/route.ts` -- add execution history check before delete, return 409

## Test plan
- [x] `execution_status` returns data via API key on dev (was 401 before fix)
- [x] `execution_logs` returns data via API key on dev (was 401 before fix)
- [x] `workflow_delete` returns 409 message for workflows with runs
- [x] `workflow_delete` succeeds for workflows without runs
- [x] All CLI commands tested across dev/staging/prod (list, create, get, update, delete, run, status, logs)
- [x] Lint and type-check pass