### PR TITLE
feat: add page-based pagination for analytics runs

### DIFF
--- a/app/api/analytics/runs/route.ts
+++ b/app/api/analytics/runs/route.ts
@@ -32,6 +32,9 @@ export const GET = requireOrganization(
       const customEnd = params.get("customEnd") ?? undefined;
       const cursor = params.get("cursor") ?? undefined;
 
+      const pageParam = params.get("page");
+      const page = pageParam ? Math.max(1, Number(pageParam)) : undefined;
+
       const limitParam = params.get("limit");
       const limit = limitParam ? Number(limitParam) : undefined;
 
@@ -51,6 +54,7 @@ export const GET = requireOrganization(
 
       const result = await getUnifiedRuns(organizationId, range, {
         cursor,
+        page,
         limit,
         status,
         source,

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -327,17 +327,13 @@ function getPageNumbers(
   if (total <= 7) {
     return Array.from({ length: total }, (_, i) => i + 1);
   }
-  // Always show first 5 or current neighborhood, ellipsis, last 2
-  const visible = new Set<number>();
-  // First pages up to 5 or current + 1
-  const leftEnd = Math.max(5, current + 1);
-  for (let i = 1; i <= Math.min(leftEnd, total); i++) {
-    visible.add(i);
+  // Always first 2, last 2, current +/- 2
+  const visible = new Set<number>([1, 2, total - 1, total]);
+  for (let i = current - 2; i <= current + 2; i++) {
+    if (i >= 1 && i <= total) {
+      visible.add(i);
+    }
   }
-  // Last 2
-  visible.add(total - 1);
-  visible.add(total);
-
   const sorted = [...visible].sort((a, b) => a - b);
   const result: (number | "ellipsis")[] = [];
   for (const num of sorted) {

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -324,22 +324,20 @@ function getPageNumbers(
   current: number,
   total: number
 ): (number | "ellipsis")[] {
-  if (total <= 7) {
+  if (total <= 5) {
     return Array.from({ length: total }, (_, i) => i + 1);
   }
-  const pages: (number | "ellipsis")[] = [1];
-  if (current > 3) {
-    pages.push("ellipsis");
-  }
-  const start = Math.max(2, current - 1);
-  const end = Math.min(total - 1, current + 1);
+  const pages: (number | "ellipsis")[] = [];
+  const start = Math.max(1, current - 1);
+  const end = Math.min(total, current + 1);
   for (let i = start; i <= end; i++) {
     pages.push(i);
   }
-  if (current < total - 2) {
+  if (end < total) {
     pages.push("ellipsis");
+    pages.push(total - 1);
+    pages.push(total);
   }
-  pages.push(total);
   return pages;
 }
 

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useAtom, useAtomValue } from "jotai";
-import { ChevronDown, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+} from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
@@ -315,20 +321,107 @@ function TableSkeleton(): ReactNode {
   );
 }
 
+function getPageNumbers(
+  current: number,
+  total: number
+): (number | "ellipsis")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  const pages: (number | "ellipsis")[] = [1];
+  if (current > 3) {
+    pages.push("ellipsis");
+  }
+  const start = Math.max(2, current - 1);
+  const end = Math.min(total - 1, current + 1);
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+  if (current < total - 2) {
+    pages.push("ellipsis");
+  }
+  pages.push(total);
+  return pages;
+}
+
+function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  loading,
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  loading: boolean;
+}): ReactNode {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const pages = getPageNumbers(page, totalPages);
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center gap-1">
+      <Button
+        className="gap-1"
+        disabled={page <= 1 || loading}
+        onClick={() => onPageChange(page - 1)}
+        size="sm"
+        variant="ghost"
+      >
+        <ChevronLeft className="size-4" />
+        Previous
+      </Button>
+      {pages.map((p, idx) =>
+        p === "ellipsis" ? (
+          <span
+            className="px-2 text-muted-foreground text-sm"
+            key={idx < 3 ? "ellipsis-start" : "ellipsis-end"}
+          >
+            ...
+          </span>
+        ) : (
+          <Button
+            className={cn(
+              "size-8",
+              p === page &&
+                "bg-primary text-primary-foreground hover:bg-primary/90"
+            )}
+            disabled={loading}
+            key={p}
+            onClick={() => onPageChange(p)}
+            size="sm"
+            variant={p === page ? "default" : "ghost"}
+          >
+            {p}
+          </Button>
+        )
+      )}
+      <Button
+        className="gap-1"
+        disabled={page >= totalPages || loading}
+        onClick={() => onPageChange(page + 1)}
+        size="sm"
+        variant="ghost"
+      >
+        Next
+        <ChevronRight className="size-4" />
+      </Button>
+    </nav>
+  );
+}
+
 function RunsTableContent({
   loading,
   isEmpty,
   runs,
-  nextCursor,
-  loadingMore,
-  handleLoadMore,
+  pageLoading,
 }: {
   loading: boolean;
   isEmpty: boolean;
   runs: UnifiedRun[];
-  nextCursor: string | null;
-  loadingMore: boolean;
-  handleLoadMore: () => Promise<void>;
+  pageLoading: boolean;
 }): ReactNode {
   if (loading && isEmpty) {
     return <TableSkeleton />;
@@ -343,49 +436,27 @@ function RunsTableContent({
   }
 
   return (
-    <>
-      <div className="overflow-x-auto">
-        <table className="min-w-[700px] w-full text-left">
-          <thead>
-            <tr className="border-b text-xs text-muted-foreground">
-              <th className="w-8 pb-2 pl-3" />
-              <th className="pb-2 pr-3 font-medium">Name</th>
-              <th className="pb-2 pr-3 font-medium">Status</th>
-              <th className="pb-2 pr-3 font-medium">Source</th>
-              <th className="pb-2 pr-3 font-medium">Duration</th>
-              <th className="pb-2 pr-3 font-medium">Network</th>
-              <th className="pb-2 pr-3 font-medium">Gas</th>
-              <th className="pb-2 pr-3 text-right font-medium">Time</th>
-            </tr>
-          </thead>
-          <tbody>
-            {runs.map((run) => (
-              <ExpandableRunRow key={run.id} run={run} />
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {nextCursor ? (
-        <div className="mt-4 flex justify-center">
-          <Button
-            disabled={loadingMore}
-            onClick={() => {
-              handleLoadMore().catch(() => {
-                /* errors handled in handler */
-              });
-            }}
-            size="sm"
-            variant="outline"
-          >
-            {loadingMore ? (
-              <Loader2 className="mr-1.5 size-4 animate-spin" />
-            ) : null}
-            Load more
-          </Button>
-        </div>
-      ) : null}
-    </>
+    <div className={cn("overflow-x-auto", pageLoading && "opacity-50")}>
+      <table className="min-w-[700px] w-full text-left">
+        <thead>
+          <tr className="border-b text-xs text-muted-foreground">
+            <th className="w-8 pb-2 pl-3" />
+            <th className="pb-2 pr-3 font-medium">Name</th>
+            <th className="pb-2 pr-3 font-medium">Status</th>
+            <th className="pb-2 pr-3 font-medium">Source</th>
+            <th className="pb-2 pr-3 font-medium">Duration</th>
+            <th className="pb-2 pr-3 font-medium">Network</th>
+            <th className="pb-2 pr-3 font-medium">Gas</th>
+            <th className="pb-2 pr-3 text-right font-medium">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <ExpandableRunRow key={run.id} run={run} />
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 
@@ -396,43 +467,46 @@ export function RunsTable(): ReactNode {
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
   const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
-  const [loadingMore, setLoadingMore] = useState(false);
+  const [pageLoading, setPageLoading] = useState(false);
 
-  const handleLoadMore = useCallback(async (): Promise<void> => {
-    if (!runsData?.nextCursor) {
-      return;
-    }
+  const currentPage = runsData?.page ?? 1;
+  const pageSize = runsData?.pageSize ?? 50;
+  const totalPages = runsData ? Math.ceil(runsData.total / pageSize) : 1;
 
-    setLoadingMore(true);
-    try {
-      const params = new URLSearchParams({
-        range,
-        cursor: runsData.nextCursor,
-      });
-      if (statusFilter) {
-        params.set("status", statusFilter);
-      }
-      if (sourceFilter) {
-        params.set("source", sourceFilter);
-      }
-
-      const response = await fetch(`/api/analytics/runs?${params.toString()}`);
-      if (response.ok) {
-        const newData = (await response.json()) as {
-          runs: UnifiedRun[];
-          nextCursor: string | null;
-          total: number;
-        };
-        setRunsData({
-          runs: [...(runsData?.runs ?? []), ...newData.runs],
-          nextCursor: newData.nextCursor,
-          total: newData.total,
+  const handlePageChange = useCallback(
+    async (newPage: number): Promise<void> => {
+      setPageLoading(true);
+      try {
+        const params = new URLSearchParams({
+          range,
+          page: String(newPage),
         });
+        if (statusFilter) {
+          params.set("status", statusFilter);
+        }
+        if (sourceFilter) {
+          params.set("source", sourceFilter);
+        }
+
+        const response = await fetch(
+          `/api/analytics/runs?${params.toString()}`
+        );
+        if (response.ok) {
+          const data = (await response.json()) as {
+            runs: UnifiedRun[];
+            nextCursor: string | null;
+            total: number;
+            page: number;
+            pageSize: number;
+          };
+          setRunsData(data);
+        }
+      } finally {
+        setPageLoading(false);
       }
-    } finally {
-      setLoadingMore(false);
-    }
-  }, [runsData, range, statusFilter, sourceFilter, setRunsData]);
+    },
+    [range, statusFilter, sourceFilter, setRunsData]
+  );
 
   const allRuns = runsData?.runs ?? [];
 
@@ -466,20 +540,30 @@ export function RunsTable(): ReactNode {
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             <span>Workflow Runs</span>
-            {runsData ? (
-              <span className="text-sm font-normal text-muted-foreground">
-                {runsData.total.toLocaleString()} total
-              </span>
-            ) : null}
+            <div className="flex items-center gap-3">
+              <Pagination
+                loading={pageLoading}
+                onPageChange={(p) => {
+                  handlePageChange(p).catch(() => {
+                    /* errors handled in handler */
+                  });
+                }}
+                page={currentPage}
+                totalPages={totalPages}
+              />
+              {runsData ? (
+                <span className="text-sm font-normal text-muted-foreground">
+                  {runsData.total.toLocaleString()} total
+                </span>
+              ) : null}
+            </div>
           </CardTitle>
         </CardHeader>
         <CardContent>
           <RunsTableContent
-            handleLoadMore={handleLoadMore}
             isEmpty={isEmpty}
             loading={loading}
-            loadingMore={loadingMore}
-            nextCursor={runsData?.nextCursor ?? null}
+            pageLoading={pageLoading}
             runs={runs}
           />
         </CardContent>

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -515,23 +515,16 @@ export function RunsTable(): ReactNode {
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             <span>Workflow Runs</span>
-            <div className="flex items-center gap-3">
-              <Pagination
-                loading={pageLoading}
-                onPageChange={(p) => {
-                  handlePageChange(p).catch(() => {
-                    /* errors handled in handler */
-                  });
-                }}
-                page={currentPage}
-                totalPages={totalPages}
-              />
-              {runsData ? (
-                <span className="text-sm font-normal text-muted-foreground">
-                  {runsData.total.toLocaleString()} total
-                </span>
-              ) : null}
-            </div>
+            <Pagination
+              loading={pageLoading}
+              onPageChange={(p) => {
+                handlePageChange(p).catch(() => {
+                  /* errors handled in handler */
+                });
+              }}
+              page={currentPage}
+              totalPages={totalPages}
+            />
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -8,11 +8,10 @@ import {
   ExternalLink,
   Loader2,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
   NormalizedStatus,
@@ -362,52 +361,50 @@ function Pagination({
   const pages = getPageNumbers(page, totalPages);
 
   return (
-    <nav aria-label="Pagination" className="flex items-center gap-1">
-      <Button
-        className="gap-1"
+    <nav aria-label="Pagination" className="flex items-center gap-0.5">
+      <button
+        className="flex items-center gap-0.5 rounded px-1.5 py-1 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
         disabled={page <= 1 || loading}
         onClick={() => onPageChange(page - 1)}
-        size="sm"
-        variant="ghost"
+        type="button"
       >
-        <ChevronLeft className="size-4" />
-        Previous
-      </Button>
+        <ChevronLeft className="size-3" />
+        Prev
+      </button>
       {pages.map((p, idx) =>
         p === "ellipsis" ? (
           <span
-            className="px-2 text-muted-foreground text-sm"
+            className="px-1 text-muted-foreground/50 text-xs"
             key={idx < 3 ? "ellipsis-start" : "ellipsis-end"}
           >
             ...
           </span>
         ) : (
-          <Button
+          <button
             className={cn(
-              "size-8",
-              p === page &&
-                "bg-primary text-primary-foreground hover:bg-primary/90"
+              "flex size-6 items-center justify-center rounded text-xs transition-colors",
+              p === page
+                ? "bg-muted font-medium text-foreground"
+                : "text-muted-foreground hover:text-foreground"
             )}
             disabled={loading}
             key={p}
             onClick={() => onPageChange(p)}
-            size="sm"
-            variant={p === page ? "default" : "ghost"}
+            type="button"
           >
             {p}
-          </Button>
+          </button>
         )
       )}
-      <Button
-        className="gap-1"
+      <button
+        className="flex items-center gap-0.5 rounded px-1.5 py-1 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
         disabled={page >= totalPages || loading}
         onClick={() => onPageChange(page + 1)}
-        size="sm"
-        variant="ghost"
+        type="button"
       >
         Next
-        <ChevronRight className="size-4" />
-      </Button>
+        <ChevronRight className="size-3" />
+      </button>
     </nav>
   );
 }
@@ -467,6 +464,8 @@ export function RunsTable(): ReactNode {
   const statusFilter = useAtomValue(analyticsStatusFilterAtom);
   const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [pageLoading, setPageLoading] = useState(false);
 
   const currentPage = runsData?.page ?? 1;
@@ -476,6 +475,16 @@ export function RunsTable(): ReactNode {
   const handlePageChange = useCallback(
     async (newPage: number): Promise<void> => {
       setPageLoading(true);
+
+      // Update URL without full navigation
+      const url = new URL(window.location.href);
+      if (newPage > 1) {
+        url.searchParams.set("page", String(newPage));
+      } else {
+        url.searchParams.delete("page");
+      }
+      router.replace(url.pathname + url.search, { scroll: false });
+
       try {
         const params = new URLSearchParams({
           range,
@@ -505,8 +514,18 @@ export function RunsTable(): ReactNode {
         setPageLoading(false);
       }
     },
-    [range, statusFilter, sourceFilter, setRunsData]
+    [range, statusFilter, sourceFilter, setRunsData, router]
   );
+
+  // Load initial page from URL ?page= param after data arrives
+  const urlPage = Number(searchParams.get("page")) || 1;
+  useEffect(() => {
+    if (urlPage > 1 && runsData && currentPage !== urlPage) {
+      handlePageChange(urlPage).catch(() => {
+        /* errors handled in handler */
+      });
+    }
+  }, [urlPage, runsData, currentPage, handlePageChange]);
 
   const allRuns = runsData?.runs ?? [];
 

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -348,7 +348,7 @@ function Pagination({
         <ChevronLeft className="size-3.5" />
         Prev
       </Button>
-      <span className="font-medium text-muted-foreground text-xs tabular-nums">
+      <span className="min-w-16 text-center font-medium text-muted-foreground text-xs tabular-nums">
         {page} of {totalPages}
       </span>
       <Button

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -12,6 +12,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
   NormalizedStatus,
@@ -336,28 +337,30 @@ function Pagination({
   }
 
   return (
-    <nav aria-label="Pagination" className="flex items-center gap-1.5">
-      <button
-        className="flex items-center gap-0.5 rounded px-1.5 py-1 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
+    <nav aria-label="Pagination" className="flex items-center gap-1">
+      <Button
+        className="h-7 gap-1 px-2 text-xs"
         disabled={page <= 1 || loading}
         onClick={() => onPageChange(page - 1)}
-        type="button"
+        size="sm"
+        variant="ghost"
       >
-        <ChevronLeft className="size-3" />
+        <ChevronLeft className="size-3.5" />
         Prev
-      </button>
-      <span className="text-muted-foreground text-xs tabular-nums">
+      </Button>
+      <span className="font-medium text-muted-foreground text-xs tabular-nums">
         {page} of {totalPages}
       </span>
-      <button
-        className="flex items-center gap-0.5 rounded px-1.5 py-1 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
+      <Button
+        className="h-7 gap-1 px-2 text-xs"
         disabled={page >= totalPages || loading}
         onClick={() => onPageChange(page + 1)}
-        type="button"
+        size="sm"
+        variant="ghost"
       >
         Next
-        <ChevronRight className="size-3" />
-      </button>
+        <ChevronRight className="size-3.5" />
+      </Button>
     </nav>
   );
 }

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -473,15 +473,18 @@ export function RunsTable(): ReactNode {
     [range, statusFilter, sourceFilter, setRunsData, router]
   );
 
-  // Load initial page from URL ?page= param after data arrives
+  // Restore page from URL ?page= param once after initial data load
   const urlPage = Number(searchParams.get("page")) || 1;
+  const hasRestoredPage = useRef(false);
   useEffect(() => {
-    if (urlPage > 1 && runsData && currentPage !== urlPage) {
-      handlePageChange(urlPage).catch(() => {
-        /* errors handled in handler */
-      });
+    if (hasRestoredPage.current || !runsData || urlPage <= 1) {
+      return;
     }
-  }, [urlPage, runsData, currentPage, handlePageChange]);
+    hasRestoredPage.current = true;
+    handlePageChange(urlPage).catch(() => {
+      /* errors handled in handler */
+    });
+  }, [urlPage, runsData, handlePageChange]);
 
   const allRuns = runsData?.runs ?? [];
 

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -11,6 +11,7 @@ import {
 import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -249,7 +250,7 @@ function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
         )}
         onClick={() => {
           handleToggleExpand().catch(() => {
-            /* errors handled in handler */
+            /* noop - errors handled with toast in handlePageChange */
           });
         }}
       >
@@ -465,7 +466,11 @@ export function RunsTable(): ReactNode {
             pageSize: number;
           };
           setRunsData(data);
+        } else {
+          toast.error("Failed to load runs");
         }
+      } catch {
+        toast.error("Failed to load runs");
       } finally {
         setPageLoading(false);
       }
@@ -482,7 +487,7 @@ export function RunsTable(): ReactNode {
     }
     hasRestoredPage.current = true;
     handlePageChange(urlPage).catch(() => {
-      /* errors handled in handler */
+      /* noop - errors handled with toast in handlePageChange */
     });
   }, [urlPage, runsData, handlePageChange]);
 
@@ -522,7 +527,7 @@ export function RunsTable(): ReactNode {
               loading={pageLoading}
               onPageChange={(p) => {
                 handlePageChange(p).catch(() => {
-                  /* errors handled in handler */
+                  /* noop - errors handled with toast in handlePageChange */
                 });
               }}
               page={currentPage}

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -320,32 +320,6 @@ function TableSkeleton(): ReactNode {
   );
 }
 
-function getPageNumbers(
-  current: number,
-  total: number
-): (number | "ellipsis")[] {
-  if (total <= 7) {
-    return Array.from({ length: total }, (_, i) => i + 1);
-  }
-  // Always first 2, last 2, current +/- 2
-  const visible = new Set<number>([1, 2, total - 1, total]);
-  for (let i = current - 2; i <= current + 2; i++) {
-    if (i >= 1 && i <= total) {
-      visible.add(i);
-    }
-  }
-  const sorted = [...visible].sort((a, b) => a - b);
-  const result: (number | "ellipsis")[] = [];
-  for (const num of sorted) {
-    const prev = result.at(-1);
-    if (typeof prev === "number" && num - prev > 1) {
-      result.push("ellipsis");
-    }
-    result.push(num);
-  }
-  return result;
-}
-
 function Pagination({
   page,
   totalPages,
@@ -361,10 +335,8 @@ function Pagination({
     return null;
   }
 
-  const pages = getPageNumbers(page, totalPages);
-
   return (
-    <nav aria-label="Pagination" className="flex items-center gap-0.5">
+    <nav aria-label="Pagination" className="flex items-center gap-1.5">
       <button
         className="flex items-center gap-0.5 rounded px-1.5 py-1 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
         disabled={page <= 1 || loading}
@@ -374,31 +346,9 @@ function Pagination({
         <ChevronLeft className="size-3" />
         Prev
       </button>
-      {pages.map((p, idx) =>
-        p === "ellipsis" ? (
-          <span
-            className="px-1 text-muted-foreground/50 text-xs"
-            key={idx < 3 ? "ellipsis-start" : "ellipsis-end"}
-          >
-            ...
-          </span>
-        ) : (
-          <button
-            className={cn(
-              "flex size-6 items-center justify-center rounded text-xs transition-colors",
-              p === page
-                ? "bg-muted font-medium text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-            disabled={loading}
-            key={p}
-            onClick={() => onPageChange(p)}
-            type="button"
-          >
-            {p}
-          </button>
-        )
-      )}
+      <span className="text-muted-foreground text-xs tabular-nums">
+        {page} of {totalPages}
+      </span>
       <button
         className="flex items-center gap-0.5 rounded px-1.5 py-1 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
         disabled={page >= totalPages || loading}

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -324,21 +324,30 @@ function getPageNumbers(
   current: number,
   total: number
 ): (number | "ellipsis")[] {
-  if (total <= 5) {
+  if (total <= 7) {
     return Array.from({ length: total }, (_, i) => i + 1);
   }
-  const pages: (number | "ellipsis")[] = [];
-  const start = Math.max(1, current - 1);
-  const end = Math.min(total, current + 1);
-  for (let i = start; i <= end; i++) {
-    pages.push(i);
+  // Always show first 5 or current neighborhood, ellipsis, last 2
+  const visible = new Set<number>();
+  // First pages up to 5 or current + 1
+  const leftEnd = Math.max(5, current + 1);
+  for (let i = 1; i <= Math.min(leftEnd, total); i++) {
+    visible.add(i);
   }
-  if (end < total) {
-    pages.push("ellipsis");
-    pages.push(total - 1);
-    pages.push(total);
+  // Last 2
+  visible.add(total - 1);
+  visible.add(total);
+
+  const sorted = [...visible].sort((a, b) => a - b);
+  const result: (number | "ellipsis")[] = [];
+  for (const num of sorted) {
+    const prev = result.at(-1);
+    if (typeof prev === "number" && num - prev > 1) {
+      result.push("ellipsis");
+    }
+    result.push(num);
   }
-  return pages;
+  return result;
 }
 
 function Pagination({

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -629,8 +629,9 @@ export async function getNetworkBreakdown(
 }
 
 /**
- * Fetch unified runs with cursor-based pagination.
- * Runs fetch + count in parallel to avoid sequential blocking.
+ * Fetch unified runs with page-based or cursor-based pagination.
+ * Merges workflow and direct runs, sorts by time, then applies
+ * offset for the requested page. Runs fetch + count in parallel.
  */
 export async function getUnifiedRuns(
   organizationId: string,
@@ -666,7 +667,12 @@ export async function getUnifiedRuns(
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const pageLimit = Math.min(limit, 100);
   const skipDirect = Boolean(projectId) || source === "direct";
-  const offset = cursor ? undefined : (page - 1) * pageLimit;
+  const offset = cursor ? 0 : (page - 1) * pageLimit;
+
+  // Fetch enough rows from each source to fill the requested page after merging.
+  // We need offset + pageLimit + 1 rows from each source to correctly paginate
+  // the merged, sorted result set.
+  const fetchLimit = cursor ? pageLimit + 1 : offset + pageLimit + 1;
 
   // Fire run fetches and count queries in parallel
   const [workflowRuns, directRuns, total] = await Promise.all([
@@ -678,9 +684,8 @@ export async function getUnifiedRuns(
           rangeEnd,
           status,
           cursor,
-          pageLimit + 1,
-          projectId,
-          offset
+          fetchLimit,
+          projectId
         ),
     skipDirect || source === "workflow"
       ? ([] as UnifiedRun[])
@@ -690,8 +695,7 @@ export async function getUnifiedRuns(
           rangeEnd,
           status,
           cursor,
-          pageLimit + 1,
-          offset
+          fetchLimit
         ),
     getUnifiedRunsTotal(
       organizationId,
@@ -703,12 +707,15 @@ export async function getUnifiedRuns(
     ),
   ]);
 
+  // Merge both sources, sort by time, then apply offset for the requested page
   const allRuns = [...workflowRuns, ...directRuns].sort(
     (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
   );
 
-  const hasMore = allRuns.length > pageLimit;
-  const pagedRuns = allRuns.slice(0, pageLimit);
+  const sliceStart = cursor ? 0 : offset;
+  const sliced = allRuns.slice(sliceStart, sliceStart + pageLimit + 1);
+  const hasMore = sliced.length > pageLimit;
+  const pagedRuns = sliced.slice(0, pageLimit);
   const nextCursor = hasMore ? (pagedRuns.at(-1)?.startedAt ?? null) : null;
 
   return { runs: pagedRuns, nextCursor, total, page, pageSize: pageLimit };
@@ -721,8 +728,7 @@ async function fetchWorkflowRuns(
   status: NormalizedStatus | undefined,
   cursor: string | undefined,
   limit: number,
-  projectId?: string,
-  offset?: number
+  projectId?: string
 ): Promise<UnifiedRun[]> {
   // Scope to org's workflows via subquery so leftJoin still enforces org isolation
   const orgWorkflowIds = db
@@ -814,8 +820,7 @@ async function fetchWorkflowRuns(
     .leftJoin(logSummary, eq(workflowExecutions.id, logSummary.executionId))
     .where(and(...conditions))
     .orderBy(desc(workflowExecutions.startedAt))
-    .limit(limit)
-    .offset(offset ?? 0);
+    .limit(limit);
 
   return result.map((row) => ({
     id: row.id,
@@ -842,8 +847,7 @@ async function fetchDirectRuns(
   rangeEnd: Date,
   status: NormalizedStatus | undefined,
   cursor: string | undefined,
-  limit: number,
-  offset?: number
+  limit: number
 ): Promise<UnifiedRun[]> {
   const conditions = [
     eq(directExecutions.organizationId, organizationId),
@@ -879,8 +883,7 @@ async function fetchDirectRuns(
     .from(directExecutions)
     .where(and(...conditions))
     .orderBy(desc(directExecutions.createdAt))
-    .limit(limit)
-    .offset(offset ?? 0);
+    .limit(limit);
 
   return result.map((row) => ({
     id: row.id,

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -637,6 +637,7 @@ export async function getUnifiedRuns(
   range: TimeRange,
   options: {
     cursor?: string;
+    page?: number;
     limit?: number;
     status?: NormalizedStatus;
     source?: RunSource;
@@ -644,9 +645,16 @@ export async function getUnifiedRuns(
     customEnd?: string;
     projectId?: string;
   } = {}
-): Promise<{ runs: UnifiedRun[]; nextCursor: string | null; total: number }> {
+): Promise<{
+  runs: UnifiedRun[];
+  nextCursor: string | null;
+  total: number;
+  page: number;
+  pageSize: number;
+}> {
   const {
     cursor,
+    page = 1,
     limit = 50,
     status,
     source,
@@ -658,6 +666,7 @@ export async function getUnifiedRuns(
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const pageLimit = Math.min(limit, 100);
   const skipDirect = Boolean(projectId) || source === "direct";
+  const offset = cursor ? undefined : (page - 1) * pageLimit;
 
   // Fire run fetches and count queries in parallel
   const [workflowRuns, directRuns, total] = await Promise.all([
@@ -670,7 +679,8 @@ export async function getUnifiedRuns(
           status,
           cursor,
           pageLimit + 1,
-          projectId
+          projectId,
+          offset
         ),
     skipDirect || source === "workflow"
       ? ([] as UnifiedRun[])
@@ -680,7 +690,8 @@ export async function getUnifiedRuns(
           rangeEnd,
           status,
           cursor,
-          pageLimit + 1
+          pageLimit + 1,
+          offset
         ),
     getUnifiedRunsTotal(
       organizationId,
@@ -700,7 +711,7 @@ export async function getUnifiedRuns(
   const pagedRuns = allRuns.slice(0, pageLimit);
   const nextCursor = hasMore ? (pagedRuns.at(-1)?.startedAt ?? null) : null;
 
-  return { runs: pagedRuns, nextCursor, total };
+  return { runs: pagedRuns, nextCursor, total, page, pageSize: pageLimit };
 }
 
 async function fetchWorkflowRuns(
@@ -710,7 +721,8 @@ async function fetchWorkflowRuns(
   status: NormalizedStatus | undefined,
   cursor: string | undefined,
   limit: number,
-  projectId?: string
+  projectId?: string,
+  offset?: number
 ): Promise<UnifiedRun[]> {
   // Scope to org's workflows via subquery so leftJoin still enforces org isolation
   const orgWorkflowIds = db
@@ -802,7 +814,8 @@ async function fetchWorkflowRuns(
     .leftJoin(logSummary, eq(workflowExecutions.id, logSummary.executionId))
     .where(and(...conditions))
     .orderBy(desc(workflowExecutions.startedAt))
-    .limit(limit);
+    .limit(limit)
+    .offset(offset ?? 0);
 
   return result.map((row) => ({
     id: row.id,
@@ -829,7 +842,8 @@ async function fetchDirectRuns(
   rangeEnd: Date,
   status: NormalizedStatus | undefined,
   cursor: string | undefined,
-  limit: number
+  limit: number,
+  offset?: number
 ): Promise<UnifiedRun[]> {
   const conditions = [
     eq(directExecutions.organizationId, organizationId),
@@ -865,7 +879,8 @@ async function fetchDirectRuns(
     .from(directExecutions)
     .where(and(...conditions))
     .orderBy(desc(directExecutions.createdAt))
-    .limit(limit);
+    .limit(limit)
+    .offset(offset ?? 0);
 
   return result.map((row) => ({
     id: row.id,

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -94,6 +94,8 @@ export type RunsResponse = {
   runs: UnifiedRun[];
   nextCursor: string | null;
   total: number;
+  page: number;
+  pageSize: number;
 };
 
 export type StepLog = {


### PR DESCRIPTION
## Summary
- Users could only see the last 50 runs with no way to access older executions, making the analytics page incomplete for active organizations
- Replaces cursor-based "Load more" with compact Prev/Next pagination in the table header, with URL sync (?page=N) for bookmarkable pages
- Offset applied post-merge across both data sources (workflow + direct runs) to ensure correct page boundaries

## Test plan
- [ ] Navigate to /analytics with 50+ runs - verify "Prev 1 of N Next" appears in Workflow Runs header
- [ ] Click Next/Prev - verify table updates and URL changes to ?page=2
- [ ] Load /analytics?page=3 directly - verify correct page is shown
- [ ] Change status/source filters while on page 2 - verify table resets to page 1
- [ ] Select a project in sidebar - verify pagination adjusts to project's run count
- [ ] Trigger a fetch error - verify toast notification appears

KEEP-73