### PR TITLE
fix: KEEP-1583 exclude __current__ workflows from project and tag counts

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,4 +1,4 @@
-import { count, eq } from "drizzle-orm";
+import { and, count, eq, ne } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { projects, workflows } from "@/lib/db/schema";
@@ -31,7 +31,13 @@ export async function GET(request: Request) {
         workflowCount: count(workflows.id),
       })
       .from(projects)
-      .leftJoin(workflows, eq(workflows.projectId, projects.id))
+      .leftJoin(
+        workflows,
+        and(
+          eq(workflows.projectId, projects.id),
+          ne(workflows.name, "__current__")
+        )
+      )
       .where(eq(projects.organizationId, organizationId))
       .groupBy(projects.id)
       .orderBy(projects.name);

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,4 +1,4 @@
-import { count, eq } from "drizzle-orm";
+import { and, count, eq, ne } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { tags, workflows } from "@/lib/db/schema";
@@ -30,7 +30,10 @@ export async function GET(request: Request): Promise<NextResponse> {
         workflowCount: count(workflows.id),
       })
       .from(tags)
-      .leftJoin(workflows, eq(workflows.tagId, tags.id))
+      .leftJoin(
+        workflows,
+        and(eq(workflows.tagId, tags.id), ne(workflows.name, "__current__"))
+      )
       .where(eq(tags.organizationId, organizationId))
       .groupBy(tags.id)
       .orderBy(tags.name);


### PR DESCRIPTION
## Summary

- Overlay workflow counts (Projects and Tags settings) included internal `__current__` placeholder workflows in the SQL `COUNT`, while the sidebar correctly filtered them client-side
- Added `ne(workflows.name, "__current__")` to the `LEFT JOIN` condition in both `GET /api/projects` and `GET /api/tags` so counts are consistent across all UI surfaces