### PR TITLE
feat: add Prometheus metrics for RPC failover monitoring

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -382,6 +382,72 @@ const sessionActive = getOrCreateGauge(
   []
 );
 
+// RPC failover metrics → apiRegistry (per-pod in-memory, scrape all pods)
+const RPC_LABELS = ["chain"];
+
+const rpcPrimaryAttempts = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_primary_attempts_total",
+  "Total RPC requests attempted against primary endpoint",
+  RPC_LABELS
+);
+
+const rpcPrimaryFailures = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_primary_failures_total",
+  "Total RPC request failures on primary endpoint",
+  RPC_LABELS
+);
+
+const rpcFallbackAttempts = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_fallback_attempts_total",
+  "Total RPC requests attempted against fallback endpoint",
+  RPC_LABELS
+);
+
+const rpcFallbackFailures = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_fallback_failures_total",
+  "Total RPC request failures on fallback endpoint",
+  RPC_LABELS
+);
+
+const rpcFailoverEvents = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_failover_events_total",
+  "Total times primary failed and traffic switched to fallback",
+  RPC_LABELS
+);
+
+const rpcRecoveryEvents = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_recovery_events_total",
+  "Total times primary recovered and traffic switched back from fallback",
+  RPC_LABELS
+);
+
+const rpcBothFailedEvents = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_both_failed_total",
+  "Total times both primary and fallback endpoints failed",
+  RPC_LABELS
+);
+
+const rpcCurrentProvider = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_rpc_using_fallback",
+  "Whether the chain is currently using the fallback RPC (1=fallback, 0=primary)",
+  RPC_LABELS
+);
+
+const rpcHealthState = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_rpc_health_state",
+  "RPC health state per chain (0=primary/healthy, 1=fallback/degraded, 2=both_failed/down)",
+  RPC_LABELS
+);
+
 // API-process metrics → apiRegistry (per-pod in-memory, scrape all pods)
 const webhookLatency = getOrCreateHistogram(
   apiRegistry,
@@ -946,3 +1012,18 @@ export async function getApiProcessMetrics(): Promise<string> {
 export function getPrometheusContentType(): string {
   return dbRegistry.contentType;
 }
+
+/**
+ * RPC failover metric accessors for the RPC metrics bridge
+ */
+export const rpcMetrics = {
+  primaryAttempts: rpcPrimaryAttempts,
+  primaryFailures: rpcPrimaryFailures,
+  fallbackAttempts: rpcFallbackAttempts,
+  fallbackFailures: rpcFallbackFailures,
+  failoverEvents: rpcFailoverEvents,
+  recoveryEvents: rpcRecoveryEvents,
+  bothFailedEvents: rpcBothFailedEvents,
+  currentProvider: rpcCurrentProvider,
+  healthState: rpcHealthState,
+};

--- a/lib/metrics/rpc-metrics.ts
+++ b/lib/metrics/rpc-metrics.ts
@@ -34,6 +34,9 @@ const prometheusCollector: RpcMetricsCollector & SolanaRpcMetricsCollector = {
   recordFailoverEvent(chain: string): void {
     rpcMetrics.failoverEvents.inc({ chain });
   },
+  recordRecoveryEvent(chain: string): void {
+    rpcMetrics.recoveryEvents.inc({ chain });
+  },
   recordBothFailed(chain: string): void {
     rpcMetrics.bothFailedEvents.inc({ chain });
     rpcMetrics.healthState.set({ chain }, 2);
@@ -55,12 +58,7 @@ export const prometheusSolanaRpcMetricsCollector: SolanaRpcMetricsCollector =
 export function onRpcFailoverStateChange(
   chain: string,
   isUsingFallback: boolean,
-  reason: "failover" | "recovery"
+  _reason: "failover" | "recovery"
 ): void {
   rpcMetrics.currentProvider.set({ chain }, isUsingFallback ? 1 : 0);
-  rpcMetrics.healthState.set({ chain }, isUsingFallback ? 1 : 0);
-
-  if (reason === "recovery") {
-    rpcMetrics.recoveryEvents.inc({ chain });
-  }
 }

--- a/lib/metrics/rpc-metrics.ts
+++ b/lib/metrics/rpc-metrics.ts
@@ -1,0 +1,84 @@
+/**
+ * Prometheus-backed RPC metrics collectors for EVM and Solana providers.
+ *
+ * Implements RpcMetricsCollector and SolanaRpcMetricsCollector interfaces
+ * from the rpc-provider modules, backed by Prometheus counters and gauges.
+ *
+ * Also provides an onFailoverStateChange callback that updates the
+ * keeperhub_rpc_using_fallback gauge and records failover/recovery events.
+ */
+
+import "server-only";
+
+import type { RpcMetricsCollector } from "@/lib/rpc-provider";
+import type { SolanaRpcMetricsCollector } from "@/lib/rpc-provider/solana";
+import { rpcMetrics } from "./collectors/prometheus";
+
+/**
+ * Prometheus-backed RPC metrics collector for EVM chains.
+ * Records primary/fallback attempts, failures, and failover events.
+ */
+export const prometheusRpcMetricsCollector: RpcMetricsCollector = {
+  recordPrimaryAttempt(chain: string): void {
+    rpcMetrics.primaryAttempts.inc({ chain });
+  },
+  recordPrimaryFailure(chain: string): void {
+    rpcMetrics.primaryFailures.inc({ chain });
+  },
+  recordFallbackAttempt(chain: string): void {
+    rpcMetrics.fallbackAttempts.inc({ chain });
+  },
+  recordFallbackFailure(chain: string): void {
+    rpcMetrics.fallbackFailures.inc({ chain });
+  },
+  recordFailoverEvent(chain: string): void {
+    rpcMetrics.failoverEvents.inc({ chain });
+  },
+  recordBothFailed(chain: string): void {
+    rpcMetrics.bothFailedEvents.inc({ chain });
+    rpcMetrics.healthState.set({ chain }, 2);
+  },
+};
+
+/**
+ * Prometheus-backed RPC metrics collector for Solana chains.
+ * Uses the same underlying Prometheus counters as EVM (shared metric names).
+ */
+export const prometheusSolanaRpcMetricsCollector: SolanaRpcMetricsCollector = {
+  recordPrimaryAttempt(chain: string): void {
+    rpcMetrics.primaryAttempts.inc({ chain });
+  },
+  recordPrimaryFailure(chain: string): void {
+    rpcMetrics.primaryFailures.inc({ chain });
+  },
+  recordFallbackAttempt(chain: string): void {
+    rpcMetrics.fallbackAttempts.inc({ chain });
+  },
+  recordFallbackFailure(chain: string): void {
+    rpcMetrics.fallbackFailures.inc({ chain });
+  },
+  recordFailoverEvent(chain: string): void {
+    rpcMetrics.failoverEvents.inc({ chain });
+  },
+  recordBothFailed(chain: string): void {
+    rpcMetrics.bothFailedEvents.inc({ chain });
+    rpcMetrics.healthState.set({ chain }, 2);
+  },
+};
+
+/**
+ * Failover state change callback that updates Prometheus gauge and counters.
+ * Pass this as the onFailoverStateChange callback to RpcProviderManager.
+ */
+export function onRpcFailoverStateChange(
+  chain: string,
+  isUsingFallback: boolean,
+  reason: "failover" | "recovery"
+): void {
+  rpcMetrics.currentProvider.set({ chain }, isUsingFallback ? 1 : 0);
+  rpcMetrics.healthState.set({ chain }, isUsingFallback ? 1 : 0);
+
+  if (reason === "recovery") {
+    rpcMetrics.recoveryEvents.inc({ chain });
+  }
+}

--- a/lib/metrics/rpc-metrics.ts
+++ b/lib/metrics/rpc-metrics.ts
@@ -15,10 +15,10 @@ import type { SolanaRpcMetricsCollector } from "@/lib/rpc-provider/solana";
 import { rpcMetrics } from "./collectors/prometheus";
 
 /**
- * Prometheus-backed RPC metrics collector for EVM chains.
- * Records primary/fallback attempts, failures, and failover events.
+ * Prometheus-backed RPC metrics collector shared by EVM and Solana providers.
+ * Both interfaces are structurally identical, so a single implementation serves both.
  */
-export const prometheusRpcMetricsCollector: RpcMetricsCollector = {
+const prometheusCollector: RpcMetricsCollector & SolanaRpcMetricsCollector = {
   recordPrimaryAttempt(chain: string): void {
     rpcMetrics.primaryAttempts.inc({ chain });
   },
@@ -40,31 +40,10 @@ export const prometheusRpcMetricsCollector: RpcMetricsCollector = {
   },
 };
 
-/**
- * Prometheus-backed RPC metrics collector for Solana chains.
- * Uses the same underlying Prometheus counters as EVM (shared metric names).
- */
-export const prometheusSolanaRpcMetricsCollector: SolanaRpcMetricsCollector = {
-  recordPrimaryAttempt(chain: string): void {
-    rpcMetrics.primaryAttempts.inc({ chain });
-  },
-  recordPrimaryFailure(chain: string): void {
-    rpcMetrics.primaryFailures.inc({ chain });
-  },
-  recordFallbackAttempt(chain: string): void {
-    rpcMetrics.fallbackAttempts.inc({ chain });
-  },
-  recordFallbackFailure(chain: string): void {
-    rpcMetrics.fallbackFailures.inc({ chain });
-  },
-  recordFailoverEvent(chain: string): void {
-    rpcMetrics.failoverEvents.inc({ chain });
-  },
-  recordBothFailed(chain: string): void {
-    rpcMetrics.bothFailedEvents.inc({ chain });
-    rpcMetrics.healthState.set({ chain }, 2);
-  },
-};
+export const prometheusRpcMetricsCollector: RpcMetricsCollector =
+  prometheusCollector;
+export const prometheusSolanaRpcMetricsCollector: SolanaRpcMetricsCollector =
+  prometheusCollector;
 
 /**
  * Failover state change callback that updates Prometheus gauge and counters.

--- a/lib/metrics/rpc-metrics.ts
+++ b/lib/metrics/rpc-metrics.ts
@@ -38,6 +38,9 @@ const prometheusCollector: RpcMetricsCollector & SolanaRpcMetricsCollector = {
     rpcMetrics.bothFailedEvents.inc({ chain });
     rpcMetrics.healthState.set({ chain }, 2);
   },
+  recordSuccess(chain: string, provider: "primary" | "fallback"): void {
+    rpcMetrics.healthState.set({ chain }, provider === "primary" ? 0 : 1);
+  },
 };
 
 export const prometheusRpcMetricsCollector: RpcMetricsCollector =

--- a/lib/para/wallet-helpers.ts
+++ b/lib/para/wallet-helpers.ts
@@ -58,7 +58,7 @@ export async function initializeWalletSigner(
   rpcUrl: string
 ): Promise<ethers.Signer> {
   const wallet = await getOrganizationWallet(organizationId);
-  const rpcManager = getRpcProviderFromUrls(rpcUrl);
+  const rpcManager = await getRpcProviderFromUrls(rpcUrl);
   const provider = rpcManager.getProvider();
 
   if (wallet.provider === "turnkey") {

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -16,6 +16,7 @@ export type RpcMetricsCollector = {
   recordFallbackAttempt(chainName: string): void;
   recordFallbackFailure(chainName: string): void;
   recordFailoverEvent(chainName: string): void;
+  recordBothFailed(chainName: string): void;
 };
 
 /**
@@ -46,6 +47,9 @@ export const noopMetricsCollector: RpcMetricsCollector = {
   recordFailoverEvent: () => {
     /* noop */
   },
+  recordBothFailed: () => {
+    /* noop */
+  },
 };
 
 /**
@@ -62,6 +66,8 @@ export const consoleMetricsCollector: RpcMetricsCollector = {
     console.debug(`[RPC Metrics] Fallback failure: ${chain}`),
   recordFailoverEvent: (chain) =>
     console.debug(`[RPC Metrics] Failover event: ${chain}`),
+  recordBothFailed: (chain) =>
+    console.debug(`[RPC Metrics] Both endpoints failed: ${chain}`),
 };
 
 export type RpcProviderConfig = {
@@ -232,6 +238,7 @@ export class RpcProviderManager {
         }
 
         // Both failed -- throw without redundant retry
+        this.metricsCollector.recordBothFailed(this.config.chainName);
         console.error(
           JSON.stringify({
             level: "error",
@@ -292,6 +299,7 @@ export class RpcProviderManager {
         return fallbackResult.result as T;
       }
 
+      this.metricsCollector.recordBothFailed(this.config.chainName);
       console.error(
         JSON.stringify({
           level: "error",

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -16,6 +16,7 @@ export type RpcMetricsCollector = {
   recordFallbackAttempt(chainName: string): void;
   recordFallbackFailure(chainName: string): void;
   recordFailoverEvent(chainName: string): void;
+  recordRecoveryEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
   recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
 };
@@ -48,6 +49,9 @@ export const noopMetricsCollector: RpcMetricsCollector = {
   recordFailoverEvent: () => {
     /* noop */
   },
+  recordRecoveryEvent: () => {
+    /* noop */
+  },
   recordBothFailed: () => {
     /* noop */
   },
@@ -70,6 +74,8 @@ export const consoleMetricsCollector: RpcMetricsCollector = {
     console.debug(`[RPC Metrics] Fallback failure: ${chain}`),
   recordFailoverEvent: (chain) =>
     console.debug(`[RPC Metrics] Failover event: ${chain}`),
+  recordRecoveryEvent: (chain) =>
+    console.debug(`[RPC Metrics] Recovery event: ${chain}`),
   recordBothFailed: (chain) =>
     console.debug(`[RPC Metrics] Both endpoints failed: ${chain}`),
   recordSuccess: (chain, provider) =>
@@ -239,6 +245,7 @@ export class RpcProviderManager {
             })
           );
           this.isUsingFallback = false;
+          this.metricsCollector.recordRecoveryEvent(this.config.chainName);
           this.onFailoverStateChange?.(
             this.config.chainName,
             false,

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -17,6 +17,7 @@ export type RpcMetricsCollector = {
   recordFallbackFailure(chainName: string): void;
   recordFailoverEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
+  recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
 };
 
 /**
@@ -50,6 +51,9 @@ export const noopMetricsCollector: RpcMetricsCollector = {
   recordBothFailed: () => {
     /* noop */
   },
+  recordSuccess: () => {
+    /* noop */
+  },
 };
 
 /**
@@ -68,6 +72,8 @@ export const consoleMetricsCollector: RpcMetricsCollector = {
     console.debug(`[RPC Metrics] Failover event: ${chain}`),
   recordBothFailed: (chain) =>
     console.debug(`[RPC Metrics] Both endpoints failed: ${chain}`),
+  recordSuccess: (chain, provider) =>
+    console.debug(`[RPC Metrics] Success on ${provider}: ${chain}`),
 };
 
 export type RpcProviderConfig = {
@@ -194,6 +200,10 @@ export class RpcProviderManager {
         );
 
         if (fallbackResult.success) {
+          this.metricsCollector.recordSuccess(
+            this.config.chainName,
+            "fallback"
+          );
           return fallbackResult.result as T;
         }
 
@@ -266,6 +276,7 @@ export class RpcProviderManager {
     );
 
     if (primaryResult.success) {
+      this.metricsCollector.recordSuccess(this.config.chainName, "primary");
       return primaryResult.result as T;
     }
 

--- a/lib/rpc-provider/solana.ts
+++ b/lib/rpc-provider/solana.ts
@@ -14,6 +14,7 @@ export type SolanaRpcMetricsCollector = {
   recordFallbackFailure(chainName: string): void;
   recordFailoverEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
+  recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
 };
 
 export type SolanaFailoverStateChangeCallback = (
@@ -41,6 +42,9 @@ export const noopSolanaMetricsCollector: SolanaRpcMetricsCollector = {
   recordBothFailed: () => {
     /* noop */
   },
