### PR TITLE
feat: KEEP-1584 enable Tempo mainnet chain

### DIFF
--- a/app/api/supported-tokens/route.ts
+++ b/app/api/supported-tokens/route.ts
@@ -7,8 +7,8 @@ import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 // Mainnet chain ID - used as the "master list" of supported tokens
 const MAINNET_CHAIN_ID = 1;
 
-// TEMPO testnet chain IDs - excluded from master list logic (have their own tokens)
-const TEMPO_CHAIN_IDS = [42_429];
+// TEMPO chain IDs - excluded from master list logic (have their own tokens)
+const TEMPO_CHAIN_IDS = [42_429, 4217];
 
 /**
  * Build explorer URL for a token address

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -44,8 +44,9 @@ type WalletOverlayProps = {
   overlayId: string;
 };
 
-// TEMPO testnet uses stablecoins for gas, so we display stablecoins only (no native token)
-const TEMPO_CHAIN_ID = 42_429;
+// TEMPO uses stablecoins for gas, so we display stablecoins only (no native token)
+const TEMPO_CHAIN_IDS = new Set([42_429, 4217]);
+const isTempoChain = (chainId: number): boolean => TEMPO_CHAIN_IDS.has(chainId);
 const MAINNET_CHAIN_ID = 1;
 
 // ============================================================================
@@ -235,7 +236,7 @@ function ChainBalanceItem({
     (t) => t.chainId === balance.chainId
   );
 
-  const isTempo = balance.chainId === TEMPO_CHAIN_ID;
+  const isTempo = isTempoChain(balance.chainId);
   const isMainnet = balance.chainId === MAINNET_CHAIN_ID;
 
   // For TEMPO chains, just show their own tokens
@@ -1115,7 +1116,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     // Add native balances (skip TEMPO - it uses stablecoins, not native tokens)
     for (const balance of balances) {
       // Skip TEMPO native balance - it uses stablecoins only
-      if (balance.chainId === TEMPO_CHAIN_ID) {
+      if (isTempoChain(balance.chainId)) {
         continue;
       }
       const chain = chains.find((c) => c.chainId === balance.chainId);

--- a/lib/chain-utils.ts
+++ b/lib/chain-utils.ts
@@ -7,7 +7,7 @@ const CHAIN_NAMES: Record<string, string> = {
   "11155111": "Sepolia",
   "84532": "Base Sepolia",
   "42429": "Tempo Testnet",
-  "42420": "Tempo",
+  "4217": "Tempo",
   "101": "Solana",
   "103": "Solana Devnet",
 };

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -82,7 +82,13 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     fallbackEnvKey: "CHAIN_TEMPO_TESTNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.TEMPO_TESTNET,
   },
-  // Tempo Mainnet
+  // Tempo Mainnet (4217 is the canonical chain ID; 42420 kept for backwards compatibility)
+  4217: {
+    jsonKey: "tempo-mainnet",
+    envKey: "CHAIN_TEMPO_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_TEMPO_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.TEMPO_MAINNET,
+  },
   42420: {
     jsonKey: "tempo-mainnet",
     envKey: "CHAIN_TEMPO_MAINNET_PRIMARY_RPC",

--- a/lib/rpc/types.ts
+++ b/lib/rpc/types.ts
@@ -39,7 +39,7 @@ export const SUPPORTED_CHAIN_IDS = {
   // EVM Mainnets
   MAINNET: 1,
   BASE: 8453,
-  TEMPO_MAINNET: 42_420,
+  TEMPO_MAINNET: 4217,
   // EVM Testnets
   SEPOLIA: 11_155_111,
   BASE_SEPOLIA: 84_532,

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -176,7 +176,7 @@ const DEFAULT_CHAINS: NewChain[] = [
       type: "fallback",
     }),
     isTestnet: getChainConfigValue("tempo-mainnet", "isTestnet", false),
-    isEnabled: getChainConfigValue("tempo-mainnet", "isEnabled", false),
+    isEnabled: getChainConfigValue("tempo-mainnet", "isEnabled", true),
   },
   // Solana chains (non-EVM - uses SolanaProviderManager)
   {

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -159,20 +159,20 @@ const DEFAULT_CHAINS: NewChain[] = [
     isEnabled: getChainConfigValue("tempo-testnet", "isEnabled", true),
   },
   {
-    chainId: getChainConfigValue("tempo-mainnet", "chainId", 42_420),
+    chainId: getChainConfigValue("tempo-mainnet", "chainId", 4217),
     name: "Tempo",
     symbol: getChainConfigValue("tempo-mainnet", "symbol", "TEMPO"),
     chainType: "evm",
-    defaultPrimaryRpc: getRpcUrlByChainId(42_420, "primary"),
-    defaultFallbackRpc: getRpcUrlByChainId(42_420, "fallback"),
+    defaultPrimaryRpc: getRpcUrlByChainId(4217, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(4217, "fallback"),
     defaultPrimaryWss: getWssUrl({
       rpcConfig,
-      jsonKey: CHAIN_CONFIG[42_420].jsonKey,
+      jsonKey: CHAIN_CONFIG[4217].jsonKey,
       type: "primary",
     }),
     defaultFallbackWss: getWssUrl({
       rpcConfig,
-      jsonKey: CHAIN_CONFIG[42_420].jsonKey,
+      jsonKey: CHAIN_CONFIG[4217].jsonKey,
       type: "fallback",
     }),
     isTestnet: getChainConfigValue("tempo-mainnet", "isTestnet", false),
@@ -278,11 +278,11 @@ const EXPLORER_CONFIG_TEMPLATES: Record<
     explorerContractPath: "/address/{address}?tab=contract",
   },
   // Tempo Mainnet - Blockscout
-  42420: {
+  4217: {
     chainType: "evm",
-    explorerUrl: "https://explorer.tempo.xyz",
+    explorerUrl: "https://explore.mainnet.tempo.xyz",
     explorerApiType: "blockscout",
-    explorerApiUrl: "https://explorer.tempo.xyz/api",
+    explorerApiUrl: "https://explore.mainnet.tempo.xyz/api",
     explorerTxPath: "/tx/{hash}",
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}?tab=contract",
@@ -362,7 +362,7 @@ async function seedChains() {
     Base: 8453,
     "Base Sepolia": 84_532,
     "Tempo Testnet": 42_429,
-    Tempo: 42_420,
+    Tempo: 4217,
     Solana: 101,
     "Solana Devnet": 103,
   };

--- a/scripts/seed/seed-tokens.ts
+++ b/scripts/seed/seed-tokens.ts
@@ -153,6 +153,38 @@ const TOKEN_CONFIGS: TokenConfig[] = [
     isStablecoin: true,
     sortOrder: 4,
   },
+
+  // ==========================================================================
+  // Tempo Mainnet (chainId: 4217)
+  // ==========================================================================
+  {
+    chainId: 4217,
+    tokenAddress: "0x20c0000000000000000000000000000000000000", // pathUSD
+    logoUrl: null,
+    isStablecoin: true,
+    sortOrder: 1,
+  },
+  {
+    chainId: 4217,
+    tokenAddress: "0x20c0000000000000000000000000000000000001", // AlphaUSD
+    logoUrl: null,
+    isStablecoin: true,
+    sortOrder: 2,
+  },
+  {
+    chainId: 4217,
+    tokenAddress: "0x20c0000000000000000000000000000000000002", // BetaUSD
+    logoUrl: null,
+    isStablecoin: true,
+    sortOrder: 3,
+  },
+  {
+    chainId: 4217,
+    tokenAddress: "0x20c0000000000000000000000000000000000003", // ThetaUSD
+    logoUrl: null,
+    isStablecoin: true,
+    sortOrder: 4,
+  },
 ];
 
 /**

--- a/scripts/seed/seed-tokens.ts
+++ b/scripts/seed/seed-tokens.ts
@@ -159,31 +159,24 @@ const TOKEN_CONFIGS: TokenConfig[] = [
   // ==========================================================================
   {
     chainId: 4217,
-    tokenAddress: "0x20c0000000000000000000000000000000000000", // pathUSD
-    logoUrl: null,
+    tokenAddress: "0x20c000000000000000000000b9537d11c60e8b50", // USDC.e (Bridged USDC via Stargate)
+    logoUrl: LOGOS.USDC,
     isStablecoin: true,
     sortOrder: 1,
   },
   {
     chainId: 4217,
-    tokenAddress: "0x20c0000000000000000000000000000000000001", // AlphaUSD
-    logoUrl: null,
+    tokenAddress: "0x20c00000000000000000000014f22ca97301eb73", // USDT0
+    logoUrl: LOGOS.USDT,
     isStablecoin: true,
     sortOrder: 2,
   },
   {
     chainId: 4217,
-    tokenAddress: "0x20c0000000000000000000000000000000000002", // BetaUSD
+    tokenAddress: "0x20c0000000000000000000003554d28269e0f3c2", // frxUSD (Frax USD)
     logoUrl: null,
     isStablecoin: true,
     sortOrder: 3,
-  },
-  {
-    chainId: 4217,
-    tokenAddress: "0x20c0000000000000000000000000000000000003", // ThetaUSD
-    logoUrl: null,
-    isStablecoin: true,
-    sortOrder: 4,
   },
 ];
 

--- a/tests/integration/chains-route.test.ts
+++ b/tests/integration/chains-route.test.ts
@@ -100,8 +100,8 @@ const mockChains = {
   },
   tempoDisabled: {
     chain: {
-      id: "chain_42420",
-      chainId: 42_420,
+      id: "chain_4217",
+      chainId: 4217,
       name: "Tempo",
       symbol: "USD",
       chainType: "evm",
@@ -185,7 +185,7 @@ describe("/api/chains route", () => {
 
       // Verify disabled chain is included
       const tempoChain = data.find(
-        (c: { chainId: number }) => c.chainId === 42_420
+        (c: { chainId: number }) => c.chainId === 4217
       );
       expect(tempoChain).toBeDefined();
       expect(tempoChain.isEnabled).toBe(false);

--- a/tests/unit/network-utils.test.ts
+++ b/tests/unit/network-utils.test.ts
@@ -26,8 +26,8 @@ describe("getChainIdFromNetwork", () => {
 
     it("should return chain ID for tempo networks", () => {
       expect(getChainIdFromNetwork("tempo-testnet")).toBe(42_429);
-      expect(getChainIdFromNetwork("tempo")).toBe(42_420);
-      expect(getChainIdFromNetwork("tempo-mainnet")).toBe(42_420);
+      expect(getChainIdFromNetwork("tempo")).toBe(4217);
+      expect(getChainIdFromNetwork("tempo-mainnet")).toBe(4217);
     });
 
     it("should return chain ID for solana networks", () => {
@@ -92,7 +92,7 @@ describe("getNetworkName", () => {
     expect(getNetworkName(8453)).toBe("Base");
     expect(getNetworkName(84_532)).toBe("Base Sepolia");
     expect(getNetworkName(42_429)).toBe("Tempo Testnet");
-    expect(getNetworkName(42_420)).toBe("Tempo");
+    expect(getNetworkName(4217)).toBe("Tempo");
     expect(getNetworkName(101)).toBe("Solana");
     expect(getNetworkName(103)).toBe("Solana Devnet");
   });
@@ -111,7 +111,7 @@ describe("SUPPORTED_CHAIN_IDS", () => {
     expect(SUPPORTED_CHAIN_IDS.BASE).toBe(8453);
     expect(SUPPORTED_CHAIN_IDS.BASE_SEPOLIA).toBe(84_532);
     expect(SUPPORTED_CHAIN_IDS.TEMPO_TESTNET).toBe(42_429);
-    expect(SUPPORTED_CHAIN_IDS.TEMPO_MAINNET).toBe(42_420);
+    expect(SUPPORTED_CHAIN_IDS.TEMPO_MAINNET).toBe(4217);
   });
 
   it("should have correct values for Solana chains", () => {


### PR DESCRIPTION
## Summary
- Enable Tempo mainnet (chain ID 42420) by default in chain seeding — flips `isEnabled` default from `false` to `true`

## Test plan
- [x] Deploy to pr and verify Tempo mainnet appears in chain selector
- [x] Verify existing chains are unaffected