### PR TITLE
feat: force delete workflows with execution history

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -379,22 +379,53 @@ export async function DELETE(
     }
 
     // Check for existing executions before deleting
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get("force") === "true";
+
     const hasExecutions = await db.query.workflowExecutions.findFirst({
       where: eq(workflowExecutions.workflowId, workflowId),
       columns: { id: true },
     });
 
-    if (hasExecutions) {
+    if (hasExecutions && !force) {
       return NextResponse.json(
         {
           error:
             "Workflow has execution history. Delete executions first before deleting the workflow.",
+          hasExecutions: true,
         },
         { status: 409 }
       );
     }
 
-    await db.delete(workflows).where(eq(workflows.id, workflowId));
+    // If force delete, cascade delete logs, executions, and workflow in a transaction
+    if (hasExecutions && force) {
+      const { workflowExecutionLogs } = await import("@/lib/db/schema");
+      const { inArray } = await import("drizzle-orm");
+
+      await db.transaction(async (tx) => {
+        const executions = await tx.query.workflowExecutions.findMany({
+          where: eq(workflowExecutions.workflowId, workflowId),
+          columns: { id: true },
+        });
+
+        const executionIds = executions.map((e) => e.id);
+
+        if (executionIds.length > 0) {
+          await tx
+            .delete(workflowExecutionLogs)
+            .where(inArray(workflowExecutionLogs.executionId, executionIds));
+
+          await tx
+            .delete(workflowExecutions)
+            .where(eq(workflowExecutions.workflowId, workflowId));
+        }
+
+        await tx.delete(workflows).where(eq(workflows.id, workflowId));
+      });
+    } else {
+      await db.delete(workflows).where(eq(workflows.id, workflowId));
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -23,7 +23,7 @@ import { CodeEditor } from "@/components/ui/code-editor";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { api } from "@/lib/api-client";
+import { api, ApiError } from "@/lib/api-client";
 import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
 import { generateWorkflowCode } from "@/lib/workflow-codegen";
@@ -350,11 +350,17 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
   };
 
   // Handle delete workflow
-  const handleDeleteWorkflow = () => {
+  const handleDeleteWorkflow = (force?: boolean) => {
+    const title = force ? "Delete Workflow and All Runs" : "Delete Workflow";
+    const message = force
+      ? `Are you sure you want to delete "${currentWorkflowName}" and all its execution history? This cannot be undone.`
+      : `Are you sure you want to delete "${currentWorkflowName}"? This will permanently delete the workflow. This cannot be undone.`;
+    const confirmLabel = force ? "Delete Everything" : "Delete Workflow";
+
     push(ConfirmOverlay, {
-      title: "Delete Workflow",
-      message: `Are you sure you want to delete "${currentWorkflowName}"? This will permanently delete the workflow. This cannot be undone.`,
-      confirmLabel: "Delete Workflow",
+      title,
+      message,
+      confirmLabel,
       confirmVariant: "destructive" as const,
       destructive: true,
       onConfirm: async () => {
@@ -362,12 +368,19 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
           return;
         }
         try {
-          await api.workflow.delete(currentWorkflowId);
+          await api.workflow.delete(currentWorkflowId, { force });
           closeAll();
           toast.success("Workflow deleted successfully");
           window.location.href = "/";
         } catch (error) {
-          console.error("Failed to delete workflow:", error);
+          if (
+            error instanceof ApiError &&
+            error.status === 409 &&
+            !force
+          ) {
+            handleDeleteWorkflow(true);
+            return;
+          }
           toast.error("Failed to delete workflow. Please try again.");
         }
       },

--- a/components/overlays/delete-workflow-overlay.tsx
+++ b/components/overlays/delete-workflow-overlay.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { AlertTriangleIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Overlay } from "./overlay";
+import { useOverlay } from "./overlay-provider";
+import type { OverlayAction } from "./types";
+
+type DeleteWorkflowWithRunsOverlayProps = {
+  overlayId: string;
+  workflowName: string;
+  onViewRuns: () => void;
+  onForceDelete: () => void | Promise<void>;
+};
+
+export function DeleteWorkflowWithRunsOverlay({
+  overlayId,
+  workflowName,
+  onViewRuns,
+  onForceDelete,
+}: DeleteWorkflowWithRunsOverlayProps) {
+  const { pop } = useOverlay();
+
+  const actions: OverlayAction[] = [
+    {
+      label: "Cancel",
+      variant: "outline",
+      onClick: () => pop(),
+    },
+    {
+      label: "Delete Everything",
+      variant: "destructive",
+      onClick: async () => {
+        await onForceDelete();
+        pop();
+      },
+    },
+  ];
+
+  return (
+    <Overlay
+      actions={actions}
+      overlayId={overlayId}
+      title="Workflow has run history"
+    >
+      <div className="-mb-2 flex gap-4">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangleIcon className="size-5 text-destructive" />
+        </div>
+        <div className="space-y-4 pt-2">
+          <p className="text-muted-foreground text-sm">
+            &quot;{workflowName}&quot; has execution history. Run history may
+            contain sensitive data you want to save before deleting.
+          </p>
+          <div className="space-y-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="!bg-white !text-black hover:!bg-white/90"
+              onClick={() => {
+                onViewRuns();
+                pop();
+              }}
+            >
+              View runs
+            </Button>
+            <p className="text-muted-foreground text-xs">
+              or delete everything below
+            </p>
+          </div>
+        </div>
+      </div>
+    </Overlay>
+  );
+}

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -11,6 +11,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmOverlay } from "@/components/overlays/confirm-overlay";
+import { DeleteWorkflowWithRunsOverlay } from "@/components/overlays/delete-workflow-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import {
   AlertDialog,
@@ -184,8 +185,8 @@ export const PanelInner = () => {
   const [showDeleteDialog, setShowDeleteDialog] = useAtom(showDeleteDialogAtom);
   const clearNodeStatuses = useSetAtom(clearNodeStatusesAtom);
   const clearWorkflow = useSetAtom(clearWorkflowAtom);
-  const { open: openOverlay } = useOverlay();
   const setPropertiesPanelActiveTab = useSetAtom(propertiesPanelActiveTabAtom);
+  const { open: openOverlay } = useOverlay();
 
   // Watch showDeleteDialog atom: check for executions first, then open delete overlay or warn and switch to runs
   useEffect(() => {
@@ -223,16 +224,27 @@ export const PanelInner = () => {
       });
     };
 
-    const openCannotDeleteWarning = () => {
-      openOverlay(ConfirmOverlay, {
-        title: "Cannot delete workflow",
-        message:
-          "This workflow has run history. Run history may contain sensitive data you want to save before deleting. Delete all executions from the Runs tab first, then you can delete the workflow.",
-        confirmLabel: "View runs",
-        cancelLabel: "Cancel",
-        destructive: false,
-        onConfirm: () => {
+    const openHasExecutionsOverlay = () => {
+      openOverlay(DeleteWorkflowWithRunsOverlay, {
+        workflowName: currentWorkflowName,
+        onViewRuns: () => {
           setPropertiesPanelActiveTab("runs");
+        },
+        onForceDelete: async () => {
+          if (!currentWorkflowId) {
+            return;
+          }
+          try {
+            await api.workflow.delete(currentWorkflowId, { force: true });
+            toast.success("Workflow deleted successfully");
+            window.location.href = "/";
+          } catch (error) {
+            const msg =
+              error instanceof Error
+                ? error.message
+                : "Failed to delete workflow. Please try again.";
+            toast.error(msg);
+          }
         },
       });
     };
@@ -253,7 +265,7 @@ export const PanelInner = () => {
         setShowDeleteDialog(false);
         const executionList = Array.isArray(executions) ? executions : [];
         if (executionList.length > 0) {
-          openCannotDeleteWarning();
+          openHasExecutionsOverlay();
           return;
         }
         openDeleteWorkflowOverlay();

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -36,7 +36,7 @@ import { GoLiveOverlay } from "@/components/overlays/go-live-overlay";
 import { Switch } from "@/components/ui/switch";
 import { BUILTIN_NODE_ID } from "@/lib/builtin-variables";
 import { isAnonymousUser } from "@/lib/is-anonymous";
-import { api, type Project, type Tag } from "@/lib/api-client";
+import { api, ApiError, type Project, type Tag } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
 import { getCustomLogo } from "@/lib/extension-registry";
 import { integrationsAtom } from "@/lib/integrations-store";
@@ -947,22 +947,35 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
     });
   };
 
-  const handleDeleteWorkflow = () => {
+  const handleDeleteWorkflow = (force?: boolean) => {
+    const title = force ? "Delete Workflow and All Runs" : "Delete Workflow";
+    const message = force
+      ? `Are you sure you want to delete "${workflowName}" and all its execution history? This cannot be undone.`
+      : `Are you sure you want to delete "${workflowName}"? This will permanently delete the workflow. This cannot be undone.`;
+    const confirmLabel = force ? "Delete Everything" : "Delete Workflow";
+
     openOverlay(ConfirmOverlay, {
-      title: "Delete Workflow",
-      message: `Are you sure you want to delete "${workflowName}"? This will permanently delete the workflow. This cannot be undone.`,
-      confirmLabel: "Delete Workflow",
+      title,
+      message,
+      confirmLabel,
       confirmVariant: "destructive" as const,
       destructive: true,
       onConfirm: async () => {
         // biome-ignore lint/style/useBlockStatements: upstream code
         if (!currentWorkflowId) return;
         try {
-          await api.workflow.delete(currentWorkflowId);
+          await api.workflow.delete(currentWorkflowId, { force });
           toast.success("Workflow deleted successfully");
           window.location.href = "/";
         } catch (error) {
-          console.error("Failed to delete workflow:", error);
+          if (
+            error instanceof ApiError &&
+            error.status === 409 &&
+            !force
+          ) {
+            handleDeleteWorkflow(true);
+            return;
+          }
           toast.error("Failed to delete workflow. Please try again.");
         }
       },

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -89,7 +89,7 @@ If you installed the [Claude Code Plugin](/ai-tools/claude-code-plugin), the MCP
 | `get_workflow` | Get full workflow configuration by ID including nodes and edges. |
 | `create_workflow` | Create a workflow with explicit nodes and edges. Call `list_action_schemas` first to get valid action types. |
 | `update_workflow` | Update a workflow's name, description, nodes, or edges. |
-| `delete_workflow` | Permanently delete a workflow and stop all its executions. |
+| `delete_workflow` | Permanently delete a workflow and stop all its executions. Use `force: true` to delete workflows with execution history (cascades to all runs and logs). |
 
 ### Execution
 

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -128,6 +128,12 @@ The `tagId` field assigns the workflow to an organization tag for categorization
 DELETE /api/workflows/{workflowId}
 ```
 
+Returns `409 Conflict` if the workflow has execution history. Use the `force` query parameter to cascade delete all runs and logs:
+
+```http
+DELETE /api/workflows/{workflowId}?force=true
+```
+
 ## Execute Workflow
 
 ```http

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -545,10 +545,11 @@ export const workflowApi = {
     }),
 
   // Delete a workflow
-  delete: (id: string) =>
-    apiCall<{ success: boolean }>(`/api/workflows/${id}`, {
-      method: "DELETE",
-    }),
+  delete: (id: string, options?: { force?: boolean }) =>
+    apiCall<{ success: boolean }>(
+      `/api/workflows/${id}${options?.force ? "?force=true" : ""}`,
+      { method: "DELETE" }
+    ),
 
   // Duplicate a workflow
   duplicate: (id: string) =>


### PR DESCRIPTION
## Summary
- Backend accepts `?force=true` on `DELETE /api/workflows/:id` to cascade delete execution logs and executions in a transaction before deleting the workflow
- Frontend shows a new modal when deleting a workflow with runs: offers "View runs" (white button) and "Delete Everything" (destructive) options
- API client updated to pass force option
- Returns `hasExecutions: true` in 409 response for programmatic detection