### PR TITLE
fix: KEEP-93 sanitize MCP workflow node data before persisting

### DIFF
--- a/app/api/mcp/schemas/route.ts
+++ b/app/api/mcp/schemas/route.ts
@@ -608,7 +608,7 @@ export async function GET(request: Request) {
       "Use tagId to label a workflow with a single tag (e.g., 'production', 'monitoring'). Each workflow supports one tag. Fetch available tags from GET /api/tags first.",
       `Use {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)`,
       "All trigger types expose a 'triggeredAt' output field (ISO timestamp). Reference it with {{@triggerId:TriggerLabel.data.triggeredAt}} to include when the workflow fired.",
-      "Database Query: use inline {{@nodeId:Label.field}} template refs directly in the SQL string. Do NOT use parameterized $1/$2 placeholders with a separate dbParams array -- the UI does not support that format.",
+      "Database Query: use inline {{@nodeId:Label.field}} template refs directly in the SQL string. Do NOT use parameterized $1/$2 placeholders with a separate dbParams array. The UI does not support that format.",
       "Condition conditionConfig: every group and rule MUST have a unique 'id' field (use nanoid or UUID). Operators must be exact symbols: '===' not 'equals', '<' not 'less_than', '>' not 'greater_than'. Rule fields are 'leftOperand' and 'rightOperand', NOT 'field' and 'value'.",
     ],
   };

