### PR TITLE
fix: correct drizzle journal timestamps for migrations 0038-0039

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -271,14 +271,14 @@
     {
       "idx": 38,
       "version": "7",
-      "when": 1774565267976,
+      "when": 1774900000001,
       "tag": "0038_hot_songbird",
       "breakpoints": true
     },
     {
       "idx": 39,
       "version": "7",
-      "when": 1774580851069,
+      "when": 1774900000002,
       "tag": "0039_burly_sinister_six",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Migrations 0038 and 0039 had `when` timestamps earlier than 0037, causing `drizzle-kit migrate` to skip them silently
- Same class of issue fixed in 7cfa3187 for staging
- Root cause of `relation "mcp_oauth_auth_codes" does not exist` error in prod

## Test plan
- [ ] Merge to staging, then staging to prod
- [ ] Verify `drizzle-kit migrate` applies 0038 and 0039 on next deploy
- [ ] Verify `mcp_oauth_auth_codes` table is created