### PR TITLE
chore: add prod to PR title check branches

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, synchronize]
     branches:
       - staging
+      - prod
 
 jobs:
   check-title:


### PR DESCRIPTION
## Summary
- PR title validation was silently skipped for staging-to-prod PRs because the workflow only triggered on PRs targeting staging
- Add `prod` to the branches filter so release PRs get the same title enforcement

## Test Plan
- [ ] Verify this PR itself passes the title check
- [ ] After merge, open a test PR targeting prod and confirm the check runs