### PR TITLE
feat: add created_at label to user info metric

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -233,7 +233,7 @@ const userInfo = getOrCreateGauge(
   dbRegistry,
   "keeperhub_user_info",
   "User info with email and name labels",
-  ["email", "name", "verified"]
+  ["email", "name", "verified", "created_at"]
 );
 
 // Organization metrics (DB-sourced)
@@ -856,6 +856,7 @@ export async function updateDbMetrics(): Promise<void> {
           email: user.email,
           name: user.name,
           verified: String(user.verified),
+          created_at: user.createdAt.toISOString(),
         },
         1
       );

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -448,6 +448,7 @@ export type UserListEntry = {
   email: string;
   name: string;
   verified: boolean;
+  createdAt: Date;
 };
 
 export async function getUserListFromDb(): Promise<UserListEntry[]> {
@@ -457,6 +458,7 @@ export async function getUserListFromDb(): Promise<UserListEntry[]> {
         email: users.email,
         name: users.name,
         verified: users.emailVerified,
+        createdAt: users.createdAt,
       })
       .from(users)
       .where(eq(users.isAnonymous, false));
@@ -465,6 +467,7 @@ export async function getUserListFromDb(): Promise<UserListEntry[]> {
       email: row.email ?? "unknown",
       name: row.name ?? "unknown",
       verified: row.verified,
+      createdAt: row.createdAt,
     }));
   } catch (error) {
     console.error("[Metrics] Failed to query user list from DB:", error);


### PR DESCRIPTION
## Summary
- Adds `created_at` label (ISO 8601 timestamp) to the `keeperhub_user_info` Prometheus gauge
- Enables sorting the Grafana User Directory table by signup date
- No new metrics or endpoints - just one additional label on an existing gauge

## Changes
- `lib/metrics/db-metrics.ts` - include `createdAt` in the DB query and `UserListEntry` type
- `lib/metrics/collectors/prometheus.ts` - add `created_at` to gauge label set and populate it

## Grafana usage
After deploy, update the User Directory panel query to:
```
max by (email, name, verified, created_at) (keeperhub_user_info{cluster=~"$cluster", namespace=~"$namespace"})
```
Then sort by the `created_at` column.

## Test plan
- [ ] Verify `/api/metrics/db` includes `created_at` label on `keeperhub_user_info` series
- [ ] Confirm Grafana User Directory table shows the new column
- [ ] Confirm existing email/name/verified labels are unaffected