### PR TITLE
fix: disambiguate overloaded contract functions in ethers v6

### DIFF
--- a/keeperhub/lib/web3/abi-function-key.ts
+++ b/keeperhub/lib/web3/abi-function-key.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+type AbiEntry = {
+  type: string;
+  name: string;
+  inputs?: Array<{ type: string }>;
+};
+
+/**
+ * Build a fully qualified function key to disambiguate overloaded ABI functions.
+ * Returns "deposit(uint256,address)" when the ABI has multiple `deposit` overloads,
+ * or the plain function name when unambiguous.
+ */
+export function getAbiFunctionKey(
+  parsedAbi: AbiEntry[],
+  functionName: string,
+  functionAbi: AbiEntry
+): string {
+  const matchingFunctions = parsedAbi.filter(
+    (item) => item.type === "function" && item.name === functionName
+  );
+
+  if (matchingFunctions.length <= 1) {
+    return functionName;
+  }
+
+  const inputTypes = (functionAbi.inputs ?? []).map((i) => i.type);
+  return `${functionName}(${inputTypes.join(",")})`;
+}

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/keeperhub/lib/abi-struct-args";
 import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
+import { getAbiFunctionKey } from "@/keeperhub/lib/web3/abi-function-key";
 import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
@@ -155,21 +156,7 @@ export async function readContractCore(
     };
   }
 
-  // Build fully qualified function key to disambiguate overloaded functions.
-  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
-  const abiFunctionKey = (() => {
-    const matchingFunctions = parsedAbi.filter(
-      (item: { type: string; name: string }) =>
-        item.type === "function" && item.name === abiFunction
-    );
-    if (matchingFunctions.length <= 1) {
-      return abiFunction;
-    }
-    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
-      (i: { type: string }) => i.type
-    );
-    return `${abiFunction}(${inputTypes.join(",")})`;
-  })();
+  const abiFunctionKey = getAbiFunctionKey(parsedAbi, abiFunction, functionAbi);
 
   // Parse function arguments
   let args: unknown[] = [];

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -155,6 +155,22 @@ export async function readContractCore(
     };
   }
 
+  // Build fully qualified function key to disambiguate overloaded functions.
+  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
+  const abiFunctionKey = (() => {
+    const matchingFunctions = parsedAbi.filter(
+      (item: { type: string; name: string }) =>
+        item.type === "function" && item.name === abiFunction
+    );
+    if (matchingFunctions.length <= 1) {
+      return abiFunction;
+    }
+    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
+      (i: { type: string }) => i.type
+    );
+    return `${abiFunction}(${inputTypes.join(",")})`;
+  })();
+
   // Parse function arguments
   let args: unknown[] = [];
   if (functionArgs && functionArgs.trim() !== "") {
@@ -263,20 +279,20 @@ export async function readContractCore(
         provider
       );
 
-      if (typeof contract[abiFunction] !== "function") {
+      if (typeof contract[abiFunctionKey] !== "function") {
         throw new Error(`Function '${abiFunction}' not found in contract ABI`);
       }
 
       console.log(
         "[Read Contract] Calling function:",
-        abiFunction,
+        abiFunctionKey,
         "with args:",
         args
       );
 
       return isView
-        ? await contract[abiFunction](...args)
-        : await contract[abiFunction].staticCall(...args);
+        ? await contract[abiFunctionKey](...args)
+        : await contract[abiFunctionKey].staticCall(...args);
     });
 
     console.log("[Read Contract] Function call successful, result:", result);

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -15,6 +15,7 @@ import {
   getOrganizationWalletAddress,
   initializeParaSigner,
 } from "@/keeperhub/lib/para/wallet-helpers";
+import { getAbiFunctionKey } from "@/keeperhub/lib/web3/abi-function-key";
 import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
 import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
@@ -119,22 +120,7 @@ export async function writeContractCore(
     };
   }
 
-  // Build fully qualified function key to disambiguate overloaded functions.
-  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
-  const abiFunctionKey = (() => {
-    const matchingFunctions = parsedAbi.filter(
-      (item: { type: string; name: string }) =>
-        item.type === "function" && item.name === abiFunction
-    );
-    if (matchingFunctions.length <= 1) {
-      return abiFunction;
-    }
-    // Multiple overloads -- build explicit signature from the matched ABI entry
-    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
-      (i: { type: string }) => i.type
-    );
-    return `${abiFunction}(${inputTypes.join(",")})`;
-  })();
+  const abiFunctionKey = getAbiFunctionKey(parsedAbi, abiFunction, functionAbi);
 
   // Parse function arguments
   let args: unknown[] = [];

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -119,6 +119,23 @@ export async function writeContractCore(
     };
   }
 
+  // Build fully qualified function key to disambiguate overloaded functions.
+  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
+  const abiFunctionKey = (() => {
+    const matchingFunctions = parsedAbi.filter(
+      (item: { type: string; name: string }) =>
+        item.type === "function" && item.name === abiFunction
+    );
+    if (matchingFunctions.length <= 1) {
+      return abiFunction;
+    }
+    // Multiple overloads -- build explicit signature from the matched ABI entry
+    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
+      (i: { type: string }) => i.type
+    );
+    return `${abiFunction}(${inputTypes.join(",")})`;
+  })();
+
   // Parse function arguments
   let args: unknown[] = [];
   if (functionArgs && functionArgs.trim() !== "") {
@@ -273,7 +290,7 @@ export async function writeContractCore(
     // Call the contract function
     try {
       // Check if function exists
-      if (typeof contract[abiFunction] !== "function") {
+      if (typeof contract[abiFunctionKey] !== "function") {
         return {
           success: false,
           error: `Function '${abiFunction}' not found in contract ABI`,
@@ -285,13 +302,13 @@ export async function writeContractCore(
 
       // Simulate call first to get decodable revert data on failure
       // (eth_call returns revert data reliably, eth_estimateGas often does not)
-      await contract[abiFunction].staticCall(...args, valueOverride);
+      await contract[abiFunctionKey].staticCall(...args, valueOverride);
 
       // Get nonce from session
       const nonce = nonceManager.getNextNonce(session);
 
       // Estimate gas for the contract call
-      const estimatedGas = await contract[abiFunction].estimateGas(
+      const estimatedGas = await contract[abiFunctionKey].estimateGas(
         ...args,
         valueOverride
       );
@@ -320,7 +337,7 @@ export async function writeContractCore(
       });
 
       // Execute contract call with managed nonce and gas config
-      const tx = await contract[abiFunction](...args, {
+      const tx = await contract[abiFunctionKey](...args, {
         nonce,
         gasLimit: txGasConfig.gasLimit,
         maxFeePerGas: txGasConfig.maxFeePerGas,


### PR DESCRIPTION
## Summary
- When a contract ABI has multiple functions with the same name but different signatures (e.g. `deposit(uint256,address)` vs `deposit(uint256,address,uint16)`), ethers v6 throws "ambiguous function description"
- Builds a fully qualified function key from the matched ABI entry when overloads are detected, falls back to plain name when unambiguous
- Applied to both `write-contract-core.ts` and `read-contract-core.ts`

## Context
Discovered while executing an stUSDS leverage loop workflow on staging -- the Sky stUSDS vault has two `deposit` overloads and the workflow failed at the vault deposit step.

## Test plan
- [x] Local dev: workflow with `sky/st-usds-vault-deposit` now reaches the contract (reverts with `StUsds/mint-over-supply-cap` instead of ambiguous function error)
- [x] Contracts with single function signatures remain unaffected (no-op path)
- [x] Lint and type-check pass