### PR TITLE
feat(cowswap): add off-chain API actions and conditional order support

### DIFF
--- a/docs/plugins/cowswap.md
+++ b/docs/plugins/cowswap.md
@@ -22,6 +22,13 @@ CoW Protocol is a decentralized exchange protocol that uses batch auctions to pr
 | Check Conditional Order | Read | None | Whether a conditional order is registered |
 | Get Cabinet Value | Read | None | Read conditional order handler state |
 | Remove Conditional Order | Write | Wallet | Remove a conditional order |
+| Create Conditional Order | Write | Wallet | Create a TWAP or stop-loss conditional order on ComposableCoW |
+| Get Quote | API | None | Get a price quote from the CoW Swap orderbook |
+| Get Order Status | API | None | Check the status of an order by UID |
+| Create Order | API | None | Submit a pre-built signed order to the orderbook |
+| Cancel Order | API | None | Cancel a pending order before it is filled |
+| Get Account Orders | API | None | List all orders for a wallet address |
+| Get Trades | API | None | Get executed trades for a wallet address |
 
 ## Get Domain Separator
 

--- a/plugins/cowswap/index.ts
+++ b/plugins/cowswap/index.ts
@@ -1,0 +1,271 @@
+import type { IntegrationType } from "@/lib/types/integration";
+import { getIntegration } from "@/plugins/registry";
+
+const getQuoteAction = {
+  slug: "get-quote",
+  label: "Get Quote",
+  description:
+    "Get a price quote for a token swap from the CoW Swap orderbook API",
+  category: "CoW Swap",
+  stepFunction: "getQuoteStep",
+  stepImportPath: "get-quote",
+  configFields: [
+    {
+      key: "network",
+      label: "Network",
+      type: "chain-select" as const,
+      chainTypeFilter: "evm",
+      placeholder: "Select network",
+      required: true,
+    },
+    {
+      key: "sellToken",
+      label: "Sell Token Address",
+      type: "template-input" as const,
+      placeholder: "0x... or {{NodeName.sellToken}}",
+      example: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      required: true,
+      isAddressField: true,
+    },
+    {
+      key: "buyToken",
+      label: "Buy Token Address",
+      type: "template-input" as const,
+      placeholder: "0x... or {{NodeName.buyToken}}",
+      example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      required: true,
+      isAddressField: true,
+    },
+    {
+      key: "from",
+      label: "Trader Address",
+      type: "template-input" as const,
+      placeholder: "0x... wallet address",
+      example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      required: true,
+      isAddressField: true,
+    },
+    {
+      key: "kind",
+      label: "Order Kind",
+      type: "template-input" as const,
+      placeholder: "sell or buy",
+      example: "sell",
+      required: true,
+    },
+    {
+      key: "amount",
+      label: "Amount (in token base units)",
+      type: "template-input" as const,
+      placeholder: "1000000000000000000 (1 ETH)",
+      example: "1000000000000000000",
+      required: true,
+    },
+  ],
+  outputFields: [
+    { field: "success", description: "Whether the request succeeded" },
+    { field: "buyAmount", description: "Amount of buy token to receive" },
+    { field: "sellAmount", description: "Amount of sell token to spend" },
+    { field: "feeAmount", description: "Protocol fee amount" },
+    { field: "quote", description: "Full quote object from the API" },
+    { field: "error", description: "Error message if failed" },
+  ],
+};
+
+const getOrderStatusAction = {
+  slug: "get-order-status",
+  label: "Get Order Status",
+  description:
+    "Check the status of a CoW Swap order by its order UID from the orderbook API",
+  category: "CoW Swap",
+  stepFunction: "getOrderStatusStep",
+  stepImportPath: "get-order-status",
+  configFields: [
+    {
+      key: "network",
+      label: "Network",
+      type: "chain-select" as const,
+      chainTypeFilter: "evm",
+      placeholder: "Select network",
+      required: true,
+    },
+    {
+      key: "orderUid",
+      label: "Order UID",
+      type: "template-input" as const,
+      placeholder: "0x... 56-byte order identifier",
+      example: "0xabc123...",
+      required: true,
+    },
+  ],
+  outputFields: [
+    { field: "success", description: "Whether the request succeeded" },
+    { field: "status", description: "Order status (open, filled, cancelled, expired)" },
+    { field: "filledAmount", description: "Amount filled so far" },
+    { field: "executedBuyAmount", description: "Buy token amount actually received" },
+    { field: "executedSellAmount", description: "Sell token amount actually spent" },
+    { field: "order", description: "Full order object from the API" },
+    { field: "error", description: "Error message if failed" },
+  ],
+};
+
+const createOrderAction = {
+  slug: "create-order",
+  label: "Create Order",
+  description:
+    "Submit a pre-built signed order to the CoW Swap orderbook. The order must be fully constructed and signed externally before submission.",
+  category: "CoW Swap",
+  stepFunction: "createOrderStep",
+  stepImportPath: "create-order",
+  configFields: [
+    {
+      key: "network",
+      label: "Network",
+      type: "chain-select" as const,
+      chainTypeFilter: "evm",
+      placeholder: "Select network",
+      required: true,
+    },
+    {
+      key: "orderPayload",
+      label: "Signed Order Payload (JSON)",
+      type: "template-input" as const,
+      placeholder: '{"sellToken":"0x...","buyToken":"0x...",...}',
+      required: true,
+    },
+  ],
+  outputFields: [
+    { field: "success", description: "Whether the request succeeded" },
+    { field: "orderUid", description: "The UID of the created order" },
+    { field: "error", description: "Error message if failed" },
+  ],
+};
+
+const cancelOrderAction = {
+  slug: "cancel-order",
+  label: "Cancel Order",
+  description:
+    "Cancel a pending CoW Swap order via the orderbook API before it is filled",
+  category: "CoW Swap",
+  stepFunction: "cancelOrderStep",
+  stepImportPath: "cancel-order",
+  configFields: [
+    {
+      key: "network",
+      label: "Network",
+      type: "chain-select" as const,
+      chainTypeFilter: "evm",
+      placeholder: "Select network",
+      required: true,
+    },
+    {
+      key: "orderUid",
+      label: "Order UID",
+      type: "template-input" as const,
+      placeholder: "0x... 56-byte order identifier",
+      example: "0xabc123...",
+      required: true,
+    },
+  ],
+  outputFields: [
+    { field: "success", description: "Whether the request succeeded" },
+    { field: "error", description: "Error message if failed" },
+  ],
+};
+
+const getAccountOrdersAction = {
+  slug: "get-account-orders",
+  label: "Get Account Orders",
+  description:
+    "List all orders placed by a wallet address from the CoW Swap orderbook API",
+  category: "CoW Swap",
+  stepFunction: "getAccountOrdersStep",
+  stepImportPath: "get-account-orders",
+  configFields: [
+    {
+      key: "network",
+      label: "Network",
+      type: "chain-select" as const,
+      chainTypeFilter: "evm",
+      placeholder: "Select network",
+      required: true,
+    },
+    {
+      key: "ownerAddress",
+      label: "Owner Address",
+      type: "template-input" as const,
+      placeholder: "0x... wallet address",
+      example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      required: true,
+      isAddressField: true,
+    },
+    {
+      key: "limit",
+      label: "Limit",
+      type: "template-input" as const,
+      placeholder: "50",
+      example: "50",
+      required: false,
+    },
+  ],
+  outputFields: [
+    { field: "success", description: "Whether the request succeeded" },
+    { field: "orders", description: "Array of orders for the account" },
+    { field: "count", description: "Number of orders returned" },
+    { field: "error", description: "Error message if failed" },
+  ],
+};
+
+const getTradesAction = {
+  slug: "get-trades",
+  label: "Get Trades",
+  description:
+    "Get executed trades for a wallet address from the CoW Swap orderbook API",
+  category: "CoW Swap",
+  stepFunction: "getTradesStep",
+  stepImportPath: "get-trades",
+  configFields: [
+    {
+      key: "network",
+      label: "Network",
+      type: "chain-select" as const,
+      chainTypeFilter: "evm",
+      placeholder: "Select network",
+      required: true,
+    },
+    {
+      key: "ownerAddress",
+      label: "Owner Address",
+      type: "template-input" as const,
+      placeholder: "0x... wallet address",
+      example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      required: true,
+      isAddressField: true,
+    },
+  ],
+  outputFields: [
+    { field: "success", description: "Whether the request succeeded" },
+    { field: "trades", description: "Array of executed trades for the account" },
+    { field: "count", description: "Number of trades returned" },
+    { field: "error", description: "Error message if failed" },
+  ],
+};
+
+// Inject HTTP API actions into the protocol-registered "cowswap" integration
+// so both on-chain protocol actions and off-chain API actions appear under one entry.
+// CoW Swap does not require credentials -- the orderbook API is public.
+const cowswapProtocol = getIntegration("cowswap" as IntegrationType);
+if (!cowswapProtocol) {
+  throw new Error(
+    '[cowswap plugin] "cowswap" integration not found in registry. Ensure keeperhub/protocols is imported before keeperhub/plugins/cowswap.'
+  );
+}
+
+cowswapProtocol.actions.push(getQuoteAction);
+cowswapProtocol.actions.push(getOrderStatusAction);
+cowswapProtocol.actions.push(createOrderAction);
+cowswapProtocol.actions.push(cancelOrderAction);
+cowswapProtocol.actions.push(getAccountOrdersAction);
+cowswapProtocol.actions.push(getTradesAction);
+
+export default cowswapProtocol;

