### PR TITLE
fix: remove live indicator, zoom controls, fix analytics flash, improve hub cards

### DIFF
--- a/components/ai-elements/controls.tsx
+++ b/components/ai-elements/controls.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { useReactFlow, useStore } from "@xyflow/react";
-import { ZoomIn, ZoomOut, Maximize2, MapPin, MapPinXInside, AlignHorizontalDistributeCenter } from "lucide-react";
+import { useReactFlow } from "@xyflow/react";
+import {
+  Maximize2,
+  MapPin,
+  MapPinXInside,
+  AlignHorizontalDistributeCenter,
+} from "lucide-react";
 import { useAtom } from "jotai";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
@@ -12,21 +17,9 @@ type ControlsProps = {
   onAutoLayout?: () => void;
 };
 
-const zoomSelector = (state: { transform: [number, number, number] }): number =>
-  Math.round(state.transform[2] * 100);
-
 export const Controls = ({ onFitView, onAutoLayout }: ControlsProps) => {
-  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const { fitView } = useReactFlow();
   const [showMinimap, setShowMinimap] = useAtom(showMinimapAtom);
-  const zoomPercent = useStore(zoomSelector);
-
-  const handleZoomIn = () => {
-    zoomIn();
-  };
-
-  const handleZoomOut = () => {
-    zoomOut();
-  };
 
   const handleFitView = () => {
     if (onFitView) {
@@ -45,33 +38,6 @@ export const Controls = ({ onFitView, onAutoLayout }: ControlsProps) => {
 
   return (
     <ButtonGroup orientation="vertical">
-      <Button
-        className={buttonClass}
-        onClick={handleZoomIn}
-        size="icon"
-        title="Zoom in"
-        variant="secondary"
-      >
-        <ZoomIn className="size-4" />
-      </Button>
-      <Button
-        className={`${buttonClass} text-[10px] font-medium tabular-nums`}
-        onClick={handleFitView}
-        size="icon"
-        title="Fit view"
-        variant="secondary"
-      >
-        {zoomPercent}%
-      </Button>
-      <Button
-        className={buttonClass}
-        onClick={handleZoomOut}
-        size="icon"
-        title="Zoom out"
-        variant="secondary"
-      >
-        <ZoomOut className="size-4" />
-      </Button>
       <Button
         className={buttonClass}
         onClick={handleFitView}

--- a/components/analytics/analytics-header.tsx
+++ b/components/analytics/analytics-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAtom, useAtomValue } from "jotai";
-import { Radio, RefreshCw } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,7 +12,6 @@ import {
 import type { TimeRange } from "@/lib/analytics/types";
 import {
   analyticsLastUpdatedAtom,
-  analyticsLiveAtom,
   analyticsRangeAtom,
 } from "@/lib/atoms/analytics";
 import { cn } from "@/lib/utils";
@@ -51,7 +50,6 @@ export function AnalyticsHeader({
   onRefetch,
 }: AnalyticsHeaderProps): React.ReactNode {
   const [range, setRange] = useAtom(analyticsRangeAtom);
-  const [live, setLive] = useAtom(analyticsLiveAtom);
   const lastUpdated = useAtomValue(analyticsLastUpdatedAtom);
   const [timeAgo, setTimeAgo] = useState<string>("");
   const [refreshing, setRefreshing] = useState(false);
@@ -92,10 +90,6 @@ export function AnalyticsHeader({
     [setRange]
   );
 
-  const handleToggleLive = useCallback((): void => {
-    setLive((prev) => !prev);
-  }, [setLive]);
-
   const rangeButtons = useMemo(
     () =>
       RANGE_OPTIONS.map((option) => (
@@ -115,33 +109,6 @@ export function AnalyticsHeader({
     <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-3">
         <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              className={cn(
-                "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-                live
-                  ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                  : "bg-muted text-muted-foreground"
-              )}
-              onClick={handleToggleLive}
-              type="button"
-            >
-              <span
-                className={cn(
-                  "inline-block size-2 rounded-full",
-                  live ? "animate-pulse bg-green-500" : "bg-muted-foreground/50"
-                )}
-              />
-              <Radio className="size-3" />
-              {live ? "Live" : "Paused"}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {live ? "Receiving live updates" : "Live updates paused"}
-          </TooltipContent>
-        </Tooltip>
       </div>
 
       <div className="flex items-center gap-3">

--- a/components/analytics/analytics-page.tsx
+++ b/components/analytics/analytics-page.tsx
@@ -58,7 +58,7 @@ function AuthGate({ error }: { error: string }): ReactNode {
 }
 
 export function AnalyticsPage(): ReactNode {
-  const { data: session } = useSession();
+  const { data: session, isPending } = useSession();
   const { loading, error, refetch } = useAnalytics();
   const summary = useAtomValue(analyticsSummaryAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
@@ -82,6 +82,10 @@ export function AnalyticsPage(): ReactNode {
       });
     }
   }, [session, error, refetch]);
+
+  if (isPending) {
+    return null;
+  }
 
   const isAnonymous = !session?.user || session.user.isAnonymous;
   if (isAnonymous || error === "AUTH_REQUIRED") {

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -11,7 +11,6 @@ import type {
 import {
   analyticsErrorAtom,
   analyticsLastUpdatedAtom,
-  analyticsLiveAtom,
   analyticsLoadingAtom,
   analyticsNetworksAtom,
   analyticsProjectIdAtom,
@@ -87,7 +86,6 @@ export function useAnalytics(): UseAnalyticsReturn {
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
   const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
-  const [live, setLive] = useAtom(analyticsLiveAtom);
   const [loading, setLoading] = useAtom(analyticsLoadingAtom);
   const [error, setError] = useAtom(analyticsErrorAtom);
 
@@ -281,7 +279,6 @@ export function useAnalytics(): UseAnalyticsReturn {
 
     source.onerror = (): void => {
       cleanupSSE();
-      setLive(false);
       startPolling();
     };
 
@@ -292,7 +289,6 @@ export function useAnalytics(): UseAnalyticsReturn {
     cleanupSSE,
     setSummary,
     setLastUpdated,
-    setLive,
     startPolling,
     fetchData,
   ]);
@@ -321,20 +317,15 @@ export function useAnalytics(): UseAnalyticsReturn {
     });
   }, [activeOrgId, fetchData]);
 
-  // Manage SSE / polling based on live state
+  // SSE for real-time updates, falls back to polling on error
   useEffect(() => {
-    if (live) {
-      startSSE();
-    } else {
-      cleanupSSE();
-      startPolling();
-    }
+    startSSE();
 
     return (): void => {
       cleanupSSE();
       cleanupPolling();
     };
-  }, [live, startSSE, cleanupSSE, startPolling, cleanupPolling]);
+  }, [startSSE, cleanupSSE, cleanupPolling]);
 
   return { loading, error, refetch: fetchData };
 }

--- a/components/hub/workflow-mini-map.tsx
+++ b/components/hub/workflow-mini-map.tsx
@@ -17,8 +17,39 @@ type Bounds = {
   height: number;
 };
 
-const FIXED_NODE_SIZE = 18;
+const DEFAULT_NODE_SIZE = 18;
+const MIN_NODE_SIZE = 10;
+const NODE_GAP = 4;
 const PADDING = 20;
+
+function computeNodeSize(
+  nodeCount: number,
+  bounds: Bounds,
+  width: number,
+  height: number
+): number {
+  if (nodeCount <= 4) {
+    return DEFAULT_NODE_SIZE;
+  }
+
+  // Find minimum distance between any two nodes to avoid overlap
+  const availW = width - PADDING * 2;
+  const availH = height - PADDING * 2;
+  const scaleX = bounds.width > 0 ? availW / bounds.width : 1;
+  const scaleY = bounds.height > 0 ? availH / bounds.height : 1;
+  const scale = Math.min(scaleX, scaleY);
+
+  // Max node size that fits without overlapping nearest neighbors
+  // Use bounds span / node count as a rough density measure
+  const avgSpacingX =
+    bounds.width > 0 ? (bounds.width * scale) / Math.sqrt(nodeCount) : availW;
+  const avgSpacingY =
+    bounds.height > 0 ? (bounds.height * scale) / Math.sqrt(nodeCount) : availH;
+  const avgSpacing = Math.min(avgSpacingX, avgSpacingY);
+  const maxSize = Math.max(MIN_NODE_SIZE, avgSpacing - NODE_GAP);
+
+  return Math.min(DEFAULT_NODE_SIZE, Math.floor(maxSize));
+}
 
 function calculateBounds(nodes: WorkflowNode[]): Bounds {
   if (nodes.length === 0) {
@@ -55,12 +86,14 @@ function MiniNode({
   posScale,
   offsetX,
   offsetY,
+  nodeSize,
 }: {
   node: WorkflowNode;
   bounds: Bounds;
   posScale: number;
   offsetX: number;
   offsetY: number;
+  nodeSize: number;
 }) {
   const x = ((node.position?.x ?? 0) - bounds.minX) * posScale + offsetX;
   const y = ((node.position?.y ?? 0) - bounds.minY) * posScale + offsetY;
@@ -73,10 +106,10 @@ function MiniNode({
           ? "fill-[var(--color-text-accent)]/60"
           : "fill-[var(--color-hub-node-bg)]"
       }
-      height={FIXED_NODE_SIZE}
-      rx={FIXED_NODE_SIZE * 0.15}
-      ry={FIXED_NODE_SIZE * 0.15}
-      width={FIXED_NODE_SIZE}
+      height={nodeSize}
+      rx={nodeSize * 0.15}
+      ry={nodeSize * 0.15}
+      width={nodeSize}
       x={x}
       y={y}
     />
@@ -90,6 +123,7 @@ function MiniEdge({
   posScale,
   offsetX,
   offsetY,
+  nodeSize,
 }: {
   edge: WorkflowEdge;
   nodes: WorkflowNode[];
@@ -97,6 +131,7 @@ function MiniEdge({
   posScale: number;
   offsetX: number;
   offsetY: number;
+  nodeSize: number;
 }) {
   const sourceNode = nodes.find((n) => n.id === edge.source);
   const targetNode = nodes.find((n) => n.id === edge.target);
@@ -108,18 +143,18 @@ function MiniEdge({
   const sourceX =
     ((sourceNode.position?.x ?? 0) - bounds.minX) * posScale +
     offsetX +
-    FIXED_NODE_SIZE;
+    nodeSize;
   const sourceY =
     ((sourceNode.position?.y ?? 0) - bounds.minY) * posScale +
     offsetY +
-    FIXED_NODE_SIZE / 2;
+    nodeSize / 2;
 
   const targetX =
     ((targetNode.position?.x ?? 0) - bounds.minX) * posScale + offsetX;
   const targetY =
     ((targetNode.position?.y ?? 0) - bounds.minY) * posScale +
     offsetY +
-    FIXED_NODE_SIZE / 2;
+    nodeSize / 2;
 
   const midX = (sourceX + targetX) / 2;
 
@@ -152,26 +187,27 @@ export function WorkflowMiniMap({
       >
         <rect
           className="fill-slate-300"
-          height={FIXED_NODE_SIZE}
+          height={DEFAULT_NODE_SIZE}
           rx={6}
-          width={FIXED_NODE_SIZE * 2}
-          x={width / 2 - FIXED_NODE_SIZE}
-          y={height / 2 - FIXED_NODE_SIZE / 2}
+          width={DEFAULT_NODE_SIZE * 2}
+          x={width / 2 - DEFAULT_NODE_SIZE}
+          y={height / 2 - DEFAULT_NODE_SIZE / 2}
         />
       </svg>
     );
   }
 
   const bounds = calculateBounds(nodes);
+  const nodeSize = computeNodeSize(nodes.length, bounds, width, height);
 
-  const availW = width - PADDING * 2 - FIXED_NODE_SIZE;
-  const availH = height - PADDING * 2 - FIXED_NODE_SIZE;
+  const availW = width - PADDING * 2 - nodeSize;
+  const availH = height - PADDING * 2 - nodeSize;
   const posScaleX = bounds.width > 0 ? availW / bounds.width : 1;
   const posScaleY = bounds.height > 0 ? availH / bounds.height : 1;
   const posScale = Math.min(posScaleX, posScaleY);
 
-  const scaledContentW = bounds.width * posScale + FIXED_NODE_SIZE;
-  const scaledContentH = bounds.height * posScale + FIXED_NODE_SIZE;
+  const scaledContentW = bounds.width * posScale + nodeSize;
+  const scaledContentH = bounds.height * posScale + nodeSize;
   const offsetX = (width - scaledContentW) / 2;
   const offsetY = (height - scaledContentH) / 2;
 
@@ -190,6 +226,7 @@ export function WorkflowMiniMap({
           bounds={bounds}
           edge={edge}
           key={edge.id}
+          nodeSize={nodeSize}
           nodes={nodes}
           offsetX={offsetX}
           offsetY={offsetY}
@@ -203,6 +240,7 @@ export function WorkflowMiniMap({
             bounds={bounds}
             key={node.id}
             node={node}
+            nodeSize={nodeSize}
             offsetX={offsetX}
             offsetY={offsetY}
             posScale={posScale}

--- a/components/hub/workflow-template-card.tsx
+++ b/components/hub/workflow-template-card.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/tooltip";
 import type { SavedWorkflow } from "@/lib/api-client";
 import { WorkflowMiniMap } from "./workflow-mini-map";
-import { WorkflowNodeIcons } from "./workflow-node-icons";
 
 type WorkflowTemplateCardProps = {
   workflow: SavedWorkflow;
@@ -32,42 +31,39 @@ export function WorkflowTemplateCard({
     <article
       className={`group relative flex flex-col overflow-hidden rounded-xl border border-border/20 bg-[var(--color-hub-card)] transition-all duration-200 hover:border-border/50 hover:shadow-[0_0_20px_rgba(9,253,103,0.03)] motion-reduce:transition-none ${className ?? "aspect-square"}`}
     >
-      <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-1/2 opacity-35">
-        <WorkflowMiniMap
-          edges={workflow.edges}
-          height={120}
-          nodes={workflow.nodes}
-          width={200}
-        />
-      </div>
-
-      {isFeatured && (
-        <div className="absolute top-3 right-3 z-10 flex items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5">
-          <Star className="size-2.5 fill-[var(--color-text-accent)] text-[var(--color-text-accent)]" />
-          <span className="font-medium text-[var(--color-text-accent)] text-[10px]">
-            Featured
-          </span>
-        </div>
-      )}
-
-      <div className="flex flex-1 flex-col justify-between p-4">
-        <div className="flex flex-col gap-3">
-          <WorkflowNodeIcons nodes={workflow.nodes} />
-
-          <div>
-            <h3 className="line-clamp-2 font-semibold text-sm leading-snug">
+      <div className="relative flex flex-1 flex-col p-4">
+        <div className="shrink-0">
+          <div className="flex items-start gap-2">
+            <h3 className="line-clamp-2 flex-1 font-semibold text-sm leading-snug">
               {workflow.name}
             </h3>
-            {workflow.description && (
-              <p className="mt-1.5 line-clamp-4 text-muted-foreground/80 text-xs leading-relaxed">
-                {workflow.description}
-              </p>
+            {isFeatured && (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2 py-0.5">
+                <Star className="size-2.5 fill-[var(--color-text-accent)] text-[var(--color-text-accent)]" />
+                <span className="font-medium text-[var(--color-text-accent)] text-[10px]">
+                  Featured
+                </span>
+              </span>
             )}
           </div>
+          {workflow.description && (
+            <p className="mt-1.5 line-clamp-3 text-muted-foreground/80 text-xs leading-relaxed">
+              {workflow.description}
+            </p>
+          )}
+        </div>
+
+        <div className="pointer-events-none my-auto shrink opacity-30">
+          <WorkflowMiniMap
+            edges={workflow.edges}
+            height={160}
+            nodes={workflow.nodes}
+            width={280}
+          />
         </div>
 
         {workflow.publicTags && workflow.publicTags.length > 0 && (
-          <div className="flex flex-wrap gap-1 pt-3">
+          <div className="flex shrink-0 flex-wrap gap-1">
             {workflow.publicTags.slice(0, 3).map((tag) => (
               <span
                 className="rounded-full bg-[var(--color-hub-icon-bg)] px-2 py-0.5 text-muted-foreground text-[10px]"
@@ -96,8 +92,8 @@ export function WorkflowTemplateCard({
         )}
       </div>
 
-      <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-[var(--color-hub-card)] via-[var(--color-hub-card)]/80 via-30% to-transparent opacity-0 transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100 motion-reduce:transition-none">
-        <div className="flex w-full gap-2 p-4 pt-8">
+      <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-[var(--color-hub-card)] via-[var(--color-hub-card)] via-60% to-transparent opacity-0 transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100 motion-reduce:transition-none">
+        <div className="flex w-full gap-2 p-4 pt-12">
           <button
             className="flex h-8 flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--color-text-accent)] font-medium text-[#0a0f14] text-xs transition-colors hover:bg-[var(--color-text-accent)]/90 disabled:opacity-50"
             disabled={isDuplicating}

--- a/lib/atoms/analytics.ts
+++ b/lib/atoms/analytics.ts
@@ -31,5 +31,4 @@ export const analyticsSearchAtom = atom("");
 
 export const analyticsProjectIdAtom = atom<string | null>(null);
 
-export const analyticsLiveAtom = atom(true);
 export const analyticsLastUpdatedAtom = atom<Date | null>(null);

--- a/scripts/seed/seed-test-workflow.ts
+++ b/scripts/seed/seed-test-workflow.ts
@@ -11,8 +11,41 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { getDatabaseUrl } from "../../lib/db/connection-utils";
-import { member, users, workflows } from "../../lib/db/schema";
+import {
+  member,
+  publicTags,
+  users,
+  workflowPublicTags,
+  workflows,
+} from "../../lib/db/schema";
 import { generateId } from "../../lib/utils/id";
+
+const SEED_TAGS = [
+  { name: "Security", slug: "security" },
+  { name: "DeFi", slug: "defi" },
+  { name: "Monitoring", slug: "monitoring" },
+  { name: "Alerts", slug: "alerts" },
+  { name: "Treasury", slug: "treasury" },
+] as const;
+
+const WORKFLOW_TAGS: Record<string, string[]> = {
+  "Security: Transaction Risk Scanner": ["Security", "DeFi", "Monitoring"],
+  "Security: Unlimited Approval Detector": ["Security", "DeFi", "Alerts"],
+  "Security: Ownership Transfer Alert": [
+    "Security",
+    "Alerts",
+    "Monitoring",
+    "DeFi",
+  ],
+  "Security: Treasury Balance Monitor": [
+    "Monitoring",
+    "Treasury",
+    "Alerts",
+    "Security",
+    "DeFi",
+  ],
+  "Security: Low-Risk Baseline (ERC-20 Transfer)": ["Security", "DeFi"],
+};
 
 const connectionString = getDatabaseUrl();
 const client = postgres(connectionString, { max: 1 });
@@ -427,7 +460,31 @@ async function seed(): Promise<void> {
   const orgId = existingMember[0].organizationId;
   console.log(`  + Organization: ${orgId}\n`);
 
-  // 5. Workflows
+  // 5. Ensure public tags exist
+  const tagIdByName = new Map<string, string>();
+  for (const tag of SEED_TAGS) {
+    const existing = await db
+      .select({ id: publicTags.id })
+      .from(publicTags)
+      .where(eq(publicTags.slug, tag.slug))
+      .limit(1);
+
+    if (existing[0]) {
+      tagIdByName.set(tag.name, existing[0].id);
+      console.log(`  Tag exists: ${tag.name} (${existing[0].id})`);
+    } else {
+      const id = generateId();
+      await db.insert(publicTags).values({
+        id,
+        name: tag.name,
+        slug: tag.slug,
+      });
+      tagIdByName.set(tag.name, id);
+      console.log(`  + Tag: ${tag.name} (${id})`);
+    }
+  }
+
+  // 6. Workflows
   const workflowDefs = buildWorkflows();
   const createdIds: string[] = [];
 
@@ -443,19 +500,35 @@ async function seed(): Promise<void> {
         organizationId: orgId,
         nodes: def.nodes,
         edges: def.edges,
-        visibility: "private",
+        visibility: "public",
+        featured: true,
         enabled: true,
         createdAt: now,
         updatedAt: now,
       })
       .onConflictDoNothing();
     createdIds.push(id);
-    console.log(`  + ${def.name}`);
+
+    // Associate public tags
+    const tagNames = WORKFLOW_TAGS[def.name] ?? [];
+    for (const tagName of tagNames) {
+      const tagId = tagIdByName.get(tagName);
+      if (tagId) {
+        await db
+          .insert(workflowPublicTags)
+          .values({ workflowId: id, publicTagId: tagId })
+          .onConflictDoNothing();
+      }
+    }
+
+    console.log(
+      `  + ${def.name} (${tagNames.length} tags)`
+    );
     console.log(`    http://localhost:3000/workflows/${id}`);
   }
 
   console.log(
-    `\nDone! Created ${createdIds.length} security workflow templates.`
+    `\nDone! Created ${createdIds.length} security workflow templates with tags.`
   );
 
   await client.end();


### PR DESCRIPTION
## Summary
- Resolve visual issues flagged via Pinpoint on analytics, workflow canvas, and hub pages so the UI behaves as users expect without jarring flashes or overlapping elements
- Analytics: remove Live indicator button (SSE continues silently), fix auth flash for logged-in users by gating on session isPending
- Workflow canvas: remove zoom in/out and percentage display from controls toolbar
- Hub template cards: reworked layout with inline Featured badge, dynamically-sized mini-map nodes, and proper flex flow so tags are always visible

## Test plan
- [ ] Navigate to `/analytics` while logged in -- no "Sign in" flash, no Live button, data still updates via SSE
- [ ] Navigate to `/analytics` while logged out -- sign-in gate renders correctly
- [ ] Open any workflow -- canvas toolbar shows only Fit View, Auto-layout, and Minimap toggle (no zoom buttons or percentage)
- [ ] Visit `/hub` -- template cards show title, description, mini-map, and tags all visible within the card
- [ ] Hover a hub card -- Use Template and Preview buttons appear with clear spacing from mini-map nodes
- [ ] Check hub cards with many nodes (e.g., Multi-Token Treasury Monitor) -- nodes are spaced apart, not touching