### PR TITLE
fix: clear stale Redis container state on event-tracker startup

### DIFF
--- a/keeperhub-events/event-tracker/src/index.ts
+++ b/keeperhub-events/event-tracker/src/index.ts
@@ -7,6 +7,9 @@ logger.log(`Initializing container: ${os.hostname()}`);
 
 const initialize = async (): Promise<void> => {
   try {
+    await syncModule.removeAllContainers();
+    logger.log("Cleared stale Redis state from previous deploys");
+
     await syncModule.registerContainer();
     await synchronizeData();
 


### PR DESCRIPTION
## Summary

- On redeploy, orphaned Redis container/process keys from the previous instance caused `isWorkflowAlreadyRunningInAnotherContainer()` to return true, preventing the new container from picking up event-triggered workflows
- Calls `removeAllContainers()` on startup before registering the new container, clearing stale state scoped by `NODE_ENV` so staging and prod don't interfere with each other