### PR TITLE
refactor: KEEP-1523 add ChainAdapter interface for multi-chain support

### DIFF
--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -1,0 +1,193 @@
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { db } from "@/lib/db";
+import { explorerConfigs } from "@/lib/db/schema";
+import {
+  getAddressUrl as buildAddressUrl,
+  getTransactionUrl as buildTransactionUrl,
+} from "@/lib/explorer";
+import type { AdaptiveGasStrategy } from "../gas-strategy";
+import type { NonceManager, NonceSession } from "../nonce-manager";
+import type {
+  ChainAdapter,
+  ContractCallRequest,
+  SendTransactionRequest,
+  TransactionOptions,
+  TransactionReceipt,
+} from "./types";
+
+export class EvmChainAdapter implements ChainAdapter {
+  readonly chainFamily = "evm";
+  private readonly chainId: number;
+  private readonly gasStrategy: AdaptiveGasStrategy;
+  private readonly nonceManager: NonceManager;
+
+  constructor(
+    chainId: number,
+    gasStrategy: AdaptiveGasStrategy,
+    nonceManager: NonceManager
+  ) {
+    this.chainId = chainId;
+    this.gasStrategy = gasStrategy;
+    this.nonceManager = nonceManager;
+  }
+
+  async sendTransaction(
+    signer: ethers.Signer,
+    request: SendTransactionRequest,
+    session: NonceSession,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt> {
+    const provider = signer.provider;
+    if (!provider) {
+      throw new Error("Signer has no provider");
+    }
+
+    const walletAddress = await signer.getAddress();
+    const baseTx = { to: request.to, value: request.value };
+
+    await provider.call({ ...baseTx, from: walletAddress });
+
+    const nonce = this.nonceManager.getNextNonce(session);
+
+    const estimatedGas = await provider.estimateGas({
+      ...baseTx,
+      from: walletAddress,
+    });
+
+    const gasConfig = await this.gasStrategy.getGasConfig(
+      provider,
+      options.triggerType,
+      estimatedGas,
+      this.chainId,
+      options.gasOverrides.multiplierOverride,
+      options.gasOverrides.gasLimitOverride
+    );
+
+    const tx = await signer.sendTransaction({
+      ...baseTx,
+      nonce,
+      gasLimit: gasConfig.gasLimit,
+      maxFeePerGas: gasConfig.maxFeePerGas,
+      maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+    });
+
+    await this.nonceManager.recordTransaction(
+      session,
+      nonce,
+      tx.hash,
+      options.workflowId,
+      gasConfig.maxFeePerGas.toString()
+    );
+
+    const receipt = await tx.wait();
+    if (!receipt) {
+      throw new Error("Transaction sent but receipt not available");
+    }
+
+    await this.nonceManager.confirmTransaction(tx.hash);
+
+    return {
+      hash: receipt.hash,
+      gasUsed: receipt.gasUsed,
+      effectiveGasPrice: receipt.gasPrice,
+      blockNumber: receipt.blockNumber,
+    };
+  }
+
+  async executeContractCall(
+    signer: ethers.Signer,
+    request: ContractCallRequest,
+    session: NonceSession,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt> {
+    const provider = signer.provider;
+    if (!provider) {
+      throw new Error("Signer has no provider");
+    }
+
+    const contract = new ethers.Contract(
+      request.contractAddress,
+      request.abi,
+      signer
+    );
+
+    const valueOverride = request.value ? { value: request.value } : {};
+
+    await contract[request.functionKey].staticCall(
+      ...request.args,
+      valueOverride
+    );
+
+    const nonce = this.nonceManager.getNextNonce(session);
+
+    const estimatedGas = await contract[request.functionKey].estimateGas(
+      ...request.args,
+      valueOverride
+    );
+
+    const gasConfig = await this.gasStrategy.getGasConfig(
+      provider,
+      options.triggerType,
+      estimatedGas,
+      this.chainId,
+      options.gasOverrides.multiplierOverride,
+      options.gasOverrides.gasLimitOverride
+    );
+
+    const tx = await contract[request.functionKey](...request.args, {
+      nonce,
+      gasLimit: gasConfig.gasLimit,
+      maxFeePerGas: gasConfig.maxFeePerGas,
+      maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+      ...valueOverride,
+    });
+
+    await this.nonceManager.recordTransaction(
+      session,
+      nonce,
+      tx.hash,
+      options.workflowId,
+      gasConfig.maxFeePerGas.toString()
+    );
+
+    const receipt = await tx.wait();
+    if (!receipt) {
+      throw new Error("Transaction sent but receipt not available");
+    }
+
+    await this.nonceManager.confirmTransaction(tx.hash);
+
+    return {
+      hash: receipt.hash,
+      gasUsed: receipt.gasUsed,
+      effectiveGasPrice: receipt.gasPrice,
+      blockNumber: receipt.blockNumber,
+    };
+  }
+
+  async getTransactionUrl(txHash: string): Promise<string> {
+    const config = await this.getExplorerConfig();
+    if (!config) {
+      return "";
+    }
+    return buildTransactionUrl(config, txHash);
+  }
+
+  async getAddressUrl(address: string): Promise<string> {
+    const config = await this.getExplorerConfig();
+    if (!config) {
+      return "";
+    }
+    return buildAddressUrl(config, address);
+  }
+
+  private async getExplorerConfig(): Promise<
+    typeof explorerConfigs.$inferSelect | undefined
+  > {
+    const config = await db.query.explorerConfigs.findFirst({
+      where: eq(explorerConfigs.chainId, this.chainId),
+    });
+    return config ?? undefined;
+  }
+}

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -106,11 +106,24 @@ export class EvmChainAdapter implements ChainAdapter {
       throw new Error("Signer has no provider");
     }
 
-    const contract = new ethers.Contract(
-      request.contractAddress,
-      request.abi,
-      signer
-    );
+    let contract: ethers.Contract;
+    try {
+      contract = new ethers.Contract(
+        request.contractAddress,
+        request.abi,
+        signer
+      );
+    } catch (error) {
+      throw new Error(
+        `Failed to create contract instance: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    if (typeof contract[request.functionKey] !== "function") {
+      throw new Error(
+        `Function '${request.functionKey}' not found in contract ABI`
+      );
+    }
 
     const valueOverride = request.value ? { value: request.value } : {};
 

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -6,11 +6,13 @@ import {
   getAddressUrl as buildAddressUrl,
   getTransactionUrl as buildTransactionUrl,
 } from "@/lib/explorer";
+import type { RpcProviderManager } from "@/lib/rpc-provider";
 import type { AdaptiveGasStrategy, GasConfig } from "../gas-strategy";
 import type { NonceManager, NonceSession } from "../nonce-manager";
 import type {
   ChainAdapter,
   ContractCallRequest,
+  ReadContractRequest,
   SendTransactionRequest,
   TransactionOptions,
   TransactionReceipt,
@@ -144,6 +146,45 @@ export class EvmChainAdapter implements ChainAdapter {
     });
 
     return this.confirmTransaction(tx, session, nonce, gasConfig, options);
+  }
+
+  async readContract(
+    rpcManager: RpcProviderManager,
+    request: ReadContractRequest
+  ): Promise<unknown> {
+    return await rpcManager.executeWithFailover(async (provider) => {
+      const contract = new ethers.Contract(
+        request.contractAddress,
+        request.abi,
+        provider
+      );
+
+      if (typeof contract[request.functionKey] !== "function") {
+        throw new Error(
+          `Function '${request.functionKey}' not found in contract ABI`
+        );
+      }
+
+      return request.isView
+        ? await contract[request.functionKey](...request.args)
+        : await contract[request.functionKey].staticCall(...request.args);
+    });
+  }
+
+  async getBalance(
+    rpcManager: RpcProviderManager,
+    address: string
+  ): Promise<bigint> {
+    return await rpcManager.executeWithFailover(async (provider) =>
+      provider.getBalance(address)
+    );
+  }
+
+  async executeWithFailover<T>(
+    rpcManager: RpcProviderManager,
+    operation: (provider: ethers.JsonRpcProvider) => Promise<T>
+  ): Promise<T> {
+    return await rpcManager.executeWithFailover(operation);
   }
 
   async getTransactionUrl(txHash: string): Promise<string> {

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -21,6 +21,8 @@ export class EvmChainAdapter implements ChainAdapter {
   private readonly chainId: number;
   private readonly gasStrategy: AdaptiveGasStrategy;
   private readonly nonceManager: NonceManager;
+  private explorerConfigCache: typeof explorerConfigs.$inferSelect | null = null;
+  private explorerConfigLoaded = false;
 
   constructor(
     chainId: number,
@@ -198,9 +200,16 @@ export class EvmChainAdapter implements ChainAdapter {
   private async getExplorerConfig(): Promise<
     typeof explorerConfigs.$inferSelect | undefined
   > {
+    if (this.explorerConfigLoaded) {
+      return this.explorerConfigCache ?? undefined;
+    }
+
     const config = await db.query.explorerConfigs.findFirst({
       where: eq(explorerConfigs.chainId, this.chainId),
     });
+
+    this.explorerConfigCache = config ?? null;
+    this.explorerConfigLoaded = true;
     return config ?? undefined;
   }
 }

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -6,7 +6,7 @@ import {
   getAddressUrl as buildAddressUrl,
   getTransactionUrl as buildTransactionUrl,
 } from "@/lib/explorer";
-import type { AdaptiveGasStrategy } from "../gas-strategy";
+import type { AdaptiveGasStrategy, GasConfig } from "../gas-strategy";
 import type { NonceManager, NonceSession } from "../nonce-manager";
 import type {
   ChainAdapter,
@@ -21,7 +21,8 @@ export class EvmChainAdapter implements ChainAdapter {
   private readonly chainId: number;
   private readonly gasStrategy: AdaptiveGasStrategy;
   private readonly nonceManager: NonceManager;
-  private explorerConfigCache: typeof explorerConfigs.$inferSelect | null = null;
+  private explorerConfigCache: typeof explorerConfigs.$inferSelect | null =
+    null;
   private explorerConfigLoaded = false;
 
   constructor(
@@ -46,7 +47,11 @@ export class EvmChainAdapter implements ChainAdapter {
     }
 
     const walletAddress = await signer.getAddress();
-    const baseTx = { to: request.to, value: request.value };
+    const baseTx: ethers.TransactionRequest = {
+      to: request.to,
+      value: request.value,
+      data: request.data,
+    };
 
     await provider.call({ ...baseTx, from: walletAddress });
 
@@ -74,27 +79,7 @@ export class EvmChainAdapter implements ChainAdapter {
       maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
     });
 
-    await this.nonceManager.recordTransaction(
-      session,
-      nonce,
-      tx.hash,
-      options.workflowId,
-      gasConfig.maxFeePerGas.toString()
-    );
-
-    const receipt = await tx.wait();
-    if (!receipt) {
-      throw new Error("Transaction sent but receipt not available");
-    }
-
-    await this.nonceManager.confirmTransaction(tx.hash);
-
-    return {
-      hash: receipt.hash,
-      gasUsed: receipt.gasUsed,
-      effectiveGasPrice: receipt.gasPrice,
-      blockNumber: receipt.blockNumber,
-    };
+    return this.confirmTransaction(tx, session, nonce, gasConfig, options);
   }
 
   async executeContractCall(
@@ -158,6 +143,32 @@ export class EvmChainAdapter implements ChainAdapter {
       ...valueOverride,
     });
 
+    return this.confirmTransaction(tx, session, nonce, gasConfig, options);
+  }
+
+  async getTransactionUrl(txHash: string): Promise<string> {
+    const config = await this.getExplorerConfig();
+    if (!config) {
+      return "";
+    }
+    return buildTransactionUrl(config, txHash);
+  }
+
+  async getAddressUrl(address: string): Promise<string> {
+    const config = await this.getExplorerConfig();
+    if (!config) {
+      return "";
+    }
+    return buildAddressUrl(config, address);
+  }
+
+  private async confirmTransaction(
+    tx: ethers.TransactionResponse,
+    session: NonceSession,
+    nonce: number,
+    gasConfig: GasConfig,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt> {
     await this.nonceManager.recordTransaction(
       session,
       nonce,
@@ -179,22 +190,6 @@ export class EvmChainAdapter implements ChainAdapter {
       effectiveGasPrice: receipt.gasPrice,
       blockNumber: receipt.blockNumber,
     };
-  }
-
-  async getTransactionUrl(txHash: string): Promise<string> {
-    const config = await this.getExplorerConfig();
-    if (!config) {
-      return "";
-    }
-    return buildTransactionUrl(config, txHash);
-  }
-
-  async getAddressUrl(address: string): Promise<string> {
-    const config = await this.getExplorerConfig();
-    if (!config) {
-      return "";
-    }
-    return buildAddressUrl(config, address);
   }
 
   private async getExplorerConfig(): Promise<

--- a/lib/web3/chain-adapter/index.ts
+++ b/lib/web3/chain-adapter/index.ts
@@ -5,6 +5,7 @@ export type {
   ChainAdapter,
   ContractCallRequest,
   GasOverrides,
+  ReadContractRequest,
   SendTransactionRequest,
   TransactionOptions,
   TransactionReceipt,

--- a/lib/web3/chain-adapter/index.ts
+++ b/lib/web3/chain-adapter/index.ts
@@ -1,0 +1,11 @@
+export { EvmChainAdapter } from "./evm";
+export { clearChainAdapterCache, getChainAdapter } from "./registry";
+export { SolanaChainAdapter } from "./solana";
+export type {
+  ChainAdapter,
+  ContractCallRequest,
+  GasOverrides,
+  SendTransactionRequest,
+  TransactionOptions,
+  TransactionReceipt,
+} from "./types";

--- a/lib/web3/chain-adapter/registry.ts
+++ b/lib/web3/chain-adapter/registry.ts
@@ -1,0 +1,30 @@
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getGasStrategy } from "../gas-strategy";
+import { getNonceManager } from "../nonce-manager";
+import { EvmChainAdapter } from "./evm";
+import { SolanaChainAdapter } from "./solana";
+import type { ChainAdapter } from "./types";
+
+const adapterCache = new Map<number, ChainAdapter>();
+
+export function getChainAdapter(chainId: number): ChainAdapter {
+  const cached = adapterCache.get(chainId);
+  if (cached) {
+    return cached;
+  }
+
+  let adapter: ChainAdapter;
+
+  if (isSolanaChain(chainId)) {
+    adapter = new SolanaChainAdapter(chainId);
+  } else {
+    adapter = new EvmChainAdapter(chainId, getGasStrategy(), getNonceManager());
+  }
+
+  adapterCache.set(chainId, adapter);
+  return adapter;
+}
+
+export function clearChainAdapterCache(): void {
+  adapterCache.clear();
+}

--- a/lib/web3/chain-adapter/solana.ts
+++ b/lib/web3/chain-adapter/solana.ts
@@ -1,0 +1,60 @@
+import type { ethers } from "ethers";
+import type { NonceSession } from "../nonce-manager";
+import type {
+  ChainAdapter,
+  ContractCallRequest,
+  SendTransactionRequest,
+  TransactionOptions,
+  TransactionReceipt,
+} from "./types";
+
+export class SolanaChainAdapter implements ChainAdapter {
+  readonly chainFamily = "solana";
+  private readonly chainId: number;
+
+  constructor(chainId: number) {
+    this.chainId = chainId;
+  }
+
+  sendTransaction(
+    _signer: ethers.Signer,
+    _request: SendTransactionRequest,
+    _session: NonceSession,
+    _options: TransactionOptions
+  ): Promise<TransactionReceipt> {
+    return Promise.reject(
+      new Error(
+        `Solana sendTransaction not implemented (chainId: ${this.chainId})`
+      )
+    );
+  }
+
+  executeContractCall(
+    _signer: ethers.Signer,
+    _request: ContractCallRequest,
+    _session: NonceSession,
+    _options: TransactionOptions
+  ): Promise<TransactionReceipt> {
+    return Promise.reject(
+      new Error(
+        `Solana executeContractCall not implemented (chainId: ${this.chainId})`
+      )
+    );
+  }
+
+  getTransactionUrl(_txHash: string): Promise<string> {
+    return Promise.reject(
+      new Error(
+        `Solana getTransactionUrl not implemented (chainId: ${this.chainId})`
+      )
+    );
+  }
+
+  getAddressUrl(_address: string): Promise<string> {
+    return Promise.reject(
+      new Error(
+        `Solana getAddressUrl not implemented (chainId: ${this.chainId})`
+      )
+    );
+  }
+}

--- a/lib/web3/chain-adapter/solana.ts
+++ b/lib/web3/chain-adapter/solana.ts
@@ -1,8 +1,10 @@
 import type { ethers } from "ethers";
+import type { RpcProviderManager } from "@/lib/rpc-provider";
 import type { NonceSession } from "../nonce-manager";
 import type {
   ChainAdapter,
   ContractCallRequest,
+  ReadContractRequest,
   SendTransactionRequest,
   TransactionOptions,
   TransactionReceipt,
@@ -38,6 +40,37 @@ export class SolanaChainAdapter implements ChainAdapter {
     return Promise.reject(
       new Error(
         `Solana executeContractCall not implemented (chainId: ${this.chainId})`
+      )
+    );
+  }
+
+  readContract(
+    _rpcManager: RpcProviderManager,
+    _request: ReadContractRequest
+  ): Promise<unknown> {
+    return Promise.reject(
+      new Error(
+        `Solana readContract not implemented (chainId: ${this.chainId})`
+      )
+    );
+  }
+
+  getBalance(
+    _rpcManager: RpcProviderManager,
+    _address: string
+  ): Promise<bigint> {
+    return Promise.reject(
+      new Error(`Solana getBalance not implemented (chainId: ${this.chainId})`)
+    );
+  }
+
+  executeWithFailover<T>(
+    _rpcManager: RpcProviderManager,
+    _operation: (provider: ethers.JsonRpcProvider) => Promise<T>
+  ): Promise<T> {
+    return Promise.reject(
+      new Error(
+        `Solana executeWithFailover not implemented (chainId: ${this.chainId})`
       )
     );
   }

--- a/lib/web3/chain-adapter/types.ts
+++ b/lib/web3/chain-adapter/types.ts
@@ -1,0 +1,57 @@
+import type { ethers } from "ethers";
+import type { NonceSession } from "../nonce-manager";
+import type { TriggerType } from "../transaction-manager";
+
+export type TransactionReceipt = {
+  hash: string;
+  gasUsed: bigint;
+  effectiveGasPrice: bigint;
+  blockNumber: number;
+};
+
+export type GasOverrides = {
+  multiplierOverride?: number;
+  gasLimitOverride?: bigint;
+};
+
+export type SendTransactionRequest = {
+  to: string;
+  value?: bigint;
+  data?: string;
+};
+
+export type ContractCallRequest = {
+  contractAddress: string;
+  abi: ethers.InterfaceAbi;
+  functionKey: string;
+  args: unknown[];
+  value?: bigint;
+};
+
+export interface ChainAdapter {
+  readonly chainFamily: string;
+
+  sendTransaction(
+    signer: ethers.Signer,
+    request: SendTransactionRequest,
+    session: NonceSession,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt>;
+
+  executeContractCall(
+    signer: ethers.Signer,
+    request: ContractCallRequest,
+    session: NonceSession,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt>;
+
+  getTransactionUrl(txHash: string): Promise<string>;
+
+  getAddressUrl(address: string): Promise<string>;
+}
+
+export type TransactionOptions = {
+  triggerType: TriggerType;
+  gasOverrides: GasOverrides;
+  workflowId?: string;
+};

--- a/lib/web3/chain-adapter/types.ts
+++ b/lib/web3/chain-adapter/types.ts
@@ -1,4 +1,5 @@
 import type { ethers } from "ethers";
+import type { RpcProviderManager } from "@/lib/rpc-provider";
 import type { NonceSession } from "../nonce-manager";
 import type { TriggerType } from "../transaction-manager";
 
@@ -28,8 +29,18 @@ export type ContractCallRequest = {
   value?: bigint;
 };
 
+export type ReadContractRequest = {
+  contractAddress: string;
+  abi: ethers.InterfaceAbi;
+  functionKey: string;
+  args: unknown[];
+  isView: boolean;
+};
+
 export interface ChainAdapter {
   readonly chainFamily: string;
+
+  // ---- Write operations ----
 
   sendTransaction(
     signer: ethers.Signer,
@@ -44,6 +55,22 @@ export interface ChainAdapter {
     session: NonceSession,
     options: TransactionOptions
   ): Promise<TransactionReceipt>;
+
+  // ---- Read operations ----
+
+  readContract(
+    rpcManager: RpcProviderManager,
+    request: ReadContractRequest
+  ): Promise<unknown>;
+
+  getBalance(rpcManager: RpcProviderManager, address: string): Promise<bigint>;
+
+  executeWithFailover<T>(
+    rpcManager: RpcProviderManager,
+    operation: (provider: ethers.JsonRpcProvider) => Promise<T>
+  ): Promise<T>;
+
+  // ---- Explorer ----
 
   getTransactionUrl(txHash: string): Promise<string>;
 

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -11,8 +11,7 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
-import { getTransactionUrl } from "@/lib/explorer";
+import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
   getOrganizationWalletAddress,
@@ -21,10 +20,9 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
-import { getGasStrategy } from "@/lib/web3/gas-strategy";
-import { getNonceManager } from "@/lib/web3/nonce-manager";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import {
   type TransactionContext,
@@ -189,11 +187,10 @@ export async function approveTokenCore(
     triggerType: _context.triggerType as TransactionContext["triggerType"],
   };
 
-  // Execute transaction with nonce management and gas strategy
-  return withNonceSession(txContext, walletAddress, async (session) => {
-    const nonceManager = getNonceManager();
-    const gasStrategy = getGasStrategy();
+  const adapter = getChainAdapter(chainId);
 
+  // Execute transaction with nonce management
+  return withNonceSession(txContext, walletAddress, async (session) => {
     // Initialize Para signer
     let signer: Awaited<ReturnType<typeof initializeParaSigner>>;
     try {
@@ -205,7 +202,7 @@ export async function approveTokenCore(
       };
     }
 
-    // Create contract instance with signer
+    // Create contract instance for pre-flight checks (decimals, symbol)
     const contract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
 
     try {
@@ -235,73 +232,19 @@ export async function approveTokenCore(
         }
       }
 
-      // Simulate call first to get decodable revert data on failure
-      await contract.approve.staticCall(spenderAddress, amountRaw);
-
-      // Get nonce from session
-      const nonce = nonceManager.getNextNonce(session);
-
-      // Estimate gas for the approval
-      const estimatedGas = await contract.approve.estimateGas(
-        spenderAddress,
-        amountRaw
-      );
-
-      // Get gas configuration from strategy
-      const provider = signer.provider;
-      if (!provider) {
-        throw new Error("Signer has no provider");
-      }
-
-      const txGasConfig = await gasStrategy.getGasConfig(
-        provider,
-        txContext.triggerType ?? "manual",
-        estimatedGas,
-        chainId,
-        multiplierOverride,
-        gasLimitOverride
-      );
-
-      // Execute approve with managed nonce and gas config
-      const tx = await contract.approve(spenderAddress, amountRaw, {
-        nonce,
-        gasLimit: txGasConfig.gasLimit,
-        maxFeePerGas: txGasConfig.maxFeePerGas,
-        maxPriorityFeePerGas: txGasConfig.maxPriorityFeePerGas,
-      });
-
-      // Record pending transaction
-      await nonceManager.recordTransaction(
-        session,
-        nonce,
-        tx.hash,
+      const receipt = await adapter.executeContractCall(signer, {
+        contractAddress: tokenAddress,
+        abi: ERC20_ABI,
+        functionKey: "approve",
+        args: [spenderAddress, amountRaw],
+      }, session, {
+        triggerType: txContext.triggerType ?? "manual",
+        gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
-        txGasConfig.maxFeePerGas.toString()
-      );
-
-      // Wait for transaction to be mined
-      const receipt = await tx.wait();
-
-      if (!receipt) {
-        return {
-          success: false,
-          error: "Transaction sent but receipt not available",
-        };
-      }
-
-      // Mark transaction as confirmed
-      await nonceManager.confirmTransaction(tx.hash);
-
-      // Compute gas cost in wei: gasUnits * effectiveGasPrice
-      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
-
-      // Fetch explorer config for transaction link
-      const explorerConfig = await db.query.explorerConfigs.findFirst({
-        where: eq(explorerConfigs.chainId, chainId),
       });
-      const transactionLink = explorerConfig
-        ? getTransactionUrl(explorerConfig, receipt.hash)
-        : "";
+
+      const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
       return {
         success: true,

--- a/plugins/web3/steps/check-allowance.ts
+++ b/plugins/web3/steps/check-allowance.ts
@@ -8,9 +8,9 @@ import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { parseTokenAddress } from "./transfer-token-core";
 
 export type CheckAllowanceCoreInput = {
@@ -99,7 +99,7 @@ async function stepHandler(
   const userId = await getUserIdFromExecution(_context?.executionId);
 
   // Resolve RPC provider with failover support
-  let rpcManager: RpcProviderManager;
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
@@ -116,16 +116,20 @@ async function stepHandler(
     return { success: false, error: getErrorMessage(error) };
   }
 
+  const adapter = getChainAdapter(chainId);
+
   try {
-    const [allowanceRaw, decimals, symbol] =
-      await rpcManager.executeWithFailover((provider) => {
+    const [allowanceRaw, decimals, symbol] = await adapter.executeWithFailover(
+      rpcManager,
+      (provider) => {
         const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
         return Promise.all([
           contract.allowance(ownerAddress, spenderAddress) as Promise<bigint>,
           contract.decimals() as Promise<bigint>,
           contract.symbol() as Promise<string>,
         ]);
-      });
+      }
+    );
 
     const decimalsNum = Number(decimals);
     const allowance = ethers.formatUnits(allowanceRaw, decimalsNum);

--- a/plugins/web3/steps/check-balance.ts
+++ b/plugins/web3/steps/check-balance.ts
@@ -9,9 +9,9 @@ import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 
 /**
  * Get userId from executionId by querying the workflowExecutions table
@@ -111,7 +111,7 @@ async function stepHandler(
   }
 
   // Resolve RPC provider with failover support
-  let rpcManager: RpcProviderManager;
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
@@ -131,28 +131,14 @@ async function stepHandler(
     };
   }
 
+  const adapter = getChainAdapter(chainId);
+
   // Check balance
   try {
-    console.log("[Check Balance] Checking balance for address:", address);
-
-    const balance = await rpcManager.executeWithFailover(async (provider) =>
-      provider.getBalance(address)
-    );
+    const balance = await adapter.getBalance(rpcManager, address);
     const balanceEth = ethers.formatEther(balance);
 
-    console.log("[Check Balance] Balance retrieved successfully:", {
-      address,
-      balanceWei: balance.toString(),
-      balanceEth,
-    });
-
-    // Fetch explorer config for address link
-    const explorerConfig = await db.query.explorerConfigs.findFirst({
-      where: eq(explorerConfigs.chainId, chainId),
-    });
-    const addressLink = explorerConfig
-      ? getAddressUrl(explorerConfig, address)
-      : "";
+    const addressLink = await adapter.getAddressUrl(address);
 
     return {
       success: true,

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -4,19 +4,14 @@ import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
-import {
-  explorerConfigs,
-  supportedTokens,
-  workflowExecutions,
-} from "@/lib/db/schema";
-import { getAddressUrl } from "@/lib/explorer";
+import { supportedTokens, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import type { CustomToken, TokenFieldValue } from "@/lib/wallet/types";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 
 /**
  * Get userId from executionId by querying the workflowExecutions table
@@ -405,7 +400,7 @@ async function stepHandler(
   }
 
   // Resolve RPC provider with failover support
-  let rpcManager: RpcProviderManager;
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
@@ -425,25 +420,16 @@ async function stepHandler(
     };
   }
 
+  const adapter = getChainAdapter(chainId);
+
   // Check balance for the token
   try {
-    const balance = await rpcManager.executeWithFailover(async (provider) =>
-      fetchTokenBalance(provider, address, tokenAddress)
+    const balance = await adapter.executeWithFailover(
+      rpcManager,
+      async (provider) => fetchTokenBalance(provider, address, tokenAddress)
     );
 
-    console.log("[Check Token Balance] Token balance retrieved successfully:", {
-      address,
-      symbol: balance.symbol,
-      balance: balance.balance,
-    });
-
-    // Fetch explorer config for address link
-    const explorerConfig = await db.query.explorerConfigs.findFirst({
-      where: eq(explorerConfigs.chainId, chainId),
-    });
-    const addressLink = explorerConfig
-      ? getAddressUrl(explorerConfig, address)
-      : "";
+    const addressLink = await adapter.getAddressUrl(address);
 
     return {
       success: true,

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -11,14 +11,13 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
-import { getAddressUrl } from "@/lib/explorer";
+import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/web3/abi-function-key";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
 
 export type ReadContractCoreInput = {
@@ -34,9 +33,6 @@ export type ReadContractResult =
   | { success: true; result: unknown; addressLink: string }
   | { success: false; error: string };
 
-/**
- * Get userId from executionId by querying the workflowExecutions table
- */
 async function getUserIdFromExecution(
   executionId: string | undefined
 ): Promise<string | undefined> {
@@ -62,19 +58,9 @@ async function getUserIdFromExecution(
 export async function readContractCore(
   input: ReadContractCoreInput
 ): Promise<ReadContractResult> {
-  console.log("[Read Contract] Starting step with input:", {
-    contractAddress: input.contractAddress,
-    network: input.network,
-    abiFunction: input.abiFunction,
-    hasFunctionArgs: !!input.functionArgs,
-    executionId: input._context?.executionId,
-  });
-
   const { contractAddress, network, abi, abiFunction, functionArgs, _context } =
     input;
 
-  // Get userId from execution context (for user RPC preferences)
-  // Direct execution: no userId, use chain default RPC
   const userId = _context?.organizationId
     ? undefined
     : await getUserIdFromExecution(_context?.executionId);
@@ -85,10 +71,7 @@ export async function readContractCore(
       ErrorCategory.VALIDATION,
       "[Read Contract] Invalid contract address:",
       contractAddress,
-      {
-        plugin_name: "web3",
-        action_name: "read-contract",
-      }
+      { plugin_name: "web3", action_name: "read-contract" }
     );
     return {
       success: false,
@@ -100,16 +83,12 @@ export async function readContractCore(
   let parsedAbi: unknown;
   try {
     parsedAbi = JSON.parse(abi);
-    console.log("[Read Contract] ABI parsed successfully");
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
       "[Read Contract] Failed to parse ABI:",
       error,
-      {
-        plugin_name: "web3",
-        action_name: "read-contract",
-      }
+      { plugin_name: "web3", action_name: "read-contract" }
     );
     return {
       success: false,
@@ -117,21 +96,14 @@ export async function readContractCore(
     };
   }
 
-  // Validate ABI is an array
   if (!Array.isArray(parsedAbi)) {
     logUserError(
       ErrorCategory.VALIDATION,
       "[Read Contract] ABI is not an array",
       parsedAbi,
-      {
-        plugin_name: "web3",
-        action_name: "read-contract",
-      }
+      { plugin_name: "web3", action_name: "read-contract" }
     );
-    return {
-      success: false,
-      error: "ABI must be a JSON array",
-    };
+    return { success: false, error: "ABI must be a JSON array" };
   }
 
   // Find the selected function in the ABI to get output structure
@@ -145,10 +117,7 @@ export async function readContractCore(
       ErrorCategory.VALIDATION,
       "[Read Contract] Function not found in ABI:",
       abiFunction,
-      {
-        plugin_name: "web3",
-        action_name: "read-contract",
-      }
+      { plugin_name: "web3", action_name: "read-contract" }
     );
     return {
       success: false,
@@ -168,36 +137,26 @@ export async function readContractCore(
           ErrorCategory.VALIDATION,
           "[Read Contract] Function args is not an array",
           parsedArgs,
-          {
-            plugin_name: "web3",
-            action_name: "read-contract",
-          }
+          { plugin_name: "web3", action_name: "read-contract" }
         );
         return {
           success: false,
           error: "Function arguments must be a JSON array",
         };
       }
-      // Filter out empty strings at the end of the array (from UI padding)
       args = parsedArgs.filter((arg, index) => {
-        // Keep all non-empty values
         if (arg !== "") {
           return true;
         }
-        // Keep empty strings if they're not at the end
         return parsedArgs.slice(index + 1).some((a) => a !== "");
       });
       args = reshapeArgsForAbi(args, functionAbi);
-      console.log("[Read Contract] Function arguments parsed:", args);
     } catch (error) {
       logUserError(
         ErrorCategory.VALIDATION,
         "[Read Contract] Failed to parse function arguments:",
         error,
-        {
-          plugin_name: "web3",
-          action_name: "read-contract",
-        }
+        { plugin_name: "web3", action_name: "read-contract" }
       );
       return {
         success: false,
@@ -210,25 +169,18 @@ export async function readContractCore(
   let chainId: number;
   try {
     chainId = getChainIdFromNetwork(network);
-    console.log("[Read Contract] Resolved chain ID:", chainId);
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
       "[Read Contract] Failed to resolve network:",
       error,
-      {
-        plugin_name: "web3",
-        action_name: "read-contract",
-      }
+      { plugin_name: "web3", action_name: "read-contract" }
     );
-    return {
-      success: false,
-      error: getErrorMessage(error),
-    };
+    return { success: false, error: getErrorMessage(error) };
   }
 
-  // Resolve RPC provider with failover support
-  let rpcManager: RpcProviderManager;
+  // Resolve RPC provider
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
@@ -242,47 +194,26 @@ export async function readContractCore(
         chain_id: String(chainId),
       }
     );
-    return {
-      success: false,
-      error: getErrorMessage(error),
-    };
+    return { success: false, error: getErrorMessage(error) };
   }
 
-  // Build interface from parsed ABI for error decoding in catch block
   const contractInterface = new ethers.Interface(
     parsedAbi as ethers.InterfaceAbi
   );
 
-  // Call the contract function
+  const adapter = getChainAdapter(chainId);
+  const isView =
+    functionAbi.stateMutability === "view" ||
+    functionAbi.stateMutability === "pure";
+
   try {
-    const isView =
-      functionAbi.stateMutability === "view" ||
-      functionAbi.stateMutability === "pure";
-
-    const result = await rpcManager.executeWithFailover(async (provider) => {
-      const contract = new ethers.Contract(
-        contractAddress,
-        parsedAbi,
-        provider
-      );
-
-      if (typeof contract[abiFunctionKey] !== "function") {
-        throw new Error(`Function '${abiFunction}' not found in contract ABI`);
-      }
-
-      console.log(
-        "[Read Contract] Calling function:",
-        abiFunctionKey,
-        "with args:",
-        args
-      );
-
-      return isView
-        ? await contract[abiFunctionKey](...args)
-        : await contract[abiFunctionKey].staticCall(...args);
+    const result = await adapter.readContract(rpcManager, {
+      contractAddress,
+      abi: parsedAbi as ethers.InterfaceAbi,
+      functionKey: abiFunctionKey,
+      args,
+      isView,
     });
-
-    console.log("[Read Contract] Function call successful, result:", result);
 
     // Convert BigInt values to strings for JSON serialization
     const serializedResult = JSON.parse(
@@ -294,19 +225,16 @@ export async function readContractCore(
     // Transform array results into named objects based on ABI outputs
     let structuredResult = serializedResult;
 
-    // Check if function has outputs defined in ABI
     const outputs = (
       functionAbi as { outputs?: Array<{ name?: string; type: string }> }
     ).outputs;
 
     if (outputs && outputs.length > 0) {
       if (outputs.length === 1) {
-        // Single output: return the value directly if unnamed, or as object if named
         const singleOutput = outputs[0];
         const outputName = singleOutput.name?.trim();
         const outputType = singleOutput.type ?? "";
         const isArrayType = outputType.endsWith("[]");
-        // When the ABI output is an array type (e.g. address[]), the result is the full array; do not take [0]
         const singleValue =
           Array.isArray(serializedResult) && !isArrayType
             ? serializedResult[0]
@@ -317,23 +245,15 @@ export async function readContractCore(
           structuredResult = singleValue;
         }
       } else if (Array.isArray(serializedResult)) {
-        // Multiple outputs: always map to object with field names (named or generated)
         structuredResult = {};
-        outputs.forEach((output, index) => {
+        for (const [index, output] of outputs.entries()) {
           const fieldName = output.name?.trim() || `unnamedOutput${index}`;
           structuredResult[fieldName] = serializedResult[index];
-        });
-        console.log("[Read Contract] Structured result:", structuredResult);
+        }
       }
     }
 
-    // Fetch explorer config for address link
-    const explorerConfig = await db.query.explorerConfigs.findFirst({
-      where: eq(explorerConfigs.chainId, chainId),
-    });
-    const addressLink = explorerConfig
-      ? getAddressUrl(explorerConfig, contractAddress)
-      : "";
+    const addressLink = await adapter.getAddressUrl(contractAddress);
 
     return {
       success: true,

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -10,8 +10,7 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
-import { getTransactionUrl } from "@/lib/explorer";
+import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
   getOrganizationWalletAddress,
@@ -20,10 +19,9 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
-import { getGasStrategy } from "@/lib/web3/gas-strategy";
-import { getNonceManager } from "@/lib/web3/nonce-manager";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import {
   type TransactionContext,
@@ -162,11 +160,10 @@ export async function transferFundsCore(
     triggerType: _context.triggerType as TransactionContext["triggerType"],
   };
 
-  // Execute transaction with nonce management and gas strategy
-  return withNonceSession(txContext, walletAddress, async (session) => {
-    const nonceManager = getNonceManager();
-    const gasStrategy = getGasStrategy();
+  const adapter = getChainAdapter(chainId);
 
+  // Execute transaction with nonce management
+  return withNonceSession(txContext, walletAddress, async (session) => {
     let signer: Awaited<ReturnType<typeof initializeParaSigner>>;
     try {
       signer = await initializeParaSigner(organizationId, rpcUrl);
@@ -177,78 +174,18 @@ export async function transferFundsCore(
       };
     }
 
-    // Get nonce from session
-    const nonce = nonceManager.getNextNonce(session);
-
-    // Send transaction with managed nonce and gas strategy
     try {
-      const provider = signer.provider;
-      if (!provider) {
-        throw new Error("Signer has no provider");
-      }
-
-      const baseTx = { to: recipientAddress, value: amountInWei };
-
-      // Simulate call first to get decodable revert data on failure
-      await provider.call({ ...baseTx, from: walletAddress });
-
-      // Estimate gas
-      const estimatedGas = await provider.estimateGas({
-        ...baseTx,
-        from: walletAddress,
-      });
-
-      // Get gas configuration from strategy
-      const txGasConfig = await gasStrategy.getGasConfig(
-        provider,
-        txContext.triggerType ?? "manual",
-        estimatedGas,
-        chainId,
-        multiplierOverride,
-        gasLimitOverride
-      );
-
-      // Send transaction with nonce and gas config
-      const tx = await signer.sendTransaction({
-        ...baseTx,
-        nonce,
-        gasLimit: txGasConfig.gasLimit,
-        maxFeePerGas: txGasConfig.maxFeePerGas,
-        maxPriorityFeePerGas: txGasConfig.maxPriorityFeePerGas,
-      });
-
-      // Record pending transaction
-      await nonceManager.recordTransaction(
-        session,
-        nonce,
-        tx.hash,
+      const receipt = await adapter.sendTransaction(signer, {
+        to: recipientAddress,
+        value: amountInWei,
+      }, session, {
+        triggerType: txContext.triggerType ?? "manual",
+        gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
-        txGasConfig.maxFeePerGas.toString()
-      );
-
-      // Wait for transaction to be mined
-      const receipt = await tx.wait();
-
-      if (!receipt) {
-        return {
-          success: false,
-          error: "Transaction sent but receipt not available",
-        };
-      }
-
-      // Mark transaction as confirmed
-      await nonceManager.confirmTransaction(tx.hash);
-
-      // Compute gas cost in wei: gasUnits * effectiveGasPrice
-      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
-
-      // Fetch explorer config for transaction link
-      const explorerConfig = await db.query.explorerConfigs.findFirst({
-        where: eq(explorerConfigs.chainId, chainId),
       });
-      const transactionLink = explorerConfig
-        ? getTransactionUrl(explorerConfig, receipt.hash)
-        : "";
+
+      const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
       return {
         success: true,

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -12,11 +12,9 @@ import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
 import {
-  explorerConfigs,
   supportedTokens,
   workflowExecutions,
 } from "@/lib/db/schema";
-import { getTransactionUrl } from "@/lib/explorer";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
   getOrganizationWalletAddress,
@@ -25,10 +23,9 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
-import { getGasStrategy } from "@/lib/web3/gas-strategy";
-import { getNonceManager } from "@/lib/web3/nonce-manager";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import {
   type TransactionContext,
@@ -297,11 +294,10 @@ export async function transferTokenCore(
     triggerType: _context.triggerType as TransactionContext["triggerType"],
   };
 
-  // Execute transaction with nonce management and gas strategy
-  return withNonceSession(txContext, walletAddress, async (session) => {
-    const nonceManager = getNonceManager();
-    const gasStrategy = getGasStrategy();
+  const adapter = getChainAdapter(chainId);
 
+  // Execute transaction with nonce management
+  return withNonceSession(txContext, walletAddress, async (session) => {
     // Initialize Para signer
     let signer: Awaited<ReturnType<typeof initializeParaSigner>>;
     let signerAddress: string;
@@ -315,7 +311,7 @@ export async function transferTokenCore(
       };
     }
 
-    // Create contract instance with signer
+    // Create contract instance for pre-flight checks (decimals, symbol, balance)
     const contract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
 
     try {
@@ -348,73 +344,19 @@ export async function transferTokenCore(
         };
       }
 
-      // Simulate call first to get decodable revert data on failure
-      await contract.transfer.staticCall(recipientAddress, amountRaw);
-
-      // Get nonce from session
-      const nonce = nonceManager.getNextNonce(session);
-
-      // Estimate gas for the transfer
-      const estimatedGas = await contract.transfer.estimateGas(
-        recipientAddress,
-        amountRaw
-      );
-
-      // Get gas configuration from strategy
-      const provider = signer.provider;
-      if (!provider) {
-        throw new Error("Signer has no provider");
-      }
-
-      const txGasConfig = await gasStrategy.getGasConfig(
-        provider,
-        txContext.triggerType ?? "manual",
-        estimatedGas,
-        chainId,
-        multiplierOverride,
-        gasLimitOverride
-      );
-
-      // Execute transfer with managed nonce and gas config
-      const tx = await contract.transfer(recipientAddress, amountRaw, {
-        nonce,
-        gasLimit: txGasConfig.gasLimit,
-        maxFeePerGas: txGasConfig.maxFeePerGas,
-        maxPriorityFeePerGas: txGasConfig.maxPriorityFeePerGas,
-      });
-
-      // Record pending transaction
-      await nonceManager.recordTransaction(
-        session,
-        nonce,
-        tx.hash,
+      const receipt = await adapter.executeContractCall(signer, {
+        contractAddress: tokenAddress,
+        abi: ERC20_ABI,
+        functionKey: "transfer",
+        args: [recipientAddress, amountRaw],
+      }, session, {
+        triggerType: txContext.triggerType ?? "manual",
+        gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
-        txGasConfig.maxFeePerGas.toString()
-      );
-
-      // Wait for transaction to be mined
-      const receipt = await tx.wait();
-
-      if (!receipt) {
-        return {
-          success: false,
-          error: "Transaction sent but receipt not available",
-        };
-      }
-
-      // Mark transaction as confirmed
-      await nonceManager.confirmTransaction(tx.hash);
-
-      // Compute gas cost in wei: gasUnits * effectiveGasPrice
-      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
-
-      // Fetch explorer config for transaction link
-      const explorerConfig = await db.query.explorerConfigs.findFirst({
-        where: eq(explorerConfigs.chainId, chainId),
       });
-      const transactionLink = explorerConfig
-        ? getTransactionUrl(explorerConfig, receipt.hash)
-        : "";
+
+      const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
       return {
         success: true,

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -11,8 +11,7 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
-import { getTransactionUrl } from "@/lib/explorer";
+import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
   getOrganizationWalletAddress,
@@ -22,10 +21,9 @@ import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/web3/abi-function-key";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
-import { getGasStrategy } from "@/lib/web3/gas-strategy";
-import { getNonceManager } from "@/lib/web3/nonce-manager";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import {
   type TransactionContext,
@@ -167,11 +165,9 @@ export async function writeContractCore(
   let rpcUrl: string;
   try {
     chainId = getChainIdFromNetwork(network);
-    console.log("[Write Contract] Resolved chain ID:", chainId);
 
     const rpcManager = await getRpcProvider({ chainId, userId });
     rpcUrl = await rpcManager.resolveActiveRpcUrl();
-    console.log("[Write Contract] Using RPC URL:", rpcUrl);
   } catch (error) {
     logUserError(
       ErrorCategory.VALIDATION,
@@ -193,7 +189,6 @@ export async function writeContractCore(
   try {
     walletAddress = await getOrganizationWalletAddress(organizationId);
   } catch (error) {
-    console.error("[Write Contract] Failed to get wallet address:", error);
     return {
       success: false,
       error: `Failed to get wallet address: ${getErrorMessage(error)}`,
@@ -238,131 +233,44 @@ export async function writeContractCore(
     triggerType: _context?.triggerType as TransactionContext["triggerType"],
   };
 
-  // Execute transaction with nonce management and gas strategy
-  return withNonceSession(txContext, walletAddress, async (session) => {
-    const nonceManager = getNonceManager();
-    const gasStrategy = getGasStrategy();
+  const adapter = getChainAdapter(chainId);
 
+  // Execute transaction with nonce management
+  return withNonceSession(txContext, walletAddress, async (session) => {
     // Initialize Para signer
     let signer: Awaited<ReturnType<typeof initializeParaSigner>>;
     try {
       signer = await initializeParaSigner(organizationId, rpcUrl);
     } catch (error) {
-      console.error(
-        "[Write Contract] Failed to initialize organization wallet:",
-        error
-      );
       return {
         success: false,
         error: `Failed to initialize organization wallet: ${getErrorMessage(error)}`,
       };
     }
 
-    // Create contract instance with signer
-    let contract: ethers.Contract;
+    // Create a contract interface for error formatting on failure
+    let contractInterface: ethers.Interface | undefined;
     try {
-      contract = new ethers.Contract(contractAddress, parsedAbi, signer);
-    } catch (error) {
-      console.error(
-        "[Write Contract] Failed to create contract instance:",
-        error
-      );
-      return {
-        success: false,
-        error: `Failed to create contract instance: ${getErrorMessage(error)}`,
-      };
+      contractInterface = new ethers.Interface(parsedAbi as ethers.InterfaceAbi);
+    } catch {
+      // Non-critical -- error formatting will fall back to generic messages
     }
 
-    // Call the contract function
     try {
-      // Check if function exists
-      if (typeof contract[abiFunctionKey] !== "function") {
-        return {
-          success: false,
-          error: `Function '${abiFunction}' not found in contract ABI`,
-        };
-      }
-
-      // Build value override for payable functions (e.g. WETH deposit)
-      const valueOverride = parsedEthValue ? { value: parsedEthValue } : {};
-
-      // Simulate call first to get decodable revert data on failure
-      // (eth_call returns revert data reliably, eth_estimateGas often does not)
-      await contract[abiFunctionKey].staticCall(...args, valueOverride);
-
-      // Get nonce from session
-      const nonce = nonceManager.getNextNonce(session);
-
-      // Estimate gas for the contract call
-      const estimatedGas = await contract[abiFunctionKey].estimateGas(
-        ...args,
-        valueOverride
-      );
-
-      // Get gas configuration from strategy
-      const provider = signer.provider;
-      if (!provider) {
-        throw new Error("Signer has no provider");
-      }
-
-      const txGasConfig = await gasStrategy.getGasConfig(
-        provider,
-        txContext.triggerType ?? "manual",
-        estimatedGas,
-        chainId,
-        multiplierOverride,
-        gasLimitOverride
-      );
-
-      console.log("[Write Contract] Gas config:", {
-        function: abiFunction,
-        estimatedGas: estimatedGas.toString(),
-        gasLimit: txGasConfig.gasLimit.toString(),
-        maxFeePerGas: `${ethers.formatUnits(txGasConfig.maxFeePerGas, "gwei")} gwei`,
-        maxPriorityFeePerGas: `${ethers.formatUnits(txGasConfig.maxPriorityFeePerGas, "gwei")} gwei`,
-      });
-
-      // Execute contract call with managed nonce and gas config
-      const tx = await contract[abiFunctionKey](...args, {
-        nonce,
-        gasLimit: txGasConfig.gasLimit,
-        maxFeePerGas: txGasConfig.maxFeePerGas,
-        maxPriorityFeePerGas: txGasConfig.maxPriorityFeePerGas,
-        ...valueOverride,
-      });
-
-      // Record pending transaction
-      await nonceManager.recordTransaction(
-        session,
-        nonce,
-        tx.hash,
+      const receipt = await adapter.executeContractCall(signer, {
+        contractAddress,
+        abi: parsedAbi as ethers.InterfaceAbi,
+        functionKey: abiFunctionKey,
+        args,
+        value: parsedEthValue,
+      }, session, {
+        triggerType: txContext.triggerType ?? "manual",
+        gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
-        txGasConfig.maxFeePerGas.toString()
-      );
-
-      // Wait for transaction to be mined
-      const receipt = await tx.wait();
-
-      // Mark transaction as confirmed
-      await nonceManager.confirmTransaction(tx.hash);
-
-      // Compute gas cost in wei: gasUnits * effectiveGasPrice
-      const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
-
-      console.log("[Write Contract] Transaction confirmed:", {
-        hash: receipt.hash,
-        gasUsed: receipt.gasUsed.toString(),
-        effectiveGasPrice: `${ethers.formatUnits(receipt.gasPrice, "gwei")} gwei`,
-        gasCostWei,
       });
 
-      // Fetch explorer config for transaction link
-      const explorerConfig = await db.query.explorerConfigs.findFirst({
-        where: eq(explorerConfigs.chainId, chainId),
-      });
-      const transactionLink = explorerConfig
-        ? getTransactionUrl(explorerConfig, receipt.hash)
-        : "";
+      const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
       return {
         success: true,
@@ -384,7 +292,7 @@ export async function writeContractCore(
       );
       return {
         success: false,
-        error: formatContractError(error, contract.interface),
+        error: formatContractError(error, contractInterface),
       };
     }
   });

--- a/specs/F-018-chain-adapter.md
+++ b/specs/F-018-chain-adapter.md
@@ -1,0 +1,122 @@
+# F-018: ChainAdapter Interface
+
+## Overview
+
+Polymorphic chain abstraction layer that decouples workflow step execution logic from chain-specific transaction mechanics. Steps interact with a `ChainAdapter` interface rather than calling ethers.js, gas strategy, nonce manager, and explorer APIs directly.
+
+## Architecture
+
+```
+Step (transfer-funds-core.ts)
+  |
+  +-- getChainAdapter(chainId)  -->  ChainAdapterRegistry
+  |                                    |
+  |                              isSolanaChain?
+  |                              /            \
+  |                    EvmChainAdapter    SolanaChainAdapter (stub)
+  |                         |
+  +-- adapter.sendTransaction(signer, request, session, options)
+  |       |
+  |       +-- gasStrategy.getGasConfig()     (injected)
+  |       +-- nonceManager.getNextNonce()    (injected)
+  |       +-- signer.sendTransaction()
+  |       +-- nonceManager.recordTransaction()
+  |       +-- tx.wait()
+  |       +-- nonceManager.confirmTransaction()
+  |
+  +-- adapter.getTransactionUrl(hash)
+          |
+          +-- explorerConfigs DB query (cached)
+```
+
+## Interface
+
+```typescript
+interface ChainAdapter {
+  readonly chainFamily: string;
+
+  // Write operations
+  sendTransaction(signer, request, session, options): Promise<TransactionReceipt>;
+  executeContractCall(signer, request, session, options): Promise<TransactionReceipt>;
+
+  // Read operations
+  readContract(rpcManager, request): Promise<unknown>;
+  getBalance(rpcManager, address): Promise<bigint>;
+  executeWithFailover<T>(rpcManager, operation): Promise<T>;
+
+  // Explorer
+  getTransactionUrl(txHash): Promise<string>;
+  getAddressUrl(address): Promise<string>;
+}
+```
+
+## Design Decisions
+
+### 1. Signer passed as parameter, not owned by adapter
+
+The adapter does not manage wallet lifecycle. `initializeParaSigner()` is called by the step and the resulting signer is passed to the adapter. This keeps wallet management (Para-specific, org-level) orthogonal to chain operations.
+
+### 2. Gas strategy and nonce manager injected via constructor
+
+`AdaptiveGasStrategy` and `NonceManager` are injected into `EvmChainAdapter` as constructor dependencies. They are not merged into the adapter class. This preserves their existing singleton lifecycle and allows independent testing.
+
+### 3. withNonceSession() stays in the step
+
+The nonce session lifecycle (lock acquisition, session start/end) remains in the step via `withNonceSession()`. The adapter operates within an active session -- it calls `getNextNonce()` and `recordTransaction()` but does not own the session boundary.
+
+### 4. Read operations accept rpcManager as parameter
+
+Read methods take `RpcProviderManager` as a parameter rather than owning it internally. This is because the adapter is cached per chainId (in the registry), but RPC providers vary per user (due to user RPC preferences resolved by `getRpcProvider({ chainId, userId })`). Passing rpcManager avoids coupling the adapter cache to user-specific state.
+
+### 5. Explorer config cached per adapter instance
+
+`getExplorerConfig()` queries the DB once and caches the result. Since the adapter is cached per chainId and explorer config is immutable per chain, this eliminates redundant DB queries across multiple `getTransactionUrl()`/`getAddressUrl()` calls within the same process.
+
+### 6. Protocol registry chainTypeFilter left as-is
+
+The protocol registry hardcodes `chainTypeFilter: "evm"` for all protocol actions. This is intentionally not changed in F-018 because:
+- No protocols currently support Solana
+- The Solana adapter is a stub with no real implementation
+- Making this dynamic adds complexity with no immediate consumer
+- When F-019 (Solana implementation) lands, the protocol registry can be updated to read `chainType` from the protocol's supported chains
+
+## Files
+
+| File | Role |
+|------|------|
+| `lib/web3/chain-adapter/types.ts` | Interface and supporting types |
+| `lib/web3/chain-adapter/evm.ts` | EVM implementation |
+| `lib/web3/chain-adapter/solana.ts` | Solana stub |
+| `lib/web3/chain-adapter/registry.ts` | Factory with caching |
+| `lib/web3/chain-adapter/index.ts` | Barrel exports |
+
+## Refactored Steps
+
+| Step | Adapter Methods Used |
+|------|---------------------|
+| `transfer-funds-core.ts` | `sendTransaction`, `getTransactionUrl` |
+| `write-contract-core.ts` | `executeContractCall`, `getTransactionUrl` |
+| `transfer-token-core.ts` | `executeContractCall`, `getTransactionUrl` |
+| `approve-token-core.ts` | `executeContractCall`, `getTransactionUrl` |
+| `read-contract-core.ts` | `readContract`, `getAddressUrl` |
+| `check-balance.ts` | `getBalance`, `getAddressUrl` |
+| `check-token-balance.ts` | `executeWithFailover`, `getAddressUrl` |
+| `check-allowance.ts` | `executeWithFailover` |
+
+## Not Refactored (out of scope)
+
+These steps use deeply EVM-specific patterns (Multicall3, queryFilter, explorer APIs) that don't map to a chain-agnostic interface:
+
+- `batch-read-contract.ts` -- Multicall3 aggregation
+- `query-events.ts` -- EVM event log queries with block range batching
+- `query-transactions-core.ts` -- Explorer API transaction history
+- `get-transaction.ts` -- Single transaction fetch by hash
+
+These can adopt `adapter.executeWithFailover()` incrementally if needed.
+
+## Future Work
+
+- **F-019**: Implement `SolanaChainAdapter` with real Solana transaction support
+- **F-021**: L2-specific optimizations can be per-chain adapter config
+- **F-023**: Cross-chain orchestration builds on top of the adapter registry
+- Protocol registry `chainTypeFilter` should become dynamic when Solana protocols exist

--- a/tests/integration/web3-steps.test.ts
+++ b/tests/integration/web3-steps.test.ts
@@ -66,6 +66,7 @@ vi.mock("@/lib/rpc/provider-factory", () => ({
       }
     ),
   }),
+  isSolanaChain: () => false,
 }));
 
 // Mock database

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -63,6 +63,7 @@ vi.mock("@/lib/rpc/network-utils", () => ({
 
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+  isSolanaChain: () => false,
 }));
 
 // Mock explorer

--- a/tests/unit/check-allowance.test.ts
+++ b/tests/unit/check-allowance.test.ts
@@ -52,6 +52,7 @@ vi.mock("@/lib/rpc/network-utils", () => ({
 
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+  isSolanaChain: () => false,
 }));
 
 // Mock ethers Contract methods

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/lib/rpc/network-utils", () => ({
 
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+  isSolanaChain: () => false,
 }));
 
 const mockContractFunction = vi.fn();


### PR DESCRIPTION
## Summary

- Introduces `ChainAdapter` interface abstracting the full transaction lifecycle (nonce, gas, submit, confirm, explorer URLs)
- Implements `EvmChainAdapter` extracting ~270 lines of duplicated boilerplate from 4 write-path core steps
- Adds `SolanaChainAdapter` stub for future Solana transaction support (F-019)
- `ChainAdapterRegistry` provides chainId-based adapter routing with caching

## What each step still owns

- Input validation, ABI parsing, organization context resolution
- Signer initialization (`initializeParaSigner`)
- `withNonceSession()` lifecycle
- Token-specific pre-flight checks (decimals, balance)
- Error formatting with `formatContractError()`

## What moved into the adapter

- `getNonceManager()` / `getGasStrategy()` calls
- Gas estimation, nonce acquisition, transaction recording/confirmation
- `staticCall` simulation, `tx.wait()`, explorer URL lookup

## Test plan

- [x] Type-check passes (verified locally, pre-existing registry errors only)
- [x] Lint passes (verified locally)
- [ ] Deploy to staging and verify write-contract, transfer-funds, transfer-token, approve-token steps execute correctly
- [ ] Verify gas config and nonce management behavior unchanged
- [ ] Verify explorer links still appear in step output