### PR TITLE
fix: add inline ABI for WETH contract on L2 chains

### DIFF
--- a/keeperhub/protocols/weth.ts
+++ b/keeperhub/protocols/weth.ts
@@ -23,7 +23,37 @@ export default defineProtocol({
         // Sepolia Testnet
         "11155111": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
       },
-      // ABI omitted -- resolved automatically via abi-cache
+      // Inline ABI -- Base and Optimism L2 precompile addresses aren't verified on block explorers
+      abi: JSON.stringify([
+        {
+          type: "function",
+          name: "deposit",
+          stateMutability: "payable",
+          inputs: [],
+          outputs: [],
+        },
+        {
+          type: "function",
+          name: "withdraw",
+          stateMutability: "nonpayable",
+          inputs: [{ name: "wad", type: "uint256" }],
+          outputs: [],
+        },
+        {
+          type: "function",
+          name: "balanceOf",
+          stateMutability: "view",
+          inputs: [{ name: "", type: "address" }],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "totalSupply",
+          stateMutability: "view",
+          inputs: [],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+      ]),
     },
   },
 


### PR DESCRIPTION
## Summary
- Base and Optimism use L2 precompile WETH addresses (`0x4200...0006`) that aren't verified on block explorers
- ABI auto-resolution fails, causing WETH wrap/unwrap/balance actions to silently fail on these chains
- Adds inline ABI with `deposit`, `withdraw`, `balanceOf`, and `totalSupply` functions
- Also fixes mainnet WETH (inline ABI is faster than auto-fetch)

## Test plan
- [ ] Deploy to staging
- [ ] Execute WETH wrap on Base (chain 8453) -- should now succeed
- [ ] Execute Aerodrome swap workflow (wrap + approve + swap) on Base
- [ ] Verify mainnet WETH actions still work (inline ABI takes precedence)