### PR TITLE
chore(deps): bump GitHub Actions and npm dependencies

### DIFF
--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Comment on PR (success)
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -160,7 +160,7 @@ jobs:
 
       - name: Comment on PR (failure)
         if: failure() && steps.check-namespace.outputs.exists == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -189,7 +189,7 @@ jobs:
 
       - name: Comment on PR (no environment)
         if: steps.check-namespace.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract commit hash
         id: vars

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push event tracker image
         if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           EVENTS_ECR_TRACKER_REPO: ${{ env.TRACKER_ECR_NAME }}

--- a/.github/workflows/deploy-executor.yaml
+++ b/.github/workflows/deploy-executor.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Check if executor image already exists
         if: steps.skip.outputs.skip_build == 'true'

--- a/.github/workflows/deploy-executor.yaml
+++ b/.github/workflows/deploy-executor.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build and push executor image
         if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           EXECUTOR_ECR_REPO: ${{ env.EXECUTOR_ECR_NAME }}

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-remote-report
           path: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -552,7 +552,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vitest-e2e-remote-results-pr-${{ env.PR_NUMBER }}
           path: |
@@ -682,7 +682,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-deployed-report-pr-${{ env.PR_NUMBER }}
           path: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -93,7 +93,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
@@ -459,7 +459,7 @@ jobs:
           discover-plugins: "true"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
@@ -589,7 +589,7 @@ jobs:
           install-playwright: "true"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -365,7 +365,7 @@ jobs:
 
       - name: Comment on PR
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -404,7 +404,7 @@ jobs:
 
       - name: Comment on PR (failure)
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -692,7 +692,7 @@ jobs:
 
       - name: Comment test results on PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/deploy-scheduler.yaml
+++ b/.github/workflows/deploy-scheduler.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract commit hash
         id: vars

--- a/.github/workflows/deploy-scheduler.yaml
+++ b/.github/workflows/deploy-scheduler.yaml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Build and push scheduler images
         if: steps.skip.outputs.skip_build != 'true'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           SCHEDULER_ECR_REPO: ${{ env.SCHEDULER_ECR_NAME }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vitest-e2e-results
           path: |
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-ephemeral
           path: |
@@ -335,7 +335,7 @@ jobs:
 
       - name: Upload screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-screenshots-ephemeral
           path: test-results/**/*.png


### PR DESCRIPTION
## Summary

Consolidates dependency bumps from PRs #764, #765, #766, #767, #768 into a single update:

- `docker/setup-buildx-action` 3 -> 4
- `actions/github-script` 7 -> 8
- `aws-actions/configure-aws-credentials` 4 -> 6
- `docker/bake-action` 6 -> 7
- `actions/upload-artifact` 4 -> 7

## Test plan

- [x] CI workflows pass with updated action versions
- [x] PR environment deploy/cleanup workflows function correctly

Closes #764, #765, #766, #767, #768