### PR TITLE
fix: KEEP-1589 add convergence barrier for parallel branch execution

### DIFF
--- a/lib/convergence-barrier.ts
+++ b/lib/convergence-barrier.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure convergence barrier logic for fork-join synchronization in
+ * workflow execution. Extracted so the algorithms can be tested
+ * directly without mocking the full executor.
+ */
+
+type EdgeLike = {
+  source: string;
+  target: string;
+};
+
+/** Build reverse edge map: target node ID -> source node IDs. */
+export function buildEdgesByTarget(edges: EdgeLike[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    const sources = map.get(edge.target) ?? [];
+    sources.push(edge.source);
+    map.set(edge.target, sources);
+  }
+  return map;
+}
+
+/** Build forward edge map: source node ID -> target node IDs. */
+export function buildEdgesBySource(edges: EdgeLike[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    const targets = map.get(edge.source) ?? [];
+    targets.push(edge.target);
+    map.set(edge.source, targets);
+  }
+  return map;
+}
+
+/**
+ * Signal arrival at convergence nodes (nodes with >1 incoming edge) and
+ * return the IDs of any that became fully unblocked. Non-convergence nodes
+ * in targetNodeIds are ignored.
+ */
+export function signalConvergenceArrival(
+  fromNodeId: string,
+  targetNodeIds: string[],
+  edgesByTarget: Map<string, string[]>,
+  convergenceArrivals: Map<string, Set<string>>,
+  visited: Set<string>
+): string[] {
+  const unblocked: string[] = [];
+  for (const nextId of targetNodeIds) {
+    const incomingSources = edgesByTarget.get(nextId);
+    if (incomingSources === undefined || incomingSources.length <= 1) {
+      continue;
+    }
+    let arrivals = convergenceArrivals.get(nextId);
+    if (arrivals === undefined) {
+      arrivals = new Set<string>();
+      convergenceArrivals.set(nextId, arrivals);
+    }
+    arrivals.add(fromNodeId);
+    if (arrivals.size >= incomingSources.length && !visited.has(nextId)) {
+      unblocked.push(nextId);
+    }
+  }
+  return unblocked;
+}
+
+/**
+ * Determine which downstream nodes are ready to execute, applying
+ * convergence barriers for nodes with multiple incoming edges.
+ * Non-convergence nodes pass through immediately.
+ */
+export function getReadyDownstreamIds(
+  fromNodeId: string,
+  nextNodeIds: string[],
+  edgesByTarget: Map<string, string[]>,
+  convergenceArrivals: Map<string, Set<string>>,
+  visited: Set<string>
+): string[] {
+  const readyIds: string[] = [];
+
+  for (const nextId of nextNodeIds) {
+    const incomingSources = edgesByTarget.get(nextId);
+    const isConvergenceNode =
+      incomingSources !== undefined && incomingSources.length > 1;
+
+    if (!isConvergenceNode) {
+      readyIds.push(nextId);
+    }
+  }
+
+  readyIds.push(
+    ...signalConvergenceArrival(
+      fromNodeId,
+      nextNodeIds,
+      edgesByTarget,
+      convergenceArrivals,
+      visited
+    )
+  );
+
+  return readyIds;
+}
+
+/**
+ * Propagate skip signals through branches that were not taken by a condition.
+ * BFS through the skipped subtree, signaling arrival at convergence nodes.
+ * Returns convergence node IDs that became fully unblocked (caller handles
+ * execution).
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: BFS with convergence detection requires nested branching
+export function propagateConvergenceSkips(
+  skippedNodeIds: string[],
+  edgesBySource: Map<string, string[]>,
+  edgesByTarget: Map<string, string[]>,
+  convergenceArrivals: Map<string, Set<string>>,
+  visited: Set<string>
+): string[] {
+  const unblocked: string[] = [];
+  const queue = [...skippedNodeIds];
+  const seen = new Set<string>();
+
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    if (seen.has(currentId)) {
+      continue;
+    }
+    seen.add(currentId);
+
+    const incomingSources = edgesByTarget.get(currentId);
+    const isConvergenceNode =
+      incomingSources !== undefined && incomingSources.length > 1;
+
+    if (isConvergenceNode) {
+      for (const src of incomingSources) {
+        if (seen.has(src) || skippedNodeIds.includes(src)) {
+          let arrivals = convergenceArrivals.get(currentId);
+          if (arrivals === undefined) {
+            arrivals = new Set<string>();
+            convergenceArrivals.set(currentId, arrivals);
+          }
+          arrivals.add(src);
+        }
+      }
+
+      if (
+        (convergenceArrivals.get(currentId)?.size ?? 0) >=
+        incomingSources.length
+      ) {
+        if (!visited.has(currentId)) {
+          unblocked.push(currentId);
+        }
+        continue;
+      }
+    }
+
+    const downstream = edgesBySource.get(currentId) ?? [];
+    for (const downId of downstream) {
+      if (!seen.has(downId)) {
+        queue.push(downId);
+      }
+    }
+  }
+
+  return unblocked;
+}

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -2064,6 +2064,14 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       };
       results[nodeId] = errorResult;
 
+      // Store null output so downstream templates resolve to null rather than
+      // being undefined (same pattern as disabled nodes).
+      const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
+      outputs[sanitizedNodeId] = {
+        label: getNodeName(node),
+        data: null,
+      };
+
       // Signal arrival at downstream convergence nodes to prevent deadlocks.
       // If this failure was the last arrival, execute the convergence node
       // with partial data rather than hanging forever.

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -34,6 +34,12 @@ import {
   collectSkippedTargets,
   type ConditionDecision,
 } from "@/lib/skipped-branch-utils";
+import {
+  buildEdgesByTarget,
+  getReadyDownstreamIds,
+  propagateConvergenceSkips,
+  signalConvergenceArrival,
+} from "@/lib/convergence-barrier";
 import { resolveConditionExpression } from "@/lib/condition-resolver";
 import {
   applyBigIntConversion,
@@ -1051,15 +1057,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     edgesBySource.set(edge.source, targets);
   }
 
-  // Reverse edge map: target -> source[] (for convergence detection)
-  const edgesByTarget = new Map<string, string[]>();
-  for (const edge of edges) {
-    const sources = edgesByTarget.get(edge.target) ?? [];
-    sources.push(edge.source);
-    edgesByTarget.set(edge.target, sources);
-  }
-
-  // Track arrivals at convergence nodes (nodes with >1 incoming edge)
+  const edgesByTarget = buildEdgesByTarget(edges);
   const convergenceArrivals = new Map<string, Set<string>>();
 
   // Find trigger nodes
@@ -1611,35 +1609,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   }
 
   /**
-   * Signal arrival at convergence nodes (nodes with >1 incoming edge) and
-   * return the IDs of any that became fully unblocked. Non-convergence nodes
-   * in targetNodeIds are ignored.
-   */
-  function signalConvergenceArrival(
-    fromNodeId: string,
-    targetNodeIds: string[],
-    visited: Set<string>
-  ): string[] {
-    const unblocked: string[] = [];
-    for (const nextId of targetNodeIds) {
-      const incomingSources = edgesByTarget.get(nextId);
-      if (incomingSources === undefined || incomingSources.length <= 1) {
-        continue;
-      }
-      let arrivals = convergenceArrivals.get(nextId);
-      if (arrivals === undefined) {
-        arrivals = new Set<string>();
-        convergenceArrivals.set(nextId, arrivals);
-      }
-      arrivals.add(fromNodeId);
-      if (arrivals.size >= incomingSources.length && !visited.has(nextId)) {
-        unblocked.push(nextId);
-      }
-    }
-    return unblocked;
-  }
-
-  /**
    * Execute downstream nodes with convergence barrier support.
    * For convergence nodes (multiple incoming edges), waits until all
    * upstream branches have signaled arrival before executing.
@@ -1649,85 +1618,19 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     nextNodeIds: string[],
     visited: Set<string>
   ): Promise<void> {
-    const readyIds: string[] = [];
-
-    for (const nextId of nextNodeIds) {
-      const incomingSources = edgesByTarget.get(nextId);
-      const isConvergenceNode =
-        incomingSources !== undefined && incomingSources.length > 1;
-
-      if (!isConvergenceNode) {
-        readyIds.push(nextId);
-      }
-    }
-
-    readyIds.push(...signalConvergenceArrival(fromNodeId, nextNodeIds, visited));
+    const readyIds = getReadyDownstreamIds(
+      fromNodeId,
+      nextNodeIds,
+      edgesByTarget,
+      convergenceArrivals,
+      visited
+    );
 
     if (readyIds.length > 0) {
       const settled = await Promise.allSettled(
         readyIds.map((id) => executeNode(id, visited))
       );
       processSettledResults(settled, readyIds);
-    }
-  }
-
-  /**
-   * Propagate skip signals through branches that were not taken by a condition.
-   * Ensures convergence nodes downstream of skipped branches still receive
-   * arrival signals so they can unblock when the taken branch completes.
-   */
-  async function propagateConvergenceSkips(
-    skippedNodeIds: string[],
-    visited: Set<string>
-  ): Promise<void> {
-    // BFS through the skipped subtree
-    const queue = [...skippedNodeIds];
-    const seen = new Set<string>();
-
-    while (queue.length > 0) {
-      const currentId = queue.shift() as string;
-      if (seen.has(currentId)) {
-        continue;
-      }
-      seen.add(currentId);
-
-      const incomingSources = edgesByTarget.get(currentId);
-      const isConvergenceNode =
-        incomingSources !== undefined && incomingSources.length > 1;
-
-      if (isConvergenceNode) {
-        // Find which source(s) in the skipped subtree lead here
-        for (const src of incomingSources) {
-          if (seen.has(src) || skippedNodeIds.includes(src)) {
-            let arrivals = convergenceArrivals.get(currentId);
-            if (arrivals === undefined) {
-              arrivals = new Set<string>();
-              convergenceArrivals.set(currentId, arrivals);
-            }
-            arrivals.add(src);
-          }
-        }
-
-        // If all arrivals received, execute this convergence node
-        if (
-          (convergenceArrivals.get(currentId)?.size ?? 0) >=
-          incomingSources.length
-        ) {
-          if (!visited.has(currentId)) {
-            await executeNode(currentId, visited);
-          }
-          // Don't propagate further; executeNode handles downstream
-          continue;
-        }
-      }
-
-      // Propagate skip to downstream nodes
-      const downstream = edgesBySource.get(currentId) ?? [];
-      for (const downId of downstream) {
-        if (!seen.has(downId)) {
-          queue.push(downId);
-        }
-      }
     }
   }
 
