### PR TITLE
fix: KEEP-1590 wrap protocol step body in withStepLogging to capture all failures

### DIFF
--- a/plugins/protocol/steps/protocol-read.ts
+++ b/plugins/protocol/steps/protocol-read.ts
@@ -52,75 +52,80 @@ export async function protocolReadStep(
 ): Promise<ReadContractResult> {
   "use step";
 
-  // 1. Resolve protocol metadata from config or action type
-  const meta = resolveProtocolMeta(input);
-  if (!meta) {
-    return {
-      success: false,
-      error:
-        "Invalid _protocolMeta: failed to parse JSON and could not derive from action type",
-    };
-  }
+  return await withStepLogging(input, async () => {
+    // 1. Resolve protocol metadata from config or action type
+    const meta = resolveProtocolMeta(input);
+    if (!meta) {
+      return {
+        success: false,
+        error:
+          "Invalid _protocolMeta: failed to parse JSON and could not derive from action type",
+      };
+    }
 
-  // 2. Look up protocol definition from runtime registry
-  const protocol = getProtocol(meta.protocolSlug);
-  if (!protocol) {
-    return { success: false, error: `Unknown protocol: ${meta.protocolSlug}` };
-  }
+    // 2. Look up protocol definition from runtime registry
+    const protocol = getProtocol(meta.protocolSlug);
+    if (!protocol) {
+      return {
+        success: false,
+        error: `Unknown protocol: ${meta.protocolSlug}`,
+      };
+    }
 
-  // 3. Resolve contract for the selected network
-  const contract = protocol.contracts[meta.contractKey];
-  if (!contract) {
-    return {
-      success: false,
-      error: `Unknown contract key "${meta.contractKey}" in protocol "${meta.protocolSlug}"`,
-    };
-  }
+    // 3. Resolve contract for the selected network
+    const contract = protocol.contracts[meta.contractKey];
+    if (!contract) {
+      return {
+        success: false,
+        error: `Unknown contract key "${meta.contractKey}" in protocol "${meta.protocolSlug}"`,
+      };
+    }
 
-  const contractAddress = contract.userSpecifiedAddress
-    ? input.contractAddress
-    : contract.addresses[input.network];
-  if (!contractAddress) {
-    return {
-      success: false,
-      error: contract.userSpecifiedAddress
-        ? `Missing contract address for "${meta.contractKey}" in protocol "${meta.protocolSlug}"`
-        : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on network "${input.network}"`,
-    };
-  }
+    const contractAddress = contract.userSpecifiedAddress
+      ? input.contractAddress
+      : contract.addresses[input.network];
+    if (!contractAddress) {
+      return {
+        success: false,
+        error: contract.userSpecifiedAddress
+          ? `Missing contract address for "${meta.contractKey}" in protocol "${meta.protocolSlug}"`
+          : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on network "${input.network}"`,
+      };
+    }
 
-  // 4. Resolve ABI (from definition or auto-fetch from explorer)
-  let resolvedAbi: string;
-  try {
-    const abiResult = await resolveAbi({
+    // 4. Resolve ABI (from definition or auto-fetch from explorer)
+    let resolvedAbi: string;
+    try {
+      const abiResult = await resolveAbi({
+        contractAddress,
+        network: input.network,
+        abi: contract.abi,
+      });
+      resolvedAbi = abiResult.abi;
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to resolve ABI for contract "${meta.contractKey}" in protocol "${meta.protocolSlug}": ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    // 5. Build function arguments from named inputs ordered by action definition
+    const functionArgs = buildFunctionArgs(input, meta);
+
+    // 6. Delegate to readContractCore
+    const coreInput: ReadContractCoreInput = {
       contractAddress,
       network: input.network,
-      abi: contract.abi,
-    });
-    resolvedAbi = abiResult.abi;
-  } catch (error) {
-    return {
-      success: false,
-      error: `Failed to resolve ABI for contract "${meta.contractKey}" in protocol "${meta.protocolSlug}": ${error instanceof Error ? error.message : String(error)}`,
+      abi: resolvedAbi,
+      abiFunction: meta.functionName,
+      functionArgs,
+      _context: input._context
+        ? { executionId: input._context.executionId }
+        : undefined,
     };
-  }
 
-  // 5. Build function arguments from named inputs ordered by action definition
-  const functionArgs = buildFunctionArgs(input, meta);
-
-  // 6. Delegate to readContractCore
-  const coreInput: ReadContractCoreInput = {
-    contractAddress,
-    network: input.network,
-    abi: resolvedAbi,
-    abiFunction: meta.functionName,
-    functionArgs,
-    _context: input._context
-      ? { executionId: input._context.executionId }
-      : undefined,
-  };
-
-  return await withStepLogging(input, () => readContractCore(coreInput));
+    return await readContractCore(coreInput);
+  });
 }
 
 protocolReadStep.maxRetries = 0;

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -52,84 +52,89 @@ export async function protocolWriteStep(
 ): Promise<WriteContractResult> {
   "use step";
 
-  // 1. Resolve protocol metadata from config or action type
-  const meta = resolveProtocolMeta(input);
-  if (!meta) {
-    return {
-      success: false,
-      error:
-        "Invalid _protocolMeta: failed to parse JSON and could not derive from action type",
-    };
-  }
+  return await withStepLogging(input, async () => {
+    // 1. Resolve protocol metadata from config or action type
+    const meta = resolveProtocolMeta(input);
+    if (!meta) {
+      return {
+        success: false,
+        error:
+          "Invalid _protocolMeta: failed to parse JSON and could not derive from action type",
+      };
+    }
 
-  // 2. Look up protocol definition from runtime registry
-  const protocol = getProtocol(meta.protocolSlug);
-  if (!protocol) {
-    return { success: false, error: `Unknown protocol: ${meta.protocolSlug}` };
-  }
+    // 2. Look up protocol definition from runtime registry
+    const protocol = getProtocol(meta.protocolSlug);
+    if (!protocol) {
+      return {
+        success: false,
+        error: `Unknown protocol: ${meta.protocolSlug}`,
+      };
+    }
 
-  // 3. Resolve contract for the selected network
-  const contract = protocol.contracts[meta.contractKey];
-  if (!contract) {
-    return {
-      success: false,
-      error: `Unknown contract key "${meta.contractKey}" in protocol "${meta.protocolSlug}"`,
-    };
-  }
+    // 3. Resolve contract for the selected network
+    const contract = protocol.contracts[meta.contractKey];
+    if (!contract) {
+      return {
+        success: false,
+        error: `Unknown contract key "${meta.contractKey}" in protocol "${meta.protocolSlug}"`,
+      };
+    }
 
-  const contractAddress = contract.userSpecifiedAddress
-    ? input.contractAddress
-    : contract.addresses[input.network];
-  if (!contractAddress) {
-    return {
-      success: false,
-      error: contract.userSpecifiedAddress
-        ? `Missing contract address for "${meta.contractKey}" in protocol "${meta.protocolSlug}"`
-        : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on network "${input.network}"`,
-    };
-  }
+    const contractAddress = contract.userSpecifiedAddress
+      ? input.contractAddress
+      : contract.addresses[input.network];
+    if (!contractAddress) {
+      return {
+        success: false,
+        error: contract.userSpecifiedAddress
+          ? `Missing contract address for "${meta.contractKey}" in protocol "${meta.protocolSlug}"`
+          : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on network "${input.network}"`,
+      };
+    }
 
-  // 4. Resolve ABI (from definition or auto-fetch from explorer)
-  let resolvedAbi: string;
-  try {
-    const abiResult = await resolveAbi({
+    // 4. Resolve ABI (from definition or auto-fetch from explorer)
+    let resolvedAbi: string;
+    try {
+      const abiResult = await resolveAbi({
+        contractAddress,
+        network: input.network,
+        abi: contract.abi,
+      });
+      resolvedAbi = abiResult.abi;
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to resolve ABI for contract "${meta.contractKey}" in protocol "${meta.protocolSlug}": ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    // 5. Build function arguments from named inputs ordered by action definition
+    const functionArgs = buildFunctionArgs(input, meta);
+
+    // 6. Delegate to writeContractCore
+    const ethValue =
+      typeof input.ethValue === "string" && input.ethValue.trim() !== ""
+        ? input.ethValue.trim()
+        : undefined;
+
+    const coreInput: WriteContractCoreInput = {
       contractAddress,
       network: input.network,
-      abi: contract.abi,
-    });
-    resolvedAbi = abiResult.abi;
-  } catch (error) {
-    return {
-      success: false,
-      error: `Failed to resolve ABI for contract "${meta.contractKey}" in protocol "${meta.protocolSlug}": ${error instanceof Error ? error.message : String(error)}`,
+      abi: resolvedAbi,
+      abiFunction: meta.functionName,
+      functionArgs,
+      ethValue,
+      _context: input._context
+        ? {
+            executionId: input._context.executionId,
+            triggerType: input._context.triggerType,
+          }
+        : undefined,
     };
-  }
 
-  // 5. Build function arguments from named inputs ordered by action definition
-  const functionArgs = buildFunctionArgs(input, meta);
-
-  // 6. Delegate to writeContractCore
-  const ethValue =
-    typeof input.ethValue === "string" && input.ethValue.trim() !== ""
-      ? input.ethValue.trim()
-      : undefined;
-
-  const coreInput: WriteContractCoreInput = {
-    contractAddress,
-    network: input.network,
-    abi: resolvedAbi,
-    abiFunction: meta.functionName,
-    functionArgs,
-    ethValue,
-    _context: input._context
-      ? {
-          executionId: input._context.executionId,
-          triggerType: input._context.triggerType,
-        }
-      : undefined,
-  };
-
-  return await withStepLogging(input, () => writeContractCore(coreInput));
+    return await writeContractCore(coreInput);
+  });
 }
 
 protocolWriteStep.maxRetries = 0;

--- a/protocols/compound-v3.ts
+++ b/protocols/compound-v3.ts
@@ -23,6 +23,105 @@ export default defineProtocol({
         // Arbitrum One (USDC market)
         "42161": "0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf",
       },
+      // Inline ABI -- Comet is a proxy; block explorer auto-fetch fails on Base/Arbitrum
+      abi: JSON.stringify([
+        {
+          type: "function",
+          name: "supply",
+          stateMutability: "nonpayable",
+          inputs: [
+            { name: "asset", type: "address" },
+            { name: "amount", type: "uint256" },
+          ],
+          outputs: [],
+        },
+        {
+          type: "function",
+          name: "withdraw",
+          stateMutability: "nonpayable",
+          inputs: [
+            { name: "asset", type: "address" },
+            { name: "amount", type: "uint256" },
+          ],
+          outputs: [],
+        },
+        {
+          type: "function",
+          name: "balanceOf",
+          stateMutability: "view",
+          inputs: [{ name: "account", type: "address" }],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "userCollateral",
+          stateMutability: "view",
+          inputs: [
+            { name: "account", type: "address" },
+            { name: "asset", type: "address" },
+          ],
+          outputs: [
+            { name: "balance", type: "uint128" },
+            { name: "_reserved", type: "uint128" },
+          ],
+        },
+        {
+          type: "function",
+          name: "borrowBalanceOf",
+          stateMutability: "view",
+          inputs: [{ name: "account", type: "address" }],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "getUtilization",
+          stateMutability: "view",
+          inputs: [],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "getSupplyRate",
+          stateMutability: "view",
+          inputs: [{ name: "utilization", type: "uint256" }],
+          outputs: [{ name: "", type: "uint64" }],
+        },
+        {
+          type: "function",
+          name: "getBorrowRate",
+          stateMutability: "view",
+          inputs: [{ name: "utilization", type: "uint256" }],
+          outputs: [{ name: "", type: "uint64" }],
+        },
+        {
+          type: "function",
+          name: "totalSupply",
+          stateMutability: "view",
+          inputs: [],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "totalBorrow",
+          stateMutability: "view",
+          inputs: [],
+          outputs: [{ name: "", type: "uint256" }],
+        },
+        {
+          type: "function",
+          name: "isLiquidatable",
+          stateMutability: "view",
+          inputs: [{ name: "account", type: "address" }],
+          outputs: [{ name: "", type: "bool" }],
+        },
+        {
+          type: "function",
+          name: "numAssets",
+          stateMutability: "view",
+          inputs: [],
+          outputs: [{ name: "", type: "uint8" }],
+        },
+      ]),
     },
   },
 

--- a/tests/unit/protocol-read-step.test.ts
+++ b/tests/unit/protocol-read-step.test.ts
@@ -1,0 +1,477 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+// ── Mocks (before imports) ───────────────────────────────────────────
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+const mockWithStepLogging = vi.fn((_input: unknown, fn: () => unknown) => fn());
+
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (...args: unknown[]) =>
+    mockWithStepLogging(...(args as [unknown, () => unknown])),
+}));
+
+const mockResolveProtocolMeta = vi.fn();
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: (...args: unknown[]) => mockResolveProtocolMeta(...args),
+}));
+
+const mockGetProtocol = vi.fn();
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: (...args: unknown[]) => mockGetProtocol(...args),
+}));
+
+const mockResolveAbi = vi.fn();
+vi.mock("@/lib/abi-cache", () => ({
+  resolveAbi: (...args: unknown[]) => mockResolveAbi(...args),
+}));
+
+const mockReadContractCore = vi.fn();
+vi.mock("@/plugins/web3/steps/read-contract-core", () => ({
+  readContractCore: (...args: unknown[]) => mockReadContractCore(...args),
+}));
+
+// ── Import under test ────────────────────────────────────────────────
+
+import { protocolReadStep } from "@/plugins/protocol/steps/protocol-read";
+import type { ProtocolMeta } from "@/plugins/protocol/steps/resolve-protocol-meta";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const COMPOUND_META: ProtocolMeta = {
+  protocolSlug: "compound",
+  contractKey: "comet",
+  functionName: "getUtilization",
+  actionType: "read",
+};
+
+const COMPOUND_PROTOCOL = {
+  name: "Compound V3",
+  slug: "compound",
+  contracts: {
+    comet: {
+      label: "Comet Market",
+      userSpecifiedAddress: true,
+      addresses: {
+        "1": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        "8453": "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+      },
+      abi: '[{"name":"getUtilization","type":"function","inputs":[],"outputs":[{"type":"uint256"}]}]',
+    },
+  },
+  actions: [
+    {
+      slug: "get-utilization",
+      label: "Get Utilization",
+      type: "read" as const,
+      contract: "comet",
+      function: "getUtilization",
+      inputs: [],
+      outputs: [{ name: "utilization", type: "uint256", label: "Utilization" }],
+    },
+  ],
+};
+
+const FIXED_ADDRESS_PROTOCOL = {
+  name: "Fixed Protocol",
+  slug: "fixed-proto",
+  contracts: {
+    pool: {
+      label: "Pool",
+      userSpecifiedAddress: false,
+      addresses: {
+        "1": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      },
+    },
+  },
+  actions: [
+    {
+      slug: "get-value",
+      label: "Get Value",
+      type: "read" as const,
+      contract: "pool",
+      function: "getValue",
+      inputs: [],
+    },
+  ],
+};
+
+function makeInput(overrides: Record<string, unknown> = {}): {
+  network: string;
+  _actionType: string;
+  _context: {
+    executionId: string;
+    nodeId: string;
+    nodeName: string;
+    nodeType: string;
+  };
+  [key: string]: unknown;
+} {
+  return {
+    network: "8453",
+    _actionType: "compound/get-utilization",
+    contractAddress: "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+    _context: {
+      executionId: "exec-123",
+      nodeId: "action-1",
+      nodeName: "Test Action",
+      nodeType: "action",
+    },
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("protocolReadStep", () => {
+  describe("withStepLogging wrapper", () => {
+    it("calls withStepLogging for every execution path", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      await protocolReadStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls withStepLogging even when protocol meta resolution fails", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid _protocolMeta");
+      }
+    });
+
+    it("calls withStepLogging even when protocol lookup fails", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(undefined);
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+    });
+
+    it("calls withStepLogging even when ABI resolution throws", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockRejectedValue(new Error("ABI fetch failed"));
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("meta resolution failures", () => {
+    it("returns error when _protocolMeta is invalid JSON and _actionType is missing", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      const result = await protocolReadStep(
+        makeInput({ _actionType: undefined, _protocolMeta: "not-json" })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid _protocolMeta");
+      }
+    });
+
+    it("returns error when both _protocolMeta and _actionType are missing", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      const result = await protocolReadStep(
+        makeInput({ _actionType: undefined, _protocolMeta: undefined })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid _protocolMeta");
+      }
+    });
+  });
+
+  describe("protocol lookup failures", () => {
+    it("returns error for unknown protocol slug", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        ...COMPOUND_META,
+        protocolSlug: "nonexistent",
+      });
+      mockGetProtocol.mockReturnValue(undefined);
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Unknown protocol: nonexistent");
+      }
+    });
+  });
+
+  describe("contract resolution failures", () => {
+    it("returns error for unknown contract key", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        ...COMPOUND_META,
+        contractKey: "bogus-contract",
+      });
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('Unknown contract key "bogus-contract"');
+        expect(result.error).toContain("compound");
+      }
+    });
+
+    it("returns error when userSpecifiedAddress is true but contractAddress is missing", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+
+      const result = await protocolReadStep(
+        makeInput({ contractAddress: undefined })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Missing contract address");
+      }
+    });
+
+    it("returns error when fixed-address contract is not deployed on the requested network", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        protocolSlug: "fixed-proto",
+        contractKey: "pool",
+        functionName: "getValue",
+        actionType: "read",
+      });
+      mockGetProtocol.mockReturnValue(FIXED_ADDRESS_PROTOCOL);
+
+      const result = await protocolReadStep(
+        makeInput({ network: "42161" }) // Arbitrum -- not in addresses
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("is not deployed on network");
+        expect(result.error).toContain("42161");
+      }
+    });
+  });
+
+  describe("ABI resolution failures", () => {
+    it("returns error when resolveAbi throws an Error", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockRejectedValue(new Error("Explorer API timeout"));
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Failed to resolve ABI");
+        expect(result.error).toContain("Explorer API timeout");
+      }
+    });
+
+    it("returns error when resolveAbi throws a non-Error value", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockRejectedValue("string error");
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Failed to resolve ABI");
+        expect(result.error).toContain("string error");
+      }
+    });
+  });
+
+  describe("successful delegation to readContractCore", () => {
+    it("passes resolved inputs to readContractCore and returns success", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({
+        abi: '[{"name":"getUtilization","type":"function"}]',
+      });
+      mockReadContractCore.mockResolvedValue({
+        success: true,
+        result: "850000000000000000",
+        addressLink: "https://basescan.org/address/0xb125",
+      });
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe("850000000000000000");
+      }
+
+      expect(mockReadContractCore).toHaveBeenCalledWith({
+        contractAddress: "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+        network: "8453",
+        abi: '[{"name":"getUtilization","type":"function"}]',
+        abiFunction: "getUtilization",
+        functionArgs: undefined,
+        _context: { executionId: "exec-123" },
+      });
+    });
+
+    it("propagates readContractCore failure result", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockReadContractCore.mockResolvedValue({
+        success: false,
+        error: "execution reverted",
+      });
+
+      const result = await protocolReadStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("execution reverted");
+      }
+    });
+
+    it("passes function arguments for actions with inputs", async () => {
+      const metaWithInputs: ProtocolMeta = {
+        protocolSlug: "compound",
+        contractKey: "comet",
+        functionName: "balanceOf",
+        actionType: "read",
+      };
+
+      const protocolWithInputs = {
+        ...COMPOUND_PROTOCOL,
+        actions: [
+          {
+            slug: "get-balance",
+            label: "Get Balance",
+            type: "read" as const,
+            contract: "comet",
+            function: "balanceOf",
+            inputs: [{ name: "account", type: "address", label: "Account" }],
+          },
+        ],
+      };
+
+      mockResolveProtocolMeta.mockReturnValue(metaWithInputs);
+      mockGetProtocol.mockReturnValue(protocolWithInputs);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockReadContractCore.mockResolvedValue({
+        success: true,
+        result: "1000000",
+        addressLink: "https://basescan.org/address/0xb125",
+      });
+
+      const result = await protocolReadStep(
+        makeInput({ account: "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF" })
+      );
+
+      expect(result.success).toBe(true);
+
+      const coreCall = (mockReadContractCore as Mock).mock.calls[0][0];
+      const parsedArgs = JSON.parse(coreCall.functionArgs);
+      expect(parsedArgs).toEqual([
+        "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF",
+      ]);
+    });
+
+    it("omits _context when input has no _context", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockReadContractCore.mockResolvedValue({
+        success: true,
+        result: "0",
+        addressLink: "",
+      });
+
+      await protocolReadStep(makeInput({ _context: undefined }));
+
+      const coreCall = (mockReadContractCore as Mock).mock.calls[0][0];
+      expect(coreCall._context).toBeUndefined();
+    });
+  });
+
+  describe("Compound V3 specific scenarios", () => {
+    it("handles Compound get-utilization on Base (the original failing case)", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({
+        abi: COMPOUND_PROTOCOL.contracts.comet.abi,
+      });
+      mockReadContractCore.mockResolvedValue({
+        success: true,
+        result: "850000000000000000",
+        addressLink:
+          "https://basescan.org/address/0xb125E6687d4313864e53df431d5425969c15Eb2F",
+      });
+
+      const result = await protocolReadStep(
+        makeInput({
+          network: "8453",
+          contractAddress: "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+          _actionType: "compound/get-utilization",
+        })
+      );
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+    });
+
+    it("handles Compound on Ethereum mainnet", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({
+        abi: COMPOUND_PROTOCOL.contracts.comet.abi,
+      });
+      mockReadContractCore.mockResolvedValue({
+        success: true,
+        result: "700000000000000000",
+        addressLink:
+          "https://etherscan.io/address/0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+      });
+
+      const result = await protocolReadStep(
+        makeInput({
+          network: "1",
+          contractAddress: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        })
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it("fails with logged error when Compound comet address is missing for Base", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+
+      const result = await protocolReadStep(
+        makeInput({
+          network: "8453",
+          contractAddress: undefined,
+        })
+      );
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Missing contract address");
+      }
+    });
+  });
+});

