### PR TITLE
refactor: update commands and agents for flat directory structure

### DIFF
--- a/.claude/agents/blueprint-pipeline.md
+++ b/.claude/agents/blueprint-pipeline.md
@@ -205,7 +205,7 @@ Deviations:
 
 **Process:**
 1. Read all created and modified files
-2. Check each file follows KeeperHub conventions (keeperhub/ directory, proper imports, no emojis, "use step" compliance)
+2. Check each file follows KeeperHub conventions (proper imports, no emojis, "use step" compliance)
 3. Run automated checks:
    - `pnpm check` -- lint must pass
    - `pnpm type-check` -- TypeScript must pass
@@ -231,7 +231,7 @@ Success Criteria:
 2. [criterion text]: [PASS|FAIL] [evidence]
 
 Convention Compliance:
-- keeperhub/ directory: [PASS|FAIL]
+- Directory structure: [PASS|FAIL]
 - "use step" patterns: [PASS|FAIL|N/A]
 - No emojis: [PASS|FAIL]
 - No debug artifacts: [PASS|FAIL]

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -12,7 +12,7 @@ You create and modify files, run checks, and report results. You do NOT make arc
 </role>
 
 <capabilities>
-- Create and modify files in `keeperhub/` directory
+- Create and modify files in the project
 - Create test files in `tests/unit/` and `tests/integration/`
 - Run `pnpm check`, `pnpm type-check`, `pnpm build`, `pnpm discover-plugins`
 - Run `pnpm vitest run` for specific test files
@@ -25,7 +25,7 @@ You create and modify files, run checks, and report results. You do NOT make arc
 1. Read the Task Brief from the Orchestrator
 2. Read the Research Report if one was provided (contains patterns, type signatures, conventions)
 3. Read relevant existing code (referenced files, sibling implementations to match patterns)
-4. Read scoped CLAUDE.md files in the target directory (e.g., `keeperhub/plugins/CLAUDE.md` for plugin work)
+4. Read scoped CLAUDE.md files in the target directory (e.g., `plugins/CLAUDE.md` for plugin work)
 5. For protocol tasks, read `.claude/agents/protocol-domain.md`. For plugin tasks, read `.claude/agents/plugin-domain.md`
 6. Write tests for new functionality unless the Task Brief explicitly excludes tests
 7. Implement each subtask, creating or modifying files as specified in the brief
@@ -41,9 +41,8 @@ You create and modify files, run checks, and report results. You do NOT make arc
 
 <coding_conventions>
 **Directory structure:**
-- All custom code in `keeperhub/` directory (NOT root-level directories)
-- Plugin code in `keeperhub/plugins/`
-- Protocol definitions in `keeperhub/protocols/`
+- Plugin code in `plugins/`
+- Protocol definitions in `protocols/`
 
 **Plugin step files ("use step" rules -- CRITICAL):**
 - `import "server-only"` at top of step files
@@ -56,7 +55,7 @@ You create and modify files, run checks, and report results. You do NOT make arc
 - Security-critical steps: set `stepFunction.maxRetries = 0`
 
 **Protocol definitions:**
-- `export default defineProtocol({...})` in `keeperhub/protocols/`
+- `export default defineProtocol({...})` in `protocols/`
 
 **Biome/Ultracite lint rules:**
 - Use block statements: `if (x) { return y; }` not `if (x) return y;`
@@ -103,7 +102,7 @@ Before proceeding autonomously, pause and report to the Orchestrator for guidanc
 Report back to the Orchestrator (do NOT attempt to resolve these yourself beyond 2 attempts):
 - Lint or type-check fails after 2 fix rounds: include cached error output in your report
 - Unclear brief (missing file paths, ambiguous requirements): describe what is unclear
-- Task requires modifying core files outside `keeperhub/`: flag the files and ask for confirmation
+- Task requires modifying core framework files: flag the files and ask for confirmation
 - Dependency not installed (package not in package.json): report the missing package
 - Existing code pattern conflicts with the brief's instructions: describe the conflict
 </escalation>

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -66,7 +66,7 @@ These are the most frequent failure patterns in KeeperHub. Check these first.
 - Symptom: Build fails with bundler error about unexpected exports
 - Cause: A helper function is exported from a file with `"use step"` directive
 - Fix: Move the exported helper to a `*-core.ts` file (without "use step"), import from both step files
-- Reference pattern: `keeperhub/plugins/web3/steps/decode-calldata-core.ts`
+- Reference pattern: `plugins/web3/steps/decode-calldata-core.ts`
 
 **Cognitive complexity exceeds 15**
 - Symptom: Lint error `noExcessiveCognitiveComplexity` on a function
@@ -90,7 +90,7 @@ These are the most frequent failure patterns in KeeperHub. Check these first.
 
 **Wrong import path**
 - Symptom: Type error or module not found
-- Cause: Using `@/plugins/` instead of `@/keeperhub/plugins/`, or similar path mismatch
+- Cause: Using `@/plugins/` instead of `@/plugins/`, or similar path mismatch
 - Fix: Correct the import path to match the actual file location
 
 **Type mismatch in step input/output**
@@ -104,7 +104,7 @@ These are the most frequent failure patterns in KeeperHub. Check these first.
 - Fix: Add vi.mock() for common dependencies:
   - `vi.mock("server-only", () => ({}))`
   - `vi.mock("@/lib/steps/step-handler", ...)`
-  - `vi.mock("@/keeperhub/lib/metrics/instrumentation/plugin", ...)`
+  - `vi.mock("@/lib/metrics/instrumentation/plugin", ...)`
   - `vi.mock("@/lib/db", ...)`
   - `vi.mock("drizzle-orm", ...)`
 </common_keeperhub_fixes>

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -195,9 +195,8 @@ Success Criteria:
 </escalation>
 
 <project_conventions>
