### PR TITLE
test: KEEP-172 add unit tests for API key routes

### DIFF
--- a/tests/integration/api-keys-route.test.ts
+++ b/tests/integration/api-keys-route.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSession = {
+  user: {
+    id: "user-123",
+    name: "Test User",
+    email: "test@techops.services",
+  },
+};
+
+const {
+  mockGetSession,
+  mockFindMany,
+  mockInsertReturning,
+  mockDeleteReturning,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockInsertReturning: vi.fn(),
+  mockDeleteReturning: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: mockGetSession,
+    },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      apiKeys: {
+        findMany: mockFindMany,
+      },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: mockInsertReturning,
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: mockDeleteReturning,
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apiKeys: {
+    id: "id",
+    userId: "user_id",
+    name: "name",
+    keyHash: "key_hash",
+    keyPrefix: "key_prefix",
+    createdAt: "created_at",
+    lastUsedAt: "last_used_at",
+  },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+import { DELETE } from "@/app/api/api-keys/[keyId]/route";
+import { GET, POST } from "@/app/api/api-keys/route";
+
+function createRequest(
+  method: string,
+  body?: Record<string, unknown>
+): Request {
+  const url = "http://localhost:3000/api/api-keys";
+  const init: RequestInit = { method, headers: {} };
+  if (body) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  return new Request(url, init);
+}
+
+function createDeleteContext(keyId: string): {
+  params: Promise<{ keyId: string }>;
+} {
+  return { params: Promise.resolve({ keyId }) };
+}
+
+describe("GET /api/api-keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return user's API keys", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const mockKeys = [
+      {
+        id: "key-1",
+        name: "My Key",
+        keyPrefix: "wfb_abc1234",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastUsedAt: null,
+      },
+      {
+        id: "key-2",
+        name: null,
+        keyPrefix: "wfb_xyz9876",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        lastUsedAt: "2026-01-03T00:00:00.000Z",
+      },
+    ];
+    mockFindMany.mockResolvedValue(mockKeys);
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual(mockKeys);
+    expect(data).toHaveLength(2);
+  });
+
+  it("should return empty array when user has no keys", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockFindMany.mockResolvedValue([]);
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual([]);
+  });
+
+  it("should return 500 on database error", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockFindMany.mockRejectedValue(new Error("DB connection failed"));
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe("DB connection failed");
+  });
+});
+
+describe("POST /api/api-keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 403 for anonymous user by name", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "anon-1", name: "Anonymous", email: "real@test.com" },
+    });
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error).toBe("Anonymous users cannot create API keys");
+  });
+
+  it("should return 403 for anonymous user by temp email", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "anon-2", name: "Some User", email: "temp-abc@test.com" },
+    });
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(403);
+  });
+
+  it("should create API key with name", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockInsertReturning.mockResolvedValue([
+      {
+        id: "new-key-id",
+        name: "My Key",
+        keyPrefix: "wfb_abc1234",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const response = await POST(createRequest("POST", { name: "My Key" }));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.id).toBe("new-key-id");
+    expect(data.name).toBe("My Key");
+    expect(data.key).toBeDefined();
+    expect(data.key.startsWith("wfb_")).toBe(true);
+  });
+
+  it("should create API key without name", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockInsertReturning.mockResolvedValue([
+      {
+        id: "new-key-id",
+        name: null,
+        keyPrefix: "wfb_abc1234",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const response = await POST(createRequest("POST"));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.name).toBeNull();
+    expect(data.key.startsWith("wfb_")).toBe(true);
+  });
+
+  it("should return 500 on database error", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockInsertReturning.mockRejectedValue(new Error("Insert failed"));
+
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe("Insert failed");
+  });
+});
+
+describe("DELETE /api/api-keys/:keyId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("key-1")
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should delete own key", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockDeleteReturning.mockResolvedValue([{ id: "key-1" }]);
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("key-1")
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+  });
+
+  it("should return 404 when key not found", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockDeleteReturning.mockResolvedValue([]);
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("nonexistent")
+    );
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error).toBe("API key not found");
+  });
+
+  it("should return 404 when key belongs to another user", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockDeleteReturning.mockResolvedValue([]);
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("other-user-key")
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 500 on database error", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockDeleteReturning.mockRejectedValue(new Error("Delete failed"));
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("key-1")
+    );
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe("Delete failed");
+  });
+});

