### PR TITLE
chore: add release type to PR title check

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,7 +16,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Allowed prefixes (must match release.yml classification)
-          PATTERN="^(feat|fix|bug|hotfix|breaking|chore|docs|refactor|test|ci|build|perf|style)(\([^)]*\))?[!]?:[[:space:]].+"
+          PATTERN="^(feat|fix|bug|hotfix|breaking|chore|docs|refactor|test|ci|build|perf|style|release)(\([^)]*\))?[!]?:[[:space:]].+"
 
           if printf '%s' "$PR_TITLE" | grep -qiE "$PATTERN"; then
             echo "PR title is valid: $PR_TITLE"
@@ -44,6 +44,7 @@ jobs:
             echo "    perf:      Performance"
             echo "    style:     Code style"
             echo "    breaking:  Breaking change"
+            echo "    release:   Production release"
             echo ""
             echo "  Examples:"
             echo "    feat: KEEP-1234 Add user authentication"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **No co-authored with Claude in PR descriptions and git commits**
 - **Do not git push or create Github PRs without user's confirmation**
 - **Do not leave code comments with summaries of user's prompt**
-- **PR titles must follow conventional commit format**: `<type>: <description>` or `<type>(scope): <description>`. Allowed types: `feat`, `fix`, `hotfix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `breaking`. This is enforced by the `pr-title-check` workflow on PRs targeting `staging`.
+- **PR titles must follow conventional commit format**: `<type>: <description>` or `<type>(scope): <description>`. Allowed types: `feat`, `fix`, `hotfix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `breaking`, `release`. This is enforced by the `pr-title-check` workflow on PRs targeting `staging`.
 - **Use `kh` CLI and KeeperHub MCP tools for all KeeperHub API interactions**: NEVER use raw `curl` or `fetch` against KeeperHub endpoints. Use MCP tools (`mcp__keeperhub-dev__*`, `mcp__keeperhub-staging__*`, `mcp__keeperhub__*`) for the target environment, or the `kh` CLI which handles auth and CF Access headers automatically via `~/.config/kh/hosts.yml`.
 
 ## Code Quality: Lint and Type Checking


### PR DESCRIPTION
## Summary
- Adds `release` as an allowed PR title type for production release PRs
- Updates the regex, error message, and CLAUDE.md

## Test plan
- [ ] PR title check workflow passes on this PR