### PR TITLE
chore: add LocalStack auth token support across all environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ SENTRY_AUTH_TOKEN=
 # Internal config
 KEEPERHUB_API_KEY=
 
+# LocalStack (required for local dev with SQS)
+# Get token from: 1Password not called "localstack.cloud"
+LOCALSTACK_AUTH_TOKEN=
+
 # AUTH config
 
 NEXT_PUBLIC_AUTH_PROVIDERS=email,github,google

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -212,6 +212,7 @@ jobs:
         env:
           DB_PASSWORD: ${{ steps.db-password.outputs.password }}
           PG_VERSION: ${{ env.PG_VERSION }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           LOGDIR=$(mktemp -d)
@@ -233,7 +234,7 @@ jobs:
           # LocalStack
           (
             kubectl delete job create-sqs-queue -n ${NAMESPACE} --ignore-not-found
-            envsubst '$PR_NUMBER' < deploy/pr-environment/localstack.template.yaml | kubectl apply -f -
+            envsubst '$PR_NUMBER $LOCALSTACK_AUTH_TOKEN' < deploy/pr-environment/localstack.template.yaml | kubectl apply -f -
             echo "Waiting for LocalStack..."
             kubectl wait --for=condition=ready pod -l app=localstack,pr=pr-${PR_NUMBER} \
               -n ${NAMESPACE} --timeout=5m || {

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -5,45 +5,45 @@ on:
   workflow_call:
     inputs:
       caller_event:
-        description: 'Event name from the calling workflow (push, pull_request)'
+        description: "Event name from the calling workflow (push, pull_request)"
         type: string
         required: false
-        default: ''
+        default: ""
       caller_action:
-        description: 'Event action from the calling workflow (labeled, synchronize)'
+        description: "Event action from the calling workflow (labeled, synchronize)"
         type: string
         required: false
-        default: ''
+        default: ""
       has_e2e_label:
-        description: 'Whether the PR has the run-e2e-tests-ephemeral label'
+        description: "Whether the PR has the run-e2e-tests-ephemeral label"
         type: boolean
         required: false
         default: false
       label_name:
-        description: 'Name of the label that was just added (for labeled events)'
+        description: "Name of the label that was just added (for labeled events)"
         type: string
         required: false
-        default: ''
+        default: ""
       image_tag:
-        description: 'ECR image tag (short SHA). When provided, runs app from Docker instead of bare-metal build.'
+        description: "ECR image tag (short SHA). When provided, runs app from Docker instead of bare-metal build."
         type: string
         required: false
-        default: ''
+        default: ""
       ecr_registry:
-        description: 'ECR registry URL'
+        description: "ECR registry URL"
         type: string
         required: false
-        default: ''
+        default: ""
       ecr_repo:
-        description: 'ECR repository name'
+        description: "ECR repository name"
         type: string
         required: false
-        default: ''
+        default: ""
       ecr_region:
-        description: 'AWS region for ECR'
+        description: "AWS region for ECR"
         type: string
         required: false
-        default: ''
+        default: ""
   workflow_dispatch: {}
 
 jobs:
@@ -106,13 +106,14 @@ jobs:
           --health-retries 5
 
       localstack:
-        image: localstack/localstack:4.14.0
+        image: localstack/localstack:latest
         ports:
           - 4566:4566
         env:
           SERVICES: sqs
           DEBUG: 0
           EAGER_SERVICE_LOADING: 1
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         options: >-
           --health-cmd "curl -sf http://localhost:4566/_localstack/health || exit 1"
           --health-interval 10s

--- a/deploy/local/hybrid/README.md
+++ b/deploy/local/hybrid/README.md
@@ -4,11 +4,11 @@ Run most services in Docker Compose with only the schedule executor in Minikube.
 
 ## Why Hybrid Mode?
 
-| Mode | Memory | Workflow Execution | Best For |
-|------|--------|-------------------|----------|
-| Docker Compose (`dev` profile) | ~2-3GB | Direct (no isolation) | UI/API development |
-| Full Minikube | ~8GB | K8s Jobs | Production-like testing |
-| **Hybrid (`minikube` profile)** | ~4-5GB | K8s Jobs | Workflow testing during dev |
+| Mode                            | Memory | Workflow Execution    | Best For                    |
+| ------------------------------- | ------ | --------------------- | --------------------------- |
+| Docker Compose (`dev` profile)  | ~2-3GB | Direct (no isolation) | UI/API development          |
+| Full Minikube                   | ~8GB   | K8s Jobs              | Production-like testing     |
+| **Hybrid (`minikube` profile)** | ~4-5GB | K8s Jobs              | Workflow testing during dev |
 
 ## Architecture
 
@@ -40,14 +40,26 @@ echo "127.0.0.1 host.minikube.internal" | sudo tee -a /etc/hosts
 
 This allows both the host and Minikube pods to resolve the same SQS queue URLs.
 
+### LocalStack Auth Token
+
+LocalStack requires an auth token. Add it to your `.env` file or export it:
+
+```bash
+export LOCALSTACK_AUTH_TOKEN="your-token-here"
+```
+
+Get a token from 1Password note called "localstack.cloud".
+
 ## Quick Start
 
 **Option 1: One-command setup**
+
 ```bash
 make hybrid-setup
 ```
 
 **Option 2: Step-by-step**
+
 ```bash
 # 1. Start Docker Compose services
 docker compose --profile minikube up -d
@@ -179,25 +191,25 @@ awslocal sqs get-queue-attributes --queue-url http://host.minikube.internal:4566
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `setup.sh` | Full setup script (prerequisites, hosts, compose, minikube, scheduler) |
-| `deploy.sh` | Deployment helper script for scheduler components |
-| `init-localstack.sh` | LocalStack initialization (creates SQS queue) |
-| `README.md` | This file |
+| File                 | Purpose                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| `setup.sh`           | Full setup script (prerequisites, hosts, compose, minikube, scheduler) |
+| `deploy.sh`          | Deployment helper script for scheduler components                      |
+| `init-localstack.sh` | LocalStack initialization (creates SQS queue)                          |
+| `README.md`          | This file                                                              |
 
 ## Comparison: dev vs minikube Profile
 
-| Component | `dev` Profile | `minikube` Profile |
-|-----------|--------------|-------------------|
-| db | Docker Compose | Docker Compose |
-| localstack | Docker Compose | Docker Compose |
-| redis | Docker Compose | Docker Compose |
-| app-dev | Docker Compose | Docker Compose |
-| dispatcher | Docker Compose (loop) | Docker Compose (loop) |
-| sc-event-worker | Docker Compose | Docker Compose |
-| sc-event-tracker | Docker Compose | Docker Compose |
-| schedule-executor | - | Minikube Deployment |
+| Component         | `dev` Profile         | `minikube` Profile    |
+| ----------------- | --------------------- | --------------------- |
+| db                | Docker Compose        | Docker Compose        |
+| localstack        | Docker Compose        | Docker Compose        |
+| redis             | Docker Compose        | Docker Compose        |
+| app-dev           | Docker Compose        | Docker Compose        |
+| dispatcher        | Docker Compose (loop) | Docker Compose (loop) |
+| sc-event-worker   | Docker Compose        | Docker Compose        |
+| sc-event-tracker  | Docker Compose        | Docker Compose        |
+| schedule-executor | -                     | Minikube Deployment   |
 
 In both profiles, the dispatcher runs in Docker Compose as a cron loop.
 In `minikube` profile, the executor runs in Minikube and executes workflows via the KeeperHub API.

--- a/deploy/local/setup-local.sh
+++ b/deploy/local/setup-local.sh
@@ -413,6 +413,12 @@ setup_localstack() {
     echo "==================================="
     echo ""
 
+    if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
+        echo "WARNING: LOCALSTACK_AUTH_TOKEN is not set. LocalStack may not work correctly."
+        echo "Set it in your .env file or export it: export LOCALSTACK_AUTH_TOKEN=your-token"
+        echo "Get a token from 1Password note called 'localstack.cloud'"
+    fi
+
     # Check if LocalStack is already running
     if kubectl get pods -n local -l app=localstack 2>/dev/null | grep -q "Running"; then
         echo "LocalStack is already running"
@@ -443,6 +449,8 @@ spec:
           ports:
             - containerPort: 4566
           env:
+            - name: LOCALSTACK_AUTH_TOKEN
+              value: "${LOCALSTACK_AUTH_TOKEN}"
             - name: SERVICES
               value: "sqs"
             - name: DEBUG

--- a/deploy/pr-environment/localstack.template.yaml
+++ b/deploy/pr-environment/localstack.template.yaml
@@ -1,5 +1,5 @@
 # LocalStack for SQS in PR environment
-# Variables to be replaced: ${PR_NUMBER}
+# Variables to be replaced: ${PR_NUMBER}, ${LOCALSTACK_AUTH_TOKEN}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,6 +42,8 @@ spec:
             - containerPort: 4566
               name: edge
           env:
+            - name: LOCALSTACK_AUTH_TOKEN
+              value: "${LOCALSTACK_AUTH_TOKEN}"
             - name: SERVICES
               value: "sqs"
             - name: DEBUG
@@ -110,4 +112,3 @@ spec:
       targetPort: 4566
       name: edge
   type: ClusterIP
-

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -40,6 +40,7 @@ services:
     environment:
       - SERVICES=sqs
       - DEBUG=0
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
     volumes:
       - test_localstack_data:/var/lib/localstack
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
       - SQS_ENDPOINT_STRATEGY=path
       # Use host.minikube.internal so queue URLs work from both host and Minikube
       - LOCALSTACK_HOST=host.minikube.internal:4566
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
     volumes:
       - ./deploy/local/hybrid/init-localstack.sh:/etc/localstack/init/ready.d/init-aws.sh:ro
       - keeperhub_localstack_data:/var/lib/localstack

--- a/k8s/localstack.yaml
+++ b/k8s/localstack.yaml
@@ -26,6 +26,8 @@ spec:
           ports:
             - containerPort: 4566
           env:
+            - name: LOCALSTACK_AUTH_TOKEN
+              value: "${LOCALSTACK_AUTH_TOKEN}"
             - name: SERVICES
               value: "sqs"
             - name: DEBUG

--- a/tests/e2e/vitest/README.md
+++ b/tests/e2e/vitest/README.md
@@ -34,8 +34,8 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/workflow_builder" np
 # Start minikube
 minikube start
 
-# Deploy LocalStack
-kubectl apply -f k8s/localstack.yaml
+# Deploy LocalStack (requires LOCALSTACK_AUTH_TOKEN in environment)
+envsubst < k8s/localstack.yaml | kubectl apply -f -
 
 # Deploy the app
 kubectl apply -f k8s/keeperhub.yaml
@@ -57,22 +57,26 @@ pnpm test:e2e:schedule
 ## Test Scenarios
 
 ### 1. Schedule Creation Flow
+
 1. Create a workflow with Schedule trigger via UI
 2. Verify schedule record exists in database
 3. Verify nextRunAt is calculated correctly
 
 ### 2. Schedule Execution Flow
+
 1. Create a workflow with Schedule trigger set to run in 1 minute
 2. Wait for dispatcher to send message to SQS
 3. Wait for executor to process message
 4. Verify execution record created with status "running" then "completed"
 
 ### 3. Schedule Update Flow
+
 1. Modify workflow schedule (change cron expression)
 2. Verify schedule record updated
 3. Verify nextRunAt recalculated
 
 ### 4. Schedule Deletion Flow
+
 1. Change trigger type from Schedule to Manual/Webhook
 2. Verify schedule record deleted
 


### PR DESCRIPTION
## Summary

LocalStack now requires an auth token (`LOCALSTACK_AUTH_TOKEN`) for all usage. This PR updates all environments to support the new requirement while keeping the token out of the public repo.

- Docker Compose (dev + test): read token from `.env` via `${LOCALSTACK_AUTH_TOKEN:-}`
- Local K8s (minikube): inject token via `envsubst` before `kubectl apply`
- CI (PR environments): inject token from GitHub secret into `envsubst`
- CI (e2e ephemeral): revert image pin to `:latest` now that token-based auth is in place
- Documentation and `.env.example` updated with setup instructions

## Test results

### PR Environment (techops-staging, namespace pr-661)
- Deployed via `deploy-pr-environment` workflow (run 23442685621) -- all jobs passed
- LocalStack pod running with `localstack/localstack:latest` (sha256:3e10aca632f3...)
- `LOCALSTACK_AUTH_TOKEN` set on the deployment, SQS functional

### Docker Compose (local, `--profile dev`)
- Container started and reached `healthy` status
- Image: `localstack/localstack:latest`
- Token injected from `.env`, SQS queue `keeperhub-workflow-queue` created and accessible

### Minikube (local K8s)
- Manifest applied via `envsubst < k8s/localstack.yaml | kubectl apply -f -`
- Pod reached Ready state, image `localstack/localstack:latest`
- Token injected via envsubst, init job completed, SQS queue created and accessible