### PR TITLE
feat: auto-expand config panel on node click

### DIFF
--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -30,6 +30,7 @@ import {
   hasUnsavedChangesAtom,
   isGeneratingAtom,
   isPanelAnimatingAtom,
+  isSidebarCollapsedAtom,
   isTransitioningFromHomepageAtom,
   nodesAtom,
   onEdgesChangeAtom,
@@ -92,6 +93,8 @@ export function WorkflowCanvas() {
   const [showMinimap] = useAtom(showMinimapAtom);
   const rightPanelWidth = useAtomValue(rightPanelWidthAtom);
   const isPanelAnimating = useAtomValue(isPanelAnimatingAtom);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useAtom(isSidebarCollapsedAtom);
+  const setIsPanelAnimating = useSetAtom(isPanelAnimatingAtom);
   const [isTransitioningFromHomepage, setIsTransitioningFromHomepage] = useAtom(
     isTransitioningFromHomepageAtom
   );
@@ -403,8 +406,13 @@ export function WorkflowCanvas() {
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
       setSelectedNode(node.id);
+      if (isSidebarCollapsed) {
+        setIsPanelAnimating(true);
+        setIsSidebarCollapsed(false);
+        setTimeout(() => setIsPanelAnimating(false), 350);
+      }
     },
-    [setSelectedNode]
+    [setSelectedNode, isSidebarCollapsed, setIsPanelAnimating, setIsSidebarCollapsed]
   );
 
   const connectingHandleId = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
- Auto-expand the right sidebar config panel when clicking any node on the workflow canvas
- Collapse button continues to work independently -- no auto-collapse behavior