### PR TITLE
fix: KEEP-189 pass wallet and RPC env vars to K8s Job containers

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -76,6 +76,21 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
+  PARA_API_KEY:
+    type: parameterStore
+    name: para-api-key
+    parameter_name: /eks/techops-prod/keeperhub/para-api-key
+  PARA_ENVIRONMENT:
+    type: kv
+    value: "prod"
+  WALLET_ENCRYPTION_KEY:
+    type: parameterStore
+    name: wallet-encryption-key
+    parameter_name: /eks/techops-prod/keeperhub/wallet-encryption-key
+  CHAIN_RPC_CONFIG:
+    type: parameterStore
+    name: chain-rpc-config
+    parameter_name: /eks/techops-prod/keeperhub/chain-rpc-config
 
 externalSecrets:
   clusterSecretStoreName: techops-prod

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -76,6 +76,21 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
+  PARA_API_KEY:
+    type: parameterStore
+    name: para-api-key
+    parameter_name: /eks/techops-staging/keeperhub/para-api-key
+  PARA_ENVIRONMENT:
+    type: kv
+    value: "beta"
+  WALLET_ENCRYPTION_KEY:
+    type: parameterStore
+    name: wallet-encryption-key
+    parameter_name: /eks/techops-staging/keeperhub/wallet-encryption-key
+  CHAIN_RPC_CONFIG:
+    type: parameterStore
+    name: chain-rpc-config
+    parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
 
 externalSecrets:
   clusterSecretStoreName: techops-staging

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -26,6 +26,11 @@ export const CONFIG = {
   healthPort: Number(process.env.HEALTH_PORT) || 3080,
   integrationEncryptionKey: process.env.INTEGRATION_ENCRYPTION_KEY || "",
 
+  paraApiKey: process.env.PARA_API_KEY || "",
+  paraEnvironment: process.env.PARA_ENVIRONMENT || "beta",
+  walletEncryptionKey: process.env.WALLET_ENCRYPTION_KEY || "",
+  chainRpcConfig: process.env.CHAIN_RPC_CONFIG || "",
+
   visibilityTimeout: 300,
   waitTimeSeconds: 20,
   maxMessages: 10,

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -53,6 +53,10 @@ export async function createWorkflowJob(params: {
       name: "INTEGRATION_ENCRYPTION_KEY",
       value: CONFIG.integrationEncryptionKey,
     },
+    { name: "PARA_API_KEY", value: CONFIG.paraApiKey },
+    { name: "PARA_ENVIRONMENT", value: CONFIG.paraEnvironment },
+    { name: "WALLET_ENCRYPTION_KEY", value: CONFIG.walletEncryptionKey },
+    { name: "CHAIN_RPC_CONFIG", value: CONFIG.chainRpcConfig },
   ];
 
   if (scheduleId) {


### PR DESCRIPTION
## Summary

- K8s Job containers spawned by the executor were missing `PARA_API_KEY`, `WALLET_ENCRYPTION_KEY`, `PARA_ENVIRONMENT`, and `CHAIN_RPC_CONFIG`
- Without these, any wallet-dependent workflow step (Send Transaction, Approve Token, etc.) fails with "PARA_API_KEY not configured" when triggered by schedule/block/event triggers
- Manual runs via the main Next.js app pod were unaffected because that pod already has these vars

## Changes

| File | Change |
|------|--------|
| `keeperhub-executor/config.ts` | Add `paraApiKey`, `paraEnvironment`, `walletEncryptionKey`, `chainRpcConfig` to executor config |
| `keeperhub-executor/k8s-job.ts` | Pass all 4 vars in the `envVars` array to K8s Job containers |
| `deploy/executor/staging/values.yaml` | Add vars with `techops-staging` Parameter Store paths |
| `deploy/executor/prod/values.yaml` | Add vars with `techops-prod` Parameter Store paths |

## Test plan

- [ ] Deploy to staging and trigger a scheduled workflow that uses wallet signing (e.g. Send Transaction)
- [ ] Verify the workflow executes past validation and successfully signs/sends the transaction
- [ ] Verify RPC resolution uses configured providers (not public fallbacks)
- [ ] Verify personal (non-org) wallet workflows also work correctly via K8s Jobs