### PR TITLE
hotfix: pass organizationId to workflow executor in background execution

### DIFF
--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -21,7 +21,8 @@ async function executeWorkflowBackground(
   workflowId: string,
   nodes: WorkflowNode[],
   edges: WorkflowEdge[],
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  organizationId?: string | null
 ) {
   try {
     console.log("[Workflow Execute] Starting execution:", executionId);
@@ -44,6 +45,7 @@ async function executeWorkflowBackground(
         triggerInput: input,
         executionId,
         workflowId,
+        organizationId: organizationId ?? undefined,
       },
     ]);
 
@@ -260,7 +262,8 @@ export async function POST(
       workflowId,
       workflow.nodes as WorkflowNode[],
       workflow.edges as WorkflowEdge[],
-      input
+      input,
+      workflow.organizationId
     );
 
     // Return immediately with the execution ID


### PR DESCRIPTION
## Summary

- `executeWorkflowBackground()` in the manual execution API route was not passing the workflow's `organizationId` to the `executeWorkflow()` call
- This caused all organization-scoped wallet operations (web3 signing steps) to fail with `Failed to initialize organization wallet: no valid wallet id found` because `initializeWalletSigner` requires an org context to look up the wallet
- The in-process executor (`keeperhub-executor/in-process.ts`) already passes `organizationId` correctly -- this bug only affected the DevKit-based execution path (`POST /api/workflow/[workflowId]/execute`)

## Changes

`app/api/workflow/[workflowId]/execute/route.ts`:
1. Added `organizationId` parameter to `executeWorkflowBackground()`
2. Forwarded `organizationId` into the `executeWorkflow()` input object
3. Passed `workflow.organizationId` at the call site

## Impact

Any workflow with web3 signing steps (transfer-token, transfer-funds, write-contract, approve-token) running through the manual/scheduled execution path was broken for organization-scoped wallets. This fix restores wallet context for all execution paths.