### PR TITLE
chore: update org references from techops-services to KeeperHub

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -64,7 +64,7 @@ Create a pull request for the current branch against the staging base branch, wi
    ```
 8. Create the PR targeting staging with review requested from the keeperhub team.
    Do NOT ask for confirmation -- proceed directly:
-   `gh pr create --base staging --reviewer techops-services/keeperhub --title "..." --body "..."`
+   `gh pr create --base staging --reviewer KeeperHub/keeperhub --title "..." --body "..."`
 9. Output the PR URL.
 </process>
 
@@ -73,7 +73,7 @@ Create a pull request for the current branch against the staging base branch, wi
 - All changes committed before PR creation
 - PR targets staging as base branch
 - PR title follows conventional commit format
-- Review requested from techops-services/keeperhub
+- Review requested from KeeperHub/keeperhub
 - PR summary leads with intent (why), not a changelog of what changed
 - PR URL returned to the user
   </success_criteria>

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -106,12 +106,12 @@ jobs:
           for repo in keeperhub-events keeperhub-scheduler; do
             status=$(curl -sf -o /dev/null -w "%{http_code}" \
               -H "Authorization: Bearer $TOKEN" \
-              "https://api.github.com/repos/techops-services/$repo")
+              "https://api.github.com/repos/KeeperHub/$repo")
             if [ "$status" != "200" ]; then
-              echo "::error::KEEPERHUB_SUBMODULE_TOKEN cannot access techops-services/$repo (HTTP $status). Token may be expired or revoked."
+              echo "::error::KEEPERHUB_SUBMODULE_TOKEN cannot access KeeperHub/$repo (HTTP $status). Token may be expired or revoked."
               exit 1
             fi
-            echo "Verified access to techops-services/$repo"
+            echo "Verified access to KeeperHub/$repo"
           done
 
       - name: Set up Docker Buildx

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "keeperhub-scheduler"]
 	path = keeperhub-scheduler
-	url = https://github.com/techops-services/keeperhub-scheduler.git
+	url = https://github.com/KeeperHub/keeperhub-scheduler.git
 	branch = staging
 [submodule "keeperhub-events"]
 	path = keeperhub-events
-	url = https://github.com/techops-services/keeperhub-events.git
+	url = https://github.com/KeeperHub/keeperhub-events.git
 	branch = staging

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ A Web3 workflow automation platform (forked from vercel-labs/workflow-builder-te
 
 ## Core Value
 
-Users and Agents can build and deploy Web3 automation workflows through a visual builder or with [KeeperHub MCP](https://github.com/techops-services/keeperhub-mcp) without writing code.
+Users and Agents can build and deploy Web3 automation workflows through a visual builder or with [KeeperHub MCP](https://github.com/KeeperHub/keeperhub-mcp) without writing code.
 
 ## Add KeeperHub to your Agent
 
 **1. Install the plugin**
 
 ```
-/plugin marketplace add techops-services/claude-plugins
+/plugin marketplace add KeeperHub/claude-plugins
 /plugin install keeperhub@techops-plugins
 ```
 
-You can view the plugin source code here https://github.com/techops-services/claude-plugins/tree/main/plugins/keeperhub
+You can view the plugin source code here https://github.com/KeeperHub/claude-plugins/tree/main/plugins/keeperhub
 
 **2. Run setup**
 

--- a/components/overlays/feedback-overlay.tsx
+++ b/components/overlays/feedback-overlay.tsx
@@ -125,7 +125,7 @@ export function FeedbackOverlay({ overlayId }: FeedbackOverlayProps) {
           </p>
           <a
             className="text-primary text-sm underline"
-            href="https://github.com/techops-services/keeperhub/issues?q=is%3Aopen+is%3Aissue+label%3Auser-feedback"
+            href="https://github.com/KeeperHub/keeperhub/issues?q=is%3Aopen+is%3Aissue+label%3Auser-feedback"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/docs-site/theme.config.tsx
+++ b/docs-site/theme.config.tsx
@@ -22,10 +22,10 @@ const config = {
     </span>
   ),
   project: {
-    link: "https://github.com/techops-services/keeperhub",
+    link: "https://github.com/KeeperHub/keeperhub",
   },
   docsRepositoryBase:
-    "https://github.com/techops-services/keeperhub/edit/main/docs",
+    "https://github.com/KeeperHub/keeperhub/edit/main/docs",
   footer: {
     content: (
       <span style={{ color: "#7a9ca8", fontSize: "13px" }}>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -175,7 +175,7 @@ KEEPERHUB_API_KEY=kh_your_key pnpm start
 
 **Via Claude Code Plugin** -- if you install the [Claude Code plugin](/ai-tools/claude-code-plugin), the MCP server is set up automatically. No manual config needed.
 
-Source code and full docs: [github.com/techops-services/keeperhub-mcp](https://github.com/techops-services/keeperhub-mcp)
+Source code and full docs: [github.com/KeeperHub/keeperhub-mcp](https://github.com/KeeperHub/keeperhub-mcp)
 
 ### How do I connect Claude Code to KeeperHub?
 
@@ -198,7 +198,7 @@ Add this to your MCP client config (e.g. `~/.claude.json`):
 Or skip the manual config entirely -- install the Claude Code plugin and run `/keeperhub:login`:
 
 ```bash
