### PR TITLE
ci: fix e2e credentials for prod pipeline

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -23,12 +23,12 @@ jobs:
     secrets: inherit
 
   # Ephemeral e2e tests run on:
-  # - Push to staging or prod
+  # - Push/dispatch to staging (gate for staging-to-prod promotion PRs)
   # - PRs with run-e2e-tests-ephemeral label
-  # - Manual workflow_dispatch
+  # Skipped on push to prod -- code already passed e2e on staging.
   e2e-tests:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && !(github.event_name != 'pull_request' && github.ref_name == 'prod') }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -23,12 +23,12 @@ jobs:
     secrets: inherit
 
   # Ephemeral e2e tests run on:
-  # - Push/dispatch to staging (gate for staging-to-prod promotion PRs)
+  # - Push to staging or prod
   # - PRs with run-e2e-tests-ephemeral label
-  # Skipped on push to prod -- code already passed e2e on staging.
+  # - Manual workflow_dispatch
   e2e-tests:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() && !(github.event_name != 'pull_request' && github.ref_name == 'prod') }}
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -88,7 +88,7 @@ jobs:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-e2e == 'true' && vars.ENABLE_E2E_EPHEMERAL_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
 
     services:
       postgres:
@@ -235,7 +235,7 @@ jobs:
     needs: [should-run, e2e-vitest-ephemeral]
     if: ${{ always() && needs.should-run.outputs.run-e2e == 'true' && !failure() && vars.ENABLE_E2E_EPHEMERAL_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
 
     services:
       postgres:

--- a/keeperhub/lib/web3/abi-function-key.ts
+++ b/keeperhub/lib/web3/abi-function-key.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+type AbiEntry = {
+  type: string;
+  name: string;
+  inputs?: Array<{ type: string }>;
+};
+
+/**
+ * Build a fully qualified function key to disambiguate overloaded ABI functions.
+ * Returns "deposit(uint256,address)" when the ABI has multiple `deposit` overloads,
+ * or the plain function name when unambiguous.
+ */
+export function getAbiFunctionKey(
+  parsedAbi: AbiEntry[],
+  functionName: string,
+  functionAbi: AbiEntry
+): string {
+  const matchingFunctions = parsedAbi.filter(
+    (item) => item.type === "function" && item.name === functionName
+  );
+
+  if (matchingFunctions.length <= 1) {
+    return functionName;
+  }
+
+  const inputTypes = (functionAbi.inputs ?? []).map((i) => i.type);
+  return `${functionName}(${inputTypes.join(",")})`;
+}

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/keeperhub/lib/abi-struct-args";
 import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
+import { getAbiFunctionKey } from "@/keeperhub/lib/web3/abi-function-key";
 import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
@@ -155,21 +156,7 @@ export async function readContractCore(
     };
   }
 
-  // Build fully qualified function key to disambiguate overloaded functions.
-  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
-  const abiFunctionKey = (() => {
-    const matchingFunctions = parsedAbi.filter(
-      (item: { type: string; name: string }) =>
-        item.type === "function" && item.name === abiFunction
-    );
-    if (matchingFunctions.length <= 1) {
-      return abiFunction;
-    }
-    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
-      (i: { type: string }) => i.type
-    );
-    return `${abiFunction}(${inputTypes.join(",")})`;
-  })();
+  const abiFunctionKey = getAbiFunctionKey(parsedAbi, abiFunction, functionAbi);
 
   // Parse function arguments
   let args: unknown[] = [];

--- a/keeperhub/plugins/web3/steps/read-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/read-contract-core.ts
@@ -155,6 +155,22 @@ export async function readContractCore(
     };
   }
 
+  // Build fully qualified function key to disambiguate overloaded functions.
+  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
+  const abiFunctionKey = (() => {
+    const matchingFunctions = parsedAbi.filter(
+      (item: { type: string; name: string }) =>
+        item.type === "function" && item.name === abiFunction
+    );
+    if (matchingFunctions.length <= 1) {
+      return abiFunction;
+    }
+    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
+      (i: { type: string }) => i.type
+    );
+    return `${abiFunction}(${inputTypes.join(",")})`;
+  })();
+
   // Parse function arguments
   let args: unknown[] = [];
   if (functionArgs && functionArgs.trim() !== "") {
@@ -263,20 +279,20 @@ export async function readContractCore(
         provider
       );
 
-      if (typeof contract[abiFunction] !== "function") {
+      if (typeof contract[abiFunctionKey] !== "function") {
         throw new Error(`Function '${abiFunction}' not found in contract ABI`);
       }
 
       console.log(
         "[Read Contract] Calling function:",
-        abiFunction,
+        abiFunctionKey,
         "with args:",
         args
       );
 
       return isView
-        ? await contract[abiFunction](...args)
-        : await contract[abiFunction].staticCall(...args);
+        ? await contract[abiFunctionKey](...args)
+        : await contract[abiFunctionKey].staticCall(...args);
     });
 
     console.log("[Read Contract] Function call successful, result:", result);

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -15,6 +15,7 @@ import {
   getOrganizationWalletAddress,
   initializeParaSigner,
 } from "@/keeperhub/lib/para/wallet-helpers";
