### PR TITLE
ci: use environment-level variable for E2E ephemeral test gating

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -49,6 +49,7 @@ on:
 jobs:
   should-run:
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     outputs:
       run-e2e: ${{ steps.check.outputs.run-e2e }}
     steps:
@@ -64,6 +65,12 @@ jobs:
           EFFECTIVE_EVENT: ${{ inputs.caller_event || github.event_name }}
         run: |
           echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+
+          # Check environment-level kill switch
+          if [[ "${{ vars.ENABLE_E2E_EPHEMERAL_TESTS }}" != "true" ]]; then
+            echo "E2E tests disabled for this environment (ENABLE_E2E_EPHEMERAL_TESTS=${{ vars.ENABLE_E2E_EPHEMERAL_TESTS }})"
+            exit 0
+          fi
 
           # Check for [skip e2e] flag in commit message (push events only)
           if [[ "$EFFECTIVE_EVENT" == "push" ]]; then
@@ -86,7 +93,7 @@ jobs:
   # DISABLED: ephemeral E2E tests temporarily disabled while KEEP-1351 stabilises auth/rate-limit infrastructure
   e2e-vitest-ephemeral:
     needs: should-run
-    if: ${{ needs.should-run.outputs.run-e2e == 'true' && vars.ENABLE_E2E_EPHEMERAL_TESTS == 'true' }}
+    if: ${{ needs.should-run.outputs.run-e2e == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
 
@@ -235,7 +242,7 @@ jobs:
   # DISABLED: ephemeral E2E tests temporarily disabled while KEEP-1351 stabilises auth/rate-limit infrastructure
   e2e-playwright-ephemeral:
     needs: [should-run, e2e-vitest-ephemeral]
-    if: ${{ always() && needs.should-run.outputs.run-e2e == 'true' && !failure() && vars.ENABLE_E2E_EPHEMERAL_TESTS == 'true' }}
+    if: ${{ always() && needs.should-run.outputs.run-e2e == 'true' && !failure() }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
 


### PR DESCRIPTION
## Summary

- Moved `ENABLE_E2E_EPHEMERAL_TESTS` check from job-level `if` conditions into the `should-run` job
- Added `environment` context to `should-run` so `vars` resolves from the correct environment (prod/staging) instead of repo level
- Prod has `ENABLE_E2E_EPHEMERAL_TESTS=false` but tests were running because the repo-level variable is `true` and job `if` conditions evaluate before the environment loads

This fixes prod CI failures from E2E tests that should have been skipped.