--- a/plugins/cowswap/steps/cancel-order.ts
+++ b/plugins/cowswap/steps/cancel-order.ts
@@ -1,0 +1,129 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const PLUGIN_NAME = "cowswap";
+const ACTION_NAME = "cancel-order";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const COW_API_CHAIN_PATHS: Record<number, string> = {
+  1: "mainnet",
+  8453: "base",
+  42161: "arbitrum_one",
+  10: "optimism",
+};
+
+export type CancelOrderInput = StepInput & {
+  network: string;
+  orderUid: string;
+};
+
+type CancelOrderResult =
+  | { success: true }
+  | { success: false; error: string };
+
+async function stepHandler(input: CancelOrderInput): Promise<CancelOrderResult> {
+  if (!input.orderUid) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Missing orderUid for cancel-order",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "orderUid is required" };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Unsupported network",
+      input.network,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Unsupported network: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const chainPath = COW_API_CHAIN_PATHS[chainId];
+  if (!chainPath) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Network not supported by CoW Swap API",
+      { chainId, network: input.network },
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Chain ID ${chainId} is not supported by the CoW Swap API`,
+    };
+  }
+
+  const url = `https://api.cow.fi/${chainPath}/api/v1/orders/${encodeURIComponent(input.orderUid)}`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[CoW Swap] API error on cancel-order",
+        { status: response.status, body: errorBody },
+        { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+      );
+      return {
+        success: false,
+        error: `CoW Swap API returned HTTP ${response.status}: ${errorBody}`,
+      };
+    }
+
+    return { success: true };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[CoW Swap] Error cancelling order",
+      error,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+    );
+    return {
+      success: false,
+      error: `Failed to cancel order: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+export async function cancelOrderStep(
+  input: CancelOrderInput
+): Promise<CancelOrderResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: PLUGIN_NAME,
+      actionName: ACTION_NAME,
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+cancelOrderStep.maxRetries = 0;
+
+export const _integrationType = "cowswap";

--- a/plugins/cowswap/steps/create-order.ts
+++ b/plugins/cowswap/steps/create-order.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const PLUGIN_NAME = "cowswap";
+const ACTION_NAME = "create-order";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const COW_API_CHAIN_PATHS: Record<number, string> = {
+  1: "mainnet",
+  8453: "base",
+  42161: "arbitrum_one",
+  10: "optimism",
+};
+
+export type CreateOrderInput = StepInput & {
+  network: string;
+  orderPayload: string;
+};
+
+type CreateOrderResult =
+  | { success: true; orderUid: string }
+  | { success: false; error: string };
+
+async function stepHandler(input: CreateOrderInput): Promise<CreateOrderResult> {
+  if (!input.orderPayload) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Missing orderPayload for create-order",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "orderPayload is required" };
+  }
+
+  let parsedOrder: unknown;
+  try {
+    parsedOrder = JSON.parse(input.orderPayload);
+  } catch {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Invalid JSON in orderPayload",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "orderPayload must be valid JSON" };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Unsupported network",
+      input.network,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Unsupported network: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const chainPath = COW_API_CHAIN_PATHS[chainId];
+  if (!chainPath) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Network not supported by CoW Swap API",
+      { chainId, network: input.network },
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Chain ID ${chainId} is not supported by the CoW Swap API`,
+    };
+  }
+
+  const url = `https://api.cow.fi/${chainPath}/api/v1/orders`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(parsedOrder),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[CoW Swap] API error on create-order",
+        { status: response.status, body: errorBody },
+        { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+      );
+      return {
+        success: false,
+        error: `CoW Swap API returned HTTP ${response.status}: ${errorBody}`,
+      };
+    }
+
+    const orderUid = (await response.json()) as string;
+    return { success: true, orderUid };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[CoW Swap] Error creating order",
+      error,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+    );
+    return {
+      success: false,
+      error: `Failed to create order: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+export async function createOrderStep(
+  input: CreateOrderInput
+): Promise<CreateOrderResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: PLUGIN_NAME,
+      actionName: ACTION_NAME,
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+createOrderStep.maxRetries = 0;
+
+export const _integrationType = "cowswap";

--- a/plugins/cowswap/steps/get-account-orders.ts
+++ b/plugins/cowswap/steps/get-account-orders.ts
@@ -1,0 +1,132 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const PLUGIN_NAME = "cowswap";
+const ACTION_NAME = "get-account-orders";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const COW_API_CHAIN_PATHS: Record<number, string> = {
+  1: "mainnet",
+  8453: "base",
+  42161: "arbitrum_one",
+  10: "optimism",
+};
+
+export type GetAccountOrdersInput = StepInput & {
+  network: string;
+  ownerAddress: string;
+  limit?: string;
+};
+
+type GetAccountOrdersResult =
+  | { success: true; orders: unknown[]; count: number }
+  | { success: false; error: string };
+
+async function stepHandler(
+  input: GetAccountOrdersInput
+): Promise<GetAccountOrdersResult> {
+  if (!input.ownerAddress) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Missing ownerAddress for get-account-orders",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "ownerAddress is required" };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Unsupported network",
+      input.network,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Unsupported network: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const chainPath = COW_API_CHAIN_PATHS[chainId];
+  if (!chainPath) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Network not supported by CoW Swap API",
+      { chainId, network: input.network },
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Chain ID ${chainId} is not supported by the CoW Swap API`,
+    };
+  }
+
+  const limit = input.limit ?? "50";
+  const url = `https://api.cow.fi/${chainPath}/api/v1/account/${encodeURIComponent(input.ownerAddress)}/orders?limit=${encodeURIComponent(limit)}`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[CoW Swap] API error on get-account-orders",
+        { status: response.status, body: errorBody },
+        { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+      );
+      return {
+        success: false,
+        error: `CoW Swap API returned HTTP ${response.status}: ${errorBody}`,
+      };
+    }
+
+    const orders = (await response.json()) as unknown[];
+    return { success: true, orders, count: orders.length };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[CoW Swap] Error fetching account orders",
+      error,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+    );
+    return {
+      success: false,
+      error: `Failed to fetch account orders: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+export async function getAccountOrdersStep(
+  input: GetAccountOrdersInput
+): Promise<GetAccountOrdersResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: PLUGIN_NAME,
+      actionName: ACTION_NAME,
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+export const _integrationType = "cowswap";

--- a/plugins/cowswap/steps/get-order-status.ts
+++ b/plugins/cowswap/steps/get-order-status.ts
@@ -1,0 +1,151 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const PLUGIN_NAME = "cowswap";
+const ACTION_NAME = "get-order-status";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const COW_API_CHAIN_PATHS: Record<number, string> = {
+  1: "mainnet",
+  8453: "base",
+  42161: "arbitrum_one",
+  10: "optimism",
+};
+
+export type GetOrderStatusInput = StepInput & {
+  network: string;
+  orderUid: string;
+};
+
+type GetOrderStatusResult =
+  | {
+      success: true;
+      status: string;
+      filledAmount: string;
+      executedBuyAmount: string;
+      executedSellAmount: string;
+      order: unknown;
+    }
+  | { success: false; error: string };
+
+type CowOrderResponse = {
+  status: string;
+  executedBuyAmount: string;
+  executedSellAmount: string;
+  executedFeeAmount: string;
+};
+
+async function stepHandler(
+  input: GetOrderStatusInput
+): Promise<GetOrderStatusResult> {
+  if (!input.orderUid) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Missing orderUid for get-order-status",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "orderUid is required" };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Unsupported network",
+      input.network,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Unsupported network: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const chainPath = COW_API_CHAIN_PATHS[chainId];
+  if (!chainPath) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Network not supported by CoW Swap API",
+      { chainId, network: input.network },
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Chain ID ${chainId} is not supported by the CoW Swap API`,
+    };
+  }
+
+  const url = `https://api.cow.fi/${chainPath}/api/v1/orders/${encodeURIComponent(input.orderUid)}`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[CoW Swap] API error on get-order-status",
+        { status: response.status, body: errorBody },
+        { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+      );
+      return {
+        success: false,
+        error: `CoW Swap API returned HTTP ${response.status}: ${errorBody}`,
+      };
+    }
+
+    const data = (await response.json()) as CowOrderResponse;
+    return {
+      success: true,
+      status: data.status,
+      filledAmount: data.executedSellAmount,
+      executedBuyAmount: data.executedBuyAmount,
+      executedSellAmount: data.executedSellAmount,
+      order: data,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[CoW Swap] Error fetching order status",
+      error,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+    );
+    return {
+      success: false,
+      error: `Failed to fetch order status: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+export async function getOrderStatusStep(
+  input: GetOrderStatusInput
+): Promise<GetOrderStatusResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: PLUGIN_NAME,
+      actionName: ACTION_NAME,
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+export const _integrationType = "cowswap";

--- a/plugins/cowswap/steps/get-quote.ts
+++ b/plugins/cowswap/steps/get-quote.ts
@@ -1,0 +1,166 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const PLUGIN_NAME = "cowswap";
+const ACTION_NAME = "get-quote";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const COW_API_CHAIN_PATHS: Record<number, string> = {
+  1: "mainnet",
+  8453: "base",
+  42161: "arbitrum_one",
+  10: "optimism",
+};
+
+export type GetQuoteInput = StepInput & {
+  network: string;
+  sellToken: string;
+  buyToken: string;
+  from: string;
+  kind: string;
+  amount: string;
+};
+
+type GetQuoteResult =
+  | {
+      success: true;
+      buyAmount: string;
+      sellAmount: string;
+      feeAmount: string;
+      quote: unknown;
+    }
+  | { success: false; error: string };
+
+type CowQuoteResponse = {
+  quote: {
+    buyAmount: string;
+    sellAmount: string;
+    feeAmount: string;
+  };
+};
+
+async function stepHandler(input: GetQuoteInput): Promise<GetQuoteResult> {
+  if (!input.sellToken || !input.buyToken || !input.from) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Missing required fields for get-quote",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "sellToken, buyToken, and from are required" };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Unsupported network",
+      input.network,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Unsupported network: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const chainPath = COW_API_CHAIN_PATHS[chainId];
+  if (!chainPath) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Network not supported by CoW Swap API",
+      { chainId, network: input.network },
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Chain ID ${chainId} is not supported by the CoW Swap API`,
+    };
+  }
+
+  const kind = input.kind === "buy" ? "buy" : "sell";
+  const body: Record<string, string> = {
+    sellToken: input.sellToken,
+    buyToken: input.buyToken,
+    from: input.from,
+    kind,
+  };
+
+  if (kind === "sell") {
+    body.sellAmountBeforeFee = input.amount;
+  } else {
+    body.buyAmountAfterFee = input.amount;
+  }
+
+  const url = `https://api.cow.fi/${chainPath}/api/v1/quote`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[CoW Swap] API error on get-quote",
+        { status: response.status, body: errorBody },
+        { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+      );
+      return {
+        success: false,
+        error: `CoW Swap API returned HTTP ${response.status}: ${errorBody}`,
+      };
+    }
+
+    const data = (await response.json()) as CowQuoteResponse;
+    return {
+      success: true,
+      buyAmount: data.quote.buyAmount,
+      sellAmount: data.quote.sellAmount,
+      feeAmount: data.quote.feeAmount,
+      quote: data.quote,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[CoW Swap] Error fetching quote",
+      error,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+    );
+    return {
+      success: false,
+      error: `Failed to fetch quote: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+export async function getQuoteStep(input: GetQuoteInput): Promise<GetQuoteResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: PLUGIN_NAME,
+      actionName: ACTION_NAME,
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+export const _integrationType = "cowswap";

--- a/plugins/cowswap/steps/get-trades.ts
+++ b/plugins/cowswap/steps/get-trades.ts
@@ -1,0 +1,128 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+
+const PLUGIN_NAME = "cowswap";
+const ACTION_NAME = "get-trades";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const COW_API_CHAIN_PATHS: Record<number, string> = {
+  1: "mainnet",
+  8453: "base",
+  42161: "arbitrum_one",
+  10: "optimism",
+};
+
+export type GetTradesInput = StepInput & {
+  network: string;
+  ownerAddress: string;
+};
+
+type GetTradesResult =
+  | { success: true; trades: unknown[]; count: number }
+  | { success: false; error: string };
+
+async function stepHandler(input: GetTradesInput): Promise<GetTradesResult> {
+  if (!input.ownerAddress) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Missing ownerAddress for get-trades",
+      undefined,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return { success: false, error: "ownerAddress is required" };
+  }
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Unsupported network",
+      input.network,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Unsupported network: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const chainPath = COW_API_CHAIN_PATHS[chainId];
+  if (!chainPath) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[CoW Swap] Network not supported by CoW Swap API",
+      { chainId, network: input.network },
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME }
+    );
+    return {
+      success: false,
+      error: `Chain ID ${chainId} is not supported by the CoW Swap API`,
+    };
+  }
+
+  const url = `https://api.cow.fi/${chainPath}/api/v2/trades?owner=${encodeURIComponent(input.ownerAddress)}`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[CoW Swap] API error on get-trades",
+        { status: response.status, body: errorBody },
+        { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+      );
+      return {
+        success: false,
+        error: `CoW Swap API returned HTTP ${response.status}: ${errorBody}`,
+      };
+    }
+
+    const trades = (await response.json()) as unknown[];
+    return { success: true, trades, count: trades.length };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[CoW Swap] Error fetching trades",
+      error,
+      { plugin_name: PLUGIN_NAME, action_name: ACTION_NAME, service: "cow-api" }
+    );
+    return {
+      success: false,
+      error: `Failed to fetch trades: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+export async function getTradesStep(
+  input: GetTradesInput
+): Promise<GetTradesResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: PLUGIN_NAME,
+      actionName: ACTION_NAME,
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+export const _integrationType = "cowswap";

--- a/protocols/cowswap.ts
+++ b/protocols/cowswap.ts
@@ -236,5 +236,27 @@ export default defineProtocol({
         },
       ],
     },
+    {
+      slug: "create-conditional-order",
+      label: "Create Conditional Order",
+      description:
+        "Create a programmatic conditional order (TWAP, stop-loss) on ComposableCoW that will be automatically executed when conditions are met",
+      type: "write",
+      contract: "composableCow",
+      function: "create",
+      inputs: [
+        {
+          name: "params",
+          type: "bytes",
+          label:
+            "Conditional Order Params (ABI-encoded ConditionalOrderParams struct)",
+        },
+        {
+          name: "dispatch",
+          type: "bool",
+          label: "Dispatch (true to emit event for watchtower to pick up)",
+        },
+      ],
+    },
   ],
 });

--- a/scripts/seed/workflows/cowswap/api-actions.json
+++ b/scripts/seed/workflows/cowswap/api-actions.json
@@ -1,0 +1,79 @@
+{
+  "protocol": "cowswap",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "read",
+  "name": "Protocol Test: CoW Swap API Actions",
+  "description": "Tests CoW Swap off-chain API actions (get-quote, get-account-orders, get-trades)",
+  "nodes": [
+    {
+      "id": "node-1",
+      "type": "trigger",
+      "position": { "x": 100, "y": 200 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-quote",
+      "type": "action",
+      "position": { "x": 450, "y": 0 },
+      "data": {
+        "label": "Get Quote",
+        "description": "Get a swap quote: 1 WETH -> USDC on mainnet",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-quote",
+          "network": "1",
+          "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "buyToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "kind": "sell",
+          "amount": "1000000000000000000"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-account-orders",
+      "type": "action",
+      "position": { "x": 450, "y": 200 },
+      "data": {
+        "label": "Get Account Orders",
+        "description": "List orders for vitalik.eth on mainnet",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-account-orders",
+          "network": "1",
+          "ownerAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "limit": "5"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-trades",
+      "type": "action",
+      "position": { "x": 450, "y": 400 },
+      "data": {
+        "label": "Get Trades",
+        "description": "Get executed trades for vitalik.eth on mainnet",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-trades",
+          "network": "1",
+          "ownerAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e-trigger-to-get-quote", "source": "node-1", "target": "cowswap-get-quote", "type": "animated" },
+    { "id": "e-trigger-to-get-account-orders", "source": "node-1", "target": "cowswap-get-account-orders", "type": "animated" },
+    { "id": "e-trigger-to-get-trades", "source": "node-1", "target": "cowswap-get-trades", "type": "animated" }
+  ]
+}

--- a/scripts/seed/workflows/cowswap/read-actions.json
+++ b/scripts/seed/workflows/cowswap/read-actions.json
@@ -1,0 +1,125 @@
+{
+  "protocol": "cowswap",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "read",
+  "name": "Protocol Test: CoW Swap Read Actions",
+  "description": "Tests all CoW Swap on-chain read actions on Ethereum mainnet",
+  "nodes": [
+    {
+      "id": "node-1",
+      "type": "trigger",
+      "position": { "x": 100, "y": 300 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-domain-separator",
+      "type": "action",
+      "position": { "x": 450, "y": 0 },
+      "data": {
+        "label": "Get Domain Separator",
+        "description": "Returns the EIP-712 domain separator for this deployment",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-domain-separator",
+          "network": "1"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-vault-relayer",
+      "type": "action",
+      "position": { "x": 450, "y": 150 },
+      "data": {
+        "label": "Get Vault Relayer",
+        "description": "Returns the GPv2VaultRelayer address",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-vault-relayer",
+          "network": "1"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-filled-amount",
+      "type": "action",
+      "position": { "x": 450, "y": 300 },
+      "data": {
+        "label": "Get Order Fill Amount",
+        "description": "Check fill amount for a zero order UID",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-filled-amount",
+          "network": "1",
+          "orderUid": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-pre-signature",
+      "type": "action",
+      "position": { "x": 450, "y": 450 },
+      "data": {
+        "label": "Get Pre-Signature Status",
+        "description": "Check pre-signature for a zero order UID",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-pre-signature",
+          "network": "1",
+          "orderUid": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-check-single-order",
+      "type": "action",
+      "position": { "x": 450, "y": 600 },
+      "data": {
+        "label": "Check Conditional Order",
+        "description": "Check if a conditional order exists for the settlement contract",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/check-single-order",
+          "network": "1",
+          "owner": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
+          "orderHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "cowswap-get-cabinet",
+      "type": "action",
+      "position": { "x": 450, "y": 750 },
+      "data": {
+        "label": "Get Cabinet Value",
+        "description": "Read conditional order state from cabinet",
+        "type": "action",
+        "config": {
+          "actionType": "cowswap/get-cabinet",
+          "network": "1",
+          "owner": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e-trigger-to-get-domain-separator", "source": "node-1", "target": "cowswap-get-domain-separator", "type": "animated" },
+    { "id": "e-trigger-to-get-vault-relayer", "source": "node-1", "target": "cowswap-get-vault-relayer", "type": "animated" },
+    { "id": "e-trigger-to-get-filled-amount", "source": "node-1", "target": "cowswap-get-filled-amount", "type": "animated" },
+    { "id": "e-trigger-to-get-pre-signature", "source": "node-1", "target": "cowswap-get-pre-signature", "type": "animated" },
+    { "id": "e-trigger-to-check-single-order", "source": "node-1", "target": "cowswap-check-single-order", "type": "animated" },
+    { "id": "e-trigger-to-get-cabinet", "source": "node-1", "target": "cowswap-get-cabinet", "type": "animated" }
+  ]
+}

--- a/tests/unit/protocol-cowswap.test.ts
+++ b/tests/unit/protocol-cowswap.test.ts
@@ -78,8 +78,8 @@ describe("CoW Swap Protocol Definition", () => {
     }
   });
 
-  it("has exactly 9 actions", () => {
-    expect(cowswapDef.actions).toHaveLength(9);
+  it("has exactly 10 actions", () => {
+    expect(cowswapDef.actions).toHaveLength(10);
   });
 
   it("registers in the protocol registry and is retrievable", () => {
@@ -90,11 +90,11 @@ describe("CoW Swap Protocol Definition", () => {
     expect(retrieved?.name).toBe("CoW Swap");
   });
 
-  it("has 6 read actions and 3 write actions", () => {
+  it("has 6 read actions and 4 write actions", () => {
     const readActions = cowswapDef.actions.filter((a) => a.type === "read");
     const writeActions = cowswapDef.actions.filter((a) => a.type === "write");
     expect(readActions).toHaveLength(6);
-    expect(writeActions).toHaveLength(3);
+    expect(writeActions).toHaveLength(4);
   });
 
   it("has 2 contracts", () => {


### PR DESCRIPTION
## Summary

- Complete the CowSwap DEX integration so users can quote, place, monitor, and cancel orders through KeeperHub workflows -- the existing 9 on-chain actions only covered order management, not the core trading flow
- Adds 7 new actions (1 on-chain + 6 off-chain API) for a total of 16 CowSwap actions
- Includes seed workflows for repeatable protocol testing

## Changes

**On-chain (protocol definition):**
- `create-conditional-order`: Create TWAP/stop-loss orders via ComposableCoW

**Off-chain API (plugin injection, Safe plugin pattern):**
- `get-quote`: Fetch swap quotes from CoW Protocol orderbook
- `create-order`: Submit pre-signed orders to the orderbook
- `get-order-status`: Check order fill status by UID
- `cancel-order`: Cancel pending orders via API
- `get-account-orders`: List all orders for a wallet
- `get-trades`: Query executed trades for an address

No API key required -- CoW Protocol API is open.
Supported chains: Ethereum, Base, Arbitrum One, Optimism.

## Test plan

- [x] `pnpm check` passes (lint clean)
- [x] `pnpm type-check` passes (zero errors)
- [x] `pnpm discover-plugins` registers all 16 CowSwap actions
- [x] `protocol-cowswap.test.ts` passes (30 tests, updated action counts)
- [x] All 6 on-chain read actions verified via MCP tools on mainnet
- [x] get-quote returns valid quote (1 WETH = ~2164 USDC)
- [x] get-account-orders returns orders for known wallet
- [x] get-trades returns executed trades
- [x] get-order-status returns correct order data
- [x] cancel-order endpoint reachable (returns expected error for invalid input)
- [ ] Verify actions appear in deployed MCP schema endpoint