--- a/tests/integration/org-api-keys-route.test.ts
+++ b/tests/integration/org-api-keys-route.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORG_ID = "org-123";
+const USER_ID = "user-123";
+
+const {
+  mockResolveOrganizationId,
+  mockGetSession,
+  mockGetOrgContext,
+  mockOrgKeysFindMany,
+  mockUsersFindMany,
+  mockInsertReturning,
+  mockUpdateReturning,
+} = vi.hoisted(() => ({
+  mockResolveOrganizationId: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockGetOrgContext: vi.fn(),
+  mockOrgKeysFindMany: vi.fn(),
+  mockUsersFindMany: vi.fn(),
+  mockInsertReturning: vi.fn(),
+  mockUpdateReturning: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  resolveOrganizationId: mockResolveOrganizationId,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: mockGetSession,
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/org-context", () => ({
+  getOrgContext: mockGetOrgContext,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      organizationApiKeys: { findMany: mockOrgKeysFindMany },
+      users: { findMany: mockUsersFindMany },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: mockInsertReturning,
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: mockUpdateReturning,
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organizationApiKeys: {
+    id: "id",
+    organizationId: "organization_id",
+    name: "name",
+    keyHash: "key_hash",
+    keyPrefix: "key_prefix",
+    createdBy: "created_by",
+    createdAt: "created_at",
+    lastUsedAt: "last_used_at",
+    expiresAt: "expires_at",
+    revokedAt: "revoked_at",
+  },
+  users: {
+    id: "id",
+    name: "name",
+  },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+import { DELETE } from "@/app/api/keys/[keyId]/route";
+import { GET, POST } from "@/app/api/keys/route";
+
+function createRequest(
+  method: string,
+  body?: Record<string, unknown>
+): Request {
+  const url = "http://localhost:3000/api/keys";
+  const init: RequestInit = { method, headers: {} };
+  if (body) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  return new Request(url, init);
+}
+
+function createDeleteContext(keyId: string): {
+  params: Promise<{ keyId: string }>;
+} {
+  return { params: Promise.resolve({ keyId }) };
+}
+
+describe("GET /api/keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 400 when no active organization", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      error: "No active organization",
+      status: 400,
+    });
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("No active organization");
+  });
+
+  it("should return org keys with creator names", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockOrgKeysFindMany.mockResolvedValue([
+      {
+        id: "key-1",
+        name: "Production Key",
+        keyPrefix: "kh_abc12",
+        createdBy: USER_ID,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastUsedAt: "2026-03-01T00:00:00.000Z",
+        expiresAt: null,
+      },
+      {
+        id: "key-2",
+        name: "MCP Key",
+        keyPrefix: "kh_xyz98",
+        createdBy: null,
+        createdAt: "2026-02-01T00:00:00.000Z",
+        lastUsedAt: null,
+        expiresAt: "2027-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockUsersFindMany.mockResolvedValue([{ id: USER_ID, name: "Test User" }]);
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveLength(2);
+    expect(data[0].createdByName).toBe("Test User");
+    expect(data[0].createdBy).toBeUndefined();
+    expect(data[1].createdByName).toBeNull();
+  });
+
+  it("should return empty array when org has no keys", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockOrgKeysFindMany.mockResolvedValue([]);
+    mockUsersFindMany.mockResolvedValue([]);
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual([]);
+  });
+
+  it("should return 500 on database error", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockOrgKeysFindMany.mockRejectedValue(new Error("DB connection failed"));
+
+    const response = await GET(createRequest("GET"));
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("POST /api/keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 400 when no active organization", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: USER_ID, name: "Test User", email: "test@test.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({ organization: null });
+
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("No active organization");
+  });
+
+  it("should return 403 for anonymous user by name", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "anon-1", name: "Anonymous", email: "real@test.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({
+      organization: { id: ORG_ID },
+    });
+
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error).toBe("Anonymous users cannot create API keys");
+  });
+
+  it("should return 403 for anonymous user by temp email", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "anon-2", name: "Some User", email: "temp-abc@test.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({
+      organization: { id: ORG_ID },
+    });
+
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(403);
+  });
+
+  it("should create kh_ key with name", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: USER_ID, name: "Test User", email: "test@test.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({
+      organization: { id: ORG_ID },
+    });
+    mockInsertReturning.mockResolvedValue([
+      {
+        id: "new-key-id",
+        name: "Production Key",
+        keyPrefix: "kh_abc12",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: null,
+      },
+    ]);
+
+    const response = await POST(
+      createRequest("POST", { name: "Production Key" })
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.id).toBe("new-key-id");
+    expect(data.name).toBe("Production Key");
+    expect(data.key).toBeDefined();
+    expect(data.key.startsWith("kh_")).toBe(true);
+  });
+
+  it("should create kh_ key with expiration", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: USER_ID, name: "Test User", email: "test@test.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({
+      organization: { id: ORG_ID },
+    });
+    mockInsertReturning.mockResolvedValue([
+      {
+        id: "new-key-id",
+        name: "Expiring Key",
+        keyPrefix: "kh_xyz98",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2027-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const response = await POST(
+      createRequest("POST", {
+        name: "Expiring Key",
+        expiresAt: "2027-01-01T00:00:00.000Z",
+      })
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.key.startsWith("kh_")).toBe(true);
+    expect(data.expiresAt).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  it("should return 500 on database error", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: USER_ID, name: "Test User", email: "test@test.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({
+      organization: { id: ORG_ID },
+    });
+    mockInsertReturning.mockRejectedValue(new Error("Insert failed"));
+
+    const response = await POST(createRequest("POST", { name: "Test" }));
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe("Insert failed");
+  });
+});
+
+describe("DELETE /api/keys/:keyId (revoke)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("key-1")
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should revoke key belonging to org", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockUpdateReturning.mockResolvedValue([{ id: "key-1" }]);
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("key-1")
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+  });
+
+  it("should return 404 when key not found", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockUpdateReturning.mockResolvedValue([]);
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("nonexistent")
+    );
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error).toBe("API key not found");
+  });
+
+  it("should return 404 when key belongs to different org", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockUpdateReturning.mockResolvedValue([]);
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("other-org-key")
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 500 on database error", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      organizationId: ORG_ID,
+    });
+    mockUpdateReturning.mockRejectedValue(new Error("Update failed"));
+
+    const response = await DELETE(
+      createRequest("DELETE"),
+      createDeleteContext("key-1")
+    );
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe("Update failed");
+  });
+});

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -1,0 +1,383 @@
+import { createHash } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const VALID_API_KEY = "wfb_test-key-abc123";
+const VALID_KEY_HASH = createHash("sha256").update(VALID_API_KEY).digest("hex");
+const OWNER_USER_ID = "user-owner-123";
+const OTHER_USER_ID = "user-other-456";
+const WORKFLOW_ID = "wf-abc-123";
+
+const webhookWorkflow = {
+  id: WORKFLOW_ID,
+  userId: OWNER_USER_ID,
+  organizationId: "org-123",
+  nodes: [
+    {
+      id: "trigger-1",
+      type: "trigger",
+      position: { x: 0, y: 0 },
+      data: {
+        label: "Webhook Trigger",
+        type: "trigger",
+        config: { triggerType: "Webhook" },
+        status: "idle",
+      },
+    },
+  ],
+  edges: [],
+};
+
+const manualWorkflow = {
+  ...webhookWorkflow,
+  nodes: [
+    {
+      id: "trigger-1",
+      type: "trigger",
+      position: { x: 0, y: 0 },
+      data: {
+        label: "Manual Trigger",
+        type: "trigger",
+        config: { triggerType: "Manual" },
+        status: "idle",
+      },
+    },
+  ],
+};
+
+const {
+  mockWorkflowsFindFirst,
+  mockApiKeysFindFirst,
+  mockInsertReturning,
+  mockValidateIntegrations,
+  mockEnforceExecutionLimit,
+  mockCheckConcurrency,
+} = vi.hoisted(() => ({
+  mockWorkflowsFindFirst: vi.fn(),
+  mockApiKeysFindFirst: vi.fn(),
+  mockInsertReturning: vi.fn(),
+  mockValidateIntegrations: vi.fn(),
+  mockEnforceExecutionLimit: vi.fn(),
+  mockCheckConcurrency: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      workflows: { findFirst: mockWorkflowsFindFirst },
+      apiKeys: { findFirst: mockApiKeysFindFirst },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: mockInsertReturning,
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          catch: vi.fn(),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apiKeys: { keyHash: "key_hash", id: "id", lastUsedAt: "last_used_at" },
+  workflows: { id: "id" },
+  workflowExecutions: { id: "id" },
+}));
+
+vi.mock("@/lib/db/integrations", () => ({
+  validateWorkflowIntegrations: mockValidateIntegrations,
+}));
+
+vi.mock("@/lib/billing/execution-guard", () => ({
+  EXECUTION_LIMIT_ERROR: "Execution limit reached",
+  enforceExecutionLimit: mockEnforceExecutionLimit,
+}));
+
+vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
+  checkConcurrencyLimit: mockCheckConcurrency,
+}));
+
+vi.mock("@/lib/metrics", () => ({
+  createTimer: () => () => 0,
+  getMetricsCollector: () => ({ incrementCounter: vi.fn() }),
+}));
+
+vi.mock("@/lib/metrics/types", () => ({
+  LabelKeys: { TRIGGER_TYPE: "trigger_type", WORKFLOW_ID: "workflow_id" },
+  MetricNames: { WORKFLOW_EXECUTIONS_TOTAL: "workflow_executions_total" },
+}));
+
+vi.mock("@/lib/metrics/instrumentation/api", () => ({
+  recordWebhookMetrics: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "WORKFLOW_ENGINE" },
+  logSystemError: vi.fn(),
+}));
+
+vi.mock("workflow/api", () => ({
+  start: vi.fn().mockResolvedValue({ runId: "run-123" }),
+}));
+
+vi.mock("@/lib/workflow-executor.workflow", () => ({
+  executeWorkflow: vi.fn(),
+}));
+
+import { OPTIONS, POST } from "@/app/api/workflows/[workflowId]/webhook/route";
+
+function createWebhookRequest(
+  apiKey?: string,
+  body?: Record<string, unknown>
+): Request {
+  const url = `http://localhost:3000/api/workflows/${WORKFLOW_ID}/webhook`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return new Request(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+function createContext(workflowId: string): {
+  params: Promise<{ workflowId: string }>;
+} {
+  return { params: Promise.resolve({ workflowId }) };
+}
+
+function setupHappyPath(): void {
+  mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+  mockApiKeysFindFirst.mockResolvedValue({
+    id: "key-1",
+    userId: OWNER_USER_ID,
+    keyHash: VALID_KEY_HASH,
+  });
+  mockValidateIntegrations.mockResolvedValue({ valid: true });
+  mockEnforceExecutionLimit.mockResolvedValue({ blocked: false });
+  mockCheckConcurrency.mockResolvedValue({ allowed: true });
+  mockInsertReturning.mockResolvedValue([
+    { id: "exec-001", status: "running" },
+  ]);
+}
+
+describe("POST /api/workflows/:workflowId/webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("workflow lookup", () => {
+    it("should return 404 when workflow not found", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(null);
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe("Workflow not found");
+    });
+  });
+
+  describe("API key validation", () => {
+    it("should return 401 when no authorization header", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+
+      const response = await POST(
+        createWebhookRequest(),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBe("Missing Authorization header");
+    });
+
+    it("should return 401 for non-wfb key format", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+
+      const response = await POST(
+        createWebhookRequest("kh_wrong_prefix"),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBe("Invalid API key format");
+    });
+
+    it("should return 401 when key not found in database", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue(null);
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBe("Invalid API key");
+    });
+
+    it("should return 403 when key belongs to different user", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue({
+        id: "key-other",
+        userId: OTHER_USER_ID,
+        keyHash: VALID_KEY_HASH,
+      });
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error).toBe(
+        "You do not have permission to run this workflow"
+      );
+    });
+  });
+
+  describe("webhook trigger validation", () => {
+    it("should return 400 when workflow is not webhook-triggered", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(manualWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue({
+        id: "key-1",
+        userId: OWNER_USER_ID,
+        keyHash: VALID_KEY_HASH,
+      });
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe(
+        "This workflow is not configured for webhook triggers"
+      );
+    });
+  });
+
+  describe("integration validation", () => {
+    it("should return 403 when workflow has invalid integrations", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue({
+        id: "key-1",
+        userId: OWNER_USER_ID,
+        keyHash: VALID_KEY_HASH,
+      });
+      mockValidateIntegrations.mockResolvedValue({
+        valid: false,
+        invalidIds: ["int-999"],
+      });
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error).toBe(
+        "Workflow contains invalid integration references"
+      );
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("should return 429 when execution limit reached", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue({
+        id: "key-1",
+        userId: OWNER_USER_ID,
+        keyHash: VALID_KEY_HASH,
+      });
+      mockValidateIntegrations.mockResolvedValue({ valid: true });
+      mockEnforceExecutionLimit.mockResolvedValue({
+        blocked: true,
+        response: new Response(
+          JSON.stringify({ error: "Execution limit reached" }),
+          { status: 429 }
+        ),
+      });
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(429);
+    });
+
+    it("should return 429 when concurrency limit reached", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue({
+        id: "key-1",
+        userId: OWNER_USER_ID,
+        keyHash: VALID_KEY_HASH,
+      });
+      mockValidateIntegrations.mockResolvedValue({ valid: true });
+      mockEnforceExecutionLimit.mockResolvedValue({ blocked: false });
+      mockCheckConcurrency.mockResolvedValue({
+        allowed: false,
+        running: 10,
+        limit: 10,
+      });
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(429);
+      const data = await response.json();
+      expect(data.error).toBe("Too many concurrent workflow executions");
+      expect(data.running).toBe(10);
+      expect(data.limit).toBe(10);
+    });
+  });
+
+  describe("successful execution", () => {
+    it("should return 200 with execution ID", async () => {
+      setupHappyPath();
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY, { event: "test" }),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.executionId).toBe("exec-001");
+      expect(data.status).toBe("running");
+    });
+
+    it("should include CORS headers", async () => {
+      setupHappyPath();
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+        "POST"
+      );
+    });
+  });
+
+  describe("OPTIONS preflight", () => {
+    it("should return CORS headers", () => {
+      const response = OPTIONS();
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toContain(
+        "Authorization"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for user-scoped `wfb_` API key CRUD (`/api/api-keys`) covering auth, create, list, delete, and error paths
- Add unit tests for org-scoped `kh_` API key CRUD (`/api/keys`) covering auth, org context, create with expiration, soft revoke, and creator name resolution
- Add unit tests for webhook trigger endpoint (`/api/workflows/:id/webhook`) covering API key validation, ownership checks, trigger type validation, rate limiting, and successful execution

## Test plan

- [x] `pnpm vitest run tests/integration/api-keys-route.test.ts` -- 15 tests pass
- [x] `pnpm vitest run tests/integration/org-api-keys-route.test.ts` -- 17 tests pass
- [x] `pnpm vitest run tests/integration/webhook-route.test.ts` -- 12 tests pass
- [x] All 44 tests pass when run together