### PR TITLE
fix: resolve e2e playwright test failures

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,17 +73,10 @@ const RootLayout = ({ children }: RootLayoutProps) => (
         <Provider>
           <AuthProvider>
             <OverlayProvider>
-              <Suspense
-                fallback={
-                  <GitHubStarsProvider stars={null}>
-                    <LayoutContent>{children}</LayoutContent>
-                  </GitHubStarsProvider>
-                }
-              >
-                <GitHubStarsLoader>
-                  <LayoutContent>{children}</LayoutContent>
-                </GitHubStarsLoader>
+              <Suspense fallback={<GitHubStarsProvider stars={null} />}>
+                <GitHubStarsLoader />
               </Suspense>
+              <LayoutContent>{children}</LayoutContent>
               <Toaster />
               <GlobalModals />
               <MobileWarningDialog />

--- a/components/github-stars-loader.tsx
+++ b/components/github-stars-loader.tsx
@@ -29,7 +29,11 @@ async function getGitHubStars(): Promise<number | null> {
   }
 }
 
-export async function GitHubStarsLoader({ children }: { children: ReactNode }) {
+export async function GitHubStarsLoader({
+  children,
+}: {
+  children?: ReactNode;
+} = {}) {
   const stars = await getGitHubStars();
   return <GitHubStarsProvider stars={stars}>{children}</GitHubStarsProvider>;
 }

--- a/components/github-stars-provider.tsx
+++ b/components/github-stars-provider.tsx
@@ -5,7 +5,7 @@ import { createContext, type ReactNode, useContext } from "react";
 const GitHubStarsContext = createContext<number | null>(null);
 
 type GitHubStarsProviderProps = {
-  children: ReactNode;
+  children?: ReactNode;
   stars: number | null;
 };
 

--- a/tests/e2e/playwright/utils/cleanup.ts
+++ b/tests/e2e/playwright/utils/cleanup.ts
@@ -125,16 +125,18 @@ export async function cleanupTestUsers(): Promise<number> {
 
     // 2. Para wallets - delete from API first, then DB
     const paraWallets = await sql`
-      SELECT wallet_id FROM para_wallets WHERE user_id IN ${sql(userIds)}
+      SELECT para_wallet_id FROM para_wallets WHERE user_id IN ${sql(userIds)}
     `;
 
     if (paraWallets.length > 0) {
       const paraConfig = getParaPortalConfig();
       if (paraConfig) {
         const results = await Promise.allSettled(
-          paraWallets.map((w) =>
-            deleteParaPregenWallet(paraConfig, w.wallet_id as string)
-          )
+          paraWallets
+            .filter((w) => w.para_wallet_id != null)
+            .map((w) =>
+              deleteParaPregenWallet(paraConfig, w.para_wallet_id as string)
+            )
         );
         const failed = results.filter(
           (r) =>


### PR DESCRIPTION
## Summary

Follow-up to #691 (Turnkey wallet provider) which renamed `wallet_id` to `para_wallet_id` in migration 0036 and restructured the Suspense layout.

- Fix duplicate `workflow-canvas` elements causing Playwright strict mode violations: moved `LayoutContent` outside the Suspense boundary in `app/layout.tsx` so the canvas renders exactly once instead of in both the fallback and resolved content
- Fix `PostgresError: column "wallet_id" does not exist` in test cleanup: migration 0036 renamed `wallet_id` to `para_wallet_id` but `cleanup.ts` still referenced the old name
- Added null filter for `para_wallet_id` since Turnkey wallets don't have a Para wallet ID

## Test plan

- [ ] Verify e2e-playwright-ephemeral CI passes
- [ ] Verify no duplicate `workflow-canvas` elements in DOM after page reload
- [ ] Verify test cleanup completes without errors