@@ -2027,7 +1930,19 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             // nodes downstream receive arrival signals from skipped sources
             const skippedTargets = handleMap.get(notTakenHandle) ?? [];
             if (skippedTargets.length > 0) {
-              await propagateConvergenceSkips(skippedTargets, visited);
+              const unblockedIds = propagateConvergenceSkips(
+                skippedTargets,
+                edgesBySource,
+                edgesByTarget,
+                convergenceArrivals,
+                visited
+              );
+              if (unblockedIds.length > 0) {
+                const settled = await Promise.allSettled(
+                  unblockedIds.map((id) => executeNode(id, visited))
+                );
+                processSettledResults(settled, unblockedIds);
+              }
             }
           } else {
             // Legacy fallback: no sourceHandle on edges, use old gate behavior
@@ -2076,7 +1991,13 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // If this failure was the last arrival, execute the convergence node
       // with partial data rather than hanging forever.
       const nextNodes = edgesBySource.get(nodeId) ?? [];
-      const unblockedIds = signalConvergenceArrival(nodeId, nextNodes, visited);
+      const unblockedIds = signalConvergenceArrival(
+        nodeId,
+        nextNodes,
+        edgesByTarget,
+        convergenceArrivals,
+        visited
+      );
       if (unblockedIds.length > 0) {
         const settled = await Promise.allSettled(
           unblockedIds.map((id) => executeNode(id, visited))

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1051,6 +1051,17 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     edgesBySource.set(edge.source, targets);
   }
 
+  // Reverse edge map: target -> source[] (for convergence detection)
+  const edgesByTarget = new Map<string, string[]>();
+  for (const edge of edges) {
+    const sources = edgesByTarget.get(edge.target) || [];
+    sources.push(edge.source);
+    edgesByTarget.set(edge.target, sources);
+  }
+
+  // Track arrivals at convergence nodes (nodes with >1 incoming edge)
+  const convergenceArrivals = new Map<string, Set<string>>();
+
   // Find trigger nodes
   const nodesWithIncoming = new Set(edges.map((e) => e.target));
   const triggerNodes = nodes.filter(
@@ -1599,6 +1610,109 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
   }
 
+  /**
+   * Execute downstream nodes with convergence barrier support.
+   * For convergence nodes (multiple incoming edges), waits until all
+   * upstream branches have signaled arrival before executing.
+   */
+  async function executeReadyDownstream(
+    fromNodeId: string,
+    nextNodeIds: string[],
+    visited: Set<string>
+  ): Promise<void> {
+    const readyIds: string[] = [];
+
+    for (const nextId of nextNodeIds) {
+      const incomingSources = edgesByTarget.get(nextId);
+      const isConvergenceNode =
+        incomingSources !== undefined && incomingSources.length > 1;
+
+      if (isConvergenceNode) {
+        // Signal arrival from this source
+        let arrivals = convergenceArrivals.get(nextId);
+        if (arrivals === undefined) {
+          arrivals = new Set<string>();
+          convergenceArrivals.set(nextId, arrivals);
+        }
+        arrivals.add(fromNodeId);
+
+        // Only execute when all incoming sources have arrived
+        if (arrivals.size >= incomingSources.length) {
+          readyIds.push(nextId);
+        }
+      } else {
+        readyIds.push(nextId);
+      }
+    }
+
+    if (readyIds.length > 0) {
+      const settled = await Promise.allSettled(
+        readyIds.map((id) => executeNode(id, visited))
+      );
+      processSettledResults(settled, readyIds);
+    }
+  }
+
+  /**
+   * Propagate skip signals through branches that were not taken by a condition.
+   * Ensures convergence nodes downstream of skipped branches still receive
+   * arrival signals so they can unblock when the taken branch completes.
+   */
+  async function propagateConvergenceSkips(
+    skippedNodeIds: string[],
+    visited: Set<string>
+  ): Promise<void> {
+    // BFS through the skipped subtree
+    const queue = [...skippedNodeIds];
+    const seen = new Set<string>();
+
+    while (queue.length > 0) {
+      const currentId = queue.shift() as string;
+      if (seen.has(currentId)) {
+        continue;
+      }
+      seen.add(currentId);
+
+      const incomingSources = edgesByTarget.get(currentId);
+      const isConvergenceNode =
+        incomingSources !== undefined && incomingSources.length > 1;
+
+      if (isConvergenceNode) {
+        // Find which source(s) in the skipped subtree lead here
+        for (const src of incomingSources) {
+          if (seen.has(src) || skippedNodeIds.includes(src)) {
+            let arrivals = convergenceArrivals.get(currentId);
+            if (arrivals === undefined) {
+              arrivals = new Set<string>();
+              convergenceArrivals.set(currentId, arrivals);
+            }
+            arrivals.add(src);
+          }
+        }
+
+        // If all arrivals received, execute this convergence node
+        if (
+          (convergenceArrivals.get(currentId)?.size ?? 0) >=
+          incomingSources.length
+        ) {
+          if (!visited.has(currentId)) {
+            await executeNode(currentId, visited);
+          }
+          // Don't propagate further; executeNode handles downstream
+          continue;
+        }
+      }
+
+      // Propagate skip to downstream nodes
+      const downstream = edgesBySource.get(currentId) ?? [];
+      for (const downId of downstream) {
+        if (!seen.has(downId)) {
+          queue.push(downId);
+        }
+      }
+    }
+  }
+
   // Helper to execute a single node
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Node execution requires type checking and error handling
   async function executeNode(nodeId: string, visited: Set<string> = new Set()) {
@@ -1628,10 +1742,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       };
 
       const nextNodes = edgesBySource.get(nodeId) || [];
-      const settled = await Promise.allSettled(
-        nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
-      );
-      processSettledResults(settled, nextNodes);
+      await executeReadyDownstream(nodeId, nextNodes, visited);
       return;
     }
 
@@ -1860,10 +1971,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             currentEdgesBySource: edgesBySource,
             continueAfterCollect: async (collectId) => {
               const nextNodes = edgesBySource.get(collectId) ?? [];
-              const settled = await Promise.allSettled(
-                nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
-              );
-              processSettledResults(settled, nextNodes);
+              await executeReadyDownstream(collectId, nextNodes, visited);
             },
           });
 
