### PR TITLE
fix: pin LocalStack to 4.14.0 to avoid license requirement

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -106,7 +106,7 @@ jobs:
           --health-retries 5
 
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack:4.14.0
         ports:
           - 4566:4566
         env:


### PR DESCRIPTION
## Summary
- LocalStack latest tag jumped to 2026.x today which requires a paid license, causing container initialization to fail in CI with "License activation failed"
- Pin to 4.14.0 (last community edition release) which was verified locally to work without a license

## Test Plan
- [ ] CI e2e-vitest-ephemeral job initializes containers successfully
- [ ] E2E tests pass with pinned LocalStack version