### PR TITLE
feat: KEEP-194 array and tuple input builders for ABI function args

### DIFF
--- a/components/workflow/config/abi-types.ts
+++ b/components/workflow/config/abi-types.ts
@@ -1,0 +1,5 @@
+export type AbiComponent = {
+  name: string;
+  type: string;
+  components?: AbiComponent[];
+};

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -19,6 +19,9 @@ import {
 import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 import { SaveAddressBookmark } from "@/components/address-book/save-address-bookmark";
+import type { AbiComponent } from "@/components/workflow/config/abi-types";
+import { ArrayInputField } from "@/components/workflow/config/array-input-field";
+import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
 import { computeSelector } from "@/lib/abi-utils";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
 import { toChecksumAddress } from "@/lib/address-utils";
@@ -294,10 +297,13 @@ export function AbiFunctionArgsField({
         return [];
       }
 
-      return func.inputs.map((input: { name: string; type: string }) => ({
-        name: input.name || "unnamed",
-        type: input.type,
-      }));
+      return func.inputs.map(
+        (input: { name: string; type: string; components?: AbiComponent[] }) => ({
+          name: input.name || "unnamed",
+          type: input.type,
+          components: input.components,
+        })
+      );
     } catch {
       return [];
     }
@@ -334,7 +340,7 @@ export function AbiFunctionArgsField({
   }, [functionValue, value, parsePropValue]);
 
   // Handle individual arg change - update local state and propagate to parent
-  const handleArgChange = (index: number, newValue: string) => {
+  const handleArgChange = (index: number, newValue: unknown) => {
     const newArgs = [...localArgValues];
     // Ensure array is long enough
     while (newArgs.length <= index) {
@@ -360,21 +366,51 @@ export function AbiFunctionArgsField({
   return (
     <div className="space-y-3">
       {functionInputs.map(
-        (input: { name: string; type: string }, index: number) => (
-          <div className="space-y-1.5" key={`${field.key}-arg-${index}`}>
-            <Label className="ml-1 text-xs" htmlFor={`${field.key}-${index}`}>
-              {input.name}{" "}
-              <span className="text-muted-foreground">({input.type})</span>
-            </Label>
-            <TemplateBadgeInput
-              disabled={disabled}
-              id={`${field.key}-${index}`}
-              onChange={(val) => handleArgChange(index, val as string)}
-              placeholder={`Enter ${input.type} value or {{NodeName.value}}`}
-              value={(localArgValues[index] as string) || ""}
-            />
-          </div>
-        )
+        (
+          input: { name: string; type: string; components?: AbiComponent[] },
+          index: number,
+        ) => {
+          const isArray = input.type.endsWith("[]");
+          const baseType = isArray ? input.type.slice(0, -2) : input.type;
+          const hasTupleComponents =
+            input.components !== undefined && input.components.length > 0;
+          const isTuple = baseType === "tuple" && hasTupleComponents;
+
+          return (
+            <div className="space-y-1.5" key={`${field.key}-arg-${index}`}>
+              <Label className="ml-1 text-xs" htmlFor={`${field.key}-${index}`}>
+                {input.name}{" "}
+                <span className="text-muted-foreground">({input.type})</span>
+              </Label>
+              {isArray ? (
+                <ArrayInputField
+                  components={isTuple ? input.components : undefined}
+                  disabled={disabled}
+                  fieldKey={`${field.key}-${index}`}
+                  itemType={baseType}
+                  onChange={(val) => handleArgChange(index, val)}
+                  value={localArgValues[index]}
+                />
+              ) : isTuple ? (
+                <TupleInputField
+                  components={input.components ?? []}
+                  disabled={disabled}
+                  fieldKey={`${field.key}-${index}`}
+                  onChange={(val) => handleArgChange(index, val)}
+                  value={localArgValues[index]}
+                />
+              ) : (
+                <TemplateBadgeInput
+                  disabled={disabled}
+                  id={`${field.key}-${index}`}
+                  onChange={(val) => handleArgChange(index, val as string)}
+                  placeholder={`Enter ${input.type} value or {{NodeName.value}}`}
+                  value={(localArgValues[index] as string) || ""}
+                />
+              )}
+            </div>
+          );
+        }
       )}
     </div>
   );

--- a/components/workflow/config/args-list-field.tsx
+++ b/components/workflow/config/args-list-field.tsx
@@ -97,7 +97,10 @@ export function serializeArgsList(entries: ArgSetEntry[]): string {
         if (typeof v === "string") {
           return v.trim() !== "";
         }
-        return Array.isArray(v) && v.length > 0;
+        if (Array.isArray(v)) {
+          return v.length > 0;
+        }
+        return typeof v === "object" && v !== null;
       })
     )
     .map((e) => e.values);

--- a/components/workflow/config/args-list-field.tsx
+++ b/components/workflow/config/args-list-field.tsx
@@ -4,16 +4,20 @@ import { Plus, Trash2 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
+import type { AbiComponent } from "@/components/workflow/config/abi-types";
+import { ArrayInputField } from "@/components/workflow/config/array-input-field";
+import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
 import type { ActionConfigFieldBase } from "@/plugins/registry";
 
 type FunctionInput = {
   name: string;
   type: string;
+  components?: AbiComponent[];
 };
 
 type ArgSetEntry = {
   id: number;
-  values: string[];
+  values: unknown[];
 };
 
 export function parseFunctionInputs(
@@ -39,10 +43,13 @@ export function parseFunctionInputs(
       return [];
     }
 
-    return func.inputs.map((input: { name: string; type: string }) => ({
-      name: input.name || "unnamed",
-      type: input.type,
-    }));
+    return func.inputs.map(
+      (input: { name: string; type: string; components?: AbiComponent[] }) => ({
+        name: input.name || "unnamed",
+        type: input.type,
+        components: input.components,
+      })
+    );
   } catch {
     return [];
   }
@@ -65,11 +72,16 @@ export function parseArgsListValue(
 
     return parsed.map((argSet: unknown) => {
       const arr = Array.isArray(argSet) ? argSet : [];
-      const values: string[] = [];
+      const values: unknown[] = [];
       for (let i = 0; i < paramCount; i++) {
-        values.push(
-          arr[i] !== undefined && arr[i] !== null ? String(arr[i]) : ""
-        );
+        const item = arr[i];
+        if (Array.isArray(item)) {
+          values.push(item);
+        } else if (item !== undefined && item !== null) {
+          values.push(String(item));
+        } else {
+          values.push("");
+        }
       }
       return { id: nextId(), values };
     });
@@ -80,7 +92,14 @@ export function parseArgsListValue(
 
 export function serializeArgsList(entries: ArgSetEntry[]): string {
   const sets = entries
-    .filter((e) => e.values.some((v) => v.trim() !== ""))
+    .filter((e) =>
+      e.values.some((v) => {
+        if (typeof v === "string") {
+          return v.trim() !== "";
+        }
+        return Array.isArray(v) && v.length > 0;
+      })
+    )
     .map((e) => e.values);
   return sets.length > 0 ? JSON.stringify(sets) : "";
 }
@@ -152,7 +171,7 @@ export function ArgsListField({
   function updateArgValue(
     targetId: number,
     argIndex: number,
-    argValue: string
+    argValue: unknown
   ): void {
     const updated = entries.map((entry) => {
       if (entry.id !== targetId) {
@@ -200,29 +219,60 @@ export function ArgsListField({
             )}
           </div>
 
-          {functionInputs.map((input, argIndex) => (
-            <div
-              className="space-y-1.5"
-              key={`${field.key}-${entry.id}-arg-${argIndex}`}
-            >
-              <label
-                className="text-xs font-medium"
-                htmlFor={`${field.key}-${entry.id}-${argIndex}`}
+          {functionInputs.map((input, argIndex) => {
+            const isArray = input.type.endsWith("[]");
+            const baseType = isArray ? input.type.slice(0, -2) : input.type;
+            const hasTupleComponents =
+              input.components !== undefined && input.components.length > 0;
+            const isTuple = baseType === "tuple" && hasTupleComponents;
+
+            return (
+              <div
+                className="space-y-1.5"
+                key={`${field.key}-${entry.id}-arg-${argIndex}`}
               >
-                {input.name}{" "}
-                <span className="text-muted-foreground">({input.type})</span>
-              </label>
-              <TemplateBadgeInput
-                disabled={disabled}
-                id={`${field.key}-${entry.id}-${argIndex}`}
-                onChange={(val) =>
-                  updateArgValue(entry.id, argIndex, String(val))
-                }
-                placeholder={`Enter ${input.type} value or {{NodeName.value}}`}
-                value={entry.values[argIndex] ?? ""}
-              />
-            </div>
-          ))}
+                <label
+                  className="text-xs font-medium"
+                  htmlFor={`${field.key}-${entry.id}-${argIndex}`}
+                >
+                  {input.name}{" "}
+                  <span className="text-muted-foreground">({input.type})</span>
+                </label>
+                {isArray ? (
+                  <ArrayInputField
+                    components={isTuple ? input.components : undefined}
+                    disabled={disabled}
+                    fieldKey={`${field.key}-${entry.id}-${argIndex}`}
+                    itemType={baseType}
+                    onChange={(val) =>
+                      updateArgValue(entry.id, argIndex, val)
+                    }
+                    value={entry.values[argIndex]}
+                  />
+                ) : isTuple ? (
+                  <TupleInputField
+                    components={input.components ?? []}
+                    disabled={disabled}
+                    fieldKey={`${field.key}-${entry.id}-${argIndex}`}
+                    onChange={(val) =>
+                      updateArgValue(entry.id, argIndex, val)
+                    }
+                    value={entry.values[argIndex]}
+                  />
+                ) : (
+                  <TemplateBadgeInput
+                    disabled={disabled}
+                    id={`${field.key}-${entry.id}-${argIndex}`}
+                    onChange={(val) =>
+                      updateArgValue(entry.id, argIndex, String(val))
+                    }
+                    placeholder={`Enter ${input.type} value or {{NodeName.value}}`}
+                    value={(entry.values[argIndex] as string) ?? ""}
+                  />
+                )}
+              </div>
+            );
+          })}
         </div>
       ))}
 

--- a/components/workflow/config/array-input-field.tsx
+++ b/components/workflow/config/array-input-field.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
+import type { AbiComponent } from "@/components/workflow/config/abi-types";
+import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
+
+type ArrayItem = {
+  id: number;
+  value: unknown;
+};
+
+type ArrayInputFieldProps = {
+  itemType: string;
+  value: unknown;
+  onChange: (value: unknown[]) => void;
+  disabled?: boolean;
+  fieldKey: string;
+  components?: AbiComponent[];
+};
+
+function parseArrayValue(
+  value: unknown,
+  nextId: () => number
+): ArrayItem[] {
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map((v) => ({
+      id: nextId(),
+      value: v ?? "",
+    }));
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        return parsed.map((v) => ({
+          id: nextId(),
+          value: v ?? "",
+        }));
+      }
+    } catch {
+      return [{ id: nextId(), value }];
+    }
+  }
+
+  return [];
+}
+
+function serializeItems(items: ArrayItem[]): unknown[] {
+  return items.map((item) => item.value);
+}
+
+function makeEmptyValue(components?: AbiComponent[]): unknown {
+  if (components && components.length > 0) {
+    const obj: Record<string, unknown> = {};
+    for (const comp of components) {
+      obj[comp.name] = "";
+    }
+    return obj;
+  }
+  return "";
+}
+
+export function ArrayInputField({
+  itemType,
+  value,
+  onChange,
+  disabled,
+  fieldKey,
+  components,
+}: ArrayInputFieldProps): React.ReactNode {
+  const idCounter = useRef(0);
+  const nextId = (): number => {
+    idCounter.current += 1;
+    return idCounter.current;
+  };
+
+  const [items, setItems] = useState<ArrayItem[]>(() =>
+    parseArrayValue(value, nextId)
+  );
+
+  function updateItems(updated: ArrayItem[]): void {
+    setItems(updated);
+    onChange(serializeItems(updated));
+  }
+
+  function addItem(): void {
+    updateItems([
+      ...items,
+      { id: nextId(), value: makeEmptyValue(components) },
+    ]);
+  }
+
+  function removeItem(targetId: number): void {
+    const updated = items.filter((item) => item.id !== targetId);
+    updateItems(updated);
+  }
+
+  function updateItemValue(targetId: number, newValue: unknown): void {
+    const updated = items.map((item) => {
+      if (item.id !== targetId) {
+        return item;
+      }
+      return { ...item, value: newValue };
+    });
+    updateItems(updated);
+  }
+
+  const isTuple = components !== undefined && components.length > 0;
+
+  return (
+    <div className="space-y-1.5">
+      {items.length === 0 && (
+        <div className="rounded-md border border-dashed p-2 text-center text-muted-foreground text-xs">
+          Empty array
+        </div>
+      )}
+      {items.map((item, index) => (
+        <div
+          className={isTuple ? "space-y-1" : "flex items-center gap-1.5"}
+          key={item.id}
+        >
+          {isTuple ? (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground text-xs">
+                  [{index}]
+                </span>
+                <Button
+                  className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+                  disabled={disabled}
+                  onClick={() => removeItem(item.id)}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </div>
+              <TupleInputField
+                components={components}
+                disabled={disabled}
+                fieldKey={`${fieldKey}-item-${item.id}`}
+                onChange={(val) => updateItemValue(item.id, val)}
+                value={item.value}
+              />
+            </>
+          ) : (
+            <>
+              <span className="w-5 shrink-0 text-center text-muted-foreground text-xs">
+                {index}
+              </span>
+              <div className="flex-1">
+                <TemplateBadgeInput
+                  disabled={disabled}
+                  id={`${fieldKey}-item-${item.id}`}
+                  onChange={(val) =>
+                    updateItemValue(item.id, String(val))
+                  }
+                  placeholder={`Enter ${itemType} value or {{NodeName.value}}`}
+                  value={typeof item.value === "string" ? item.value : ""}
+                />
+              </div>
+              <Button
+                className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+                disabled={disabled}
+                onClick={() => removeItem(item.id)}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </>
+          )}
+        </div>
+      ))}
+      <Button
+        className="w-full"
+        disabled={disabled}
+        onClick={addItem}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <Plus className="mr-1.5 h-3.5 w-3.5" />
+        Add Item
+      </Button>
+    </div>
+  );
+}

--- a/components/workflow/config/tuple-input-field.tsx
+++ b/components/workflow/config/tuple-input-field.tsx
@@ -59,11 +59,9 @@ export function TupleInputField({
     <div className="space-y-2 rounded-md border border-border/50 p-2.5">
       {components.map((comp) => {
         const isArray = comp.type.endsWith("[]");
-        const isTuple =
-          comp.type === "tuple" ||
-          (isArray && comp.type === "tuple[]");
         const hasSubs =
           comp.components !== undefined && comp.components.length > 0;
+        const isTuple = comp.type === "tuple" && hasSubs;
 
         return (
           <div className="space-y-1" key={`${fieldKey}-${comp.name}`}>
@@ -80,11 +78,11 @@ export function TupleInputField({
                 components={hasSubs ? comp.components : undefined}
                 disabled={disabled}
                 fieldKey={`${fieldKey}-${comp.name}`}
-                itemType={isArray ? comp.type.slice(0, -2) : comp.type}
+                itemType={comp.type.slice(0, -2)}
                 onChange={(val) => handleFieldChange(comp.name, val)}
                 value={obj[comp.name]}
               />
-            ) : isTuple && hasSubs ? (
+            ) : isTuple ? (
               <TupleInputField
                 components={comp.components ?? []}
                 disabled={disabled}

--- a/components/workflow/config/tuple-input-field.tsx
+++ b/components/workflow/config/tuple-input-field.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
+import { ArrayInputField } from "@/components/workflow/config/array-input-field";
+import type { AbiComponent } from "@/components/workflow/config/abi-types";
+
+type TupleInputFieldProps = {
+  components: AbiComponent[];
+  value: unknown;
+  onChange: (value: Record<string, unknown>) => void;
+  disabled?: boolean;
+  fieldKey: string;
+};
+
+function parseObjectValue(
+  value: unknown,
+  components: AbiComponent[]
+): Record<string, unknown> {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Not JSON
+    }
+  }
+
+  const obj: Record<string, unknown> = {};
+  for (const comp of components) {
+    obj[comp.name] = "";
+  }
+  return obj;
+}
+
+export function TupleInputField({
+  components,
+  value,
+  onChange,
+  disabled,
+  fieldKey,
+}: TupleInputFieldProps): React.ReactNode {
+  const obj = parseObjectValue(value, components);
+
+  function handleFieldChange(name: string, fieldValue: unknown): void {
+    onChange({ ...obj, [name]: fieldValue });
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-border/50 p-2.5">
+      {components.map((comp) => {
+        const isArray = comp.type.endsWith("[]");
+        const isTuple =
+          comp.type === "tuple" ||
+          (isArray && comp.type === "tuple[]");
+        const hasSubs =
+          comp.components !== undefined && comp.components.length > 0;
+
+        return (
+          <div className="space-y-1" key={`${fieldKey}-${comp.name}`}>
+            <label
+              className="text-xs font-medium"
+              htmlFor={`${fieldKey}-${comp.name}`}
+            >
+              {comp.name}{" "}
+              <span className="text-muted-foreground">({comp.type})</span>
+            </label>
+
+            {isArray ? (
+              <ArrayInputField
+                components={hasSubs ? comp.components : undefined}
+                disabled={disabled}
+                fieldKey={`${fieldKey}-${comp.name}`}
+                itemType={isArray ? comp.type.slice(0, -2) : comp.type}
+                onChange={(val) => handleFieldChange(comp.name, val)}
+                value={obj[comp.name]}
+              />
+            ) : isTuple && hasSubs ? (
+              <TupleInputField
+                components={comp.components ?? []}
+                disabled={disabled}
+                fieldKey={`${fieldKey}-${comp.name}`}
+                onChange={(val) => handleFieldChange(comp.name, val)}
+                value={obj[comp.name]}
+              />
+            ) : (
+              <TemplateBadgeInput
+                disabled={disabled}
+                id={`${fieldKey}-${comp.name}`}
+                onChange={(val) => handleFieldChange(comp.name, String(val))}
+                placeholder={`Enter ${comp.type} value or {{NodeName.value}}`}
+                value={(obj[comp.name] as string) ?? ""}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/abi-struct-args.ts
+++ b/lib/abi-struct-args.ts
@@ -30,6 +30,10 @@ function isTupleInput(input: AbiInput): boolean {
   );
 }
 
+function isPreStructuredObject(arg: unknown): boolean {
+  return arg !== null && typeof arg === "object" && !Array.isArray(arg);
+}
+
 function buildTupleArg(
   components: AbiComponent[],
   args: unknown[],
@@ -70,22 +74,14 @@ export function reshapeArgsForAbi(
   let cursor = 0;
 
   for (const input of functionAbi.inputs ?? []) {
-    if (isTupleInput(input)) {
-      const currentArg = cursor < args.length ? args[cursor] : undefined;
-      if (
-        currentArg !== null &&
-        typeof currentArg === "object" &&
-        !Array.isArray(currentArg)
-      ) {
-        reshaped.push(currentArg);
-        cursor++;
-      } else {
-        const result = buildTupleArg(input.components ?? [], args, cursor);
-        reshaped.push(result.value);
-        cursor = result.nextCursor;
-      }
+    const currentArg = cursor < args.length ? args[cursor] : undefined;
+
+    if (isTupleInput(input) && !isPreStructuredObject(currentArg)) {
+      const result = buildTupleArg(input.components ?? [], args, cursor);
+      reshaped.push(result.value);
+      cursor = result.nextCursor;
     } else {
-      reshaped.push(cursor < args.length ? args[cursor] : undefined);
+      reshaped.push(currentArg);
       cursor++;
     }
   }

--- a/lib/abi-struct-args.ts
+++ b/lib/abi-struct-args.ts
@@ -71,9 +71,19 @@ export function reshapeArgsForAbi(
 
   for (const input of functionAbi.inputs ?? []) {
     if (isTupleInput(input)) {
-      const result = buildTupleArg(input.components ?? [], args, cursor);
-      reshaped.push(result.value);
-      cursor = result.nextCursor;
+      const currentArg = cursor < args.length ? args[cursor] : undefined;
+      if (
+        currentArg !== null &&
+        typeof currentArg === "object" &&
+        !Array.isArray(currentArg)
+      ) {
+        reshaped.push(currentArg);
+        cursor++;
+      } else {
+        const result = buildTupleArg(input.components ?? [], args, cursor);
+        reshaped.push(result.value);
+        cursor = result.nextCursor;
+      }
     } else {
       reshaped.push(cursor < args.length ? args[cursor] : undefined);
       cursor++;

--- a/lib/abi-validate-args.ts
+++ b/lib/abi-validate-args.ts
@@ -31,7 +31,7 @@ type FunctionAbiEntry = {
 export type ValidationResult = { ok: true } | { ok: false; error: string };
 
 const TEMPLATE_VARIABLE_RE = /^\{\{.+\}\}$/;
-const BYTES_N_RE = /^bytes\d+$/;
+const BYTES_TYPE_RE = /^bytes\d*$/;
 
 function isTemplateVariable(value: unknown): boolean {
   return typeof value === "string" && TEMPLATE_VARIABLE_RE.test(value.trim());
@@ -42,14 +42,17 @@ function stripArraySuffix(type: string): string {
 }
 
 /**
- * Types that may legitimately hold an empty string:
- * - `string`: empty string is a valid string value
- * - `bytes` / `bytesN`: empty bytes serialize as `0x`, valid
- *
- * Everything else (uint*, int*, address, bool, function, etc.) rejects "".
+ * Only `string` legitimately holds an empty string. Every other leaf type
+ * rejects "" -- including `bytes`/`bytesN`, because ethers BytesLike requires
+ * the literal "0x" for empty bytes and silently lets "" fall through to a
+ * cryptic encoder error otherwise.
  */
 function leafAllowsEmptyString(type: string): boolean {
-  return type === "string" || type === "bytes" || BYTES_N_RE.test(type);
+  return type === "string";
+}
+
+function isBytesType(type: string): boolean {
+  return BYTES_TYPE_RE.test(type);
 }
 
 function validateLeaf(
@@ -62,9 +65,10 @@ function validateLeaf(
   }
 
   if (value === "" && !leafAllowsEmptyString(type)) {
+    const hint = isBytesType(type) ? ' (use "0x" for empty bytes)' : "";
     return {
       ok: false,
-      error: `${path}: ${type} cannot be empty`,
+      error: `${path}: ${type} cannot be empty${hint}`,
     };
   }
 

--- a/lib/abi-validate-args.ts
+++ b/lib/abi-validate-args.ts
@@ -1,0 +1,169 @@
+/**
+ * Validate args against an ABI function signature before encoding.
+ *
+ * The UI seeds empty fields with "" so React inputs stay controlled. For
+ * non-string ABI types (uint*, int*, address, bool, bytes*, etc.) an empty
+ * string is not a valid value and would either crash the encoder or, worse,
+ * get silently coerced. This walks the ABI structure and rejects such values
+ * with a path-aware error so the failure surfaces cleanly through the step
+ * error channel.
+ *
+ * Template variables (`{{NodeName.value}}`) are passed through untouched at
+ * leaf positions -- they are resolved later in the execution pipeline.
+ */
+
+type AbiComponent = {
+  name: string;
+  type: string;
+  components?: AbiComponent[];
+};
+
+type AbiInput = {
+  name: string;
+  type: string;
+  components?: AbiComponent[];
+};
+
+type FunctionAbiEntry = {
+  inputs?: AbiInput[];
+};
+
+export type ValidationResult = { ok: true } | { ok: false; error: string };
+
+const TEMPLATE_VARIABLE_RE = /^\{\{.+\}\}$/;
+const BYTES_N_RE = /^bytes\d+$/;
+
+function isTemplateVariable(value: unknown): boolean {
+  return typeof value === "string" && TEMPLATE_VARIABLE_RE.test(value.trim());
+}
+
+function stripArraySuffix(type: string): string {
+  return type.endsWith("[]") ? type.slice(0, -2) : type;
+}
+
+/**
+ * Types that may legitimately hold an empty string:
+ * - `string`: empty string is a valid string value
+ * - `bytes` / `bytesN`: empty bytes serialize as `0x`, valid
+ *
+ * Everything else (uint*, int*, address, bool, function, etc.) rejects "".
+ */
+function leafAllowsEmptyString(type: string): boolean {
+  return type === "string" || type === "bytes" || BYTES_N_RE.test(type);
+}
+
+function validateLeaf(
+  value: unknown,
+  type: string,
+  path: string
+): ValidationResult {
+  if (isTemplateVariable(value)) {
+    return { ok: true };
+  }
+
+  if (value === "" && !leafAllowsEmptyString(type)) {
+    return {
+      ok: false,
+      error: `${path}: ${type} cannot be empty`,
+    };
+  }
+
+  if (value === undefined || value === null) {
+    return {
+      ok: false,
+      error: `${path}: ${type} is missing`,
+    };
+  }
+
+  return { ok: true };
+}
+
+function validateArray(
+  value: unknown,
+  type: string,
+  components: AbiComponent[] | undefined,
+  path: string
+): ValidationResult {
+  if (!Array.isArray(value)) {
+    return { ok: false, error: `${path}: expected array for ${type}` };
+  }
+  const baseType = stripArraySuffix(type);
+  for (let i = 0; i < value.length; i++) {
+    const result = validateValue(
+      value[i],
+      baseType,
+      components,
+      `${path}[${i}]`
+    );
+    if (!result.ok) {
+      return result;
+    }
+  }
+  return { ok: true };
+}
+
+function validateTuple(
+  value: unknown,
+  components: AbiComponent[] | undefined,
+  path: string
+): ValidationResult {
+  if (!components || components.length === 0) {
+    return { ok: true };
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: `${path}: expected object for tuple` };
+  }
+  const obj = value as Record<string, unknown>;
+  for (const comp of components) {
+    if (!(comp.name in obj)) {
+      return {
+        ok: false,
+        error: `${path}.${comp.name}: ${comp.type} is missing`,
+      };
+    }
+    const result = validateValue(
+      obj[comp.name],
+      comp.type,
+      comp.components,
+      `${path}.${comp.name}`
+    );
+    if (!result.ok) {
+      return result;
+    }
+  }
+  return { ok: true };
+}
+
+function validateValue(
+  value: unknown,
+  type: string,
+  components: AbiComponent[] | undefined,
+  path: string
+): ValidationResult {
+  if (isTemplateVariable(value)) {
+    return { ok: true };
+  }
+  if (type.endsWith("[]")) {
+    return validateArray(value, type, components, path);
+  }
+  if (type === "tuple") {
+    return validateTuple(value, components, path);
+  }
+  return validateLeaf(value, type, path);
+}
+
+export function validateArgsForAbi(
+  args: unknown[],
+  functionAbi: FunctionAbiEntry
+): ValidationResult {
+  const inputs = functionAbi.inputs ?? [];
+  for (let i = 0; i < inputs.length; i++) {
+    const input = inputs[i];
+    const label = input.name ? `${input.name}` : `arg${i}`;
+    const result = validateValue(args[i], input.type, input.components, label);
+    if (!result.ok) {
+      return result;
+    }
+  }
+  return { ok: true };
+}

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -10,6 +10,7 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import { validateArgsForAbi } from "@/lib/abi-validate-args";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
@@ -151,6 +152,13 @@ export async function readContractCore(
         return parsedArgs.slice(index + 1).some((a) => a !== "");
       });
       args = reshapeArgsForAbi(args, functionAbi);
+      const validation = validateArgsForAbi(args, functionAbi);
+      if (!validation.ok) {
+        return {
+          success: false,
+          error: `Invalid function arguments: ${validation.error}`,
+        };
+      }
     } catch (error) {
       logUserError(
         ErrorCategory.VALIDATION,

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -10,6 +10,7 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import { validateArgsForAbi } from "@/lib/abi-validate-args";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
@@ -144,6 +145,13 @@ export async function writeContractCore(
         return parsedArgs.slice(index + 1).some((a) => a !== "");
       });
       args = reshapeArgsForAbi(args, functionAbi);
+      const validation = validateArgsForAbi(args, functionAbi);
+      if (!validation.ok) {
+        return {
+          success: false,
+          error: `Invalid function arguments: ${validation.error}`,
+        };
+      }
     } catch (error) {
       return {
         success: false,

--- a/tests/unit/abi-validate-args.test.ts
+++ b/tests/unit/abi-validate-args.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import { validateArgsForAbi } from "@/lib/abi-validate-args";
+
+describe("validateArgsForAbi", () => {
+  it("accepts empty args when ABI has no inputs", () => {
+    expect(validateArgsForAbi([], { inputs: [] })).toEqual({ ok: true });
+  });
+
+  it("rejects empty string for uint256", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "amount", type: "uint256" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "amount: uint256 cannot be empty",
+    });
+  });
+
+  it("rejects empty string for address", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "recipient", type: "address" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "recipient: address cannot be empty",
+    });
+  });
+
+  it("rejects empty string for bool", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "flag", type: "bool" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "flag: bool cannot be empty",
+    });
+  });
+
+  it("allows empty string for string type", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "note", type: "string" }],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("allows empty string for bytes", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "data", type: "bytes" }],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("allows empty string for bytes32", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "hash", type: "bytes32" }],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("allows template variable in uint256 slot", () => {
+    const result = validateArgsForAbi(["{{Node1.value}}"], {
+      inputs: [{ name: "amount", type: "uint256" }],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("allows template variable inside a tuple field", () => {
+    const result = validateArgsForAbi(
+      [{ target: "{{Node1.addr}}", value: "100" }],
+      {
+        inputs: [
+          {
+            name: "call",
+            type: "tuple",
+            components: [
+              { name: "target", type: "address" },
+              { name: "value", type: "uint256" },
+            ],
+          },
+        ],
+      }
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects tuple with empty numeric field and reports path", () => {
+    const result = validateArgsForAbi([{ target: "0xabc", value: "" }], {
+      inputs: [
+        {
+          name: "call",
+          type: "tuple",
+          components: [
+            { name: "target", type: "address" },
+            { name: "value", type: "uint256" },
+          ],
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "call.value: uint256 cannot be empty",
+    });
+  });
+
+  it("rejects tuple array element with empty field and reports indexed path", () => {
+    const result = validateArgsForAbi(
+      [
+        [
+          { target: "0xabc", allowFailure: true, callData: "0x01" },
+          { target: "0xdef", allowFailure: false, callData: "" },
+        ],
+      ],
+      {
+        inputs: [
+          {
+            name: "calls",
+            type: "tuple[]",
+            components: [
+              { name: "target", type: "address" },
+              { name: "allowFailure", type: "bool" },
+              { name: "callData", type: "bytes" },
+            ],
+          },
+        ],
+      }
+    );
+    // callData is bytes so empty is allowed -- this should pass
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects tuple array element with empty address and reports indexed path", () => {
+    const result = validateArgsForAbi(
+      [
+        [
+          { target: "0xabc", value: "1" },
+          { target: "", value: "2" },
+        ],
+      ],
+      {
+        inputs: [
+          {
+            name: "calls",
+            type: "tuple[]",
+            components: [
+              { name: "target", type: "address" },
+              { name: "value", type: "uint256" },
+            ],
+          },
+        ],
+      }
+    );
+    expect(result).toEqual({
+      ok: false,
+      error: "calls[1].target: address cannot be empty",
+    });
+  });
+
+  it("rejects nested tuple with empty leaf and reports dotted path", () => {
+    const result = validateArgsForAbi([{ outer: { inner: "" } }], {
+      inputs: [
+        {
+          name: "wrapper",
+          type: "tuple",
+          components: [
+            {
+              name: "outer",
+              type: "tuple",
+              components: [{ name: "inner", type: "uint256" }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "wrapper.outer.inner: uint256 cannot be empty",
+    });
+  });
+
+  it("rejects primitive array with empty element", () => {
+    const result = validateArgsForAbi([["0xabc", ""]], {
+      inputs: [{ name: "recipients", type: "address[]" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "recipients[1]: address cannot be empty",
+    });
+  });
+
+  it("allows empty primitive array", () => {
+    const result = validateArgsForAbi([[]], {
+      inputs: [{ name: "recipients", type: "address[]" }],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts fully-valid flat args", () => {
+    const result = validateArgsForAbi(["0xabc", "1000", true], {
+      inputs: [
+        { name: "to", type: "address" },
+        { name: "amount", type: "uint256" },
+        { name: "flag", type: "bool" },
+      ],
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects tuple that is missing a declared component", () => {
+    const result = validateArgsForAbi([{ target: "0xabc" }], {
+      inputs: [
+        {
+          name: "call",
+          type: "tuple",
+          components: [
+            { name: "target", type: "address" },
+            { name: "value", type: "uint256" },
+          ],
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "call.value: uint256 is missing",
+    });
+  });
+
+  it("rejects non-object passed where tuple expected", () => {
+    const result = validateArgsForAbi(["not-an-object"], {
+      inputs: [
+        {
+          name: "call",
+          type: "tuple",
+          components: [{ name: "target", type: "address" }],
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "call: expected object for tuple",
+    });
+  });
+
+  it("uses argN label when input name is empty", () => {
+    const result = validateArgsForAbi([""], {
+      inputs: [{ name: "", type: "uint256" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "arg0: uint256 cannot be empty",
+    });
+  });
+});

--- a/tests/unit/abi-validate-args.test.ts
+++ b/tests/unit/abi-validate-args.test.ts
@@ -43,16 +43,29 @@ describe("validateArgsForAbi", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  it("allows empty string for bytes", () => {
+  it("rejects empty string for bytes with 0x hint", () => {
     const result = validateArgsForAbi([""], {
       inputs: [{ name: "data", type: "bytes" }],
     });
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: false,
+      error: 'data: bytes cannot be empty (use "0x" for empty bytes)',
+    });
   });
 
-  it("allows empty string for bytes32", () => {
+  it("rejects empty string for bytes32 with 0x hint", () => {
     const result = validateArgsForAbi([""], {
       inputs: [{ name: "hash", type: "bytes32" }],
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: 'hash: bytes32 cannot be empty (use "0x" for empty bytes)',
+    });
+  });
+
+  it('accepts "0x" for empty bytes', () => {
+    const result = validateArgsForAbi(["0x"], {
+      inputs: [{ name: "data", type: "bytes" }],
     });
     expect(result).toEqual({ ok: true });
   });
@@ -102,7 +115,7 @@ describe("validateArgsForAbi", () => {
     });
   });
 
-  it("rejects tuple array element with empty field and reports indexed path", () => {
+  it("rejects tuple array element with empty bytes field and reports indexed path", () => {
     const result = validateArgsForAbi(
       [
         [
@@ -124,8 +137,11 @@ describe("validateArgsForAbi", () => {
         ],
       }
     );
-    // callData is bytes so empty is allowed -- this should pass
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'calls[1].callData: bytes cannot be empty (use "0x" for empty bytes)',
+    });
   });
 
   it("rejects tuple array element with empty address and reports indexed path", () => {


### PR DESCRIPTION
## Summary

- Add `ArrayInputField` component for constructing array arguments (`uint256[]`, `address[]`, etc.) with dynamic add/remove items
- Add `TupleInputField` component for struct/tuple arguments with named sub-fields per component
- Support nested types: tuple arrays (`Call3[]`), tuples containing arrays, recursive nesting
- Support empty arrays (`[]`) and template variables (`{{NodeName.value}}`) at every level
- Update `reshapeArgsForAbi` to pass through pre-structured tuple objects from the new UI

## Test plan

- [x] Verify primitive array inputs (`uint256[]`, `address[]`) render correctly and serialize to nested JSON arrays
- [x] Verify tuple inputs (`tuple` with components) render sub-fields and serialize to objects
- [x] Verify tuple array inputs (`tuple[]` like Multicall3 `aggregate3`) render correctly
- [x] Verify empty arrays can be submitted (0 items, serializes as `[]`)
- [x] Verify template variables work in array items and tuple sub-fields
- [x] Verify existing non-array function args still work unchanged
- [x] Verify batch mode (ArgsListField) handles array/tuple params correctly
- [x] Test end-to-end: read/write contract with array args executes successfully