### PR TITLE
ci: pass CHAIN_RPC_CONFIG secret to e2e vitest tests

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -207,6 +207,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -179,6 +179,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
+          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Start application
         uses: ./.github/actions/start-app
@@ -273,6 +274,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
           WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
+          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Start application
         uses: ./.github/actions/start-app


### PR DESCRIPTION
## Summary

- E2E check-balance tests were failing because CI had no `CHAIN_RPC_CONFIG`, falling through to public RPCs (`eth.llamarpc.com`) which are Cloudflare-blocked from GitHub Actions runner IPs
- Added `CHAIN_RPC_CONFIG` secret to the vitest e2e step so tests use the same paid RPC endpoints as staging/prod
- Requires `CHAIN_RPC_CONFIG` to be set as a GitHub environment secret in `staging` (already done)

## Test plan

- [x] Verified `CHAIN_RPC_CONFIG` secret is set in GitHub staging environment
- [x] Confirm tests pass on PR
- [x] Merge and confirm check-balance tests pass on next staging push