--- a/tests/unit/protocol-read-step.test.ts
+++ b/tests/unit/protocol-read-step.test.ts
@@ -170,6 +170,18 @@ describe("protocolReadStep", () => {
       expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
       expect(result.success).toBe(false);
     });
+
+    it("propagates thrown errors from readContractCore through withStepLogging", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockReadContractCore.mockRejectedValue(new Error("RPC timeout"));
+
+      await expect(protocolReadStep(makeInput())).rejects.toThrow(
+        "RPC timeout"
+      );
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("meta resolution failures", () => {

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -1,0 +1,430 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+// ── Mocks (before imports) ───────────────────────────────────────────
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+const mockWithStepLogging = vi.fn((_input: unknown, fn: () => unknown) => fn());
+
+vi.mock("@/lib/steps/step-handler", () => ({
+  withStepLogging: (...args: unknown[]) =>
+    mockWithStepLogging(...(args as [unknown, () => unknown])),
+}));
+
+const mockResolveProtocolMeta = vi.fn();
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: (...args: unknown[]) => mockResolveProtocolMeta(...args),
+}));
+
+const mockGetProtocol = vi.fn();
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: (...args: unknown[]) => mockGetProtocol(...args),
+}));
+
+const mockResolveAbi = vi.fn();
+vi.mock("@/lib/abi-cache", () => ({
+  resolveAbi: (...args: unknown[]) => mockResolveAbi(...args),
+}));
+
+const mockWriteContractCore = vi.fn();
+vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
+  writeContractCore: (...args: unknown[]) => mockWriteContractCore(...args),
+}));
+
+// ── Import under test ────────────────────────────────────────────────
+
+import { protocolWriteStep } from "@/plugins/protocol/steps/protocol-write";
+import type { ProtocolMeta } from "@/plugins/protocol/steps/resolve-protocol-meta";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const COMPOUND_SUPPLY_META: ProtocolMeta = {
+  protocolSlug: "compound",
+  contractKey: "comet",
+  functionName: "supply",
+  actionType: "write",
+};
+
+const COMPOUND_PROTOCOL = {
+  name: "Compound V3",
+  slug: "compound",
+  contracts: {
+    comet: {
+      label: "Comet Market",
+      userSpecifiedAddress: true,
+      addresses: {
+        "1": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        "8453": "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+      },
+      abi: '[{"name":"supply","type":"function","inputs":[{"name":"asset","type":"address"},{"name":"amount","type":"uint256"}],"outputs":[]}]',
+    },
+  },
+  actions: [
+    {
+      slug: "supply",
+      label: "Supply Asset",
+      type: "write" as const,
+      contract: "comet",
+      function: "supply",
+      inputs: [
+        { name: "asset", type: "address", label: "Asset Address" },
+        { name: "amount", type: "uint256", label: "Amount" },
+      ],
+    },
+  ],
+};
+
+const FIXED_ADDRESS_PROTOCOL = {
+  name: "Fixed Protocol",
+  slug: "fixed-proto",
+  contracts: {
+    vault: {
+      label: "Vault",
+      userSpecifiedAddress: false,
+      addresses: {
+        "1": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+      },
+    },
+  },
+  actions: [
+    {
+      slug: "deposit",
+      label: "Deposit",
+      type: "write" as const,
+      contract: "vault",
+      function: "deposit",
+      inputs: [{ name: "amount", type: "uint256", label: "Amount" }],
+    },
+  ],
+};
+
+function makeInput(overrides: Record<string, unknown> = {}): {
+  network: string;
+  _actionType: string;
+  _context: {
+    executionId: string;
+    nodeId: string;
+    nodeName: string;
+    nodeType: string;
+    triggerType: string;
+  };
+  [key: string]: unknown;
+} {
+  return {
+    network: "8453",
+    _actionType: "compound/supply",
+    contractAddress: "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+    asset: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    amount: "1000000",
+    _context: {
+      executionId: "exec-456",
+      nodeId: "action-1",
+      nodeName: "Test Action",
+      nodeType: "action",
+      triggerType: "manual",
+    },
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("protocolWriteStep", () => {
+  describe("withStepLogging wrapper", () => {
+    it("calls withStepLogging for every execution path", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      await protocolWriteStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls withStepLogging even when protocol meta resolution fails", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid _protocolMeta");
+      }
+    });
+
+    it("calls withStepLogging even when protocol lookup fails", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(undefined);
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+    });
+
+    it("calls withStepLogging even when ABI resolution throws", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockRejectedValue(new Error("ABI fetch failed"));
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("meta resolution failures", () => {
+    it("returns error when both _protocolMeta and _actionType are invalid", async () => {
+      mockResolveProtocolMeta.mockReturnValue(undefined);
+
+      const result = await protocolWriteStep(
+        makeInput({ _actionType: undefined, _protocolMeta: "bad-json" })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid _protocolMeta");
+      }
+    });
+  });
+
+  describe("protocol lookup failures", () => {
+    it("returns error for unknown protocol slug", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        ...COMPOUND_SUPPLY_META,
+        protocolSlug: "nonexistent",
+      });
+      mockGetProtocol.mockReturnValue(undefined);
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Unknown protocol: nonexistent");
+      }
+    });
+  });
+
+  describe("contract resolution failures", () => {
+    it("returns error for unknown contract key", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        ...COMPOUND_SUPPLY_META,
+        contractKey: "bogus",
+      });
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('Unknown contract key "bogus"');
+      }
+    });
+
+    it("returns error when userSpecifiedAddress is true but contractAddress is missing", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+
+      const result = await protocolWriteStep(
+        makeInput({ contractAddress: undefined })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Missing contract address");
+      }
+    });
+
+    it("returns error when fixed-address contract is not deployed on the requested network", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        protocolSlug: "fixed-proto",
+        contractKey: "vault",
+        functionName: "deposit",
+        actionType: "write",
+      });
+      mockGetProtocol.mockReturnValue(FIXED_ADDRESS_PROTOCOL);
+
+      const result = await protocolWriteStep(makeInput({ network: "42161" }));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("is not deployed on network");
+        expect(result.error).toContain("42161");
+      }
+    });
+  });
+
+  describe("ABI resolution failures", () => {
+    it("returns error when resolveAbi throws an Error", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockRejectedValue(new Error("Explorer API timeout"));
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Failed to resolve ABI");
+        expect(result.error).toContain("Explorer API timeout");
+      }
+    });
+
+    it("returns error when resolveAbi throws a non-Error value", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockRejectedValue("raw string error");
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("raw string error");
+      }
+    });
+  });
+
+  describe("successful delegation to writeContractCore", () => {
+    it("passes resolved inputs to writeContractCore and returns success", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({
+        abi: COMPOUND_PROTOCOL.contracts.comet.abi,
+      });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xabc123",
+        transactionLink: "https://basescan.org/tx/0xabc123",
+        gasUsed: "150000",
+      });
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactionHash).toBe("0xabc123");
+      }
+
+      expect(mockWriteContractCore).toHaveBeenCalledWith({
+        contractAddress: "0xb125E6687d4313864e53df431d5425969c15Eb2F",
+        network: "8453",
+        abi: COMPOUND_PROTOCOL.contracts.comet.abi,
+        abiFunction: "supply",
+        functionArgs: JSON.stringify([
+          "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "1000000",
+        ]),
+        ethValue: undefined,
+        _context: { executionId: "exec-456", triggerType: "manual" },
+      });
+    });
+
+    it("propagates writeContractCore failure result", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockWriteContractCore.mockResolvedValue({
+        success: false,
+        error: "insufficient funds",
+      });
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("insufficient funds");
+      }
+    });
+
+    it("passes ethValue when provided", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xdef",
+        transactionLink: "",
+        gasUsed: "21000",
+      });
+
+      await protocolWriteStep(makeInput({ ethValue: "0.5" }));
+
+      const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+      expect(coreCall.ethValue).toBe("0.5");
+    });
+
+    it("ignores empty/whitespace ethValue", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xdef",
+        transactionLink: "",
+        gasUsed: "21000",
+      });
+
+      await protocolWriteStep(makeInput({ ethValue: "  " }));
+
+      const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+      expect(coreCall.ethValue).toBeUndefined();
+    });
+
+    it("omits _context when input has no _context", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0x111",
+        transactionLink: "",
+        gasUsed: "21000",
+      });
+
+      await protocolWriteStep(makeInput({ _context: undefined }));
+
+      const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+      expect(coreCall._context).toBeUndefined();
+    });
+  });
+
+  describe("Compound V3 specific scenarios", () => {
+    it("handles Compound supply on Base", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({
+        abi: COMPOUND_PROTOCOL.contracts.comet.abi,
+      });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xbase-tx",
+        transactionLink: "https://basescan.org/tx/0xbase-tx",
+        gasUsed: "200000",
+      });
+
+      const result = await protocolWriteStep(makeInput());
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+    });
+
+    it("fails with logged error when Compound comet address is missing", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+
+      const result = await protocolWriteStep(
+        makeInput({ contractAddress: undefined })
+      );
+
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Missing contract address");
+      }
+    });
+  });
+});

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -176,6 +176,18 @@ describe("protocolWriteStep", () => {
       expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
       expect(result.success).toBe(false);
     });
+
+    it("propagates thrown errors from writeContractCore through withStepLogging", async () => {
+      mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+      mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({ abi: "[]" });
+      mockWriteContractCore.mockRejectedValue(new Error("RPC timeout"));
+
+      await expect(protocolWriteStep(makeInput())).rejects.toThrow(
+        "RPC timeout"
+      );
+      expect(mockWithStepLogging).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("meta resolution failures", () => {


### PR DESCRIPTION
## Summary

- Protocol read/write steps had 5 early-return error paths that bypassed `withStepLogging`, causing validation failures to produce zero execution log entries -- workflow nodes would silently disappear from the trace
- Moved `withStepLogging` to wrap the entire step body so all failure paths (meta resolution, protocol lookup, contract resolution, ABI fetch) are captured in `workflow_execution_logs`
- Added inline ABI for Compound V3 Comet contract -- block explorer auto-fetch fails on Base/Arbitrum proxies
- Added unit tests for both `protocolReadStep` and `protocolWriteStep` covering all error paths and the `withStepLogging` wrapper