-- All custom code goes in `keeperhub/` directory
-- Plugin code goes in `keeperhub/plugins/`
-- Protocol definitions go in `keeperhub/protocols/`
+- Plugin code goes in `plugins/`
+- Protocol definitions go in `protocols/`
 - Run `pnpm discover-plugins` after plugin/protocol changes
 - Run `pnpm check` (lint) and `pnpm type-check` (TypeScript) before committing
 - Read `.claude/lint-output.txt` and `.claude/typecheck-output.txt` for cached error output

--- a/.claude/agents/plugin-domain.md
+++ b/.claude/agents/plugin-domain.md
@@ -1,7 +1,7 @@
 <overview>
 Custom workflow plugins provide integrations with external services and internal infrastructure for the KeeperHub workflow builder.
 
-- All custom plugins go in `plugins/` (NOT `plugins/`)
+- All custom plugins go in `plugins/`
 - Each plugin has a directory: `plugins/[plugin-name]/`
 - `pnpm discover-plugins` auto-generates `plugins/index.ts`, `lib/step-registry.ts`, `lib/codegen-registry.ts`
 - Three plugin variants: credential-based (external API), system plugin (pure logic), infrastructure plugin (uses internal infra)

--- a/.claude/agents/plugin-domain.md
+++ b/.claude/agents/plugin-domain.md
@@ -1,9 +1,9 @@
 <overview>
 Custom workflow plugins provide integrations with external services and internal infrastructure for the KeeperHub workflow builder.
 
-- All custom plugins go in `keeperhub/plugins/` (NOT `plugins/`)
-- Each plugin has a directory: `keeperhub/plugins/[plugin-name]/`
-- `pnpm discover-plugins` auto-generates `keeperhub/plugins/index.ts`, `lib/step-registry.ts`, `lib/codegen-registry.ts`
+- All custom plugins go in `plugins/` (NOT `plugins/`)
+- Each plugin has a directory: `plugins/[plugin-name]/`
+- `pnpm discover-plugins` auto-generates `plugins/index.ts`, `lib/step-registry.ts`, `lib/codegen-registry.ts`
 - Three plugin variants: credential-based (external API), system plugin (pure logic), infrastructure plugin (uses internal infra)
 </overview>
 
@@ -11,7 +11,7 @@ Custom workflow plugins provide integrations with external services and internal
 Exact file layout for a plugin:
 
 ```
-keeperhub/plugins/[plugin-name]/
+plugins/[plugin-name]/
   index.ts          # Plugin definition + registerIntegration()
   icon.tsx          # SVG icon component
   credentials.ts    # Credential type (skip if requiresCredentials: false)
@@ -89,7 +89,7 @@ STEP FILE TEMPLATE (CREDENTIAL-BASED):
 ```typescript
 import "server-only";
 
