### PR TITLE
fix: auth regressions and hard-scope API keys to creation org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Exits with code 1 if errors are found. Errors are hardcoded colors in CSS and ar
 
 ### Exempt Files
 
-- `keeperhub/api/og/generate-og.tsx` -- server-rendered OG images, not interactive UI
+- `app/api/og/generate-og.tsx` -- server-rendered OG images, not interactive UI
 - `lib/monaco-theme.ts` -- editor syntax highlighting, uses Monaco's theming API
 - `lib/next-boilerplate/` -- upstream template code
 - `docs-site/` -- separate documentation site
@@ -145,20 +145,14 @@ Exits with code 1 if errors are found. Errors are hardcoded colors in CSS and ar
 ## Project Structure
 
 ```
-app/              - Next.js app directory
+app/              - Next.js app directory (API routes, pages)
 components/       - UI components
-lib/              - Core utilities
-plugins/          - Core plugins
+lib/              - Core utilities, DB schemas, middleware
+plugins/          - Workflow plugins (web3, discord, sendgrid, etc.)
 scripts/          - Build/migration scripts
 tests/            - Test files
-
-keeperhub/        - 🚨 ALL CUSTOM CODE GOES HERE
-  ├── api/        - Custom API routes
-  ├── app/        - Custom pages
-  ├── components/ - Custom components
-  ├── db/         - Custom schemas
-  ├── lib/        - Custom utilities
-  └── plugins/    - Custom plugins
+specs/            - Internal specs and design system
+docs/             - Public-facing docs (published to docs.keeperhub.com)
 ```
 
 ## Common Commands
@@ -202,13 +196,13 @@ Without the migration file, the table will not be created on deploy and you will
 
 ## Plugin Development
 
-**Context**: Building Web3 integrations for the workflow system. Plugins go in `keeperhub/plugins/`.
+**Context**: Building Web3 integrations for the workflow system. Plugins go in `plugins/`.
 
 **Current Plugins**: `web3`, `webhook`, `discord`, `sendgrid`
 
 **When creating new plugins**:
 
-1. Check existing plugins: `ls keeperhub/plugins/`
+1. Check existing plugins: `ls plugins/`
 2. Pick a recent, similar plugin as reference
 3. Copy its exact structure and pattern
 4. Keep it **absolutely minimal** - no extra features, no over-engineering
@@ -221,8 +215,7 @@ Without the migration file, the table will not be created on deploy and you will
 
 **Files**:
 
-- `keeperhub/api/mcp/schemas/route.ts` - Implementation
-- `app/api/mcp/schemas/route.ts` - Thin wrapper (re-exports from keeperhub)
+- `app/api/mcp/schemas/route.ts`
 
 This endpoint serves workflow schemas to the KeeperHub MCP server. It's the source of truth for what actions, triggers, and capabilities are available.
 
@@ -247,7 +240,7 @@ These are defined directly in the file because they rarely change and aren't in 
 
 1. **New System Action**: Add entry to `SYSTEM_ACTIONS` object, implement step in `lib/steps/`
 2. **New Trigger**: Add entry to `TRIGGERS` object, implement UI in `components/workflow/config/trigger-config.tsx`
