### PR TITLE
ci: KEEP-1587 run executor deploy after build-images in CI pipeline

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -51,12 +51,23 @@ jobs:
       image_tag: ${{ needs.build-images.outputs.image_tag }}
     secrets: inherit
 
+  # Executor deploy runs after build-images and e2e-tests (same as deploy).
+  # The executor's RUNNER_IMAGE references the workflow-runner image built by
+  # build-images, so it must wait for that job to complete.
+  deploy-executor:
+    needs: [build-images, e2e-tests]
+    if: ${{ github.event_name != 'pull_request' && !failure() && !cancelled() }}
+    uses: ./.github/workflows/deploy-executor.yaml
+    with:
+      image_tag: ${{ needs.build-images.outputs.image_tag }}
+    secrets: inherit
+
   # Release and docs-sync only run on prod pushes, after successful deploy.
   # Previously a separate workflow — moved here so e2e/deploy failures block release.
   # Note: if ENABLE_E2E_EPHEMERAL_TESTS is false, e2e jobs are skipped (not failed),
   # so deploy and release proceed unconditionally — the variable is the kill switch.
   release:
-    needs: [deploy]
+    needs: [deploy, deploy-executor]
     if: ${{ github.ref_name == 'prod' && !failure() && !cancelled() }}
     uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/deploy-executor.yaml
+++ b/.github/workflows/deploy-executor.yaml
@@ -1,16 +1,15 @@
-# Type: standalone | Builds and deploys the unified workflow executor.
-# Runs independently from ci-pipeline.yml because the executor has its own
-# Dockerfile stage, ECR repo, and Helm release separate from the main app.
+# Type: reusable | Called by ci-pipeline.yml
+# Builds and deploys the unified workflow executor.
+# Expects workflow-runner images to already exist in ECR (built by build-images.yml).
 on:
-  push:
-    branches:
-      - staging
-      - prod
-    paths:
-      - "keeperhub-executor/**"
-      - "deploy/executor/**"
-      - ".github/workflows/deploy-executor.yaml"
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Pre-built image tag (short SHA).'
+        type: string
+        required: false
+        default: ''
+  workflow_dispatch: {}
 
 name: deploy-executor
 
@@ -59,14 +58,21 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Extract commit hash
+        id: vars
+        shell: bash
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [[ -n "${INPUT_IMAGE_TAG}" ]]; then
+            echo "sha_short=${INPUT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true'
         uses: docker/setup-buildx-action@v3
-
-      - name: Extract commit hash
-        id: vars
-        run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check if executor image already exists
         if: steps.skip.outputs.skip_build == 'true'


### PR DESCRIPTION
## Summary

- Convert `deploy-executor.yaml` from a standalone push-triggered workflow to a reusable workflow called by `ci-pipeline.yml`
- Eliminates a race condition where the executor could deploy referencing a `workflow-runner` image that hasn't been built yet, since `build-images.yml` and `deploy-executor.yaml` previously ran as independent parallel workflows
- The executor deploy now runs after `build-images` and `e2e-tests`, matching the existing `deploy-keeperhub` pattern
- Release is gated on both deploys completing

## Context

Follow-up to #704. While investigating the org integration validation bug, we identified that `deploy-executor.yaml` and `ci-pipeline.yml` (which calls `build-images.yml`) trigger independently on push to staging/prod. The executor's Helm values reference `workflow-runner-${IMAGE_TAG}`, but the workflow-runner image is built by `build-images.yml` -- not by `deploy-executor.yaml`. If the executor deploys first, workflow pods fail with ImagePullBackOff.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/deploy-executor.yaml` | Replace `push` trigger with `workflow_call` + `workflow_dispatch`, accept `image_tag` input |
| `.github/workflows/ci-pipeline.yml` | Add `deploy-executor` job after `build-images` and `e2e-tests`, gate `release` on both deploys |

## Test plan

- [ ] Merge to staging and verify CI pipeline runs: build-images -> e2e-tests -> deploy + deploy-executor (parallel) -> release
- [ ] Verify `deploy-executor.yaml` no longer triggers independently on push
- [ ] Verify `workflow_dispatch` still works for manual executor deploys