### PR TITLE
fix: mark reconstructed MCP sessions as initialized

### DIFF
--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -217,6 +217,18 @@ async function resolveSession(
 
   await entry.server.connect(transport);
 
+  // The SDK's transport tracks an `_initialized` flag that is only set when it
+  // processes an actual `initialize` JSON-RPC message.  Reconstructed sessions
+  // skip that step, so the flag stays false and every subsequent request is
+  // rejected with "Server not initialized".  The valid JWT proves the client
+  // already completed initialization, so we mark both fields directly.
+  const reconstructed = transport as unknown as {
+    _initialized: boolean;
+    sessionId: string;
+  };
+  reconstructed._initialized = true;
+  reconstructed.sessionId = sessionId;
+
   // Cache locally for subsequent same-pod requests.
   setSession(sessionId, entry);
 


### PR DESCRIPTION
## Summary
- Fixes "Server not initialized" errors after pod restarts or cross-pod routing
- When sessions are reconstructed from JWT, the SDK transport's `_initialized` flag stays false because no actual `initialize` JSON-RPC message was processed
- Sets `_initialized = true` and `sessionId` on the reconstructed transport since the valid JWT proves initialization already happened

## Context
Follow-up to #733 (Accept header fix). Together these two fixes resolve all MCP connectivity issues with Claude Code.

## Test plan
- [ ] Deploy to staging, reconnect MCP in Claude Code, verify tool calls work across pod restarts
- [ ] Verify fresh sessions (new OAuth) still work normally