### PR TITLE
fix: KEEP-1587 correct executor DATABASE_URL parameter path

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -49,8 +49,8 @@ args:
 env:
   DATABASE_URL:
     type: parameterStore
-    name: database-url
-    parameter_name: /eks/techops-prod/keeperhub/database-url
+    name: db-url
+    parameter_name: /eks/techops-prod/keeperhub/db-url
   INTEGRATION_ENCRYPTION_KEY:
     type: parameterStore
     name: integration-encryption-key

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -49,8 +49,8 @@ args:
 env:
   DATABASE_URL:
     type: parameterStore
-    name: database-url
-    parameter_name: /eks/techops-staging/keeperhub/database-url
+    name: db-url
+    parameter_name: /eks/techops-staging/keeperhub/db-url
   INTEGRATION_ENCRYPTION_KEY:
     type: parameterStore
     name: integration-encryption-key


### PR DESCRIPTION
## Summary

- Fix executor deploy failure caused by referencing non-existent SSM parameter
- Change `database-url` to `db-url` in both staging and prod executor values
- The parameter `/eks/techops-{env}/keeperhub/db-url` already exists and is used by the main app

## Context

The executor deploy timed out because the ExternalSecret for `database-url` could not find the SSM parameter at `/eks/techops-staging/keeperhub/database-url`. The actual parameter is at `/eks/techops-staging/keeperhub/db-url`, matching the main app's configuration.

Error from staging:
```
error retrieving secret at .data[0], key: /eks/techops-staging/keeperhub/database-url, err: Secret does not exist
```