### PR TITLE
hotfix: use sql template instead of js values

### DIFF
--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -287,7 +287,7 @@ export class NonceManager {
           gasPrice,
           status: "pending",
           submittedAt: new Date(),
-          confirmedAt: null,
+          confirmedAt: sql`null`,
         },
       });
 


### PR DESCRIPTION
# Summary:

This pull request updates how default values are stored in the `confirmed_at` column on `pending_transactions` as it could introduce wrong insertions