-import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { fetchCredentials } from "@/lib/credential-fetcher";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
@@ -162,7 +162,7 @@ STEP FILE TEMPLATE (SYSTEM PLUGIN -- no credentials):
 ```typescript
 import "server-only";
 
-import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -316,7 +316,7 @@ CRITICAL "use step" bundler rules (violations break production builds):
 <registration>
 Post-creation steps:
 
-1. `pnpm discover-plugins` -- auto-generates keeperhub/plugins/index.ts, lib/step-registry.ts
+1. `pnpm discover-plugins` -- auto-generates plugins/index.ts, lib/step-registry.ts
 2. `pnpm check` -- lint check
 3. `pnpm type-check` -- TypeScript validation
 </registration>
@@ -330,7 +330,7 @@ Production rules (violations break the build):
 4. Must export `_integrationType` constant matching plugin type
 5. Wrap with `withPluginMetrics` AND `withStepLogging` (see discord/steps/send-message.ts as reference)
 6. No emojis in code or comments
-7. All custom code in keeperhub/ directory
+7. Plugins in plugins/, protocols in protocols/
 8. Security-critical steps must set `maxRetries = 0`
 </critical_rules>
 

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -41,23 +41,23 @@ Your job is to produce actionable research reports with exact file paths, line n
 <research_strategies>
 **Find existing pattern:**
 Use Grep to find similar implementations, then Read the best example:
-- Protocols: `Grep for "defineProtocol" in keeperhub/protocols/`
-- Plugin steps: `Grep for "use step" in keeperhub/plugins/`
-- Plugin definitions: `Grep for "definePlugin" in keeperhub/plugins/`
-- API routes: `Grep for "export async function" in app/api/ or keeperhub/api/`
+- Protocols: `Grep for "defineProtocol" in protocols/`
+- Plugin steps: `Grep for "use step" in plugins/`
+- Plugin definitions: `Grep for "definePlugin" in plugins/`
+- API routes: `Grep for "export async function" in app/api/ or app/api/`
 - Test patterns: `Grep for "describe(" in tests/`
 
 **Discover types:**
 Read type definition files and extract relevant interfaces:
 - Plugin types: `lib/types/plugin.ts`, `lib/types/step.ts`
-- Protocol types: `keeperhub/lib/protocols/types.ts`
+- Protocol types: `lib/protocols/types.ts`
 - Workflow types: `lib/types/workflow.ts`
-- Database schema: `lib/db/schema.ts`, `keeperhub/db/`
+- Database schema: `lib/db/schema.ts`, `db/`
 
 **Check conventions:**
 Read scoped CLAUDE.md files for directory-specific rules:
 - Root: `CLAUDE.md`
-- Plugins: `keeperhub/plugins/CLAUDE.md`
+- Plugins: `plugins/CLAUDE.md`
 - E2E tests: `tests/e2e/playwright/CLAUDE.md`
 
 **Understand dependencies:**

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -26,7 +26,7 @@ You are strictly read-only. You NEVER modify files. You read code, run checks, r
 2. For each created or modified file:
    a. Read the file contents
    b. Check it follows KeeperHub conventions:
-      - Code is in `keeperhub/` directory (not root-level)
+      - Code is in the correct directory (plugins/, protocols/, lib/, etc.)
       - Proper imports (`import "server-only"` in step files)
       - No emojis in code, comments, or strings
       - Block statements used (no single-line if statements)
@@ -53,7 +53,7 @@ You are strictly read-only. You NEVER modify files. You read code, run checks, r
 </workflow>
 
 <quality_checks>
-- **Convention compliance**: All code in `keeperhub/`, proper "use step" patterns, correct imports
+- **Convention compliance**: Proper "use step" patterns, correct imports
 - **Lint and type safety**: `pnpm check` and `pnpm type-check` pass with zero errors
 - **Test coverage**: Relevant tests exist and pass for new functionality
 - **Plugin registration**: If plugins or protocols were created/modified, `pnpm discover-plugins` was run and output is current
@@ -133,7 +133,7 @@ Success Criteria:
 2. [criterion text]: [PASS|FAIL] [evidence]
 
 Convention Compliance:
-- keeperhub/ directory: [PASS|FAIL]
+- Directory structure: [PASS|FAIL]
 - "use step" patterns: [PASS|FAIL|N/A]
 - No emojis: [PASS|FAIL]
 - No debug artifacts: [PASS|FAIL]

--- a/.claude/commands/add-feature.md
+++ b/.claude/commands/add-feature.md
@@ -19,9 +19,8 @@ Important: Features touching database schemas (lib/db/, drizzle/), security code
 Project conventions: @CLAUDE.md
 Tech stack and structure: @.planning/ROADMAP.md
 Blueprint pipeline: @.claude/agents/blueprint-pipeline.md
-Existing plugins: !`ls keeperhub/plugins/`
-Existing protocols: !`ls keeperhub/protocols/`
-Custom code directory: !`ls keeperhub/`
+Existing plugins: !`ls plugins/`
+Existing protocols: !`ls protocols/`
 </context>
 
 <process>
@@ -42,8 +41,7 @@ Risk classification guidance:
 - Tier 3 (HALT): Schema migrations (any file in lib/db/ or drizzle/), security/auth middleware, wallet signing/transaction submission, credential handling
 
 KeeperHub conventions for the Orchestrator to enforce:
-- All custom code goes in keeperhub/ directory (NOT root-level directories)
-- Plugins go in keeperhub/plugins/, protocols go in keeperhub/protocols/
+- Plugins go in plugins/, protocols go in protocols/
 - "use step" bundler constraints: step files NEVER export functions (only step fn + _integrationType + type exports). Violations break the production build.
 - Shared step logic goes in *-core.ts files without "use step"
 - Run pnpm discover-plugins after any plugin or protocol changes
@@ -54,7 +52,7 @@ KeeperHub conventions for the Orchestrator to enforce:
 - Target branch: staging (always)
 
 Research guidance for the Researcher agent:
-- Explore keeperhub/ to find the right directory for new code
+- Explore the codebase to find the right directory for new code
 - Find the most similar existing implementation as a pattern reference
 - Identify all files that need to be created or modified
 - Check for TypeScript types/interfaces needed in the new code

--- a/.claude/commands/add-plugin.md
+++ b/.claude/commands/add-plugin.md
@@ -9,17 +9,17 @@ Add a new KeeperHub workflow plugin. $ARGUMENTS is either:
 - Just a plugin name (e.g., "coinbase") -- pipeline will ask for details
 - Empty -- pipeline will ask what plugin to build
 
-This command invokes the Orchestrator agent which runs the full Blueprint pipeline: DECOMPOSE -> RESEARCH -> IMPLEMENT -> VERIFY -> PR. The pipeline produces a complete, lint-clean plugin in `keeperhub/plugins/` with step files, icon, credentials (if needed), and documentation.
+This command invokes the Orchestrator agent which runs the full Blueprint pipeline: DECOMPOSE -> RESEARCH -> IMPLEMENT -> VERIFY -> PR. The pipeline produces a complete, lint-clean plugin in `plugins/` with step files, icon, credentials (if needed), and documentation.
 </objective>
 
 <context>
 Domain knowledge: @.claude/agents/plugin-domain.md
-Example credential plugin: @keeperhub/plugins/discord/index.ts
-Example system plugin: @keeperhub/plugins/web3/index.ts
+Example credential plugin: @plugins/discord/index.ts
+Example system plugin: @plugins/web3/index.ts
 Plugin registry: @plugins/registry.ts
 Project conventions: @CLAUDE.md
 Blueprint pipeline: @.claude/agents/blueprint-pipeline.md
-Existing plugins: !`ls keeperhub/plugins/`
+Existing plugins: !`ls plugins/`
 </context>
 
 <process>
@@ -39,25 +39,25 @@ Orchestrator: Before spawning agents, determine:
 3. What actions does this plugin need?
 
 Required artifacts for a NEW plugin:
-- keeperhub/plugins/{name}/index.ts -- plugin definition
-- keeperhub/plugins/{name}/icon.tsx -- SVG icon
-- keeperhub/plugins/{name}/credentials.ts -- credential type (if credential-based)
-- keeperhub/plugins/{name}/test.ts -- connection test
-- keeperhub/plugins/{name}/steps/{action-slug}.ts -- one per action
+- plugins/{name}/index.ts -- plugin definition
+- plugins/{name}/icon.tsx -- SVG icon
+- plugins/{name}/credentials.ts -- credential type (if credential-based)
+- plugins/{name}/test.ts -- connection test
+- plugins/{name}/steps/{action-slug}.ts -- one per action
 - docs/plugins/{name}.md -- documentation page
 
 Required artifacts for an ACTION ADDITION to an existing plugin:
-- keeperhub/plugins/{existing-plugin}/steps/{action-slug}.ts -- new step file
-- keeperhub/plugins/{existing-plugin}/index.ts -- add action entry to actions array
+- plugins/{existing-plugin}/steps/{action-slug}.ts -- new step file
+- plugins/{existing-plugin}/index.ts -- add action entry to actions array
 
 Required modifications (both cases):
 - docs/plugins/_meta.json -- add/update nav entry
 - docs/plugins/overview.md -- add/update Available Plugins table
-- (auto-generated) keeperhub/plugins/index.ts
+- (auto-generated) plugins/index.ts
 - (auto-generated) lib/step-registry.ts
 
 Research questions for the Researcher agent:
-- Does a similar plugin already exist (check keeperhub/plugins/)?
+- Does a similar plugin already exist (check plugins/)?
 - Should this be a new plugin or a new action on an existing plugin?
 - What does the API for this service look like (authentication, endpoints)?
 - What patterns does the most similar existing plugin use?
@@ -76,7 +76,7 @@ The Orchestrator handles: determining plugin variant, decomposing subtasks, dele
 
 <success_criteria>
 - Orchestrator pipeline completes end-to-end
-- Plugin directory exists at keeperhub/plugins/{name}/ with all required files
+- Plugin directory exists at plugins/{name}/ with all required files
 - All checks pass: pnpm check, pnpm type-check, pnpm discover-plugins
 - PR created targeting staging branch with conventional commit format
 - Verifier agent explicitly approved before PR creation (SAFE-04 gate)

--- a/.claude/commands/add-protocol.md
+++ b/.claude/commands/add-protocol.md
@@ -9,16 +9,16 @@ Add a new KeeperHub protocol plugin. $ARGUMENTS is either:
 - A file path ending in `.md` (e.g., `specs/my-protocol.md`) -- pipeline reads spec file for details
 - Empty -- pipeline will ask user what protocol to add
 
-This command invokes the Orchestrator agent which runs the full Blueprint pipeline: DECOMPOSE -> RESEARCH -> IMPLEMENT -> VERIFY -> PR. The pipeline produces a complete, lint-clean, type-safe protocol definition in `keeperhub/protocols/` with tests and documentation.
+This command invokes the Orchestrator agent which runs the full Blueprint pipeline: DECOMPOSE -> RESEARCH -> IMPLEMENT -> VERIFY -> PR. The pipeline produces a complete, lint-clean, type-safe protocol definition in `protocols/` with tests and documentation.
 </objective>
 
 <context>
 Domain knowledge: @.claude/agents/protocol-domain.md
-Example protocol: @keeperhub/protocols/weth.ts
-Protocol registry: @keeperhub/lib/protocol-registry.ts
+Example protocol: @protocols/weth.ts
+Protocol registry: @lib/protocol-registry.ts
 Project conventions: @CLAUDE.md
 Blueprint pipeline: @.claude/agents/blueprint-pipeline.md
-Existing protocols: !`ls keeperhub/protocols/`
+Existing protocols: !`ls protocols/`
 </context>
 
 <process>
@@ -32,7 +32,7 @@ Domain Reference: .claude/agents/protocol-domain.md
 Task Type: Protocol plugin creation (Tier 1 -- follows existing pattern)
 
 Required artifacts:
-- keeperhub/protocols/{slug}.ts -- protocol definition using defineProtocol()
+- protocols/{slug}.ts -- protocol definition using defineProtocol()
 - tests/unit/protocol-{slug}.test.ts -- Vitest unit tests
 - docs/plugins/{slug}.md -- documentation page
 - public/protocols/{slug}.png -- icon (if user provides one)
@@ -41,18 +41,18 @@ Required artifacts:
 Required modifications:
 - docs/plugins/_meta.ts -- add nav entry
 - docs/plugins/overview.md -- add to protocols table
-- (auto-generated) keeperhub/protocols/index.ts
+- (auto-generated) protocols/index.ts
 - (auto-generated) lib/types/integration.ts
 
 Research questions for the Researcher agent:
 - What contracts does this protocol have and on which chains?
 - Does any existing protocol definition serve as a closer pattern than WETH?
-- Does the slug "{slug}" already exist in lib/types/integration.ts or keeperhub/protocols/?
+- Does the slug "{slug}" already exist in lib/types/integration.ts or protocols/?
 - Does the protocol have Sepolia testnet deployments? If so, include addresses for chain "11155111".
 - Which chains in the protocol's contracts have explorer configs? (Only 1, 8453, 84532, 11155111 -- see protocol-domain.md)
 
 Success criteria:
-- keeperhub/protocols/{slug}.ts imports without throwing (defineProtocol validation passes)
+- protocols/{slug}.ts imports without throwing (defineProtocol validation passes)
 - pnpm discover-plugins runs without errors and registers the protocol
 - pnpm check passes with zero lint errors
 - pnpm type-check passes with zero TypeScript errors
@@ -68,7 +68,7 @@ The Orchestrator handles: gathering protocol details from user or spec file, dec
 
 <success_criteria>
 - Orchestrator pipeline completes end-to-end
-- Protocol definition at keeperhub/protocols/{slug}.ts passes defineProtocol() validation
+- Protocol definition at protocols/{slug}.ts passes defineProtocol() validation
 - All checks pass: pnpm check, pnpm type-check, vitest unit tests
 - PR created targeting staging branch with conventional commit format
 - Verifier agent explicitly approved before PR creation (SAFE-04 gate)

--- a/.claude/commands/develop-plugin.md
+++ b/.claude/commands/develop-plugin.md
@@ -10,20 +10,20 @@ This command has deep knowledge of the KeeperHub plugin architecture and creates
 </objective>
 
 <context>
-Existing keeperhub plugins: !`ls keeperhub/plugins/`
+Existing keeperhub plugins: !`ls plugins/`
 Available integration types: @lib/types/integration.ts
-Current plugin index: @keeperhub/plugins/index.ts
+Current plugin index: @plugins/index.ts
 Plugin registry: @plugins/registry.ts
 CLAUDE.md rules: @CLAUDE.md
 Plugin development guide: @plugins/AGENTS.md
 </context>
 
 <architecture>
-CRITICAL: Follow these conventions EXACTLY. All custom plugins go in `keeperhub/plugins/` (NOT `plugins/`).
+CRITICAL: Follow these conventions EXACTLY. All custom plugins go in `plugins/` (NOT `plugins/`).
 
 DIRECTORY STRUCTURE for each plugin:
 ```
