### PR TITLE
fix: replace blocked ETH mainnet RPC with reliable endpoints

### DIFF
--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -26,7 +26,8 @@
  * These are used as last resort when no config is provided
  */
 export const PUBLIC_RPCS = {
-  ETH_MAINNET: "https://eth.llamarpc.com",
+  ETH_MAINNET: "https://chain.techops.services/eth-mainnet",
+  ETH_MAINNET_FALLBACK: "https://1rpc.io/eth",
   SEPOLIA: "https://ethereum-sepolia-rpc.publicnode.com",
   BASE_MAINNET: "https://mainnet.base.org",
   BASE_SEPOLIA: "https://sepolia.base.org",
@@ -44,6 +45,7 @@ export type ChainConfigEntry = {
   envKey: string;
   fallbackEnvKey: string;
   publicDefault: string;
+  publicFallback?: string;
 };
 
 export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
@@ -53,6 +55,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_ETH_MAINNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_ETH_MAINNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.ETH_MAINNET,
+    publicFallback: PUBLIC_RPCS.ETH_MAINNET_FALLBACK,
   },
   // Sepolia Testnet
   11155111: {
@@ -157,12 +160,16 @@ export function getRpcUrlByChainId(
 
   const rpcConfig = getRpcConfigSingleton();
   const envKey = type === "primary" ? config.envKey : config.fallbackEnvKey;
+  const publicDefault =
+    type === "fallback" && config.publicFallback
+      ? config.publicFallback
+      : config.publicDefault;
 
   return getRpcUrl({
     rpcConfig,
     jsonKey: config.jsonKey,
     envValue: process.env[envKey],
-    publicDefault: config.publicDefault,
+    publicDefault,
     type,
   });
 }

--- a/tests/e2e/vitest/check-balance.test.ts
+++ b/tests/e2e/vitest/check-balance.test.ts
@@ -56,7 +56,7 @@ const RPC_URLS = {
     fallback: getRpcUrl(
       "eth-mainnet",
       "CHAIN_ETH_MAINNET_FALLBACK_RPC",
-      PUBLIC_RPCS.ETH_MAINNET,
+      PUBLIC_RPCS.ETH_MAINNET_FALLBACK,
       "fallback"
     ),
   },

--- a/tests/unit/rpc-config.test.ts
+++ b/tests/unit/rpc-config.test.ts
@@ -417,7 +417,7 @@ describe("RPC Config Resolution", () => {
       const jsonString = JSON.stringify({
         "eth-mainnet": {
           primaryRpcUrl: "https://chain.techops.services/eth-mainnet",
-          fallbackRpcUrl: "https://chain.techops.services/eth-mainnet",
+          fallbackRpcUrl: "https://1rpc.io/eth",
         },
         "solana-mainnet": {
           primaryRpcUrl: "https://solana-mainnet.g.alchemy.com/v2/key123",

--- a/tests/unit/rpc-config.test.ts
+++ b/tests/unit/rpc-config.test.ts
@@ -417,7 +417,7 @@ describe("RPC Config Resolution", () => {
       const jsonString = JSON.stringify({
         "eth-mainnet": {
           primaryRpcUrl: "https://chain.techops.services/eth-mainnet",
-          fallbackRpcUrl: "https://eth.llamarpc.com",
+          fallbackRpcUrl: "https://chain.techops.services/eth-mainnet",
         },
         "solana-mainnet": {
           primaryRpcUrl: "https://solana-mainnet.g.alchemy.com/v2/key123",


### PR DESCRIPTION
## Summary
- CI check-balance E2E tests were failing because eth.llamarpc.com returns 403 Forbidden (Cloudflare challenge) from GHA runner IPs, taking out both primary and fallback since they resolved to the same URL
- Replace with chain.techops.services/eth-mainnet (primary) and 1rpc.io/eth (fallback) so failover actually works when one provider goes down
- Add `publicFallback` field to `ChainConfigEntry` so chains can specify distinct public defaults for primary and fallback resolution

## Test Plan
- [ ] CI `e2e-vitest-ephemeral` job passes (check-balance tests specifically)
- [ ] `pnpm check` and `pnpm type-check` pass
- [ ] Unit tests in `rpc-config.test.ts` pass