### PR TITLE
fix: KEEP-1578 prevent suggestion widget jumping in template editors

### DIFF
--- a/components/ui/sql-template-editor.tsx
+++ b/components/ui/sql-template-editor.tsx
@@ -351,9 +351,15 @@ export function SqlTemplateEditor({
       // Initial decoration pass
       updateDecorations();
 
-      // Update decorations on every content change
+      let decorationRaf: number | undefined;
       editor.onDidChangeModelContent(() => {
-        updateDecorations();
+        if (decorationRaf !== undefined) {
+          cancelAnimationFrame(decorationRaf);
+        }
+        decorationRaf = requestAnimationFrame(() => {
+          decorationRaf = undefined;
+          updateDecorations();
+        });
       });
 
       // Register completion provider for @ trigger
@@ -436,6 +442,8 @@ export function SqlTemplateEditor({
             scrollBeyondLastLine: false,
             fontSize: 12,
             readOnly: disabled,
+            wordBasedSuggestions: "off",
+            quickSuggestions: false,
             wordWrap: "off",
           }}
           value={displayValue}

--- a/components/ui/template-code-editor.tsx
+++ b/components/ui/template-code-editor.tsx
@@ -341,8 +341,15 @@ export function TemplateCodeEditor({
 
       updateDecorations();
 
+      let decorationRaf: number | undefined;
       editor.onDidChangeModelContent(() => {
-        updateDecorations();
+        if (decorationRaf !== undefined) {
+          cancelAnimationFrame(decorationRaf);
+        }
+        decorationRaf = requestAnimationFrame(() => {
+          decorationRaf = undefined;
+          updateDecorations();
+        });
       });
 
       const disposable = monaco.languages.registerCompletionItemProvider(
@@ -421,6 +428,8 @@ export function TemplateCodeEditor({
             tabSize: 2,
             wordWrap: "on",
             readOnly: disabled,
+            wordBasedSuggestions: "off",
+            quickSuggestions: false,
             padding: { top: 8, bottom: 8 },
             renderLineHighlight: "gutter",
             overviewRulerLanes: 0,


### PR DESCRIPTION
## Summary

- Disable Monaco built-in word-based and quick suggestions in both `TemplateCodeEditor` and `SqlTemplateEditor` so only the custom `@` trigger provider drives the suggest widget
- Debounce `updateDecorations` via `requestAnimationFrame` to prevent layout thrashing while the suggest widget is open