-keeperhub/plugins/[plugin-name]/
+plugins/[plugin-name]/
   index.ts          # Plugin definition + registerIntegration()
   icon.tsx          # SVG icon component
   credentials.ts    # Credential type (skip if requiresCredentials: false)
@@ -107,7 +107,7 @@ FILE 2 - steps/[action-slug].ts (TWO-LAYER PATTERN):
 ```typescript
 import "server-only";
 
-import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { fetchCredentials } from "@/lib/credential-fetcher";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
@@ -205,7 +205,7 @@ Use this pattern for system/utility plugins that don't call external APIs.
 ```typescript
 import "server-only";
 
-import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -382,7 +382,7 @@ CRITICAL RULES:
 4. Must export `_integrationType` constant matching plugin type
 5. Wrap with withPluginMetrics AND withStepLogging (see discord/steps/send-message.ts)
 6. No emojis in code or comments
-7. All custom code in keeperhub/ directory
+7. Plugins in plugins/, protocols in protocols/
 8. Security-critical steps must set maxRetries = 0 (fail-safe, not fail-open)
 
 WORKFLOW BUNDLER CONSTRAINTS ("use step"):
@@ -484,8 +484,8 @@ UTILITY PLUGINS:
 
 4. CREATE PLUGIN FILES
    If NEW PLUGIN:
