### PR TITLE
ci: add TechOps ECR push + techops-prod values (KEEP-1188)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -135,32 +135,32 @@ jobs:
           files: docker-bake.hcl
           push: true
 
-      # ── Copy images to secondary ECR (e.g. TechOps account) ──
-      - name: Configure secondary ECR credentials
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.SECONDARY_ECR_REGION != ''
+      # ── Copy images to TechOps ECR ──
+      - name: Configure TechOps AWS credentials
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.SECONDARY_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SECONDARY_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.SECONDARY_ECR_REGION }}
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.TO_REGION }}
 
-      - name: Login to secondary ECR
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.SECONDARY_ECR_REGION != ''
-        id: login-secondary-ecr
+      - name: Login to TechOps ECR
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        id: login-techops-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Copy images to secondary ECR
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.SECONDARY_ECR_REGION != ''
+      - name: Copy images to TechOps ECR
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         env:
           SRC_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          DST_REGISTRY: ${{ steps.login-secondary-ecr.outputs.registry }}
+          DST_REGISTRY: ${{ steps.login-techops-ecr.outputs.registry }}
           ECR_REPO: ${{ env.AWS_ECR_NAME }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
         run: |
           for prefix in app migrator; do
-            echo "Copying ${prefix}-${IMAGE_TAG} to secondary ECR..."
+            echo "Copying ${prefix}-${IMAGE_TAG} to TechOps ECR..."
             docker buildx imagetools create \
               --tag "${DST_REGISTRY}/${ECR_REPO}:${prefix}-${IMAGE_TAG}" \
               "${SRC_REGISTRY}/${ECR_REPO}:${prefix}-${IMAGE_TAG}"
           done
-          echo "Secondary ECR push complete"
+          echo "TechOps ECR push complete"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -134,3 +134,33 @@ jobs:
         with:
           files: docker-bake.hcl
           push: true
+
+      # ── Copy images to secondary ECR (e.g. TechOps account) ──
+      - name: Configure secondary ECR credentials
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.SECONDARY_ECR_REGION != ''
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.SECONDARY_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SECONDARY_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.SECONDARY_ECR_REGION }}
+
+      - name: Login to secondary ECR
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.SECONDARY_ECR_REGION != ''
+        id: login-secondary-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Copy images to secondary ECR
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.SECONDARY_ECR_REGION != ''
+        env:
+          SRC_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          DST_REGISTRY: ${{ steps.login-secondary-ecr.outputs.registry }}
+          ECR_REPO: ${{ env.AWS_ECR_NAME }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          for prefix in app migrator; do
+            echo "Copying ${prefix}-${IMAGE_TAG} to secondary ECR..."
+            docker buildx imagetools create \
+              --tag "${DST_REGISTRY}/${ECR_REPO}:${prefix}-${IMAGE_TAG}" \
+              "${SRC_REGISTRY}/${ECR_REPO}:${prefix}-${IMAGE_TAG}"
+          done
+          echo "Secondary ECR push complete"

--- a/deploy/docs-site/techops-prod/values.yaml
+++ b/deploy/docs-site/techops-prod/values.yaml
@@ -1,0 +1,68 @@
+replicaCount: 2
+
+service:
+  enabled: true
+  name: keeperhub-docs
+  port: 3000
+  type: ClusterIP
+  containerPort: 3000
+  tls:
+    enabled: true
+    issuerName: cloudflare
+
+ingress:
+  enabled: true
+  hosts:
+    - docs.keeperhub.com
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.options: traefik-cloudflare-origin-pull@kubernetescrd
+
+httpWwwRedirect:
+  enabled: false
+httpBasicAuth:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-docs-prod
+  tag: ${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+resources:
+  limits:
+    memory: 256Mi
+  requests:
+    cpu: 10m
+    memory: 128Mi
+
+env:
+  NODE_ENV:
+    type: kv
+    value: "production"
+  HOSTNAME:
+    type: kv
+    value: "0.0.0.0"
+
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  httpGet:
+    path: /
+    port: 3000
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  httpGet:
+    path: /
+    port: 3000

--- a/deploy/keeperhub/techops-prod/values.yaml
+++ b/deploy/keeperhub/techops-prod/values.yaml
@@ -30,7 +30,7 @@ service:
 ingress:
   enabled: true
   hosts:
-    - app-techops.keeperhub.com
+    - app.keeperhub.com
   annotations:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
@@ -139,7 +139,7 @@ env:
     value: "http://localhost:3000"
   BETTER_AUTH_URL:
     type: kv
-    value: "https://app-techops.keeperhub.com"
+    value: "https://app.keeperhub.com"
   BETTER_AUTH_SECRET:
     type: parameterStore
     name: better-auth-secret


### PR DESCRIPTION
## Summary
- build-images.yml: copy images to TechOps ECR after primary build using `docker buildx imagetools create` (uses existing `TO_*` secrets)
- Fix techops-prod ingress host and BETTER_AUTH_URL to production hostnames
- Add techops-prod values for docs-site

## Test plan
- [ ] Merge to prod triggers CI
- [ ] Verify `keeperhub-prod` and `keeperhub-docs-prod` images appear in TechOps ECR (us-east-2)
- [ ] Verify `keeperhub-prod` ServiceAccount is created on TechOps cluster