### PR TITLE
fix: add inline ABI for stETH contract in Lido protocol

### DIFF
--- a/keeperhub/protocols/lido.ts
+++ b/keeperhub/protocols/lido.ts
@@ -29,7 +29,26 @@ export default defineProtocol({
         // Sepolia Testnet
         "11155111": "0x3e3FE7dBc6B4C189E7128855dD526361c49b40Af",
       },
-      // Proxy -- ABI auto-resolved via abi-cache
+      // Inline ABI -- Lido's AppProxy ABI auto-resolution doesn't include ERC20 functions
+      abi: JSON.stringify([
+        {
+          type: "function",
+          name: "balanceOf",
+          stateMutability: "view",
+          inputs: [{ name: "_account", type: "address" }],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "approve",
+          stateMutability: "nonpayable",
+          inputs: [
+            { name: "_spender", type: "address" },
+            { name: "_amount", type: "uint256" },
+          ],
+          outputs: [{ name: "", type: "bool" }],
+        },
+      ]),
     },
   },
 


### PR DESCRIPTION
## Summary
- Lido's stETH contract uses an AppProxy pattern where ABI auto-resolution doesn't include ERC20 functions
- The `lido/get-steth-balance` and `lido/approve-steth` actions fail with "Function not found in ABI"
- Adds inline ABI with `balanceOf` and `approve` to the stETH contract definition

## Test plan
- [ ] Deploy to staging
- [ ] Execute Lido read actions workflow -- `get-steth-balance` should now pass
- [ ] All other Lido read actions remain passing