### PR TITLE
fix: org API keys hitting non-existent route

### DIFF
--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -316,13 +316,13 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
 
   // Organisation keys
   const orgKeys = useApiKeys(
-    "/api/keeperhub/keys",
-    (id) => `/api/keeperhub/keys/${id}`
+    "/api/keys",
+    (id) => `/api/keys/${id}`
   );
 
   const currentKeys = activeTab === "webhook" ? webhookKeys : orgKeys;
   const createEndpoint =
-    activeTab === "webhook" ? "/api/api-keys" : "/api/keeperhub/keys";
+    activeTab === "webhook" ? "/api/api-keys" : "/api/keys";
 
   return (
     <Overlay

--- a/lib/hooks/use-onboarding-status.ts
+++ b/lib/hooks/use-onboarding-status.ts
@@ -122,7 +122,7 @@ export function useOnboardingStatus(): OnboardingStatus {
 
       const results = await Promise.allSettled([
         fetch("/api/workflows").then((r) => r.json()),
-        fetch("/api/keeperhub/keys").then((r) => r.json()),
+        fetch("/api/keys").then((r) => r.json()),
         fetch("/api/user/wallet").then((r) => r.json()),
       ]);
 


### PR DESCRIPTION
## Summary
- Organisation API keys overlay and onboarding hook were fetching `/api/keeperhub/keys`, a route that never existed, causing the server to return HTML 404 pages that broke JSON parsing
- Corrects the endpoints to `/api/keys` which is where the org keys route actually lives

## Test Plan
- [ ] Open API Keys overlay > Organisation tab -- keys load without error
- [ ] Create a new org API key -- succeeds, key is displayed
- [ ] Delete an org API key -- succeeds without error
- [ ] Onboarding checklist correctly detects existing org API keys