### PR TITLE
fix: KEEP-199 add missing env vars to executor deployment

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -91,6 +91,21 @@ env:
     type: parameterStore
     name: chain-rpc-config
     parameter_name: /eks/techops-prod/keeperhub/chain-rpc-config
+  ETHERSCAN_API_KEY:
+    type: parameterStore
+    name: etherscan-api-key
+    parameter_name: /eks/techops-prod/keeperhub/etherscan-api-key
+  OPENAI_API_KEY:
+    type: parameterStore
+    name: openai-api-key
+    parameter_name: /eks/techops-prod/keeperhub/openai-api-key
+  SENDGRID_API_KEY:
+    type: parameterStore
+    name: sendgrid-api-key
+    parameter_name: /eks/techops-prod/keeperhub/sendgrid-api-key
+  FROM_ADDRESS:
+    type: kv
+    value: "noreply@keeperhub.com"
 
 externalSecrets:
   clusterSecretStoreName: techops-prod

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -91,6 +91,21 @@ env:
     type: parameterStore
     name: chain-rpc-config
     parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+  ETHERSCAN_API_KEY:
+    type: parameterStore
+    name: etherscan-api-key
+    parameter_name: /eks/techops-staging/keeperhub/etherscan-api-key
+  OPENAI_API_KEY:
+    type: parameterStore
+    name: openai-api-key
+    parameter_name: /eks/techops-staging/keeperhub/openai-api-key
+  SENDGRID_API_KEY:
+    type: parameterStore
+    name: sendgrid-api-key
+    parameter_name: /eks/techops-staging/keeperhub/sendgrid-api-key
+  FROM_ADDRESS:
+    type: kv
+    value: "noreply@keeperhub.com"
 
 externalSecrets:
   clusterSecretStoreName: techops-staging


### PR DESCRIPTION
## Summary

- Follow-up to #747 - the executor code correctly forwards env vars to runner pods, but the executor deployment itself was missing ETHERSCAN_API_KEY, OPENAI_API_KEY, SENDGRID_API_KEY, and FROM_ADDRESS
- Without these on the executor pod, `CONFIG.etherscanApiKey` is always empty and `getRunnerSystemEnvVars()` returns nothing for these keys
- Adds all four to both staging and prod executor values files, matching the same Parameter Store paths used by the main keeperhub deployment

## Test plan

- [ ] Deploy to staging and verify executor pod has ETHERSCAN_API_KEY set (`kubectl exec` or check env)
- [ ] Run a workflow with Etherscan steps via scheduled trigger on staging
- [ ] Verify no "Invalid Etherscan key" errors in runner pod logs
- [ ] Deploy to prod and confirm the same