### PR TITLE
test(chronicle): add named feed seed workflows

### DIFF
--- a/scripts/seed/workflows/chronicle/mcp-test-mainnet-named-feeds.json
+++ b/scripts/seed/workflows/chronicle/mcp-test-mainnet-named-feeds.json
@@ -1,0 +1,160 @@
+{
+  "protocol": "chronicle",
+  "network": "1",
+  "networkName": "mainnet",
+  "type": "read",
+  "name": "MCP Test: Chronicle All Mainnet Named Feeds",
+  "description": "Test all 8 named feed read actions on mainnet: ETH/USD, BTC/USD, USDC/USD, USDT/USD (read + readWithAge each)",
+  "nodes": [
+    {
+      "id": "trigger-1",
+      "type": "trigger",
+      "position": { "x": 50, "y": 400 },
+      "data": {
+        "type": "trigger",
+        "label": "Manual Trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle",
+        "description": "Run manually"
+      }
+    },
+    {
+      "id": "eth-read",
+      "type": "action",
+      "position": { "x": 350, "y": 50 },
+      "data": {
+        "type": "action",
+        "label": "ETH/USD Read",
+        "description": "Read ETH/USD price from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/eth-usd-read",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"ethUsd\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "eth-age",
+      "type": "action",
+      "position": { "x": 350, "y": 150 },
+      "data": {
+        "type": "action",
+        "label": "ETH/USD Read with Age",
+        "description": "Read ETH/USD price with timestamp from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/eth-usd-read-with-age",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"ethUsd\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "btc-read",
+      "type": "action",
+      "position": { "x": 350, "y": 250 },
+      "data": {
+        "type": "action",
+        "label": "BTC/USD Read",
+        "description": "Read BTC/USD price from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/btc-usd-read",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"btcUsd\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "btc-age",
+      "type": "action",
+      "position": { "x": 350, "y": 350 },
+      "data": {
+        "type": "action",
+        "label": "BTC/USD Read with Age",
+        "description": "Read BTC/USD price with timestamp from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/btc-usd-read-with-age",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"btcUsd\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "usdc-read",
+      "type": "action",
+      "position": { "x": 350, "y": 450 },
+      "data": {
+        "type": "action",
+        "label": "USDC/USD Read",
+        "description": "Read USDC/USD price from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/usdc-usd-read",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"usdcUsd\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "usdc-age",
+      "type": "action",
+      "position": { "x": 350, "y": 550 },
+      "data": {
+        "type": "action",
+        "label": "USDC/USD Read with Age",
+        "description": "Read USDC/USD price with timestamp from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/usdc-usd-read-with-age",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"usdcUsd\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "usdt-read",
+      "type": "action",
+      "position": { "x": 350, "y": 650 },
+      "data": {
+        "type": "action",
+        "label": "USDT/USD Read",
+        "description": "Read USDT/USD price from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/usdt-usd-read",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"usdtUsd\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "usdt-age",
+      "type": "action",
+      "position": { "x": 350, "y": 750 },
+      "data": {
+        "type": "action",
+        "label": "USDT/USD Read with Age",
+        "description": "Read USDT/USD price with timestamp from Chronicle mainnet oracle",
+        "config": {
+          "actionType": "chronicle/usdt-usd-read-with-age",
+          "network": "1",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"usdtUsd\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger-1", "target": "eth-read" },
+    { "id": "e2", "source": "trigger-1", "target": "eth-age" },
+    { "id": "e3", "source": "trigger-1", "target": "btc-read" },
+    { "id": "e4", "source": "trigger-1", "target": "btc-age" },
+    { "id": "e5", "source": "trigger-1", "target": "usdc-read" },
+    { "id": "e6", "source": "trigger-1", "target": "usdc-age" },
+    { "id": "e7", "source": "trigger-1", "target": "usdt-read" },
+    { "id": "e8", "source": "trigger-1", "target": "usdt-age" }
+  ]
+}

--- a/scripts/seed/workflows/chronicle/mcp-test-sepolia-named-feeds.json
+++ b/scripts/seed/workflows/chronicle/mcp-test-sepolia-named-feeds.json
@@ -1,0 +1,92 @@
+{
+  "protocol": "chronicle",
+  "network": "11155111",
+  "networkName": "sepolia",
+  "type": "read",
+  "name": "MCP Test: Chronicle Sepolia-Only Named Feeds",
+  "description": "Test all 4 Sepolia-only named feed read actions: DAI/USD and LINK/USD (read + readWithAge each)",
+  "nodes": [
+    {
+      "id": "trigger-1",
+      "type": "trigger",
+      "position": { "x": 50, "y": 250 },
+      "data": {
+        "type": "trigger",
+        "label": "Manual Trigger",
+        "config": { "triggerType": "Manual" },
+        "status": "idle",
+        "description": "Run manually"
+      }
+    },
+    {
+      "id": "dai-read",
+      "type": "action",
+      "position": { "x": 350, "y": 100 },
+      "data": {
+        "type": "action",
+        "label": "DAI/USD Read",
+        "description": "Read DAI/USD price from Chronicle Sepolia oracle",
+        "config": {
+          "actionType": "chronicle/dai-usd-read",
+          "network": "11155111",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"daiUsd\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "dai-age",
+      "type": "action",
+      "position": { "x": 350, "y": 250 },
+      "data": {
+        "type": "action",
+        "label": "DAI/USD Read with Age",
+        "description": "Read DAI/USD price with timestamp from Chronicle Sepolia oracle",
+        "config": {
+          "actionType": "chronicle/dai-usd-read-with-age",
+          "network": "11155111",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"daiUsd\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "link-read",
+      "type": "action",
+      "position": { "x": 350, "y": 400 },
+      "data": {
+        "type": "action",
+        "label": "LINK/USD Read",
+        "description": "Read LINK/USD price from Chronicle Sepolia oracle",
+        "config": {
+          "actionType": "chronicle/link-usd-read",
+          "network": "11155111",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"linkUsd\",\"functionName\":\"read\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    },
+    {
+      "id": "link-age",
+      "type": "action",
+      "position": { "x": 350, "y": 550 },
+      "data": {
+        "type": "action",
+        "label": "LINK/USD Read with Age",
+        "description": "Read LINK/USD price with timestamp from Chronicle Sepolia oracle",
+        "config": {
+          "actionType": "chronicle/link-usd-read-with-age",
+          "network": "11155111",
+          "_protocolMeta": "{\"protocolSlug\":\"chronicle\",\"contractKey\":\"linkUsd\",\"functionName\":\"readWithAge\",\"actionType\":\"read\"}"
+        },
+        "status": "idle"
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger-1", "target": "dai-read" },
+    { "id": "e2", "source": "trigger-1", "target": "dai-age" },
+    { "id": "e3", "source": "trigger-1", "target": "link-read" },
+    { "id": "e4", "source": "trigger-1", "target": "link-age" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Complete the Chronicle seed workflow coverage so `/test-protocol chronicle` can exercise all 17 actions without manual workflow creation
- Adds mainnet named feeds (ETH/USD, BTC/USD, USDC/USD, USDT/USD) and Sepolia-only feeds (DAI/USD, LINK/USD), complementing the existing custom oracle, self-kiss, and cross-protocol seeds from #602

## Test Plan
- [ ] Verify seed files are valid JSON and load without errors
- [ ] `/test-protocol chronicle` passes all 16 read actions and correctly skips the write action (wallet auth)