--- a/app/api/mcp/schemas/route.ts
+++ b/app/api/mcp/schemas/route.ts
@@ -32,7 +32,7 @@ const SYSTEM_ACTIONS = {
     },
     optionalFields: {
       conditionConfig:
-        "object - Visual condition builder config with { group: ConditionGroup }. When provided, the 'condition' field is auto-generated from this visual config.",
+        'object - Visual condition builder config. Structure: { group: { id: "nanoid", logic: "AND" | "OR", rules: [{ id: "nanoid", leftOperand: "{{@nodeId:Label.field}}", operator: "===" | "==" | "!==" | "!=" | ">" | ">=" | "<" | "<=" | "contains" | "startsWith" | "endsWith" | "isEmpty" | "isNotEmpty" | "exists" | "doesNotExist" | "matchesRegex", rightOperand: "value" }] } }. Every group and rule MUST have a unique id. Operator must be the exact symbol (e.g. "===" not "equals", "<" not "less_than"). When provided, the condition expression is auto-generated from this visual config.',
     },
     outputFields: {
       result: "boolean - Whether the condition evaluated to true",
@@ -67,7 +67,8 @@ const SYSTEM_ACTIONS = {
     category: "System",
     requiredFields: {
       integrationId: "string - ID of the database integration",
-      dbQuery: "string - SQL query to execute",
+      dbQuery:
+        "string - SQL query with inline template references for dynamic values. Use {{@nodeId:Label.field}} directly in the SQL string. Example: \"INSERT INTO logs (vault, price) VALUES ('{{@compute:Compare.bestVault}}', '{{@compute:Compare.bestPrice}}')\" or \"SELECT * FROM positions WHERE address = '{{@trigger:Trigger.data.address}}'\"",
     },
     optionalFields: {
       dbSchema: "string - JSON schema for result typing",
@@ -607,6 +608,8 @@ export async function GET(request: Request) {
       "Use tagId to label a workflow with a single tag (e.g., 'production', 'monitoring'). Each workflow supports one tag. Fetch available tags from GET /api/tags first.",
       `Use {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)`,
       "All trigger types expose a 'triggeredAt' output field (ISO timestamp). Reference it with {{@triggerId:TriggerLabel.data.triggeredAt}} to include when the workflow fired.",
+      "Database Query: use inline {{@nodeId:Label.field}} template refs directly in the SQL string. Do NOT use parameterized $1/$2 placeholders with a separate dbParams array -- the UI does not support that format.",
+      "Condition conditionConfig: every group and rule MUST have a unique 'id' field (use nanoid or UUID). Operators must be exact symbols: '===' not 'equals', '<' not 'less_than', '>' not 'greater_than'. Rule fields are 'leftOperand' and 'rightOperand', NOT 'field' and 'value'.",
     ],
   };
 

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -7,6 +7,7 @@ import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 import { remapTemplateRefsInString } from "@/lib/utils/template";
+import { sanitizeWorkflowData } from "@/lib/workflow/sanitize-nodes";
 // Node type for type-safe node manipulation
 type WorkflowNodeLike = {
   id: string;
@@ -156,12 +157,20 @@ export async function POST(
     for (const n of oldNodes) {
       idMap.set(n.id, nanoid());
     }
-    const newNodes = duplicateNodes(oldNodes, idMap);
-    const newEdges = updateEdgeReferences(
+    const duplicatedNodes = duplicateNodes(oldNodes, idMap);
+    const duplicatedEdges = updateEdgeReferences(
       sourceWorkflow.edges as WorkflowEdgeLike[],
       oldNodes,
-      newNodes
+      duplicatedNodes
     );
+
+    // Sanitize nodes/edges: strip React Flow UI state and normalize formats
+    const sanitized = sanitizeWorkflowData(
+      duplicatedNodes as Record<string, unknown>[],
+      duplicatedEdges as Record<string, unknown>[],
+    );
+    const newNodes = sanitized.nodes;
+    const newEdges = sanitized.edges;
 
     // Count workflows in current context (org or anonymous) to generate unique name
     const existingWorkflows = isAnonymous

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -167,7 +167,7 @@ export async function POST(
     // Sanitize nodes/edges: strip React Flow UI state and normalize formats
     const sanitized = sanitizeWorkflowData(
       duplicatedNodes as Record<string, unknown>[],
-      duplicatedEdges as Record<string, unknown>[],
+      duplicatedEdges as Record<string, unknown>[]
     );
     const newNodes = sanitized.nodes;
     const newEdges = sanitized.edges;

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -6,6 +6,7 @@ import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflows } from "@/lib/db/schema";
 import { syncWorkflowSchedule } from "@/lib/schedule-service";
+import { sanitizeWorkflowData } from "@/lib/workflow/sanitize-nodes";
 async function fetchWorkflowPublicTags(
   workflowId: string
 ): Promise<Array<{ id: string; name: string; slug: string }>> {
@@ -154,6 +155,19 @@ function buildUpdateData(
   for (const field of fields) {
     if (body[field] !== undefined) {
       updateData[field] = body[field];
+    }
+  }
+
+  // Sanitize nodes/edges: strip React Flow UI state and normalize MCP-generated formats
+  if (Array.isArray(updateData.nodes) || Array.isArray(updateData.edges)) {
+    const nodes = (updateData.nodes ?? []) as Record<string, unknown>[];
+    const edges = (updateData.edges ?? []) as Record<string, unknown>[];
+    const sanitized = sanitizeWorkflowData(nodes, edges);
+    if (updateData.nodes !== undefined) {
+      updateData.nodes = sanitized.nodes;
+    }
+    if (updateData.edges !== undefined) {
+      updateData.edges = sanitized.edges;
     }
   }
 

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -7,6 +7,7 @@ import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, tags, workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
+import { sanitizeWorkflowData } from "@/lib/workflow/sanitize-nodes";
 function createDefaultNodes() {
   const triggerId = nanoid();
   const actionId = nanoid();
@@ -29,7 +30,6 @@ function createDefaultNodes() {
     id: actionId,
     type: "action" as const,
     position: { x: 272, y: 0 },
-    selected: true,
     data: {
       label: "",
       description: "",
@@ -123,6 +123,11 @@ export async function POST(request: Request) {
       nodes = defaults.nodes;
       edges = defaults.edges;
     }
+
+    // Sanitize nodes/edges: strip React Flow UI state and normalize MCP-generated formats
+    const sanitized = sanitizeWorkflowData(nodes, edges);
+    nodes = sanitized.nodes;
+    edges = sanitized.edges;
 
     const isAnonymous = !organizationId;
     const workflowName = await generateWorkflowName(

--- a/app/api/workflows/current/route.ts
+++ b/app/api/workflows/current/route.ts
@@ -5,6 +5,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
+import { sanitizeWorkflowData } from "@/lib/workflow/sanitize-nodes";
 
 const CURRENT_WORKFLOW_NAME = "~~__CURRENT__~~";
 
@@ -76,14 +77,18 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { nodes, edges } = body;
+    const { nodes: rawNodes, edges: rawEdges } = body;
 
-    if (!(nodes && edges)) {
+    if (!(rawNodes && rawEdges)) {
       return NextResponse.json(
         { error: "Nodes and edges are required" },
         { status: 400 }
       );
     }
+
+    // Sanitize nodes/edges: strip React Flow UI state and normalize formats
+    const sanitized = sanitizeWorkflowData(rawNodes, rawEdges);
+    const { nodes, edges } = sanitized;
 
     // Check if current workflow exists
     const [existingWorkflow] = await db

--- a/lib/workflow/sanitize-nodes.ts
+++ b/lib/workflow/sanitize-nodes.ts
@@ -1,0 +1,350 @@
+/**
+ * Sanitizes workflow nodes and edges before persisting to the database.
+ *
+ * Handles two classes of issues:
+ * 1. React Flow UI state leaking into stored data (dragging, measured, selected, etc.)
+ * 2. MCP/AI producing inconsistent node formats (wrong type separators, config at wrong level)
+ * 3. Missing positions -- applies auto-layout when all nodes are at origin
+ * 4. Condition config normalization (missing ids, wrong operator formats, field name aliases)
+ *
+ * Canonical node format expected by the workflow executor:
+ *   { id, type: "trigger"|"action", position: {x,y}, data: { label, description, type, config: { actionType, ...params }, status, enabled? } }
+ */
+
+import { computeAutoLayout } from "@/lib/auto-layout";
+import type { ConditionOperator } from "@/lib/condition-builder-types";
+import type { Edge, Node } from "@xyflow/react";
+import { nanoid } from "nanoid";
+
+/** Map common MCP/AI operator aliases to canonical ConditionOperator values */
+const OPERATOR_ALIASES: Record<string, ConditionOperator> = {
+  equals: "===",
+  equal: "===",
+  eq: "===",
+  not_equals: "!==",
+  not_equal: "!==",
+  neq: "!==",
+  greater_than: ">",
+  gt: ">",
+  greater_than_or_equal: ">=",
+  gte: ">=",
+  less_than: "<",
+  lt: "<",
+  less_than_or_equal: "<=",
+  lte: "<=",
+  starts_with: "startsWith",
+  ends_with: "endsWith",
+  is_empty: "isEmpty",
+  is_not_empty: "isNotEmpty",
+  does_not_exist: "doesNotExist",
+  matches_regex: "matchesRegex",
+  "==": "==",
+  "===": "===",
+  "!=": "!=",
+  "!==": "!==",
+  ">": ">",
+  ">=": ">=",
+  "<": "<",
+  "<=": "<=",
+  contains: "contains",
+  startsWith: "startsWith",
+  endsWith: "endsWith",
+  isEmpty: "isEmpty",
+  isNotEmpty: "isNotEmpty",
+  exists: "exists",
+  doesNotExist: "doesNotExist",
+  matchesRegex: "matchesRegex",
+};
+
+const KNOWN_DATA_FIELDS = new Set([
+  "label",
+  "description",
+  "type",
+  "config",
+  "status",
+  "enabled",
+]);
+
+
+// ---------------------------------------------------------------------------
+// Condition config normalization
+// ---------------------------------------------------------------------------
+
+/** Normalize a condition operator string to a canonical ConditionOperator value */
+function normalizeOperator(op: unknown): ConditionOperator {
+  if (typeof op === "string") {
+    return OPERATOR_ALIASES[op] ?? "===";
+  }
+  // Handle object-shaped operators (e.g. { key: "equals", label: "Equals" })
+  if (typeof op === "object" && op !== null && "key" in op) {
+    const key = (op as Record<string, unknown>).key;
+    return typeof key === "string" ? (OPERATOR_ALIASES[key] ?? "===") : "===";
+  }
+  return "===";
+}
+
+/** Normalize a single condition rule to the canonical format */
+function normalizeConditionRule(raw: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: (raw.id as string) || nanoid(),
+    leftOperand: String(raw.leftOperand ?? raw.field ?? ""),
+    operator: normalizeOperator(raw.operator),
+    rightOperand: String(raw.rightOperand ?? raw.value ?? ""),
+  };
+}
+
+/** Normalize a condition group, recursively handling nested groups */
+function normalizeConditionGroup(raw: Record<string, unknown>): Record<string, unknown> {
+  const rules = Array.isArray(raw.rules) ? raw.rules : [];
+  return {
+    id: (raw.id as string) || nanoid(),
+    logic: raw.logic === "OR" ? "OR" : "AND",
+    rules: rules.map((item: Record<string, unknown>) => {
+      if ("rules" in item || "logic" in item) {
+        return normalizeConditionGroup(item);
+      }
+      return normalizeConditionRule(item);
+    }),
+  };
+}
+
+/**
+ * Normalize conditionConfig inside a Condition node's config.
+ * Fixes: missing ids, wrong operator formats, field name aliases, array-shaped groups.
+ */
+function normalizeConditionConfig(config: Record<string, unknown>): Record<string, unknown> {
+  if (config.actionType !== "Condition" || !config.conditionConfig) {
+    return config;
+  }
+
+  const conditionConfig = config.conditionConfig as Record<string, unknown>;
+  let group = conditionConfig.group as Record<string, unknown> | Record<string, unknown>[];
+
+  // Handle group as array (broken format from some MCP outputs)
+  if (Array.isArray(group)) {
+    group = {
+      id: nanoid(),
+      logic: (conditionConfig.logicalOperator as string) ?? "AND",
+      rules: group.flatMap((g: Record<string, unknown>) =>
+        Array.isArray(g.rules) ? g.rules : [g]
+      ),
+    };
+  }
+
+  if (typeof group !== "object" || group === null) {
+    return config;
+  }
+
+  return {
+    ...config,
+    conditionConfig: {
+      group: normalizeConditionGroup(group),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Node format normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether a node.type is a specific step type rather than the generic "trigger"/"action".
+ * Step types use slash (e.g. "web3/read-contract") or colon (e.g. "web3:read-contract") separators.
+ */
+function isSpecificStepType(nodeType: string): boolean {
+  return nodeType.includes("/") || nodeType.includes(":");
+}
+
+/** Normalize colon-separated step types to slash-separated (web3:read-contract -> web3/read-contract) */
+function normalizeStepType(stepType: string): string {
+  return stepType.replace(":", "/");
+}
+
+/** Determine if a node is a trigger based on various format signals */
+function isTriggerNode(node: Record<string, unknown>): boolean {
+  if (node.type === "trigger") {
+    return true;
+  }
+
+  const typeStr = String(node.type ?? "");
+  if (
+    typeStr === "Schedule" ||
+    typeStr.toLowerCase().includes("trigger") ||
+    typeStr === "system:schedule" ||
+    typeStr === "system/schedule"
+  ) {
+    return true;
+  }
+
+  const data = node.data as Record<string, unknown> | undefined;
+  if (data?.type === "trigger") {
+    return true;
+  }
+  const config = data?.config as Record<string, unknown> | undefined;
+  if (config?.triggerType !== undefined) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Extract config from a data object where config fields may be at the root level
+ * instead of nested inside data.config.
+ */
+function extractConfig(
+  data: Record<string, unknown>,
+  existingConfig: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const config: Record<string, unknown> = { ...existingConfig };
+
+  // Move any unknown fields from data root into config
+  for (const [key, value] of Object.entries(data)) {
+    if (!KNOWN_DATA_FIELDS.has(key) && value !== undefined) {
+      config[key] = value;
+    }
+  }
+
+  return config;
+}
+
+function sanitizeNode(raw: Record<string, unknown>): Record<string, unknown> {
+  const nodeType = String(raw.type ?? "action");
+  const rawData = (raw.data ?? {}) as Record<string, unknown>;
+  const isTrigger = isTriggerNode(raw);
+  const canonicalType = isTrigger ? "trigger" : "action";
+
+  // Build config: start with existing data.config, then pick up misplaced root-level fields
+  let existingConfig = (rawData.config ?? {}) as Record<string, unknown>;
+
+  // If node.type is a specific step type, move it into config.actionType
+  if (!isTrigger && isSpecificStepType(nodeType)) {
+    const normalized = normalizeStepType(nodeType);
+    if (!existingConfig.actionType) {
+      existingConfig = { ...existingConfig, actionType: normalized };
+    }
+  }
+
+  // If the node type is "Schedule" (format 3 trigger), ensure triggerType is set
+  if (isTrigger && nodeType === "Schedule" && !existingConfig.triggerType) {
+    existingConfig = { ...existingConfig, triggerType: "Schedule" };
+  }
+
+  // Extract misplaced config fields from data root level into config
+  const rawConfig = extractConfig(rawData, existingConfig);
+
+  // Normalize condition config for Condition nodes (fix ids, operators, field names)
+  const config = normalizeConditionConfig(rawConfig);
+
+  // Build clean data object
+  const data: Record<string, unknown> = {
+    label: rawData.label ?? "",
+    type: canonicalType,
+    config,
+    status: rawData.status ?? "idle",
+  };
+
+  if (rawData.description !== undefined) {
+    data.description = rawData.description;
+  }
+  if (rawData.enabled !== undefined) {
+    data.enabled = rawData.enabled;
+  }
+
+  // Build clean node with only known fields
+  const node: Record<string, unknown> = {
+    id: raw.id,
+    type: canonicalType,
+    data,
+  };
+
+  // Preserve position if provided (strip to just x/y)
+  if (raw.position !== undefined && raw.position !== null) {
+    const pos = raw.position as Record<string, unknown>;
+    node.position = {
+      x: typeof pos.x === "number" ? pos.x : 0,
+      y: typeof pos.y === "number" ? pos.y : 0,
+    };
+  } else {
+    node.position = { x: 0, y: 0 };
+  }
+
+  return node;
+}
+
+function sanitizeEdge(raw: Record<string, unknown>): Record<string, unknown> {
+  const edge: Record<string, unknown> = {
+    id: raw.id,
+    source: raw.source,
+    target: raw.target,
+  };
+
+  // Preserve optional known fields
+  if (raw.type !== undefined) {
+    edge.type = raw.type;
+  }
+  if (raw.sourceHandle !== undefined) {
+    edge.sourceHandle = raw.sourceHandle;
+  }
+  if (raw.targetHandle !== undefined) {
+    edge.targetHandle = raw.targetHandle;
+  }
+  if (raw.label !== undefined) {
+    edge.label = raw.label;
+  }
+  if (raw.data !== undefined) {
+    edge.data = raw.data;
+  }
+
+  return edge;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-layout
+// ---------------------------------------------------------------------------
+
+/** Check if all nodes are at the same position (e.g. all at origin), meaning no layout was provided */
+function needsAutoLayout(sanitizedNodes: Record<string, unknown>[]): boolean {
+  if (sanitizedNodes.length <= 1) {
+    return false;
+  }
+  const firstPos = sanitizedNodes[0].position as { x: number; y: number };
+  return sanitizedNodes.every((n) => {
+    const pos = n.position as { x: number; y: number };
+    return pos.x === firstPos.x && pos.y === firstPos.y;
+  });
+}
+
+/**
+ * Sanitize workflow nodes and edges, stripping React Flow UI state and normalizing
+ * inconsistent MCP/AI-generated node formats to the canonical structure.
+ */
+export function sanitizeWorkflowData(
+  nodes: Record<string, unknown>[],
+  edges: Record<string, unknown>[]
+): {
+  nodes: Record<string, unknown>[];
+  edges: Record<string, unknown>[];
+} {
+  const sanitizedNodes = nodes.map(sanitizeNode);
+  const sanitizedEdges = edges.map(sanitizeEdge);
+
+  // Apply auto-layout when no meaningful positions were provided
+  if (needsAutoLayout(sanitizedNodes)) {
+    const positions = computeAutoLayout(
+      sanitizedNodes as Node[],
+      sanitizedEdges as Edge[],
+    );
+    for (const node of sanitizedNodes) {
+      const pos = positions.get(node.id as string);
+      if (pos) {
+        node.position = pos;
+      }
+    }
+  }
+
+  return {
+    nodes: sanitizedNodes,
+    edges: sanitizedEdges,
+  };
+}

--- a/lib/workflow/sanitize-nodes.ts
+++ b/lib/workflow/sanitize-nodes.ts
@@ -4,7 +4,7 @@
  * Handles two classes of issues:
  * 1. React Flow UI state leaking into stored data (dragging, measured, selected, etc.)
  * 2. MCP/AI producing inconsistent node formats (wrong type separators, config at wrong level)
- * 3. Missing positions -- applies auto-layout when all nodes are at origin
+ * 3. Missing positions. Applies auto-layout when all nodes are at origin
  * 4. Condition config normalization (missing ids, wrong operator formats, field name aliases)
  *
  * Canonical node format expected by the workflow executor:

--- a/lib/workflow/sanitize-nodes.ts
+++ b/lib/workflow/sanitize-nodes.ts
@@ -38,22 +38,6 @@ const OPERATOR_ALIASES: Record<string, ConditionOperator> = {
   is_not_empty: "isNotEmpty",
   does_not_exist: "doesNotExist",
   matches_regex: "matchesRegex",
-  "==": "==",
-  "===": "===",
-  "!=": "!=",
-  "!==": "!==",
-  ">": ">",
-  ">=": ">=",
-  "<": "<",
-  "<=": "<=",
-  contains: "contains",
-  startsWith: "startsWith",
-  endsWith: "endsWith",
-  isEmpty: "isEmpty",
-  isNotEmpty: "isNotEmpty",
-  exists: "exists",
-  doesNotExist: "doesNotExist",
-  matchesRegex: "matchesRegex",
 };
 
 const KNOWN_DATA_FIELDS = new Set([
@@ -65,14 +49,23 @@ const KNOWN_DATA_FIELDS = new Set([
   "enabled",
 ]);
 
-
 // ---------------------------------------------------------------------------
 // Condition config normalization
 // ---------------------------------------------------------------------------
 
+/** The set of valid canonical operators for fast lookup */
+const VALID_OPERATORS = new Set<string>([
+  "==", "===", "!=", "!==", ">", ">=", "<", "<=",
+  "contains", "startsWith", "endsWith",
+  "isEmpty", "isNotEmpty", "exists", "doesNotExist", "matchesRegex",
+]);
+
 /** Normalize a condition operator string to a canonical ConditionOperator value */
 function normalizeOperator(op: unknown): ConditionOperator {
   if (typeof op === "string") {
+    if (VALID_OPERATORS.has(op)) {
+      return op as ConditionOperator;
+    }
     return OPERATOR_ALIASES[op] ?? "===";
   }
   // Handle object-shaped operators (e.g. { key: "equals", label: "Equals" })
@@ -333,7 +326,7 @@ export function sanitizeWorkflowData(
   if (needsAutoLayout(sanitizedNodes)) {
     const positions = computeAutoLayout(
       sanitizedNodes as Node[],
-      sanitizedEdges as Edge[],
+      sanitizedEdges as Edge[]
     );
     for (const node of sanitizedNodes) {
       const pos = positions.get(node.id as string);

--- a/tests/unit/sanitize-nodes.test.ts
+++ b/tests/unit/sanitize-nodes.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeWorkflowData } from "@/lib/workflow/sanitize-nodes";
+
+describe("sanitizeWorkflowData", () => {
+  describe("React Flow UI state stripping", () => {
+    it("strips transient React Flow properties from nodes", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "n1",
+            type: "action",
+            dragging: false,
+            measured: { width: 150, height: 40 },
+            selected: true,
+            resizing: false,
+            zIndex: 5,
+            selectable: true,
+            connectable: true,
+            deletable: true,
+            focusable: true,
+            positionAbsolute: { x: 100, y: 200 },
+            className: "some-class",
+            style: { opacity: 1 },
+            hidden: false,
+            position: { x: 10, y: 20 },
+            data: {
+              label: "Test",
+              type: "action",
+              config: { actionType: "web3/check-balance" },
+              status: "idle",
+            },
+          },
+        ],
+        []
+      );
+
+      expect(nodes[0]).toEqual({
+        id: "n1",
+        type: "action",
+        position: { x: 10, y: 20 },
+        data: {
+          label: "Test",
+          type: "action",
+          config: { actionType: "web3/check-balance" },
+          status: "idle",
+        },
+      });
+    });
+
+    it("strips junk properties from edges", () => {
+      const { edges } = sanitizeWorkflowData(
+        [],
+        [
+          {
+            id: "e1",
+            source: "a",
+            target: "b",
+            type: "animated",
+            sourceHandle: "true",
+            animated: true,
+            selected: false,
+            className: "edge-class",
+            style: { stroke: "red" },
+            zIndex: 10,
+          },
+        ]
+      );
+
+      expect(edges[0]).toEqual({
+        id: "e1",
+        source: "a",
+        target: "b",
+        type: "animated",
+        sourceHandle: "true",
+      });
+    });
+  });
+
+  describe("MCP format normalization", () => {
+    it("normalizes colon-separated types to slash (Format 2: Compound pattern)", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "n1",
+            type: "web3:read-contract",
+            data: { type: "action", network: "1", contractAddress: "0x123" },
+          },
+        ],
+        []
+      );
+
+      expect(nodes[0].type).toBe("action");
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      expect(config.actionType).toBe("web3/read-contract");
+      expect(config.network).toBe("1");
+      expect(config.contractAddress).toBe("0x123");
+    });
+
+    it("normalizes slash-separated types with root config (Format 3: Ethena pattern)", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "n1",
+            type: "ethena/vault-total-assets",
+            data: { label: "Read Assets", network: "1" },
+          },
+        ],
+        []
+      );
+
+      expect(nodes[0].type).toBe("action");
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      expect(config.actionType).toBe("ethena/vault-total-assets");
+      expect(config.network).toBe("1");
+      expect(data.label).toBe("Read Assets");
+    });
+
+    it("detects Schedule as trigger node", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "t1",
+            type: "Schedule",
+            data: { type: "action", timezone: "UTC", cronExpression: "0 * * * *" },
+          },
+        ],
+        []
+      );
+
+      expect(nodes[0].type).toBe("trigger");
+      const data = nodes[0].data as Record<string, unknown>;
+      expect(data.type).toBe("trigger");
+      const config = data.config as Record<string, unknown>;
+      expect(config.triggerType).toBe("Schedule");
+      expect(config.timezone).toBe("UTC");
+    });
+
+    it("detects system:schedule as trigger node", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [{ id: "t1", type: "system:schedule", data: { schedule: "0 * * * *" } }],
+        []
+      );
+
+      expect(nodes[0].type).toBe("trigger");
+    });
+
+    it("passes through canonical format without corruption", () => {
+      const canonical = {
+        id: "a1",
+        type: "action",
+        position: { x: 252, y: 0 },
+        data: {
+          label: "Check Balance",
+          type: "action",
+          config: { actionType: "web3/check-balance", network: "1" },
+          status: "idle",
+        },
+      };
+
+      const { nodes } = sanitizeWorkflowData([canonical], []);
+      expect(nodes[0]).toEqual(canonical);
+    });
+
+    it("moves misplaced config fields from data root into data.config", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "n1",
+            type: "action",
+            data: {
+              label: "Test",
+              type: "action",
+              config: { actionType: "web3/check-balance" },
+              network: "1",
+              address: "0x123",
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      expect(config.network).toBe("1");
+      expect(config.address).toBe("0x123");
+      expect(data).not.toHaveProperty("network");
+      expect(data).not.toHaveProperty("address");
+    });
+  });
+
+  describe("Condition config normalization", () => {
+    it("generates missing ids for groups and rules", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "c1",
+            type: "action",
+            data: {
+              label: "Condition",
+              type: "action",
+              config: {
+                actionType: "Condition",
+                conditionConfig: {
+                  group: {
+                    rules: [{ leftOperand: "{{@a:B.x}}", operator: "===", rightOperand: "1" }],
+                    logic: "AND",
+                  },
+                },
+              },
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      const conditionConfig = config.conditionConfig as Record<string, unknown>;
+      const group = conditionConfig.group as Record<string, unknown>;
+      expect(group.id).toBeDefined();
+      expect(typeof group.id).toBe("string");
+      const rules = group.rules as Record<string, unknown>[];
+      expect(rules[0].id).toBeDefined();
+      expect(typeof rules[0].id).toBe("string");
+    });
+
+    it("maps operator aliases to canonical symbols", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "c1",
+            type: "action",
+            data: {
+              label: "Condition",
+              type: "action",
+              config: {
+                actionType: "Condition",
+                conditionConfig: {
+                  group: {
+                    rules: [
+                      { leftOperand: "a", operator: "equals", rightOperand: "1" },
+                      { leftOperand: "b", operator: "less_than", rightOperand: "2" },
+                      { leftOperand: "c", operator: "greater_than", rightOperand: "3" },
+                      { leftOperand: "d", operator: "not_equals", rightOperand: "4" },
+                    ],
+                    logic: "AND",
+                  },
+                },
+              },
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      const conditionConfig = config.conditionConfig as Record<string, unknown>;
+      const group = conditionConfig.group as Record<string, unknown>;
+      const rules = group.rules as Record<string, unknown>[];
+      expect(rules[0].operator).toBe("===");
+      expect(rules[1].operator).toBe("<");
+      expect(rules[2].operator).toBe(">");
+      expect(rules[3].operator).toBe("!==");
+    });
+
+    it("maps field/value to leftOperand/rightOperand", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "c1",
+            type: "action",
+            data: {
+              label: "Condition",
+              type: "action",
+              config: {
+                actionType: "Condition",
+                conditionConfig: {
+                  group: {
+                    rules: [{ field: "{{@a:B.balance}}", operator: "===", value: "100" }],
+                    logic: "AND",
+                  },
+                },
+              },
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      const conditionConfig = config.conditionConfig as Record<string, unknown>;
+      const group = conditionConfig.group as Record<string, unknown>;
+      const rules = group.rules as Record<string, unknown>[];
+      expect(rules[0].leftOperand).toBe("{{@a:B.balance}}");
+      expect(rules[0].rightOperand).toBe("100");
+      expect(rules[0]).not.toHaveProperty("field");
+      expect(rules[0]).not.toHaveProperty("value");
+    });
+
+    it("normalizes array-shaped group to single group object", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "c1",
+            type: "action",
+            data: {
+              label: "Condition",
+              type: "action",
+              config: {
+                actionType: "Condition",
+                conditionConfig: {
+                  group: [
+                    { rules: [{ field: "x", operator: "equals", value: "1" }] },
+                  ],
+                  logicalOperator: "OR",
+                },
+              },
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      const conditionConfig = config.conditionConfig as Record<string, unknown>;
+      const group = conditionConfig.group as Record<string, unknown>;
+      expect(group.logic).toBe("OR");
+      expect(Array.isArray(group.rules)).toBe(true);
+      expect(group).not.toBeInstanceOf(Array);
+    });
+
+    it("preserves already valid operators without mutation", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "c1",
+            type: "action",
+            data: {
+              label: "Condition",
+              type: "action",
+              config: {
+                actionType: "Condition",
+                conditionConfig: {
+                  group: {
+                    id: "existing-id",
+                    rules: [
+                      { id: "rule-1", leftOperand: "a", operator: "===", rightOperand: "b" },
+                      { id: "rule-2", leftOperand: "c", operator: ">=", rightOperand: "d" },
+                    ],
+                    logic: "AND",
+                  },
+                },
+              },
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      const conditionConfig = config.conditionConfig as Record<string, unknown>;
+      const group = conditionConfig.group as Record<string, unknown>;
+      expect(group.id).toBe("existing-id");
+      const rules = group.rules as Record<string, unknown>[];
+      expect(rules[0].id).toBe("rule-1");
+      expect(rules[0].operator).toBe("===");
+      expect(rules[1].operator).toBe(">=");
+    });
+  });
+
+  describe("Auto-layout", () => {
+    it("applies auto-layout when all nodes are at the same position", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          { id: "t1", type: "trigger", data: { label: "Trigger", type: "trigger", config: { triggerType: "Manual" } } },
+          { id: "a1", type: "action", data: { label: "Action", type: "action", config: { actionType: "web3/check-balance" } } },
+        ],
+        [{ id: "e1", source: "t1", target: "a1" }]
+      );
+
+      const pos0 = nodes[0].position as { x: number; y: number };
+      const pos1 = nodes[1].position as { x: number; y: number };
+      expect(pos0.x !== pos1.x || pos0.y !== pos1.y).toBe(true);
+    });
+
+    it("does not override existing different positions", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          { id: "t1", type: "trigger", position: { x: 0, y: 0 }, data: { label: "Trigger", type: "trigger", config: {} } },
+          { id: "a1", type: "action", position: { x: 500, y: 100 }, data: { label: "Action", type: "action", config: {} } },
+        ],
+        []
+      );
+
+      const pos1 = nodes[1].position as { x: number; y: number };
+      expect(pos1.x).toBe(500);
+      expect(pos1.y).toBe(100);
+    });
+
+    it("skips auto-layout for single node", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [{ id: "t1", type: "trigger", data: { label: "Trigger", type: "trigger", config: {} } }],
+        []
+      );
+
+      const pos = nodes[0].position as { x: number; y: number };
+      expect(pos.x).toBe(0);
+      expect(pos.y).toBe(0);
+    });
+  });
+
+  describe("Defaults", () => {
+    it("defaults position to {0, 0} when not provided", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [{ id: "n1", type: "action", data: { label: "Test", type: "action", config: {} } }],
+        []
+      );
+
+      expect(nodes[0].position).toEqual({ x: 0, y: 0 });
+    });
+
+    it("defaults status to idle when not provided", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [{ id: "n1", type: "action", data: { label: "Test", type: "action", config: {} } }],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      expect(data.status).toBe("idle");
+    });
+
+    it("defaults label to empty string when not provided", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [{ id: "n1", type: "action", data: { type: "action", config: {} } }],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      expect(data.label).toBe("");
+    });
+  });
+});

