### PR TITLE
feat: auto-layout button for workflow canvas

### DIFF
--- a/components/ai-elements/canvas.tsx
+++ b/components/ai-elements/canvas.tsx
@@ -11,6 +11,8 @@ export const Canvas = ({ children, ...props }: CanvasProps) => {
     <ReactFlow
       deleteKeyCode={["Backspace", "Delete"]}
       fitView
+      maxZoom={4}
+      minZoom={0.1}
       panActivationKeyCode={null}
       selectionOnDrag={false}
       zoomOnDoubleClick={false}

--- a/components/ai-elements/controls.tsx
+++ b/components/ai-elements/controls.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useReactFlow } from "@xyflow/react";
+import { useReactFlow, useStore } from "@xyflow/react";
 import { ZoomIn, ZoomOut, Maximize2, MapPin, MapPinXInside } from "lucide-react";
 import { useAtom } from "jotai";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { showMinimapAtom } from "@/lib/workflow-store";
 
-export const Controls = () => {
+type ControlsProps = {
+  onFitView?: () => void;
+};
+
+const zoomSelector = (state: { transform: [number, number, number] }): number =>
+  Math.round(state.transform[2] * 100);
+
+export const Controls = ({ onFitView }: ControlsProps) => {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const [showMinimap, setShowMinimap] = useAtom(showMinimapAtom);
+  const zoomPercent = useStore(zoomSelector);
 
   const handleZoomIn = () => {
     zoomIn();
@@ -20,17 +28,24 @@ export const Controls = () => {
   };
 
   const handleFitView = () => {
-    fitView({ padding: 0.2, duration: 300 });
+    if (onFitView) {
+      onFitView();
+    } else {
+      fitView({ padding: 0.2, duration: 300 });
+    }
   };
 
   const handleToggleMinimap = () => {
     setShowMinimap(!showMinimap);
   };
 
+  const buttonClass =
+    "border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground";
+
   return (
     <ButtonGroup orientation="vertical">
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={buttonClass}
         onClick={handleZoomIn}
         size="icon"
         title="Zoom in"
@@ -39,7 +54,16 @@ export const Controls = () => {
         <ZoomIn className="size-4" />
       </Button>
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={`${buttonClass} text-[10px] font-medium tabular-nums`}
+        onClick={handleFitView}
+        size="icon"
+        title="Fit view"
+        variant="secondary"
+      >
+        {zoomPercent}%
+      </Button>
+      <Button
+        className={buttonClass}
         onClick={handleZoomOut}
         size="icon"
         title="Zoom out"
@@ -48,7 +72,7 @@ export const Controls = () => {
         <ZoomOut className="size-4" />
       </Button>
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={buttonClass}
         onClick={handleFitView}
         size="icon"
         title="Fit view"
@@ -57,7 +81,7 @@ export const Controls = () => {
         <Maximize2 className="size-4" />
       </Button>
       <Button
-        className="border hover:bg-black/5 disabled:opacity-100 dark:hover:bg-white/5 disabled:[&>svg]:text-muted-foreground"
+        className={buttonClass}
         onClick={handleToggleMinimap}
         size="icon"
         title={showMinimap ? "Hide minimap" : "Show minimap"}

--- a/components/ai-elements/controls.tsx
+++ b/components/ai-elements/controls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReactFlow, useStore } from "@xyflow/react";
-import { ZoomIn, ZoomOut, Maximize2, MapPin, MapPinXInside } from "lucide-react";
+import { ZoomIn, ZoomOut, Maximize2, MapPin, MapPinXInside, AlignHorizontalDistributeCenter } from "lucide-react";
 import { useAtom } from "jotai";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
@@ -9,12 +9,13 @@ import { showMinimapAtom } from "@/lib/workflow-store";
 
 type ControlsProps = {
   onFitView?: () => void;
+  onAutoLayout?: () => void;
 };
 
 const zoomSelector = (state: { transform: [number, number, number] }): number =>
   Math.round(state.transform[2] * 100);
 
-export const Controls = ({ onFitView }: ControlsProps) => {
+export const Controls = ({ onFitView, onAutoLayout }: ControlsProps) => {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const [showMinimap, setShowMinimap] = useAtom(showMinimapAtom);
   const zoomPercent = useStore(zoomSelector);
@@ -80,6 +81,17 @@ export const Controls = ({ onFitView }: ControlsProps) => {
       >
         <Maximize2 className="size-4" />
       </Button>
+      {onAutoLayout && (
+        <Button
+          className={buttonClass}
+          onClick={onAutoLayout}
+          size="icon"
+          title="Auto-layout"
+          variant="secondary"
+        >
+          <AlignHorizontalDistributeCenter className="size-4" />
+        </Button>
+      )}
       <Button
         className={buttonClass}
         onClick={handleToggleMinimap}

--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -23,8 +23,10 @@ import "@xyflow/react/dist/style.css";
 
 import { PlayCircle, Zap } from "lucide-react";
 import { nanoid } from "nanoid";
+import { toast } from "sonner";
 import {
   addNodeAtom,
+  autoLayoutAtom,
   autosaveAtom,
   currentWorkflowIdAtom,
   edgesAtom,
@@ -41,6 +43,7 @@ import {
   selectedEdgeAtom,
   selectedNodeAtom,
   showMinimapAtom,
+  undoAtom,
   type WorkflowNode,
   type WorkflowNodeType,
 } from "@/lib/workflow-store";
@@ -106,6 +109,8 @@ export function WorkflowCanvas() {
   const setSelectedNode = useSetAtom(selectedNodeAtom);
   const setSelectedEdge = useSetAtom(selectedEdgeAtom);
   const addNode = useSetAtom(addNodeAtom);
+  const triggerAutoLayout = useSetAtom(autoLayoutAtom);
+  const triggerUndo = useSetAtom(undoAtom);
   const setHasUnsavedChanges = useSetAtom(hasUnsavedChangesAtom);
   const triggerAutosave = useSetAtom(autosaveAtom);
   const setActiveTab = useSetAtom(propertiesPanelActiveTabAtom);
@@ -117,6 +122,7 @@ export function WorkflowCanvas() {
   const justCreatedNodeFromConnection = useRef(false);
   const viewportInitialized = useRef(false);
   const [isCanvasReady, setIsCanvasReady] = useState(false);
+  const [isAnimatingLayout, setIsAnimatingLayout] = useState(false);
   const [contextMenuState, setContextMenuState] =
     useState<ContextMenuState>(null);
 
@@ -177,6 +183,24 @@ export function WorkflowCanvas() {
     },
     [fitView, getViewport, setViewport, isSidebarCollapsed, rightPanelWidth]
   );
+
+  const handleAutoLayout = useCallback(() => {
+    setIsAnimatingLayout(true);
+    triggerAutoLayout();
+    setTimeout(() => {
+      setIsAnimatingLayout(false);
+      fitViewSidebarAware({ duration: 300 });
+      toast("Layout applied", {
+        action: {
+          label: "Revert",
+          onClick: () => {
+            triggerUndo();
+          },
+        },
+        duration: 5000,
+      });
+    }, 300);
+  }, [triggerAutoLayout, triggerUndo, fitViewSidebarAware]);
 
   // Track which workflow we've fitted view for to prevent re-running
   const fittedViewForWorkflowRef = useRef<string | null | undefined>(undefined);
@@ -689,7 +713,7 @@ export function WorkflowCanvas() {
     >
       {/* React Flow Canvas */}
       <Canvas
-        className="bg-background"
+        className={`bg-background${isAnimatingLayout ? " [&_.react-flow__node]:transition-[transform] [&_.react-flow__node]:duration-300 [&_.react-flow__node]:ease-in-out" : ""}`}
         connectionLineComponent={Connection}
         connectionMode={ConnectionMode.Strict}
         defaultEdgeOptions={{ type: "animated" }}
@@ -727,7 +751,7 @@ export function WorkflowCanvas() {
               />
             </div>
           )}
-          <Controls onFitView={() => fitViewSidebarAware({ duration: 300 })} />
+          <Controls onFitView={() => fitViewSidebarAware({ duration: 300 })} onAutoLayout={handleAutoLayout} />
         </Panel>
       </Canvas>
 

--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -7,6 +7,7 @@ import {
   type NodeMouseHandler,
   type OnConnect,
   type OnConnectStartParams,
+  useOnViewportChange,
   useReactFlow,
   useUpdateNodeInternals,
   type Connection as XYFlowConnection,
@@ -30,6 +31,7 @@ import {
   hasUnsavedChangesAtom,
   isGeneratingAtom,
   isPanelAnimatingAtom,
+  isSidebarCollapsedAtom,
   isTransitioningFromHomepageAtom,
   nodesAtom,
   onEdgesChangeAtom,
@@ -84,6 +86,9 @@ function getActionType(node: { data?: unknown }): string | undefined {
   return config?.actionType as string | undefined;
 }
 
+const VIEWPORT_STORAGE_PREFIX = "wf-viewport-";
+const FIT_VIEW_DEFAULTS = { maxZoom: 1, minZoom: 0.1, padding: 0.2, duration: 0 } as const;
+
 export function WorkflowCanvas() {
   const [nodes, setNodes] = useAtom(nodesAtom);
   const [edges, setEdges] = useAtom(edgesAtom);
@@ -92,6 +97,7 @@ export function WorkflowCanvas() {
   const [showMinimap] = useAtom(showMinimapAtom);
   const rightPanelWidth = useAtomValue(rightPanelWidthAtom);
   const isPanelAnimating = useAtomValue(isPanelAnimatingAtom);
+  const isSidebarCollapsed = useAtomValue(isSidebarCollapsedAtom);
   const [isTransitioningFromHomepage, setIsTransitioningFromHomepage] = useAtom(
     isTransitioningFromHomepageAtom
   );
@@ -121,6 +127,56 @@ export function WorkflowCanvas() {
   const closeContextMenu = useCallback(() => {
     setContextMenuState(null);
   }, []);
+
+  // Persist viewport per workflow in localStorage
+  const saveViewportTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useOnViewportChange({
+    onChange: useCallback(
+      (viewport: { x: number; y: number; zoom: number }) => {
+        if (!currentWorkflowId || !viewportInitialized.current) {
+          return;
+        }
+        if (saveViewportTimeout.current) {
+          clearTimeout(saveViewportTimeout.current);
+        }
+        saveViewportTimeout.current = setTimeout(() => {
+          localStorage.setItem(
+            `${VIEWPORT_STORAGE_PREFIX}${currentWorkflowId}`,
+            JSON.stringify(viewport)
+          );
+        }, 500);
+      },
+      [currentWorkflowId]
+    ),
+  });
+
+  // Sidebar-aware fit view: fit then shift viewport left to account for sidebar
+  const fitViewSidebarAware = useCallback(
+    (options?: { duration?: number }) => {
+      const duration = options?.duration ?? 300;
+      fitView({ ...FIT_VIEW_DEFAULTS, duration });
+
+      if (isSidebarCollapsed || !rightPanelWidth) {
+        return;
+      }
+
+      const panelPercent = Number.parseFloat(rightPanelWidth);
+      if (Number.isNaN(panelPercent) || panelPercent <= 0) {
+        return;
+      }
+
+      const shiftPx = (window.innerWidth * panelPercent) / 100 / 2;
+      const shiftDelay = duration > 0 ? duration + 50 : 0;
+      setTimeout(() => {
+        const vp = getViewport();
+        setViewport(
+          { ...vp, x: vp.x - shiftPx },
+          { duration: duration > 0 ? 200 : 0 }
+        );
+      }, shiftDelay);
+    },
+    [fitView, getViewport, setViewport, isSidebarCollapsed, rightPanelWidth]
+  );
 
   // Track which workflow we've fitted view for to prevent re-running
   const fittedViewForWorkflowRef = useRef<string | null | undefined>(undefined);
@@ -174,7 +230,19 @@ export function WorkflowCanvas() {
 
     // Use fitView after a brief delay to ensure React Flow and nodes are ready
     setTimeout(() => {
-      fitView({ maxZoom: 1, minZoom: 0.5, padding: 0.2, duration: 0 });
+      // Restore saved viewport if available
+      const savedKey = currentWorkflowId ? `${VIEWPORT_STORAGE_PREFIX}${currentWorkflowId}` : null;
+      const saved = savedKey ? localStorage.getItem(savedKey) : null;
+      if (saved) {
+        try {
+          const vp = JSON.parse(saved) as { x: number; y: number; zoom: number };
+          setViewport(vp, { duration: 0 });
+        } catch {
+          fitView(FIT_VIEW_DEFAULTS);
+        }
+      } else {
+        fitView(FIT_VIEW_DEFAULTS);
+      }
       fittedViewForWorkflowRef.current = currentWorkflowId;
       viewportInitialized.current = true;
       // Show canvas immediately so width animation can be seen
@@ -185,6 +253,7 @@ export function WorkflowCanvas() {
   }, [
     currentWorkflowId,
     fitView,
+    setViewport,
     isTransitioningFromHomepage,
     setIsTransitioningFromHomepage,
   ]);
@@ -199,7 +268,7 @@ export function WorkflowCanvas() {
       hadRealNodesRef.current = true;
       // Fit view to center the new node
       setTimeout(() => {
-        fitView({ maxZoom: 1, minZoom: 0.5, padding: 0.2, duration: 0 });
+        fitView(FIT_VIEW_DEFAULTS);
         viewportInitialized.current = true;
         setIsCanvasReady(true);
       }, 0);
@@ -215,7 +284,7 @@ export function WorkflowCanvas() {
       // Check for Cmd+/ (Mac) or Ctrl+/ (Windows/Linux)
       if ((event.metaKey || event.ctrlKey) && event.key === "/") {
         event.preventDefault();
-        fitView({ padding: 0.2, duration: 300 });
+        fitViewSidebarAware({ duration: 300 });
       }
     };
 
@@ -223,7 +292,7 @@ export function WorkflowCanvas() {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [fitView]);
+  }, [fitViewSidebarAware]);
 
   const nodeTypes = useMemo(
     () => ({
@@ -645,14 +714,21 @@ export function WorkflowCanvas() {
         onSelectionChange={isGenerating ? undefined : onSelectionChange}
       >
         <Panel
-          className="workflow-controls-panel border-none bg-transparent p-0"
-          position="bottom-left"
+          className="workflow-controls-panel flex items-end gap-2 border-none bg-transparent p-0"
+          position="bottom-right"
         >
-          <Controls />
+          {showMinimap && (
+            <div className="overflow-hidden rounded-md">
+              <MiniMap
+                bgColor="var(--sidebar)"
+                maskColor="rgba(255, 255, 255, 0.1)"
+                nodeStrokeColor="var(--border)"
+                className="!relative !m-0"
+              />
+            </div>
+          )}
+          <Controls onFitView={() => fitViewSidebarAware({ duration: 300 })} />
         </Panel>
-        {showMinimap && (
-          <MiniMap bgColor="var(--sidebar)" nodeStrokeColor="var(--border)" />
-        )}
       </Canvas>
 
       {/* AI Prompt */}

--- a/keeperhub/lib/auto-layout.ts
+++ b/keeperhub/lib/auto-layout.ts
@@ -1,0 +1,380 @@
+import type { Edge, Node } from "@xyflow/react";
+
+const NODE_WIDTH = 192;
+const NODE_HEIGHT = 192;
+const H_GAP = 60;
+const V_GAP = 40;
+
+type NodeConfig = { actionType?: string };
+type NodeData = { config?: NodeConfig };
+
+function getActionType(node: Node): string | undefined {
+  return (node.data as NodeData | undefined)?.config?.actionType;
+}
+
+function isBranchingNode(node: Node): boolean {
+  const actionType = getActionType(node);
+  return actionType === "Condition" || actionType === "For Each";
+}
+
+type GraphData = {
+  nodeMap: Map<string, Node>;
+  outEdges: Map<string, Edge[]>;
+  inDegree: Map<string, number>;
+  inEdges: Map<string, Edge[]>;
+};
+
+function buildGraph(realNodes: Node[], forwardEdges: Edge[]): GraphData {
+  const nodeMap = new Map<string, Node>();
+  const outEdges = new Map<string, Edge[]>();
+  const inEdges = new Map<string, Edge[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const node of realNodes) {
+    nodeMap.set(node.id, node);
+    outEdges.set(node.id, []);
+    inEdges.set(node.id, []);
+    inDegree.set(node.id, 0);
+  }
+
+  for (const edge of forwardEdges) {
+    const out = outEdges.get(edge.source);
+    if (out) {
+      out.push(edge);
+    }
+    const inp = inEdges.get(edge.target);
+    if (inp) {
+      inp.push(edge);
+    }
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+
+  return { nodeMap, outEdges, inEdges, inDegree };
+}
+
+function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
+  const roots: string[] = [];
+  const triggerNode = realNodes.find((n) => n.type === "trigger");
+
+  if (triggerNode && inDegree.get(triggerNode.id) === 0) {
+    roots.push(triggerNode.id);
+  }
+
+  for (const node of realNodes) {
+    if (inDegree.get(node.id) === 0 && !roots.includes(node.id)) {
+      roots.push(node.id);
+    }
+  }
+
+  return roots;
+}
+
+/**
+ * Assign columns using longest-path from roots (topological order).
+ * This correctly handles convergence: a node with multiple parents
+ * gets placed at max(parent columns) + 1.
+ */
+function assignColumns(
+  roots: string[],
+  outEdges: Map<string, Edge[]>,
+  inDegree: Map<string, number>
+): Map<string, number> {
+  const column = new Map<string, number>();
+  const remaining = new Map<string, number>();
+
+  for (const [id, deg] of inDegree) {
+    remaining.set(id, deg);
+  }
+
+  const queue: string[] = [];
+  for (const root of roots) {
+    column.set(root, 0);
+    queue.push(root);
+  }
+
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head++];
+    const currentCol = column.get(current) ?? 0;
+
+    for (const edge of outEdges.get(current) ?? []) {
+      const child = edge.target;
+      const newCol = currentCol + 1;
+      const existing = column.get(child);
+      if (existing === undefined || newCol > existing) {
+        column.set(child, newCol);
+      }
+
+      const rem = (remaining.get(child) ?? 1) - 1;
+      remaining.set(child, rem);
+      if (rem <= 0) {
+        queue.push(child);
+      }
+    }
+  }
+
+  return column;
+}
+
+type SortedEdges = {
+  children: string[];
+  hasMultipleBranches: boolean;
+};
+
+/**
+ * Sort outgoing edges of each node so that:
+ * - "true"/"loop" targets come first (top)
+ * - normal targets in the middle
+ * - "false"/"done" targets last (bottom)
+ *
+ * Also reports whether the node actually fans out into multiple
+ * distinct handle groups (used to decide branching vs linear layout).
+ */
+function sortedChildren(
+  nodeId: string,
+  outEdges: Map<string, Edge[]>
+): SortedEdges {
+  const edges = outEdges.get(nodeId) ?? [];
+  const top: string[] = [];
+  const normal: string[] = [];
+  const bottom: string[] = [];
+
+  for (const edge of edges) {
+    const handle = edge.sourceHandle;
+    if (handle === "true" || handle === "loop") {
+      top.push(edge.target);
+    } else if (handle === "false" || handle === "done") {
+      bottom.push(edge.target);
+    } else {
+      normal.push(edge.target);
+    }
+  }
+
+  // Count how many non-empty groups we have
+  let groupCount = 0;
+  if (top.length > 0) {
+    groupCount++;
+  }
+  if (normal.length > 0) {
+    groupCount++;
+  }
+  if (bottom.length > 0) {
+    groupCount++;
+  }
+
+  return {
+    children: [...top, ...normal, ...bottom],
+    hasMultipleBranches: groupCount >= 2,
+  };
+}
+
+/**
+ * Compute the "owned subtree size" for each node.
+ * A node's owned size is how many vertical rows it and its
+ * exclusive descendants need. Shared nodes (convergence points)
+ * are only counted once -- by the first DFS path that reaches them.
+ */
+function computeOwnedSize(
+  nodeId: string,
+  outEdges: Map<string, Edge[]>,
+  nodeMap: Map<string, Node>,
+  claimed: Set<string>,
+  cache: Map<string, number>
+): number {
+  if (cache.has(nodeId)) {
+    return cache.get(nodeId) ?? 1;
+  }
+  if (claimed.has(nodeId)) {
+    return 0;
+  }
+  claimed.add(nodeId);
+
+  const { children, hasMultipleBranches } = sortedChildren(nodeId, outEdges);
+  if (children.length === 0) {
+    cache.set(nodeId, 1);
+    return 1;
+  }
+
+  const node = nodeMap.get(nodeId);
+  const branching =
+    node !== undefined && isBranchingNode(node) && hasMultipleBranches;
+
+  // For branching nodes: sum children sizes (they fan out vertically)
+  // For linear nodes: max of children sizes (they stack in the same lane)
+  let size = 0;
+  if (branching) {
+    for (const child of children) {
+      size += computeOwnedSize(child, outEdges, nodeMap, claimed, cache);
+    }
+  } else {
+    for (const child of children) {
+      const cs = computeOwnedSize(child, outEdges, nodeMap, claimed, cache);
+      if (cs > size) {
+        size = cs;
+      }
+    }
+  }
+
+  const result = Math.max(size, 1);
+  cache.set(nodeId, result);
+  return result;
+}
+
+type LayoutState = {
+  positions: Map<string, { x: number; y: number }>;
+  columns: Map<string, number>;
+  outEdges: Map<string, Edge[]>;
+  nodeMap: Map<string, Node>;
+  placed: Set<string>;
+  ownedSizes: Map<string, number>;
+};
+
+/** Place a node at the given vertical band and recurse into children. */
+function placeNode(
+  nodeId: string,
+  bandTop: number,
+  bandHeight: number,
+  state: LayoutState
+): void {
+  if (state.placed.has(nodeId)) {
+    return;
+  }
+  state.placed.add(nodeId);
+
+  const col = state.columns.get(nodeId) ?? 0;
+  const x = col * (NODE_WIDTH + H_GAP);
+  const centerY = bandTop + bandHeight / 2 - NODE_HEIGHT / 2;
+  state.positions.set(nodeId, { x, y: centerY });
+
+  const { children, hasMultipleBranches } = sortedChildren(
+    nodeId,
+    state.outEdges
+  );
+  if (children.length === 0) {
+    return;
+  }
+
+  const node = state.nodeMap.get(nodeId);
+  const branching =
+    node !== undefined && isBranchingNode(node) && hasMultipleBranches;
+
+  if (branching) {
+    placeBranchChildren(children, bandTop, bandHeight, state);
+  } else {
+    placeLinearChildren(children, bandTop, bandHeight, state);
+  }
+}
+
+/** Place children of a branching node, dividing vertical band by owned sizes */
+function placeBranchChildren(
+  children: string[],
+  bandTop: number,
+  bandHeight: number,
+  state: LayoutState
+): void {
+  // Compute how much vertical space each child needs
+  let totalSize = 0;
+  const sizes: Array<{ id: string; size: number }> = [];
+  for (const child of children) {
+    const size = state.ownedSizes.get(child) ?? 1;
+    sizes.push({ id: child, size });
+    totalSize += size;
+  }
+
+  if (totalSize === 0) {
+    return;
+  }
+
+  // Divide the band proportionally
+  let currentTop = bandTop;
+  for (const entry of sizes) {
+    const childBandHeight = (entry.size / totalSize) * bandHeight;
+    placeNode(entry.id, currentTop, childBandHeight, state);
+    currentTop += childBandHeight;
+  }
+}
+
+/** Place children of a linear node -- they all share the same band */
+function placeLinearChildren(
+  children: string[],
+  bandTop: number,
+  bandHeight: number,
+  state: LayoutState
+): void {
+  for (const child of children) {
+    placeNode(child, bandTop, bandHeight, state);
+  }
+}
+
+/**
+ * Compute a clean left-to-right DAG layout for workflow nodes.
+ *
+ * - Columns via longest-path topological sort (handles convergence)
+ * - Vertical bands via DFS with owned-subtree sizing
+ * - Branching nodes (Condition, ForEach) fan out: true/loop on top, false/done on bottom
+ */
+export function computeAutoLayout(
+  nodes: Node[],
+  edges: Edge[]
+): Map<string, { x: number; y: number }> {
+  const realNodes = nodes.filter((n) => n.type !== "add");
+  const realNodeIds = new Set(realNodes.map((n) => n.id));
+
+  const forwardEdges = edges.filter(
+    (e) =>
+      realNodeIds.has(e.source) &&
+      realNodeIds.has(e.target) &&
+      e.sourceHandle !== "loop"
+  );
+
+  const graph = buildGraph(realNodes, forwardEdges);
+  const roots = findRoots(realNodes, graph.inDegree);
+  const columns = assignColumns(roots, graph.outEdges, graph.inDegree);
+
+  // Compute owned subtree sizes for vertical spacing
+  const ownedSizes = new Map<string, number>();
+  const claimed = new Set<string>();
+  for (const root of roots) {
+    computeOwnedSize(root, graph.outEdges, graph.nodeMap, claimed, ownedSizes);
+  }
+
+  // Total vertical space needed
+  let totalRows = 0;
+  for (const root of roots) {
+    totalRows += ownedSizes.get(root) ?? 1;
+  }
+  const totalHeight = totalRows * (NODE_HEIGHT + V_GAP);
+
+  const state: LayoutState = {
+    positions: new Map(),
+    columns,
+    outEdges: graph.outEdges,
+    nodeMap: graph.nodeMap,
+    placed: new Set(),
+    ownedSizes,
+  };
+
+  // Place each root in its vertical band
+  let currentTop = 0;
+  for (const root of roots) {
+    const rootSize = ownedSizes.get(root) ?? 1;
+    const bandHeight = (rootSize / totalRows) * totalHeight;
+    placeNode(root, currentTop, bandHeight, state);
+    currentTop += bandHeight;
+  }
+
+  // Place any unplaced nodes (cycles or truly disconnected)
+  let unplacedY = currentTop;
+  for (const node of realNodes) {
+    if (!state.placed.has(node.id)) {
+      const col = columns.get(node.id) ?? 0;
+      state.positions.set(node.id, {
+        x: col * (NODE_WIDTH + H_GAP),
+        y: unplacedY,
+      });
+      unplacedY += NODE_HEIGHT + V_GAP;
+    }
+  }
+
+  return state.positions;
+}

--- a/lib/auto-layout.ts
+++ b/lib/auto-layout.ts
@@ -5,35 +5,17 @@ const NODE_HEIGHT = 192;
 const H_GAP = 60;
 const V_GAP = 40;
 
-type NodeConfig = { actionType?: string };
-type NodeData = { config?: NodeConfig };
-
-function getActionType(node: Node): string | undefined {
-  return (node.data as NodeData | undefined)?.config?.actionType;
-}
-
-function isBranchingNode(node: Node): boolean {
-  const actionType = getActionType(node);
-  return actionType === "Condition" || actionType === "For Each";
-}
-
 type GraphData = {
-  nodeMap: Map<string, Node>;
   outEdges: Map<string, Edge[]>;
   inDegree: Map<string, number>;
-  inEdges: Map<string, Edge[]>;
 };
 
 function buildGraph(realNodes: Node[], forwardEdges: Edge[]): GraphData {
-  const nodeMap = new Map<string, Node>();
   const outEdges = new Map<string, Edge[]>();
-  const inEdges = new Map<string, Edge[]>();
   const inDegree = new Map<string, number>();
 
   for (const node of realNodes) {
-    nodeMap.set(node.id, node);
     outEdges.set(node.id, []);
-    inEdges.set(node.id, []);
     inDegree.set(node.id, 0);
   }
 
@@ -42,14 +24,10 @@ function buildGraph(realNodes: Node[], forwardEdges: Edge[]): GraphData {
     if (out) {
       out.push(edge);
     }
-    const inp = inEdges.get(edge.target);
-    if (inp) {
-      inp.push(edge);
-    }
     inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
   }
 
-  return { nodeMap, outEdges, inEdges, inDegree };
+  return { outEdges, inDegree };
 }
 
 function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
@@ -116,24 +94,16 @@ function assignColumns(
   return column;
 }
 
-type SortedEdges = {
-  children: string[];
-  hasMultipleBranches: boolean;
-};
-
 /**
  * Sort outgoing edges of each node so that:
  * - "true"/"loop" targets come first (top)
  * - normal targets in the middle
  * - "false"/"done" targets last (bottom)
- *
- * Also reports whether the node actually fans out into multiple
- * distinct handle groups (used to decide branching vs linear layout).
  */
 function sortedChildren(
   nodeId: string,
   outEdges: Map<string, Edge[]>
-): SortedEdges {
+): string[] {
   const edges = outEdges.get(nodeId) ?? [];
   const top: string[] = [];
   const normal: string[] = [];
@@ -150,22 +120,7 @@ function sortedChildren(
     }
   }
 
-  // Count how many non-empty groups we have
-  let groupCount = 0;
-  if (top.length > 0) {
-    groupCount++;
-  }
-  if (normal.length > 0) {
-    groupCount++;
-  }
-  if (bottom.length > 0) {
-    groupCount++;
-  }
-
-  return {
-    children: [...top, ...normal, ...bottom],
-    hasMultipleBranches: groupCount >= 2,
-  };
+  return [...top, ...normal, ...bottom];
 }
 
 /**
@@ -177,7 +132,6 @@ function sortedChildren(
 function computeOwnedSize(
   nodeId: string,
   outEdges: Map<string, Edge[]>,
-  nodeMap: Map<string, Node>,
   claimed: Set<string>,
   cache: Map<string, number>
 ): number {
@@ -189,26 +143,22 @@ function computeOwnedSize(
   }
   claimed.add(nodeId);
 
-  const { children, hasMultipleBranches } = sortedChildren(nodeId, outEdges);
+  const children = sortedChildren(nodeId, outEdges);
   if (children.length === 0) {
     cache.set(nodeId, 1);
     return 1;
   }
 
-  const node = nodeMap.get(nodeId);
-  const branching =
-    node !== undefined && isBranchingNode(node) && hasMultipleBranches;
-
-  // For branching nodes: sum children sizes (they fan out vertically)
-  // For linear nodes: max of children sizes (they stack in the same lane)
+  // Any node with multiple children fans out vertically (sum sizes).
+  // Single-child nodes are linear (inherit the child's size).
   let size = 0;
-  if (branching) {
+  if (children.length > 1) {
     for (const child of children) {
-      size += computeOwnedSize(child, outEdges, nodeMap, claimed, cache);
+      size += computeOwnedSize(child, outEdges, claimed, cache);
     }
   } else {
     for (const child of children) {
-      const cs = computeOwnedSize(child, outEdges, nodeMap, claimed, cache);
+      const cs = computeOwnedSize(child, outEdges, claimed, cache);
       if (cs > size) {
         size = cs;
       }
@@ -224,7 +174,6 @@ type LayoutState = {
   positions: Map<string, { x: number; y: number }>;
   columns: Map<string, number>;
   outEdges: Map<string, Edge[]>;
-  nodeMap: Map<string, Node>;
   placed: Set<string>;
   ownedSizes: Map<string, number>;
 };
@@ -246,19 +195,12 @@ function placeNode(
   const centerY = bandTop + bandHeight / 2 - NODE_HEIGHT / 2;
   state.positions.set(nodeId, { x, y: centerY });
 
-  const { children, hasMultipleBranches } = sortedChildren(
-    nodeId,
-    state.outEdges
-  );
+  const children = sortedChildren(nodeId, state.outEdges);
   if (children.length === 0) {
     return;
   }
 
-  const node = state.nodeMap.get(nodeId);
-  const branching =
-    node !== undefined && isBranchingNode(node) && hasMultipleBranches;
-
-  if (branching) {
+  if (children.length > 1) {
     placeBranchChildren(children, bandTop, bandHeight, state);
   } else {
     placeLinearChildren(children, bandTop, bandHeight, state);
@@ -335,7 +277,7 @@ export function computeAutoLayout(
   const ownedSizes = new Map<string, number>();
   const claimed = new Set<string>();
   for (const root of roots) {
-    computeOwnedSize(root, graph.outEdges, graph.nodeMap, claimed, ownedSizes);
+    computeOwnedSize(root, graph.outEdges, claimed, ownedSizes);
   }
 
   // Total vertical space needed
@@ -349,7 +291,6 @@ export function computeAutoLayout(
     positions: new Map(),
     columns,
     outEdges: graph.outEdges,
-    nodeMap: graph.nodeMap,
     placed: new Set(),
     ownedSizes,
   };

--- a/lib/auto-layout.ts
+++ b/lib/auto-layout.ts
@@ -244,11 +244,14 @@ function placeChildrenOf(parentId: string, ctx: PlacementCtx): void {
   }
 
   // 2+ children: compute centered positions for ALL children,
-  // but only place the unplaced ones
+  // but only place the unplaced ones.
+  // Linear children (0-1 outgoing edges) get spread=1 for even spacing.
+  // Only children that themselves branch get their full subtree spread.
   const spreads: number[] = [];
   let totalSpread = 0;
   for (const id of allChildren) {
-    const s = ctx.spreadMap.get(id) ?? 1;
+    const childEdgeCount = (ctx.outEdges.get(id) ?? []).length;
+    const s = childEdgeCount > 1 ? (ctx.spreadMap.get(id) ?? 1) : 1;
     spreads.push(s);
     totalSpread += s;
   }
@@ -311,12 +314,139 @@ function placeLevelByLevel(
 }
 
 /**
+ * Build parent map from forward edges.
+ */
+function buildParentMap(forwardEdges: Edge[]): Map<string, string[]> {
+  const parents = new Map<string, string[]>();
+  for (const edge of forwardEdges) {
+    const p = parents.get(edge.target);
+    if (p) {
+      if (!p.includes(edge.source)) {
+        p.push(edge.source);
+      }
+    } else {
+      parents.set(edge.target, [edge.source]);
+    }
+  }
+  return parents;
+}
+
+/**
+ * Check if all parents of a node are in the same column (siblings).
+ */
+function areParentsSiblings(
+  nodeParents: string[],
+  columns: Map<string, number>
+): boolean {
+  const firstCol = columns.get(nodeParents[0]);
+  for (const p of nodeParents) {
+    if (columns.get(p) !== firstCol) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Compute the average Y position of a list of parent nodes.
+ * Returns undefined if no parents have positions.
+ */
+function averageParentY(
+  nodeParents: string[],
+  positions: Map<string, { x: number; y: number }>
+): number | undefined {
+  let sumY = 0;
+  let count = 0;
+  for (const parentId of nodeParents) {
+    const parentPos = positions.get(parentId);
+    if (parentPos) {
+      sumY += parentPos.y;
+      count++;
+    }
+  }
+  return count > 0 ? sumY / count : undefined;
+}
+
+/**
+ * Center convergence nodes between their parents, but ONLY when all parents
+ * are in the same column (siblings). Shifts uniquely-owned descendants
+ * (inDegree=1) to avoid cascading through shared subtrees.
+ */
+function centerSiblingConvergence(
+  positions: Map<string, { x: number; y: number }>,
+  forwardEdges: Edge[],
+  inDegree: Map<string, number>,
+  columns: Map<string, number>,
+  outEdges: Map<string, Edge[]>
+): void {
+  const parents = buildParentMap(forwardEdges);
+
+  for (const [nodeId, degree] of inDegree) {
+    if (degree <= 1) {
+      continue;
+    }
+
+    const nodeParents = parents.get(nodeId);
+    const pos = positions.get(nodeId);
+    if (!(nodeParents && pos)) {
+      continue;
+    }
+
+    if (!areParentsSiblings(nodeParents, columns)) {
+      continue;
+    }
+
+    const targetY = averageParentY(nodeParents, positions);
+    if (targetY === undefined) {
+      continue;
+    }
+
+    const deltaY = targetY - pos.y;
+    if (Math.abs(deltaY) < 1) {
+      continue;
+    }
+
+    shiftOwned(nodeId, deltaY, positions, outEdges, inDegree, new Set());
+  }
+}
+
+/**
+ * Shift a node and its descendants that have inDegree=1 (uniquely owned).
+ * Stops at convergence nodes to avoid cascading into shared subtrees.
+ */
+function shiftOwned(
+  nodeId: string,
+  deltaY: number,
+  positions: Map<string, { x: number; y: number }>,
+  outEdges: Map<string, Edge[]>,
+  inDegree: Map<string, number>,
+  visited: Set<string>
+): void {
+  if (visited.has(nodeId)) {
+    return;
+  }
+  visited.add(nodeId);
+
+  const pos = positions.get(nodeId);
+  if (pos) {
+    positions.set(nodeId, { x: pos.x, y: pos.y + deltaY });
+  }
+
+  for (const edge of outEdges.get(nodeId) ?? []) {
+    const childDegree = inDegree.get(edge.target) ?? 0;
+    if (childDegree <= 1) {
+      shiftOwned(edge.target, deltaY, positions, outEdges, inDegree, visited);
+    }
+  }
+}
+
+/**
  * Compute a clean left-to-right DAG layout for workflow nodes.
  *
  * - Columns via longest-path topological sort (handles convergence)
  * - Rows via level-by-level forward sweep with subtree-spread sizing
  * - Edge ordering: true/loop on top, false/done on bottom
- * - Covered children (reachable from a sibling) are placed by the sibling
+ * - Sibling convergence nodes centered between their parents
  */
 export function computeAutoLayout(
   nodes: Node[],
@@ -375,6 +505,15 @@ export function computeAutoLayout(
       nextUnplacedY += STEP_Y;
     }
   }
+
+  // Phase 3: Center convergence nodes whose parents are siblings (same column)
+  centerSiblingConvergence(
+    positions,
+    forwardEdges,
+    graph.inDegree,
+    columns,
+    graph.outEdges
+  );
 
   return positions;
 }

--- a/lib/auto-layout.ts
+++ b/lib/auto-layout.ts
@@ -201,36 +201,41 @@ function placeNode(
   }
 
   if (children.length > 1) {
-    placeBranchChildren(children, bandTop, bandHeight, state);
+    placeBranchChildren(children, bandTop, bandHeight, state, centerY);
   } else {
     placeLinearChildren(children, bandTop, bandHeight, state);
   }
 }
 
-/** Place children of a branching node, dividing vertical band by owned sizes */
+/** Place children of a branching node using fixed spacing based on owned sizes */
 function placeBranchChildren(
   children: string[],
-  bandTop: number,
-  bandHeight: number,
-  state: LayoutState
+  _bandTop: number,
+  _bandHeight: number,
+  state: LayoutState,
+  parentY: number
 ): void {
-  // Compute how much vertical space each child needs
-  let totalSize = 0;
-  const sizes: Array<{ id: string; size: number }> = [];
+  const step = NODE_HEIGHT + V_GAP;
+
+  // Compute total slots needed
+  let totalSlots = 0;
+  const sizes: Array<{ id: string; slots: number }> = [];
   for (const child of children) {
-    const size = state.ownedSizes.get(child) ?? 1;
-    sizes.push({ id: child, size });
-    totalSize += size;
+    const slots = state.ownedSizes.get(child) ?? 1;
+    sizes.push({ id: child, slots });
+    totalSlots += slots;
   }
 
-  if (totalSize === 0) {
+  if (totalSlots === 0) {
     return;
   }
 
-  // Divide the band proportionally
-  let currentTop = bandTop;
+  // Center the children block around the parent's Y
+  const totalHeight = totalSlots * step;
+  let currentTop = parentY + NODE_HEIGHT / 2 - totalHeight / 2;
+
   for (const entry of sizes) {
-    const childBandHeight = (entry.size / totalSize) * bandHeight;
+    const childBandHeight = entry.slots * step;
     placeNode(entry.id, currentTop, childBandHeight, state);
     currentTop += childBandHeight;
   }
@@ -280,12 +285,7 @@ export function computeAutoLayout(
     computeOwnedSize(root, graph.outEdges, claimed, ownedSizes);
   }
 
-  // Total vertical space needed
-  let totalRows = 0;
-  for (const root of roots) {
-    totalRows += ownedSizes.get(root) ?? 1;
-  }
-  const totalHeight = totalRows * (NODE_HEIGHT + V_GAP);
+  const step = NODE_HEIGHT + V_GAP;
 
   const state: LayoutState = {
     positions: new Map(),
@@ -295,11 +295,11 @@ export function computeAutoLayout(
     ownedSizes,
   };
 
-  // Place each root in its vertical band
+  // Place each root using fixed spacing
   let currentTop = 0;
   for (const root of roots) {
     const rootSize = ownedSizes.get(root) ?? 1;
-    const bandHeight = (rootSize / totalRows) * totalHeight;
+    const bandHeight = rootSize * step;
     placeNode(root, currentTop, bandHeight, state);
     currentTop += bandHeight;
   }

--- a/lib/auto-layout.ts
+++ b/lib/auto-layout.ts
@@ -5,12 +5,10 @@ const NODE_HEIGHT = 192;
 const H_GAP = 60;
 const V_GAP = 40;
 
-type GraphData = {
-  outEdges: Map<string, Edge[]>;
-  inDegree: Map<string, number>;
-};
-
-function buildGraph(realNodes: Node[], forwardEdges: Edge[]): GraphData {
+function buildGraph(
+  realNodes: Node[],
+  forwardEdges: Edge[]
+): { outEdges: Map<string, Edge[]>; inDegree: Map<string, number> } {
   const outEdges = new Map<string, Edge[]>();
   const inDegree = new Map<string, number>();
 
@@ -49,8 +47,6 @@ function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
 
 /**
  * Assign columns using longest-path from roots (topological order).
- * This correctly handles convergence: a node with multiple parents
- * gets placed at max(parent columns) + 1.
  */
 function assignColumns(
   roots: string[],
@@ -95,10 +91,7 @@ function assignColumns(
 }
 
 /**
- * Sort outgoing edges of each node so that:
- * - "true"/"loop" targets come first (top)
- * - normal targets in the middle
- * - "false"/"done" targets last (bottom)
+ * Sort outgoing edges: true/loop first, normal middle, false/done last.
  */
 function sortedChildren(
   nodeId: string,
@@ -108,8 +101,15 @@ function sortedChildren(
   const top: string[] = [];
   const normal: string[] = [];
   const bottom: string[] = [];
+  const seen = new Set<string>();
 
   for (const edge of edges) {
+    // Skip duplicate edges (same source->target)
+    if (seen.has(edge.target)) {
+      continue;
+    }
+    seen.add(edge.target);
+
     const handle = edge.sourceHandle;
     if (handle === "true" || handle === "loop") {
       top.push(edge.target);
@@ -123,142 +123,200 @@ function sortedChildren(
   return [...top, ...normal, ...bottom];
 }
 
+const STEP_Y = NODE_HEIGHT + V_GAP;
+
 /**
- * Compute the "owned subtree size" for each node.
- * A node's owned size is how many vertical rows it and its
- * exclusive descendants need. Shared nodes (convergence points)
- * are only counted once -- by the first DFS path that reaches them.
+ * Compute how many vertical rows a node's subtree needs.
+ * - Leaf: 1
+ * - Linear (1 child): propagates child's spread (so downstream branches
+ *   are accounted for at all ancestor levels, preventing overlap)
+ * - Branching (N children): sum of owned children's spreads
+ *   (convergence children that were already visited contribute 0)
+ * - Already-visited (convergence): 0 (don't double-count)
  */
-function computeOwnedSize(
+function computeSpread(
   nodeId: string,
   outEdges: Map<string, Edge[]>,
-  claimed: Set<string>,
-  cache: Map<string, number>
+  visited: Set<string>,
+  spreadMap: Map<string, number>
 ): number {
-  if (cache.has(nodeId)) {
-    return cache.get(nodeId) ?? 1;
-  }
-  if (claimed.has(nodeId)) {
+  if (visited.has(nodeId)) {
     return 0;
   }
-  claimed.add(nodeId);
+  visited.add(nodeId);
 
   const children = sortedChildren(nodeId, outEdges);
+
   if (children.length === 0) {
-    cache.set(nodeId, 1);
+    spreadMap.set(nodeId, 1);
     return 1;
   }
 
-  // Any node with multiple children fans out vertically (sum sizes).
-  // Single-child nodes are linear (inherit the child's size).
-  let size = 0;
-  if (children.length > 1) {
-    for (const child of children) {
-      size += computeOwnedSize(child, outEdges, claimed, cache);
+  if (children.length === 1) {
+    const childSpread = computeSpread(
+      children[0],
+      outEdges,
+      visited,
+      spreadMap
+    );
+    const spread = Math.max(1, childSpread);
+    spreadMap.set(nodeId, spread);
+    return spread;
+  }
+
+  // Branching: sum only owned children (convergence children contribute 0)
+  let total = 0;
+  for (const child of children) {
+    total += computeSpread(child, outEdges, visited, spreadMap);
+  }
+  const spread = Math.max(total, 1);
+  spreadMap.set(nodeId, spread);
+  return spread;
+}
+
+type PlacementCtx = {
+  positions: Map<string, { x: number; y: number }>;
+  placed: Set<string>;
+  columns: Map<string, number>;
+  outEdges: Map<string, Edge[]>;
+  spreadMap: Map<string, number>;
+};
+
+/**
+ * Place a list of nodes vertically, centered around centerY,
+ * using each node's subtree spread to allocate space.
+ */
+function spreadNodes(
+  nodeIds: string[],
+  centerY: number,
+  ctx: PlacementCtx
+): void {
+  const spreads: number[] = [];
+  let totalSpread = 0;
+  for (const id of nodeIds) {
+    const s = ctx.spreadMap.get(id) ?? 1;
+    spreads.push(s);
+    totalSpread += s;
+  }
+
+  let y = centerY - ((totalSpread - 1) * STEP_Y) / 2;
+  for (let i = 0; i < nodeIds.length; i++) {
+    const id = nodeIds[i];
+    const s = spreads[i];
+    const nodeCenterY = y + ((s - 1) * STEP_Y) / 2;
+    const col = ctx.columns.get(id) ?? 0;
+    ctx.positions.set(id, { x: col * (NODE_WIDTH + H_GAP), y: nodeCenterY });
+    ctx.placed.add(id);
+    y += s * STEP_Y;
+  }
+}
+
+/**
+ * Place children of a single parent node.
+ * - 1 total child: linear, shares parent Y
+ * - 2+ total children: centered around parent Y using ALL children's spreads
+ *   (true above, false below). Already-placed children act as phantom spacers
+ *   so the centering accounts for them, but only unplaced children get positioned.
+ */
+function placeChildrenOf(parentId: string, ctx: PlacementCtx): void {
+  const parentPos = ctx.positions.get(parentId);
+  if (!parentPos) {
+    return;
+  }
+
+  const allChildren = sortedChildren(parentId, ctx.outEdges);
+  const unplaced = allChildren.filter((c) => !ctx.placed.has(c));
+
+  if (unplaced.length === 0) {
+    return;
+  }
+
+  // Truly single output: linear, share parent Y
+  if (allChildren.length <= 1) {
+    const child = unplaced[0];
+    const col = ctx.columns.get(child) ?? 0;
+    ctx.positions.set(child, {
+      x: col * (NODE_WIDTH + H_GAP),
+      y: parentPos.y,
+    });
+    ctx.placed.add(child);
+    return;
+  }
+
+  // 2+ children: compute centered positions for ALL children,
+  // but only place the unplaced ones
+  const spreads: number[] = [];
+  let totalSpread = 0;
+  for (const id of allChildren) {
+    const s = ctx.spreadMap.get(id) ?? 1;
+    spreads.push(s);
+    totalSpread += s;
+  }
+
+  let y = parentPos.y - ((totalSpread - 1) * STEP_Y) / 2;
+  for (let i = 0; i < allChildren.length; i++) {
+    const child = allChildren[i];
+    const s = spreads[i];
+    const centerY = y + ((s - 1) * STEP_Y) / 2;
+    if (!ctx.placed.has(child)) {
+      const col = ctx.columns.get(child) ?? 0;
+      ctx.positions.set(child, {
+        x: col * (NODE_WIDTH + H_GAP),
+        y: centerY,
+      });
+      ctx.placed.add(child);
     }
-  } else {
-    for (const child of children) {
-      const cs = computeOwnedSize(child, outEdges, claimed, cache);
-      if (cs > size) {
-        size = cs;
+    y += s * STEP_Y;
+  }
+}
+
+/**
+ * Place nodes level by level (column by column), left to right.
+ * Each parent spreads its children vertically based on their subtree spread.
+ */
+function placeLevelByLevel(
+  roots: string[],
+  columns: Map<string, number>,
+  outEdges: Map<string, Edge[]>,
+  spreadMap: Map<string, number>
+): Map<string, { x: number; y: number }> {
+  const ctx: PlacementCtx = {
+    positions: new Map(),
+    placed: new Set(),
+    columns,
+    outEdges,
+    spreadMap,
+  };
+
+  let maxCol = 0;
+  for (const col of columns.values()) {
+    if (col > maxCol) {
+      maxCol = col;
+    }
+  }
+
+  // Place roots centered around y=0
+  spreadNodes(roots, 0, ctx);
+
+  // Process columns left to right
+  for (let col = 0; col <= maxCol; col++) {
+    for (const [nodeId, nodeCol] of columns) {
+      if (nodeCol === col && ctx.placed.has(nodeId)) {
+        placeChildrenOf(nodeId, ctx);
       }
     }
   }
 
-  const result = Math.max(size, 1);
-  cache.set(nodeId, result);
-  return result;
-}
-
-type LayoutState = {
-  positions: Map<string, { x: number; y: number }>;
-  columns: Map<string, number>;
-  outEdges: Map<string, Edge[]>;
-  placed: Set<string>;
-  ownedSizes: Map<string, number>;
-};
-
-/** Place a node at the given vertical band and recurse into children. */
-function placeNode(
-  nodeId: string,
-  bandTop: number,
-  bandHeight: number,
-  state: LayoutState
-): void {
-  if (state.placed.has(nodeId)) {
-    return;
-  }
-  state.placed.add(nodeId);
-
-  const col = state.columns.get(nodeId) ?? 0;
-  const x = col * (NODE_WIDTH + H_GAP);
-  const centerY = bandTop + bandHeight / 2 - NODE_HEIGHT / 2;
-  state.positions.set(nodeId, { x, y: centerY });
-
-  const children = sortedChildren(nodeId, state.outEdges);
-  if (children.length === 0) {
-    return;
-  }
-
-  if (children.length > 1) {
-    placeBranchChildren(children, bandTop, bandHeight, state, centerY);
-  } else {
-    placeLinearChildren(children, bandTop, bandHeight, state);
-  }
-}
-
-/** Place children of a branching node using fixed spacing based on owned sizes */
-function placeBranchChildren(
-  children: string[],
-  _bandTop: number,
-  _bandHeight: number,
-  state: LayoutState,
-  parentY: number
-): void {
-  const step = NODE_HEIGHT + V_GAP;
-
-  // Compute total slots needed
-  let totalSlots = 0;
-  const sizes: Array<{ id: string; slots: number }> = [];
-  for (const child of children) {
-    const slots = state.ownedSizes.get(child) ?? 1;
-    sizes.push({ id: child, slots });
-    totalSlots += slots;
-  }
-
-  if (totalSlots === 0) {
-    return;
-  }
-
-  // Center the children block around the parent's Y
-  const totalHeight = totalSlots * step;
-  let currentTop = parentY + NODE_HEIGHT / 2 - totalHeight / 2;
-
-  for (const entry of sizes) {
-    const childBandHeight = entry.slots * step;
-    placeNode(entry.id, currentTop, childBandHeight, state);
-    currentTop += childBandHeight;
-  }
-}
-
-/** Place children of a linear node -- they all share the same band */
-function placeLinearChildren(
-  children: string[],
-  bandTop: number,
-  bandHeight: number,
-  state: LayoutState
-): void {
-  for (const child of children) {
-    placeNode(child, bandTop, bandHeight, state);
-  }
+  return ctx.positions;
 }
 
 /**
  * Compute a clean left-to-right DAG layout for workflow nodes.
  *
  * - Columns via longest-path topological sort (handles convergence)
- * - Vertical bands via DFS with owned-subtree sizing
- * - Branching nodes (Condition, ForEach) fan out: true/loop on top, false/done on bottom
+ * - Rows via level-by-level forward sweep with subtree-spread sizing
+ * - Edge ordering: true/loop on top, false/done on bottom
+ * - Covered children (reachable from a sibling) are placed by the sibling
  */
 export function computeAutoLayout(
   nodes: Node[],
@@ -278,151 +336,45 @@ export function computeAutoLayout(
   const roots = findRoots(realNodes, graph.inDegree);
   const columns = assignColumns(roots, graph.outEdges, graph.inDegree);
 
-  // Compute owned subtree sizes for vertical spacing
-  const ownedSizes = new Map<string, number>();
-  const claimed = new Set<string>();
+  // Phase 1: Compute subtree spreads (bottom-up)
+  const spreadVisited = new Set<string>();
+  const spreadMap = new Map<string, number>();
   for (const root of roots) {
-    computeOwnedSize(root, graph.outEdges, claimed, ownedSizes);
+    computeSpread(root, graph.outEdges, spreadVisited, spreadMap);
   }
-
-  const step = NODE_HEIGHT + V_GAP;
-
-  const state: LayoutState = {
-    positions: new Map(),
-    columns,
-    outEdges: graph.outEdges,
-    placed: new Set(),
-    ownedSizes,
-  };
-
-  // Place each root using fixed spacing
-  let currentTop = 0;
-  for (const root of roots) {
-    const rootSize = ownedSizes.get(root) ?? 1;
-    const bandHeight = rootSize * step;
-    placeNode(root, currentTop, bandHeight, state);
-    currentTop += bandHeight;
-  }
-
-  // Place any unplaced nodes (cycles or truly disconnected)
-  let unplacedY = currentTop;
+  // Ensure disconnected nodes have spread computed
   for (const node of realNodes) {
-    if (!state.placed.has(node.id)) {
+    if (!spreadMap.has(node.id)) {
+      computeSpread(node.id, graph.outEdges, spreadVisited, spreadMap);
+    }
+  }
+
+  // Phase 2: Place nodes level by level
+  const positions = placeLevelByLevel(
+    roots,
+    columns,
+    graph.outEdges,
+    spreadMap
+  );
+
+  // Place any unplaced nodes (disconnected)
+  let maxY = 0;
+  for (const pos of positions.values()) {
+    if (pos.y > maxY) {
+      maxY = pos.y;
+    }
+  }
+  let nextUnplacedY = maxY + STEP_Y;
+  for (const node of realNodes) {
+    if (!positions.has(node.id)) {
       const col = columns.get(node.id) ?? 0;
-      state.positions.set(node.id, {
+      positions.set(node.id, {
         x: col * (NODE_WIDTH + H_GAP),
-        y: unplacedY,
+        y: nextUnplacedY,
       });
-      unplacedY += NODE_HEIGHT + V_GAP;
+      nextUnplacedY += STEP_Y;
     }
   }
 
-  // Post-process: center convergence nodes between their placed parents
-  centerConvergenceNodes(state.positions, forwardEdges, graph.inDegree);
-
-  return state.positions;
-}
-
-/**
- * For nodes with multiple parents, reposition them to the vertical
- * center of their parents. This keeps convergence points aligned
- * with the visual midpoint of the branches feeding into them.
- * Also shifts all downstream nodes by the same delta.
- */
-type AdjacencyLists = {
-  parents: Map<string, string[]>;
-  children: Map<string, string[]>;
-};
-
-function buildAdjacencyLists(forwardEdges: Edge[]): AdjacencyLists {
-  const parents = new Map<string, string[]>();
-  const children = new Map<string, string[]>();
-
-  for (const edge of forwardEdges) {
-    const p = parents.get(edge.target);
-    if (p) {
-      p.push(edge.source);
-    } else {
-      parents.set(edge.target, [edge.source]);
-    }
-    const c = children.get(edge.source);
-    if (c) {
-      c.push(edge.target);
-    } else {
-      children.set(edge.source, [edge.target]);
-    }
-  }
-
-  return { parents, children };
-}
-
-function computeParentCenterY(
-  nodeParents: string[],
-  positions: Map<string, { x: number; y: number }>
-): number | undefined {
-  let sumY = 0;
-  let count = 0;
-  for (const parentId of nodeParents) {
-    const parentPos = positions.get(parentId);
-    if (parentPos) {
-      sumY += parentPos.y;
-      count++;
-    }
-  }
-  return count > 0 ? sumY / count : undefined;
-}
-
-function centerConvergenceNodes(
-  positions: Map<string, { x: number; y: number }>,
-  forwardEdges: Edge[],
-  inDegree: Map<string, number>
-): void {
-  const { parents, children } = buildAdjacencyLists(forwardEdges);
-
-  for (const [nodeId, degree] of inDegree) {
-    if (degree <= 1) {
-      continue;
-    }
-
-    const nodeParents = parents.get(nodeId);
-    const pos = positions.get(nodeId);
-    if (!(nodeParents && pos)) {
-      continue;
-    }
-
-    const targetY = computeParentCenterY(nodeParents, positions);
-    if (targetY === undefined) {
-      continue;
-    }
-
-    const deltaY = targetY - pos.y;
-    if (Math.abs(deltaY) < 1) {
-      continue;
-    }
-
-    shiftSubtree(nodeId, deltaY, positions, children, new Set());
-  }
-}
-
-/** Shift a node and all its descendants by deltaY */
-function shiftSubtree(
-  nodeId: string,
-  deltaY: number,
-  positions: Map<string, { x: number; y: number }>,
-  children: Map<string, string[]>,
-  visited: Set<string>
-): void {
-  if (visited.has(nodeId)) {
-    return;
-  }
-  visited.add(nodeId);
-
-  const pos = positions.get(nodeId);
-  if (pos) {
-    positions.set(nodeId, { x: pos.x, y: pos.y + deltaY });
-  }
-
-  for (const child of children.get(nodeId) ?? []) {
-    shiftSubtree(child, deltaY, positions, children, visited);
-  }
+  return positions;
 }

--- a/lib/auto-layout.ts
+++ b/lib/auto-layout.ts
@@ -317,5 +317,112 @@ export function computeAutoLayout(
     }
   }
 
+  // Post-process: center convergence nodes between their placed parents
+  centerConvergenceNodes(state.positions, forwardEdges, graph.inDegree);
+
   return state.positions;
+}
+
+/**
+ * For nodes with multiple parents, reposition them to the vertical
+ * center of their parents. This keeps convergence points aligned
+ * with the visual midpoint of the branches feeding into them.
+ * Also shifts all downstream nodes by the same delta.
+ */
+type AdjacencyLists = {
+  parents: Map<string, string[]>;
+  children: Map<string, string[]>;
+};
+
+function buildAdjacencyLists(forwardEdges: Edge[]): AdjacencyLists {
+  const parents = new Map<string, string[]>();
+  const children = new Map<string, string[]>();
+
+  for (const edge of forwardEdges) {
+    const p = parents.get(edge.target);
+    if (p) {
+      p.push(edge.source);
+    } else {
+      parents.set(edge.target, [edge.source]);
+    }
+    const c = children.get(edge.source);
+    if (c) {
+      c.push(edge.target);
+    } else {
+      children.set(edge.source, [edge.target]);
+    }
+  }
+
+  return { parents, children };
+}
+
+function computeParentCenterY(
+  nodeParents: string[],
+  positions: Map<string, { x: number; y: number }>
+): number | undefined {
+  let sumY = 0;
+  let count = 0;
+  for (const parentId of nodeParents) {
+    const parentPos = positions.get(parentId);
+    if (parentPos) {
+      sumY += parentPos.y;
+      count++;
+    }
+  }
+  return count > 0 ? sumY / count : undefined;
+}
+
+function centerConvergenceNodes(
+  positions: Map<string, { x: number; y: number }>,
+  forwardEdges: Edge[],
+  inDegree: Map<string, number>
+): void {
+  const { parents, children } = buildAdjacencyLists(forwardEdges);
+
+  for (const [nodeId, degree] of inDegree) {
+    if (degree <= 1) {
+      continue;
+    }
+
+    const nodeParents = parents.get(nodeId);
+    const pos = positions.get(nodeId);
+    if (!(nodeParents && pos)) {
+      continue;
+    }
+
+    const targetY = computeParentCenterY(nodeParents, positions);
+    if (targetY === undefined) {
+      continue;
+    }
+
+    const deltaY = targetY - pos.y;
+    if (Math.abs(deltaY) < 1) {
+      continue;
+    }
+
+    shiftSubtree(nodeId, deltaY, positions, children, new Set());
+  }
+}
+
+/** Shift a node and all its descendants by deltaY */
+function shiftSubtree(
+  nodeId: string,
+  deltaY: number,
+  positions: Map<string, { x: number; y: number }>,
+  children: Map<string, string[]>,
+  visited: Set<string>
+): void {
+  if (visited.has(nodeId)) {
+    return;
+  }
+  visited.add(nodeId);
+
+  const pos = positions.get(nodeId);
+  if (pos) {
+    positions.set(nodeId, { x: pos.x, y: pos.y + deltaY });
+  }
+
+  for (const child of children.get(nodeId) ?? []) {
+    shiftSubtree(child, deltaY, positions, children, visited);
+  }
 }

--- a/lib/auto-layout.ts
+++ b/lib/auto-layout.ts
@@ -212,11 +212,41 @@ function spreadNodes(
 }
 
 /**
+ * Check if a node has branch handles (true/false/done/loop) on its edges.
+ * Used to determine phantom centering behavior.
+ */
+function hasBranchHandles(
+  nodeId: string,
+  outEdges: Map<string, Edge[]>
+): boolean {
+  for (const edge of outEdges.get(nodeId) ?? []) {
+    const h = edge.sourceHandle;
+    if (h === "true" || h === "false" || h === "done" || h === "loop") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Compute immediate spread for a child: 1 for linear, full spread for branching.
+ */
+function childPlacementSpread(
+  childId: string,
+  outEdges: Map<string, Edge[]>,
+  spreadMap: Map<string, number>
+): number {
+  const edgeCount = (outEdges.get(childId) ?? []).length;
+  return edgeCount > 1 ? (spreadMap.get(childId) ?? 1) : 1;
+}
+
+/**
  * Place children of a single parent node.
- * - 1 total child: linear, shares parent Y
- * - 2+ total children: centered around parent Y using ALL children's spreads
- *   (true above, false below). Already-placed children act as phantom spacers
- *   so the centering accounts for them, but only unplaced children get positioned.
+ * - 1 effective child: linear, shares parent Y
+ * - 2+ effective children: centered around parent Y.
+ *   For branch nodes (true/false handles): ALL children used for centering
+ *   (phantoms for already-placed) so true goes above, false below.
+ *   For normal nodes: only unplaced children centered around parent.
  */
 function placeChildrenOf(parentId: string, ctx: PlacementCtx): void {
   const parentPos = ctx.positions.get(parentId);
@@ -231,8 +261,13 @@ function placeChildrenOf(parentId: string, ctx: PlacementCtx): void {
     return;
   }
 
-  // Truly single output: linear, share parent Y
-  if (allChildren.length <= 1) {
+  // Branch nodes (true/false handles): use ALL children for centering (phantoms)
+  // Normal nodes: only center unplaced children
+  const isBranch = hasBranchHandles(parentId, ctx.outEdges);
+  const childrenToCenter = isBranch ? allChildren : unplaced;
+
+  // Single effective child: linear, share parent Y
+  if (childrenToCenter.length <= 1) {
     const child = unplaced[0];
     const col = ctx.columns.get(child) ?? 0;
     ctx.positions.set(child, {
@@ -243,22 +278,20 @@ function placeChildrenOf(parentId: string, ctx: PlacementCtx): void {
     return;
   }
 
-  // 2+ children: compute centered positions for ALL children,
-  // but only place the unplaced ones.
-  // Linear children (0-1 outgoing edges) get spread=1 for even spacing.
-  // Only children that themselves branch get their full subtree spread.
+  // 2+ children: centered around parent Y.
+  // Linear children get spread=1 for even spacing.
+  // Branching children get their full subtree spread.
   const spreads: number[] = [];
   let totalSpread = 0;
-  for (const id of allChildren) {
-    const childEdgeCount = (ctx.outEdges.get(id) ?? []).length;
-    const s = childEdgeCount > 1 ? (ctx.spreadMap.get(id) ?? 1) : 1;
+  for (const id of childrenToCenter) {
+    const s = childPlacementSpread(id, ctx.outEdges, ctx.spreadMap);
     spreads.push(s);
     totalSpread += s;
   }
 
   let y = parentPos.y - ((totalSpread - 1) * STEP_Y) / 2;
-  for (let i = 0; i < allChildren.length; i++) {
-    const child = allChildren[i];
+  for (let i = 0; i < childrenToCenter.length; i++) {
+    const child = childrenToCenter[i];
     const s = spreads[i];
     const centerY = y + ((s - 1) * STEP_Y) / 2;
     if (!ctx.placed.has(child)) {

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -1,6 +1,7 @@
 import type { Edge, EdgeChange, Node, NodeChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { atom } from "jotai";
+import { computeAutoLayout } from "@/keeperhub/lib/auto-layout";
 import { buildExecutionLogsMap } from "@/lib/template-helpers";
 import { api } from "./api-client";
 
@@ -273,6 +274,32 @@ export const addNodeAtom = atom(null, (get, set, node: WorkflowNode) => {
   set(hasUnsavedChangesAtom, true);
 
   // Trigger immediate autosave
+  set(autosaveAtom, { immediate: true });
+});
+
+export const autoLayoutAtom = atom(null, (get, set) => {
+  const currentNodes = get(nodesAtom);
+  const currentEdges = get(edgesAtom);
+
+  // Save current state to history for undo support
+  const history = get(historyAtom);
+  set(historyAtom, [...history, { nodes: currentNodes, edges: currentEdges }]);
+  set(futureAtom, []);
+
+  const positions = computeAutoLayout(currentNodes, currentEdges);
+
+  // Only create new object references for nodes whose position actually changed.
+  // Preserving references prevents React Flow from re-triggering selection/layout handlers.
+  const updatedNodes = currentNodes.map((node) => {
+    const pos = positions.get(node.id);
+    if (pos && (node.position.x !== pos.x || node.position.y !== pos.y)) {
+      return { ...node, position: pos };
+    }
+    return node;
+  });
+
+  set(nodesAtom, updatedNodes);
+  set(hasUnsavedChangesAtom, true);
   set(autosaveAtom, { immediate: true });
 });
 

--- a/lib/workflow-store.ts
+++ b/lib/workflow-store.ts
@@ -1,7 +1,7 @@
 import type { Edge, EdgeChange, Node, NodeChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { atom } from "jotai";
-import { computeAutoLayout } from "@/keeperhub/lib/auto-layout";
+import { computeAutoLayout } from "@/lib/auto-layout";
 import { buildExecutionLogsMap } from "@/lib/template-helpers";
 import { api } from "./api-client";
 


### PR DESCRIPTION
## Summary

- Adds auto-layout button to workflow canvas zoom controls
- Implements level-by-level forward sweep algorithm for clean left-to-right DAG layouts
- Columns via longest-path topological sort, rows via subtree spread sizing
- True/loop branches above parent, false/done below (matching handle positions)
- Sibling convergence centering: shared downstream nodes centered between parents
- Animated transitions with viewport auto-fit after layout
- Persists viewport position per workflow