### PR TITLE
fix: sync sidebar collapsed state when adding node via edge button

### DIFF
--- a/components/workflow/add-step-button.tsx
+++ b/components/workflow/add-step-button.tsx
@@ -17,6 +17,8 @@ import {
   autosaveAtom,
   edgesAtom,
   hasUnsavedChangesAtom,
+  isPanelAnimatingAtom,
+  isSidebarCollapsedAtom,
   nodesAtom,
   propertiesPanelActiveTabAtom,
   type WorkflowEdge,
@@ -56,6 +58,8 @@ export function AddStepButton({
   const setEdges = useSetAtom(edgesAtom);
   const setNodes = useSetAtom(nodesAtom);
   const setActiveTab = useSetAtom(propertiesPanelActiveTabAtom);
+  const setIsPanelAnimating = useSetAtom(isPanelAnimatingAtom);
+  const setSidebarCollapsed = useSetAtom(isSidebarCollapsedAtom);
   const setHasUnsavedChanges = useSetAtom(hasUnsavedChangesAtom);
   const triggerAutosave = useSetAtom(autosaveAtom);
 
@@ -141,6 +145,9 @@ export function AddStepButton({
 
       addNode(newNode);
       setActiveTab("properties");
+      setIsPanelAnimating(true);
+      setSidebarCollapsed(false);
+      setTimeout(() => setIsPanelAnimating(false), 350);
 
       setTimeout(() => {
         setNodes((currentNodes) =>
@@ -180,6 +187,8 @@ export function AddStepButton({
       setEdges,
       setNodes,
       setActiveTab,
+      setIsPanelAnimating,
+      setSidebarCollapsed,
       setHasUnsavedChanges,
       triggerAutosave,
     ]

--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -122,6 +122,8 @@ export function WorkflowCanvas() {
   const connectingNodeId = useRef<string | null>(null);
   const justCreatedNodeFromConnection = useRef(false);
   const viewportInitialized = useRef(false);
+  // Guard: suppress sidebar auto-open during workflow switch
+  const isLoadingWorkflow = useRef(false);
   const [isCanvasReady, setIsCanvasReady] = useState(false);
   const [isAnimatingLayout, setIsAnimatingLayout] = useState(false);
   const [contextMenuState, setContextMenuState] =
@@ -134,6 +136,15 @@ export function WorkflowCanvas() {
   const closeContextMenu = useCallback(() => {
     setContextMenuState(null);
   }, []);
+
+  // Suppress sidebar auto-open briefly after workflow switch
+  useEffect(() => {
+    isLoadingWorkflow.current = true;
+    const timer = setTimeout(() => {
+      isLoadingWorkflow.current = false;
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [currentWorkflowId]);
 
   // Persist viewport per workflow in localStorage
   const saveViewportTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -497,7 +508,8 @@ export function WorkflowCanvas() {
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
       setSelectedNode(node.id);
-      if (isSidebarCollapsed) {
+      // Don't auto-open sidebar during workflow switch
+      if (isSidebarCollapsed && !isLoadingWorkflow.current) {
         setIsPanelAnimating(true);
         setIsSidebarCollapsed(false);
         setTimeout(() => setIsPanelAnimating(false), 350);


### PR DESCRIPTION
## Summary

- When adding a node via the edge "+" button, the sidebar's collapsed state (`isSidebarCollapsedAtom`) was not updated, causing the toggle button to remain in "collapsed" state while the sidebar content was active. Clicking the toggle would then double-open the sidebar, duplicating its width with empty space.
- Sets `isSidebarCollapsedAtom` to `false` and triggers `isPanelAnimatingAtom` for smooth canvas width transition, matching the existing pattern used in `onNodeClick`.