--- a/tests/unit/sanitize-nodes.test.ts
+++ b/tests/unit/sanitize-nodes.test.ts
@@ -334,6 +334,42 @@ describe("sanitizeWorkflowData", () => {
       expect(group).not.toBeInstanceOf(Array);
     });
 
+    it("handles object-shaped operators with key property", () => {
+      const { nodes } = sanitizeWorkflowData(
+        [
+          {
+            id: "c1",
+            type: "action",
+            data: {
+              label: "Condition",
+              type: "action",
+              config: {
+                actionType: "Condition",
+                conditionConfig: {
+                  group: {
+                    rules: [
+                      { leftOperand: "a", operator: { key: "equals", label: "Equals" }, rightOperand: "1" },
+                      { leftOperand: "b", operator: { key: "less_than", label: "Less Than" }, rightOperand: "2" },
+                    ],
+                    logic: "AND",
+                  },
+                },
+              },
+            },
+          },
+        ],
+        []
+      );
+
+      const data = nodes[0].data as Record<string, unknown>;
+      const config = data.config as Record<string, unknown>;
+      const conditionConfig = config.conditionConfig as Record<string, unknown>;
+      const group = conditionConfig.group as Record<string, unknown>;
+      const rules = group.rules as Record<string, unknown>[];
+      expect(rules[0].operator).toBe("===");
+      expect(rules[1].operator).toBe("<");
+    });
+
     it("preserves already valid operators without mutation", () => {
       const { nodes } = sanitizeWorkflowData(
         [


### PR DESCRIPTION
## Summary

- Add `lib/workflow/sanitize-nodes.ts`. Server-side sanitization for all workflow write paths
- Strip React Flow UI state (`dragging`, `measured`, `selected`, etc.) from persisted nodes/edges
- Normalize 3 inconsistent MCP/AI node formats to canonical structure (colon to slash types, root-level config to nested config, generic type detection)
- Auto-layout nodes via `computeAutoLayout` when no positions are provided
- Normalize Condition node config: generate missing `id` fields, map operator aliases (`equals` to `===`, `less_than` to `<`), fix `field`/`value` to `leftOperand`/`rightOperand`, handle array-shaped groups
- Improve MCP schemas docs for Database Query (inline template refs, not `$1` params) and Condition (`conditionConfig` exact shape with required ids and operator symbols)
- Unit tests for all sanitization logic (19 tests)

## Routes updated

| Route | Change |
|-------|--------|
| `app/api/workflows/create/route.ts` | Sanitize before insert, remove `selected: true` from defaults |
| `app/api/workflows/[workflowId]/route.ts` | Sanitize in `buildUpdateData()` for PATCH |
| `app/api/workflows/[workflowId]/duplicate/route.ts` | Sanitize after duplication, before insert |
| `app/api/workflows/current/route.ts` | Sanitize before insert and update |
| `app/api/mcp/schemas/route.ts` | Improved docs for Database Query and Condition nodes |