### PR TITLE
feat: add wallet provider info icons and multi-provider docs

### DIFF
--- a/components/onboarding/getting-started-checklist.tsx
+++ b/components/onboarding/getting-started-checklist.tsx
@@ -229,16 +229,16 @@ export function GettingStartedChecklist({
               <Info className="size-3.5 text-muted-foreground" />
             </TooltipTrigger>
             <TooltipContent className="max-w-64 text-xs" side="top">
-              Non-custodial wallet powered by{" "}
+              Non-custodial wallet for signing blockchain transactions. Choose
+              from multiple providers.{" "}
               <a
                 className="underline"
-                href="https://www.getpara.com/"
+                href="https://docs.keeperhub.com/wallet-management"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                Para
+                Learn more
               </a>
-              . Works across multiple networks.
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -5,6 +5,7 @@ import {
   Eye,
   EyeOff,
   ExternalLink,
+  Info,
   KeyRound,
   Plus,
   RefreshCw,
@@ -36,6 +37,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
 import { useSession } from "@/lib/auth-client";
 import { useActiveMember } from "@/lib/hooks/use-organization";
@@ -573,6 +580,35 @@ function CreateWalletForm({
               <div className="flex items-center gap-1.5">
                 <ShieldCheck className="h-3.5 w-3.5 text-primary" />
                 <span className="font-medium text-xs">Turnkey</span>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger
+                      asChild
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Info className="size-3 text-muted-foreground" />
+                    </TooltipTrigger>
+                    <TooltipContent className="text-xs" side="top">
+                      <a
+                        className="underline"
+                        href="https://www.turnkey.com"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Website
+                      </a>
+                      {" · "}
+                      <a
+                        className="underline"
+                        href="https://docs.keeperhub.com/wallet-management/turnkey"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Docs
+                      </a>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </div>
               <span className="text-muted-foreground text-[10px] leading-tight">
                 Secure enclave. Supports private key export.
@@ -591,6 +627,35 @@ function CreateWalletForm({
               <div className="flex items-center gap-1.5">
                 <Shield className="h-3.5 w-3.5 text-muted-foreground" />
                 <span className="font-medium text-xs">Para</span>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger
+                      asChild
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Info className="size-3 text-muted-foreground" />
+                    </TooltipTrigger>
+                    <TooltipContent className="text-xs" side="top">
+                      <a
+                        className="underline"
+                        href="https://www.getpara.com"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Website
+                      </a>
+                      {" · "}
+                      <a
+                        className="underline"
+                        href="https://docs.keeperhub.com/wallet-management/para"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Docs
+                      </a>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </div>
               <span className="text-muted-foreground text-[10px] leading-tight">
                 MPC-based signing. No key export.

--- a/docs/wallet-management/index.md
+++ b/docs/wallet-management/index.md
@@ -7,6 +7,12 @@ description: "Manage wallets, gas, and address books in KeeperHub."
 
 Secure wallet integration and management for your blockchain automations.
 
-- [Para Integration](/wallet-management/para) -- Secure wallet management without handling private keys
+## Wallet Providers
+
+- [Turnkey](/wallet-management/turnkey) -- Secure enclave wallets with private key export
+- [Para](/wallet-management/para) -- MPC-based wallet management without handling private keys
+
+## Other
+
 - [Gas Management](/wallet-management/gas) -- Gas estimation, optimization, and funding
 - [Address Book](/wallet-management/address-book) -- Save and manage frequently used addresses

--- a/docs/wallet-management/para.md
+++ b/docs/wallet-management/para.md
@@ -1,59 +1,54 @@
 ---
 title: "Para Wallet Integration"
-description: "How KeeperHub integrates with Para for secure, simplified wallet management without handling private keys."
+description: "How KeeperHub integrates with Para for MPC-based wallet management."
 ---
 
 # Para Integration
 
-KeeperHub uses Para for secure wallet management, eliminating the need for users to handle private keys or complex wallet security procedures.
+Para is one of the wallet providers available in KeeperHub. It uses multi-party computation (MPC) for signing, so private keys are never exposed to any single party.
 
-## Automatic Wallet Creation
+## Creating a Para Wallet
 
-When you create a new KeeperHub account, a Para wallet is automatically generated and associated with your account. The public address is displayed in the KeeperHub interface for reference.
+In the Organization Wallet dialog, select **Para** as your provider and enter the email address for wallet creation. The wallet will be shared across your organization.
+
+## How It Works
+
+Para uses MPC-based signing to execute transactions without exposing private keys. This provides:
+
+- **No private key management** -- cryptographic operations happen securely across multiple parties
+- **Simplified experience** -- no need for seed phrases or hardware wallets
+- **Integrated operations** -- seamless signing for workflow transactions
 
 ## Wallet Funding
 
-Topping up your Para wallet with ETH is only required for specific keeper operations:
+Topping up your Para wallet with ETH is only required for workflow operations that execute on-chain transactions.
 
 **When funding is needed**:
-- Write function calls from Poker keepers (require gas fees)
-- Filler keeper operations that transfer ETH to other wallets
-- Any keeper operations that execute blockchain transactions
+
+- Write function calls (require gas fees)
+- Token or ETH transfer operations
+- Any workflow steps that execute blockchain transactions
 
 **When funding is not needed**:
-- Watcher keepers (read-only monitoring)
-- Multisig keepers (monitoring multisig changes)
-- Read function calls from Poker keepers
 
-Balance updates are reflected in the KeeperHub interface and displayed per network (Mainnet/Sepolia).
+- Read-only monitoring workflows
+- Multisig monitoring workflows
+- Read function calls
+
+Balance updates are reflected in the KeeperHub interface and displayed per network.
 
 ## Wallet Management
 
-**Deposit**: Transfer ETH to your Para wallet address to fund keeper operations.
+**Deposit**: Transfer ETH to your Para wallet address to fund workflow operations.
 
 **Withdraw**: Use the Withdraw function in the UI to transfer wallet balance out of KeeperHub.
 
-## Security Benefits
-
-**No Private Key Management**: Para handles all cryptographic operations securely without exposing private keys to users.
-
-**Simplified Experience**: Users don't need prior knowledge of Ethereum wallet management or security best practices.
-
-**Integrated Operations**: Seamless integration with keeper functions for automated transactions.
-
-## Supported Operations
-
-Para wallets can execute:
-- ETH transfers for Filler keeper operations
-- Smart contract function calls for Poker keeper operations
-- Gas fee payments for all transaction-based keepers
-
 ## Network Support
 
-Currently supports:
 - Ethereum Mainnet
 - Sepolia Testnet
 
 ## Limitations
 
-Token transfers are not yet supported but are planned for future releases.
+- Private key export is not supported (use [Turnkey](/wallet-management/turnkey) if key export is required)
+- Token transfers are not yet supported but are planned for future releases

--- a/docs/wallet-management/turnkey.md
+++ b/docs/wallet-management/turnkey.md
@@ -1,0 +1,57 @@
+---
+title: "Turnkey Wallet Integration"
+description: "How KeeperHub integrates with Turnkey for secure enclave wallet management with key export."
+---
+
+# Turnkey Integration
+
+Turnkey is one of the wallet providers available in KeeperHub. It uses secure enclaves to protect private keys and supports key export for advanced users.
+
+## Creating a Turnkey Wallet
+
+In the Organization Wallet dialog, select **Turnkey** as your provider and enter the email address for wallet creation. The wallet will be shared across your organization.
+
+## How It Works
+
+Turnkey generates and stores private keys inside secure hardware enclaves (TEEs). Signing requests are authenticated and executed within the enclave.
+
+- **Secure enclave storage** -- keys never leave the hardware boundary during normal operation
+- **Private key export** -- export your key if you need to migrate to another solution
+- **Integrated operations** -- seamless signing for workflow transactions
+
+## Wallet Funding
+
+Topping up your Turnkey wallet with ETH is only required for workflow operations that execute on-chain transactions.
+
+**When funding is needed**:
+
+- Write function calls (require gas fees)
+- Token or ETH transfer operations
+- Any workflow steps that execute blockchain transactions
+
+**When funding is not needed**:
+
+- Read-only monitoring workflows
+- Multisig monitoring workflows
+- Read function calls
+
+Balance updates are reflected in the KeeperHub interface and displayed per network.
+
+## Wallet Management
+
+**Deposit**: Transfer ETH to your Turnkey wallet address to fund workflow operations.
+
+**Withdraw**: Use the Withdraw function in the UI to transfer wallet balance out of KeeperHub.
+
+**Export Key**: Use the key export feature to retrieve your private key if you need to migrate to another wallet solution.
+
+## Network Support
+
+- Ethereum Mainnet
+- Sepolia Testnet
+
+## When to Choose Turnkey
+
+- You want the option to export private keys
+- You prefer hardware enclave security model
+- Your organization requires key portability


### PR DESCRIPTION
## Summary

- Add info icon tooltips to Turnkey and Para provider cards in the Organization Wallet dialog, linking to each provider's website and KeeperHub docs
- Update setup guide "Create Wallet" tooltip to be provider-agnostic (previously referenced only Para)
- Refresh wallet docs: updated `para.md` (removed outdated auto-creation and keeper references), created `turnkey.md`, updated `index.md` to list both providers