### PR TITLE
fix: increase event-tracker prod memory limit

### DIFF
--- a/deploy/event-tracker/prod/values.yaml
+++ b/deploy/event-tracker/prod/values.yaml
@@ -29,10 +29,10 @@ podAnnotations:
 
 resources:
   limits:
-    memory: 512Mi
+    memory: 1Gi
   requests:
     cpu: 50m
-    memory: 128Mi
+    memory: 256Mi
 
 env:
   NODE_ENV:


### PR DESCRIPTION
## Summary

- Event-tracker pod was getting OOMKilled in prod with 512Mi memory limit
- Each event-triggered workflow spawns a child node process (~50-100MB each), quickly exceeding the limit
- Bumps memory limit to 1Gi and requests to 256Mi