### PR TITLE
feat: KEEP-193 payable amount input for write-contract

### DIFF
--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -122,6 +122,7 @@ async function handleWriteCall(
     abi: resolvedAbi,
     abiFunction: body.functionName as string,
     functionArgs: body.functionArgs as string | undefined,
+    ethValue: body.ethValue as string | undefined,
     gasLimitMultiplier: body.gasLimitMultiplier as string | undefined,
     _context: { organizationId },
   });

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, Info } from "lucide-react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -391,22 +391,63 @@ const FIELD_RENDERERS: Partial<
   "schema-builder": SchemaBuilderField,
 };
 
+function deriveStateMutability(
+  abiJson: string,
+  funcName: string
+): string {
+  try {
+    const abi: unknown = JSON.parse(abiJson);
+    if (Array.isArray(abi)) {
+      const func = abi.find(
+        (item: { type: string; name: string }) =>
+          item.type === "function" && item.name === funcName
+      );
+      return (func?.stateMutability as string) ?? "nonpayable";
+    }
+  } catch {
+    // invalid ABI
+  }
+  return "nonpayable";
+}
+
 /**
- * Helper: Render abi-function-select field
+ * Abi-function-select field component.
+ * Derives _abiStateMutability on mount (for saved workflows) and on change.
  */
