### PR TITLE
feat: add MetaMorpho vault actions to Morpho protocol

### DIFF
--- a/keeperhub/protocols/morpho.ts
+++ b/keeperhub/protocols/morpho.ts
@@ -1,4 +1,5 @@
 import { defineProtocol } from "@/keeperhub/lib/protocol-registry";
+import { erc4626VaultActions } from "@/keeperhub/lib/standards/erc4626";
 
 export default defineProtocol({
   name: "Morpho",
@@ -21,9 +22,18 @@ export default defineProtocol({
       },
       // ABI omitted -- resolved automatically via abi-cache
     },
+    vault: {
+      label: "MetaMorpho Vault",
+      addresses: {},
+      userSpecifiedAddress: true,
+    },
   },
 
   actions: [
+    // MetaMorpho ERC-4626 vault actions (user-specified vault address)
+    ...erc4626VaultActions("vault"),
+
+    // Morpho Blue lending market actions
     {
       slug: "get-position",
       label: "Get Position",

--- a/tests/unit/protocol-morpho.test.ts
+++ b/tests/unit/protocol-morpho.test.ts
@@ -81,19 +81,19 @@ describe("Morpho Protocol Definition", () => {
     }
   });
 
-  it("has exactly 27 actions", () => {
-    expect(morphoDef.actions).toHaveLength(27);
+  it("has exactly 32 actions", () => {
+    expect(morphoDef.actions).toHaveLength(32);
   });
 
   it("has 2 contracts", () => {
     expect(Object.keys(morphoDef.contracts)).toHaveLength(2);
   });
 
-  it("has 14 read actions and 13 write actions", () => {
+  it("has 18 read actions and 14 write actions", () => {
     const readActions = morphoDef.actions.filter((a) => a.type === "read");
     const writeActions = morphoDef.actions.filter((a) => a.type === "write");
-    expect(readActions).toHaveLength(14);
-    expect(writeActions).toHaveLength(13);
+    expect(readActions).toHaveLength(18);
+    expect(writeActions).toHaveLength(14);
   });
 
   it("all MarketParams actions include the 5 struct fields as flat inputs", () => {

--- a/tests/unit/protocol-morpho.test.ts
+++ b/tests/unit/protocol-morpho.test.ts
@@ -68,30 +68,32 @@ describe("Morpho Protocol Definition", () => {
     }
   });
 
-  it("each action's contract has at least one chain address", () => {
+  it("each action's contract has at least one chain address or is user-specified", () => {
     for (const action of morphoDef.actions) {
       const contract = morphoDef.contracts[action.contract];
       expect(contract).toBeDefined();
-      expect(
-        Object.keys(contract.addresses).length,
-        `contract "${action.contract}" for action "${action.slug}" must have at least one chain`
-      ).toBeGreaterThan(0);
+      if (!contract.userSpecifiedAddress) {
+        expect(
+          Object.keys(contract.addresses).length,
+          `contract "${action.contract}" for action "${action.slug}" must have at least one chain`
+        ).toBeGreaterThan(0);
+      }
     }
   });
 
-  it("has exactly 14 actions", () => {
-    expect(morphoDef.actions).toHaveLength(14);
+  it("has exactly 27 actions", () => {
+    expect(morphoDef.actions).toHaveLength(27);
   });
 
-  it("has 1 contract", () => {
-    expect(Object.keys(morphoDef.contracts)).toHaveLength(1);
+  it("has 2 contracts", () => {
+    expect(Object.keys(morphoDef.contracts)).toHaveLength(2);
   });
 
-  it("has 4 read actions and 10 write actions", () => {
+  it("has 14 read actions and 13 write actions", () => {
     const readActions = morphoDef.actions.filter((a) => a.type === "read");
     const writeActions = morphoDef.actions.filter((a) => a.type === "write");
-    expect(readActions).toHaveLength(4);
-    expect(writeActions).toHaveLength(10);
+    expect(readActions).toHaveLength(14);
+    expect(writeActions).toHaveLength(13);
   });
 
   it("all MarketParams actions include the 5 struct fields as flat inputs", () => {


### PR DESCRIPTION
## Summary

- Adds 13 MetaMorpho ERC-4626 vault actions (10 read, 3 write) to existing `morpho.ts`
- Uses `erc4626VaultActions("vault")` with `userSpecifiedAddress: true` since MetaMorpho vaults are deployed by many curators (Steakhouse, Gauntlet, Re7)
- Keeps Morpho Blue lending and MetaMorpho vaults under one "Morpho" protocol entry

Replaces #577 which incorrectly created a separate `metamorpho.ts` protocol file.

## Changes

- `keeperhub/protocols/morpho.ts` -- Added vault contract + ERC-4626 actions
- `tests/unit/protocol-morpho.test.ts` -- Updated assertions (27 actions, 2 contracts, 14 read / 13 write)

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm type-check` passes
- [x] Morpho protocol tests pass (14/14)
- [ ] Verify vault actions appear in MCP schemas
- [ ] Test vault read actions via MCP (e.g., morpho/vault-total-assets with Steakhouse USDC vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB)