### PR TITLE
chore: regenerate drizzle/schema.ts from 0037 snapshot

### DIFF
--- a/drizzle/relations.ts
+++ b/drizzle/relations.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm/relations";
-import { users, sessions, workflowExecutions, workflowExecutionLogs, integrations, organization, organizationApiKeys, accounts, workflows, workflowSchedules, paraWallets, organizationTokens, apiKeys, tags, invitation, member, addressBookEntry, projects, categories, protocols, chains, explorerConfigs, userRpcPreferences } from "./schema";
+import { users, sessions, workflowExecutions, workflowExecutionLogs, integrations, organization, organizationApiKeys, accounts, workflows, workflowSchedules, paraWallets, organizationTokens, apiKeys, tags, invitation, member, addressBookEntry, projects, chains, explorerConfigs, userRpcPreferences } from "./schema";
 
 export const sessionsRelations = relations(sessions, ({one}) => ({
 	user: one(users, {
@@ -21,9 +21,7 @@ export const usersRelations = relations(users, ({many}) => ({
 	members: many(member),
 	addressBookEntries: many(addressBookEntry),
 	workflows: many(workflows),
-	protocols: many(protocols),
 	projects: many(projects),
-	categories: many(categories),
 	userRpcPreferences: many(userRpcPreferences),
 }));
 
@@ -67,9 +65,7 @@ export const organizationRelations = relations(organization, ({many}) => ({
 	members: many(member),
 	addressBookEntries: many(addressBookEntry),
 	workflows: many(workflows),
-	protocols: many(protocols),
 	projects: many(projects),
-	categories: many(categories),
 }));
 
 export const organizationApiKeysRelations = relations(organizationApiKeys, ({one}) => ({
@@ -108,14 +104,6 @@ export const workflowsRelations = relations(workflows, ({one, many}) => ({
 	tag: one(tags, {
 		fields: [workflows.tagId],
 		references: [tags.id]
-	}),
-	category: one(categories, {
-		fields: [workflows.categoryId],
-		references: [categories.id]
-	}),
-	protocol: one(protocols, {
-		fields: [workflows.protocolId],
-		references: [protocols.id]
 	}),
 }));
 
@@ -208,29 +196,6 @@ export const projectsRelations = relations(projects, ({one, many}) => ({
 	}),
 }));
 
-export const categoriesRelations = relations(categories, ({one, many}) => ({
-	workflows: many(workflows),
-	organization: one(organization, {
-		fields: [categories.organizationId],
-		references: [organization.id]
-	}),
-	user: one(users, {
-		fields: [categories.userId],
-		references: [users.id]
-	}),
-}));
-
-export const protocolsRelations = relations(protocols, ({one, many}) => ({
-	workflows: many(workflows),
-	organization: one(organization, {
-		fields: [protocols.organizationId],
-		references: [organization.id]
-	}),
-	user: one(users, {
-		fields: [protocols.userId],
-		references: [users.id]
-	}),
-}));
 
 export const explorerConfigsRelations = relations(explorerConfigs, ({one}) => ({
 	chain: one(chains, {

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, foreignKey, unique, text, timestamp, jsonb, boolean, index, uniqueIndex, integer, serial, primaryKey } from "drizzle-orm/pg-core"
+import { pgTable, foreignKey, unique, text, timestamp, jsonb, boolean, index, uniqueIndex, integer, serial, primaryKey, numeric } from "drizzle-orm/pg-core"
 import { sql } from "drizzle-orm"
 
 export const sessions = pgTable("sessions", {
@@ -32,8 +32,10 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
 	error: text(),
 	startedAt: timestamp("started_at", { mode: 'string' }).defaultNow().notNull(),
 	completedAt: timestamp("completed_at", { mode: 'string' }),
-	duration: text(),
+	duration: numeric(),
 	timestamp: timestamp({ mode: 'string' }).defaultNow().notNull(),
+	iterationIndex: integer("iteration_index"),
+	forEachNodeId: text("for_each_node_id"),
 }, (table) => [
 	foreignKey({
 			columns: [table.executionId],
@@ -45,13 +47,13 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
 export const integrations = pgTable("integrations", {
 	id: text().primaryKey().notNull(),
 	userId: text("user_id").notNull(),
+	organizationId: text("organization_id"),
 	name: text().notNull(),
 	type: text().notNull(),
 	config: jsonb().notNull(),
+	isManaged: boolean("is_managed").default(false),
 	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
 	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
-	isManaged: boolean("is_managed").default(false),
-	organizationId: text("organization_id"),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -131,7 +133,7 @@ export const workflowExecutions = pgTable("workflow_executions", {
 	error: text(),
 	startedAt: timestamp("started_at", { mode: 'string' }).defaultNow().notNull(),
 	completedAt: timestamp("completed_at", { mode: 'string' }),
-	duration: text(),
+	duration: numeric(),
 	totalSteps: text("total_steps"),
 	completedSteps: text("completed_steps").default('0'),
 	currentNodeId: text("current_node_id"),
@@ -139,7 +141,9 @@ export const workflowExecutions = pgTable("workflow_executions", {
 	lastSuccessfulNodeId: text("last_successful_node_id"),
 	lastSuccessfulNodeName: text("last_successful_node_name"),
 	executionTrace: jsonb("execution_trace"),
+	runId: text("run_id"),
 }, (table) => [
+	index("idx_workflow_executions_status").using("btree", table.status.asc().nullsLast().op("text_ops")),
 	foreignKey({
 			columns: [table.workflowId],
 			foreignColumns: [workflows.id],
@@ -193,12 +197,16 @@ export const workflowSchedules = pgTable("workflow_schedules", {
 export const paraWallets = pgTable("para_wallets", {
 	id: text().primaryKey().notNull(),
 	userId: text("user_id").notNull(),
-	email: text().notNull(),
-	walletId: text("wallet_id").notNull(),
-	walletAddress: text("wallet_address").notNull(),
-	userShare: text("user_share").notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
 	organizationId: text("organization_id"),
+	provider: text().notNull(),
+	email: text().notNull(),
+	walletAddress: text("wallet_address").notNull(),
+	paraWalletId: text("para_wallet_id"),
+	userShare: text("user_share"),
+	turnkeySubOrgId: text("turnkey_sub_org_id"),
+	turnkeyWalletId: text("turnkey_wallet_id"),
+	turnkeyPrivateKeyId: text("turnkey_private_key_id"),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -305,6 +313,7 @@ export const invitation = pgTable("invitation", {
 	status: text().default('pending').notNull(),
 	expiresAt: timestamp("expires_at", { mode: 'string' }).notNull(),
 	inviterId: text("inviter_id").notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
 }, (table) => [
 	foreignKey({
 			columns: [table.organizationId],
@@ -364,22 +373,20 @@ export const workflows = pgTable("workflows", {
 	name: text().notNull(),
 	description: text(),
 	userId: text("user_id").notNull(),
-	nodes: jsonb().notNull(),
-	edges: jsonb().notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
-	visibility: text().default('private').notNull(),
 	organizationId: text("organization_id"),
 	isAnonymous: boolean("is_anonymous").default(false).notNull(),
-	enabled: boolean().default(false).notNull(),
 	featured: boolean().default(false).notNull(),
 	featuredOrder: integer("featured_order").default(0),
 	featuredProtocol: text("featured_protocol"),
 	featuredProtocolOrder: integer("featured_protocol_order").default(0),
 	projectId: text("project_id"),
 	tagId: text("tag_id"),
-	categoryId: text("category_id"),
-	protocolId: text("protocol_id"),
+	nodes: jsonb().notNull(),
+	edges: jsonb().notNull(),
+	visibility: text().default('private').notNull(),
+	enabled: boolean().default(false).notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -401,37 +408,6 @@ export const workflows = pgTable("workflows", {
 			foreignColumns: [tags.id],
 			name: "workflows_tag_id_tags_id_fk"
 		}).onDelete("set null"),
-	foreignKey({
-			columns: [table.categoryId],
-			foreignColumns: [categories.id],
-			name: "workflows_category_id_categories_id_fk"
-		}).onDelete("set null"),
-	foreignKey({
-			columns: [table.protocolId],
-			foreignColumns: [protocols.id],
-			name: "workflows_protocol_id_protocols_id_fk"
-		}).onDelete("set null"),
-]);
-
-export const protocols = pgTable("protocols", {
-	id: text().primaryKey().notNull(),
-	name: text().notNull(),
-	organizationId: text("organization_id").notNull(),
-	userId: text("user_id").notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("idx_protocols_org").using("btree", table.organizationId.asc().nullsLast().op("text_ops")),
-	foreignKey({
-			columns: [table.organizationId],
-			foreignColumns: [organization.id],
-			name: "protocols_organization_id_organization_id_fk"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.id],
-			name: "protocols_user_id_users_id_fk"
-		}),
 ]);
 
 export const betaAccessRequests = pgTable("beta_access_requests", {
@@ -441,7 +417,6 @@ export const betaAccessRequests = pgTable("beta_access_requests", {
 });
 
 export const pendingTransactions = pgTable("pending_transactions", {
-	id: serial().primaryKey().notNull(),
 	walletAddress: text("wallet_address").notNull(),
 	chainId: integer("chain_id").notNull(),
 	nonce: integer().notNull(),
@@ -455,7 +430,7 @@ export const pendingTransactions = pgTable("pending_transactions", {
 }, (table) => [
 	index("idx_pending_tx_execution").using("btree", table.executionId.asc().nullsLast().op("text_ops")),
 	index("idx_pending_tx_status").using("btree", table.walletAddress.asc().nullsLast().op("int4_ops"), table.chainId.asc().nullsLast().op("int4_ops"), table.status.asc().nullsLast().op("text_ops")),
-	unique("pending_tx_wallet_chain_nonce").on(table.walletAddress, table.chainId, table.nonce),
+	primaryKey({ columns: [table.walletAddress, table.chainId, table.nonce], name: "pending_transactions_wallet_address_chain_id_nonce_pk"}),
 ]);
 
 export const projects = pgTable("projects", {
@@ -478,27 +453,6 @@ export const projects = pgTable("projects", {
 			columns: [table.userId],
 			foreignColumns: [users.id],
 			name: "projects_user_id_users_id_fk"
-		}),
-]);
-
-export const categories = pgTable("categories", {
-	id: text().primaryKey().notNull(),
-	name: text().notNull(),
-	organizationId: text("organization_id").notNull(),
-	userId: text("user_id").notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("idx_categories_org").using("btree", table.organizationId.asc().nullsLast().op("text_ops")),
-	foreignKey({
-			columns: [table.organizationId],
-			foreignColumns: [organization.id],
-			name: "categories_organization_id_organization_id_fk"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.id],
-			name: "categories_user_id_users_id_fk"
 		}),
 ]);
 
@@ -556,9 +510,9 @@ export const chains = pgTable("chains", {
 	defaultFallbackWss: text("default_fallback_wss"),
 	isTestnet: boolean("is_testnet").default(false),
 	isEnabled: boolean("is_enabled").default(true),
+	gasConfig: jsonb("gas_config").default({}),
 	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
 	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
-	gasConfig: jsonb("gas_config").default({}),
 }, (table) => [
 	index("idx_chains_chain_id").using("btree", table.chainId.asc().nullsLast().op("int4_ops")),
 	unique("chains_chain_id_unique").on(table.chainId),
@@ -571,4 +525,227 @@ export const walletLocks = pgTable("wallet_locks", {
 	lockedAt: timestamp("locked_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	primaryKey({ columns: [table.walletAddress, table.chainId], name: "wallet_locks_wallet_address_chain_id_pk"}),
+]);
+
+export const billingEvents = pgTable("billing_events", {
+	id: text().primaryKey().notNull(),
+	providerEventId: text("provider_event_id").notNull(),
+	type: text().notNull(),
+	data: jsonb(),
+	processed: boolean().default(false).notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	unique("billing_events_provider_event_id_unique").on(table.providerEventId),
+]);
+
+export const deviceCode = pgTable("device_code", {
+	id: text().primaryKey().notNull(),
+	deviceCode: text("device_code").notNull(),
+	userCode: text("user_code").notNull(),
+	userId: text("user_id"),
+	expiresAt: timestamp("expires_at", { mode: 'string' }).notNull(),
+	status: text().notNull(),
+	lastPolledAt: timestamp("last_polled_at", { mode: 'string' }),
+	pollingInterval: integer("polling_interval"),
+	clientId: text("client_id"),
+	scope: text(),
+	createdAt: timestamp("created_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { mode: 'string' }),
+}, (table) => [
+	foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "device_code_user_id_users_id_fk"
+		}),
+]);
+
+export const directExecutions = pgTable("direct_executions", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull(),
+	apiKeyId: text("api_key_id").notNull(),
+	type: text().notNull(),
+	input: jsonb(),
+	output: jsonb(),
+	status: text().default('pending').notNull(),
+	transactionHash: text("transaction_hash"),
+	network: text().notNull(),
+	error: text(),
+	gasUsedWei: text("gas_used_wei"),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+	completedAt: timestamp("completed_at", { mode: 'string' }),
+}, (table) => [
+	index("idx_direct_executions_org").using("btree", table.organizationId.asc().nullsLast().op("text_ops")),
+	index("idx_direct_executions_status").using("btree", table.status.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "direct_executions_organization_id_organization_id_fk"
+		}),
+]);
+
+export const executionDebt = pgTable("execution_debt", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull(),
+	overageRecordId: text("overage_record_id").notNull(),
+	providerInvoiceId: text("provider_invoice_id"),
+	debtExecutions: integer("debt_executions").notNull(),
+	status: text().default('active').notNull(),
+	enforcedAt: timestamp("enforced_at", { mode: 'string' }).notNull(),
+	clearedAt: timestamp("cleared_at", { mode: 'string' }),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	index("idx_execution_debt_org_status").using("btree", table.organizationId.asc().nullsLast().op("text_ops"), table.status.asc().nullsLast().op("text_ops")),
+	index("idx_execution_debt_invoice").using("btree", table.providerInvoiceId.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "execution_debt_organization_id_organization_id_fk"
+		}).onDelete("cascade"),
+	foreignKey({
+			columns: [table.overageRecordId],
+			foreignColumns: [overageBillingRecords.id],
+			name: "execution_debt_overage_record_id_overage_billing_records_id_fk"
+		}).onDelete("cascade"),
+	unique("execution_debt_overage_record_id_unique").on(table.overageRecordId),
+]);
+
+export const keyExportCodes = pgTable("key_export_codes", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull(),
+	codeHash: text("code_hash").notNull(),
+	expiresAt: timestamp("expires_at", { mode: 'string' }).notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+	attempts: integer().default(0).notNull(),
+}, (table) => [
+	foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "key_export_codes_organization_id_organization_id_fk"
+		}).onDelete("cascade"),
+]);
+
+export const mcpOauthClients = pgTable("mcp_oauth_clients", {
+	id: text().primaryKey().notNull(),
+	clientId: text("client_id").notNull(),
+	clientSecretHash: text("client_secret_hash").notNull(),
+	clientName: text("client_name").notNull(),
+	redirectUris: jsonb("redirect_uris").notNull(),
+	scopes: jsonb().notNull(),
+	grantTypes: jsonb("grant_types").notNull(),
+	organizationId: text("organization_id"),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	unique("mcp_oauth_clients_client_id_unique").on(table.clientId),
+]);
+
+export const mcpOauthRefreshTokens = pgTable("mcp_oauth_refresh_tokens", {
+	id: text().primaryKey().notNull(),
+	tokenHash: text("token_hash").notNull(),
+	clientId: text("client_id").notNull(),
+	userId: text("user_id").notNull(),
+	organizationId: text("organization_id").notNull(),
+	scope: text().notNull(),
+	expiresAt: timestamp("expires_at", { mode: 'string' }).notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	index("idx_mcp_refresh_tokens_client").using("btree", table.clientId.asc().nullsLast().op("text_ops")),
+	index("idx_mcp_refresh_tokens_user").using("btree", table.userId.asc().nullsLast().op("text_ops")),
+	unique("mcp_oauth_refresh_tokens_token_hash_unique").on(table.tokenHash),
+]);
+
+export const organizationSpendCaps = pgTable("organization_spend_caps", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull(),
+	dailyCapWei: text("daily_cap_wei").notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "organization_spend_caps_organization_id_organization_id_fk"
+		}),
+	unique("organization_spend_caps_organization_id_unique").on(table.organizationId),
+]);
+
+export const organizationSubscriptions = pgTable("organization_subscriptions", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull(),
+	providerCustomerId: text("provider_customer_id"),
+	providerSubscriptionId: text("provider_subscription_id"),
+	providerPriceId: text("provider_price_id"),
+	plan: text().default('free').notNull(),
+	tier: text(),
+	status: text().default('active').notNull(),
+	currentPeriodStart: timestamp("current_period_start", { mode: 'string' }),
+	currentPeriodEnd: timestamp("current_period_end", { mode: 'string' }),
+	cancelAtPeriodEnd: boolean("cancel_at_period_end").default(false).notNull(),
+	billingAlert: text("billing_alert"),
+	billingAlertUrl: text("billing_alert_url"),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	index("idx_org_subscriptions_org").using("btree", table.organizationId.asc().nullsLast().op("text_ops")),
+	index("idx_org_subscriptions_provider_sub").using("btree", table.providerSubscriptionId.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "organization_subscriptions_organization_id_organization_id_fk"
+		}).onDelete("cascade"),
+	unique("organization_subscriptions_organization_id_unique").on(table.organizationId),
+	unique("organization_subscriptions_provider_customer_id_unique").on(table.providerCustomerId),
+]);
+
+export const overageBillingRecords = pgTable("overage_billing_records", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull(),
+	periodStart: timestamp("period_start", { mode: 'string' }).notNull(),
+	periodEnd: timestamp("period_end", { mode: 'string' }).notNull(),
+	executionLimit: integer("execution_limit").notNull(),
+	totalExecutions: integer("total_executions").notNull(),
+	overageCount: integer("overage_count").notNull(),
+	overageRateCents: integer("overage_rate_cents").notNull(),
+	totalChargeCents: integer("total_charge_cents").notNull(),
+	providerInvoiceItemId: text("provider_invoice_item_id"),
+	providerInvoiceId: text("provider_invoice_id"),
+	status: text().default('pending').notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	index("idx_overage_billing_org").using("btree", table.organizationId.asc().nullsLast().op("text_ops")),
+	index("idx_overage_billing_status").using("btree", table.status.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "overage_billing_records_organization_id_organization_id_fk"
+		}).onDelete("cascade"),
+	unique("overage_billing_org_period").on(table.organizationId, table.periodStart, table.periodEnd),
+]);
+
+export const publicTags = pgTable("public_tags", {
+	id: text().primaryKey().notNull(),
+	name: text().notNull(),
+	slug: text().notNull(),
+	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
+}, (table) => [
+	unique("public_tags_name_unique").on(table.name),
+	unique("public_tags_slug_unique").on(table.slug),
+]);
+
+export const workflowPublicTags = pgTable("workflow_public_tags", {
+	workflowId: text("workflow_id").notNull(),
+	publicTagId: text("public_tag_id").notNull(),
+}, (table) => [
+	index("idx_workflow_public_tags_workflow").using("btree", table.workflowId.asc().nullsLast().op("text_ops")),
+	index("idx_workflow_public_tags_tag").using("btree", table.publicTagId.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.workflowId],
+			foreignColumns: [workflows.id],
+			name: "workflow_public_tags_workflow_id_workflows_id_fk"
+		}).onDelete("cascade"),
+	foreignKey({
+			columns: [table.publicTagId],
+			foreignColumns: [publicTags.id],
+			name: "workflow_public_tags_public_tag_id_public_tags_id_fk"
+		}).onDelete("cascade"),
+	primaryKey({ columns: [table.workflowId, table.publicTagId], name: "workflow_public_tags_workflow_id_public_tag_id_pk"}),
 ]);


### PR DESCRIPTION
## Summary

Follow-up to #691 (Turnkey wallet provider) and #711 (e2e test fixes).

The auto-generated `drizzle/schema.ts` snapshot was stale -- last updated around migration 0013, now regenerated from `0037_snapshot.json` to match current database state.

- 12 tables added (billing, MCP OAuth, device_code, key_export_codes, direct_executions, public_tags, etc.)
- 2 tables removed (categories, protocols -- dropped in earlier migrations)
- Column updates across para_wallets, pending_transactions, workflow_executions, workflow_execution_logs, invitation, workflows

This file is not imported by any runtime code. It is used by `drizzle-kit` as a reference when generating new migrations via `drizzle-kit pull`.

## Test plan

- [ ] Verify lint passes
- [ ] Verify no runtime imports of `drizzle/schema.ts` (confirmed: zero consumers)