@@ -1895,22 +2003,19 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 edgesBySourceHandle
               ),
             });
-            const handleSettled = await Promise.allSettled(
-              handleTargets.map((nextNodeId) =>
-                executeNode(nextNodeId, visited)
-              )
-            );
-            processSettledResults(handleSettled, handleTargets);
+            await executeReadyDownstream(nodeId, handleTargets, visited);
+
+            // Propagate skip signals for the not-taken branch so convergence
+            // nodes downstream receive arrival signals from skipped sources
+            const skippedTargets = handleMap.get(notTakenHandle) ?? [];
+            if (skippedTargets.length > 0) {
+              await propagateConvergenceSkips(skippedTargets, visited);
+            }
           } else {
             // Legacy fallback: no sourceHandle on edges, use old gate behavior
             if (conditionResult === true) {
               const nextNodes = edgesBySource.get(nodeId) ?? [];
-              const legacySettled = await Promise.allSettled(
-                nextNodes.map((nextNodeId) =>
-                  executeNode(nextNodeId, visited)
-                )
-              );
-              processSettledResults(legacySettled, nextNodes);
+              await executeReadyDownstream(nodeId, nextNodes, visited);
             }
           }
         } else {
@@ -1921,10 +2026,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             nextNodes.length,
             "next nodes in parallel"
           );
