### PR TITLE
chore: add repo setup tooling

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -481,7 +481,7 @@ jobs:
         if: steps.pr.outputs.has_pr == 'true'
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG="${{ steps.tag.outputs.release_tag }}"

--- a/.github/workflows/keeperhub-daily-main-sync-with-upstream.yml
+++ b/.github/workflows/keeperhub-daily-main-sync-with-upstream.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Notify Discord (Success)
         if: steps.check_updates.outputs.has_changes == 'true'
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
           LOGS: ${{ env.COMMIT_LOG }}
         run: |
           # Send JSON payload to Discord
@@ -76,7 +76,7 @@ jobs:
       - name: Notify Discord (No Changes)
         if: steps.check_updates.outputs.has_changes == 'false'
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
         run: |
           curl -H "Content-Type: application/json" \
           -d "{\"username\": \"KeeperHub Sync\", \"content\": \"**Daily Sync Report**\n\nNo new updates from upstream today.\"}" \
@@ -85,7 +85,7 @@ jobs:
       - name: Notify Discord (Failure)
         if: failure()
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
         run: |
           curl -H "Content-Type: application/json" \
           -d "{\"username\": \"KeeperHub Sync\", \"content\": \"**Daily Sync Failed**\n\nPlease check the GitHub Actions logs.\"}" \

--- a/.github/workflows/keeperhub-daily-merge-staging.yml
+++ b/.github/workflows/keeperhub-daily-merge-staging.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Notify Discord (Success)
         if: steps.merge_process.outputs.merge_status == 'success'
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
         run: |
           curl -H "Content-Type: application/json" \
           -d "{\"username\": \"KeeperHub Merge Bot\", \"content\": \"**Daily Merge Successful**\n\nBranch \`main\` has been merged into \`staging\`.\nLockfiles were automatically regenerated.\"}" \
@@ -116,7 +116,7 @@ jobs:
       - name: Notify Discord (No Changes)
         if: steps.merge_process.outputs.merge_status == 'no_changes'
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
         run: |
           curl -H "Content-Type: application/json" \
           -d "{\"username\": \"KeeperHub Merge Bot\", \"content\": \"**Daily Merge Check Complete**\n\nNo changes to merge - \`staging\` is already up to date with \`main\`.\"}" \
@@ -125,7 +125,7 @@ jobs:
       - name: Notify Discord (Conflict/Failure)
         if: steps.merge_process.outputs.merge_status == 'conflict' || failure()
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
         run: |
           curl -H "Content-Type: application/json" \
           -d "{\"username\": \"KeeperHub Merge Bot\", \"content\": \"**Daily Merge Failed**\n\nManual intervention required.\nThere are conflicts in files other than the lockfile.\n\nPlease merge \`main\` into \`staging\` manually.\"}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,7 @@ jobs:
         if: steps.discover_prs.outputs.has_prs == 'true'
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
         run: |
           NEW_TAG="${{ steps.version.outputs.new_tag }}"
           RELEASE_URL="${{ steps.create_release.outputs.release_url }}"
@@ -309,7 +309,7 @@ jobs:
         if: failure() && steps.discover_prs.outputs.has_prs == 'true'
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
         run: |
           curl -s -H "Content-Type: application/json" \
             -d "{\"username\": \"KeeperHub Release Bot\", \"content\": \"Release workflow failed. Please check the GitHub Actions logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \


### PR DESCRIPTION
## Summary

- Split Discord webhook secrets so workflow notifications route to dedicated channels (github, releases) instead of a shared webhook
- Add Dependabot configuration for automated dependency updates

## Test plan

- [ ] Confirm `DISCORD_WEBHOOK_GITHUB` and `DISCORD_WEBHOOK_RELEASES` secrets are set in repo settings
- [ ] Trigger a test workflow run to verify Discord notifications land in the correct channels