-3. **New Plugin**: Just create the plugin normally in `keeperhub/plugins/` - it's picked up automatically
+3. **New Plugin**: Just create the plugin normally in `plugins/` - it's picked up automatically
 
 ### Testing the Endpoint
 

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -1,15 +1,13 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { start } from "workflow/api";
-import { authenticateApiKey } from "@/lib/api-key-auth";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
-import { getOrgContext } from "@/lib/middleware/org-context";
+import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
-import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
@@ -104,73 +102,36 @@ export async function POST(
 
       userId = workflow.userId;
     } else {
-      // Try API key authentication first
-      const apiKeyAuth = await authenticateApiKey(request);
-      let organizationId: string | null = null;
-
-      if (apiKeyAuth.authenticated) {
-        // API key authentication successful
-        organizationId = apiKeyAuth.organizationId || null;
-
-        // Get workflow and verify organization access
-        workflow = await db.query.workflows.findFirst({
-          where: eq(workflows.id, workflowId),
-        });
-
-        if (!workflow) {
-          return NextResponse.json(
-            { error: "Workflow not found" },
-            { status: 404 }
-          );
-        }
-
-        // Check that workflow belongs to the API key's organization
-        const isSameOrg =
-          !workflow.isAnonymous &&
-          workflow.organizationId &&
-          organizationId === workflow.organizationId;
-
-        if (!isSameOrg) {
-          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-        }
-
-        userId = workflow.userId;
-      } else {
-        // Fall back to session authentication
-        const session = await auth.api.getSession({
-          headers: request.headers,
-        });
-
-        if (!session) {
-          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        // Get workflow and verify ownership
-        workflow = await db.query.workflows.findFirst({
-          where: eq(workflows.id, workflowId),
-        });
-
-        if (!workflow) {
-          return NextResponse.json(
-            { error: "Workflow not found" },
-            { status: 404 }
-          );
-        }
-
-        // Check access: owner or org member
-        const isOwner = workflow.userId === session.user.id;
-        const orgContext = await getOrgContext();
-        const isSameOrg =
-          !workflow.isAnonymous &&
-          workflow.organizationId &&
-          orgContext.organization?.id === workflow.organizationId;
-
-        if (!(isOwner || isSameOrg)) {
-          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-        }
-
-        userId = session.user.id;
+      const authContext = await getDualAuthContext(request);
+      if ("error" in authContext) {
+        return NextResponse.json(
+          { error: authContext.error },
+          { status: authContext.status }
+        );
       }
+
+      workflow = await db.query.workflows.findFirst({
+        where: eq(workflows.id, workflowId),
+      });
+
+      if (!workflow) {
+        return NextResponse.json(
+          { error: "Workflow not found" },
+          { status: 404 }
+        );
+      }
+
+      const isOwner = authContext.authMethod === "session" && workflow.userId === authContext.userId;
+      const isSameOrg =
+        !workflow.isAnonymous &&
+        workflow.organizationId &&
+        authContext.organizationId === workflow.organizationId;
+
+      if (!(isOwner || isSameOrg)) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+
+      userId = authContext.userId ?? workflow.userId;
     }
 
     // Validate that all integrationIds in workflow nodes belong to the user or org

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -42,6 +42,53 @@ The MCP endpoint supports two authentication methods:
 
 **API keys (headless):** Pass an organization API key (`kh_` prefix) as a Bearer token. Create one at [app.keeperhub.com](https://app.keeperhub.com) under Settings > API Keys > Organisation tab.
 
+## Organization Scoping
+
+Each MCP connection is scoped to a single organization. The org is determined by your authentication method:
+
+- **OAuth:** The org active in your browser session when you approve the authorization request.
+- **API key:** The org the key was created in (visible on the API Keys page).
+
+All tools operate within this org -- listing workflows, creating workflows, executing, and viewing integrations. There is no way to access another org's resources from the same connection.
+
+### Switching Organizations
+
+To work with a different org, re-authenticate:
+
+**OAuth (Claude Code):** Switch your active org at [app.keeperhub.com](https://app.keeperhub.com) using the org switcher, then reconnect the MCP server. In Claude Code, remove and re-add the server:
+
+```bash
+claude mcp remove keeperhub
+claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+```
+
+Complete the OAuth flow again -- the new active org will be captured.
+
+**API key:** Create a separate API key in the target org and update the MCP server configuration with the new key.
+
+### Working with Multiple Organizations
+
+If you regularly work across multiple orgs, add a separate MCP server entry for each:
+
+```json
+{
+  "mcpServers": {
+    "keeperhub-acme": {
+      "type": "http",
+      "url": "https://app.keeperhub.com/mcp",
+      "headers": { "Authorization": "Bearer kh_acme_key" }
+    },
+    "keeperhub-personal": {
+      "type": "http",
+      "url": "https://app.keeperhub.com/mcp",
+      "headers": { "Authorization": "Bearer kh_personal_key" }
+    }
+  }
+}
+```
+
+Each server entry has its own tool namespace, so the AI agent can distinguish which org to target based on the server name.
+
 ## Tools Reference
 
 ### Workflow Management

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -136,6 +136,14 @@ export function authenticateOAuthToken(request: Request): OAuthAuthResult {
     };
   }
 
+  if (!payload.org) {
+    return {
+      authenticated: false,
+      error: "OAuth token missing organization claim",
+      statusCode: 401,
+    };
+  }
+
   return {
     authenticated: true,
     userId: payload.sub,

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -46,18 +46,13 @@ async function callApi(
   authHeader: string,
   path: string,
   method: string,
-  body?: unknown,
-  organizationId?: string
+  body?: unknown
 ): Promise<ApiResponse> {
   const url = `${baseUrl}${path}`;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     Authorization: authHeader,
   };
-
-  if (organizationId) {
-    headers["X-Organization-Id"] = organizationId;
-  }
 
   const response = await fetch(url, {
     method,
@@ -102,16 +97,10 @@ export function registerTools(
         .string()
         .optional()
         .describe("Optional tag ID to filter workflows"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org. The API key creator must be a member of the target org."
-        ),
     },
     { title: "List Workflows", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("list_workflows", scope, async (args) =>
-      withToolLogging("list_workflows", args.organizationId, async () => {
+      withToolLogging("list_workflows", undefined, async () => {
         const params = new URLSearchParams();
         if (args.projectId) {
           params.set("projectId", args.projectId);
@@ -121,14 +110,7 @@ export function registerTools(
         }
         const query = params.toString();
         const path = `/api/workflows${query ? `?${query}` : ""}`;
-        const data = await callApi(
-          baseUrl,
-          authHeader,
-          path,
-          "GET",
-          undefined,
-          args.organizationId
-        );
+        const data = await callApi(baseUrl, authHeader, path, "GET");
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
         };
@@ -141,23 +123,15 @@ export function registerTools(
     "Get a single workflow by ID, including its nodes, edges, and configuration.",
     {
       workflowId: z.string().describe("The workflow ID"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org."
-        ),
     },
     { title: "Get Workflow", readOnlyHint: true, destructiveHint: false },
     withScopeCheck("get_workflow", scope, async (args) =>
-      withToolLogging("get_workflow", args.organizationId, async () => {
+      withToolLogging("get_workflow", undefined, async () => {
         const data = await callApi(
           baseUrl,
           authHeader,
           `/api/workflows/${args.workflowId}`,
-          "GET",
-          undefined,
-          args.organizationId
+          "GET"
         );
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
@@ -189,16 +163,10 @@ export function registerTools(
         .string()
         .optional()
         .describe("Optional tag ID to label the workflow"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org."
-        ),
     },
     { title: "Create Workflow", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("create_workflow", scope, async (args) =>
-      withToolLogging("create_workflow", args.organizationId, async () => {
+      withToolLogging("create_workflow", undefined, async () => {
         const data = await callApi(
           baseUrl,
           authHeader,
@@ -211,8 +179,7 @@ export function registerTools(
             edges: args.edges,
             projectId: args.projectId,
             tagId: args.tagId,
-          },
-          args.organizationId
+          }
         );
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
@@ -246,24 +213,17 @@ export function registerTools(
         .nullable()
         .optional()
         .describe("Tag ID to assign (null to unassign)"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org."
-        ),
     },
     { title: "Update Workflow", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("update_workflow", scope, async (args) =>
-      withToolLogging("update_workflow", args.organizationId, async () => {
-        const { workflowId, organizationId, ...body } = args;
+      withToolLogging("update_workflow", undefined, async () => {
+        const { workflowId, ...body } = args;
         const data = await callApi(
           baseUrl,
           authHeader,
           `/api/workflows/${workflowId}`,
           "PUT",
-          body,
-          organizationId
+          body
         );
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
@@ -277,23 +237,15 @@ export function registerTools(
     "Delete a workflow by ID. This action is irreversible.",
     {
       workflowId: z.string().describe("The workflow ID to delete"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org."
-        ),
     },
     { title: "Delete Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("delete_workflow", scope, async (args) =>
-      withToolLogging("delete_workflow", args.organizationId, async () => {
+      withToolLogging("delete_workflow", undefined, async () => {
         const data = await callApi(
           baseUrl,
           authHeader,
           `/api/workflows/${args.workflowId}`,
-          "DELETE",
-          undefined,
-          args.organizationId
+          "DELETE"
         );
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
@@ -315,23 +267,16 @@ export function registerTools(
         .record(z.string(), z.unknown())
         .optional()
         .describe("Optional input data to pass to the workflow trigger"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org. Use this to execute workflows under a different org's context (wallet, settings)."
-        ),
     },
     { title: "Execute Workflow", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("execute_workflow", scope, async (args) =>
-      withToolLogging("execute_workflow", args.organizationId, async () => {
+      withToolLogging("execute_workflow", undefined, async () => {
         const data = await callApi(
           baseUrl,
           authHeader,
           `/api/workflow/${args.workflowId}/execute`,
           "POST",
-          { input: args.input ?? {} },
-          args.organizationId
+          { input: args.input ?? {} }
         );
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
@@ -531,24 +476,15 @@ export function registerTools(
   server.tool(
     "list_integrations",
     "List all configured integrations (credentials) for the organization. These are required for actions like Discord notifications or Sendgrid emails.",
-    {
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org."
-        ),
-    },
+    {},
     { title: "List Integrations", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("list_integrations", scope, async (args) =>
-      withToolLogging("list_integrations", args.organizationId, async () => {
+    withScopeCheck("list_integrations", scope, async (_args) =>
+      withToolLogging("list_integrations", undefined, async () => {
         const data = await callApi(
           baseUrl,
           authHeader,
           "/api/integrations",
-          "GET",
-          undefined,
-          args.organizationId
+          "GET"
         );
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
@@ -562,12 +498,6 @@ export function registerTools(
     "Get details for a specific wallet integration. Required for web3 write actions like fund transfers and contract writes.",
     {
       integrationId: z.string().describe("The integration (wallet) ID"),
-      organizationId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional organization ID to override the API key's default org."
-        ),
     },
     {
       title: "Get Wallet Integration",
@@ -575,23 +505,17 @@ export function registerTools(
       destructiveHint: false,
     },
     withScopeCheck("get_wallet_integration", scope, async (args) =>
-      withToolLogging(
-        "get_wallet_integration",
-        args.organizationId,
-        async () => {
-          const data = await callApi(
-            baseUrl,
-            authHeader,
-            `/api/integrations/${args.integrationId}`,
-            "GET",
-            undefined,
-            args.organizationId
-          );
-          return {
-            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-          };
-        }
-      )
+      withToolLogging("get_wallet_integration", undefined, async () => {
+        const data = await callApi(
+          baseUrl,
+          authHeader,
+          `/api/integrations/${args.integrationId}`,
+          "GET"
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        };
+      })
     )
   );
 
@@ -815,14 +739,7 @@ export function registerDynamicTools(
       const toolName = slugToToolName(plugin.type, action.slug);
       const flatFields = flattenConfigFields(action.configFields);
 
-      const inputSchema: Record<string, z.ZodTypeAny> = {
-        organizationId: z
-          .string()
-          .optional()
-          .describe(
-            "Optional organization ID to override the API key's default org."
-          ),
-      };
+      const inputSchema: Record<string, z.ZodTypeAny> = {};
 
       for (const field of flatFields) {
         const fieldSchema = field.required
@@ -845,18 +762,14 @@ export function registerDynamicTools(
         inputSchema,
         annotations,
         withScopeCheck(toolName, scope, async (args) => {
-          const { organizationId, ...fieldArgs } = args as Record<
-            string,
-            string | undefined
-          >;
-          return await withToolLogging(toolName, organizationId, async () => {
+          const fieldArgs = args as Record<string, string | undefined>;
+          return await withToolLogging(toolName, undefined, async () => {
             const data = await callApi(
               baseUrl,
               authHeader,
               `/api/execute/${integration}/${slug}`,
               "POST",
-              fieldArgs,
-              organizationId
+              fieldArgs
             );
             return {
               content: [{ type: "text", text: JSON.stringify(data, null, 2) }],

--- a/lib/middleware/auth-helpers.ts
+++ b/lib/middleware/auth-helpers.ts
@@ -3,10 +3,15 @@ import { authenticateApiKey } from "@/lib/api-key-auth";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { member } from "@/lib/db/schema";
+import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
 import { getOrgContext } from "@/lib/middleware/org-context";
 
 export type DualAuthContext =
-  | { userId: string | null; organizationId: string | null }
+  | {
+      userId: string | null;
+      organizationId: string | null;
+      authMethod: "oauth" | "api-key" | "session";
+    }
   | { error: string; status: number };
 
 /**
@@ -22,40 +27,60 @@ export async function getDualAuthContext(
 ): Promise<DualAuthContext> {
   const required = options?.required ?? true;
 
+  const oauthAuth = authenticateOAuthToken(request);
+  if (oauthAuth.authenticated) {
+    return {
+      userId: oauthAuth.userId ?? null,
+      organizationId: oauthAuth.organizationId ?? null,
+      authMethod: "oauth",
+    };
+  }
+
   const apiKeyAuth = await authenticateApiKey(request);
   if (apiKeyAuth.authenticated) {
-    const defaultOrgId = apiKeyAuth.organizationId || null;
-    const userId = apiKeyAuth.userId || null;
-
-    // Check for X-Organization-Id override
-    if (defaultOrgId) {
-      const overrideResult = await resolveOrganizationOverride(
-        request,
-        defaultOrgId,
-        userId
-      );
-      if ("error" in overrideResult) {
-        return { error: overrideResult.error, status: overrideResult.status };
-      }
-      return { userId, organizationId: overrideResult.organizationId };
-    }
-
-    return { userId, organizationId: defaultOrgId };
+    return resolveApiKeyContext(request, apiKeyAuth);
   }
 
   const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user && required) {
+    return { error: "Unauthorized", status: 401 };
+  }
   if (!session?.user) {
-    if (required) {
-      return { error: "Unauthorized", status: 401 };
-    }
-    return { userId: null, organizationId: null };
+    return { userId: null, organizationId: null, authMethod: "session" };
   }
 
   const orgContext = await getOrgContext();
   return {
     userId: session.user.id,
     organizationId: orgContext.organization?.id || null,
+    authMethod: "session",
   };
+}
+
+async function resolveApiKeyContext(
+  request: Request,
+  apiKeyAuth: { organizationId?: string; userId?: string }
+): Promise<DualAuthContext> {
+  const defaultOrgId = apiKeyAuth.organizationId || null;
+  const userId = apiKeyAuth.userId || null;
+
+  if (defaultOrgId) {
+    const overrideResult = await resolveOrganizationOverride(
+      request,
+      defaultOrgId,
+      userId
+    );
+    if ("error" in overrideResult) {
+      return { error: overrideResult.error, status: overrideResult.status };
+    }
+    return {
+      userId,
+      organizationId: overrideResult.organizationId,
+      authMethod: "api-key",
+    };
+  }
+
+  return { userId, organizationId: defaultOrgId, authMethod: "api-key" };
 }
 
 /**

--- a/lib/middleware/auth-helpers.ts
+++ b/lib/middleware/auth-helpers.ts
@@ -1,8 +1,5 @@
-import { and, eq } from "drizzle-orm";
 import { authenticateApiKey } from "@/lib/api-key-auth";
 import { auth } from "@/lib/auth";
-import { db } from "@/lib/db";
-import { member } from "@/lib/db/schema";
 import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
 import { getOrgContext } from "@/lib/middleware/org-context";
 
@@ -15,10 +12,11 @@ export type DualAuthContext =
   | { error: string; status: number };
 
 /**
- * Resolves user and organization context from either API key or session auth.
+ * Resolves user and organization context from OAuth token, API key, or session auth.
  * For API key auth, userId is the key creator (if available).
+ * API keys are hard-scoped to their creation org (no cross-org override).
  *
- * @param required - If true (default), returns 401 when neither auth method succeeds.
+ * @param required - If true (default), returns 401 when no auth method succeeds.
  *   Set to false for routes that allow unauthenticated access (e.g. public workflows).
  */
 export async function getDualAuthContext(
@@ -38,7 +36,7 @@ export async function getDualAuthContext(
 
   const apiKeyAuth = await authenticateApiKey(request);
   if (apiKeyAuth.authenticated) {
-    return resolveApiKeyContext(request, apiKeyAuth);
+    return resolveApiKeyContext(apiKeyAuth);
   }
 
   const session = await auth.api.getSession({ headers: request.headers });
@@ -52,35 +50,20 @@ export async function getDualAuthContext(
   const orgContext = await getOrgContext();
   return {
     userId: session.user.id,
-    organizationId: orgContext.organization?.id || null,
+    organizationId: orgContext.organization?.id ?? null,
     authMethod: "session",
   };
 }
 
-async function resolveApiKeyContext(
-  request: Request,
-  apiKeyAuth: { organizationId?: string; userId?: string }
-): Promise<DualAuthContext> {
-  const defaultOrgId = apiKeyAuth.organizationId || null;
-  const userId = apiKeyAuth.userId || null;
-
-  if (defaultOrgId) {
-    const overrideResult = await resolveOrganizationOverride(
-      request,
-      defaultOrgId,
-      userId
-    );
-    if ("error" in overrideResult) {
-      return { error: overrideResult.error, status: overrideResult.status };
-    }
-    return {
-      userId,
-      organizationId: overrideResult.organizationId,
-      authMethod: "api-key",
-    };
-  }
-
-  return { userId, organizationId: defaultOrgId, authMethod: "api-key" };
+function resolveApiKeyContext(apiKeyAuth: {
+  organizationId?: string;
+  userId?: string;
+}): DualAuthContext {
+  return {
+    userId: apiKeyAuth.userId ?? null,
+    organizationId: apiKeyAuth.organizationId ?? null,
+    authMethod: "api-key",
+  };
 }
 
 /**
@@ -93,20 +76,11 @@ export async function resolveOrganizationId(
   const apiKeyAuth = await authenticateApiKey(request);
 
   if (apiKeyAuth.authenticated) {
-    const defaultOrgId = apiKeyAuth.organizationId;
-    if (!defaultOrgId) {
+    const organizationId = apiKeyAuth.organizationId;
+    if (!organizationId) {
       return { error: "No active organization", status: 400 };
     }
-
-    const overrideResult = await resolveOrganizationOverride(
-      request,
-      defaultOrgId,
-      apiKeyAuth.userId || null
-    );
-    if ("error" in overrideResult) {
-      return { error: overrideResult.error, status: overrideResult.status };
-    }
-    return { organizationId: overrideResult.organizationId };
+    return { organizationId };
   }
 
   const session = await auth.api.getSession({ headers: request.headers });
@@ -133,9 +107,9 @@ export async function resolveCreatorContext(
 > {
   const apiKeyAuth = await authenticateApiKey(request);
   if (apiKeyAuth.authenticated) {
-    const defaultOrgId = apiKeyAuth.organizationId || null;
-    const userId = apiKeyAuth.userId || null;
-    if (!defaultOrgId) {
+    const organizationId = apiKeyAuth.organizationId ?? null;
+    const userId = apiKeyAuth.userId ?? null;
+    if (!organizationId) {
       return { error: "No active organization", status: 400 };
     }
     if (!userId) {
@@ -144,16 +118,7 @@ export async function resolveCreatorContext(
         status: 400,
       };
     }
-
-    const overrideResult = await resolveOrganizationOverride(
-      request,
-      defaultOrgId,
-      userId
-    );
-    if ("error" in overrideResult) {
-      return { error: overrideResult.error, status: overrideResult.status };
-    }
-    return { organizationId: overrideResult.organizationId, userId };
+    return { organizationId, userId };
   }
 
   const session = await auth.api.getSession({ headers: request.headers });
@@ -162,57 +127,9 @@ export async function resolveCreatorContext(
   }
 
   const context = await getOrgContext();
-  const organizationId = context.organization?.id || null;
+  const organizationId = context.organization?.id ?? null;
   if (!organizationId) {
     return { error: "No active organization", status: 400 };
   }
   return { organizationId, userId: session.user.id };
-}
-
-/**
- * Resolves an optional organization override from the X-Organization-Id header.
- * If the header is present, validates that the given userId is a member of
- * the target organization. Returns the override org ID if valid, or the
- * default org ID if no override is requested.
- *
- * @param request - The incoming HTTP request (checks X-Organization-Id header)
- * @param defaultOrgId - The organization ID from auth (API key or session)
- * @param userId - The user ID to verify membership for
- * @returns The resolved organization ID, or an error
- */
-export async function resolveOrganizationOverride(
-  request: Request,
-  defaultOrgId: string,
-  userId: string | null
-): Promise<{ organizationId: string } | { error: string; status: number }> {
-  const overrideOrgId = request.headers.get("x-organization-id");
-
-  if (!overrideOrgId || overrideOrgId === defaultOrgId) {
-    return { organizationId: defaultOrgId };
-  }
-
-  if (!userId) {
-    return {
-      error:
-        "Organization override requires an API key with an associated user. Recreate the API key from the web app.",
-      status: 400,
-    };
-  }
-
-  const [membership] = await db
-    .select({ id: member.id })
-    .from(member)
-    .where(
-      and(eq(member.organizationId, overrideOrgId), eq(member.userId, userId))
-    )
-    .limit(1);
-
-  if (!membership) {
-    return {
-      error: `User is not a member of organization ${overrideOrgId}`,
-      status: 403,
-    };
-  }
-
-  return { organizationId: overrideOrgId };
 }

--- a/specs/api-key-hard-org-scoping.md
+++ b/specs/api-key-hard-org-scoping.md
@@ -1,0 +1,94 @@
+# API Key Hard Org-Scoping
+
+Remove the `X-Organization-Id` header override mechanism. API keys become hard-scoped to their creation org, matching OAuth token behavior.
+
+## Problem
+
+API keys (`kh_` prefix) and OAuth tokens have inconsistent org-scoping:
+
+| | OAuth | API Key |
+|---|---|---|
+| Org binding | Hard-scoped via JWT `org` claim | Soft-scoped via DB row, overridable |
+| Cross-org access | Impossible (signed JWT) | Possible via `X-Organization-Id` header |
+| Membership check | None needed (immutable claim) | DB lookup on `member` table per override request |
+| Key leak blast radius | Single org | All orgs the key creator belongs to |
+
+The `X-Organization-Id` header allows any `kh_` API key to access resources in any org its creator is a member of. This was a convenience feature for multi-org users but creates an unnecessary attack surface.
+
+## Solution
+
+Hard-scope API keys to their native org. Remove `X-Organization-Id` processing from the server. API keys and OAuth tokens then have identical security properties: one credential, one org.
+
+### Server Changes (this PR)
+
+**`lib/middleware/auth-helpers.ts`**
+
+- Delete `resolveOrganizationOverride` function (lines 183-218)
+- Remove `member` table import and `and`/`eq` from drizzle-orm (dead code after deletion)
+- Simplify `resolveApiKeyContext`: return the key's native org directly
+- Simplify `resolveOrganizationId`: return the key's org directly, no override check
+- Simplify `resolveCreatorContext`: return the key's org directly, no override check
+- Update JSDoc on `getDualAuthContext` to mention OAuth as a third auth method
+
+**`lib/mcp/tools.ts`**
+
+- Remove `organizationId` parameter from `callApi` function
+- Remove `X-Organization-Id` header injection from `callApi`
+- Remove `organizationId` from all static tool schemas (list_workflows, get_workflow, create_workflow, update_workflow, delete_workflow, execute_workflow, list_integrations, get_wallet_integration)
+- Remove `organizationId` from dynamic tool schema in `registerDynamicTools`
+- Clean up tool handlers that destructured `organizationId` from args
+
+**`tests/unit/dual-auth-context.test.ts`**
+
+- Add `authMethod` to all existing assertions (currently missing, causes test failures)
+- Add test: API key with `X-Organization-Id` header gets the key's native org (not the override)
+- Add test: OAuth returns authMethod "oauth"
+
+### CLI Changes (separate PR -- cli repo)
+
+**`cmd/serve/tools.go`**
+- Remove `organizationId` from tool input schemas
+- Remove `X-Organization-Id` header injection from tool handlers
+
+**`internal/http/client.go`**
+- Remove `orgOverride` field and `X-Organization-Id` header injection from `Client.Do()`
+
+**`internal/config/hosts.go`** -- per-org token support
+- Change `HostConfig` to support per-org tokens:
+  ```yaml
+  hosts:
+    app.keeperhub.com:
+      orgs:
+        org_abc: { token: "kh_..." }
+        org_xyz: { token: "kh_..." }
+      default_org: org_abc
+      # Legacy flat token still supported for migration
+      token: "kh_..."
+  ```
+- `ResolveToken(host)` reads the active org's token from the `orgs` map, falling back to the flat `token` field
+
+**`cmd/org/switch.go`**
+- Update to select the active org's token locally (no longer just a server-side session mutation)
+
+**`cmd/kh/main.go`**
+- Wire `--org` flag to select token from `orgs` map instead of injecting `X-Organization-Id`
+- Wire `DefaultOrg` from `config.yml` as fallback (currently defined but unused)
+
+### MCP Schemas Endpoint
+
+No changes needed. The `/api/mcp/schemas` endpoint describes plugin capabilities; it does not reference `X-Organization-Id`.
+
+## Breaking Changes
+
+| Who | What breaks | Migration |
+|---|---|---|
+| CLI users with `--org` flag | Flag no longer overrides org on API key requests | Create a `kh_` key per org; use per-org token config in `hosts.yml` |
+| MCP clients passing `organizationId` tool arg | Parameter removed from tool schemas | Connect with an API key scoped to the target org |
+| Direct API consumers using `X-Organization-Id` header | Header is ignored | Use an API key created in the target org |
+
+## Security Properties After Change
+
+- API key leak: attacker can only access the single org the key was created in
+- OAuth token leak: attacker can only access the single org from the JWT claim
+- Session cookie: org determined by server-side active org (unchanged)
+- No cross-org access path exists for any credential type

--- a/tests/unit/dual-auth-context.test.ts
+++ b/tests/unit/dual-auth-context.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockAuthenticateApiKey, mockGetSession, mockGetOrgContext } =
-  vi.hoisted(() => ({
-    mockAuthenticateApiKey: vi.fn(),
-    mockGetSession: vi.fn(),
-    mockGetOrgContext: vi.fn(),
-  }));
+const {
+  mockAuthenticateApiKey,
+  mockAuthenticateOAuthToken,
+  mockGetSession,
+  mockGetOrgContext,
+} = vi.hoisted(() => ({
+  mockAuthenticateApiKey: vi.fn(),
+  mockAuthenticateOAuthToken: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockGetOrgContext: vi.fn(),
+}));
 
 vi.mock("@/lib/api-key-auth", () => ({
   authenticateApiKey: mockAuthenticateApiKey,
@@ -23,6 +28,10 @@ vi.mock("@/lib/middleware/org-context", () => ({
   getOrgContext: mockGetOrgContext,
 }));
 
+vi.mock("@/lib/mcp/oauth-auth", () => ({
+  authenticateOAuthToken: mockAuthenticateOAuthToken,
+}));
+
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 
 function makeRequest(headers: Record<string, string> = {}): Request {
@@ -34,6 +43,27 @@ function makeRequest(headers: Record<string, string> = {}): Request {
 describe("getDualAuthContext", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAuthenticateOAuthToken.mockReturnValue({ authenticated: false });
+  });
+
+  describe("OAuth authentication", () => {
+    it("returns userId and organizationId from OAuth token", async () => {
+      mockAuthenticateOAuthToken.mockReturnValue({
+        authenticated: true,
+        userId: "user_oauth",
+        organizationId: "org_oauth",
+      });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({
+        userId: "user_oauth",
+        organizationId: "org_oauth",
+        authMethod: "oauth",
+      });
+      expect(mockAuthenticateApiKey).not.toHaveBeenCalled();
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
   });
 
   describe("API key authentication", () => {
@@ -51,6 +81,7 @@ describe("getDualAuthContext", () => {
       expect(result).toEqual({
         userId: "user_creator",
         organizationId: "org_123",
+        authMethod: "api-key",
       });
       expect(mockGetSession).not.toHaveBeenCalled();
     });
@@ -66,6 +97,28 @@ describe("getDualAuthContext", () => {
       expect(result).toEqual({
         userId: null,
         organizationId: "org_123",
+        authMethod: "api-key",
+      });
+    });
+
+    it("ignores X-Organization-Id header (hard org-scoping)", async () => {
+      mockAuthenticateApiKey.mockResolvedValue({
+        authenticated: true,
+        organizationId: "org_native",
+        userId: "user_creator",
+      });
+
+      const result = await getDualAuthContext(
+        makeRequest({
+          Authorization: "Bearer kh_test",
+          "X-Organization-Id": "org_other",
+        })
+      );
+
+      expect(result).toEqual({
+        userId: "user_creator",
+        organizationId: "org_native",
+        authMethod: "api-key",
       });
     });
   });
@@ -88,6 +141,7 @@ describe("getDualAuthContext", () => {
       expect(result).toEqual({
         userId: "user_session",
         organizationId: "org_session",
+        authMethod: "session",
       });
     });
 
@@ -102,6 +156,7 @@ describe("getDualAuthContext", () => {
       expect(result).toEqual({
         userId: "user_no_org",
         organizationId: null,
+        authMethod: "session",
       });
     });
   });
@@ -126,11 +181,34 @@ describe("getDualAuthContext", () => {
       expect(result).toEqual({
         userId: null,
         organizationId: null,
+        authMethod: "session",
       });
     });
   });
 
   describe("auth priority", () => {
+    it("prefers OAuth over API key and session", async () => {
+      mockAuthenticateOAuthToken.mockReturnValue({
+        authenticated: true,
+        userId: "user_oauth",
+        organizationId: "org_oauth",
+      });
+      mockAuthenticateApiKey.mockResolvedValue({
+        authenticated: true,
+        organizationId: "org_apikey",
+        userId: "user_apikey",
+      });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toEqual({
+        userId: "user_oauth",
+        organizationId: "org_oauth",
+        authMethod: "oauth",
+      });
+      expect(mockAuthenticateApiKey).not.toHaveBeenCalled();
+    });
+
     it("prefers API key over session when both present", async () => {
       mockAuthenticateApiKey.mockResolvedValue({
         authenticated: true,
@@ -146,6 +224,7 @@ describe("getDualAuthContext", () => {
       expect(result).toEqual({
         userId: "user_apikey",
         organizationId: "org_apikey",
+        authMethod: "api-key",
       });
       expect(mockGetSession).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Fix auth regressions from getDualAuthContext migration (PR #737)
- Hard-scope API keys to their creation org, removing the X-Organization-Id override mechanism
- Align API key security model with OAuth tokens (one credential = one org)

### Auth regression fixes (commit 1)

- 401 instead of 403 for cross-org API keys: removed unnecessary `!userId` guard that returned 401 before org validation could run
- Cross-org execution via isOwner: restricted `isOwner` check to session auth only, preventing API keys from bypassing org checks
- OAuth tokens with missing org claim: added defensive guard rejecting tokens without the required `org` claim
- Added `authMethod: "oauth" | "api-key" | "session"` to `DualAuthContext` to distinguish auth sources

### Hard org-scoping (commit 2)

- Deleted `resolveOrganizationOverride` and the `X-Organization-Id` header processing
- Simplified `resolveApiKeyContext`, `resolveOrganizationId`, `resolveCreatorContext` to return the key's native org directly
- Removed `organizationId` parameter from all MCP tool schemas (static + dynamic) and `callApi`
- Spec: `specs/api-key-hard-org-scoping.md`

### Why

API keys had inconsistent org-scoping compared to OAuth tokens. OAuth tokens are hard-scoped via signed JWT claims. API keys allowed cross-org access via `X-Organization-Id` header + membership check. This created unnecessary attack surface -- a leaked API key could access all orgs its creator belongs to. Now both credential types have identical security properties: one credential, one org.

### Breaking changes

- `X-Organization-Id` header is no longer processed on API key requests
- MCP tools no longer accept `organizationId` parameter
- CLI `--org` flag will need a follow-up PR to use per-org token config instead of header override

## Test plan

- [x] Unit tests: getDualAuthContext with OAuth, API key, session auth
- [x] Unit test: X-Organization-Id header is ignored (hard org-scoping)
- [x] Unit test: auth priority (OAuth > API key > session)
- [x] Lint check passes
- [x] Type check passes
- [ ] E2E: API key from org A cannot access org B workflows
- [ ] E2E: MCP tools operate under the API key's native org