-          const nextSettled = await Promise.allSettled(
-            nextNodes.map((nextNodeId) => executeNode(nextNodeId, visited))
-          );
-          processSettledResults(nextSettled, nextNodes);
+          await executeReadyDownstream(nodeId, nextNodes, visited);
         }
       }
     } catch (error) {
@@ -1943,8 +2045,36 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         error: errorMessage,
       };
       results[nodeId] = errorResult;
-      // Note: stepHandler already logged the error for action steps
-      // Trigger steps don't throw, so this catch is mainly for unexpected errors
+
+      // Signal arrival at downstream convergence nodes to prevent deadlocks.
+      // If this failure was the last arrival, execute the convergence node
+      // with partial data rather than hanging forever.
+      const nextNodes = edgesBySource.get(nodeId) ?? [];
+      const unblockedIds: string[] = [];
+      for (const nextId of nextNodes) {
+        const incomingSources = edgesByTarget.get(nextId);
+        if (incomingSources !== undefined && incomingSources.length > 1) {
+          let arrivals = convergenceArrivals.get(nextId);
+          if (arrivals === undefined) {
+            arrivals = new Set<string>();
+            convergenceArrivals.set(nextId, arrivals);
+          }
+          arrivals.add(nodeId);
+
+          if (
+            arrivals.size >= incomingSources.length &&
+            !visited.has(nextId)
+          ) {
+            unblockedIds.push(nextId);
+          }
+        }
+      }
+      if (unblockedIds.length > 0) {
+        const settled = await Promise.allSettled(
+          unblockedIds.map((id) => executeNode(id, visited))
+        );
+        processSettledResults(settled, unblockedIds);
+      }
     }
   }
 

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1054,7 +1054,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   // Reverse edge map: target -> source[] (for convergence detection)
   const edgesByTarget = new Map<string, string[]>();
   for (const edge of edges) {
-    const sources = edgesByTarget.get(edge.target) || [];
+    const sources = edgesByTarget.get(edge.target) ?? [];
     sources.push(edge.source);
     edgesByTarget.set(edge.target, sources);
   }
@@ -1741,7 +1741,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         data: null,
       };
 
