### PR TITLE
feat: add org-specific error log filtering

### DIFF
--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -113,7 +113,8 @@ export function logUserError(
   const context = extractContext(message);
 
   // Log as warning (user errors don't wake up DevOps)
-  console.warn(message, error ?? "");
+  const orgTag = labels?.org_name ? ` [org:${labels.org_name}]` : "";
+  console.warn(`${message}${orgTag}`, error ?? "");
 
   // Emit metric
   metrics.recordError(
@@ -155,7 +156,8 @@ export function logSystemError(
   const context = extractContext(message);
 
   // Log as error (system failures are critical)
-  console.error(message, error);
+  const orgTag = labels?.org_name ? ` [org:${labels.org_name}]` : "";
+  console.error(`${message}${orgTag}`, error);
 
   // Emit metric
   metrics.recordError(

--- a/lib/steps/step-handler.ts
+++ b/lib/steps/step-handler.ts
@@ -24,6 +24,7 @@ export type StepContext = {
   triggerType?: string;
   iterationIndex?: number;
   forEachNodeId?: string;
+  organizationId?: string;
 };
 
 /**

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -102,6 +102,8 @@ export type WorkflowExecutionInput = {
   triggerInput?: Record<string, unknown>;
   executionId?: string;
   workflowId?: string; // Used by steps to fetch credentials
+  organizationId?: string;
+  organizationName?: string; // Used for log filtering by org name
 };
 
 /**
@@ -317,6 +319,7 @@ export function evaluateConditionExpression(
         "[Condition] Failed to evaluate user expression:",
         error,
         {
+          ...baseLogLabels,
           expression: conditionExpression,
         }
       );
@@ -1010,14 +1013,30 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
   console.log("[Workflow Executor] Starting workflow execution");
 
-  const { nodes, edges, triggerInput = {}, executionId, workflowId } = input;
+  const {
+    nodes,
+    edges,
+    triggerInput = {},
+    executionId,
+    workflowId,
+    organizationId,
+    organizationName,
+  } = input;
 
   console.log("[Workflow Executor] Input:", {
     nodeCount: nodes.length,
     edgeCount: edges.length,
     hasExecutionId: !!executionId,
     workflowId: workflowId || "none",
+    organizationId: organizationId || "none",
   });
+
+  // Common labels for error logging — includes org name for log filtering
+  const baseLogLabels: Record<string, string> = {
+    ...(workflowId ? { workflow_id: workflowId } : {}),
+    ...(executionId ? { execution_id: executionId } : {}),
+    ...(organizationName ? { org_name: organizationName } : {}),
+  };
 
   const outputs: NodeOutputs = {};
   const results: Record<string, ExecutionResult> = {};
@@ -1231,6 +1250,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         nodeType: actionType,
         iterationIndex: iterationMeta?.iterationIndex,
         forEachNodeId: iterationMeta?.forEachNodeId,
+        organizationId,
       };
 
       const stepResult = await executeActionStep({
@@ -1538,6 +1558,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             nodeName: collectLabel,
             nodeType: "Collect",
             forEachNodeId,
+            organizationId,
           } satisfies StepContext,
         });
       }
@@ -1656,10 +1677,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               ErrorCategory.VALIDATION,
               "[Workflow Executor] Failed to parse webhook mock request:",
               error,
-              {
-                ...(workflowId ? { workflow_id: workflowId } : {}),
-                ...(executionId ? { execution_id: executionId } : {}),
-              }
+              baseLogLabels
             );
           }
         } else if (triggerInput && Object.keys(triggerInput).length > 0) {
@@ -1710,6 +1728,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           nodeId: node.id,
           nodeName: getNodeName(node),
           nodeType: node.data.type,
+          organizationId,
         };
 
         // Execute trigger step (handles logging internally)
@@ -1753,6 +1772,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           nodeName: getNodeName(node),
           nodeType: actionType,
           triggerType: workflowTriggerType,
+          organizationId,
         };
 
         // Execute the action step with stepHandler (logging is handled inside)
@@ -1914,8 +1934,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         "[Workflow Executor] Error executing node:",
         error,
         {
-          ...(workflowId ? { workflow_id: workflowId } : {}),
-          ...(executionId ? { execution_id: executionId } : {}),
+          ...baseLogLabels,
           node_id: nodeId,
         }
       );
@@ -2010,10 +2029,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           ErrorCategory.WORKFLOW_ENGINE,
           "[Workflow Executor] Failed to update execution record:",
           completeError,
-          {
-            ...(workflowId ? { workflow_id: workflowId } : {}),
-            ...(executionId ? { execution_id: executionId } : {}),
-          }
+          baseLogLabels
         );
       }
     }
@@ -2028,10 +2044,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       ErrorCategory.WORKFLOW_ENGINE,
       "[Workflow Executor] Fatal error during workflow execution:",
       error,
-      {
-        ...(workflowId ? { workflow_id: workflowId } : {}),
-        ...(executionId ? { execution_id: executionId } : {}),
-      }
+      baseLogLabels
     );
 
     const errorMessage = await getErrorMessageAsync(error);
@@ -2063,10 +2076,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           ErrorCategory.INFRASTRUCTURE,
           "[Workflow Executor] Failed to log error:",
           logError,
-          {
-            ...(workflowId ? { workflow_id: workflowId } : {}),
-            ...(executionId ? { execution_id: executionId } : {}),
-          }
+          baseLogLabels
         );
       }
     }

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -319,7 +319,6 @@ export function evaluateConditionExpression(
         "[Condition] Failed to evaluate user expression:",
         error,
         {
-          ...baseLogLabels,
           expression: conditionExpression,
         }
       );

--- a/scripts/runtime/workflow-runner.ts
+++ b/scripts/runtime/workflow-runner.ts
@@ -28,6 +28,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { validateWorkflowIntegrations } from "../../lib/db/integrations";
 import {
+  organization,
   workflowExecutions,
   workflowSchedules,
   workflows,
@@ -316,6 +317,16 @@ async function main(): Promise<void> {
 
     console.log(`[Runner] Loaded workflow: ${workflow.name || workflowId}`);
 
+    // Resolve organization name for log filtering
+    let organizationName: string | undefined;
+    if (workflow.organizationId) {
+      const org = await db.query.organization.findFirst({
+        where: eq(organization.id, workflow.organizationId),
+        columns: { name: true },
+      });
+      organizationName = org?.name;
+    }
+
     // Validate integration ownership
     const nodes = workflow.nodes as WorkflowNode[];
     const edges = workflow.edges as WorkflowEdge[];
@@ -349,6 +360,8 @@ async function main(): Promise<void> {
       triggerInput: input,
       executionId,
       workflowId,
+      organizationId: workflow.organizationId ?? undefined,
+      organizationName,
     });
 
     const duration = Date.now() - startTime;

--- a/scripts/runtime/workflow-runner.ts
+++ b/scripts/runtime/workflow-runner.ts
@@ -320,10 +320,11 @@ async function main(): Promise<void> {
     // Resolve organization name for log filtering
     let organizationName: string | undefined;
     if (workflow.organizationId) {
-      const org = await db.query.organization.findFirst({
-        where: eq(organization.id, workflow.organizationId),
-        columns: { name: true },
-      });
+      const [org] = await db
+        .select({ name: organization.name })
+        .from(organization)
+        .where(eq(organization.id, workflow.organizationId))
+        .limit(1);
       organizationName = org?.name;
     }
 

--- a/scripts/runtime/workflow_runtime_analysis/workflow-runner-profiled.ts
+++ b/scripts/runtime/workflow_runtime_analysis/workflow-runner-profiled.ts
@@ -730,10 +730,11 @@ async function main(): Promise<void> {
     // Resolve organization name for log filtering
     let organizationName: string | undefined;
     if (workflow.organizationId) {
-      const org = await db.query.organization.findFirst({
-        where: eq(organization.id, workflow.organizationId),
-        columns: { name: true },
-      });
+      const [org] = await db
+        .select({ name: organization.name })
+        .from(organization)
+        .where(eq(organization.id, workflow.organizationId))
+        .limit(1);
       organizationName = org?.name;
     }
 

--- a/scripts/runtime/workflow_runtime_analysis/workflow-runner-profiled.ts
+++ b/scripts/runtime/workflow_runtime_analysis/workflow-runner-profiled.ts
@@ -37,6 +37,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { validateWorkflowIntegrations } from "../../../lib/db/integrations";
 import {
+  organization,
   workflowExecutions,
   workflowSchedules,
   workflows,
@@ -726,6 +727,16 @@ async function main(): Promise<void> {
 
     console.log(`[Runner] Loaded workflow: ${workflow.name || workflowId}`);
 
+    // Resolve organization name for log filtering
+    let organizationName: string | undefined;
+    if (workflow.organizationId) {
+      const org = await db.query.organization.findFirst({
+        where: eq(organization.id, workflow.organizationId),
+        columns: { name: true },
+      });
+      organizationName = org?.name;
+    }
+
     const nodes = workflow.nodes as WorkflowNode[];
     const edges = workflow.edges as WorkflowEdge[];
     const validation = await validateWorkflowIntegrations(
@@ -753,6 +764,8 @@ async function main(): Promise<void> {
       triggerInput: input,
       executionId,
       workflowId,
+      organizationId: workflow.organizationId ?? undefined,
+      organizationName,
     });
 
     profiler.markStepEnd("workflow-execution");


### PR DESCRIPTION
  ## Summary
  - Error logs from `logUserError`/`logSystemError` now include `[org:OrgName]`
    tag in console output when org context is available
  - Workflow runners resolve the organization name from DB and pass it through
    the executor to all step contexts and error log calls
  - Enables filtering error logs by organization in Loki (e.g. `|~ "\[org:Ajna\]"`)

  ## Changes
  - `lib/logging.ts` - Append `[org:OrgName]` to console.warn/error when `org_name` label present
  - `lib/workflow-executor.workflow.ts` - Add `organizationId`/`organizationName` to input type, thread through `baseLogLabels` and all `StepContext` constructions
  - `lib/steps/step-handler.ts` - Add `organizationId` to `StepContext` type
  - `scripts/runtime/workflow-runner.ts` - Query organization table for name, pass to executor
  - `scripts/runtime/.../workflow-runner-profiled.ts` - Same