-/plugin marketplace add techops-services/claude-plugins
+/plugin marketplace add KeeperHub/claude-plugins
 /plugin install keeperhub@techops-plugins
 /keeperhub:login
 ```

--- a/docs/ai-tools/claude-code-plugin.md
+++ b/docs/ai-tools/claude-code-plugin.md
@@ -5,7 +5,7 @@ description: "Build and manage KeeperHub workflows directly from Claude Code wit
 
 # Claude Code Plugin
 
-[GitHub](https://github.com/techops-services/claude-plugins/tree/main/plugins/keeperhub)
+[GitHub](https://github.com/KeeperHub/claude-plugins/tree/main/plugins/keeperhub)
 
 The KeeperHub plugin for Claude Code lets you create workflows, browse templates, debug executions, and explore plugins without leaving your terminal.
 
@@ -13,7 +13,7 @@ The KeeperHub plugin for Claude Code lets you create workflows, browse templates
 
 ```bash
 # Add the marketplace
-/plugin marketplace add techops-services/claude-plugins
+/plugin marketplace add KeeperHub/claude-plugins
 
 # Install the plugin
 /plugin install keeperhub@techops-plugins

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -5,7 +5,7 @@ description: "Model Context Protocol server for AI agents to build and manage Ke
 
 # MCP Server
 
-[GitHub](https://github.com/techops-services/keeperhub-mcp)
+[GitHub](https://github.com/KeeperHub/keeperhub-mcp)
 
 The KeeperHub MCP server exposes 19 tools over the Model Context Protocol, enabling AI agents to create, execute, and monitor blockchain automation workflows.
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -140,7 +140,7 @@ export async function sendVerificationOTP(
   const { email, otp, type } = data;
 
   const logoUrl =
-    "https://raw.githubusercontent.com/techops-services/keeperhub/staging/public/keeperhub_logo.png";
+    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo.png";
 
   const subjectMap = {
     "sign-in": "Your KeeperHub sign-in code",
@@ -260,7 +260,7 @@ export async function sendOAuthPasswordResetEmail(
   const { email, providerName } = data;
 
   const logoUrl =
-    "https://raw.githubusercontent.com/techops-services/keeperhub/staging/public/keeperhub_logo.png";
+    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo.png";
 
   const subject = "Password Reset Request - KeeperHub";
 
@@ -350,7 +350,7 @@ export async function sendInvitationEmail(
     data;
 
   const logoUrl =
-    "https://raw.githubusercontent.com/techops-services/keeperhub/staging/public/keeperhub_logo.png";
+    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo.png";
 
   const subject = `You've been invited to join ${organizationName} on KeeperHub`;
 

--- a/specs/KEEPERHUB_PARALLEL_REFACTOR_PLAN.md
+++ b/specs/KEEPERHUB_PARALLEL_REFACTOR_PLAN.md
@@ -8,7 +8,7 @@ This document outlines the complete plan to refactor KeeperHub from editing the 
 
 - `upstream` - Vercel's original template (`vercel-labs/workflow-builder-template`)
 - `origin` - TechOps fork (`techops-services/workflow-builder-template`)
-- `fork` - KeeperHub repo (`techops-services/keeperhub`)
+- `fork` - KeeperHub repo (`KeeperHub/keeperhub`)
 
 **Current Approach:** Directly editing upstream files, merging upstream changes with conflict resolution.
 

--- a/specs/mcp-server/mcp-server.md
+++ b/specs/mcp-server/mcp-server.md
@@ -18,7 +18,7 @@ Create a standalone MCP (Model Context Protocol) server for KeeperHub that enabl
 - **Single org scope** - each API key bound to one organization
 
 ### Architecture
-- **Separate repository** (`techops-services/keeperhub-mcp`)
+- **Separate repository** (`KeeperHub/keeperhub-mcp`)
 - **TypeScript/Node.js** runtime for type sharing with main app
 - **Docker container** distribution (similar to Terraform MCP pattern)
 - **Calls KeeperHub REST APIs** for all operations
@@ -149,7 +149,7 @@ CMD ["node", "dist/index.js"]
         "--rm",
         "-e",
         "KEEPERHUB_API_KEY",
-        "techops-services/keeperhub-mcp"
+        "KeeperHub/keeperhub-mcp"
       ]
     }
   }
@@ -253,7 +253,7 @@ Add to organization settings:
 ## Open Questions
 
 - Should we support streaming for AI workflow generation via MCP?
-- Docker image naming: `techops-services/keeperhub-mcp` or `ghcr.io/techops-services/keeperhub-mcp`?
+- Docker image naming: `KeeperHub/keeperhub-mcp` or `ghcr.io/KeeperHub/keeperhub-mcp`?
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary
- Update git submodule URLs for `keeperhub-scheduler` and `keeperhub-events`
- Update CI/CD submodule token verification in `build-images.yml`
- Update GitHub issues URL in feedback overlay component
- Update `raw.githubusercontent.com` logo URLs in email templates
- Update docs-site GitHub link, README, and documentation URLs

**Note**: Helm chart references are intentionally kept as cross-org dependency.

## Context
Repository migration from `techops-services` to `KeeperHub` GitHub organization.