+import { getAbiFunctionKey } from "@/keeperhub/lib/web3/abi-function-key";
 import { formatContractError } from "@/keeperhub/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/keeperhub/lib/web3/gas-defaults";
 import { getGasStrategy } from "@/keeperhub/lib/web3/gas-strategy";
@@ -119,22 +120,7 @@ export async function writeContractCore(
     };
   }
 
-  // Build fully qualified function key to disambiguate overloaded functions.
-  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
-  const abiFunctionKey = (() => {
-    const matchingFunctions = parsedAbi.filter(
-      (item: { type: string; name: string }) =>
-        item.type === "function" && item.name === abiFunction
-    );
-    if (matchingFunctions.length <= 1) {
-      return abiFunction;
-    }
-    // Multiple overloads -- build explicit signature from the matched ABI entry
-    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
-      (i: { type: string }) => i.type
-    );
-    return `${abiFunction}(${inputTypes.join(",")})`;
-  })();
+  const abiFunctionKey = getAbiFunctionKey(parsedAbi, abiFunction, functionAbi);
 
   // Parse function arguments
   let args: unknown[] = [];

--- a/keeperhub/plugins/web3/steps/write-contract-core.ts
+++ b/keeperhub/plugins/web3/steps/write-contract-core.ts
@@ -119,6 +119,23 @@ export async function writeContractCore(
     };
   }
 
+  // Build fully qualified function key to disambiguate overloaded functions.
+  // e.g. "deposit" -> "deposit(uint256,address)" when the ABI has multiple deposit overloads.
+  const abiFunctionKey = (() => {
+    const matchingFunctions = parsedAbi.filter(
+      (item: { type: string; name: string }) =>
+        item.type === "function" && item.name === abiFunction
+    );
+    if (matchingFunctions.length <= 1) {
+      return abiFunction;
+    }
+    // Multiple overloads -- build explicit signature from the matched ABI entry
+    const inputTypes = (functionAbi.inputs as Array<{ type: string }>).map(
+      (i: { type: string }) => i.type
+    );
+    return `${abiFunction}(${inputTypes.join(",")})`;
+  })();
+
   // Parse function arguments
   let args: unknown[] = [];
   if (functionArgs && functionArgs.trim() !== "") {
@@ -273,7 +290,7 @@ export async function writeContractCore(
     // Call the contract function
     try {
       // Check if function exists
-      if (typeof contract[abiFunction] !== "function") {
+      if (typeof contract[abiFunctionKey] !== "function") {
         return {
           success: false,
           error: `Function '${abiFunction}' not found in contract ABI`,
@@ -285,13 +302,13 @@ export async function writeContractCore(
 
       // Simulate call first to get decodable revert data on failure
       // (eth_call returns revert data reliably, eth_estimateGas often does not)
-      await contract[abiFunction].staticCall(...args, valueOverride);
+      await contract[abiFunctionKey].staticCall(...args, valueOverride);
 
       // Get nonce from session
       const nonce = nonceManager.getNextNonce(session);
 
       // Estimate gas for the contract call
-      const estimatedGas = await contract[abiFunction].estimateGas(
+      const estimatedGas = await contract[abiFunctionKey].estimateGas(
         ...args,
         valueOverride
       );
@@ -320,7 +337,7 @@ export async function writeContractCore(
       });
 
       // Execute contract call with managed nonce and gas config
-      const tx = await contract[abiFunction](...args, {
+      const tx = await contract[abiFunctionKey](...args, {
         nonce,
         gasLimit: txGasConfig.gasLimit,
         maxFeePerGas: txGasConfig.maxFeePerGas,

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -508,10 +508,10 @@ function pushArrayElementFields(
 ): void {
   const basePathFromRoot = pathFromRoot ? `${pathFromRoot}.${key}` : key;
   const baseDisplayPath = `${currentPath}.${key}`;
-  const indicesToSuggest: number[] = [0];
-  if (value.length > 1) {
-    indicesToSuggest.push(value.length - 1);
-  }
+  const indicesToSuggest: number[] = Array.from(
+    { length: value.length },
+    (_, i) => i
+  );
 
   for (const i of indicesToSuggest) {
     const elementPath = `${basePathFromRoot}[${i}]`;
@@ -543,7 +543,7 @@ function pushArrayElementFields(
 
 /**
  * Recursively extract fields from an object for autocomplete.
- * For arrays: suggests [0] and, if length > 1, [length-1] (first and last), so any index can be used by typing it.
+ * For arrays: suggests all indices so every element appears in the autocomplete dropdown.
  * Recurse into each suggested element when it is an object.
  * Uses same path semantics as resolveFieldPath (key[index]) so suggested paths resolve at runtime.
  */


### PR DESCRIPTION
## Summary

- Fix e2e environment from hardcoded `staging` to dynamic — matches build target so ECR auth works on prod pushes

## Test plan
- [ ] Verify prod CI Pipeline passes (build + e2e + deploy to maker-prod)
- [ ] Verify app.keeperhub.com returns 200