### PR TITLE
feat: adjust zoom controls UI and persist viewport per workflow

### DIFF
--- a/components/ai-elements/canvas.tsx
+++ b/components/ai-elements/canvas.tsx
@@ -11,6 +11,8 @@ export const Canvas = ({ children, ...props }: CanvasProps) => {
     <ReactFlow
       deleteKeyCode={["Backspace", "Delete"]}
       fitView
+      maxZoom={4}
+      minZoom={0.1}
       panActivationKeyCode={null}
       selectionOnDrag={false}
       zoomOnDoubleClick={false}

--- a/components/ai-elements/controls.tsx
+++ b/components/ai-elements/controls.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useReactFlow } from "@xyflow/react";
+import { useReactFlow, useStore } from "@xyflow/react";
 import { ZoomIn, ZoomOut, Maximize2, MapPin, MapPinXInside } from "lucide-react";
 import { useAtom } from "jotai";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { showMinimapAtom } from "@/lib/workflow-store";
 
-export const Controls = () => {
+type ControlsProps = {
+  onFitView?: () => void;
+};
+
+const zoomSelector = (state: { transform: [number, number, number] }): number =>
+  Math.round(state.transform[2] * 100);
+
+export const Controls = ({ onFitView }: ControlsProps) => {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const [showMinimap, setShowMinimap] = useAtom(showMinimapAtom);
+  const zoomPercent = useStore(zoomSelector);
 
   const handleZoomIn = () => {
     zoomIn();
@@ -20,17 +28,24 @@ export const Controls = () => {
   };
 
   const handleFitView = () => {
-    fitView({ padding: 0.2, duration: 300 });
+    if (onFitView) {
+      onFitView();
+    } else {
+      fitView({ padding: 0.2, duration: 300 });
+    }
   };
 
   const handleToggleMinimap = () => {
     setShowMinimap(!showMinimap);
   };
 
+  const buttonClass =
+    "border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground";
+
   return (
     <ButtonGroup orientation="vertical">
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={buttonClass}
         onClick={handleZoomIn}
         size="icon"
         title="Zoom in"
@@ -39,7 +54,16 @@ export const Controls = () => {
         <ZoomIn className="size-4" />
       </Button>
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={`${buttonClass} text-[10px] font-medium tabular-nums`}
+        onClick={handleFitView}
+        size="icon"
+        title="Fit view"
+        variant="secondary"
+      >
+        {zoomPercent}%
+      </Button>
+      <Button
+        className={buttonClass}
         onClick={handleZoomOut}
         size="icon"
         title="Zoom out"
@@ -48,7 +72,7 @@ export const Controls = () => {
         <ZoomOut className="size-4" />
       </Button>
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={buttonClass}
         onClick={handleFitView}
         size="icon"
         title="Fit view"
@@ -57,7 +81,7 @@ export const Controls = () => {
         <Maximize2 className="size-4" />
       </Button>
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={buttonClass}
         onClick={handleToggleMinimap}
         size="icon"
         title={showMinimap ? "Hide minimap" : "Show minimap"}

--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -7,6 +7,7 @@ import {
   type NodeMouseHandler,
   type OnConnect,
   type OnConnectStartParams,
+  useOnViewportChange,
   useReactFlow,
   useUpdateNodeInternals,
   type Connection as XYFlowConnection,
@@ -30,6 +31,7 @@ import {
   hasUnsavedChangesAtom,
   isGeneratingAtom,
   isPanelAnimatingAtom,
+  isSidebarCollapsedAtom,
   isTransitioningFromHomepageAtom,
   nodesAtom,
   onEdgesChangeAtom,
@@ -84,6 +86,9 @@ function getActionType(node: { data?: unknown }): string | undefined {
   return config?.actionType as string | undefined;
 }
 
+const VIEWPORT_STORAGE_PREFIX = "wf-viewport-";
+const FIT_VIEW_DEFAULTS = { maxZoom: 1, minZoom: 0.1, padding: 0.2, duration: 0 } as const;
+
 export function WorkflowCanvas() {
   const [nodes, setNodes] = useAtom(nodesAtom);
   const [edges, setEdges] = useAtom(edgesAtom);
@@ -92,6 +97,7 @@ export function WorkflowCanvas() {
   const [showMinimap] = useAtom(showMinimapAtom);
   const rightPanelWidth = useAtomValue(rightPanelWidthAtom);
   const isPanelAnimating = useAtomValue(isPanelAnimatingAtom);
+  const isSidebarCollapsed = useAtomValue(isSidebarCollapsedAtom);
   const [isTransitioningFromHomepage, setIsTransitioningFromHomepage] = useAtom(
     isTransitioningFromHomepageAtom
   );
@@ -121,6 +127,56 @@ export function WorkflowCanvas() {
   const closeContextMenu = useCallback(() => {
     setContextMenuState(null);
   }, []);
+
+  // Persist viewport per workflow in localStorage
+  const saveViewportTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useOnViewportChange({
+    onChange: useCallback(
+      (viewport: { x: number; y: number; zoom: number }) => {
+        if (!currentWorkflowId || !viewportInitialized.current) {
+          return;
+        }
+        if (saveViewportTimeout.current) {
+          clearTimeout(saveViewportTimeout.current);
+        }
+        saveViewportTimeout.current = setTimeout(() => {
+          localStorage.setItem(
+            `${VIEWPORT_STORAGE_PREFIX}${currentWorkflowId}`,
+            JSON.stringify(viewport)
+          );
+        }, 500);
+      },
+      [currentWorkflowId]
+    ),
+  });
+
+  // Sidebar-aware fit view: fit then shift viewport left to account for sidebar
+  const fitViewSidebarAware = useCallback(
+    (options?: { duration?: number }) => {
+      const duration = options?.duration ?? 300;
+      fitView({ ...FIT_VIEW_DEFAULTS, duration });
+
+      if (isSidebarCollapsed || !rightPanelWidth) {
+        return;
+      }
+
+      const panelPercent = Number.parseFloat(rightPanelWidth);
+      if (Number.isNaN(panelPercent) || panelPercent <= 0) {
+        return;
+      }
+
+      const shiftPx = (window.innerWidth * panelPercent) / 100 / 2;
+      const shiftDelay = duration > 0 ? duration + 50 : 0;
+      setTimeout(() => {
+        const vp = getViewport();
+        setViewport(
+          { ...vp, x: vp.x - shiftPx },
+          { duration: duration > 0 ? 200 : 0 }
+        );
+      }, shiftDelay);
+    },
+    [fitView, getViewport, setViewport, isSidebarCollapsed, rightPanelWidth]
+  );
 
   // Track which workflow we've fitted view for to prevent re-running
   const fittedViewForWorkflowRef = useRef<string | null | undefined>(undefined);
@@ -174,7 +230,19 @@ export function WorkflowCanvas() {
 
     // Use fitView after a brief delay to ensure React Flow and nodes are ready
     setTimeout(() => {
-      fitView({ maxZoom: 1, minZoom: 0.5, padding: 0.2, duration: 0 });
+      // Restore saved viewport if available
+      const savedKey = currentWorkflowId ? `${VIEWPORT_STORAGE_PREFIX}${currentWorkflowId}` : null;
+      const saved = savedKey ? localStorage.getItem(savedKey) : null;
+      if (saved) {
+        try {
+          const vp = JSON.parse(saved) as { x: number; y: number; zoom: number };
+          setViewport(vp, { duration: 0 });
+        } catch {
+          fitView(FIT_VIEW_DEFAULTS);
+        }
+      } else {
+        fitView(FIT_VIEW_DEFAULTS);
+      }
       fittedViewForWorkflowRef.current = currentWorkflowId;
       viewportInitialized.current = true;
       // Show canvas immediately so width animation can be seen
@@ -185,6 +253,7 @@ export function WorkflowCanvas() {
   }, [
     currentWorkflowId,
     fitView,
+    setViewport,
     isTransitioningFromHomepage,
     setIsTransitioningFromHomepage,
   ]);
@@ -199,7 +268,7 @@ export function WorkflowCanvas() {
       hadRealNodesRef.current = true;
       // Fit view to center the new node
       setTimeout(() => {
-        fitView({ maxZoom: 1, minZoom: 0.5, padding: 0.2, duration: 0 });
+        fitView(FIT_VIEW_DEFAULTS);
         viewportInitialized.current = true;
         setIsCanvasReady(true);
       }, 0);
@@ -215,7 +284,7 @@ export function WorkflowCanvas() {
       // Check for Cmd+/ (Mac) or Ctrl+/ (Windows/Linux)
       if ((event.metaKey || event.ctrlKey) && event.key === "/") {
         event.preventDefault();
-        fitView({ padding: 0.2, duration: 300 });
+        fitViewSidebarAware({ duration: 300 });
       }
     };
 
@@ -223,7 +292,7 @@ export function WorkflowCanvas() {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [fitView]);
+  }, [fitViewSidebarAware]);
 
   const nodeTypes = useMemo(
     () => ({
@@ -645,14 +714,21 @@ export function WorkflowCanvas() {
         onSelectionChange={isGenerating ? undefined : onSelectionChange}
       >
         <Panel
-          className="workflow-controls-panel border-none bg-transparent p-0"
-          position="bottom-left"
+          className="workflow-controls-panel flex items-end gap-2 border-none bg-transparent p-0"
+          position="bottom-right"
         >
-          <Controls />
+          {showMinimap && (
+            <div className="overflow-hidden rounded-md">
+              <MiniMap
+                bgColor="var(--sidebar)"
+                maskColor="rgba(255, 255, 255, 0.1)"
+                nodeStrokeColor="var(--border)"
+                className="!relative !m-0"
+              />
+            </div>
+          )}
+          <Controls onFitView={() => fitViewSidebarAware({ duration: 300 })} />
         </Panel>
-        {showMinimap && (
-          <MiniMap bgColor="var(--sidebar)" nodeStrokeColor="var(--border)" />
-        )}
       </Canvas>
 
       {/* AI Prompt */}


### PR DESCRIPTION
## Summary
- Move zoom controls from bottom-left to bottom-right of the workflow canvas
- Display live zoom percentage between zoom in/out buttons
- Expand zoom range from 50%-200% to 10%-400%
- Persist viewport (position + zoom) per workflow in localStorage across sessions
- Make fit-view sidebar-aware by shifting viewport to account for right panel width
- Reposition minimap next to controls with rounded corners and subtle mask overlay