-      const nextNodes = edgesBySource.get(nodeId) || [];
+      const nextNodes = edgesBySource.get(nodeId) ?? [];
       await executeReadyDownstream(nodeId, nextNodes, visited);
       return;
     }

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1611,6 +1611,35 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   }
 
   /**
+   * Signal arrival at convergence nodes (nodes with >1 incoming edge) and
+   * return the IDs of any that became fully unblocked. Non-convergence nodes
+   * in targetNodeIds are ignored.
+   */
+  function signalConvergenceArrival(
+    fromNodeId: string,
+    targetNodeIds: string[],
+    visited: Set<string>
+  ): string[] {
+    const unblocked: string[] = [];
+    for (const nextId of targetNodeIds) {
+      const incomingSources = edgesByTarget.get(nextId);
+      if (incomingSources === undefined || incomingSources.length <= 1) {
+        continue;
+      }
+      let arrivals = convergenceArrivals.get(nextId);
+      if (arrivals === undefined) {
+        arrivals = new Set<string>();
+        convergenceArrivals.set(nextId, arrivals);
+      }
+      arrivals.add(fromNodeId);
+      if (arrivals.size >= incomingSources.length && !visited.has(nextId)) {
+        unblocked.push(nextId);
+      }
+    }
+    return unblocked;
+  }
+
+  /**
    * Execute downstream nodes with convergence barrier support.
    * For convergence nodes (multiple incoming edges), waits until all
    * upstream branches have signaled arrival before executing.
@@ -1627,23 +1656,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       const isConvergenceNode =
         incomingSources !== undefined && incomingSources.length > 1;
 
-      if (isConvergenceNode) {
-        // Signal arrival from this source
-        let arrivals = convergenceArrivals.get(nextId);
-        if (arrivals === undefined) {
-          arrivals = new Set<string>();
-          convergenceArrivals.set(nextId, arrivals);
-        }
-        arrivals.add(fromNodeId);
-
-        // Only execute when all incoming sources have arrived
-        if (arrivals.size >= incomingSources.length) {
-          readyIds.push(nextId);
-        }
-      } else {
+      if (!isConvergenceNode) {
         readyIds.push(nextId);
       }
     }
+
+    readyIds.push(...signalConvergenceArrival(fromNodeId, nextNodeIds, visited));
 
     if (readyIds.length > 0) {
       const settled = await Promise.allSettled(
@@ -2050,25 +2068,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // If this failure was the last arrival, execute the convergence node
       // with partial data rather than hanging forever.
       const nextNodes = edgesBySource.get(nodeId) ?? [];
-      const unblockedIds: string[] = [];
-      for (const nextId of nextNodes) {
-        const incomingSources = edgesByTarget.get(nextId);
-        if (incomingSources !== undefined && incomingSources.length > 1) {
-          let arrivals = convergenceArrivals.get(nextId);
-          if (arrivals === undefined) {
-            arrivals = new Set<string>();
-            convergenceArrivals.set(nextId, arrivals);
-          }
-          arrivals.add(nodeId);
-
-          if (
-            arrivals.size >= incomingSources.length &&
-            !visited.has(nextId)
-          ) {
-            unblockedIds.push(nextId);
-          }
-        }
-      }
+      const unblockedIds = signalConvergenceArrival(nodeId, nextNodes, visited);
       if (unblockedIds.length > 0) {
         const settled = await Promise.allSettled(
           unblockedIds.map((id) => executeNode(id, visited))

--- a/tests/unit/convergence-barrier.test.ts
+++ b/tests/unit/convergence-barrier.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type EdgeLike = {
+  source: string;
+  target: string;
+};
+
+/**
+ * Builds the reverse edge map (target -> source[]) used by the convergence
+ * barrier in the workflow executor to determine how many incoming edges
+ * each node has.
+ */
+function buildEdgesByTarget(edges: EdgeLike[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    const sources = map.get(edge.target) ?? [];
+    sources.push(edge.source);
+    map.set(edge.target, sources);
+  }
+  return map;
+}
+
+function buildEdgesBySource(edges: EdgeLike[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    const targets = map.get(edge.source) ?? [];
+    targets.push(edge.target);
+    map.set(edge.source, targets);
+  }
+  return map;
+}
+
+/**
+ * Mirrors the convergence barrier logic from executeReadyDownstream in the
+ * workflow executor. Returns which nodes are ready to execute (all incoming
+ * branches have arrived) vs which are still waiting.
+ */
+function simulateConvergenceBarrier(
+  fromNodeId: string,
+  nextNodeIds: string[],
+  edgesByTarget: Map<string, string[]>,
+  arrivals: Map<string, Set<string>>
+): { ready: string[]; waiting: string[] } {
+  const ready: string[] = [];
+  const waiting: string[] = [];
+
+  for (const nextId of nextNodeIds) {
+    const incomingSources = edgesByTarget.get(nextId);
+    const isConvergenceNode =
+      incomingSources !== undefined && incomingSources.length > 1;
+
+    if (isConvergenceNode) {
+      let nodeArrivals = arrivals.get(nextId);
+      if (nodeArrivals === undefined) {
+        nodeArrivals = new Set<string>();
+        arrivals.set(nextId, nodeArrivals);
+      }
+      nodeArrivals.add(fromNodeId);
+
+      if (nodeArrivals.size >= incomingSources.length) {
+        ready.push(nextId);
+      } else {
+        waiting.push(nextId);
+      }
+    } else {
+      ready.push(nextId);
+    }
+  }
+
+  return { ready, waiting };
+}
+
+/**
+ * Mirrors propagateConvergenceSkips from the workflow executor.
+ * BFS through skipped subtree, signaling arrival at convergence nodes.
+ * Returns convergence nodes that became fully arrived (ready to execute).
+ */
+function simulateSkipPropagation(
+  skippedNodeIds: string[],
+  edgesBySource: Map<string, string[]>,
+  edgesByTarget: Map<string, string[]>,
+  arrivals: Map<string, Set<string>>
+): string[] {
+  const unblocked: string[] = [];
+  const queue = [...skippedNodeIds];
+  const seen = new Set<string>();
+
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    if (seen.has(currentId)) {
+      continue;
+    }
+    seen.add(currentId);
+
+    const incomingSources = edgesByTarget.get(currentId);
+    const isConvergenceNode =
+      incomingSources !== undefined && incomingSources.length > 1;
+
+    if (isConvergenceNode) {
+      for (const src of incomingSources) {
+        if (seen.has(src) || skippedNodeIds.includes(src)) {
+          let nodeArrivals = arrivals.get(currentId);
+          if (nodeArrivals === undefined) {
+            nodeArrivals = new Set<string>();
+            arrivals.set(currentId, nodeArrivals);
+          }
+          nodeArrivals.add(src);
+        }
+      }
+
+      if ((arrivals.get(currentId)?.size ?? 0) >= incomingSources.length) {
+        unblocked.push(currentId);
+        continue;
+      }
+    }
+
+    const downstream = edgesBySource.get(currentId) ?? [];
+    for (const downId of downstream) {
+      if (!seen.has(downId)) {
+        queue.push(downId);
+      }
+    }
+  }
+
+  return unblocked;
+}
+
+describe("convergence barrier", () => {
+  describe("basic convergence: A -> [B, C, D] -> E", () => {
+    const edges: EdgeLike[] = [
+      { source: "A", target: "B" },
+      { source: "A", target: "C" },
+      { source: "A", target: "D" },
+      { source: "B", target: "E" },
+      { source: "C", target: "E" },
+      { source: "D", target: "E" },
+    ];
+
+    it("should detect E as a convergence node with 3 incoming edges", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const sources = targetMap.get("E");
+      expect(sources).toEqual(["B", "C", "D"]);
+      expect(sources?.length).toBe(3);
+    });
+
+    it("should block E when only first branch arrives", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      const result = simulateConvergenceBarrier(
+        "B",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual([]);
+      expect(result.waiting).toEqual(["E"]);
+      expect(arrivals.get("E")?.size).toBe(1);
+    });
+
+    it("should block E when two branches have arrived", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      const result = simulateConvergenceBarrier(
+        "C",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual([]);
+      expect(result.waiting).toEqual(["E"]);
+      expect(arrivals.get("E")?.size).toBe(2);
+    });
+
+    it("should release E when all three branches have arrived", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      simulateConvergenceBarrier("C", ["E"], targetMap, arrivals);
+      const result = simulateConvergenceBarrier(
+        "D",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual(["E"]);
+      expect(result.waiting).toEqual([]);
+      expect(arrivals.get("E")?.size).toBe(3);
+    });
+
+    it("should not block non-convergence nodes", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      const result = simulateConvergenceBarrier(
+        "A",
+        ["B", "C", "D"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual(["B", "C", "D"]);
+      expect(result.waiting).toEqual([]);
+    });
+  });
+
+  describe("mixed topology: A -> [B, C] -> E, A -> D -> F", () => {
+    const edges: EdgeLike[] = [
+      { source: "A", target: "B" },
+      { source: "A", target: "C" },
+      { source: "A", target: "D" },
+      { source: "B", target: "E" },
+      { source: "C", target: "E" },
+      { source: "D", target: "F" },
+    ];
+
+    it("should detect E as convergence (2 incoming) but not F (1 incoming)", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      expect(targetMap.get("E")?.length).toBe(2);
+      expect(targetMap.get("F")?.length).toBe(1);
+    });
+
+    it("should block E until both B and C arrive", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      const first = simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      expect(first.ready).toEqual([]);
+
+      const second = simulateConvergenceBarrier(
+        "C",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(second.ready).toEqual(["E"]);
+    });
+
+    it("should not block F (single incoming edge from D)", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      const result = simulateConvergenceBarrier(
+        "D",
+        ["F"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual(["F"]);
+    });
+  });
+
+  describe("duplicate arrival from same source is idempotent", () => {
+    const edges: EdgeLike[] = [
+      { source: "B", target: "E" },
+      { source: "C", target: "E" },
+    ];
+
+    it("should not count duplicate arrivals from the same source", () => {
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      const result = simulateConvergenceBarrier(
+        "B",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+
+      expect(result.ready).toEqual([]);
+      expect(arrivals.get("E")?.size).toBe(1);
+    });
+  });
+
+  describe("condition skip propagation", () => {
+    it("should signal arrival at convergence node from skipped branch", () => {
+      // Condition -> [true: B, false: C] -> E
+      const edges: EdgeLike[] = [
+        { source: "Cond", target: "B" },
+        { source: "Cond", target: "C" },
+        { source: "B", target: "E" },
+        { source: "C", target: "E" },
+      ];
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      // Condition takes true branch (B), skips false branch (C)
+      // Propagate skip for C
+      const unblocked = simulateSkipPropagation(
+        ["C"],
+        sourceMap,
+        targetMap,
+        arrivals
+      );
+
+      // C's arrival at E was signaled, but E still needs B's arrival
+      expect(unblocked).toEqual([]);
+      expect(arrivals.get("E")?.has("C")).toBe(true);
+      expect(arrivals.get("E")?.size).toBe(1);
+
+      // Now B arrives at E
+      const result = simulateConvergenceBarrier(
+        "B",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual(["E"]);
+    });
+
+    it("should unblock convergence when skip is the last arrival", () => {
+      // B already arrived, then C gets skipped
+      const edges: EdgeLike[] = [
+        { source: "B", target: "E" },
+        { source: "C", target: "E" },
+      ];
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      // B arrives first
+      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      expect(arrivals.get("E")?.size).toBe(1);
+
+      // C gets skipped and propagation signals its arrival
+      const unblocked = simulateSkipPropagation(
+        ["C"],
+        sourceMap,
+        targetMap,
+        arrivals
+      );
+      expect(unblocked).toEqual(["E"]);
+    });
+
+    it("should propagate through chain of non-convergence nodes to reach convergence", () => {
+      // Cond -> [true: B, false: C -> D] -> E
+      // C is skipped, D is downstream of C and leads to E
+      const edges: EdgeLike[] = [
+        { source: "Cond", target: "B" },
+        { source: "Cond", target: "C" },
+        { source: "C", target: "D" },
+        { source: "B", target: "E" },
+        { source: "D", target: "E" },
+      ];
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      // Skip C, which chains through D to E
+      const unblocked = simulateSkipPropagation(
+        ["C"],
+        sourceMap,
+        targetMap,
+        arrivals
+      );
+
+      // D is not a convergence node so skip propagates through it
+      // E gets arrival from D (via skip chain)
+      expect(arrivals.get("E")?.has("D")).toBe(true);
+      expect(unblocked).toEqual([]);
+
+      // B arrives at E, completing the barrier
+      const result = simulateConvergenceBarrier(
+        "B",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual(["E"]);
+    });
+  });
+
+  describe("failure signaling at convergence nodes", () => {
+    it("should allow manual arrival signaling for failed nodes", () => {
+      // A -> [B, C] -> E where B fails
+      const edges: EdgeLike[] = [
+        { source: "B", target: "E" },
+        { source: "C", target: "E" },
+      ];
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+
+      // B fails: manually signal arrival at E (mirrors catch block logic)
+      const incomingSources = targetMap.get("E") ?? [];
+      expect(incomingSources.length).toBeGreaterThan(1);
+
+      let nodeArrivals = arrivals.get("E");
+      if (nodeArrivals === undefined) {
+        nodeArrivals = new Set<string>();
+        arrivals.set("E", nodeArrivals);
+      }
+      nodeArrivals.add("B");
+
+      // C completes and triggers barrier check
+      const result = simulateConvergenceBarrier(
+        "C",
+        ["E"],
+        targetMap,
+        arrivals
+      );
+      expect(result.ready).toEqual(["E"]);
+    });
+  });
+});

--- a/tests/unit/convergence-barrier.test.ts
+++ b/tests/unit/convergence-barrier.test.ts
@@ -2,134 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-type EdgeLike = {
-  source: string;
-  target: string;
-};
-
-/**
- * Builds the reverse edge map (target -> source[]) used by the convergence
- * barrier in the workflow executor to determine how many incoming edges
- * each node has.
- */
-function buildEdgesByTarget(edges: EdgeLike[]): Map<string, string[]> {
-  const map = new Map<string, string[]>();
-  for (const edge of edges) {
-    const sources = map.get(edge.target) ?? [];
-    sources.push(edge.source);
-    map.set(edge.target, sources);
-  }
-  return map;
-}
-
-function buildEdgesBySource(edges: EdgeLike[]): Map<string, string[]> {
-  const map = new Map<string, string[]>();
-  for (const edge of edges) {
-    const targets = map.get(edge.source) ?? [];
-    targets.push(edge.target);
-    map.set(edge.source, targets);
-  }
-  return map;
-}
-
-/**
- * Mirrors the convergence barrier logic from executeReadyDownstream in the
- * workflow executor. Returns which nodes are ready to execute (all incoming
- * branches have arrived) vs which are still waiting.
- */
-function simulateConvergenceBarrier(
-  fromNodeId: string,
-  nextNodeIds: string[],
-  edgesByTarget: Map<string, string[]>,
-  arrivals: Map<string, Set<string>>
-): { ready: string[]; waiting: string[] } {
-  const ready: string[] = [];
-  const waiting: string[] = [];
-
-  for (const nextId of nextNodeIds) {
-    const incomingSources = edgesByTarget.get(nextId);
-    const isConvergenceNode =
-      incomingSources !== undefined && incomingSources.length > 1;
-
-    if (isConvergenceNode) {
-      let nodeArrivals = arrivals.get(nextId);
-      if (nodeArrivals === undefined) {
-        nodeArrivals = new Set<string>();
-        arrivals.set(nextId, nodeArrivals);
-      }
-      nodeArrivals.add(fromNodeId);
-
-      if (nodeArrivals.size >= incomingSources.length) {
-        ready.push(nextId);
-      } else {
-        waiting.push(nextId);
-      }
-    } else {
-      ready.push(nextId);
-    }
-  }
-
-  return { ready, waiting };
-}
-
-/**
- * Mirrors propagateConvergenceSkips from the workflow executor.
- * BFS through skipped subtree, signaling arrival at convergence nodes.
- * Returns convergence nodes that became fully arrived (ready to execute).
- */
-function simulateSkipPropagation(
-  skippedNodeIds: string[],
-  edgesBySource: Map<string, string[]>,
-  edgesByTarget: Map<string, string[]>,
-  arrivals: Map<string, Set<string>>
-): string[] {
-  const unblocked: string[] = [];
-  const queue = [...skippedNodeIds];
-  const seen = new Set<string>();
-
-  while (queue.length > 0) {
-    const currentId = queue.shift() as string;
-    if (seen.has(currentId)) {
-      continue;
-    }
-    seen.add(currentId);
-
-    const incomingSources = edgesByTarget.get(currentId);
-    const isConvergenceNode =
-      incomingSources !== undefined && incomingSources.length > 1;
-
-    if (isConvergenceNode) {
-      for (const src of incomingSources) {
-        if (seen.has(src) || skippedNodeIds.includes(src)) {
-          let nodeArrivals = arrivals.get(currentId);
-          if (nodeArrivals === undefined) {
-            nodeArrivals = new Set<string>();
-            arrivals.set(currentId, nodeArrivals);
-          }
-          nodeArrivals.add(src);
-        }
-      }
-
-      if ((arrivals.get(currentId)?.size ?? 0) >= incomingSources.length) {
-        unblocked.push(currentId);
-        continue;
-      }
-    }
-
-    const downstream = edgesBySource.get(currentId) ?? [];
-    for (const downId of downstream) {
-      if (!seen.has(downId)) {
-        queue.push(downId);
-      }
-    }
-  }
-
-  return unblocked;
-}
+import {
+  buildEdgesBySource,
+  buildEdgesByTarget,
+  getReadyDownstreamIds,
+  propagateConvergenceSkips,
+  signalConvergenceArrival,
+} from "@/lib/convergence-barrier";
 
 describe("convergence barrier", () => {
   describe("basic convergence: A -> [B, C, D] -> E", () => {
-    const edges: EdgeLike[] = [
+    const edges = [
       { source: "A", target: "B" },
       { source: "A", target: "C" },
       { source: "A", target: "D" },
@@ -148,68 +31,72 @@ describe("convergence barrier", () => {
     it("should block E when only first branch arrives", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      const result = simulateConvergenceBarrier(
+      const ready = getReadyDownstreamIds(
         "B",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual([]);
-      expect(result.waiting).toEqual(["E"]);
+      expect(ready).toEqual([]);
       expect(arrivals.get("E")?.size).toBe(1);
     });
 
     it("should block E when two branches have arrived", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
-      const result = simulateConvergenceBarrier(
+      getReadyDownstreamIds("B", ["E"], targetMap, arrivals, visited);
+      const ready = getReadyDownstreamIds(
         "C",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual([]);
-      expect(result.waiting).toEqual(["E"]);
+      expect(ready).toEqual([]);
       expect(arrivals.get("E")?.size).toBe(2);
     });
 
     it("should release E when all three branches have arrived", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
-      simulateConvergenceBarrier("C", ["E"], targetMap, arrivals);
-      const result = simulateConvergenceBarrier(
+      getReadyDownstreamIds("B", ["E"], targetMap, arrivals, visited);
+      getReadyDownstreamIds("C", ["E"], targetMap, arrivals, visited);
+      const ready = getReadyDownstreamIds(
         "D",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual(["E"]);
-      expect(result.waiting).toEqual([]);
+      expect(ready).toEqual(["E"]);
       expect(arrivals.get("E")?.size).toBe(3);
     });
 
     it("should not block non-convergence nodes", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      const result = simulateConvergenceBarrier(
+      const ready = getReadyDownstreamIds(
         "A",
         ["B", "C", "D"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual(["B", "C", "D"]);
-      expect(result.waiting).toEqual([]);
+      expect(ready).toEqual(["B", "C", "D"]);
     });
   });
 
   describe("mixed topology: A -> [B, C] -> E, A -> D -> F", () => {
-    const edges: EdgeLike[] = [
+    const edges = [
       { source: "A", target: "B" },
       { source: "A", target: "C" },
       { source: "A", target: "D" },
@@ -227,35 +114,45 @@ describe("convergence barrier", () => {
     it("should block E until both B and C arrive", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      const first = simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
-      expect(first.ready).toEqual([]);
+      const first = getReadyDownstreamIds(
+        "B",
+        ["E"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(first).toEqual([]);
 
-      const second = simulateConvergenceBarrier(
+      const second = getReadyDownstreamIds(
         "C",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(second.ready).toEqual(["E"]);
+      expect(second).toEqual(["E"]);
     });
 
     it("should not block F (single incoming edge from D)", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      const result = simulateConvergenceBarrier(
+      const ready = getReadyDownstreamIds(
         "D",
         ["F"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual(["F"]);
+      expect(ready).toEqual(["F"]);
     });
   });
 
   describe("duplicate arrival from same source is idempotent", () => {
-    const edges: EdgeLike[] = [
+    const edges = [
       { source: "B", target: "E" },
       { source: "C", target: "E" },
     ];
@@ -263,17 +160,19 @@ describe("convergence barrier", () => {
     it("should not count duplicate arrivals from the same source", () => {
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
-      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
-      const result = simulateConvergenceBarrier(
+      getReadyDownstreamIds("B", ["E"], targetMap, arrivals, visited);
+      getReadyDownstreamIds("B", ["E"], targetMap, arrivals, visited);
+      const ready = getReadyDownstreamIds(
         "B",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
 
-      expect(result.ready).toEqual([]);
+      expect(ready).toEqual([]);
       expect(arrivals.get("E")?.size).toBe(1);
     });
   });
@@ -281,7 +180,7 @@ describe("convergence barrier", () => {
   describe("condition skip propagation", () => {
     it("should signal arrival at convergence node from skipped branch", () => {
       // Condition -> [true: B, false: C] -> E
-      const edges: EdgeLike[] = [
+      const edges = [
         { source: "Cond", target: "B" },
         { source: "Cond", target: "C" },
         { source: "B", target: "E" },
@@ -290,14 +189,15 @@ describe("convergence barrier", () => {
       const sourceMap = buildEdgesBySource(edges);
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
       // Condition takes true branch (B), skips false branch (C)
-      // Propagate skip for C
-      const unblocked = simulateSkipPropagation(
+      const unblocked = propagateConvergenceSkips(
         ["C"],
         sourceMap,
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
 
       // C's arrival at E was signaled, but E still needs B's arrival
@@ -306,35 +206,38 @@ describe("convergence barrier", () => {
       expect(arrivals.get("E")?.size).toBe(1);
 
       // Now B arrives at E
-      const result = simulateConvergenceBarrier(
+      const ready = getReadyDownstreamIds(
         "B",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual(["E"]);
+      expect(ready).toEqual(["E"]);
     });
 
     it("should unblock convergence when skip is the last arrival", () => {
       // B already arrived, then C gets skipped
-      const edges: EdgeLike[] = [
+      const edges = [
         { source: "B", target: "E" },
         { source: "C", target: "E" },
       ];
       const sourceMap = buildEdgesBySource(edges);
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
       // B arrives first
-      simulateConvergenceBarrier("B", ["E"], targetMap, arrivals);
+      signalConvergenceArrival("B", ["E"], targetMap, arrivals, visited);
       expect(arrivals.get("E")?.size).toBe(1);
 
       // C gets skipped and propagation signals its arrival
-      const unblocked = simulateSkipPropagation(
+      const unblocked = propagateConvergenceSkips(
         ["C"],
         sourceMap,
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
       expect(unblocked).toEqual(["E"]);
     });
@@ -342,7 +245,7 @@ describe("convergence barrier", () => {
     it("should propagate through chain of non-convergence nodes to reach convergence", () => {
       // Cond -> [true: B, false: C -> D] -> E
       // C is skipped, D is downstream of C and leads to E
-      const edges: EdgeLike[] = [
+      const edges = [
         { source: "Cond", target: "B" },
         { source: "Cond", target: "C" },
         { source: "C", target: "D" },
@@ -352,13 +255,15 @@ describe("convergence barrier", () => {
       const sourceMap = buildEdgesBySource(edges);
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
       // Skip C, which chains through D to E
-      const unblocked = simulateSkipPropagation(
+      const unblocked = propagateConvergenceSkips(
         ["C"],
         sourceMap,
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
 
       // D is not a convergence node so skip propagates through it
@@ -367,45 +272,40 @@ describe("convergence barrier", () => {
       expect(unblocked).toEqual([]);
 
       // B arrives at E, completing the barrier
-      const result = simulateConvergenceBarrier(
+      const ready = getReadyDownstreamIds(
         "B",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual(["E"]);
+      expect(ready).toEqual(["E"]);
     });
   });
 
   describe("failure signaling at convergence nodes", () => {
-    it("should allow manual arrival signaling for failed nodes", () => {
+    it("should allow signaling arrival for failed nodes", () => {
       // A -> [B, C] -> E where B fails
-      const edges: EdgeLike[] = [
+      const edges = [
         { source: "B", target: "E" },
         { source: "C", target: "E" },
       ];
       const targetMap = buildEdgesByTarget(edges);
       const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
 
-      // B fails: manually signal arrival at E (mirrors catch block logic)
-      const incomingSources = targetMap.get("E") ?? [];
-      expect(incomingSources.length).toBeGreaterThan(1);
-
-      let nodeArrivals = arrivals.get("E");
-      if (nodeArrivals === undefined) {
-        nodeArrivals = new Set<string>();
-        arrivals.set("E", nodeArrivals);
-      }
-      nodeArrivals.add("B");
+      // B fails: signal arrival at E (same call the catch block makes)
+      signalConvergenceArrival("B", ["E"], targetMap, arrivals, visited);
 
       // C completes and triggers barrier check
-      const result = simulateConvergenceBarrier(
+      const ready = getReadyDownstreamIds(
         "C",
         ["E"],
         targetMap,
-        arrivals
+        arrivals,
+        visited
       );
-      expect(result.ready).toEqual(["E"]);
+      expect(ready).toEqual(["E"]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Parallel branches converging into a single node now wait for all upstream branches to complete before the convergence node executes
- Adds `edgesByTarget` reverse edge map and `convergenceArrivals` tracking to detect and gate convergence nodes (nodes with >1 incoming edge)
- `executeReadyDownstream` replaces direct `Promise.allSettled` calls at all 6 downstream execution sites
- `propagateConvergenceSkips` handles condition-skipped branches by BFS-signaling arrival at downstream convergence nodes
- Failed nodes signal arrival in the catch block to prevent convergence deadlocks
- Adds 13 unit tests covering basic convergence, mixed topologies, skip propagation, and failure signaling