### PR TITLE
feat: replace Private/Public with Share terminology and icon

### DIFF
--- a/components/overlays/go-live-overlay.tsx
+++ b/components/overlays/go-live-overlay.tsx
@@ -133,14 +133,19 @@ export function GoLiveOverlay({
         </div>
 
         {!isEditing && (
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Share2 className="size-4 shrink-0" />
-            <p className="text-sm">
-              Shared workflows are visible on the Hub. Others can view the
-              structure and duplicate it. Your credentials and logs remain
-              private.
+          <>
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Share2 className="size-4 shrink-0" />
+              <p className="text-sm">
+                Shared workflows are visible on the Hub. Others can view the
+                structure and duplicate it. Your credentials and logs remain
+                private.
+              </p>
+            </div>
+            <p className="text-muted-foreground/60 text-xs">
+              Link will be accessible to others once shared
             </p>
-          </div>
+          </>
         )}
 
       </div>

--- a/components/overlays/go-live-overlay.tsx
+++ b/components/overlays/go-live-overlay.tsx
@@ -133,18 +133,26 @@ export function GoLiveOverlay({
         </div>
 
         {!isEditing && (
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Share2 className="size-4 shrink-0" />
-            <p className="text-sm">
-              Shared workflows are visible on the Hub. Others can view the
-              structure and duplicate it. Your credentials and logs remain
-              private.
-            </p>
+          <div className="flex items-start gap-2.5 rounded-md border border-border/40 bg-muted/30 px-3 py-2.5">
+            <Share2 className="mt-[3px] size-4 shrink-0 text-muted-foreground" />
+            <div className="space-y-1 text-muted-foreground text-sm">
+              <p>
+                Shared workflows are visible on the{" "}
+                <a
+                  className="underline underline-offset-2 hover:text-foreground"
+                  href="/hub"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Hub
+                </a>
+                . Others can view the structure and duplicate it. Your
+                credentials and logs remain private.
+              </p>
+              <p>Workflow link will be accessible to others once shared.</p>
+            </div>
           </div>
         )}
-        <p className="text-muted-foreground/60 text-xs">
-          Link will be accessible to others once shared
-        </p>
 
       </div>
     </Overlay>

--- a/components/overlays/go-live-overlay.tsx
+++ b/components/overlays/go-live-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, Globe } from "lucide-react";
+import { AlertTriangle, Share2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Overlay } from "@/components/overlays/overlay";
@@ -35,9 +35,9 @@ export function GoLiveOverlay({
   const [selectedTags, setSelectedTags] = useState<PublicTag[]>(initialTags);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const title = isEditing ? "Public Settings" : "Go Live";
-  const submitLabel = isEditing ? "Save Changes" : "Go Live";
-  const submittingTitle = isEditing ? "Saving..." : "Going Live...";
+  const title = isEditing ? "Share Settings" : "Share";
+  const submitLabel = isEditing ? "Save Changes" : "Share";
+  const submittingTitle = isEditing ? "Saving..." : "Sharing...";
 
   const handleSubmit = async (): Promise<void> => {
     const trimmedName = name.trim();
@@ -122,9 +122,9 @@ export function GoLiveOverlay({
 
         {!isEditing && (
           <div className="flex items-center gap-2 text-muted-foreground">
-            <Globe className="size-4 shrink-0" />
+            <Share2 className="size-4 shrink-0" />
             <p className="text-sm">
-              Public workflows are visible on the Hub. Others can view the
+              Shared workflows are visible on the Hub. Others can view the
               structure and duplicate it. Your credentials and logs remain
               private.
             </p>

--- a/components/overlays/go-live-overlay.tsx
+++ b/components/overlays/go-live-overlay.tsx
@@ -34,6 +34,7 @@ export function GoLiveOverlay({
   const [name, setName] = useState(currentName);
   const [selectedTags, setSelectedTags] = useState<PublicTag[]>(initialTags);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const title = isEditing ? "Share Settings" : "Share";
   const submitLabel = isEditing ? "Save Changes" : "Share";
@@ -80,9 +81,20 @@ export function GoLiveOverlay({
   return (
     <Overlay
       actions={[
+        {
+          label: copied ? "Copied" : "Copy link",
+          variant: "ghost" as const,
+          onClick: () => {
+            navigator.clipboard.writeText(window.location.href);
+            setCopied(true);
+            toast.success("Link copied to clipboard");
+            setTimeout(() => setCopied(false), 2000);
+          },
+        },
         { label: "Cancel", variant: "outline", onClick: closeAll },
         {
           label: submitLabel,
+          variant: "outline" as const,
           onClick: handleSubmit,
           disabled: !name.trim(),
         },
@@ -130,6 +142,7 @@ export function GoLiveOverlay({
             </p>
           </div>
         )}
+
       </div>
     </Overlay>
   );

--- a/components/overlays/go-live-overlay.tsx
+++ b/components/overlays/go-live-overlay.tsx
@@ -133,20 +133,18 @@ export function GoLiveOverlay({
         </div>
 
         {!isEditing && (
-          <>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Share2 className="size-4 shrink-0" />
-              <p className="text-sm">
-                Shared workflows are visible on the Hub. Others can view the
-                structure and duplicate it. Your credentials and logs remain
-                private.
-              </p>
-            </div>
-            <p className="text-muted-foreground/60 text-xs">
-              Link will be accessible to others once shared
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Share2 className="size-4 shrink-0" />
+            <p className="text-sm">
+              Shared workflows are visible on the Hub. Others can view the
+              structure and duplicate it. Your credentials and logs remain
+              private.
             </p>
-          </>
+          </div>
         )}
+        <p className="text-muted-foreground/60 text-xs">
+          Link will be accessible to others once shared
+        </p>
 
       </div>
     </Overlay>

--- a/components/overlays/make-public-overlay.tsx
+++ b/components/overlays/make-public-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Globe } from "lucide-react";
+import { Share2 } from "lucide-react";
 import { Overlay } from "./overlay";
 import { useOverlay } from "./overlay-provider";
 import type { OverlayComponentProps } from "./types";
@@ -24,15 +24,15 @@ export function MakePublicOverlay({
     <Overlay
       actions={[
         { label: "Cancel", variant: "outline", onClick: closeAll },
-        { label: "Make Public", onClick: handleConfirm },
+        { label: "Share", onClick: handleConfirm },
       ]}
       overlayId={overlayId}
-      title="Make Workflow Public?"
+      title="Share Workflow?"
     >
       <div className="flex items-center gap-2 text-muted-foreground">
-        <Globe className="size-5 shrink-0" />
+        <Share2 className="size-5 shrink-0" />
         <p className="text-sm">
-          Making this workflow public means anyone with the link can:
+          Sharing this workflow means anyone with the link can:
         </p>
       </div>
 

--- a/components/overlays/make-public-overlay.tsx
+++ b/components/overlays/make-public-overlay.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { Share2 } from "lucide-react";
+import { Check, Link2, Share2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { Overlay } from "./overlay";
 import { useOverlay } from "./overlay-provider";
 import type { OverlayComponentProps } from "./types";
@@ -14,10 +17,18 @@ export function MakePublicOverlay({
   onConfirm,
 }: MakePublicOverlayProps) {
   const { closeAll } = useOverlay();
+  const [copied, setCopied] = useState(false);
 
   const handleConfirm = () => {
     closeAll();
     onConfirm();
+  };
+
+  const handleCopyLink = async (): Promise<void> => {
+    await navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    toast.success("Link copied to clipboard");
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -49,6 +60,25 @@ export function MakePublicOverlay({
         <li>Your integration credentials (API keys, tokens)</li>
         <li>Execution logs and run history</li>
       </ul>
+
+      <div className="mt-5 flex items-center gap-3 border-t border-border/50 pt-4">
+        <Button
+          className="gap-2 text-keeperhub-green hover:text-keeperhub-green"
+          onClick={handleCopyLink}
+          size="sm"
+          variant="outline"
+        >
+          {copied ? (
+            <Check className="size-4" />
+          ) : (
+            <Link2 className="size-4" />
+          )}
+          {copied ? "Copied" : "Copy link"}
+        </Button>
+        <span className="text-muted-foreground text-xs">
+          Link will be accessible to others once shared
+        </span>
+      </div>
     </Overlay>
   );
 }

--- a/components/overlays/public-tag-selector.tsx
+++ b/components/overlays/public-tag-selector.tsx
@@ -174,7 +174,7 @@ export function PublicTagSelector({
 
       {orgSuggestions.length > 0 && (
         <div>
-          <p className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wider">
+          <p className="mb-2 text-muted-foreground text-sm">
             From your organization
           </p>
           <div className="flex flex-wrap gap-1.5">

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1496,7 +1496,7 @@ function VisibilityButton({
         <Button
           className={
             isPublic
-              ? "border border-keeperhub-green/40 bg-keeperhub-green/10 text-keeperhub-green hover:bg-keeperhub-green/20"
+              ? "border border-keeperhub-green/20 text-keeperhub-green hover:bg-keeperhub-green/10"
               : "border hover:bg-black/5 dark:hover:bg-white/5"
           }
           disabled={!state.currentWorkflowId || state.isGenerating}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1494,7 +1494,11 @@ function VisibilityButton({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          className="border hover:bg-black/5 dark:hover:bg-white/5"
+          className={
+            isPublic
+              ? "border border-keeperhub-green/40 bg-keeperhub-green/10 text-keeperhub-green hover:bg-keeperhub-green/20"
+              : "border hover:bg-black/5 dark:hover:bg-white/5"
+          }
           disabled={!state.currentWorkflowId || state.isGenerating}
           size="icon"
           title={isPublic ? "Shared workflow" : "Private workflow"}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -6,9 +6,9 @@ import {
   Check,
   Copy,
   Download,
-  Globe,
   Loader2,
   Lock,
+  Share2,
   Play,
   Plus,
   Redo2,
@@ -1054,7 +1054,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       return;
     }
 
-    // Show Go Live overlay when making public
+    // Show Share overlay when making public
     if (newVisibility === "public") {
       openOverlay(GoLiveOverlay, {
         workflowId: currentWorkflowId,
@@ -1101,7 +1101,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
         if (name !== workflowName) {
           state.setCurrentWorkflowName(name);
         }
-        toast.success("Public settings updated");
+        toast.success("Share settings updated");
       },
     });
   };
@@ -1497,11 +1497,11 @@ function VisibilityButton({
           className="border hover:bg-black/5 dark:hover:bg-white/5"
           disabled={!state.currentWorkflowId || state.isGenerating}
           size="icon"
-          title={isPublic ? "Public workflow" : "Private workflow"}
+          title={isPublic ? "Shared workflow" : "Private workflow"}
           variant="secondary"
         >
           {isPublic ? (
-            <Globe className="size-4" />
+            <Share2 className="size-4" />
           ) : (
             <Lock className="size-4" />
           )}
@@ -1522,15 +1522,15 @@ function VisibilityButton({
             onClick={() => actions.handleEditPublicSettings()}
           >
             <Settings2 className="size-4" />
-            Public Settings
+            Share Settings
           </DropdownMenuItem>
         ) : (
           <DropdownMenuItem
             className="flex items-center gap-2"
             onClick={() => actions.handleToggleVisibility("public")}
           >
-            <Globe className="size-4" />
-            Public
+            <Share2 className="size-4" />
+            Share
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- Replace Globe/Lock icons with Share2/Lock for more intuitive visibility toggle
- Rename "Public"/"Go Live" to "Share" across toolbar, overlays, and toast messages
- Add subtle green border tint on share button when workflow is shared
- Add "Copy link" ghost button in share overlay footer
- Combine info text into a styled callout with Hub link
- Remove uppercase from org tags label, match font size with Tags description
- Database values (private/public) unchanged - UI only

## Test plan
- [ ] Click visibility button - dropdown shows "Private" and "Share" (or "Share Settings" if already shared)
- [ ] Share a private workflow - verify "Share" overlay with callout, copy link button, and Hub link
- [ ] When shared, toolbar button shows Share2 icon with subtle green tint
- [ ] "Share Settings" view shows Copy link in footer, no link hint in content
- [ ] Org tags label shows as "From your organization" (not uppercase)

KEEP-169