### PR TITLE
chore: add DISCORD_WEBHOOK_SIGNUPS env var to prod deploy

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -218,6 +218,11 @@ env:
   FROM_ADDRESS:
     type: kv
     value: "noreply@keeperhub.com"
+  # Discord
+  DISCORD_WEBHOOK_SIGNUPS:
+    type: parameterStore
+    name: discord-webhook-signups
+    parameter_name: /eks/maker-prod/keeperhub/discord-webhook-signups
   # Sentry
   SENTRY_DSN:
     type: parameterStore


### PR DESCRIPTION
## Summary
- Add `DISCORD_WEBHOOK_SIGNUPS` parameterStore env var to prod values.yaml for new user signup notifications to Discord

## Deploy notes
- Requires the corresponding SSM parameter to be created first (see techops-services/infrastructure PR)
- After Terraform apply, set the actual webhook URL in SSM