-   - Create directory: `keeperhub/plugins/[name]/`
-   - Create `keeperhub/plugins/[name]/steps/` directory
+   - Create directory: `plugins/[name]/`
+   - Create `plugins/[name]/steps/` directory
    - Write index.ts following the exact pattern above
    - Write icon.tsx (use a Lucide icon or placeholder SVG)
    - Write credentials.ts (if requiresCredentials: true, skip for system plugins)
@@ -499,7 +499,7 @@ UTILITY PLUGINS:
 
 5. REGISTER PLUGIN
    - Run: `pnpm discover-plugins`
-   - This auto-generates: keeperhub/plugins/index.ts, lib/types/integration.ts, lib/step-registry.ts
+   - This auto-generates: plugins/index.ts, lib/types/integration.ts, lib/step-registry.ts
 
 6. VALIDATE
    - Run: `pnpm type-check`
@@ -576,8 +576,8 @@ UTILITY PLUGINS:
 
 <verification>
 Before completing, verify:
-- All plugin files exist in keeperhub/plugins/[name]/
-- `pnpm discover-plugins` ran successfully (plugin appears in keeperhub/plugins/index.ts)
+- All plugin files exist in plugins/[name]/
+- `pnpm discover-plugins` ran successfully (plugin appears in plugins/index.ts)
 - `pnpm type-check` passes with no errors
 - `pnpm check` passes with no lint errors
 - Plugin type appears in lib/types/integration.ts
@@ -587,7 +587,7 @@ Before completing, verify:
 </verification>
 
 <success_criteria>
