### PR TITLE
fix: KEEP-199 forward system env vars to workflow runner pods

### DIFF
--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -30,6 +30,7 @@ export const CONFIG = {
   paraEnvironment: process.env.PARA_ENVIRONMENT || "beta",
   walletEncryptionKey: process.env.WALLET_ENCRYPTION_KEY || "",
   chainRpcConfig: process.env.CHAIN_RPC_CONFIG || "",
+  etherscanApiKey: process.env.ETHERSCAN_API_KEY || "",
 
   visibilityTimeout: 300,
   waitTimeSeconds: 20,

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -1,13 +1,5 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type Mock,
-} from "vitest";
 import type { V1Job } from "@kubernetes/client-node";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 let mockCreateNamespacedJob: Mock;
 
@@ -17,7 +9,9 @@ vi.mock("@kubernetes/client-node", () => {
   } as V1Job);
 
   class MockKubeConfig {
-    loadFromDefault(): void {}
+    loadFromDefault(): void {
+      // no-op for test mock
+    }
     makeApiClient(): { createNamespacedJob: Mock } {
       return { createNamespacedJob: mockCreateNamespacedJob };
     }
@@ -179,7 +173,9 @@ describe("createWorkflowJob", () => {
     expect(getEnvVar(envVars, "WORKFLOW_ID")).toBe("wf-1");
     expect(getEnvVar(envVars, "EXECUTION_ID")).toBe("exec-1234abcd");
     expect(getEnvVar(envVars, "WORKFLOW_INPUT")).toBe('{"test":true}');
-    expect(getEnvVar(envVars, "DATABASE_URL")).toBe("postgres://localhost/test");
+    expect(getEnvVar(envVars, "DATABASE_URL")).toBe(
+      "postgres://localhost/test"
+    );
     expect(getEnvVar(envVars, "INTEGRATION_ENCRYPTION_KEY")).toBe(
       "test-enc-key"
     );

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -1,0 +1,193 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import type { V1Job } from "@kubernetes/client-node";
+
+let mockCreateNamespacedJob: Mock;
+
+vi.mock("@kubernetes/client-node", () => {
+  mockCreateNamespacedJob = vi.fn().mockResolvedValue({
+    metadata: { name: "workflow-test-123" },
+  } as V1Job);
+
+  class MockKubeConfig {
+    loadFromDefault(): void {}
+    makeApiClient(): { createNamespacedJob: Mock } {
+      return { createNamespacedJob: mockCreateNamespacedJob };
+    }
+  }
+
+  return {
+    KubeConfig: MockKubeConfig,
+    BatchV1Api: class {},
+  };
+});
+
+vi.mock("./config", () => ({
+  CONFIG: {
+    databaseUrl: "postgres://localhost/test",
+    integrationEncryptionKey: "test-enc-key",
+    paraApiKey: "test-para-key",
+    paraEnvironment: "beta",
+    walletEncryptionKey: "test-wallet-key",
+    chainRpcConfig: '{"eth":"http://localhost:8545"}',
+    etherscanApiKey: "test-etherscan-key",
+    namespace: "test-ns",
+    runnerImage: "runner:latest",
+    imagePullPolicy: "Never",
+    jobTtlSeconds: 3600,
+    jobActiveDeadline: 300,
+    maxConcurrentJobs: 5,
+  },
+}));
+
+vi.mock("./runner-env", () => ({
+  getRunnerSystemEnvVars: vi.fn().mockReturnValue([
+    { name: "OPENAI_API_KEY", value: "sk-test" },
+    { name: "SLACK_API_KEY", value: "xoxb-test" },
+  ]),
+}));
+
+const { createWorkflowJob } = await import("./k8s-job");
+const { CONFIG } = await import("./config");
+const { getRunnerSystemEnvVars } = await import("./runner-env");
+
+function getSubmittedJob(): V1Job {
+  const call = mockCreateNamespacedJob.mock.calls[0][0];
+  return call.body as V1Job;
+}
+
+function getJobEnvVars(job: V1Job): Array<{ name: string; value: string }> {
+  return (job.spec?.template?.spec?.containers?.[0]?.env ?? []) as Array<{
+    name: string;
+    value: string;
+  }>;
+}
+
+function getEnvVar(
+  envVars: Array<{ name: string; value: string }>,
+  name: string
+): string | undefined {
+  return envVars.find((v) => v.name === name)?.value;
+}
+
+describe("createWorkflowJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (CONFIG as Record<string, unknown>).etherscanApiKey = "test-etherscan-key";
+  });
+
+  it("includes ETHERSCAN_API_KEY when configured", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: { triggerType: "schedule" },
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "ETHERSCAN_API_KEY")).toBe("test-etherscan-key");
+  });
+
+  it("omits ETHERSCAN_API_KEY when not configured", async () => {
+    (CONFIG as Record<string, unknown>).etherscanApiKey = "";
+
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(envVars.find((v) => v.name === "ETHERSCAN_API_KEY")).toBeUndefined();
+  });
+
+  it("includes system env vars from runner-env", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "OPENAI_API_KEY")).toBe("sk-test");
+    expect(getEnvVar(envVars, "SLACK_API_KEY")).toBe("xoxb-test");
+  });
+
+  it("deduplicates system vars against explicit vars", async () => {
+    (getRunnerSystemEnvVars as Mock).mockReturnValue([
+      { name: "DATABASE_URL", value: "should-be-ignored" },
+      { name: "OPENAI_API_KEY", value: "sk-test" },
+    ]);
+
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    const dbUrls = envVars.filter((v) => v.name === "DATABASE_URL");
+    expect(dbUrls).toHaveLength(1);
+    expect(dbUrls[0].value).toBe("postgres://localhost/test");
+  });
+
+  it("includes SCHEDULE_ID for scheduled triggers", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+      scheduleId: "sched-42",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "SCHEDULE_ID")).toBe("sched-42");
+  });
+
+  it("omits SCHEDULE_ID for non-scheduled triggers", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "block",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(envVars.find((v) => v.name === "SCHEDULE_ID")).toBeUndefined();
+  });
+
+  it("includes all infrastructure env vars", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: { test: true },
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+
+    expect(getEnvVar(envVars, "WORKFLOW_ID")).toBe("wf-1");
+    expect(getEnvVar(envVars, "EXECUTION_ID")).toBe("exec-1234abcd");
+    expect(getEnvVar(envVars, "WORKFLOW_INPUT")).toBe('{"test":true}');
+    expect(getEnvVar(envVars, "DATABASE_URL")).toBe("postgres://localhost/test");
+    expect(getEnvVar(envVars, "INTEGRATION_ENCRYPTION_KEY")).toBe(
+      "test-enc-key"
+    );
+    expect(getEnvVar(envVars, "PARA_API_KEY")).toBe("test-para-key");
+    expect(getEnvVar(envVars, "PARA_ENVIRONMENT")).toBe("beta");
+    expect(getEnvVar(envVars, "WALLET_ENCRYPTION_KEY")).toBe("test-wallet-key");
+    expect(getEnvVar(envVars, "CHAIN_RPC_CONFIG")).toBe(
+      '{"eth":"http://localhost:8545"}'
+    );
+  });
+});

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -58,7 +58,9 @@ export async function createWorkflowJob(params: {
     { name: "PARA_ENVIRONMENT", value: CONFIG.paraEnvironment },
     { name: "WALLET_ENCRYPTION_KEY", value: CONFIG.walletEncryptionKey },
     { name: "CHAIN_RPC_CONFIG", value: CONFIG.chainRpcConfig },
-    { name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey },
+    ...(CONFIG.etherscanApiKey
+      ? [{ name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey }]
+      : []),
     ...getRunnerSystemEnvVars(),
   ];
 

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -61,8 +61,14 @@ export async function createWorkflowJob(params: {
     ...(CONFIG.etherscanApiKey
       ? [{ name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey }]
       : []),
-    ...getRunnerSystemEnvVars(),
   ];
+
+  const explicitNames = new Set(envVars.map((v) => v.name));
+  for (const systemVar of getRunnerSystemEnvVars()) {
+    if (!explicitNames.has(systemVar.name)) {
+      envVars.push(systemVar);
+    }
+  }
 
   if (scheduleId) {
     envVars.push({ name: "SCHEDULE_ID", value: scheduleId });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -1,5 +1,6 @@
 import { BatchV1Api, KubeConfig, type V1Job } from "@kubernetes/client-node";
 import { CONFIG } from "./config";
+import { getRunnerSystemEnvVars } from "./runner-env";
 
 const kc = new KubeConfig();
 kc.loadFromDefault();
@@ -57,6 +58,8 @@ export async function createWorkflowJob(params: {
     { name: "PARA_ENVIRONMENT", value: CONFIG.paraEnvironment },
     { name: "WALLET_ENCRYPTION_KEY", value: CONFIG.walletEncryptionKey },
     { name: "CHAIN_RPC_CONFIG", value: CONFIG.chainRpcConfig },
+    { name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey },
+    ...getRunnerSystemEnvVars(),
   ];
 
   if (scheduleId) {

--- a/keeperhub-executor/runner-env.test.ts
+++ b/keeperhub-executor/runner-env.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  RUNNER_SYSTEM_ENV_VARS,
+  getRunnerSystemEnvVars,
+} from "./runner-env";
+
+describe("runner-env", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("RUNNER_SYSTEM_ENV_VARS", () => {
+    it("is sorted alphabetically", () => {
+      const sorted = [...RUNNER_SYSTEM_ENV_VARS].sort();
+      expect(RUNNER_SYSTEM_ENV_VARS).toEqual(sorted);
+    });
+
+    it("contains no duplicates", () => {
+      const unique = new Set(RUNNER_SYSTEM_ENV_VARS);
+      expect(unique.size).toBe(RUNNER_SYSTEM_ENV_VARS.length);
+    });
+  });
+
+  describe("getRunnerSystemEnvVars", () => {
+    it("returns empty array when no system vars are set", () => {
+      for (const name of RUNNER_SYSTEM_ENV_VARS) {
+        delete process.env[name];
+      }
+
+      const result = getRunnerSystemEnvVars();
+      expect(result).toEqual([]);
+    });
+
+    it("includes only defined vars", () => {
+      for (const name of RUNNER_SYSTEM_ENV_VARS) {
+        delete process.env[name];
+      }
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.SLACK_API_KEY = "xoxb-test";
+
+      const result = getRunnerSystemEnvVars();
+      expect(result).toEqual([
+        { name: "OPENAI_API_KEY", value: "sk-test" },
+        { name: "SLACK_API_KEY", value: "xoxb-test" },
+      ]);
+    });
+
+    it("skips vars set to undefined", () => {
+      for (const name of RUNNER_SYSTEM_ENV_VARS) {
+        delete process.env[name];
+      }
+      process.env.LINEAR_API_KEY = "lin-test";
+
+      const result = getRunnerSystemEnvVars();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        name: "LINEAR_API_KEY",
+        value: "lin-test",
+      });
+    });
+
+    it("preserves empty string values (set but empty)", () => {
+      for (const name of RUNNER_SYSTEM_ENV_VARS) {
+        delete process.env[name];
+      }
+      process.env.FROM_ADDRESS = "";
+
+      const result = getRunnerSystemEnvVars();
+      expect(result).toEqual([{ name: "FROM_ADDRESS", value: "" }]);
+    });
+
+    it("returns all vars when all are set", () => {
+      for (const name of RUNNER_SYSTEM_ENV_VARS) {
+        process.env[name] = `test-${name}`;
+      }
+
+      const result = getRunnerSystemEnvVars();
+      expect(result).toHaveLength(RUNNER_SYSTEM_ENV_VARS.length);
+
+      for (const entry of result) {
+        expect(entry.value).toBe(`test-${entry.name}`);
+      }
+    });
+  });
+});

--- a/keeperhub-executor/runner-env.test.ts
+++ b/keeperhub-executor/runner-env.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  RUNNER_SYSTEM_ENV_VARS,
-  getRunnerSystemEnvVars,
-} from "./runner-env";
+import { getRunnerSystemEnvVars, RUNNER_SYSTEM_ENV_VARS } from "./runner-env";
 
 describe("runner-env", () => {
   const originalEnv = process.env;

--- a/keeperhub-executor/runner-env.ts
+++ b/keeperhub-executor/runner-env.ts
@@ -9,21 +9,16 @@
  * - A new system credential is introduced
  */
 export const RUNNER_SYSTEM_ENV_VARS = [
-  // Web3 plugin (ETHERSCAN_API_KEY is in CONFIG, passed explicitly in k8s-job.ts)
-  "OPENAI_API_KEY",
-
-  // SendGrid plugin
-  "SENDGRID_API_KEY",
-  "FROM_ADDRESS",
-
-  // Credentials (lib/steps/credentials.ts)
-  "LINEAR_API_KEY",
-  "LINEAR_TEAM_ID",
-  "RESEND_API_KEY",
-  "RESEND_FROM_EMAIL",
-  "SLACK_API_KEY",
   "AI_GATEWAY_API_KEY",
   "FIRECRAWL_API_KEY",
+  "FROM_ADDRESS",
+  "LINEAR_API_KEY",
+  "LINEAR_TEAM_ID",
+  "OPENAI_API_KEY",
+  "RESEND_API_KEY",
+  "RESEND_FROM_EMAIL",
+  "SENDGRID_API_KEY",
+  "SLACK_API_KEY",
 ] as const;
 
 /**

--- a/keeperhub-executor/runner-env.ts
+++ b/keeperhub-executor/runner-env.ts
@@ -1,0 +1,47 @@
+/**
+ * System environment variables forwarded to workflow runner pods.
+ *
+ * When a plugin reads from process.env, the variable MUST be listed here
+ * or it will be undefined in K8s Job runner containers.
+ *
+ * Add new entries when:
+ * - A plugin step reads process.env.SOME_KEY
+ * - A new system credential is introduced
+ */
+export const RUNNER_SYSTEM_ENV_VARS = [
+  // Web3 plugin (ETHERSCAN_API_KEY is in CONFIG, passed explicitly in k8s-job.ts)
+  "OPENAI_API_KEY",
+
+  // SendGrid plugin
+  "SENDGRID_API_KEY",
+  "FROM_ADDRESS",
+
+  // Credentials (lib/steps/credentials.ts)
+  "LINEAR_API_KEY",
+  "LINEAR_TEAM_ID",
+  "RESEND_API_KEY",
+  "RESEND_FROM_EMAIL",
+  "SLACK_API_KEY",
+  "AI_GATEWAY_API_KEY",
+  "FIRECRAWL_API_KEY",
+] as const;
+
+/**
+ * Build env var entries from the current process environment.
+ * Skips variables that are not set (undefined).
+ */
+export function getRunnerSystemEnvVars(): Array<{
+  name: string;
+  value: string;
+}> {
+  const vars: Array<{ name: string; value: string }> = [];
+
+  for (const name of RUNNER_SYSTEM_ENV_VARS) {
+    const value = process.env[name];
+    if (value !== undefined) {
+      vars.push({ name, value });
+    }
+  }
+
+  return vars;
+}

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -20,6 +20,7 @@
  * Environment variables (optional):
  *   WORKFLOW_INPUT - JSON string of trigger input (default: {})
  *   SCHEDULE_ID - ID of the schedule (for scheduled executions)
+ *   + system credentials from runner-env.ts (ETHERSCAN_API_KEY, etc.)
  */
 
 import { eq } from "drizzle-orm";


### PR DESCRIPTION
## Summary

- ETHERSCAN_API_KEY was missing from the K8s Job env var list in `k8s-job.ts`, causing random "Invalid Etherscan key" errors on scheduled workflow triggers. Manual runs worked because they execute in-process where the env var exists.
- Added ETHERSCAN_API_KEY explicitly to executor CONFIG and the job spec.
- Created `keeperhub-executor/runner-env.ts` as a centralized registry of system env vars that must be forwarded to runner pods. This prevents the same class of bug for other plugin env vars (OPENAI_API_KEY, SENDGRID_API_KEY, LINEAR_API_KEY, etc.).

## Test plan

- [ ] Deploy to staging and run a workflow with Etherscan steps via scheduled trigger
- [ ] Verify no "Invalid Etherscan key" errors in runner pod logs
- [ ] Verify manual runs still work as before