### PR TITLE
feat: add Streamable HTTP MCP endpoint with OAuth, rate limiting, and tool annotations

### DIFF
--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: playwright-cli
+description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+playwright-cli fill e5 "user@example.com"
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli snapshot --filename=after-click.yaml
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start
+playwright-cli video-stop video.webm
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+# Connect to browser via extension
+playwright-cli open --extension
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command.
+
+If `--filename` is not provided, a new snapshot file is created with a timestamp. Default to automatic file naming, use `--filename=` when artifact is a part of the workflow result.
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Local installation
+
+In some cases user might want to install playwright-cli locally. If running globally available `playwright-cli` binary fails, use `npx playwright-cli` to run the commands. For example:
+
+```bash
+npx playwright-cli open https://example.com
+npx playwright-cli click e1
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)

--- a/.claude/skills/playwright-cli/references/request-mocking.md
+++ b/.claude/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.claude/skills/playwright-cli/references/running-code.md
+++ b/.claude/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,232 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.loading', { state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.result', { timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.click('.maybe-missing', { timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.fill('input[name=email]', 'user@example.com');
+  await page.fill('input[name=password]', 'secret');
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.claude/skills/playwright-cli/references/session-management.md
+++ b/.claude/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,169 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.claude/skills/playwright-cli/references/storage-state.md
+++ b/.claude/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.claude/skills/playwright-cli/references/test-generation.md
+++ b/.claude/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,88 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test:
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertion
+await expect(page.getByText('Success')).toBeVisible();
+```

