### PR TITLE
fix: mark reconstructed MCP sessions as initialized

### DIFF
--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -217,6 +217,18 @@ async function resolveSession(
 
   await entry.server.connect(transport);
 
+  // The SDK's transport tracks an `_initialized` flag that is only set when it
+  // processes an actual `initialize` JSON-RPC message.  Reconstructed sessions
+  // skip that step, so the flag stays false and every subsequent request is
+  // rejected with "Server not initialized".  The valid JWT proves the client
+  // already completed initialization, so we mark both fields directly.
+  const reconstructed = transport as unknown as {
+    _initialized: boolean;
+    sessionId: string;
+  };
+  reconstructed._initialized = true;
+  reconstructed.sessionId = sessionId;
+
   // Cache locally for subsequent same-pod requests.
   setSession(sessionId, entry);
 


### PR DESCRIPTION
## Summary
- Fixes "Server not initialized" errors after pod restarts or cross-pod routing
- Sets `_initialized` and `sessionId` on reconstructed transport since the valid JWT proves initialization already happened
- Follow-up to #734 (Accept header fix)

## Test plan
- [x] Lint and type-check pass
- [x] Verified SDK source: `_initialized` and `sessionId` are plain properties checked by `validateSession`
- [x] Merged to staging via #735
- [ ] Verify MCP tool calls work after prod deploy