### PR TITLE
fix: KEEP-188 OAuth authorize page scroll and scope description

### DIFF
--- a/app/oauth/authorize/page.tsx
+++ b/app/oauth/authorize/page.tsx
@@ -199,7 +199,7 @@ export default async function AuthorizePage({
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center overflow-y-auto bg-background">
+    <main className="pointer-events-auto flex min-h-screen items-center justify-center overflow-y-auto bg-background">
       <div className="w-full max-w-md rounded-lg border border-border bg-card p-8 shadow-sm">
         <h1 className="mb-1 text-xl font-semibold text-foreground">
           Authorize Access

--- a/app/oauth/authorize/page.tsx
+++ b/app/oauth/authorize/page.tsx
@@ -193,12 +193,13 @@ export default async function AuthorizePage({
 
   const scopeDescriptions: Record<string, string> = {
     "mcp:read": "Read your workflows, executions, and plugin schemas",
-    "mcp:write": "Create, update, and execute workflows on your behalf",
+    "mcp:write":
+      "Read and write access to your workflows, executions, and integrations",
     "mcp:admin": "Full access to your KeeperHub organization",
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background">
+    <main className="flex min-h-screen items-center justify-center overflow-y-auto bg-background">
       <div className="w-full max-w-md rounded-lg border border-border bg-card p-8 shadow-sm">
         <h1 className="mb-1 text-xl font-semibold text-foreground">
           Authorize Access

--- a/components/overlays/overlay-container.tsx
+++ b/components/overlays/overlay-container.tsx
@@ -157,13 +157,6 @@ function DesktopOverlayContainer() {
   const renderStack = frozenStackRef.current;
   const currentIndex = renderStack.length - 1;
 
-  // DEBUG
-  console.log("[DesktopOverlay]", {
-    isOpen,
-    stackLength: stack.length,
-    frozenStackLength: frozenStackRef.current.length,
-    renderStackLength: renderStack.length,
-  });
 
   // Measure content height when it changes, reset on fresh open
   // biome-ignore lint/correctness/useExhaustiveDependencies: upstream code
@@ -212,11 +205,8 @@ function DesktopOverlayContainer() {
   }, [isOpen, handleEscapeKey]);
 
   const handleExitComplete = useCallback(() => {
-    console.log("[DesktopOverlay] handleExitComplete called");
     frozenStackRef.current = [];
   }, []);
-
-  console.log("[DesktopOverlay] Rendering, isOpen:", isOpen);
 
   // Don't render Dialog at all when closed - this ensures clean unmount
   if (!isOpen && frozenStackRef.current.length === 0) {


### PR DESCRIPTION
## Summary

- Add `overflow-y-auto` to the `/oauth/authorize` page `<main>` element so Approve/Deny buttons are reachable when the page opens in a small viewport or popup (global `overflow: hidden` on `html, body` was preventing scroll)
- Update `mcp:write` scope description to clarify it includes read access ("Read and write access to your workflows, executions, and integrations")
- Remove 3 leftover debug `console.log` statements from `overlay-container.tsx`

Closes KEEP-188

## Test plan

- [ ] Open `/oauth/authorize` in a small browser window (e.g. 400x500) and verify Approve/Deny buttons are scrollable into view
- [ ] Verify the `mcp:write` permission description reads "Read and write access to your workflows, executions, and integrations"
- [ ] Verify no `[DesktopOverlay]` console.log messages appear in browser devtools when opening/closing overlays