-function renderAbiFunctionSelect(
-  field: ActionConfigFieldBase,
-  config: Record<string, unknown>,
-  onUpdateConfig: (key: string, value: unknown) => void,
-  disabled?: boolean
-) {
+function AbiFunctionSelectFieldWrapper({
+  field,
+  config,
+  onUpdateConfig,
+  disabled,
+}: {
+  field: ActionConfigFieldBase;
+  config: Record<string, unknown>;
+  onUpdateConfig: (key: string, value: unknown) => void;
+  disabled?: boolean;
+}): React.ReactElement {
   const abiField = field.abiField || "abi";
   const abiValue = (config[abiField] as string | undefined) || "";
   const value =
     (config[field.key] as string | undefined) || field.defaultValue || "";
 
+  useEffect(() => {
+    if (value && config._abiStateMutability === undefined) {
+      const mutability = deriveStateMutability(abiValue, value);
+      onUpdateConfig("_abiStateMutability", mutability);
+    }
+  }, [value, abiValue, config._abiStateMutability, onUpdateConfig]);
+
+  const handleFunctionChange = (val: unknown): void => {
+    onUpdateConfig(field.key, val);
+    const funcName = typeof val === "string" ? val : "";
+    onUpdateConfig(
+      "_abiStateMutability",
+      deriveStateMutability(abiValue, funcName)
+    );
+  };
+
   return (
-    <div className="space-y-2" key={field.key}>
+    <div className="space-y-2">
       <Label className="ml-1" htmlFor={field.key}>
         {field.label}
       </Label>
@@ -415,7 +456,7 @@ function renderAbiFunctionSelect(
         disabled={disabled}
         field={field}
         functionFilter={field.functionFilter}
-        onChange={(val) => onUpdateConfig(field.key, val)}
+        onChange={handleFunctionChange}
         value={value}
       />
     </div>
@@ -499,7 +540,15 @@ function renderField(
 
   // Special handling for abi-function-select
   if (field.type === "abi-function-select") {
-    return renderAbiFunctionSelect(field, config, onUpdateConfig, disabled);
+    return (
+      <AbiFunctionSelectFieldWrapper
+        config={config}
+        disabled={disabled}
+        field={field}
+        key={field.key}
+        onUpdateConfig={onUpdateConfig}
+      />
+    );
   }
 
   // Special handling for abi-function-args

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -391,23 +391,43 @@ const FIELD_RENDERERS: Partial<
   "schema-builder": SchemaBuilderField,
 };
 
-function deriveStateMutability(
-  abiJson: string,
-  funcName: string
-): string {
+type AbiItem = {
+  type?: unknown;
+  name?: unknown;
+  stateMutability?: unknown;
+};
+
+/**
+ * Derives the stateMutability of a named function from an ABI JSON string.
+ * Fails closed: returns "nonpayable" on any parse/lookup failure so the
+ * payable value field stays hidden when the ABI is malformed or the function
+ * cannot be located. A genuinely payable function on a malformed ABI will
+ * still revert at execution time with a clear chain error, rather than
+ * silently sending value.
+ */
+function deriveStateMutability(abiJson: string, funcName: string): string {
+  let parsed: unknown;
   try {
-    const abi: unknown = JSON.parse(abiJson);
-    if (Array.isArray(abi)) {
-      const func = abi.find(
-        (item: { type: string; name: string }) =>
-          item.type === "function" && item.name === funcName
-      );
-      return (func?.stateMutability as string) ?? "nonpayable";
-    }
+    parsed = JSON.parse(abiJson);
   } catch {
-    // invalid ABI
+    return "nonpayable";
   }
-  return "nonpayable";
+
+  if (!Array.isArray(parsed)) {
+    return "nonpayable";
+  }
+
+  const func = (parsed as AbiItem[]).find(
+    (item) =>
+      item != null &&
+      typeof item === "object" &&
+      item.type === "function" &&
+      item.name === funcName
+  );
+
+  return typeof func?.stateMutability === "string"
+    ? func.stateMutability
+    : "nonpayable";
 }
 
 /**

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, Info } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -449,13 +449,21 @@ function AbiFunctionSelectFieldWrapper({
   const abiValue = (config[abiField] as string | undefined) || "";
   const value =
     (config[field.key] as string | undefined) || field.defaultValue || "";
+  const persistedMutability = config._abiStateMutability;
+
+  // Latest-ref pattern: parent passes a fresh onUpdateConfig every render
+  // (it's not memoized at the call site in action-config.tsx), so including
+  // it in the effect deps would re-run the effect every render. The ref lets
+  // us read the latest function without making it a dependency.
+  const onUpdateConfigRef = useRef(onUpdateConfig);
+  onUpdateConfigRef.current = onUpdateConfig;
 
   useEffect(() => {
-    if (value && config._abiStateMutability === undefined) {
+    if (value && persistedMutability === undefined) {
       const mutability = deriveStateMutability(abiValue, value);
-      onUpdateConfig("_abiStateMutability", mutability);
+      onUpdateConfigRef.current("_abiStateMutability", mutability);
     }
-  }, [value, abiValue, config._abiStateMutability, onUpdateConfig]);
+  }, [value, abiValue, persistedMutability]);
 
   const handleFunctionChange = (val: unknown): void => {
     onUpdateConfig(field.key, val);

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, Info } from "lucide-react";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -20,7 +20,7 @@ import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 import { SaveAddressBookmark } from "@/components/address-book/save-address-bookmark";
 import { computeSelector } from "@/lib/abi-utils";
-import { deriveStateMutability } from "@/lib/web3/abi-mutability";
+import { evaluateShowWhen } from "@/lib/workflow/show-when";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { getCustomFieldRenderer } from "@/lib/extension-registry";
@@ -394,51 +394,25 @@ const FIELD_RENDERERS: Partial<
 
 
 /**
- * Abi-function-select field component.
- * Derives _abiStateMutability on mount (for saved workflows) and on change.
+ * Helper: Render abi-function-select field.
+ *
+ * Mutability is not persisted; fields that want to gate on it use
+ * `showWhen: { computed: "abiFunctionMutability", ... }` which derives
+ * the value live from the ABI at render time.
  */
-function AbiFunctionSelectFieldWrapper({
-  field,
-  config,
-  onUpdateConfig,
-  disabled,
-}: {
-  field: ActionConfigFieldBase;
-  config: Record<string, unknown>;
-  onUpdateConfig: (key: string, value: unknown) => void;
-  disabled?: boolean;
-}): React.ReactElement {
+function renderAbiFunctionSelect(
+  field: ActionConfigFieldBase,
+  config: Record<string, unknown>,
+  onUpdateConfig: (key: string, value: unknown) => void,
+  disabled?: boolean
+) {
   const abiField = field.abiField || "abi";
   const abiValue = (config[abiField] as string | undefined) || "";
   const value =
     (config[field.key] as string | undefined) || field.defaultValue || "";
-  const persistedMutability = config._abiStateMutability;
-
-  // Latest-ref pattern: parent passes a fresh onUpdateConfig every render
-  // (it's not memoized at the call site in action-config.tsx), so including
-  // it in the effect deps would re-run the effect every render. The ref lets
-  // us read the latest function without making it a dependency.
-  const onUpdateConfigRef = useRef(onUpdateConfig);
-  onUpdateConfigRef.current = onUpdateConfig;
-
-  useEffect(() => {
-    if (value && persistedMutability === undefined) {
-      const mutability = deriveStateMutability(abiValue, value);
-      onUpdateConfigRef.current("_abiStateMutability", mutability);
-    }
-  }, [value, abiValue, persistedMutability]);
-
-  const handleFunctionChange = (val: unknown): void => {
-    onUpdateConfig(field.key, val);
-    const funcName = typeof val === "string" ? val : "";
-    onUpdateConfig(
-      "_abiStateMutability",
-      deriveStateMutability(abiValue, funcName)
-    );
-  };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" key={field.key}>
       <Label className="ml-1" htmlFor={field.key}>
         {field.label}
       </Label>
@@ -447,12 +421,13 @@ function AbiFunctionSelectFieldWrapper({
         disabled={disabled}
         field={field}
         functionFilter={field.functionFilter}
-        onChange={handleFunctionChange}
+        onChange={(val) => onUpdateConfig(field.key, val)}
         value={value}
       />
     </div>
   );
 }
+
 
 /**
  * Helper: Render abi-function-args field
@@ -515,15 +490,8 @@ function renderField(
   nodeId?: string
 ) {
   // Check conditional rendering
-  if (field.showWhen) {
-    const dependentValue = config[field.showWhen.field];
-    if ("oneOf" in field.showWhen) {
-      if (!field.showWhen.oneOf.includes(dependentValue as string)) {
-        return null;
-      }
-    } else if (dependentValue !== field.showWhen.equals) {
-      return null;
-    }
+  if (!evaluateShowWhen(field.showWhen, config)) {
+    return null;
   }
 
   const value =
@@ -531,15 +499,7 @@ function renderField(
 
   // Special handling for abi-function-select
   if (field.type === "abi-function-select") {
-    return (
-      <AbiFunctionSelectFieldWrapper
-        config={config}
-        disabled={disabled}
-        field={field}
-        key={field.key}
-        onUpdateConfig={onUpdateConfig}
-      />
-    );
+    return renderAbiFunctionSelect(field, config, onUpdateConfig, disabled);
   }
 
   // Special handling for abi-function-args

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -20,6 +20,7 @@ import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 import { SaveAddressBookmark } from "@/components/address-book/save-address-bookmark";
 import { computeSelector } from "@/lib/abi-utils";
+import { deriveStateMutability } from "@/lib/web3/abi-mutability";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { getCustomFieldRenderer } from "@/lib/extension-registry";
@@ -391,44 +392,6 @@ const FIELD_RENDERERS: Partial<
   "schema-builder": SchemaBuilderField,
 };
 
-type AbiItem = {
-  type?: unknown;
-  name?: unknown;
-  stateMutability?: unknown;
-};
-
-/**
- * Derives the stateMutability of a named function from an ABI JSON string.
- * Fails closed: returns "nonpayable" on any parse/lookup failure so the
- * payable value field stays hidden when the ABI is malformed or the function
- * cannot be located. A genuinely payable function on a malformed ABI will
- * still revert at execution time with a clear chain error, rather than
- * silently sending value.
- */
-function deriveStateMutability(abiJson: string, funcName: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(abiJson);
-  } catch {
-    return "nonpayable";
-  }
-
-  if (!Array.isArray(parsed)) {
-    return "nonpayable";
-  }
-
-  const func = (parsed as AbiItem[]).find(
-    (item) =>
-      item != null &&
-      typeof item === "object" &&
-      item.type === "function" &&
-      item.name === funcName
-  );
-
-  return typeof func?.stateMutability === "string"
-    ? func.stateMutability
-    : "nonpayable";
-}
 
 /**
  * Abi-function-select field component.

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -42,6 +42,7 @@ import { getCustomLogo } from "@/lib/extension-registry";
 import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
 import { cn } from "@/lib/utils";
+import { evaluateShowWhen, type ShowWhen } from "@/lib/workflow/show-when";
 import {
   addNodeAtom,
   canRedoAtom,
@@ -264,21 +265,10 @@ function isFieldEmpty(value: unknown): boolean {
 
 // Check if a conditional field should be shown based on current config
 function shouldShowField(
-  field: {
-    showWhen?:
-      | { field: string; equals: string }
-      | { field: string; oneOf: string[] };
-  },
+  field: { showWhen?: ShowWhen },
   config: Record<string, unknown>
 ): boolean {
-  if (!field.showWhen) {
-    return true;
-  }
-  const dependentValue = config[field.showWhen.field];
-  if ("oneOf" in field.showWhen) {
-    return field.showWhen.oneOf.includes(dependentValue as string);
-  }
-  return dependentValue === field.showWhen.equals;
+  return evaluateShowWhen(field.showWhen, config);
 }
 
 // Get missing required fields for a single node

--- a/lib/web3/abi-mutability.ts
+++ b/lib/web3/abi-mutability.ts
@@ -1,0 +1,43 @@
+/**
+ * Derive the stateMutability of a named function from an ABI JSON string.
+ *
+ * Fails closed: returns "nonpayable" on any parse/lookup failure so that
+ * payable-gated UI (e.g. the payable value field) stays hidden when the
+ * ABI is malformed or the function cannot be located. Server-side callers
+ * should re-check mutability against the parsed ABI before sending native
+ * value -- this helper is intended for UI gating and lightweight checks,
+ * not as the sole authority on whether a transfer is safe.
+ */
+type AbiItem = {
+  type?: unknown;
+  name?: unknown;
+  stateMutability?: unknown;
+};
+
+export function deriveStateMutability(
+  abiJson: string,
+  funcName: string
+): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(abiJson);
+  } catch {
+    return "nonpayable";
+  }
+
+  if (!Array.isArray(parsed)) {
+    return "nonpayable";
+  }
+
+  const func = (parsed as AbiItem[]).find(
+    (item) =>
+      item != null &&
+      typeof item === "object" &&
+      item.type === "function" &&
+      item.name === funcName
+  );
+
+  return typeof func?.stateMutability === "string"
+    ? func.stateMutability
+    : "nonpayable";
+}

--- a/lib/workflow/show-when.ts
+++ b/lib/workflow/show-when.ts
@@ -1,0 +1,58 @@
+/**
+ * Evaluates a `showWhen` field predicate against the current config.
+ *
+ * Supports three variants:
+ *   1. { field, equals }       - simple equality against a stored field
+ *   2. { field, oneOf }        - membership against a stored field
+ *   3. { computed, ... }       - live-derived value (no persistence)
+ *
+ * The computed variant is how we express "render this field only when
+ * another field's derived property matches" without persisting the
+ * derived value in the workflow config. Today only "abiFunctionMutability"
+ * is supported; add new kinds by extending the union in plugins/registry.ts
+ * and the switch in `evaluateComputed`.
+ */
+import { deriveStateMutability } from "@/lib/web3/abi-mutability";
+
+export type ShowWhen =
+  | { field: string; equals: string }
+  | { field: string; oneOf: string[] }
+  | {
+      computed: "abiFunctionMutability";
+      abiField: string;
+      functionField: string;
+      equals: string;
+    };
+
+function evaluateComputed(
+  showWhen: Extract<ShowWhen, { computed: string }>,
+  config: Record<string, unknown>
+): boolean {
+  if (showWhen.computed === "abiFunctionMutability") {
+    const abi = (config[showWhen.abiField] as string | undefined) || "";
+    const funcName =
+      (config[showWhen.functionField] as string | undefined) || "";
+    if (!(abi && funcName)) {
+      return false;
+    }
+    return deriveStateMutability(abi, funcName) === showWhen.equals;
+  }
+  return false;
+}
+
+export function evaluateShowWhen(
+  showWhen: ShowWhen | undefined,
+  config: Record<string, unknown>
+): boolean {
+  if (!showWhen) {
+    return true;
+  }
+  if ("computed" in showWhen) {
+    return evaluateComputed(showWhen, config);
+  }
+  const dependentValue = config[showWhen.field];
+  if ("oneOf" in showWhen) {
+    return showWhen.oneOf.includes(dependentValue as string);
+  }
+  return dependentValue === showWhen.equals;
+}

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -69,11 +69,21 @@ export type ActionConfigFieldBase = {
   // Whether this field is required (defaults to false)
   required?: boolean;
 
-  // Conditional rendering: only show if another field has a specific value
-  // Use `equals` for single value match, `oneOf` for multiple value match
+  // Conditional rendering: only show if another field has a specific value.
+  // Use `equals` for single value match, `oneOf` for multiple value match.
+  // Use `computed` to gate on a value derived from other config fields at
+  // render time (no persistence). Currently supported computations:
+  //   - "abiFunctionMutability": parses `abiField` (ABI JSON) and looks up
+  //     the stateMutability of the function named by `functionField`.
   showWhen?:
     | { field: string; equals: string }
-    | { field: string; oneOf: string[] };
+    | { field: string; oneOf: string[] }
+    | {
+        computed: "abiFunctionMutability";
+        abiField: string;
+        functionField: string;
+        equals: string;
+      };
 
   // For abi-function-select and abi-event-select: which field contains the ABI JSON
   abiField?: string;

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -1187,6 +1187,15 @@ const web3Plugin: IntegrationPlugin = {
           abiFunctionField: "abiFunction",
         },
         {
+          key: "ethValue",
+          label: "Payable Value",
+          type: "template-input",
+          placeholder: "0.0",
+          helpTip:
+            "Amount of native token (e.g. ETH, MATIC) to send with this payable function call. Specified in whole units, not wei.",
+          showWhen: { field: "_abiStateMutability", equals: "payable" },
+        },
+        {
           type: "group",
           label: "Advanced",
           defaultExpanded: false,

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -1193,7 +1193,12 @@ const web3Plugin: IntegrationPlugin = {
           placeholder: "0.0",
           helpTip:
             "Amount of native token (e.g. ETH, MATIC) to send with this payable function call. Specified in whole units, not wei.",
-          showWhen: { field: "_abiStateMutability", equals: "payable" },
+          showWhen: {
+            computed: "abiFunctionMutability",
+            abiField: "abi",
+            functionField: "abiFunction",
+            equals: "payable",
+          },
         },
         {
           type: "group",

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -222,7 +222,7 @@ export async function writeContractCore(
     } catch {
       return {
         success: false,
-        error: `Invalid ETH value "${ethValue}" -- expected a decimal string like "0.1" or "1.5"`,
+        error: `Invalid payable value "${ethValue}" -- expected a decimal string like "0.1" or "1.5"`,
       };
     }
   }

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -214,15 +214,32 @@ export async function writeContractCore(
     }
   }
 
-  // Parse ethValue early so we fail fast with a friendly message
+  // Parse ethValue early so we fail fast with a friendly message.
+  // Reject any non-zero value sent to a non-payable function: the UI hides
+  // the field for non-payable functions, but the API and workflow layers
+  // accept ethValue as an arbitrary string, so this is the authoritative
+  // server-side guard against accidentally sending native tokens to a
+  // function that cannot accept them (the tx would revert on-chain anyway,
+  // but failing here is faster, cheaper, and produces a clearer error).
   let parsedEthValue: bigint | undefined;
-  if (ethValue) {
+  if (ethValue && ethValue.trim() !== "") {
     try {
       parsedEthValue = ethers.parseEther(ethValue);
     } catch {
       return {
         success: false,
         error: `Invalid payable value "${ethValue}" -- expected a decimal string like "0.1" or "1.5"`,
+      };
+    }
+
+    if (
+      parsedEthValue > BigInt(0) &&
+      (functionAbi as { stateMutability?: string }).stateMutability !==
+        "payable"
+    ) {
+      return {
+        success: false,
+        error: `Function '${abiFunction}' is not payable -- cannot send a non-zero value with this call`,
       };
     }
   }

--- a/tests/unit/abi-mutability.test.ts
+++ b/tests/unit/abi-mutability.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveStateMutability } from "@/lib/web3/abi-mutability";
+
+const PAYABLE_DEPOSIT = JSON.stringify([
+  {
+    type: "function",
+    name: "deposit",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+]);
+
+const NONPAYABLE_TRANSFER = JSON.stringify([
+  {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+]);
+
+const VIEW_BALANCE_OF = JSON.stringify([
+  {
+    type: "function",
+    name: "balanceOf",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+  },
+]);
+
+// Mixed ABI with events, errors, and a constructor alongside functions.
+// Exercises the narrowing around items that lack a name or are not
+// of type "function".
+const MIXED_ABI = JSON.stringify([
+  { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [],
+    anonymous: false,
+  },
+  { type: "error", name: "Unauthorized", inputs: [] },
+  {
+    type: "function",
+    name: "deposit",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [{ name: "amount", type: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+]);
+
+describe("deriveStateMutability", () => {
+  it("returns 'payable' for a payable function", () => {
+    expect(deriveStateMutability(PAYABLE_DEPOSIT, "deposit")).toBe("payable");
+  });
+
+  it("returns 'nonpayable' for a nonpayable function", () => {
+    expect(deriveStateMutability(NONPAYABLE_TRANSFER, "transfer")).toBe(
+      "nonpayable"
+    );
+  });
+
+  it("returns 'view' for a view function", () => {
+    expect(deriveStateMutability(VIEW_BALANCE_OF, "balanceOf")).toBe("view");
+  });
+
+  it("locates the right function in a mixed ABI with events/errors/constructor", () => {
+    expect(deriveStateMutability(MIXED_ABI, "deposit")).toBe("payable");
+    expect(deriveStateMutability(MIXED_ABI, "withdraw")).toBe("nonpayable");
+  });
+
+  it("fails closed to 'nonpayable' when the function is not in the ABI", () => {
+    expect(deriveStateMutability(PAYABLE_DEPOSIT, "doesNotExist")).toBe(
+      "nonpayable"
+    );
+  });
+
+  it("fails closed to 'nonpayable' on invalid JSON", () => {
+    expect(deriveStateMutability("{not json", "deposit")).toBe("nonpayable");
+  });
+
+  it("fails closed to 'nonpayable' when the ABI is not a JSON array", () => {
+    expect(
+      deriveStateMutability(JSON.stringify({ foo: "bar" }), "deposit")
+    ).toBe("nonpayable");
+  });
+
+  it("fails closed to 'nonpayable' on an empty string", () => {
+    expect(deriveStateMutability("", "deposit")).toBe("nonpayable");
+  });
+
+  it("fails closed when stateMutability field is missing", () => {
+    const abi = JSON.stringify([
+      { type: "function", name: "legacy", inputs: [], outputs: [] },
+    ]);
+    expect(deriveStateMutability(abi, "legacy")).toBe("nonpayable");
+  });
+
+  it("does not match an event with the same name as a function", () => {
+    const abi = JSON.stringify([
+      {
+        type: "event",
+        name: "deposit",
+        inputs: [],
+        anonymous: false,
+      },
+    ]);
+    expect(deriveStateMutability(abi, "deposit")).toBe("nonpayable");
+  });
+
+  it("tolerates null items in the ABI array", () => {
+    const abi = JSON.stringify([
+      null,
+      {
+        type: "function",
+        name: "deposit",
+        inputs: [],
+        outputs: [],
+        stateMutability: "payable",
+      },
+    ]);
+    expect(deriveStateMutability(abi, "deposit")).toBe("payable");
+  });
+});

--- a/tests/unit/show-when.test.ts
+++ b/tests/unit/show-when.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateShowWhen } from "@/lib/workflow/show-when";
+
+const PAYABLE_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "deposit",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+]);
+
+describe("evaluateShowWhen", () => {
+  describe("no predicate", () => {
+    it("returns true when showWhen is undefined", () => {
+      expect(evaluateShowWhen(undefined, {})).toBe(true);
+    });
+  });
+
+  describe("equals variant", () => {
+    it("returns true when the field matches", () => {
+      expect(
+        evaluateShowWhen(
+          { field: "mode", equals: "advanced" },
+          { mode: "advanced" }
+        )
+      ).toBe(true);
+    });
+
+    it("returns false when the field does not match", () => {
+      expect(
+        evaluateShowWhen(
+          { field: "mode", equals: "advanced" },
+          { mode: "basic" }
+        )
+      ).toBe(false);
+    });
+
+    it("returns false when the field is absent", () => {
+      expect(evaluateShowWhen({ field: "mode", equals: "advanced" }, {})).toBe(
+        false
+      );
+    });
+  });
+
+  describe("oneOf variant", () => {
+    it("returns true when the field is in the set", () => {
+      expect(
+        evaluateShowWhen(
+          { field: "mode", oneOf: ["a", "b", "c"] },
+          { mode: "b" }
+        )
+      ).toBe(true);
+    });
+
+    it("returns false when the field is not in the set", () => {
+      expect(
+        evaluateShowWhen(
+          { field: "mode", oneOf: ["a", "b", "c"] },
+          { mode: "z" }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("computed: abiFunctionMutability", () => {
+    const predicate = {
+      computed: "abiFunctionMutability" as const,
+      abiField: "abi",
+      functionField: "abiFunction",
+      equals: "payable",
+    };
+
+    it("returns true when the selected function is payable", () => {
+      expect(
+        evaluateShowWhen(predicate, {
+          abi: PAYABLE_ABI,
+          abiFunction: "deposit",
+        })
+      ).toBe(true);
+    });
+
+    it("returns false when the selected function is not payable", () => {
+      expect(
+        evaluateShowWhen(predicate, {
+          abi: PAYABLE_ABI,
+          abiFunction: "withdraw",
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when the ABI is missing", () => {
+      expect(evaluateShowWhen(predicate, { abiFunction: "deposit" })).toBe(
+        false
+      );
+    });
+
+    it("returns false when the function is missing", () => {
+      expect(evaluateShowWhen(predicate, { abi: PAYABLE_ABI })).toBe(false);
+    });
+
+    it("returns false when the ABI is malformed (fails closed)", () => {
+      expect(
+        evaluateShowWhen(predicate, {
+          abi: "not json",
+          abiFunction: "deposit",
+        })
+      ).toBe(false);
+    });
+
+    it("re-evaluates live: swapping the ABI flips the result without any persisted cache", () => {
+      const nonPayableAbi = JSON.stringify([
+        {
+          type: "function",
+          name: "deposit",
+          inputs: [],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+      ]);
+      // Same function name, different ABI -> must reflect new mutability
+      // immediately. This is the drift case that the prior persisted
+      // _abiStateMutability implementation got wrong.
+      expect(
+        evaluateShowWhen(predicate, {
+          abi: PAYABLE_ABI,
+          abiFunction: "deposit",
+        })
+      ).toBe(true);
+      expect(
+        evaluateShowWhen(predicate, {
+          abi: nonPayableAbi,
+          abiFunction: "deposit",
+        })
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a "Payable Value" input field that appears when a payable ABI function is selected on write-contract nodes
- Derive `_abiStateMutability` from the ABI on function selection and on workflow load (handles reopened/saved workflows)
- Pass `ethValue` through the direct execution API route (`/api/execute/contract-call`)
- Update error message to chain-agnostic wording ("Invalid payable value" instead of "Invalid ETH value")

## Test plan

- [x] Select a payable function (e.g. WETH9 deposit) on a write-contract node - "Payable Value" field should appear
- [x] Select a non-payable function - field should hide
- [x] Save workflow with payable function selected, reopen - field should still be visible
- [x] Execute with a valid value (e.g. "0.1") - transaction should include the value
- [x] Execute with an invalid value (e.g. "abc") - should return "Invalid payable value" error
- [x] Call `/api/execute/contract-call` with `ethValue` param - value should pass through to execution