### PR TITLE
fix: KEEP-40 use rpc-config resolution in e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:fund-test-wallet": "tsx scripts/miscellaneous/fund-test-wallet.ts",
     "db:seed-tokens": "tsx scripts/seed/seed-tokens.ts",
     "db:setup": "pnpm db:migrate && pnpm db:setup-workflow && pnpm db:seed",
-    "db:setup-workflow": "tsx scripts/setup-workflow-db.ts",
+    "db:setup-workflow": "workflow-postgres-setup",
     "discover-plugins": "tsx scripts/discover-plugins.ts",
     "create-plugin": "tsx scripts/create-plugin.ts",
     "analyze-steps": "tsx scripts/analyze-steps.ts",

--- a/tests/e2e/vitest/gas-strategy.test.ts
+++ b/tests/e2e/vitest/gas-strategy.test.ts
@@ -26,14 +26,15 @@ import {
 vi.unmock("@/lib/db");
 vi.unmock("server-only");
 
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import { AdaptiveGasStrategy, resetGasStrategy } from "@/lib/web3/gas-strategy";
 
 // Skip if SKIP_INFRA_TESTS is true (no network access)
 const shouldSkip = process.env.SKIP_INFRA_TESTS === "true";
 
-// Real RPC endpoints
-const SEPOLIA_RPC = "https://chain.techops.services/eth-sepolia";
-const BASE_SEPOLIA_RPC = "https://sepolia.base.org";
+// Real RPC endpoints - resolved from CHAIN_RPC_CONFIG with public fallbacks
+const SEPOLIA_RPC = getRpcUrlByChainId(11_155_111, "primary");
+const BASE_SEPOLIA_RPC = getRpcUrlByChainId(84_532, "primary");
 
 describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
   let sepoliaProvider: ethers.JsonRpcProvider;

--- a/tests/e2e/vitest/rpc-failover.test.ts
+++ b/tests/e2e/vitest/rpc-failover.test.ts
@@ -16,6 +16,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { type Chain, chains, userRpcPreferences, users } from "@/lib/db/schema";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import {
   clearRpcProviderManagerCache,
   RpcProviderManager,
@@ -71,8 +72,8 @@ describe.skipIf(shouldSkip)("RPC Failover E2E", () => {
         name: "Sepolia Testnet",
         symbol: "ETH",
         chainType: "evm",
-        defaultPrimaryRpc: "https://chain.techops.services/eth-sepolia",
-        defaultFallbackRpc: "https://ethereum-sepolia-rpc.publicnode.com",
+        defaultPrimaryRpc: getRpcUrlByChainId(11_155_111, "primary"),
+        defaultFallbackRpc: getRpcUrlByChainId(11_155_111, "fallback"),
         isTestnet: true,
         isEnabled: true,
       });
@@ -363,8 +364,7 @@ describe.skipIf(shouldSkip)("RPC Failover E2E", () => {
   });
 
   describe("RPC Provider Failover (Real Endpoints)", () => {
-    // TechOps RPC endpoint (primary, more reliable)
-    const TECHOPS_SEPOLIA_RPC = "https://chain.techops.services/eth-sepolia";
+    const TECHOPS_SEPOLIA_RPC = getRpcUrlByChainId(11_155_111, "primary");
     const INVALID_RPC = "https://invalid-rpc-endpoint.example.com";
 
     beforeEach(() => {

--- a/tests/e2e/vitest/transaction-flow.test.ts
+++ b/tests/e2e/vitest/transaction-flow.test.ts
@@ -32,6 +32,7 @@ vi.unmock("@/lib/db");
 vi.mock("server-only", () => ({}));
 
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import { AdaptiveGasStrategy, resetGasStrategy } from "@/lib/web3/gas-strategy";
 import { NonceManager, resetNonceManager } from "@/lib/web3/nonce-manager";
 
@@ -43,7 +44,7 @@ const shouldSkip =
 const TEST_WALLET = "0xTestWallet1234567890123456789012345678";
 const TEST_WALLET_NORMALIZED = TEST_WALLET.toLowerCase();
 const TEST_CHAIN_ID = 11_155_111; // Sepolia
-const SEPOLIA_RPC = "https://chain.techops.services/eth-sepolia";
+const SEPOLIA_RPC = getRpcUrlByChainId(11_155_111, "primary");
 
 describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
   let client: ReturnType<typeof postgres>;


### PR DESCRIPTION
## Summary

- Replace hardcoded `chain.techops.services` URLs in e2e vitest tests with `getRpcUrlByChainId()` from `lib/rpc/rpc-config.ts`
- Tests now resolve RPCs through `CHAIN_RPC_CONFIG` -> env vars -> public defaults, consistent with the rest of the codebase
- The TechOps RPC proxy is currently returning Cloudflare Worker 1101 errors, which broke all 3 e2e vitest suites (24 test failures) after PR #727 merged

## Test plan

- [ ] Verify e2e-vitest-ephemeral passes in CI (was failing with 24 errors)
- [ ] Verify e2e-playwright-ephemeral runs (was skipped due to vitest failure)