-- Plugin directory created at keeperhub/plugins/[name]/
+- Plugin directory created at plugins/[name]/
 - All required files present: index.ts, icon.tsx, test.ts, steps/*.ts
 - credentials.ts present if plugin requires credentials
 - Plugin registered via pnpm discover-plugins
@@ -595,7 +595,7 @@ Before completing, verify:
 - Lint checks pass
 - Plugin follows all naming conventions
 - Step functions use two-layer pattern with withPluginMetrics + withStepLogging
-- All imports use correct paths (@/plugins/registry, @/keeperhub/lib/metrics/...)
+- All imports use correct paths (@/plugins/registry, @/lib/metrics/...)
 - No SDK dependencies - uses fetch() directly
 - No emojis in any files
 - Documentation page created/updated at docs/plugins/ with actions table, inputs, outputs, example workflows, and when-to-use guidance

--- a/.claude/commands/develop-plugin.md
+++ b/.claude/commands/develop-plugin.md
@@ -19,7 +19,7 @@ Plugin development guide: @plugins/AGENTS.md
 </context>
 
 <architecture>
-CRITICAL: Follow these conventions EXACTLY. All custom plugins go in `plugins/` (NOT `plugins/`).
+CRITICAL: Follow these conventions EXACTLY. All custom plugins go in `plugins/`.
 
 DIRECTORY STRUCTURE for each plugin:
 ```

--- a/.claude/commands/test-pr.md
+++ b/.claude/commands/test-pr.md
@@ -107,7 +107,7 @@ gh pr view $PR_NUMBER --json title,body,files,labels
 
 From the output:
 - Identify changed features and components
-- Map changed files to affected pages and flows (e.g., changes in `keeperhub/plugins/web3/` affect the action grid and workflow canvas)
+- Map changed files to affected pages and flows (e.g., changes in `plugins/web3/` affect the action grid and workflow canvas)
 - Record findings to guide Step 6
 
 ### Step 6: Smoke test (browser)
@@ -163,7 +163,7 @@ Tailor tests to what actually changed. Do not test unchanged areas in this step.
 
 ### Step 7p: Protocol plugin testing (conditional)
 
-**Trigger**: Only run this step if the PR modifies files matching `keeperhub/protocols/*.ts`. Check the file list from Step 5. If no protocol files changed, skip to Step 8.
+**Trigger**: Only run this step if the PR modifies files matching `protocols/*.ts`. Check the file list from Step 5. If no protocol files changed, skip to Step 8.
 
 **7p-a: Read the protocol definition**
 

--- a/.claude/commands/test-protocol.md
+++ b/.claude/commands/test-protocol.md
@@ -1,169 +1,174 @@
 ---
 description: Test all actions for a protocol by creating workflows, executing them, and verifying results
-argument: protocol-slug (e.g. sky, spark, aave, compound)
+argument: protocol-slug (e.g. sky, spark, aave, compound, lido, ethena, yearn)
 ---
 
 # Test Protocol: $ARGUMENTS
 
-You are testing all actions for the **$ARGUMENTS** protocol. Follow these steps precisely.
+Test all actions for the **$ARGUMENTS** protocol across read and write operations.
 
-## Step 1: Read Protocol Definition
+## Step 0: Determine Target Environment
+
+Ask the user which environment to test against if not obvious from context:
+- **dev**: `mcp__keeperhub-dev__*` tools (localhost:3000)
+- **staging**: `mcp__keeperhub-staging__*` tools (app-staging.keeperhub.com)
+- **prod**: `mcp__keeperhub__*` tools (app.keeperhub.com)
+
+Use the corresponding MCP tool prefix for ALL workflow and execution operations throughout this test.
+
+## Step 1: Get Wallet Address
+
+The wallet address is needed for read actions (balance checks) and write actions (recipient/onBehalfOf). Do NOT hardcode any wallet address.
+
+Create a workflow to read the wallet info:
+```
+Trigger -> web3/check-balance (network: "1", address: any known contract)
+```
+
+Or use the `/api/user/wallet` endpoint via MCP if available. The wallet address will be in the execution output or can be extracted from the organization's wallet integration.
+
+If you already know the wallet address from prior conversation context, confirm it with the user before proceeding.
+
+## Step 2: Read Protocol Definition
 
 Read the protocol definition file:
 ```
-keeperhub/protocols/$ARGUMENTS.ts
+protocols/$ARGUMENTS.ts
 ```
 
-If it does not exist, check for alternate names (e.g., `aave-v3.ts` for `aave`). List what you find:
-- Protocol name and slug
+If it does not exist, check alternate names (e.g., `aave-v3.ts` for `aave`, `compound-v3.ts` for `compound`, `uniswap-v3.ts` for `uniswap`, `yearn-v3.ts` for `yearn`).
+
+Extract:
+- Protocol name, slug, and description
 - All contracts with their addresses and supported chains
 - All actions grouped by type (read vs write)
-- Which chains are available (especially check for Sepolia 11155111)
+- Whether contracts use `userSpecifiedAddress` (need a real vault/pool address)
+- Which chains have the most contract coverage
 
-## Step 2: Check for Existing Seed Workflows
+## Step 3: Check for Existing Seed Workflows
 
 Look for pre-built workflow JSON files:
 ```
 scripts/seed/workflows/$ARGUMENTS/
 ```
 
-If seed workflows exist, use them. If not, you will need to generate them in Step 3.
+If `mcp-test-*.json` files exist, they can be used as reference but may need wallet address updates.
 
-## Step 3: Generate Seed Workflows (if needed)
+## Step 4: Test Read Actions via Direct MCP
 
-If no seed workflows exist, create them:
+For protocols with read actions, test them directly via MCP tools first (faster than workflows):
 
-### Read Actions Workflow
-Create `scripts/seed/workflows/$ARGUMENTS/read-actions.json` with:
-- One trigger node (Manual)
-- One action node per read action in the protocol
-- All actions connected from trigger via edges
-- Network: use chain "1" (mainnet) as default, or whichever chain has the most contract coverage
-- For `account`/`user` address inputs: use the first contract address from the protocol definition (it will return 0 but the call succeeds, proving the action works)
-- For `amount`/`assets`/`shares` inputs: use "1000000000000000000" (1e18)
-- For `asset` address inputs: use a well-known token address for that chain (e.g., DAI 0x6B175474E89094C44Da98b954EedeAC495271d0F on mainnet)
+```
+mcp__keeperhub-{env}__$ARGUMENTS_{action-slug}
+```
 
-Node format:
+For each read action:
+- Use the wallet address for `account`/`user` fields
+- Use `"1000000000000000000"` (1e18) for `amount`/`assets`/`shares` fields
+- Use well-known token addresses for `asset` fields (DAI, USDC, WETH for mainnet)
+- For `userSpecifiedAddress` contracts, use a well-known vault/pool address from docs or block explorers
+- Use the chain with the most contract coverage (usually "1" for mainnet)
+
+Record results as you go. If a direct MCP call returns 501 (not supported for direct execution), fall back to workflow execution in Step 5.
+
+## Step 5: Test via Workflows (for write actions + any 501 reads)
+
+### Write Action Workflows
+
+For each write action that needs testing, create a workflow using `mcp__keeperhub-{env}__workflow_create`:
+
+**Sequential chaining pattern** (approve -> action):
+```
+Trigger -> Approve Token -> Protocol Action
+```
+
+Important rules:
+- Chain write actions **sequentially** (not parallel from trigger) to avoid nonce contention
+- Include `web3/approve-token` nodes before any DeFi action that spends tokens
+- Use realistic but small amounts (0.001 ETH, 1 USDC, etc.)
+- Use the org wallet address for `recipient`/`onBehalfOf`/`receiver`/`owner`/`to` fields
+- Run write workflows **one at a time** -- parallel execution causes nonce lock failures on the same wallet
+
+### Read Action Workflows (for 501 fallbacks)
+
+Create a single workflow with all read actions chained **sequentially**:
+```
+Trigger -> Read1 -> Read2 -> Read3 -> ...
+```
+
+Sequential edges prevent the workflow engine from aborting remaining nodes if one fails.
+
+### Execution
+
+Execute with `mcp__keeperhub-{env}__workflow_execute`, then poll with `mcp__keeperhub-{env}__execution_status`. Wait 25-35 seconds between status checks for write workflows.
+
+Get detailed results with `mcp__keeperhub-{env}__execution_logs` after completion.
+
+## Step 6: Save Seed Workflows
+
+Save tested workflow configurations to `scripts/seed/workflows/$ARGUMENTS/` for reuse:
+
+**File naming convention**:
+- `mcp-test-{action-description}.json` for write action workflows
+- `mcp-test-reads.json` for the consolidated read actions workflow
+
+**Important**: Seed files should use placeholder comments for wallet-specific values. Use the actual wallet address in the file but add a top-level `"wallet"` field documenting which address was used:
+
 ```json
 {
-  "id": "unique-id",
-  "type": "action",
-  "position": { "x": 450, "y": "<increment by 150>" },
-  "data": {
-    "label": "<action label>",
-    "description": "<action description>",
-    "type": "action",
-    "config": {
-      "actionType": "<protocol-slug>/<action-slug>",
-      "network": "1",
-      "...input fields as key-value pairs"
-    },
-    "status": "idle"
-  }
+  "protocol": "$ARGUMENTS",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "wallet": "0x... (Testing org on staging)",
+  "name": "MCP Test: ...",
+  "description": "...",
+  "nodes": [...],
+  "edges": [...]
 }
 ```
 
-### Write Actions (optional)
-Only if the protocol has Sepolia (11155111) addresses. If not, skip write tests and note it in the report.
+## Step 7: Withdraw Test Funds
 
-## Step 4: Create Test Workflows
+After write tests, create and execute withdrawal workflows to recover deposited funds:
+- `vault-withdraw` / `vault-redeem` for ERC-4626 vaults
+- Protocol-specific withdraw actions (e.g., `aave/withdraw`, `compound/withdraw`)
+- Run withdrawals **sequentially** (same nonce contention concern)
 
-Use the kh CLI to create workflows on the local dev server:
+Verify final balances match expectations.
 
-```bash
-kh wf create --name "Protocol Test: $ARGUMENTS Read Actions" --nodes-file scripts/seed/workflows/$ARGUMENTS/read-actions.json --host http://localhost:3000 --json
-```
-
-If `kh wf create` is not available, fall back to curl:
-```bash
-curl -s -X POST http://localhost:3000/api/workflows/create \
-  -H "Content-Type: application/json" \
-  -H "x-api-key: <key>" \
-  -d @scripts/seed/workflows/$ARGUMENTS/read-actions.json
-```
-
-Save the returned workflow ID.
-
-## Step 5: Execute Test Workflows
-
-Execute each workflow:
-
-```bash
-kh wf run <workflow-id> --wait --timeout 2m --host http://localhost:3000 --json
-```
-
-If `kh wf run` is not available, fall back to curl:
-```bash
-# Execute
-curl -s -X POST http://localhost:3000/api/workflow/<workflow-id>/execute \
-  -H "Content-Type: application/json" \
-  -H "x-api-key: <key>" \
-  -d '{}'
-
-# Poll status
-curl -s http://localhost:3000/api/workflows/executions/<execution-id>/status \
-  -H "x-api-key: <key>"
-```
-
-## Step 6: Verify Results
-
-After execution completes, check the results:
-
-```bash
-kh r logs <execution-id> --host http://localhost:3000 --json
-```
-
-Or via curl to the logs endpoint:
-```bash
-curl -s http://localhost:3000/api/workflows/executions/<execution-id>/logs \
-  -H "x-api-key: <key>"
-```
-
-Check that:
-- Overall execution status is "success"
-- Each node's status is "success"
-- No error messages in any node output
-
-## Step 7: Report Results
+## Step 8: Report Results
 
 Print a results table:
 
-| Action | Slug | Status | Duration | Error |
-|--------|------|--------|----------|-------|
-| Get sUSDS Balance | sky/get-susds-balance | success | 245ms | - |
-| ... | ... | ... | ... | ... |
+| Action | Slug | Type | Status | Notes |
+|--------|------|------|--------|-------|
+| Get Balance | protocol/get-balance | read | Pass | returned 0 |
+| Supply WETH | protocol/supply | write | Pass | tx confirmed |
+| Swap Tokens | protocol/swap | write | Fail | tuple[] encoding bug |
 
 Summary:
 - Total actions tested: X
-- Passed: Y
-- Failed: Z
-- Skipped (write, no testnet): W
-
-## Step 8: Cleanup
-
-Delete the test workflows:
-
-```bash
-kh wf delete <workflow-id> --yes --host http://localhost:3000
-```
-
-Or via curl:
-```bash
-curl -s -X DELETE http://localhost:3000/api/workflows/<workflow-id> \
-  -H "x-api-key: <key>"
-```
+- Reads: Y/Y passed
+- Writes: Z/W passed
+- Skipped: N (reason)
+- Seed workflows saved: list files
 
 ## Error Handling
 
-- If workflow creation fails: check if the dev server is running (`curl http://localhost:3000/api/health`)
-- If execution times out: report which nodes completed and which are stuck
-- If individual actions fail: report the specific error from the node logs, continue testing remaining actions
-- If kh CLI is not available: use curl fallback for all operations
+- **501 on direct MCP call**: Action is not a protocol action (e.g., `web3/check-balance`). Test via workflow instead.
+- **Nonce lock failure**: Too many parallel write workflows. Re-run sequentially.
+- **"Function not found in ABI"**: Contract ABI auto-resolution failed. May need inline ABI in protocol definition -- file a fix.
+- **"exceed deposit limit"**: Vault is full. Try a different vault address or smaller amount.
+- **"OperationNotAllowed"**: Protocol-specific restriction (cooldowns, timelocks). Note as expected behavior.
+- **Contract revert with no data**: Usually means insufficient balance, missing approval, or wrong function args.
 
-## Notes
+## Key Differences from Legacy Command
 
-- Always use `--host http://localhost:3000` to target the local dev server
-- The protocol slug matches the filename in `keeperhub/protocols/` (without .ts)
-- Read actions should always succeed as they only query on-chain state
-- Write actions need funded wallets and testnet addresses -- skip if not available
-- Save seed workflows for reuse in future test runs
+- Uses MCP tools (`mcp__keeperhub-{env}__*`) not raw curl/CLI
+- Supports dev/staging/prod environments
+- Tests writes via approve->action workflow chains
+- Recovers test funds via withdrawal workflows
+- Saves seed files with wallet metadata
+- Runs write workflows sequentially to avoid nonce contention
+- Does NOT hardcode wallet addresses -- discovers them at runtime

--- a/.claude/skills/vitest-plugin/SKILL.md
+++ b/.claude/skills/vitest-plugin/SKILL.md
@@ -3,7 +3,7 @@ name: vitest-plugin
 description: >-
   Generate Vitest unit tests for KeeperHub plugin step files. Use when asked to
   "write tests for", "test this step", "generate tests", or "add unit tests"
-  for any file in keeperhub/plugins/*/steps/.
+  for any file in plugins/*/steps/.
 version: 0.1.0
 ---
 
@@ -15,7 +15,7 @@ Generate a complete, passing Vitest unit test for a KeeperHub plugin step file.
 
 ### Step 1: Identify the step file
 
-Accept a path argument or find the step file from conversation context. The step file lives at `keeperhub/plugins/{plugin}/steps/{step-name}.ts`.
+Accept a path argument or find the step file from conversation context. The step file lives at `plugins/{plugin}/steps/{step-name}.ts`.
 
 If a corresponding `-core.ts` file exists (e.g., `read-contract-core.ts` for `read-contract.ts`), read both files -- the core file contains shared logic that the step file imports.
 
@@ -46,11 +46,11 @@ vi.mock("@/lib/steps/step-handler", () => ({
   withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
 }));
 
-vi.mock("@/keeperhub/lib/metrics/instrumentation/plugin", () => ({
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
   withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
 }));
 
-vi.mock("@/keeperhub/lib/logging", () => ({
+vi.mock("@/lib/logging", () => ({
   ErrorCategory: {
     VALIDATION: "validation",
     NETWORK_RPC: "network_rpc",
@@ -141,8 +141,8 @@ vi.mock("@/lib/utils", () => ({
 #### c) Import the SUT (system under test) after all mocks
 
 ```typescript
-import { stepFunctionName } from "@/keeperhub/plugins/{plugin}/steps/{step-name}";
-import type { InputType } from "@/keeperhub/plugins/{plugin}/steps/{step-name}";
+import { stepFunctionName } from "@/plugins/{plugin}/steps/{step-name}";
+import type { InputType } from "@/plugins/{plugin}/steps/{step-name}";
 ```
 
 #### d) Test helper functions
@@ -254,8 +254,8 @@ If tests fail, read the error output and fix. Common issues:
 Read these files for patterns and context:
 
 - `tests/unit/batch-read-contract.test.ts` -- canonical example of a comprehensive step test
-- `keeperhub/plugins/web3/steps/check-balance.ts` -- simple step to understand anatomy
-- `keeperhub/plugins/web3/steps/batch-read-contract.ts` -- complex step with multiple modes
-- `keeperhub/plugins/web3/steps/read-contract-core.ts` -- core-file pattern example
+- `plugins/web3/steps/check-balance.ts` -- simple step to understand anatomy
+- `plugins/web3/steps/batch-read-contract.ts` -- complex step with multiple modes
+- `plugins/web3/steps/read-contract-core.ts` -- core-file pattern example
 - `vitest.config.mts` -- test configuration (aliases, setup file, exclusions)
 - `tests/setup.ts` -- global test setup (provides some default mocks for `@/lib/db`)

--- a/plugins/CLAUDE.md
+++ b/plugins/CLAUDE.md
@@ -7,7 +7,7 @@ This file supplements the root CLAUDE.md with plugin-specific rules. All root CL
 Every plugin follows this layout. Reference `web3/` as the canonical example.
 
 ```
-keeperhub/plugins/{plugin-name}/
+plugins/{plugin-name}/
   index.ts          # Plugin definition (IntegrationPlugin), registers actions
   icon.tsx          # Plugin icon component
   steps/            # Step files (one per action)
@@ -44,8 +44,8 @@ import "server-only";
 
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
-import { ErrorCategory, logUserError } from "@/keeperhub/lib/logging";
-import { withPluginMetrics } from "@/keeperhub/lib/metrics/instrumentation/plugin";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
@@ -120,11 +120,11 @@ vi.mock("@/lib/steps/step-handler", () => ({
   withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
 }));
 
-vi.mock("@/keeperhub/lib/metrics/instrumentation/plugin", () => ({
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
   withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
 }));
 
-vi.mock("@/keeperhub/lib/logging", () => ({
+vi.mock("@/lib/logging", () => ({
   ErrorCategory: { VALIDATION: "validation", NETWORK_RPC: "network_rpc", EXTERNAL_SERVICE: "external_service" },
   logUserError: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
- After KEEP-1561 consolidated the keeperhub/ subdirectory into the project root, all slash commands, agent definitions, skills, and plugins/CLAUDE.md still referenced the old keeperhub/ paths -- causing broken file references in the agent pipeline and incorrect guidance in code templates
- Updates 15 files across .claude/commands/, .claude/agents/, .claude/skills/, and plugins/CLAUDE.md to use the new flat layout (protocols/, plugins/, @/lib/ instead of keeperhub/protocols/, keeperhub/plugins/, @/keeperhub/lib/)
- Also regenerated lib/step-registry.ts via pnpm discover-plugins to fix stale import paths

## Test Plan
- [ ] Run `/add-protocol` and verify the command references `protocols/` not `keeperhub/protocols/`
- [ ] Run `/add-plugin` and verify the command references `plugins/` not `keeperhub/plugins/`
- [ ] Run `pnpm discover-plugins` -- should complete without errors
- [ ] Run `pnpm type-check` -- should pass (step-registry now has correct imports)
- [ ] Grep for `keeperhub/` in .claude/ directory -- should return zero matches