+  recordSuccess: () => {
+    /* noop */
+  },
 };
 
 export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
@@ -56,6 +60,8 @@ export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
     console.debug(`[Solana RPC Metrics] Failover event: ${chain}`),
   recordBothFailed: (chain) =>
     console.debug(`[Solana RPC Metrics] Both endpoints failed: ${chain}`),
+  recordSuccess: (chain, provider) =>
+    console.debug(`[Solana RPC Metrics] Success on ${provider}: ${chain}`),
 };
 
 export type SolanaProviderConfig = {
@@ -176,6 +182,10 @@ export class SolanaProviderManager {
         );
 
         if (fallbackResult.success) {
+          this.metricsCollector.recordSuccess(
+            this.config.chainName,
+            "fallback"
+          );
           return fallbackResult.result as T;
         }
 
@@ -200,6 +210,7 @@ export class SolanaProviderManager {
     );
 
     if (primaryResult.success) {
+      this.metricsCollector.recordSuccess(this.config.chainName, "primary");
       if (this.isUsingFallback) {
         console.info(
           JSON.stringify({
@@ -231,6 +242,7 @@ export class SolanaProviderManager {
       );
 
       if (fallbackResult.success) {
+        this.metricsCollector.recordSuccess(this.config.chainName, "fallback");
         if (!this.isUsingFallback) {
           console.warn(
             JSON.stringify({

--- a/lib/rpc-provider/solana.ts
+++ b/lib/rpc-provider/solana.ts
@@ -13,6 +13,7 @@ export type SolanaRpcMetricsCollector = {
   recordFallbackAttempt(chainName: string): void;
   recordFallbackFailure(chainName: string): void;
   recordFailoverEvent(chainName: string): void;
+  recordRecoveryEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
   recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
 };
@@ -39,6 +40,9 @@ export const noopSolanaMetricsCollector: SolanaRpcMetricsCollector = {
   recordFailoverEvent: () => {
     /* noop */
   },
+  recordRecoveryEvent: () => {
+    /* noop */
+  },
   recordBothFailed: () => {
     /* noop */
   },
@@ -58,6 +62,8 @@ export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
     console.debug(`[Solana RPC Metrics] Fallback failure: ${chain}`),
   recordFailoverEvent: (chain) =>
     console.debug(`[Solana RPC Metrics] Failover event: ${chain}`),
+  recordRecoveryEvent: (chain) =>
+    console.debug(`[Solana RPC Metrics] Recovery event: ${chain}`),
   recordBothFailed: (chain) =>
     console.debug(`[Solana RPC Metrics] Both endpoints failed: ${chain}`),
   recordSuccess: (chain, provider) =>
@@ -224,6 +230,7 @@ export class SolanaProviderManager {
           })
         );
         this.isUsingFallback = false;
+        this.metricsCollector.recordRecoveryEvent(this.config.chainName);
         this.onFailoverStateChange?.(this.config.chainName, false, "recovery");
       }
       return primaryResult.result as T;

--- a/lib/rpc-provider/solana.ts
+++ b/lib/rpc-provider/solana.ts
@@ -13,6 +13,7 @@ export type SolanaRpcMetricsCollector = {
   recordFallbackAttempt(chainName: string): void;
   recordFallbackFailure(chainName: string): void;
   recordFailoverEvent(chainName: string): void;
+  recordBothFailed(chainName: string): void;
 };
 
 export type SolanaFailoverStateChangeCallback = (
@@ -37,6 +38,9 @@ export const noopSolanaMetricsCollector: SolanaRpcMetricsCollector = {
   recordFailoverEvent: () => {
     /* noop */
   },
+  recordBothFailed: () => {
+    /* noop */
+  },
 };
 
 export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
@@ -50,6 +54,8 @@ export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
     console.debug(`[Solana RPC Metrics] Fallback failure: ${chain}`),
   recordFailoverEvent: (chain) =>
     console.debug(`[Solana RPC Metrics] Failover event: ${chain}`),
+  recordBothFailed: (chain) =>
+    console.debug(`[Solana RPC Metrics] Both endpoints failed: ${chain}`),
 };
 
 export type SolanaProviderConfig = {
@@ -244,6 +250,7 @@ export class SolanaProviderManager {
         return fallbackResult.result as T;
       }
 
+      this.metricsCollector.recordBothFailed(this.config.chainName);
       console.error(
         JSON.stringify({
           level: "error",

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -141,7 +141,11 @@ export async function getRpcProvider(
     chainName: config.chainName,
     metricsCollector,
     onFailoverStateChange: (chain, isUsingFallback, reason) => {
-      failoverCallback(chain, isUsingFallback, reason);
+      try {
+        failoverCallback(chain, isUsingFallback, reason);
+      } catch (error) {
+        console.error("Metrics failover callback error:", error);
+      }
       onFailoverStateChange?.(chain, isUsingFallback, reason);
     },
   });
@@ -182,7 +186,11 @@ export async function getSolanaProvider(
     chainName: config.chainName,
     metricsCollector,
     onFailoverStateChange: (chain, isUsingFallback, reason) => {
-      failoverCallback(chain, isUsingFallback, reason);
+      try {
+        failoverCallback(chain, isUsingFallback, reason);
+      } catch (error) {
+        console.error("Metrics failover callback error:", error);
+      }
       onFailoverStateChange?.(chain, isUsingFallback, reason);
     },
   });

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -6,18 +6,83 @@
  */
 
 import {
-  consoleMetricsCollector,
   createRpcProviderManager,
   type FailoverStateChangeCallback,
+  type RpcMetricsCollector,
   type RpcProviderManager,
 } from "@/lib/rpc-provider";
 import {
-  consoleSolanaMetricsCollector,
   createSolanaProviderManager,
   type SolanaFailoverStateChangeCallback,
   type SolanaProviderManager,
+  type SolanaRpcMetricsCollector,
 } from "@/lib/rpc-provider/solana";
 import { resolveRpcConfig } from "./config-service";
+
+/**
+ * Resolve the appropriate RPC metrics collector based on environment.
+ * Uses Prometheus when available (server-side), falls back to console.
+ */
+let cachedEvmCollector: RpcMetricsCollector | undefined;
+let cachedSolanaCollector: SolanaRpcMetricsCollector | undefined;
+let cachedFailoverCallback: FailoverStateChangeCallback | undefined;
+
+async function getEvmMetricsCollector(): Promise<RpcMetricsCollector> {
+  if (cachedEvmCollector) {
+    return cachedEvmCollector;
+  }
+
+  if (process.env.METRICS_COLLECTOR === "prometheus") {
+    const { prometheusRpcMetricsCollector } = await import(
+      "@/lib/metrics/rpc-metrics"
+    );
+    cachedEvmCollector = prometheusRpcMetricsCollector;
+  } else {
+    const { consoleMetricsCollector } = await import("@/lib/rpc-provider");
+    cachedEvmCollector = consoleMetricsCollector;
+  }
+
+  return cachedEvmCollector;
+}
+
+async function getSolanaMetricsCollector(): Promise<SolanaRpcMetricsCollector> {
+  if (cachedSolanaCollector) {
+    return cachedSolanaCollector;
+  }
+
+  if (process.env.METRICS_COLLECTOR === "prometheus") {
+    const { prometheusSolanaRpcMetricsCollector } = await import(
+      "@/lib/metrics/rpc-metrics"
+    );
+    cachedSolanaCollector = prometheusSolanaRpcMetricsCollector;
+  } else {
+    const { consoleSolanaMetricsCollector } = await import(
+      "@/lib/rpc-provider/solana"
+    );
+    cachedSolanaCollector = consoleSolanaMetricsCollector;
+  }
+
+  return cachedSolanaCollector;
+}
+
+async function getFailoverCallback(): Promise<FailoverStateChangeCallback> {
+  if (cachedFailoverCallback) {
+    return cachedFailoverCallback;
+  }
+
+  if (process.env.METRICS_COLLECTOR === "prometheus") {
+    const { onRpcFailoverStateChange } = await import(
+      "@/lib/metrics/rpc-metrics"
+    );
+    cachedFailoverCallback = onRpcFailoverStateChange;
+  } else {
+    cachedFailoverCallback = () => {
+      /* noop when prometheus is not enabled */
+    };
+  }
+
+  return cachedFailoverCallback;
+}
 
 // Solana chain IDs (non-EVM)
 const SOLANA_CHAIN_IDS = new Set([101, 103]);
@@ -60,7 +125,11 @@ export async function getRpcProvider(
     );
   }
 
-  const config = await resolveRpcConfig(chainId, userId);
+  const [config, metricsCollector, failoverCallback] = await Promise.all([
+    resolveRpcConfig(chainId, userId),
+    getEvmMetricsCollector(),
+    getFailoverCallback(),
+  ]);
 
   if (!config) {
     throw new Error(`Chain ${chainId} not found or not enabled`);
@@ -70,8 +139,11 @@ export async function getRpcProvider(
     primaryRpcUrl: config.primaryRpcUrl,
     fallbackRpcUrl: config.fallbackRpcUrl,
     chainName: config.chainName,
-    metricsCollector: consoleMetricsCollector,
-    onFailoverStateChange,
+    metricsCollector,
+    onFailoverStateChange: (chain, isUsingFallback, reason) => {
+      failoverCallback(chain, isUsingFallback, reason);
+      onFailoverStateChange?.(chain, isUsingFallback, reason);
+    },
   });
 }
 
@@ -94,7 +166,11 @@ export async function getSolanaProvider(
     );
   }
 
-  const config = await resolveRpcConfig(chainId, userId);
+  const [config, metricsCollector, failoverCallback] = await Promise.all([
+    resolveRpcConfig(chainId, userId),
+    getSolanaMetricsCollector(),
+    getFailoverCallback(),
+  ]);
 
   if (!config) {
     throw new Error(`Solana chain ${chainId} not found or not enabled`);
@@ -104,39 +180,56 @@ export async function getSolanaProvider(
     primaryRpcUrl: config.primaryRpcUrl,
     fallbackRpcUrl: config.fallbackRpcUrl,
     chainName: config.chainName,
-    metricsCollector: consoleSolanaMetricsCollector,
-    onFailoverStateChange,
+    metricsCollector,
+    onFailoverStateChange: (chain, isUsingFallback, reason) => {
+      failoverCallback(chain, isUsingFallback, reason);
+      onFailoverStateChange?.(chain, isUsingFallback, reason);
+    },
   });
 }
 
 /**
- * Get an RPC provider from explicit URLs (for testing or override scenarios)
+ * Get an RPC provider from explicit URLs (for testing or override scenarios).
+ * Async to resolve the metrics collector dynamically.
  */
-export function getRpcProviderFromUrls(
+export async function getRpcProviderFromUrls(
   primaryRpcUrl: string,
   fallbackRpcUrl?: string,
   chainName = "unknown"
-): RpcProviderManager {
+): Promise<RpcProviderManager> {
+  const [metricsCollector, failoverCallback] = await Promise.all([
+    getEvmMetricsCollector(),
+    getFailoverCallback(),
+  ]);
+
   return createRpcProviderManager({
     primaryRpcUrl,
     fallbackRpcUrl,
     chainName,
-    metricsCollector: consoleMetricsCollector,
+    metricsCollector,
+    onFailoverStateChange: failoverCallback,
   });
 }
 
 /**
- * Get a Solana provider from explicit URLs (for testing or override scenarios)
+ * Get a Solana provider from explicit URLs (for testing or override scenarios).
+ * Async to resolve the metrics collector dynamically.
  */
-export function getSolanaProviderFromUrls(
+export async function getSolanaProviderFromUrls(
   primaryRpcUrl: string,
   fallbackRpcUrl?: string,
   chainName = "solana"
-): SolanaProviderManager {
+): Promise<SolanaProviderManager> {
+  const [metricsCollector, failoverCallback] = await Promise.all([
+    getSolanaMetricsCollector(),
+    getFailoverCallback(),
+  ]);
+
   return createSolanaProviderManager({
     primaryRpcUrl,
     fallbackRpcUrl,
     chainName,
-    metricsCollector: consoleSolanaMetricsCollector,
+    metricsCollector,
+    onFailoverStateChange: failoverCallback,
   });
 }

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -419,7 +419,7 @@ export async function withNonceSession<T>(
 ): Promise<T> {
   const nonceManager = getNonceManager();
   const rpcManager =
-    context.rpcManager ?? getRpcProviderFromUrls(context.rpcUrl);
+    context.rpcManager ?? (await getRpcProviderFromUrls(context.rpcUrl));
   const provider = rpcManager.getProvider();
 
   const { session, validation } = await nonceManager.startSession(
@@ -451,7 +451,7 @@ export async function getCurrentNonce(
   walletAddress: string,
   rpcUrl: string
 ): Promise<number> {
-  const rpcManager = getRpcProviderFromUrls(rpcUrl);
+  const rpcManager = await getRpcProviderFromUrls(rpcUrl);
   return await rpcManager.executeWithFailover((provider) =>
     provider.getTransactionCount(walletAddress, "pending")
   );

--- a/scripts/miscellaneous/test-solana-provider.ts
+++ b/scripts/miscellaneous/test-solana-provider.ts
@@ -28,7 +28,7 @@ async function testSolanaProvider() {
   console.log("Testing Solana Provider...\n");
 
   // Test with mainnet (JSON config → env var → public RPC)
-  const mainnetProvider = getSolanaProviderFromUrls(
+  const mainnetProvider = await getSolanaProviderFromUrls(
     getRpcUrl(
       "solana-mainnet",
       "CHAIN_SOLANA_MAINNET_PRIMARY_RPC",
@@ -45,7 +45,7 @@ async function testSolanaProvider() {
   );
 
   // Test with devnet (JSON config → env var → public RPC)
-  const devnetProvider = getSolanaProviderFromUrls(
+  const devnetProvider = await getSolanaProviderFromUrls(
     getRpcUrl(
       "solana-devnet",
       "CHAIN_SOLANA_DEVNET_PRIMARY_RPC",

--- a/tests/e2e/vitest/check-balance.test.ts
+++ b/tests/e2e/vitest/check-balance.test.ts
@@ -121,7 +121,7 @@ const RPC_URLS = {
 describe("Check Balance E2E", () => {
   describe("EVM Chains", () => {
     it("should check balance on Ethereum Mainnet", async () => {
-      const provider = getRpcProviderFromUrls(
+      const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_MAINNET.primary,
         RPC_URLS.ETH_MAINNET.fallback,
         "Ethereum Mainnet"
@@ -139,7 +139,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should check balance on Sepolia Testnet", async () => {
-      const provider = getRpcProviderFromUrls(
+      const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_SEPOLIA.primary,
         RPC_URLS.ETH_SEPOLIA.fallback,
         "Sepolia Testnet"
@@ -156,7 +156,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should check balance on Base Mainnet", async () => {
-      const provider = getRpcProviderFromUrls(
+      const provider = await getRpcProviderFromUrls(
         RPC_URLS.BASE_MAINNET.primary,
         RPC_URLS.BASE_MAINNET.fallback,
         "Base Mainnet"
@@ -173,7 +173,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should handle zero address", { timeout: 30_000 }, async () => {
-      const provider = getRpcProviderFromUrls(
+      const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_MAINNET.primary,
         RPC_URLS.ETH_MAINNET.fallback,
         "Ethereum Mainnet (Zero Address)"
@@ -194,7 +194,7 @@ describe("Check Balance E2E", () => {
 
   describe("Solana Chains", () => {
     it("should check balance on Solana Mainnet", async () => {
-      const provider = getSolanaProviderFromUrls(
+      const provider = await getSolanaProviderFromUrls(
         RPC_URLS.SOLANA_MAINNET.primary,
         RPC_URLS.SOLANA_MAINNET.fallback,
         "Solana Mainnet"
@@ -215,7 +215,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should check balance on Solana Devnet", async () => {
-      const provider = getSolanaProviderFromUrls(
+      const provider = await getSolanaProviderFromUrls(
         RPC_URLS.SOLANA_DEVNET.primary,
         RPC_URLS.SOLANA_DEVNET.fallback,
         "Solana Devnet"
@@ -235,7 +235,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should get slot number", async () => {
-      const provider = getSolanaProviderFromUrls(
+      const provider = await getSolanaProviderFromUrls(
         RPC_URLS.SOLANA_MAINNET.primary,
         RPC_URLS.SOLANA_MAINNET.fallback,
         "Solana Mainnet"
@@ -251,7 +251,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should get account info", async () => {
-      const provider = getSolanaProviderFromUrls(
+      const provider = await getSolanaProviderFromUrls(
         RPC_URLS.SOLANA_MAINNET.primary,
         RPC_URLS.SOLANA_MAINNET.fallback,
         "Solana Mainnet"
@@ -284,7 +284,7 @@ describe("Check Balance E2E", () => {
   describe("Failover Behavior", () => {
     it("should failover to fallback on EVM when primary fails", async () => {
       // Use an invalid primary URL to force failover
-      const provider = getRpcProviderFromUrls(
+      const provider = await getRpcProviderFromUrls(
         "https://invalid-rpc-url-that-does-not-exist.example.com",
         RPC_URLS.ETH_MAINNET.fallback,
         "Ethereum Mainnet (Failover Test)"
@@ -302,7 +302,7 @@ describe("Check Balance E2E", () => {
 
     it("should failover to fallback on Solana when primary fails", async () => {
       // Use an invalid primary URL to force failover
-      const provider = getSolanaProviderFromUrls(
+      const provider = await getSolanaProviderFromUrls(
         "https://invalid-rpc-url-that-does-not-exist.example.com",
         RPC_URLS.SOLANA_DEVNET.fallback,
         "Solana Devnet (Failover Test)"
@@ -321,7 +321,7 @@ describe("Check Balance E2E", () => {
 
   describe("Metrics Collection", () => {
     it("should track EVM request metrics", async () => {
-      const provider = getRpcProviderFromUrls(
+      const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_MAINNET.primary,
         RPC_URLS.ETH_MAINNET.fallback,
         "Ethereum Mainnet"
@@ -349,7 +349,7 @@ describe("Check Balance E2E", () => {
     });
 
     it("should track Solana request metrics", async () => {
-      const provider = getSolanaProviderFromUrls(
+      const provider = await getSolanaProviderFromUrls(
         RPC_URLS.SOLANA_DEVNET.primary,
         RPC_URLS.SOLANA_DEVNET.fallback,
         "Solana Devnet"

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -93,6 +93,7 @@ describe("RpcProviderManager", () => {
       recordFallbackAttempt: vi.fn(),
       recordFallbackFailure: vi.fn(),
       recordFailoverEvent: vi.fn(),
+      recordRecoveryEvent: vi.fn(),
       recordBothFailed: vi.fn(),
       recordSuccess: vi.fn(),
     };

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -93,6 +93,7 @@ describe("RpcProviderManager", () => {
       recordFallbackAttempt: vi.fn(),
       recordFallbackFailure: vi.fn(),
       recordFailoverEvent: vi.fn(),
+      recordBothFailed: vi.fn(),
     };
   });
 

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -94,6 +94,7 @@ describe("RpcProviderManager", () => {
       recordFallbackFailure: vi.fn(),
       recordFailoverEvent: vi.fn(),
       recordBothFailed: vi.fn(),
+      recordSuccess: vi.fn(),
     };
   });
 

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -36,6 +36,7 @@ describe("SolanaProviderManager", () => {
       recordFallbackAttempt: vi.fn(),
       recordFallbackFailure: vi.fn(),
       recordFailoverEvent: vi.fn(),
+      recordRecoveryEvent: vi.fn(),
       recordBothFailed: vi.fn(),
       recordSuccess: vi.fn(),
     };

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -37,6 +37,7 @@ describe("SolanaProviderManager", () => {
       recordFallbackFailure: vi.fn(),
       recordFailoverEvent: vi.fn(),
       recordBothFailed: vi.fn(),
+      recordSuccess: vi.fn(),
     };
   });
 

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -36,6 +36,7 @@ describe("SolanaProviderManager", () => {
       recordFallbackAttempt: vi.fn(),
       recordFallbackFailure: vi.fn(),
       recordFailoverEvent: vi.fn(),
+      recordBothFailed: vi.fn(),
     };
   });
 


### PR DESCRIPTION
## Summary

- Add per-chain Prometheus counters and gauges to track RPC primary/fallback health and failover behavior
- New `keeperhub_rpc_health_state` gauge (0=primary, 1=fallback, 2=both_failed) for Grafana State Timeline panels with green/yellow/red visualization
- Counters for primary/fallback attempts, failures, failover events, recovery events, and both-failed events
- Auto-selects Prometheus or console collector based on `METRICS_COLLECTOR` env var