--- a/.claude/skills/playwright-cli/references/tracing.md
+++ b/.claude/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.claude/skills/playwright-cli/references/video-recording.md
+++ b/.claude/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,43 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Start recording
+playwright-cli video-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop demo.webm
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-stop recordings/login-flow-2024-01-15.webm
+playwright-cli video-stop recordings/checkout-test-run-42.webm
+```
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.github/workflows/hotfix-deploy.yml
+++ b/.github/workflows/hotfix-deploy.yml
@@ -1,0 +1,28 @@
+# Type: standalone | Manual emergency deploy: build -> deploy, no e2e.
+# Use when you need to push a fix to prod (or staging) ASAP.
+# Build step is included but skips automatically if images already exist for the SHA.
+#
+# How to use:
+#   1. Go to Actions > Hotfix Deploy > Run workflow
+#   2. Select the branch (prod or staging) -- this determines the target environment
+#   3. Click "Run workflow"
+name: Hotfix Deploy
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-images:
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+
+  deploy:
+    needs: [build-images]
+    uses: ./.github/workflows/deploy-keeperhub.yaml
+    with:
+      image_tag: ${{ needs.build-images.outputs.image_tag }}
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ tailwindcss-*.log
 .claude/worktrees/
 
 # Playwright MCP screenshots
+.playwright/
+.playwright-cli/
 .playwright-mcp/
 
 # Local reports

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { flattenConfigFields, getAllIntegrations } from "@/plugins/registry";
 import { withToolLogging } from "./logging";
@@ -108,6 +109,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org. The API key creator must be a member of the target org."
         ),
     },
+    { title: "List Workflows", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("list_workflows", scope, async (args) =>
       withToolLogging("list_workflows", args.organizationId, async () => {
         const params = new URLSearchParams();
@@ -146,6 +148,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org."
         ),
     },
+    { title: "Get Workflow", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("get_workflow", scope, async (args) =>
       withToolLogging("get_workflow", args.organizationId, async () => {
         const data = await callApi(
@@ -193,6 +196,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org."
         ),
     },
+    { title: "Create Workflow", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("create_workflow", scope, async (args) =>
       withToolLogging("create_workflow", args.organizationId, async () => {
         const data = await callApi(
@@ -249,6 +253,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org."
         ),
     },
+    { title: "Update Workflow", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("update_workflow", scope, async (args) =>
       withToolLogging("update_workflow", args.organizationId, async () => {
         const { workflowId, organizationId, ...body } = args;
@@ -279,6 +284,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org."
         ),
     },
+    { title: "Delete Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("delete_workflow", scope, async (args) =>
       withToolLogging("delete_workflow", args.organizationId, async () => {
         const data = await callApi(
@@ -316,6 +322,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org. Use this to execute workflows under a different org's context (wallet, settings)."
         ),
     },
+    { title: "Execute Workflow", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("execute_workflow", scope, async (args) =>
       withToolLogging("execute_workflow", args.organizationId, async () => {
         const data = await callApi(
@@ -341,6 +348,11 @@ export function registerTools(
         .string()
         .describe("The execution ID returned by execute_workflow"),
     },
+    {
+      title: "Get Execution Status",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
     withScopeCheck("get_execution_status", scope, async (args) =>
       withToolLogging("get_execution_status", undefined, async () => {
         const data = await callApi(
@@ -362,6 +374,7 @@ export function registerTools(
     {
       executionId: z.string().describe("The execution ID to fetch logs for"),
     },
+    { title: "Get Execution Logs", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("get_execution_logs", scope, async (args) =>
       withToolLogging("get_execution_logs", undefined, async () => {
         const data = await callApi(
@@ -394,6 +407,11 @@ export function registerTools(
         .string()
         .optional()
         .describe("Additional context or constraints for the AI generator"),
+    },
+    {
+      title: "AI Generate Workflow",
+      readOnlyHint: true,
+      destructiveHint: false,
     },
     withScopeCheck("ai_generate_workflow", scope, async (args) =>
       withToolLogging("ai_generate_workflow", undefined, async () => {
@@ -432,6 +450,11 @@ export function registerTools(
           "Whether to include supported blockchain networks (default: true)"
         ),
     },
+    {
+      title: "List Action Schemas",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
     withScopeCheck("list_action_schemas", scope, async (args) =>
       withToolLogging("list_action_schemas", undefined, async () => {
         const params = new URLSearchParams();
@@ -461,6 +484,7 @@ export function registerTools(
           "Category to filter by (e.g., 'web3', 'discord', 'sendgrid', 'system', 'triggers')"
         ),
     },
+    { title: "Search Plugins", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("search_plugins", scope, async (args) =>
       withToolLogging("search_plugins", undefined, async () => {
         const params = new URLSearchParams({ category: args.category });
@@ -487,6 +511,7 @@ export function registerTools(
           "Plugin type identifier (e.g., 'web3', 'discord', 'sendgrid')"
         ),
     },
+    { title: "Get Plugin", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("get_plugin", scope, async (args) =>
       withToolLogging("get_plugin", undefined, async () => {
         const params = new URLSearchParams({ category: args.pluginType });
@@ -514,6 +539,7 @@ export function registerTools(
           "Optional organization ID to override the API key's default org."
         ),
     },
+    { title: "List Integrations", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("list_integrations", scope, async (args) =>
       withToolLogging("list_integrations", args.organizationId, async () => {
         const data = await callApi(
@@ -542,6 +568,11 @@ export function registerTools(
         .describe(
           "Optional organization ID to override the API key's default org."
         ),
+    },
+    {
+      title: "Get Wallet Integration",
+      readOnlyHint: true,
+      destructiveHint: false,
     },
     withScopeCheck("get_wallet_integration", scope, async (args) =>
       withToolLogging(
@@ -578,6 +609,7 @@ export function registerTools(
         .describe("Search query to find relevant templates"),
       category: z.string().optional().describe("Filter templates by category"),
     },
+    { title: "Search Templates", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("search_templates", scope, async (args) =>
       withToolLogging("search_templates", undefined, async () => {
         const params = new URLSearchParams();
@@ -603,6 +635,7 @@ export function registerTools(
     {
       templateId: z.string().describe("The template workflow ID"),
     },
+    { title: "Get Template", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("get_template", scope, async (args) =>
       withToolLogging("get_template", undefined, async () => {
         const data = await callApi(
@@ -628,6 +661,7 @@ export function registerTools(
         .optional()
         .describe("Optional name for the cloned workflow"),
     },
+    { title: "Deploy Template", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("deploy_template", scope, async (args) =>
       withToolLogging("deploy_template", undefined, async () => {
         const data = await callApi(
@@ -652,6 +686,11 @@ export function registerTools(
     "tools_documentation",
     "Get documentation on how to use the KeeperHub MCP tools, including examples and best practices for workflow creation.",
     {},
+    {
+      title: "Tools Documentation",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
     withScopeCheck("tools_documentation", scope, (_args) =>
       withToolLogging("tools_documentation", undefined, () => {
         const text = [
@@ -702,6 +741,62 @@ export function registerTools(
 // Dynamic tool registration from plugin registry
 // =============================================================================
 
+const READ_ONLY_PATTERNS = [
+  "read",
+  "get",
+  "list",
+  "check",
+  "query",
+  "balance",
+  "events",
+  "monitor",
+  "fetch",
+  "decode",
+  "assess",
+  "status",
+  "pending",
+] as const;
+
+const DESTRUCTIVE_PATTERNS = [
+  "delete",
+  "remove",
+  "revoke",
+  "transfer",
+  "write",
+  "approve",
+  "send",
+  "execute",
+  "swap",
+  "cancel",
+  "publish",
+  "create",
+  "run",
+  "generate",
+  "update",
+] as const;
+
+function deriveAnnotations(slug: string): ToolAnnotations {
+  const normalized = slug.toLowerCase();
+
+  const isReadOnly = READ_ONLY_PATTERNS.some((p) => normalized.includes(p));
+  if (isReadOnly) {
+    return { readOnlyHint: true, destructiveHint: false };
+  }
+
+  const isDestructive = DESTRUCTIVE_PATTERNS.some((p) =>
+    normalized.includes(p)
+  );
+  if (isDestructive) {
+    return { readOnlyHint: false, destructiveHint: true };
+  }
+
+  return { readOnlyHint: false, destructiveHint: false };
+}
+
+function slugToTitle(slug: string): string {
+  return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function slugToToolName(integration: string, slug: string): string {
   const combined = `${integration}_${slug}`;
   return combined.replace(/[\s/-]/g, "_");
@@ -739,11 +834,16 @@ export function registerDynamicTools(
       const integration = plugin.type;
       const slug = action.slug;
       const description = action.description;
+      const annotations: ToolAnnotations = {
+        title: slugToTitle(slug),
+        ...deriveAnnotations(slug),
+      };
 
       server.tool(
         toolName,
         description,
         inputSchema,
+        annotations,
         withScopeCheck(toolName, scope, async (args) => {
           const { organizationId, ...fieldArgs } = args as Record<
             string,

--- a/specs/mcp-http/UAT-v1.md
+++ b/specs/mcp-http/UAT-v1.md
@@ -1,0 +1,309 @@
+# UAT v1: Minimal Viable HTTP MCP
+
+## Version Scope
+
+v1 covers the foundational HTTP MCP endpoint at `POST https://app.keeperhub.com/mcp`. This version validates protocol compliance with the MCP HTTP transport specification, authentication via `kh_` API keys, session management, tool listing, core workflow CRUD tools, read-only Web3 tools, error handling, and basic client integration with Claude Code and Cursor.
+
+All tools are invoked through JSON-RPC `tools/call` requests over the HTTP transport. No SSE streaming, no OAuth, no write Web3 operations in this version.
+
+---
+
+## 1. Protocol Compliance
+
+- [ ] **TC-01: Initialize handshake**
+  - Precondition: Valid `kh_` API key available
+  - Steps: Send `POST /mcp` with JSON-RPC `initialize` method containing `clientInfo` and `protocolVersion`
+  - Expected: Response contains `serverInfo` with server name/version, `protocolVersion`, and `capabilities` object. HTTP 200.
+
+- [ ] **TC-02: Mcp-Session-Id header returned on initialize**
+  - Precondition: None
+  - Steps: Send `initialize` request to `POST /mcp`
+  - Expected: Response includes `Mcp-Session-Id` header with a unique session identifier string
+
+- [ ] **TC-03: Subsequent requests require Mcp-Session-Id**
+  - Precondition: Completed initialize handshake, have session ID
+  - Steps: Send `tools/list` request without `Mcp-Session-Id` header
+  - Expected: HTTP 400 or JSON-RPC error indicating missing session header
+
+- [ ] **TC-04: Subsequent requests with valid Mcp-Session-Id succeed**
+  - Precondition: Completed initialize handshake, have session ID
+  - Steps: Send `tools/list` request with valid `Mcp-Session-Id` header
+  - Expected: HTTP 200 with valid JSON-RPC response containing tool list
+
+- [ ] **TC-05: JSON-RPC format validation**
+  - Precondition: Valid session
+  - Steps: Send request with missing `jsonrpc` field, missing `method` field, and invalid `id` type
+  - Expected: Each returns JSON-RPC error with appropriate error code (-32600 Invalid Request)
+
+- [ ] **TC-06: Content-Type negotiation**
+  - Precondition: Valid session
+  - Steps: Send request with `Content-Type: application/json`. Then send with `Content-Type: text/plain`
+  - Expected: `application/json` accepted and processed. `text/plain` rejected with HTTP 415 or appropriate error.
+
+- [ ] **TC-07: JSON-RPC batch requests**
+  - Precondition: Valid session
+  - Steps: Send a JSON-RPC batch array containing two valid `tools/call` requests
+  - Expected: Response is a JSON-RPC batch array with two results, each matching the corresponding request ID
+
+- [ ] **TC-08: JSON-RPC notification (no id field)**
+  - Precondition: Valid session
+  - Steps: Send a valid JSON-RPC request without an `id` field (notification)
+  - Expected: Server processes the notification. No response body returned (or HTTP 204).
+
+---
+
+## 2. Authentication
+
+- [ ] **TC-09: Valid kh_ API key accepted**
+  - Precondition: Active `kh_` API key for an org
+  - Steps: Send `initialize` with `Authorization: Bearer kh_abc123...`
+  - Expected: HTTP 200, successful initialize response with session ID
+
+- [ ] **TC-10: Invalid kh_ API key rejected**
+  - Precondition: None
+  - Steps: Send `initialize` with `Authorization: Bearer kh_invalid_garbage`
+  - Expected: HTTP 401 Unauthorized with JSON-RPC error
+
+- [ ] **TC-11: Expired kh_ API key rejected**
+  - Precondition: A `kh_` key that has been revoked or expired
+  - Steps: Send `initialize` with the expired key
+  - Expected: HTTP 401 Unauthorized with JSON-RPC error
+
+- [ ] **TC-12: Missing Authorization header**
+  - Precondition: None
+  - Steps: Send `initialize` without any `Authorization` header
+  - Expected: HTTP 401 Unauthorized
+
+- [ ] **TC-13: Wrong auth prefix rejected**
+  - Precondition: None
+  - Steps: Send `initialize` with `Authorization: Basic kh_abc123...`
+  - Expected: HTTP 401 Unauthorized
+
+- [ ] **TC-14: Key scoped to correct org**
+  - Precondition: Two orgs (OrgA, OrgB) with separate API keys
+  - Steps: Initialize with OrgA key. Call `workflow_list`.
+  - Expected: Only OrgA workflows returned. No OrgB data leaks.
+
+---
+
+## 3. Session Management
+
+- [ ] **TC-15: Session created on initialize**
+  - Precondition: Valid API key
+  - Steps: Send `initialize` request
+  - Expected: `Mcp-Session-Id` header present in response. Session is usable for subsequent requests.
+
+- [ ] **TC-16: Session reuse across multiple requests**
+  - Precondition: Active session
+  - Steps: Send `tools/list`, then `tools/call` for `workflow_list`, both with the same session ID
+  - Expected: Both succeed. No need to re-initialize.
+
+- [ ] **TC-17: Session timeout after 30 minutes of inactivity**
+  - Precondition: Active session
+  - Steps: Wait 30+ minutes without sending any request. Then send `tools/list` with the session ID.
+  - Expected: HTTP 400 or JSON-RPC error indicating session expired/not found. Client must re-initialize.
+
+- [ ] **TC-18: Session terminated via DELETE**
+  - Precondition: Active session
+  - Steps: Send `DELETE /mcp` with `Mcp-Session-Id` header
+  - Expected: HTTP 200 or 204. Subsequent requests with that session ID fail.
+
+- [ ] **TC-19: Max sessions per org enforced**
+  - Precondition: Know the max sessions limit (e.g., 10)
+  - Steps: Initialize sessions up to the limit + 1
+  - Expected: The request exceeding the limit returns an error (HTTP 429 or JSON-RPC error indicating session limit reached)
+
+- [ ] **TC-20: Stale session ID from different key rejected**
+  - Precondition: Two valid API keys for same org
+  - Steps: Initialize with KeyA, get SessionA. Send `tools/list` using KeyB but SessionA's ID.
+  - Expected: Error. Session is bound to the key/auth that created it.
+
+---
+
+## 4. Tool Listing
+
+- [ ] **TC-21: tools/list returns all registered tools**
+  - Precondition: Active session
+  - Steps: Send `tools/list` request
+  - Expected: Response contains an array of tool objects. Each has `name`, `description`, and `inputSchema`.
+
+- [ ] **TC-22: Workflow tools present in listing**
+  - Precondition: Active session
+  - Steps: Send `tools/list`, inspect tool names
+  - Expected: Contains `workflow_list`, `workflow_get`, `workflow_create`, `workflow_update`, `workflow_delete`, `workflow_execute`, `execution_status`, `execution_logs`
+
+- [ ] **TC-23: Web3 read tools present in listing**
+  - Precondition: Active session
+  - Steps: Send `tools/list`, inspect tool names
+  - Expected: Contains `web3_check-balance`, `web3_read-contract`, `web3_check-token-balance`
+
+- [ ] **TC-24: AI generation tool present**
+  - Precondition: Active session
+  - Steps: Send `tools/list`, inspect tool names
+  - Expected: Contains `ai_generate_workflow` (or equivalent name)
+
+- [ ] **TC-25: Schema listing tool present**
+  - Precondition: Active session
+  - Steps: Send `tools/list`, inspect tool names
+  - Expected: Contains `list_action_schemas` (or equivalent name)
+
+- [ ] **TC-26: Tool inputSchema is valid JSON Schema**
+  - Precondition: Active session
+  - Steps: Send `tools/list`. For each tool, validate `inputSchema` is a valid JSON Schema object with `type`, `properties`, and `required` fields where applicable.
+  - Expected: All schemas pass JSON Schema validation
+
+- [ ] **TC-27: tools/list with pagination cursor**
+  - Precondition: Active session
+  - Steps: Send `tools/list` with a `cursor` parameter if the tool count exceeds a page size
+  - Expected: If pagination is supported, subsequent pages return remaining tools. If not paginated, all tools returned in one response.
+
+---
+
+## 5. Workflow Tools
+
+- [ ] **TC-28: workflow_list returns org workflows**
+  - Precondition: Active session, org has at least one workflow
+  - Steps: Call `tools/call` with `name: "workflow_list"`
+  - Expected: Response contains array of workflow summaries (id, name, status)
+
+- [ ] **TC-29: workflow_get retrieves single workflow**
+  - Precondition: Active session, known workflow ID
+  - Steps: Call `tools/call` with `name: "workflow_get"`, `arguments: { "id": "<workflow-id>" }`
+  - Expected: Response contains full workflow definition including trigger, steps, and configuration
+
+- [ ] **TC-30: workflow_create creates a new workflow**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "workflow_create"`, `arguments: { "name": "UAT Test Workflow", "trigger": { "type": "manual" }, "steps": [] }`
+  - Expected: Response contains the created workflow with a new ID. Subsequent `workflow_list` includes it.
+
+- [ ] **TC-31: workflow_update modifies an existing workflow**
+  - Precondition: Active session, workflow created in TC-30
+  - Steps: Call `tools/call` with `name: "workflow_update"`, `arguments: { "id": "<id>", "name": "UAT Test Workflow Updated" }`
+  - Expected: Response confirms update. `workflow_get` reflects the new name.
+
+- [ ] **TC-32: workflow_delete removes a workflow**
+  - Precondition: Active session, workflow created in TC-30
+  - Steps: Call `tools/call` with `name: "workflow_delete"`, `arguments: { "id": "<id>" }`
+  - Expected: Response confirms deletion. `workflow_list` no longer includes it. `workflow_get` returns not found.
+
+- [ ] **TC-33: workflow_execute triggers execution**
+  - Precondition: Active session, a valid workflow with manual trigger
+  - Steps: Call `tools/call` with `name: "workflow_execute"`, `arguments: { "id": "<workflow-id>" }`
+  - Expected: Response contains an execution ID
+
+- [ ] **TC-34: execution_status returns current state**
+  - Precondition: Execution triggered in TC-33
+  - Steps: Call `tools/call` with `name: "execution_status"`, `arguments: { "executionId": "<exec-id>" }`
+  - Expected: Response contains status (pending, running, completed, or failed) and timestamps
+
+- [ ] **TC-35: execution_logs returns step-level output**
+  - Precondition: Execution completed in TC-33
+  - Steps: Call `tools/call` with `name: "execution_logs"`, `arguments: { "executionId": "<exec-id>" }`
+  - Expected: Response contains array of log entries with step IDs, statuses, outputs, and timestamps
+
+- [ ] **TC-36: workflow_execute with invalid ID**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "workflow_execute"`, `arguments: { "id": "nonexistent-id" }`
+  - Expected: JSON-RPC error indicating workflow not found
+
+- [ ] **TC-37: AI workflow generation**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "ai_generate_workflow"`, `arguments: { "prompt": "Send me an email every day at 9am" }`
+  - Expected: Response contains a generated workflow definition with appropriate trigger and steps
+
+---
+
+## 6. Web3 Read Tools
+
+- [ ] **TC-38: check-balance returns native token balance**
+  - Precondition: Active session, known wallet address, known chain
+  - Steps: Call `tools/call` with `name: "web3_check-balance"`, `arguments: { "address": "0x...", "chain": "ethereum" }`
+  - Expected: Response contains balance as a string (in wei or human-readable with decimals)
+
+- [ ] **TC-39: read-contract calls a view function**
+  - Precondition: Active session, known contract with a view function
+  - Steps: Call `tools/call` with `name: "web3_read-contract"`, `arguments: { "address": "0x...", "chain": "ethereum", "functionName": "totalSupply", "abi": [...] }`
+  - Expected: Response contains the return value from the contract call
+
+- [ ] **TC-40: check-token-balance returns ERC20 balance**
+  - Precondition: Active session, known wallet, known ERC20 token
+  - Steps: Call `tools/call` with `name: "web3_check-token-balance"`, `arguments: { "walletAddress": "0x...", "tokenAddress": "0x...", "chain": "ethereum" }`
+  - Expected: Response contains token balance with symbol and decimals
+
+- [ ] **TC-41: Web3 read with invalid chain**
+  - Precondition: Active session
+  - Steps: Call `web3_check-balance` with `chain: "nonexistent-chain"`
+  - Expected: JSON-RPC error indicating unsupported or invalid chain
+
+- [ ] **TC-42: Web3 read with invalid address**
+  - Precondition: Active session
+  - Steps: Call `web3_check-balance` with `address: "not-an-address"`
+  - Expected: JSON-RPC error indicating invalid address format
+
+---
+
+## 7. Error Handling
+
+- [ ] **TC-43: Invalid tool name**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "nonexistent_tool"`
+  - Expected: JSON-RPC error with code -32602 or similar, message indicates tool not found
+
+- [ ] **TC-44: Missing required parameters**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "workflow_get"`, `arguments: {}` (missing required `id`)
+  - Expected: JSON-RPC error indicating missing required parameter
+
+- [ ] **TC-45: Malformed JSON-RPC body**
+  - Precondition: Valid auth header
+  - Steps: Send `POST /mcp` with body `{ "not": "valid jsonrpc" }`
+  - Expected: JSON-RPC error with code -32600 (Invalid Request)
+
+- [ ] **TC-46: Malformed JSON body**
+  - Precondition: Valid auth header
+  - Steps: Send `POST /mcp` with body `{broken json`
+  - Expected: JSON-RPC error with code -32700 (Parse error)
+
+- [ ] **TC-47: Rate limiting returns 429**
+  - Precondition: Active session
+  - Steps: Send rapid-fire requests exceeding the rate limit (e.g., 100 requests in 1 second)
+  - Expected: HTTP 429 with `Retry-After` header. JSON-RPC error in body.
+
+- [ ] **TC-48: Method not found**
+  - Precondition: Active session
+  - Steps: Send JSON-RPC request with `method: "nonexistent/method"`
+  - Expected: JSON-RPC error with code -32601 (Method not found)
+
+- [ ] **TC-49: Extra/unknown parameters handled gracefully**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "workflow_list"`, `arguments: { "unknownParam": "value" }`
+  - Expected: Either ignored gracefully or returns a clear validation error. No server crash.
+
+---
+
+## 8. Client Integration
+
+- [ ] **TC-50: Configure in Claude Code via HTTP transport**
+  - Precondition: Claude Code CLI installed, valid `kh_` API key
+  - Steps: Run `claude mcp add keeperhub --transport http https://app.keeperhub.com/mcp --header "Authorization: Bearer kh_..."`. Then start a conversation and ask Claude to list workflows.
+  - Expected: MCP server connects. `tools/list` populates tools. Claude can call `workflow_list` and return results.
+
+- [ ] **TC-51: Configure in Cursor via mcp-remote**
+  - Precondition: Cursor IDE installed, `mcp-remote` npm package, valid `kh_` API key
+  - Steps: Add MCP config in Cursor settings pointing to `https://app.keeperhub.com/mcp` with Bearer auth header. Open Cursor and verify tools panel.
+  - Expected: Tools appear in Cursor's MCP tool panel. Calling a tool (e.g., list workflows) returns data.
+
+- [ ] **TC-52: Tools appear and execute end-to-end in Claude Code**
+  - Precondition: Claude Code configured per TC-50
+  - Steps: Ask Claude to "create a workflow called MCP Test that runs on a manual trigger, then list all workflows, then delete the MCP Test workflow"
+  - Expected: Claude calls `workflow_create`, `workflow_list` (shows the new one), and `workflow_delete` in sequence. All succeed.
+
+- [ ] **TC-53: Session persists across multiple Claude Code turns**
+  - Precondition: Claude Code configured and connected
+  - Steps: In one conversation, ask Claude to list workflows. Then in a follow-up message, ask for details on one.
+  - Expected: Both requests succeed using the same MCP session. No re-initialization required between turns.
+
+- [ ] **TC-54: Client handles server error gracefully**
+  - Precondition: Claude Code configured and connected
+  - Steps: Ask Claude to get a workflow with an obviously invalid ID
+  - Expected: Claude receives the error from the MCP server and reports it to the user in natural language. No crash or hang.

--- a/specs/mcp-http/UAT-v2.md
+++ b/specs/mcp-http/UAT-v2.md
@@ -1,0 +1,244 @@
+# UAT v2: Full Tool Coverage + SSE
+
+## Version Scope
+
+v2 builds on all v1 test cases (protocol compliance, authentication, session management, tool listing, workflow tools, read-only Web3, error handling, client integration). This version adds write Web3 operations with spending cap enforcement, protocol-specific plugin tools (Aave, Uniswap, Lido, Compound, Morpho, and others), Server-Sent Events (SSE) streaming via `GET /mcp`, and MCP resources for workflow data access.
+
+**Prerequisites**: All v1 test cases (TC-01 through TC-54) pass before running v2 tests.
+
+---
+
+## 1. Write Web3 Tools
+
+- [ ] **TC-55: transfer-funds sends native token**
+  - Precondition: Active session, org wallet with test ETH on a testnet (e.g., Sepolia)
+  - Steps: Call `tools/call` with `name: "web3_transfer-funds"`, `arguments: { "to": "0x...", "amount": "0.001", "chain": "sepolia" }`
+  - Expected: Response contains transaction hash. Transaction confirms on-chain. Balance decreases accordingly.
+
+- [ ] **TC-56: transfer-token sends ERC20 token**
+  - Precondition: Active session, org wallet with test ERC20 tokens on testnet
+  - Steps: Call `tools/call` with `name: "web3_transfer-token"`, `arguments: { "to": "0x...", "tokenAddress": "0x...", "amount": "10", "chain": "sepolia" }`
+  - Expected: Response contains transaction hash. Token balance decreases for sender and increases for recipient.
+
+- [ ] **TC-57: write-contract executes a state-changing function**
+  - Precondition: Active session, known test contract with a write function on testnet
+  - Steps: Call `tools/call` with `name: "web3_write-contract"`, `arguments: { "address": "0x...", "chain": "sepolia", "functionName": "approve", "abi": [...], "args": ["0xspender", "1000000"] }`
+  - Expected: Response contains transaction hash. Contract state updated.
+
+- [ ] **TC-58: Write operation requires wallet configured**
+  - Precondition: Active session, org has no wallet configured
+  - Steps: Call `web3_transfer-funds`
+  - Expected: JSON-RPC error indicating no wallet available for the org/chain
+
+- [ ] **TC-59: Write tool with insufficient balance**
+  - Precondition: Active session, wallet with zero balance
+  - Steps: Call `web3_transfer-funds` with `amount: "1000"`
+  - Expected: JSON-RPC error indicating insufficient funds. No transaction submitted.
+
+---
+
+## 2. Spending Caps
+
+- [ ] **TC-60: Transfer within spending cap succeeds**
+  - Precondition: Active session, org spending cap set to 1 ETH per transaction
+  - Steps: Call `web3_transfer-funds` with `amount: "0.5"` (under cap)
+  - Expected: Transaction succeeds normally
+
+- [ ] **TC-61: Transfer exceeding spending cap rejected**
+  - Precondition: Active session, org spending cap set to 1 ETH per transaction
+  - Steps: Call `web3_transfer-funds` with `amount: "2.0"` (over cap)
+  - Expected: JSON-RPC error indicating spending cap exceeded. No transaction submitted.
+
+- [ ] **TC-62: Token transfer respects token-specific cap**
+  - Precondition: Active session, org has a USDC spending cap of 1000 USDC
+  - Steps: Call `web3_transfer-token` with USDC amount of 1500
+  - Expected: Rejected with spending cap error
+
+- [ ] **TC-63: write-contract respects value spending cap**
+  - Precondition: Active session, spending cap of 0.1 ETH
+  - Steps: Call `web3_write-contract` with `value: "500000000000000000"` (0.5 ETH, over cap)
+  - Expected: Rejected with spending cap error
+
+- [ ] **TC-64: Cumulative spending cap tracked**
+  - Precondition: Active session, org daily spending cap set to 2 ETH
+  - Steps: Call `web3_transfer-funds` with `amount: "1.5"` (succeeds). Then call again with `amount: "1.0"` (cumulative 2.5 ETH, over daily cap).
+  - Expected: First call succeeds. Second call rejected with daily spending cap error.
+
+- [ ] **TC-65: Spending cap not applied to read operations**
+  - Precondition: Active session, any spending cap configured
+  - Steps: Call `web3_check-balance` and `web3_read-contract`
+  - Expected: Both succeed without spending cap checks
+
+---
+
+## 3. Protocol Plugin Tools
+
+### Aave
+
+- [ ] **TC-66: Aave supply**
+  - Precondition: Active session, wallet with test tokens, Aave deployment on testnet
+  - Steps: Call `tools/call` with `name: "aave_supply"`, `arguments: { "asset": "0x...", "amount": "100", "chain": "sepolia" }`
+  - Expected: Response contains transaction hash. Aave position reflects supplied amount.
+
+- [ ] **TC-67: Aave borrow**
+  - Precondition: Active session, existing Aave supply position as collateral
+  - Steps: Call `tools/call` with `name: "aave_borrow"`, `arguments: { "asset": "0x...", "amount": "50", "chain": "sepolia", "interestRateMode": 2 }`
+  - Expected: Response contains transaction hash. Borrowed tokens received.
+
+- [ ] **TC-68: Aave repay**
+  - Precondition: Active session, existing Aave borrow position
+  - Steps: Call `tools/call` with `name: "aave_repay"`, `arguments: { "asset": "0x...", "amount": "25", "chain": "sepolia", "interestRateMode": 2 }`
+  - Expected: Response contains transaction hash. Borrow balance decreases.
+
+- [ ] **TC-69: Aave get-user-account-data (read)**
+  - Precondition: Active session, wallet with Aave position
+  - Steps: Call `tools/call` with `name: "aave_get-user-account-data"`, `arguments: { "address": "0x...", "chain": "sepolia" }`
+  - Expected: Response contains total collateral, total debt, available borrow, LTV, health factor
+
+### Uniswap
+
+- [ ] **TC-70: Uniswap swap-exact-input**
+  - Precondition: Active session, wallet with tokens, Uniswap pool exists on testnet
+  - Steps: Call `tools/call` with `name: "uniswap_swap-exact-input"`, `arguments: { "tokenIn": "0x...", "tokenOut": "0x...", "amountIn": "100", "chain": "sepolia" }`
+  - Expected: Response contains transaction hash. Input tokens spent, output tokens received.
+
+- [ ] **TC-71: Uniswap quote-exact-input (read)**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "uniswap_quote-exact-input"`, `arguments: { "tokenIn": "0x...", "tokenOut": "0x...", "amountIn": "100", "chain": "sepolia" }`
+  - Expected: Response contains expected output amount without executing a transaction
+
+- [ ] **TC-72: Uniswap get-pool (read)**
+  - Precondition: Active session
+  - Steps: Call `tools/call` with `name: "uniswap_get-pool"`, `arguments: { "tokenA": "0x...", "tokenB": "0x...", "fee": 3000, "chain": "ethereum" }`
+  - Expected: Response contains pool address and liquidity info
+
+### Lido
+
+- [ ] **TC-73: Lido wrap stETH to wstETH**
+  - Precondition: Active session, wallet with stETH
+  - Steps: Call `tools/call` with `name: "lido_wrap"`, `arguments: { "amount": "1.0", "chain": "ethereum" }`
+  - Expected: Response contains transaction hash. wstETH balance increases.
+
+- [ ] **TC-74: Lido unwrap wstETH to stETH**
+  - Precondition: Active session, wallet with wstETH
+  - Steps: Call `tools/call` with `name: "lido_unwrap"`, `arguments: { "amount": "1.0", "chain": "ethereum" }`
+  - Expected: Response contains transaction hash. stETH balance increases.
+
+- [ ] **TC-75: Lido get-wsteth-balance (read)**
+  - Precondition: Active session, known wallet
+  - Steps: Call `tools/call` with `name: "lido_get-wsteth-balance"`, `arguments: { "address": "0x...", "chain": "ethereum" }`
+  - Expected: Response contains wstETH balance
+
+### Compound
+
+- [ ] **TC-76: Compound supply**
+  - Precondition: Active session, wallet with tokens, Compound market on testnet
+  - Steps: Call `tools/call` with `name: "compound_supply"`, `arguments: { "asset": "0x...", "amount": "100", "chain": "sepolia" }`
+  - Expected: Response contains transaction hash
+
+- [ ] **TC-77: Compound get-balance (read)**
+  - Precondition: Active session, address with Compound position
+  - Steps: Call `tools/call` with `name: "compound_get-balance"`, `arguments: { "address": "0x...", "chain": "ethereum" }`
+  - Expected: Response contains supply balance
+
+- [ ] **TC-78: Compound withdraw**
+  - Precondition: Active session, existing Compound supply position
+  - Steps: Call `tools/call` with `name: "compound_withdraw"`, `arguments: { "asset": "0x...", "amount": "50", "chain": "sepolia" }`
+  - Expected: Response contains transaction hash. Supply balance decreases.
+
+### Morpho
+
+- [ ] **TC-79: Morpho supply**
+  - Precondition: Active session, wallet with tokens, valid Morpho market
+  - Steps: Call `tools/call` with `name: "morpho_supply"`, `arguments: { "marketId": "0x...", "amount": "100", "chain": "ethereum" }`
+  - Expected: Response contains transaction hash
+
+- [ ] **TC-80: Morpho borrow**
+  - Precondition: Active session, collateral supplied in Morpho
+  - Steps: Call `tools/call` with `name: "morpho_borrow"`, `arguments: { "marketId": "0x...", "amount": "50", "chain": "ethereum" }`
+  - Expected: Response contains transaction hash
+
+- [ ] **TC-81: Morpho get-position (read)**
+  - Precondition: Active session, address with Morpho position
+  - Steps: Call `tools/call` with `name: "morpho_get-position"`, `arguments: { "marketId": "0x...", "address": "0x...", "chain": "ethereum" }`
+  - Expected: Response contains supply shares, borrow shares, collateral amount
+
+- [ ] **TC-82: Morpho vault-deposit**
+  - Precondition: Active session, wallet with tokens, valid Morpho vault
+  - Steps: Call `tools/call` with `name: "morpho_vault-deposit"`, `arguments: { "vault": "0x...", "amount": "100", "chain": "ethereum" }`
+  - Expected: Response contains transaction hash
+
+### Protocol tool write operations respect spending caps
+
+- [ ] **TC-83: Protocol write tool respects spending cap**
+  - Precondition: Active session, spending cap of 0.1 ETH
+  - Steps: Call `aave_supply` with an amount that exceeds the cap in ETH value
+  - Expected: Rejected with spending cap error
+
+---
+
+## 4. SSE Stream
+
+- [ ] **TC-84: GET /mcp establishes SSE connection**
+  - Precondition: Active session with valid `Mcp-Session-Id`
+  - Steps: Send `GET /mcp` with `Accept: text/event-stream` and `Mcp-Session-Id` header
+  - Expected: HTTP 200 with `Content-Type: text/event-stream`. Connection stays open.
+
+- [ ] **TC-85: SSE receives execution progress notifications**
+  - Precondition: SSE connection established, then trigger a workflow execution via POST
+  - Steps: Call `workflow_execute` via POST. Monitor SSE stream.
+  - Expected: SSE stream delivers progress events (e.g., step started, step completed) as `data:` lines with JSON payloads
+
+- [ ] **TC-86: SSE event format compliance**
+  - Precondition: SSE connection receiving events
+  - Steps: Inspect raw SSE data
+  - Expected: Each event has `id:` field, `event:` type, and `data:` JSON payload. Follows SSE specification.
+
+- [ ] **TC-87: SSE connection closed on session DELETE**
+  - Precondition: SSE connection active
+  - Steps: Send `DELETE /mcp` with session ID
+  - Expected: SSE connection closes cleanly
+
+- [ ] **TC-88: SSE keepalive/ping events**
+  - Precondition: SSE connection established, no activity
+  - Steps: Wait and monitor SSE stream for 60 seconds
+  - Expected: Server sends periodic keepalive/ping comments (`:` lines or ping events) to prevent connection timeout
+
+- [ ] **TC-89: Multiple SSE connections to same session**
+  - Precondition: Active session
+  - Steps: Open two GET /mcp SSE connections with the same session ID
+  - Expected: Either both receive events, or the second connection is rejected with an appropriate error (depending on design)
+
+---
+
+## 5. Resources
+
+- [ ] **TC-90: List workflows resource**
+  - Precondition: Active session, org has workflows
+  - Steps: Send `resources/list` JSON-RPC request
+  - Expected: Response includes `keeperhub://workflows` resource with name and description
+
+- [ ] **TC-91: Read workflows list resource**
+  - Precondition: Active session
+  - Steps: Send `resources/read` with `uri: "keeperhub://workflows"`
+  - Expected: Response contains a list of workflow summaries (ID, name, status) as resource content
+
+- [ ] **TC-92: Read single workflow resource**
+  - Precondition: Active session, known workflow ID
+  - Steps: Send `resources/read` with `uri: "keeperhub://workflows/<workflow-id>"`
+  - Expected: Response contains the full workflow definition as resource content
+
+- [ ] **TC-93: Read nonexistent workflow resource**
+  - Precondition: Active session
+  - Steps: Send `resources/read` with `uri: "keeperhub://workflows/nonexistent-id"`
+  - Expected: JSON-RPC error indicating resource not found
+
+- [ ] **TC-94: Resource templates listed**
+  - Precondition: Active session
+  - Steps: Send `resources/templates/list` JSON-RPC request
+  - Expected: Response includes `keeperhub://workflows/{id}` template with `uriTemplate` field
+
+- [ ] **TC-95: Resources accessible from Claude Code**
+  - Precondition: Claude Code configured with MCP server
+  - Steps: Ask Claude to "read the workflow resource for workflow ID X"
+  - Expected: Claude accesses the resource and displays the workflow details

--- a/specs/mcp-http/UAT-v3.md
+++ b/specs/mcp-http/UAT-v3.md
@@ -1,0 +1,266 @@
+# UAT v3: OAuth 2.1
+
+## Version Scope
+
+v3 builds on all v1 and v2 test cases. This version adds full OAuth 2.1 support as the standard MCP authorization mechanism, including authorization server metadata discovery, dynamic client registration, the authorization code flow with PKCE, token exchange, token refresh, scoped permissions, and backward compatibility with existing `kh_` Bearer API keys.
+
+**Prerequisites**: All v1 test cases (TC-01 through TC-54) and v2 test cases (TC-55 through TC-95) pass before running v3 tests.
+
+---
+
+## 1. OAuth Discovery
+
+- [ ] **TC-96: Well-known metadata endpoint exists**
+  - Precondition: None
+  - Steps: Send `GET https://app.keeperhub.com/.well-known/oauth-authorization-server`
+  - Expected: HTTP 200 with `Content-Type: application/json`
+
+- [ ] **TC-97: Metadata contains required fields**
+  - Precondition: None
+  - Steps: Parse the response from TC-96
+  - Expected: JSON contains `issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `response_types_supported`, `grant_types_supported`, `code_challenge_methods_supported` (must include `S256`)
+
+- [ ] **TC-98: Issuer matches the server URL**
+  - Precondition: Metadata from TC-96
+  - Steps: Compare `issuer` field to `https://app.keeperhub.com`
+  - Expected: Values match exactly (no trailing slash discrepancy)
+
+- [ ] **TC-99: PKCE required (S256)**
+  - Precondition: Metadata from TC-96
+  - Steps: Check `code_challenge_methods_supported`
+  - Expected: Contains `S256`. Does not allow `plain` (or if it does, `S256` is listed and server enforces it)
+
+- [ ] **TC-100: Scopes documented in metadata**
+  - Precondition: Metadata from TC-96
+  - Steps: Check for `scopes_supported` field
+  - Expected: Lists available scopes (e.g., `workflows:read`, `workflows:write`, `web3:read`, `web3:write`, `plugins:*`, or equivalent)
+
+---
+
+## 2. Dynamic Client Registration
+
+- [ ] **TC-101: Register a new client**
+  - Precondition: Registration endpoint from metadata
+  - Steps: Send `POST /register` with `{ "client_name": "UAT Test Client", "redirect_uris": ["http://localhost:3000/callback"], "grant_types": ["authorization_code"], "response_types": ["code"], "token_endpoint_auth_method": "client_secret_basic" }`
+  - Expected: HTTP 201 with `client_id`, `client_secret`, and echoed registration fields
+
+- [ ] **TC-102: Client ID is unique per registration**
+  - Precondition: None
+  - Steps: Register two clients with the same `client_name`
+  - Expected: Each receives a distinct `client_id`
+
+- [ ] **TC-103: Missing required fields rejected**
+  - Precondition: None
+  - Steps: Send `POST /register` with `{}` (empty body)
+  - Expected: HTTP 400 with error indicating missing required fields (`redirect_uris` at minimum)
+
+- [ ] **TC-104: Invalid redirect_uri rejected**
+  - Precondition: None
+  - Steps: Send `POST /register` with `redirect_uris: ["javascript:alert(1)"]`
+  - Expected: HTTP 400 with error indicating invalid redirect URI
+
+- [ ] **TC-105: Registration returns token_endpoint_auth_method**
+  - Precondition: Successful registration
+  - Steps: Inspect registration response
+  - Expected: Contains `token_endpoint_auth_method` matching the requested value
+
+---
+
+## 3. Authorization Flow
+
+- [ ] **TC-106: Authorization endpoint redirects to consent page**
+  - Precondition: Registered client from TC-101
+  - Steps: Navigate browser to `GET /authorize?response_type=code&client_id=<id>&redirect_uri=http://localhost:3000/callback&scope=workflows:read+web3:read&state=random123&code_challenge=<S256_challenge>&code_challenge_method=S256`
+  - Expected: Server renders a consent/login page (or redirects to one) showing the requested scopes and client name
+
+- [ ] **TC-107: User approves consent, receives auth code**
+  - Precondition: Consent page displayed from TC-106, user is logged in
+  - Steps: User clicks "Approve" on the consent page
+  - Expected: Browser redirects to `http://localhost:3000/callback?code=<auth_code>&state=random123`
+
+- [ ] **TC-108: State parameter preserved in callback**
+  - Precondition: Authorization initiated with `state=random123`
+  - Steps: Inspect the callback redirect URL
+  - Expected: `state` query parameter equals `random123`
+
+- [ ] **TC-109: Auth code is single-use**
+  - Precondition: Auth code from TC-107
+  - Steps: Exchange the code for a token (TC-112). Then try to exchange the same code again.
+  - Expected: First exchange succeeds. Second exchange fails with `invalid_grant` error.
+
+- [ ] **TC-110: Authorization without PKCE rejected**
+  - Precondition: Registered client
+  - Steps: Send authorization request without `code_challenge` and `code_challenge_method` parameters
+  - Expected: Error response indicating PKCE is required
+
+- [ ] **TC-111: Authorization with mismatched redirect_uri rejected**
+  - Precondition: Registered client with `redirect_uris: ["http://localhost:3000/callback"]`
+  - Steps: Send authorization request with `redirect_uri=http://evil.com/callback`
+  - Expected: Error response. No redirect to the mismatched URI.
+
+---
+
+## 4. Token Exchange
+
+- [ ] **TC-112: Exchange auth code for tokens**
+  - Precondition: Auth code from TC-107, PKCE code_verifier
+  - Steps: Send `POST /token` with `grant_type=authorization_code&code=<auth_code>&redirect_uri=http://localhost:3000/callback&client_id=<id>&code_verifier=<verifier>`
+  - Expected: HTTP 200 with `access_token`, `token_type: "bearer"`, `expires_in`, `refresh_token`, and `scope`
+
+- [ ] **TC-113: Access token works for MCP initialize**
+  - Precondition: Access token from TC-112
+  - Steps: Send `POST /mcp` with `Authorization: Bearer <access_token>` and `initialize` method
+  - Expected: HTTP 200 with valid initialize response and `Mcp-Session-Id`
+
+- [ ] **TC-114: Access token works for tools/call**
+  - Precondition: Session from TC-113
+  - Steps: Call `tools/call` with `name: "workflow_list"`
+  - Expected: Response contains workflow list for the authorized org
+
+- [ ] **TC-115: Wrong code_verifier rejected**
+  - Precondition: Auth code from TC-107
+  - Steps: Send `POST /token` with an incorrect `code_verifier`
+  - Expected: HTTP 400 with `invalid_grant` error. No tokens issued.
+
+- [ ] **TC-116: Expired auth code rejected**
+  - Precondition: Auth code obtained, then wait for expiry (typically 10 minutes)
+  - Steps: Send `POST /token` with the expired code
+  - Expected: HTTP 400 with `invalid_grant` error
+
+- [ ] **TC-117: Token response does not include credentials in URL**
+  - Precondition: Successful token exchange
+  - Steps: Verify the token endpoint response
+  - Expected: Tokens are in the response body only, never in URL parameters or headers that could be logged
+
+---
+
+## 5. Token Refresh
+
+- [ ] **TC-118: Refresh token obtains new access token**
+  - Precondition: Refresh token from TC-112
+  - Steps: Send `POST /token` with `grant_type=refresh_token&refresh_token=<refresh_token>&client_id=<id>`
+  - Expected: HTTP 200 with new `access_token`, `expires_in`, and optionally a new `refresh_token`
+
+- [ ] **TC-119: Old access token invalid after refresh**
+  - Precondition: New access token from TC-118
+  - Steps: Use the old access token from TC-112 to call `POST /mcp` with `initialize`
+  - Expected: Either still works (if not rotated) or returns 401. Behavior should be documented.
+
+- [ ] **TC-120: Refresh token rotation (if supported)**
+  - Precondition: Refresh performed in TC-118 returned a new refresh_token
+  - Steps: Use the old refresh_token again
+  - Expected: Rejected. Old refresh token is invalidated after rotation.
+
+- [ ] **TC-121: Invalid refresh token rejected**
+  - Precondition: None
+  - Steps: Send `POST /token` with `grant_type=refresh_token&refresh_token=invalid_garbage`
+  - Expected: HTTP 400 with `invalid_grant` error
+
+- [ ] **TC-122: Refresh preserves scope**
+  - Precondition: Original token had `scope: "workflows:read web3:read"`
+  - Steps: Refresh the token. Inspect the new token's scope.
+  - Expected: New token has the same scope as the original
+
+---
+
+## 6. Scoped Permissions
+
+- [ ] **TC-123: Read-only scope cannot write**
+  - Precondition: OAuth token with scope `workflows:read` only
+  - Steps: Initialize MCP session. Call `workflow_create`.
+  - Expected: JSON-RPC error indicating insufficient permissions/scope
+
+- [ ] **TC-124: Read-only scope can read**
+  - Precondition: OAuth token with scope `workflows:read` only
+  - Steps: Initialize MCP session. Call `workflow_list`.
+  - Expected: Success. Returns workflow list.
+
+- [ ] **TC-125: Web3 read scope cannot write**
+  - Precondition: OAuth token with scope `web3:read` only
+  - Steps: Call `web3_transfer-funds`
+  - Expected: JSON-RPC error indicating insufficient permissions
+
+- [ ] **TC-126: Web3 read scope can read**
+  - Precondition: OAuth token with scope `web3:read` only
+  - Steps: Call `web3_check-balance`
+  - Expected: Success
+
+- [ ] **TC-127: Per-plugin scope restricts to specific plugins**
+  - Precondition: OAuth token with scope `plugins:aave` (only Aave tools authorized)
+  - Steps: Call `aave_get-user-account-data` (should work). Call `uniswap_swap-exact-input` (should fail).
+  - Expected: Aave read succeeds. Uniswap write rejected with insufficient scope.
+
+- [ ] **TC-128: Full scope grants all access**
+  - Precondition: OAuth token with all scopes
+  - Steps: Call `workflow_create`, `web3_transfer-funds`, `aave_supply`
+  - Expected: All succeed (subject to spending caps and other non-auth restrictions)
+
+- [ ] **TC-129: Requesting unknown scope**
+  - Precondition: Registered client
+  - Steps: Authorization request with `scope=nonexistent:scope`
+  - Expected: Error response indicating invalid scope, or scope silently dropped and not included in token
+
+- [ ] **TC-130: Scope downgrade on refresh not allowed**
+  - Precondition: Token with scope `workflows:read workflows:write`
+  - Steps: Refresh with `scope=workflows:read workflows:write web3:write` (requesting additional scope)
+  - Expected: Rejected or scope limited to original grant. Cannot escalate permissions via refresh.
+
+---
+
+## 7. OAuth + MCP Integration (End-to-End)
+
+- [ ] **TC-131: Full OAuth flow to tool call**
+  - Precondition: None (start from scratch)
+  - Steps:
+    1. Register client via `POST /register`
+    2. Initiate authorization with PKCE
+    3. User logs in and approves consent
+    4. Exchange auth code for tokens
+    5. Initialize MCP session with access token
+    6. Call `tools/list`
+    7. Call `tools/call` with `workflow_list`
+  - Expected: Every step succeeds. Workflow list returned at the end.
+
+- [ ] **TC-132: OAuth session survives token refresh**
+  - Precondition: Active MCP session from OAuth token
+  - Steps: Wait for access token to expire (or simulate). Refresh the token. Continue using the MCP session with the new token.
+  - Expected: MCP session continues without re-initialization. Alternatively, if session is invalidated, client can re-initialize with the new token.
+
+- [ ] **TC-133: Revoke OAuth token terminates MCP session**
+  - Precondition: Active MCP session from OAuth token, revocation endpoint available
+  - Steps: Revoke the access token. Then call `tools/list` with the MCP session.
+  - Expected: Request fails with auth error. Session is no longer valid.
+
+- [ ] **TC-134: Multiple OAuth clients with separate sessions**
+  - Precondition: Two registered OAuth clients for the same org
+  - Steps: Each client completes the OAuth flow and initializes a separate MCP session. Each calls `workflow_list`.
+  - Expected: Both succeed independently. Each has its own session. Data returned is for the same org.
+
+---
+
+## 8. Backward Compatibility
+
+- [ ] **TC-135: kh_ API keys still work after OAuth is enabled**
+  - Precondition: OAuth fully deployed, existing `kh_` API key
+  - Steps: Send `POST /mcp` with `Authorization: Bearer kh_...` and `initialize` method
+  - Expected: HTTP 200. Session created. All tools accessible as before.
+
+- [ ] **TC-136: kh_ key and OAuth token coexist**
+  - Precondition: One session with `kh_` key, another with OAuth token, both for the same org
+  - Steps: Both sessions call `workflow_list`
+  - Expected: Both return the same org's workflows. Sessions are independent.
+
+- [ ] **TC-137: kh_ key not subject to OAuth scopes**
+  - Precondition: `kh_` API key session
+  - Steps: Call `workflow_create`, `web3_transfer-funds`, and protocol tools
+  - Expected: All succeed. `kh_` keys have full access (scoping is OAuth-only). Subject to spending caps.
+
+- [ ] **TC-138: OAuth token format distinguishable from kh_ key**
+  - Precondition: Both token types available
+  - Steps: Server receives `Authorization: Bearer <token>`. Inspect server behavior.
+  - Expected: Server correctly identifies whether the token is a `kh_` key or an OAuth access token and routes authentication accordingly. No ambiguity.
+
+- [ ] **TC-139: Existing Claude Code kh_ configs unchanged**
+  - Precondition: Claude Code configured with `kh_` key (from v1 TC-50)
+  - Steps: After OAuth deployment, use Claude Code with the existing configuration
+  - Expected: Everything works exactly as before. No config changes needed.

--- a/specs/mcp-http/UAT-v4.md
+++ b/specs/mcp-http/UAT-v4.md
@@ -1,0 +1,290 @@
+# UAT v4: Production Hardening
+
+## Version Scope
+
+v4 builds on all v1, v2, and v3 test cases. This version focuses on production readiness: external session storage backed by Redis/Upstash, SSE resumability with `Last-Event-ID`, per-session and per-org rate limiting, structured logging and metrics, security hardening (DNS rebinding protection, CORS), load testing under concurrent sessions, and graceful degradation when backing services are unavailable.
+
+**Prerequisites**: All v1 test cases (TC-01 through TC-54), v2 test cases (TC-55 through TC-95), and v3 test cases (TC-96 through TC-139) pass before running v4 tests.
+
+---
+
+## 1. External Session Store
+
+- [ ] **TC-140: Sessions persist across pod restarts**
+  - Precondition: Active MCP session, Redis/Upstash backing store configured
+  - Steps: Initialize a session and call `tools/list` to confirm it works. Restart the application pod (e.g., `kubectl rollout restart`). Send `tools/list` with the same `Mcp-Session-Id`.
+  - Expected: Request succeeds. Session data survived the restart.
+
+- [ ] **TC-141: Session data stored in Redis**
+  - Precondition: Active session
+  - Steps: Inspect Redis keys (e.g., `redis-cli keys "mcp:session:*"`)
+  - Expected: Session key exists in Redis containing session metadata (org ID, auth info, creation time)
+
+- [ ] **TC-142: Session TTL set in Redis**
+  - Precondition: Active session
+  - Steps: Check TTL on the session key in Redis (`redis-cli ttl "mcp:session:<id>"`)
+  - Expected: TTL is approximately 1800 seconds (30 minutes) or matches the configured session timeout
+
+- [ ] **TC-143: Session TTL refreshed on activity**
+  - Precondition: Active session with known TTL
+  - Steps: Wait 10 minutes, then send a `tools/list` request. Check the TTL again.
+  - Expected: TTL reset to the full timeout duration (30 minutes), not the remaining time from before
+
+- [ ] **TC-144: Session DELETE removes from Redis**
+  - Precondition: Active session
+  - Steps: Send `DELETE /mcp` with session ID. Check Redis for the key.
+  - Expected: Key no longer exists in Redis
+
+- [ ] **TC-145: Multiple pods share session state**
+  - Precondition: Multiple application pods behind a load balancer, shared Redis
+  - Steps: Initialize a session hitting Pod A. Send subsequent requests that hit Pod B (different pod).
+  - Expected: All requests succeed. Session state is consistent regardless of which pod handles the request.
+
+---
+
+## 2. Resumability
+
+- [ ] **TC-146: SSE events include unique IDs**
+  - Precondition: SSE connection established, events flowing
+  - Steps: Inspect the raw SSE stream
+  - Expected: Each event has an `id:` field with a unique, monotonically increasing identifier
+
+- [ ] **TC-147: Client reconnects with Last-Event-ID**
+  - Precondition: SSE connection that received events with IDs, then disconnected
+  - Steps: Reconnect `GET /mcp` with `Last-Event-ID: <last-received-id>` header
+  - Expected: HTTP 200. Server resumes from after the specified event ID.
+
+- [ ] **TC-148: Missed events replayed on reconnect**
+  - Precondition: SSE connection dropped during active workflow execution
+  - Steps: Reconnect with `Last-Event-ID` set to the last event received before disconnect
+  - Expected: All events that occurred between the disconnect and reconnect are replayed in order before new events stream
+
+- [ ] **TC-149: Very old Last-Event-ID handled gracefully**
+  - Precondition: Event buffer has a limited retention window
+  - Steps: Reconnect with a `Last-Event-ID` from hours ago (beyond the buffer)
+  - Expected: Server either replays from the oldest available event (with indication of gap) or returns an error asking client to re-initialize. No crash or hang.
+
+- [ ] **TC-150: Reconnect without Last-Event-ID starts fresh**
+  - Precondition: Previous SSE connection received events
+  - Steps: Reconnect `GET /mcp` without `Last-Event-ID` header
+  - Expected: No event replay. Stream starts with new events only.
+
+- [ ] **TC-151: Event buffer persists in Redis**
+  - Precondition: Events generated during a session
+  - Steps: Restart the application pod. Reconnect SSE with `Last-Event-ID`.
+  - Expected: Events from before the restart are replayed. Buffer survives pod restart.
+
+---
+
+## 3. Rate Limiting
+
+- [ ] **TC-152: Per-session rate limit enforced**
+  - Precondition: Active session, known per-session limit (e.g., 60 requests/minute)
+  - Steps: Send requests at the rate limit + 1 within the window
+  - Expected: Requests within the limit succeed. The request exceeding the limit receives HTTP 429.
+
+- [ ] **TC-153: Per-org rate limit enforced**
+  - Precondition: Two active sessions for the same org, known per-org limit
+  - Steps: Split requests across both sessions to collectively exceed the per-org limit
+  - Expected: Once the org limit is hit, both sessions receive HTTP 429 until the window resets
+
+- [ ] **TC-154: 429 response includes Retry-After header**
+  - Precondition: Rate limit triggered
+  - Steps: Inspect the 429 response headers
+  - Expected: `Retry-After` header present with a value in seconds indicating when to retry
+
+- [ ] **TC-155: 429 response body is valid JSON-RPC error**
+  - Precondition: Rate limit triggered
+  - Steps: Inspect the 429 response body
+  - Expected: Valid JSON-RPC error object with an appropriate error code and message indicating rate limit exceeded
+
+- [ ] **TC-156: Rate limit resets after window expires**
+  - Precondition: Rate limit triggered, Retry-After value known
+  - Steps: Wait for the Retry-After duration, then send another request
+  - Expected: Request succeeds. Rate limit counter has reset.
+
+- [ ] **TC-157: Read operations and write operations have separate limits**
+  - Precondition: Active session
+  - Steps: Exhaust the rate limit with `tools/list` (read) calls. Then call `workflow_create` (write).
+  - Expected: If separate limits exist, write still works when read limit is exhausted (and vice versa). If unified, both are blocked. Behavior should match documentation.
+
+- [ ] **TC-158: Rate limit state stored externally (survives pod restart)**
+  - Precondition: Rate limit partially consumed, Redis backing
+  - Steps: Consume half the rate limit. Restart the pod. Send more requests up to the original limit.
+  - Expected: The pre-restart consumption is counted. Total across restart equals the limit.
+
+---
+
+## 4. Monitoring
+
+- [ ] **TC-159: Structured logs emitted for session lifecycle**
+  - Precondition: Application logging configured (JSON structured logs)
+  - Steps: Initialize a session, call tools, terminate session. Inspect application logs.
+  - Expected: Logs contain entries for session_created, tool_call, session_terminated. Each entry has structured fields: timestamp, session_id, org_id, event_type, and relevant metadata.
+
+- [ ] **TC-160: Structured logs for tool calls include timing**
+  - Precondition: Active session
+  - Steps: Call a tool (e.g., `workflow_list`). Inspect logs.
+  - Expected: Log entry includes `tool_name`, `duration_ms`, `status` (success/error), and `org_id`
+
+- [ ] **TC-161: Structured logs for errors include context**
+  - Precondition: Active session
+  - Steps: Call a tool with invalid params to trigger an error. Inspect logs.
+  - Expected: Log entry includes `error_code`, `error_message`, `tool_name`, `session_id`, and request metadata
+
+- [ ] **TC-162: Metrics tracked for session count**
+  - Precondition: Metrics endpoint or monitoring dashboard accessible
+  - Steps: Initialize 3 sessions. Check metrics.
+  - Expected: Active session count metric reflects 3. After terminating one, it reflects 2.
+
+- [ ] **TC-163: Metrics tracked for tool call latency**
+  - Precondition: Metrics collection active
+  - Steps: Call multiple tools. Check metrics.
+  - Expected: Tool call latency histogram/percentiles available, broken down by tool name
+
+- [ ] **TC-164: Metrics tracked for error rates**
+  - Precondition: Metrics collection active
+  - Steps: Generate some successful and some failed tool calls. Check metrics.
+  - Expected: Error rate metric available, broken down by error type (auth failure, validation error, server error)
+
+- [ ] **TC-165: Auth failure logs do not leak credentials**
+  - Precondition: Logging active
+  - Steps: Send requests with invalid API keys and invalid OAuth tokens. Inspect logs.
+  - Expected: Logs contain the auth failure event but do NOT contain the full API key or token value. At most a truncated/masked version.
+
+---
+
+## 5. Security
+
+- [ ] **TC-166: DNS rebinding protection via allowedHosts**
+  - Precondition: Server configured with `allowedHosts: ["app.keeperhub.com"]`
+  - Steps: Send request with `Host: evil.com` header
+  - Expected: HTTP 403 or connection refused. Request not processed.
+
+- [ ] **TC-167: Origin validation via allowedOrigins**
+  - Precondition: Server configured with allowed origins
+  - Steps: Send request with `Origin: https://evil.com`
+  - Expected: Request rejected or CORS headers not set for that origin
+
+- [ ] **TC-168: CORS preflight returns correct headers**
+  - Precondition: None
+  - Steps: Send `OPTIONS /mcp` with `Origin: https://app.keeperhub.com`, `Access-Control-Request-Method: POST`, `Access-Control-Request-Headers: Authorization, Content-Type, Mcp-Session-Id`
+  - Expected: Response includes `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` (includes POST, GET, DELETE), `Access-Control-Allow-Headers` (includes Authorization, Content-Type, Mcp-Session-Id), `Access-Control-Expose-Headers` (includes Mcp-Session-Id)
+
+- [ ] **TC-169: CORS headers on actual requests**
+  - Precondition: None
+  - Steps: Send `POST /mcp` with valid `Origin` header
+  - Expected: Response includes `Access-Control-Allow-Origin` and `Access-Control-Expose-Headers: Mcp-Session-Id`
+
+- [ ] **TC-170: No sensitive headers exposed in CORS**
+  - Precondition: None
+  - Steps: Inspect `Access-Control-Expose-Headers`
+  - Expected: Only necessary headers exposed (e.g., `Mcp-Session-Id`). No internal headers leaked.
+
+- [ ] **TC-171: Request body size limit enforced**
+  - Precondition: Active session
+  - Steps: Send a `POST /mcp` with a body exceeding the size limit (e.g., 10MB of JSON)
+  - Expected: HTTP 413 Payload Too Large. Request not processed.
+
+- [ ] **TC-172: Session fixation not possible**
+  - Precondition: None
+  - Steps: Send `initialize` with a fabricated `Mcp-Session-Id` header
+  - Expected: Server ignores the client-provided session ID on initialize and generates its own. The response `Mcp-Session-Id` is server-generated.
+
+- [ ] **TC-173: Timing-safe token comparison**
+  - Precondition: None
+  - Steps: Send multiple requests with tokens that differ by one character at different positions. Measure response times.
+  - Expected: No statistically significant timing difference based on which character is wrong. Prevents timing attacks.
+
+---
+
+## 6. Load Testing
+
+- [ ] **TC-174: Concurrent session creation**
+  - Precondition: Load testing tool (e.g., k6, Artillery)
+  - Steps: Send 100 concurrent `initialize` requests, each with a valid API key
+  - Expected: All 100 succeed (or up to the session limit). No 500 errors. Response times under 2 seconds at p95.
+
+- [ ] **TC-175: High-frequency tool calls on single session**
+  - Precondition: Active session
+  - Steps: Send 50 `tools/call` requests per second for 60 seconds (3000 total) for `workflow_list`
+  - Expected: Requests within rate limits succeed. Rate-limited requests get 429 with Retry-After. No 500 errors. No session corruption.
+
+- [ ] **TC-176: Concurrent tool calls across multiple sessions**
+  - Precondition: 20 active sessions
+  - Steps: Each session sends 5 tool calls per second for 60 seconds (6000 total across all sessions)
+  - Expected: All within-limit requests succeed. Responses are correct (no cross-session data leaks). p95 latency under 5 seconds.
+
+- [ ] **TC-177: Session cleanup under load**
+  - Precondition: 50 active sessions, steady tool call traffic
+  - Steps: Let 25 sessions expire (no requests for 30 min). Continue traffic on remaining 25.
+  - Expected: Expired sessions cleaned up. Active sessions unaffected. Redis key count decreases. No memory leaks.
+
+- [ ] **TC-178: SSE connections under load**
+  - Precondition: 50 concurrent SSE connections
+  - Steps: Trigger workflow executions that generate events. Monitor all SSE streams.
+  - Expected: All SSE connections receive their events. No dropped events. Server memory stable.
+
+- [ ] **TC-179: Spike test (sudden burst)**
+  - Precondition: Baseline of 10 requests/second
+  - Steps: Spike to 500 requests/second for 10 seconds, then return to baseline
+  - Expected: During spike, rate limits applied. After spike, service recovers to normal latency within 30 seconds. No cascading failures.
+
+- [ ] **TC-180: Long-running session stability**
+  - Precondition: Active session
+  - Steps: Keep a session alive for 4 hours with periodic tool calls (one per minute)
+  - Expected: Session remains valid for the entire duration (TTL refreshed on each call). No degradation in response time.
+
+---
+
+## 7. Graceful Degradation
+
+- [ ] **TC-181: Redis down falls back to in-memory sessions**
+  - Precondition: Redis/Upstash connection configured
+  - Steps: Simulate Redis outage (disconnect or block port). Initialize a new session.
+  - Expected: Session created using in-memory fallback. Tools work normally. Log entry warns about Redis unavailability.
+
+- [ ] **TC-182: Existing sessions degrade gracefully when Redis goes down**
+  - Precondition: Active session stored in Redis
+  - Steps: Simulate Redis outage. Send `tools/list` with the existing session.
+  - Expected: Either the session is recreated in-memory (with possible re-auth), or a clear error instructs the client to re-initialize. No 500 crash.
+
+- [ ] **TC-183: Redis recovery restores normal operation**
+  - Precondition: Redis was down, in-memory fallback active
+  - Steps: Restore Redis. Initialize a new session. Verify it is stored in Redis.
+  - Expected: New sessions go to Redis. Transition is seamless. No manual intervention needed.
+
+- [ ] **TC-184: Upstream API errors return clean JSON-RPC errors**
+  - Precondition: Active session
+  - Steps: Call a tool that depends on an external API (e.g., `web3_check-balance` when RPC node is down)
+  - Expected: JSON-RPC error response with a meaningful message (e.g., "Upstream RPC unavailable"). No raw stack traces or internal error details exposed.
+
+- [ ] **TC-185: Database unavailable returns clean error**
+  - Precondition: Active session
+  - Steps: Simulate database outage. Call `workflow_list`.
+  - Expected: JSON-RPC error with message indicating temporary unavailability. HTTP status 503 or JSON-RPC internal error code.
+
+- [ ] **TC-186: Partial tool availability**
+  - Precondition: Active session, one external dependency down (e.g., blockchain RPC)
+  - Steps: Call a tool that does not depend on the down service (e.g., `workflow_list`). Then call one that does (e.g., `web3_check-balance`).
+  - Expected: `workflow_list` succeeds. `web3_check-balance` returns a clean error. One failure does not affect other tools.
+
+- [ ] **TC-187: Health check endpoint reflects degraded state**
+  - Precondition: Redis down or database down
+  - Steps: Call the health check endpoint (e.g., `GET /api/health` or similar)
+  - Expected: Returns degraded status with details of which backing services are unavailable. Does not return "healthy" when dependencies are down.
+
+- [ ] **TC-188: In-memory session limit enforced during fallback**
+  - Precondition: Redis down, in-memory fallback active
+  - Steps: Create sessions up to a reasonable in-memory limit (e.g., 1000)
+  - Expected: Limit enforced to prevent memory exhaustion. Clear error when limit reached.
+
+- [ ] **TC-189: Event buffer fallback when Redis is down**
+  - Precondition: Redis down, SSE events being generated
+  - Steps: Generate events during Redis outage. Client reconnects with `Last-Event-ID`.
+  - Expected: Events buffered in-memory (limited window). Replay works within the in-memory buffer. Events beyond the buffer return an appropriate error on reconnect.
+
+- [ ] **TC-190: No data loss on graceful shutdown**
+  - Precondition: Active sessions with pending operations
+  - Steps: Send SIGTERM to the application process during active tool calls
+  - Expected: In-flight requests complete (or return clean errors). Sessions are persisted to Redis before shutdown. SSE connections closed with appropriate close event.


### PR DESCRIPTION
## Summary

- Enable Claude Desktop, Cursor, and other MCP clients to connect to KeeperHub with just a URL and API key -- no local process, no Docker, no CLI install required
- Implements the full MCP protocol over Streamable HTTP at `app.keeperhub.com/mcp`, following the same pattern as Linear's `mcp.linear.app/mcp`
- Rolled out incrementally across 4 phases: v1 (core transport + 15 tools), v2 (dynamic plugin tools + workflow resources), v3 (OAuth 2.1 with PKCE + scope enforcement), v4 (rate limiting + structured logging + CORS)

## What's included

**MCP endpoint** (`app/mcp/route.ts`):
- POST/GET/DELETE handlers with stateless JWT sessions (multi-pod safe)
- 15 static tools + all plugin actions registered dynamically from registry
- SSE resumability via EventStore (Last-Event-ID replay)
- Per-org rate limiting (120 req/min) with 429 + Retry-After

**OAuth 2.1**:
- Dynamic client registration, PKCE S256, scope model (mcp:read/write/admin)
- DB-backed clients and refresh tokens, in-memory auth codes (10min TTL)
- Scope enforcement wired through every tool handler

**Tool annotations**:
- readOnlyHint/destructiveHint on all static tool registrations
- deriveAnnotations() infers hints for dynamic plugin tools from slug patterns

**Operational**:
- Hotfix deploy workflow for emergency prod/staging pushes
- OAUTH_JWT_SECRET added to all deploy configs
- Playwright CLI skill + reference docs
- UAT specs for all 4 phases

## Test plan

- [ ] `curl -X POST https://app.keeperhub.com/mcp -H "Authorization: Bearer kh_..." -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'` returns tool list with annotations
- [ ] Connect from Claude Desktop using the remote MCP URL
- [ ] OAuth flow: register client, authorize via browser, exchange code for token, call tools with Bearer token
- [ ] Scope enforcement: mcp:read token gets 403 on write tools
- [ ] Rate limit: exceed 120 req/min and get 429 with Retry-After header
- [ ] SSE reconnect: disconnect mid-stream, reconnect with Last-Event-ID, verify event replay
- [ ] `pnpm type-check` and `pnpm check` pass