### PR TITLE
ci: fix e2e environment to match build target

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -23,12 +23,12 @@ jobs:
     secrets: inherit
 
   # Ephemeral e2e tests run on:
-  # - Push to staging or prod
+  # - Push/dispatch to staging (gate for staging-to-prod promotion PRs)
   # - PRs with run-e2e-tests-ephemeral label
-  # - Manual workflow_dispatch
+  # Skipped on push to prod -- code already passed e2e on staging.
   e2e-tests:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && !(github.event_name != 'pull_request' && github.ref_name == 'prod') }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -23,12 +23,12 @@ jobs:
     secrets: inherit
 
   # Ephemeral e2e tests run on:
-  # - Push/dispatch to staging (gate for staging-to-prod promotion PRs)
+  # - Push to staging or prod
   # - PRs with run-e2e-tests-ephemeral label
-  # Skipped on push to prod -- code already passed e2e on staging.
+  # - Manual workflow_dispatch
   e2e-tests:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() && !(github.event_name != 'pull_request' && github.ref_name == 'prod') }}
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -88,7 +88,7 @@ jobs:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-e2e == 'true' && vars.ENABLE_E2E_EPHEMERAL_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
 
     services:
       postgres:
@@ -235,7 +235,7 @@ jobs:
     needs: [should-run, e2e-vitest-ephemeral]
     if: ${{ always() && needs.should-run.outputs.run-e2e == 'true' && !failure() && vars.ENABLE_E2E_EPHEMERAL_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

- Fix e2e-tests-ephemeral environment from hardcoded `staging` to dynamic (`prod`/`staging` based on branch)
- Without this, e2e on prod pushes tries to pull Sky ECR images with TechOps credentials (403)

## Test plan
- [ ] Merge to staging, verify staging e2e still works (uses staging env)
- [ ] Merge staging to prod, verify prod e2e can pull from Sky ECR