### PR TITLE
chore: Update Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+  updates:
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+        day: "monday"
+      target-branch: "staging"
+      open-pull-requests-limit: 5
+      groups:
+        minor-and-patch:
+          update-types:
+            - "minor"
+            - "patch"
+      ignore:
+        - dependency-name: "*"
+          update-types: ["version-update:semver-major"]
+      labels:
+        - "dependencies"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "monthly"
+      target-branch: "staging"
+      labels:
+        - "dependencies"


### PR DESCRIPTION
Configured Dependabot to manage npm and GitHub Actions dependencies with specific schedules and settings.