### PR TITLE
hotfix: KEEP-1587 pass organizationId to integration validation in execution paths

### DIFF
--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -196,7 +196,8 @@ export async function POST(
     // Validate that all integrationIds in workflow nodes belong to the workflow owner
     const validation = await validateWorkflowIntegrations(
       workflow.nodes as WorkflowNode[],
-      workflow.userId
+      workflow.userId,
+      workflow.organizationId
     );
     if (!validation.valid) {
       logSystemError(ErrorCategory.WORKFLOW_ENGINE, "[Webhook] Invalid integration references", new Error(String(validation.invalidIds)), { endpoint: "/api/workflows/[workflowId]/webhook", operation: "validateIntegrations" });

--- a/keeperhub-executor/in-process.ts
+++ b/keeperhub-executor/in-process.ts
@@ -65,7 +65,8 @@ export async function executeInProcess(params: {
     const edges = workflow.edges as WorkflowEdge[];
     const validation = await validateWorkflowIntegrations(
       nodes,
-      workflow.userId
+      workflow.userId,
+      workflow.organizationId
     );
 
     if (!validation.valid) {

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -205,7 +205,8 @@ async function main(): Promise<void> {
     const edges = workflow.edges as WorkflowEdge[];
     const validation = await validateWorkflowIntegrations(
       nodes,
-      workflow.userId
+      workflow.userId,
+      workflow.organizationId
     );
 
     if (!validation.valid) {


### PR DESCRIPTION
## Summary

- Workflow runner (K8s job), in-process executor, and webhook route were not passing `organizationId` to `validateWorkflowIntegrations`
- Without `organizationId`, the validation falls back to user-level ownership checks, which fails for organization-owned integrations
- This caused all Sky organization scheduled workflows to fail immediately with "Workflow contains invalid integration references" before any steps could execute
- Affected workflows: Emergency Shutdown Detector, Chief Keeper, ESM Sum Watcher, ESM Threshold Progress Tracker

## Root Cause

`validateWorkflowIntegrations(nodes, userId, organizationId?)` has an optional third parameter. When omitted, it checks `integration.userId !== workflow.userId` instead of `integration.organizationId !== workflow.organizationId`. Organization integrations are owned by the org, not the user, so this check always fails.

The API routes for create (`/api/workflows/create`) and update (`/api/workflows/[workflowId]`) already passed `organizationId` correctly. Only the execution paths (workflow-runner, in-process, webhook) were missing it.

## Changes

| File | Change |
|------|--------|
| `keeperhub-executor/workflow-runner.ts` | Pass `workflow.organizationId` to `validateWorkflowIntegrations` |
| `keeperhub-executor/in-process.ts` | Pass `workflow.organizationId` to `validateWorkflowIntegrations` |
| `app/api/workflows/[workflowId]/webhook/route.ts` | Pass `workflow.organizationId` to `validateWorkflowIntegrations` |

## Test plan

- [ ] Deploy to staging and trigger a workflow belonging to an organization
- [ ] Verify scheduled org workflows execute steps instead of failing at validation
- [ ] Verify personal (non-org) workflows still work correctly
- [ ] Verify webhook-triggered org workflows work correctly