### PR TITLE
chore: add protocol seed workflows for MCP testing

### DIFF
--- a/scripts/seed/workflows/aave/mcp-test-supply-weth.json
+++ b/scripts/seed/workflows/aave/mcp-test-supply-weth.json
@@ -1,0 +1,60 @@
+{
+  "protocol": "aave",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Aave Approve WETH + Supply",
+  "description": "Approve WETH for Aave V3 Pool then supply 0.003 WETH on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-weth",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve WETH for Aave",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\",\"symbol\":\"WETH\"}}",
+          "spenderAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "aave-supply",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Supply WETH to Aave",
+        "type": "action",
+        "config": {
+          "actionType": "aave/supply",
+          "network": "1",
+          "asset": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "amount": "3000000000000000",
+          "onBehalfOf": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9",
+          "referralCode": "0"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-weth", "type": "animated" },
+    { "id": "e2", "source": "approve-weth", "target": "aave-supply", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/aave/mcp-test-withdraw-weth.json
+++ b/scripts/seed/workflows/aave/mcp-test-withdraw-weth.json
@@ -1,0 +1,41 @@
+{
+  "protocol": "aave",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Aave Withdraw WETH",
+  "description": "Withdraw WETH from Aave V3 on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "aave-withdraw",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Withdraw WETH from Aave",
+        "type": "action",
+        "config": {
+          "actionType": "aave/withdraw",
+          "network": "1",
+          "asset": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "amount": "3000000000000000",
+          "to": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "aave-withdraw", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/aerodrome/mcp-test-swap-weth-usdc.json
+++ b/scripts/seed/workflows/aerodrome/mcp-test-swap-weth-usdc.json
@@ -1,0 +1,77 @@
+{
+  "protocol": "aerodrome",
+  "network": "8453",
+  "networkName": "base",
+  "type": "write",
+  "name": "MCP Test: Base WETH Wrap + Approve + Aerodrome Swap WETH to USDC",
+  "description": "Wrap Base ETH to WETH, approve for Aerodrome router, swap 0.0005 WETH to USDC on Base. Note: routes tuple[] encoding has a known issue -- see work log.",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "wrap",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Wrap ETH to WETH",
+        "type": "action",
+        "config": {
+          "actionType": "weth/wrap",
+          "network": "8453",
+          "ethValue": "0.001"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Approve WETH for Aerodrome",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "8453",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0x4200000000000000000000000000000000000006\",\"symbol\":\"WETH\"}}",
+          "spenderAddress": "0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "swap",
+      "type": "action",
+      "position": { "x": 816, "y": 0 },
+      "data": {
+        "label": "Swap WETH to USDC",
+        "type": "action",
+        "config": {
+          "actionType": "aerodrome/swap-exact-tokens",
+          "network": "8453",
+          "amountIn": "500000000000000",
+          "amountOutMin": "0",
+          "routes": "[[\"0x4200000000000000000000000000000000000006\",\"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913\",false,\"0x420DD381b31aEf6683db6B902084cB0FFECe40Da\"]]",
+          "to": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9",
+          "deadline": "9999999999"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "wrap", "type": "animated" },
+    { "id": "e2", "source": "wrap", "target": "approve", "type": "animated" },
+    { "id": "e3", "source": "approve", "target": "swap", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/chronicle/mcp-test-cross-protocol-monitor.json
+++ b/scripts/seed/workflows/chronicle/mcp-test-cross-protocol-monitor.json
@@ -1,0 +1,28 @@
+{
+  "protocol": "chronicle",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "read",
+  "name": "Cross-Protocol DeFi Monitor",
+  "description": "Chronicle ETH/USD oracle + Lido wstETH rate + Compound USDC supply rate -> formatted dashboard with price alerts",
+  "notes": "Sequential pipeline to ensure all outputs are available for the Code node. Node labels must NOT contain colons -- the template parser uses : as separator in {{@nodeId:Label.field}}.",
+  "nodes": [
+    {"id":"trigger-1","type":"trigger","position":{"x":100,"y":300},"data":{"type":"trigger","label":"Hourly Schedule","config":{"triggerType":"Schedule","scheduleCron":"0 * * * *","scheduleTimezone":"UTC"},"status":"idle","description":"Check every hour"}},
+    {"id":"oracle-eth","type":"action","position":{"x":350,"y":300},"data":{"type":"action","label":"Read ETH Price","description":"Get current ETH price and staleness from Chronicle oracle","config":{"actionType":"chronicle/try-read-with-age","network":"1","contractAddress":"0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E","_protocolMeta":"{\"protocolSlug\":\"chronicle\",\"contractKey\":\"oracle\",\"functionName\":\"tryReadWithAge\",\"actionType\":\"read\"}"},"status":"idle"}},
+    {"id":"lido-rate","type":"action","position":{"x":600,"y":300},"data":{"type":"action","label":"Get wstETH Rate","description":"Current wstETH-to-stETH exchange rate","config":{"actionType":"lido/get-steth-by-wsteth","network":"1","_wstETHAmount":"1000000000000000000","_protocolMeta":"{\"protocolSlug\":\"lido\",\"contractKey\":\"wsteth\",\"functionName\":\"getStETHByWstETH\",\"actionType\":\"read\"}"},"status":"idle"}},
+    {"id":"compound-rate","type":"action","position":{"x":850,"y":300},"data":{"type":"action","label":"Get USDC Supply Rate","description":"Current USDC supply rate on Compound V3","config":{"actionType":"compound/get-supply-rate","network":"1","contractAddress":"0xc3d688B66703497DAA19211EEdff47f25384cdc3","utilization":"800000000000000000","_protocolMeta":"{\"protocolSlug\":\"compound-v3\",\"contractKey\":\"cUsdcV3\",\"functionName\":\"getSupplyRate\",\"actionType\":\"read\"}"},"status":"idle"}},
+    {"id":"fmt","type":"action","position":{"x":1100,"y":300},"data":{"type":"action","label":"Format Dashboard","description":"Format all data into dashboard","config":{"actionType":"code/run-code","code":"const ethRaw = Number({{@oracle-eth:Read ETH Price.result.unnamedOutput1}});\nconst ethPrice = ethRaw / 1e18;\nconst oracleAge = Number({{@oracle-eth:Read ETH Price.result.unnamedOutput2}});\nconst now = Math.floor(Date.now() / 1000);\nconst staleMinutes = Math.floor((now - oracleAge) / 60);\nconst wstethRate = Number({{@lido-rate:Get wstETH Rate.result}}) / 1e18;\nconst supplyRatePerSec = Number({{@compound-rate:Get USDC Supply Rate.result}});\nconst supplyAPR = supplyRatePerSec > 0 ? ((supplyRatePerSec / 1e18) * 31536000 * 100).toFixed(2) : \"0.00\";\nconst ethFmt = new Intl.NumberFormat(\"en-US\", {style:\"currency\",currency:\"USD\"}).format(ethPrice);\nreturn {\n  ethPrice: ethFmt,\n  ethRaw: ethPrice.toFixed(2),\n  staleMinutes: String(staleMinutes),\n  wstethRate: wstethRate.toFixed(4),\n  compoundAPR: supplyAPR,\n  summary: `ETH: ${ethFmt} (${staleMinutes}m old) | wstETH: ${wstethRate.toFixed(4)} stETH | Compound USDC APR: ${supplyAPR}%`\n};"},"status":"idle"}},
+    {"id":"cond-price","type":"action","position":{"x":1350,"y":300},"data":{"type":"action","label":"ETH Below 2000","description":"Alert if ETH below $2,000","config":{"actionType":"Condition","condition":"{{@fmt:Format Dashboard.result.ethRaw}} < 2000","conditionConfig":{"group":{"id":"price-check","logic":"AND","rules":[{"id":"rule-eth-low","operator":"<","leftOperand":"{{@fmt:Format Dashboard.result.ethRaw}}","rightOperand":"2000"}]}}},"status":"idle"}},
+    {"id":"discord-ok","type":"action","position":{"x":1600,"y":150},"data":{"type":"action","label":"Discord DeFi Healthy","description":"Hourly dashboard summary","config":{"actionType":"discord/send-message","discordMessage":"**Hourly DeFi Dashboard**\n\n{{@fmt:Format Dashboard.result.summary}}\n\nAll systems normal."},"status":"idle"}},
+    {"id":"discord-alert","type":"action","position":{"x":1600,"y":450},"data":{"type":"action","label":"Discord ETH Alert","description":"ETH dropped below $2,000","config":{"actionType":"discord/send-message","discordMessage":"**ETH PRICE ALERT**\n\nETH/USD: {{@fmt:Format Dashboard.result.ethPrice}} (below $2,000)\nOracle age: {{@fmt:Format Dashboard.result.staleMinutes}} min\nwstETH: {{@fmt:Format Dashboard.result.wstethRate}} stETH\nCompound APR: {{@fmt:Format Dashboard.result.compoundAPR}}%"},"status":"idle"}}
+  ],
+  "edges": [
+    {"id":"e1","source":"trigger-1","target":"oracle-eth"},
+    {"id":"e2","source":"oracle-eth","target":"lido-rate"},
+    {"id":"e3","source":"lido-rate","target":"compound-rate"},
+    {"id":"e4","source":"compound-rate","target":"fmt"},
+    {"id":"e5","source":"fmt","target":"cond-price"},
+    {"id":"e6","type":"animated","source":"cond-price","target":"discord-ok","sourceHandle":"false"},
+    {"id":"e7","type":"animated","source":"cond-price","target":"discord-alert","sourceHandle":"true"}
+  ]
+}

--- a/scripts/seed/workflows/chronicle/mcp-test-read-oracle.json
+++ b/scripts/seed/workflows/chronicle/mcp-test-read-oracle.json
@@ -1,0 +1,97 @@
+{
+  "protocol": "chronicle",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "read",
+  "name": "MCP Test: Chronicle Read All Oracle Actions",
+  "description": "Test all 4 Chronicle read actions against ETH/USD oracle on mainnet",
+  "oracleAddress": "0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E",
+  "nodes": [
+    {
+      "id": "trigger-1",
+      "type": "trigger",
+      "position": { "x": 100, "y": 250 },
+      "data": {
+        "type": "trigger",
+        "label": "Manual Trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle",
+        "description": "Run manually"
+      }
+    },
+    {
+      "id": "read-1",
+      "type": "action",
+      "position": { "x": 400, "y": 100 },
+      "data": {
+        "type": "action",
+        "label": "Chronicle: Read Oracle Value",
+        "description": "Read ETH/USD price",
+        "config": {
+          "actionType": "chronicle/read",
+          "network": "1",
+          "contractAddress": "0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"oracle\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "read-2",
+      "type": "action",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "type": "action",
+        "label": "Chronicle: Try Read Oracle Value",
+        "description": "Try read ETH/USD price (no revert)",
+        "config": {
+          "actionType": "chronicle/try-read",
+          "network": "1",
+          "contractAddress": "0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"oracle\",\"functionName\":\"tryRead\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "read-3",
+      "type": "action",
+      "position": { "x": 400, "y": 400 },
+      "data": {
+        "type": "action",
+        "label": "Chronicle: Read Oracle Value with Age",
+        "description": "Read ETH/USD price with timestamp",
+        "config": {
+          "actionType": "chronicle/read-with-age",
+          "network": "1",
+          "contractAddress": "0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"oracle\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "read-4",
+      "type": "action",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "type": "action",
+        "label": "Chronicle: Try Read Oracle Value with Age",
+        "description": "Try read ETH/USD price with timestamp (no revert)",
+        "config": {
+          "actionType": "chronicle/try-read-with-age",
+          "network": "1",
+          "contractAddress": "0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"oracle\",\"functionName\":\"tryReadWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger-1", "target": "read-1" },
+    { "id": "e2", "source": "trigger-1", "target": "read-2" },
+    { "id": "e3", "source": "trigger-1", "target": "read-3" },
+    { "id": "e4", "source": "trigger-1", "target": "read-4" }
+  ]
+}

--- a/scripts/seed/workflows/chronicle/mcp-test-self-kiss.json
+++ b/scripts/seed/workflows/chronicle/mcp-test-self-kiss.json
@@ -1,0 +1,63 @@
+{
+  "protocol": "chronicle",
+  "network": "11155111",
+  "networkName": "sepolia",
+  "type": "write",
+  "wallet": "0x8b2f23b9bcb0276177d026d8d953ccf06844aaf5 (Test Org on local dev)",
+  "name": "MCP Test: Chronicle SelfKiss + Read (Sepolia)",
+  "description": "Whitelist wallet on ETH/USD Sepolia oracle via SelfKisser, then read to verify",
+  "oracleAddress": "0xdd6D76262Fd7BdDe428dcfCd94386EbAe0151603",
+  "selfKisserAddress": "0x9eE458DefDc50409DbF153515DA54Ff5B744e533",
+  "nodes": [
+    {
+      "id": "trigger-1",
+      "type": "trigger",
+      "position": { "x": 100, "y": 250 },
+      "data": {
+        "type": "trigger",
+        "label": "Manual Trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle",
+        "description": "Run manually"
+      }
+    },
+    {
+      "id": "write-1",
+      "type": "action",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "type": "action",
+        "label": "Chronicle: Whitelist on Oracle (Self)",
+        "description": "Whitelist wallet on ETH/USD Sepolia oracle via SelfKisser",
+        "config": {
+          "actionType": "chronicle/self-kiss",
+          "network": "11155111",
+          "oracle": "0xdd6D76262Fd7BdDe428dcfCd94386EbAe0151603",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"selfKisser\",\"functionName\":\"selfKiss\",\"actionType\":\"write\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "read-1",
+      "type": "action",
+      "position": { "x": 700, "y": 250 },
+      "data": {
+        "type": "action",
+        "label": "Chronicle: Try Read Oracle Value",
+        "description": "Verify whitelisting by reading ETH/USD on Sepolia",
+        "config": {
+          "actionType": "chronicle/try-read",
+          "network": "11155111",
+          "contractAddress": "0xdd6D76262Fd7BdDe428dcfCd94386EbAe0151603",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"oracle\",\"functionName\":\"tryRead\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger-1", "target": "write-1" },
+    { "id": "e2", "source": "write-1", "target": "read-1" }
+  ]
+}

--- a/scripts/seed/workflows/compound/mcp-test-supply-weth.json
+++ b/scripts/seed/workflows/compound/mcp-test-supply-weth.json
@@ -1,0 +1,59 @@
+{
+  "protocol": "compound",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Compound Approve WETH + Supply",
+  "description": "Approve WETH for Compound V3 USDC Comet then supply 0.003 WETH as collateral on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-weth",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve WETH for Compound",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\",\"symbol\":\"WETH\"}}",
+          "spenderAddress": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "compound-supply",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Supply WETH to Compound",
+        "type": "action",
+        "config": {
+          "actionType": "compound/supply",
+          "network": "1",
+          "contractAddress": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+          "asset": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "amount": "3000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-weth", "type": "animated" },
+    { "id": "e2", "source": "approve-weth", "target": "compound-supply", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/compound/mcp-test-withdraw-weth.json
+++ b/scripts/seed/workflows/compound/mcp-test-withdraw-weth.json
@@ -1,0 +1,41 @@
+{
+  "protocol": "compound",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Compound Withdraw WETH",
+  "description": "Withdraw WETH collateral from Compound V3 USDC market on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "compound-withdraw",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Withdraw WETH from Compound",
+        "type": "action",
+        "config": {
+          "actionType": "compound/withdraw",
+          "network": "1",
+          "contractAddress": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+          "asset": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "amount": "3000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "compound-withdraw", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/ethena/mcp-test-cooldown-susde.json
+++ b/scripts/seed/workflows/ethena/mcp-test-cooldown-susde.json
@@ -1,0 +1,39 @@
+{
+  "protocol": "ethena",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Ethena Cooldown sUSDe Assets",
+  "description": "Initiate cooldown on 1 USDe worth of sUSDe shares. After 7 days, call unstake to claim.",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cooldown",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Cooldown Assets",
+        "type": "action",
+        "config": {
+          "actionType": "ethena/cooldown-assets",
+          "network": "1",
+          "assets": "1000000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "cooldown", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/ethena/mcp-test-deposit-susde.json
+++ b/scripts/seed/workflows/ethena/mcp-test-deposit-susde.json
@@ -1,0 +1,58 @@
+{
+  "protocol": "ethena",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Ethena Approve USDe + Deposit sUSDe",
+  "description": "Approve USDe for sUSDe vault then deposit 2 USDe on mainnet. Requires USDe in wallet (swap USDC->USDe via Uniswap first).",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-usde",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve USDe for sUSDe",
+        "type": "action",
+        "config": {
+          "actionType": "ethena/approve-usde",
+          "network": "1",
+          "spender": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+          "amount": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "deposit-susde",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Deposit USDe to sUSDe",
+        "type": "action",
+        "config": {
+          "actionType": "ethena/vault-deposit",
+          "network": "1",
+          "contractAddress": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+          "assets": "2000000000000000000",
+          "receiver": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-usde", "type": "animated" },
+    { "id": "e2", "source": "approve-usde", "target": "deposit-susde", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/lido/mcp-test-unwrap-wsteth.json
+++ b/scripts/seed/workflows/lido/mcp-test-unwrap-wsteth.json
@@ -1,0 +1,39 @@
+{
+  "protocol": "lido",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Lido Unwrap wstETH to stETH",
+  "description": "Unwrap 0.002 wstETH to stETH on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "unwrap",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Unwrap wstETH",
+        "type": "action",
+        "config": {
+          "actionType": "lido/unwrap",
+          "network": "1",
+          "_wstETHAmount": "2000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "unwrap", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/lido/mcp-test-wrap-steth.json
+++ b/scripts/seed/workflows/lido/mcp-test-wrap-steth.json
@@ -1,0 +1,56 @@
+{
+  "protocol": "lido",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Lido Approve stETH + Wrap to wstETH",
+  "description": "Approve stETH for wstETH contract then wrap 0.002 stETH back to wstETH on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-steth",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve stETH",
+        "type": "action",
+        "config": {
+          "actionType": "lido/approve-steth",
+          "network": "1",
+          "spender": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "amount": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "wrap",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Wrap stETH to wstETH",
+        "type": "action",
+        "config": {
+          "actionType": "lido/wrap",
+          "network": "1",
+          "_stETHAmount": "2000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-steth", "type": "animated" },
+    { "id": "e2", "source": "approve-steth", "target": "wrap", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/morpho/mcp-test-vault-deposit.json
+++ b/scripts/seed/workflows/morpho/mcp-test-vault-deposit.json
@@ -1,0 +1,59 @@
+{
+  "protocol": "morpho",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Morpho Vault Approve USDC + Deposit",
+  "description": "Approve USDC for Steakhouse MetaMorpho vault then deposit 2 USDC on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-usdc",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve USDC",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48\",\"symbol\":\"USDC\"}}",
+          "spenderAddress": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "vault-deposit",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Deposit USDC to Vault",
+        "type": "action",
+        "config": {
+          "actionType": "morpho/vault-deposit",
+          "network": "1",
+          "contractAddress": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "assets": "2000000",
+          "receiver": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-usdc", "type": "animated" },
+    { "id": "e2", "source": "approve-usdc", "target": "vault-deposit", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/morpho/mcp-test-vault-withdraw.json
+++ b/scripts/seed/workflows/morpho/mcp-test-vault-withdraw.json
@@ -1,0 +1,42 @@
+{
+  "protocol": "morpho",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Morpho Vault Withdraw USDC",
+  "description": "Withdraw 2 USDC from Steakhouse MetaMorpho vault on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "vault-withdraw",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Withdraw USDC from Vault",
+        "type": "action",
+        "config": {
+          "actionType": "morpho/vault-withdraw",
+          "network": "1",
+          "contractAddress": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "assets": "2000000",
+          "receiver": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9",
+          "owner": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "vault-withdraw", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/sky/mcp-test-convert-dai-usds.json
+++ b/scripts/seed/workflows/sky/mcp-test-convert-dai-usds.json
@@ -1,0 +1,58 @@
+{
+  "protocol": "sky",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Sky Approve DAI + Convert DAI to USDS",
+  "description": "Approve DAI for Sky DaiUsds converter then convert 5 DAI to USDS on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-dai",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve DAI for Converter",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0x6B175474E89094C44Da98b954EedeAC495271d0F\",\"symbol\":\"DAI\"}}",
+          "spenderAddress": "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "convert-dai-usds",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Convert DAI to USDS",
+        "type": "action",
+        "config": {
+          "actionType": "sky/convert-dai-to-usds",
+          "network": "1",
+          "usr": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9",
+          "amount": "5000000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-dai", "type": "animated" },
+    { "id": "e2", "source": "approve-dai", "target": "convert-dai-usds", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/sky/mcp-test-convert-usds-dai.json
+++ b/scripts/seed/workflows/sky/mcp-test-convert-usds-dai.json
@@ -1,0 +1,58 @@
+{
+  "protocol": "sky",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Sky Convert USDS to DAI",
+  "description": "Approve USDS then convert 5 USDS back to DAI on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-usds",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve USDS for Converter",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xdC035D45d973E3EC169d2276DDab16f1e407384F\",\"symbol\":\"USDS\"}}",
+          "spenderAddress": "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "convert-usds-dai",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Convert USDS to DAI",
+        "type": "action",
+        "config": {
+          "actionType": "sky/convert-usds-to-dai",
+          "network": "1",
+          "usr": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9",
+          "amount": "5000000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-usds", "type": "animated" },
+    { "id": "e2", "source": "approve-usds", "target": "convert-usds-dai", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/spark/mcp-test-deposit-sdai.json
+++ b/scripts/seed/workflows/spark/mcp-test-deposit-sdai.json
@@ -1,0 +1,58 @@
+{
+  "protocol": "spark",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Spark Approve DAI + Deposit sDAI",
+  "description": "Approve DAI for sDAI vault then deposit 3 DAI into sDAI on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-dai",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve DAI for sDAI",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0x6B175474E89094C44Da98b954EedeAC495271d0F\",\"symbol\":\"DAI\"}}",
+          "spenderAddress": "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "deposit-sdai",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Deposit DAI to sDAI",
+        "type": "action",
+        "config": {
+          "actionType": "spark/vault-deposit",
+          "network": "1",
+          "assets": "3000000000000000000",
+          "receiver": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-dai", "type": "animated" },
+    { "id": "e2", "source": "approve-dai", "target": "deposit-sdai", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/spark/mcp-test-redeem-sdai.json
+++ b/scripts/seed/workflows/spark/mcp-test-redeem-sdai.json
@@ -1,0 +1,41 @@
+{
+  "protocol": "spark",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Spark Redeem sDAI",
+  "description": "Redeem sDAI shares back to DAI on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "spark-redeem",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Redeem sDAI to DAI",
+        "type": "action",
+        "config": {
+          "actionType": "spark/vault-redeem",
+          "network": "1",
+          "shares": "2557065683279584032",
+          "receiver": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9",
+          "owner": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "spark-redeem", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/uniswap/mcp-test-swap-dai-usdc.json
+++ b/scripts/seed/workflows/uniswap/mcp-test-swap-dai-usdc.json
@@ -1,0 +1,63 @@
+{
+  "protocol": "uniswap",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Swap DAI to USDC",
+  "description": "Approve DAI then swap 5 DAI to USDC via Uniswap V3 on mainnet (for Morpho testing)",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-dai",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve DAI",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0x6B175474E89094C44Da98b954EedeAC495271d0F\",\"symbol\":\"DAI\"}}",
+          "spenderAddress": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "swap",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Swap DAI to USDC",
+        "type": "action",
+        "config": {
+          "actionType": "uniswap/swap-exact-input",
+          "network": "1",
+          "tokenIn": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "tokenOut": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "amountIn": "5000000000000000000",
+          "amountOutMinimum": "0",
+          "fee": "100",
+          "sqrtPriceLimitX96": "0",
+          "recipient": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-dai", "type": "animated" },
+    { "id": "e2", "source": "approve-dai", "target": "swap", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/uniswap/mcp-test-swap-usdc-usde.json
+++ b/scripts/seed/workflows/uniswap/mcp-test-swap-usdc-usde.json
@@ -1,0 +1,63 @@
+{
+  "protocol": "uniswap",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Swap USDC to USDe",
+  "description": "Approve USDC then swap 3 USDC to USDe via Uniswap V3 on mainnet (for Ethena testing)",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-usdc",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve USDC",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48\",\"symbol\":\"USDC\"}}",
+          "spenderAddress": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "swap",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Swap USDC to USDe",
+        "type": "action",
+        "config": {
+          "actionType": "uniswap/swap-exact-input",
+          "network": "1",
+          "tokenIn": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "tokenOut": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+          "amountIn": "3000000",
+          "amountOutMinimum": "0",
+          "fee": "100",
+          "sqrtPriceLimitX96": "0",
+          "recipient": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-usdc", "type": "animated" },
+    { "id": "e2", "source": "approve-usdc", "target": "swap", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/uniswap/mcp-test-swap-weth-wsteth.json
+++ b/scripts/seed/workflows/uniswap/mcp-test-swap-weth-wsteth.json
@@ -1,0 +1,45 @@
+{
+  "protocol": "uniswap",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Swap WETH to wstETH",
+  "description": "Swap 0.005 WETH to wstETH via Uniswap V3 on mainnet (for Lido testing)",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "swap",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Swap WETH to wstETH",
+        "type": "action",
+        "config": {
+          "actionType": "uniswap/swap-exact-input",
+          "network": "1",
+          "tokenIn": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenOut": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+          "amountIn": "5000000000000000",
+          "amountOutMinimum": "0",
+          "fee": "100",
+          "sqrtPriceLimitX96": "0",
+          "recipient": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "swap", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/uniswap/mcp-test-swap.json
+++ b/scripts/seed/workflows/uniswap/mcp-test-swap.json
@@ -1,0 +1,63 @@
+{
+  "protocol": "uniswap",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Uniswap Approve+Swap WETH to DAI",
+  "description": "Approve WETH for Uniswap SwapRouter02 then swap 0.005 WETH to DAI on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve-weth",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve WETH",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\",\"symbol\":\"WETH\"}}",
+          "spenderAddress": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "swap-weth-dai",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Swap WETH to DAI",
+        "type": "action",
+        "config": {
+          "actionType": "uniswap/swap-exact-input",
+          "network": "1",
+          "tokenIn": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenOut": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          "amountIn": "5000000000000000",
+          "amountOutMinimum": "0",
+          "fee": "3000",
+          "sqrtPriceLimitX96": "0",
+          "recipient": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve-weth", "type": "animated" },
+    { "id": "e2", "source": "approve-weth", "target": "swap-weth-dai", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/yearn/mcp-test-deposit-yvweth.json
+++ b/scripts/seed/workflows/yearn/mcp-test-deposit-yvweth.json
@@ -1,0 +1,59 @@
+{
+  "protocol": "yearn",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "write",
+  "name": "MCP Test: Yearn Approve WETH + Deposit yvWETH",
+  "description": "Approve WETH for yvWETH vault then deposit 0.001 WETH on mainnet",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "approve",
+      "type": "action",
+      "position": { "x": 272, "y": 0 },
+      "data": {
+        "label": "Approve WETH for Yearn",
+        "type": "action",
+        "config": {
+          "actionType": "web3/approve-token",
+          "network": "1",
+          "tokenConfig": "{\"mode\":\"custom\",\"customToken\":{\"address\":\"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\",\"symbol\":\"WETH\"}}",
+          "spenderAddress": "0xa258C4606Ca8206D8aA700cE2143D7db854D168c",
+          "amount": "max"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "deposit",
+      "type": "action",
+      "position": { "x": 544, "y": 0 },
+      "data": {
+        "label": "Deposit WETH to yvWETH",
+        "type": "action",
+        "config": {
+          "actionType": "yearn/vault-deposit",
+          "network": "1",
+          "contractAddress": "0xa258C4606Ca8206D8aA700cE2143D7db854D168c",
+          "assets": "1000000000000000",
+          "receiver": "0xCE2910044c51479D61DB3F8798Df6C5672F51dE9"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "approve", "type": "animated" },
+    { "id": "e2", "source": "approve", "target": "deposit", "type": "animated" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Consolidate all MCP test workflow templates from protocol testing sessions into scripts/seed/workflows/ for reuse in future /test-protocol runs
- Covers 11 protocols with read and write action templates, plus a cross-protocol monitor demo combining Chronicle + Lido + Compound

## Protocols Covered
| Protocol | Workflows | Types |
|----------|-----------|-------|
| Aave | 2 | supply, withdraw |
| Aerodrome | 1 | swap |
| Chronicle | 3 | read oracle, selfKiss, cross-protocol monitor |
| Compound | 2 | supply, withdraw |
| Ethena | 2 | deposit sUSDe, cooldown |
| Lido | 2 | wrap stETH, unwrap wstETH |
| Morpho | 2 | vault deposit, vault withdraw |
| Sky | 2 | convert DAI->USDS, convert USDS->DAI |
| Spark | 2 | deposit sDAI, redeem sDAI |
| Uniswap | 4 | various swap pairs |
| Yearn | 1 | deposit yvWETH |

## Test Plan
- [ ] Spot-check: pick any seed file, create workflow via MCP, execute, verify pass