### PR TITLE
fix: add Chronicle DAI/USD mainnet oracle address

### DIFF
--- a/protocols/chronicle.ts
+++ b/protocols/chronicle.ts
@@ -132,6 +132,7 @@ export default defineProtocol({
       label: "DAI/USD Oracle",
       abi: ORACLE_ABI,
       addresses: {
+        "1": "0xCCd47B363b81E94321518D0393ACcb0846f4D4C6",
         "11155111": "0xaf900d10f197762794C41dac395C5b8112eD13E1",
       },
     },


### PR DESCRIPTION
## Summary

- Adds mainnet (chain 1) address `0xCCd47B363b81E94321518D0393ACcb0846f4D4C6` for the Chronicle DAI/USD oracle
- Fixes scheduled workflow `14r4z26xz2snorag69gdw` which was failing with `Protocol "chronicle" contract "daiUsd" is not deployed on network "1"`
- The `daiUsd` contract previously only had a Sepolia testnet address