### PR TITLE
fix: pass ethValue to writeContractCore in direct execution route

### DIFF
--- a/keeperhub/api/execute/[...slug]/route.ts
+++ b/keeperhub/api/execute/[...slug]/route.ts
@@ -141,12 +141,14 @@ async function executeProtocolAction(
     return NextResponse.json(result);
   }
 
+  const ethValue = body.ethValue ? String(body.ethValue) : undefined;
   const coreInput: WriteContractCoreInput = {
     contractAddress,
     network,
     abi: resolvedAbi,
     abiFunction: meta.functionName,
     functionArgs,
+    ethValue,
     _context: { organizationId },
   };
   const result = await writeContractCore(coreInput);


### PR DESCRIPTION
## Summary
- The `/api/execute/[...slug]` route was not forwarding `body.ethValue` to `writeContractCore`, causing all payable protocol transactions (e.g. WETH wrap) executed via MCP direct execution to send 0 ETH
- Adds `ethValue` extraction from the request body and passes it to `WriteContractCoreInput`

## Test plan
- [ ] Deploy to staging PR environment
- [ ] Execute `weth/wrap` via MCP staging tools with `ethValue: "0.001"` on Sepolia
- [ ] Verify the on-chain transaction sends the correct ETH amount (not 0)
- [ ] Execute `weth/unwrap` to confirm non-payable write actions still work