### PR TITLE
fix: use env-based base URL in OAuth metadata endpoint

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,6 +1,12 @@
 export const dynamic = "force-dynamic";
 
+const TRAILING_SLASH = /\/$/;
+
 function deriveBaseUrl(request: Request): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
+  if (envUrl) {
+    return envUrl.replace(TRAILING_SLASH, "");
+  }
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
 }

--- a/tests/e2e/vitest/transaction-flow.test.ts
+++ b/tests/e2e/vitest/transaction-flow.test.ts
@@ -705,11 +705,7 @@ describe.skipIf(skipRealTx)("Real Transaction Tests (Sepolia)", () => {
     await paraClient.setUserShare(decryptedShare);
 
     sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC);
-    wallet = new ParaEthersSigner(
-      // biome-ignore lint/suspicious/noExplicitAny: Para server-sdk type incompatibility with core-sdk ParaCore
-      paraClient as any,
-      sepoliaProvider
-    );
+    wallet = new ParaEthersSigner(paraClient as any, sepoliaProvider);
 
     console.log(`Test wallet (Para): ${walletAddress}`);
 


### PR DESCRIPTION
## Summary

- OAuth metadata at `/.well-known/oauth-authorization-server` was returning `https://0.0.0.0:3000` as the base URL for all OAuth endpoints (authorization, token, registration)
- Behind a reverse proxy the `request.url` resolves to the internal pod address, not the public domain
- Claude Code MCP clients fetch this metadata, get unreachable URLs, and fail with "Unable to connect"
- Now uses `NEXT_PUBLIC_APP_URL` / `BETTER_AUTH_URL` env vars first, matching the existing pattern in `app/mcp/route.ts`

## Test plan

- [ ] Verify `curl https://app.keeperhub.com/.well-known/oauth-authorization-server` returns `app.keeperhub.com` URLs (not `0.0.0.0:3000`)
- [ ] Verify Claude Code `/mcp` connect flow opens browser for OAuth