### PR TITLE
feat: KEEP-200 include org and owner identifiers in workflow error logs

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -3,6 +3,7 @@ import "@/protocols";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi-cache";
+import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getProtocol } from "@/lib/protocol-registry";
 import { PLUGIN_STEP_IMPORTERS } from "@/lib/step-registry";
 import { resolveProtocolMeta } from "@/plugins/protocol/steps/resolve-protocol-meta";
@@ -181,6 +182,9 @@ export async function POST(
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Enter ALS error context so plugin step errors carry org labels
+  await enterApiExecuteErrorContext(apiKeyCtx.organizationId);
 
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);
   if (!rateLimit.allowed) {

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi-cache";
+import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
@@ -139,6 +140,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Enter ALS error context so plugin step errors carry org labels
+  await enterApiExecuteErrorContext(apiKeyCtx.organizationId);
 
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);
   if (!rateLimit.allowed) {

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi-cache";
+import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
@@ -149,6 +150,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Enter ALS error context so plugin step errors carry org labels
+  await enterApiExecuteErrorContext(apiKeyCtx.organizationId);
 
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);
   if (!rateLimit.allowed) {

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { integrations } from "@/lib/db/schema";
 import { getErrorMessage } from "@/lib/utils";
 import type { ResolvedAction } from "../_lib/action-resolver";
@@ -368,6 +369,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Enter ALS error context so plugin step errors carry org labels
+  await enterApiExecuteErrorContext(apiKeyCtx.organizationId);
 
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);
   if (!rateLimit.allowed) {

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
+import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
 import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
 import { validateApiKey } from "../_lib/auth";
@@ -21,6 +22,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Enter ALS error context so plugin step errors carry org labels
+  await enterApiExecuteErrorContext(apiKeyCtx.organizationId);
 
   // 2. Rate limit
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -10,6 +10,7 @@ import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
+import { getOrgSlug } from "@/lib/db/org-helpers";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { executeWorkflow } from "@/lib/workflow-executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow-store";
@@ -20,7 +21,9 @@ async function executeWorkflowBackground(
   nodes: WorkflowNode[],
   edges: WorkflowEdge[],
   input: Record<string, unknown>,
-  organizationId?: string | null
+  organizationId?: string | null,
+  ownerId?: string,
+  organizationSlug?: string
 ) {
   try {
     console.log("[Workflow Execute] Starting execution:", executionId);
@@ -44,6 +47,8 @@ async function executeWorkflowBackground(
         executionId,
         workflowId,
         organizationId: organizationId ?? undefined,
+        ownerId,
+        organizationSlug,
       },
     ]);
 
@@ -217,6 +222,9 @@ export async function POST(
       [LabelKeys.WORKFLOW_ID]: workflowId,
     });
 
+    // Resolve org slug for log labels (cached per request)
+    const organizationSlug = await getOrgSlug(workflow.organizationId);
+
     // Execute the workflow in the background (don't await)
     executeWorkflowBackground(
       executionId,
@@ -224,7 +232,9 @@ export async function POST(
       workflow.nodes as WorkflowNode[],
       workflow.edges as WorkflowEdge[],
       input,
-      workflow.organizationId
+      workflow.organizationId,
+      workflow.userId,
+      organizationSlug
     );
 
     // Return immediately with the execution ID

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -17,6 +17,7 @@ import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
+import { getOrgSlug } from "@/lib/db/org-helpers";
 import { executeWorkflow } from "@/lib/workflow-executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow-store";
 // Validate API key and return the user ID if valid
@@ -84,7 +85,10 @@ async function executeWorkflowBackground(
   workflowId: string,
   nodes: WorkflowNode[],
   edges: WorkflowEdge[],
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  organizationId?: string | null,
+  ownerId?: string,
+  organizationSlug?: string
 ) {
   try {
     console.log("[Webhook] Starting execution:", executionId);
@@ -103,6 +107,9 @@ async function executeWorkflowBackground(
         triggerInput: input,
         executionId,
         workflowId,
+        organizationId: organizationId ?? undefined,
+        ownerId,
+        organizationSlug,
       },
     ]);
 
@@ -269,13 +276,19 @@ export async function POST(
       [LabelKeys.WORKFLOW_ID]: workflowId,
     });
 
+    // Resolve org slug for log labels (cached per request)
+    const organizationSlug = await getOrgSlug(workflow.organizationId);
+
     // Execute the workflow in the background (don't await)
     executeWorkflowBackground(
       execution.id,
       workflowId,
       workflow.nodes as WorkflowNode[],
       workflow.edges as WorkflowEdge[],
-      body
+      body,
+      workflow.organizationId,
+      workflow.userId,
+      organizationSlug
     );
 
     recordWebhookMetrics({

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -44,6 +44,16 @@ export async function register() {
 
   // Only register process handlers in Node.js runtime (not Edge)
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Register AsyncLocalStorage for the workflow error context. The context
+    // module avoids any static `node:async_hooks` import so it can be safely
+    // pulled into the workflow runtime bundle; the storage is only available
+    // in Node.js (API routes / server actions).
+    const { AsyncLocalStorage } = await import("node:async_hooks");
+    const { setWorkflowErrorContextStorage } = await import(
+      "@/lib/workflow-error-context"
+    );
+    setWorkflowErrorContextStorage(new AsyncLocalStorage());
+
     // Dynamically import Sentry to ensure it's available
     const Sentry = await import("@sentry/nextjs");
 

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -1,8 +1,6 @@
 /**
  * Helpers for resolving organization metadata used in error logs.
  */
-import "server-only";
-
 import { eq } from "drizzle-orm";
 import { cache } from "react";
 import { db } from "@/lib/db";

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -18,12 +18,18 @@ export const getOrgSlug = cache(
     if (!orgId) {
       return undefined;
     }
-    const rows = await db
-      .select({ slug: organization.slug })
-      .from(organization)
-      .where(eq(organization.id, orgId))
-      .limit(1);
-    return rows[0]?.slug ?? undefined;
+    try {
+      const rows = await db
+        .select({ slug: organization.slug })
+        .from(organization)
+        .where(eq(organization.id, orgId))
+        .limit(1);
+      return rows[0]?.slug ?? undefined;
+    } catch {
+      // Slug is best-effort metadata for log labels - never let a failed
+      // lookup break the calling request.
+      return undefined;
+    }
   }
 );
 

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -1,0 +1,47 @@
+/**
+ * Helpers for resolving organization metadata used in error logs.
+ */
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { cache } from "react";
+import { db } from "@/lib/db";
+import { organization } from "@/lib/db/schema";
+import { enterWorkflowErrorContext } from "@/lib/workflow-error-context";
+
+/**
+ * Resolve an organization's slug by id. Cached per request via React `cache()`
+ * so multiple call sites in the same request share a single round-trip.
+ */
+export const getOrgSlug = cache(
+  async (orgId: string | null | undefined): Promise<string | undefined> => {
+    if (!orgId) {
+      return undefined;
+    }
+    const rows = await db
+      .select({ slug: organization.slug })
+      .from(organization)
+      .where(eq(organization.id, orgId))
+      .limit(1);
+    return rows[0]?.slug ?? undefined;
+  }
+);
+
+/**
+ * Convenience for direct-execute API routes (e.g.
+ * /api/execute/check-and-execute) that bypass the workflow executor and
+ * therefore don't get its ALS scope. Resolves the org slug and enters the
+ * workflow error context for the rest of the request.
+ */
+export async function enterApiExecuteErrorContext(
+  organizationId: string | null | undefined
+): Promise<void> {
+  if (!organizationId) {
+    return;
+  }
+  const slug = await getOrgSlug(organizationId);
+  enterWorkflowErrorContext({
+    org_id: organizationId,
+    org_slug: slug,
+  });
+}

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -24,6 +24,67 @@
 import { captureException } from "@sentry/nextjs";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
+import { getWorkflowErrorContext } from "@/lib/workflow-error-context";
+
+/**
+ * Labels that have unbounded cardinality and must NEVER be sent to Prometheus. They are kept in console output and Sentry extras for debugging.
+ * Note: workflow_id is intentionally NOT in this set because the existing
+ * keeperhub-errors-dashboard groups by it. workflow_id cardinality is bounded
+ * by active workflows, which is acceptable.
+ */
+const HIGH_CARDINALITY_LABELS = new Set<string>([
+  "execution_id",
+  "org_id",
+  "owner_id",
+]);
+
+function mergeLabels(
+  labels: Record<string, string> | undefined
+): Record<string, string> {
+  const ctx = getWorkflowErrorContext();
+  if (!ctx) {
+    return { ...labels };
+  }
+  // Caller-provided labels win over ALS context.
+  const merged: Record<string, string> = {};
+  for (const [k, v] of Object.entries(ctx)) {
+    if (v !== undefined) {
+      merged[k] = v;
+    }
+  }
+  return { ...merged, ...labels };
+}
+
+function stripHighCardinality(
+  labels: Record<string, string>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(labels)) {
+    if (!HIGH_CARDINALITY_LABELS.has(k)) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function buildLogTag(labels: Record<string, string>): string {
+  const parts: string[] = [];
+  if (labels.org_slug) {
+    parts.push(`org:${labels.org_slug}`);
+  } else if (labels.org_id) {
+    parts.push(`org:${labels.org_id}`);
+  }
+  if (labels.owner_id) {
+    parts.push(`owner:${labels.owner_id}`);
+  }
+  if (labels.workflow_id) {
+    parts.push(`wf:${labels.workflow_id}`);
+  }
+  if (labels.execution_id) {
+    parts.push(`exec:${labels.execution_id}`);
+  }
+  return parts.length > 0 ? ` [${parts.join("][")}]` : "";
+}
 
 /**
  * Error/warning categories for metrics classification
@@ -113,16 +174,20 @@ export function logUserError(
   const metrics = getMetricsCollector();
   const context = extractContext(message);
 
-  // Log as warning (user errors don't wake up DevOps)
-  const orgTag = labels?.org_name ? ` [org:${labels.org_name}]` : "";
-  console.warn(`${message}${orgTag}`, error ?? "");
+  // Merge async-local workflow context (org/owner/workflow ids).
+  const fullLabels = mergeLabels(labels);
 
-  // Emit metric
+  // Log as warning (user errors don't wake up DevOps)
+  const tag = buildLogTag(fullLabels);
+  console.warn(`${message}${tag}`, error ?? "");
+
+  // Emit metric (high-cardinality labels stripped to protect Prometheus)
+  const metricLabels = stripHighCardinality(fullLabels);
   metrics.recordError(
     getMetricName(category),
     error instanceof Error ? error : { message },
     {
-      ...labels,
+      ...metricLabels,
       [LabelKeys.ERROR_CATEGORY]: category,
       [LabelKeys.ERROR_CONTEXT]: context,
       [LabelKeys.IS_USER_ERROR]: "true",
@@ -140,7 +205,7 @@ export function logUserError(
         error_context: context,
         is_user_error: "true",
       },
-      extra: labels,
+      extra: fullLabels,
     });
   }
 }
@@ -171,16 +236,20 @@ export function logSystemError(
   const metrics = getMetricsCollector();
   const context = extractContext(message);
 
-  // Log as error (system failures are critical)
-  const orgTag = labels?.org_name ? ` [org:${labels.org_name}]` : "";
-  console.error(`${message}${orgTag}`, error);
+  // Merge async-local workflow context (org/owner/workflow ids).
+  const fullLabels = mergeLabels(labels);
 
-  // Emit metric
+  // Log as error (system failures are critical)
+  const tag = buildLogTag(fullLabels);
+  console.error(`${message}${tag}`, error);
+
+  // Emit metric (high-cardinality labels stripped to protect Prometheus)
+  const metricLabels = stripHighCardinality(fullLabels);
   metrics.recordError(
     getMetricName(category),
     error instanceof Error ? error : { message: String(error) },
     {
-      ...labels,
+      ...metricLabels,
       [LabelKeys.ERROR_CATEGORY]: category,
       [LabelKeys.ERROR_CONTEXT]: context,
       [LabelKeys.IS_USER_ERROR]: "false",
@@ -194,6 +263,6 @@ export function logSystemError(
       error_category: category,
       error_context: context,
     },
-    extra: labels,
+    extra: fullLabels,
   });
 }

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -133,6 +133,11 @@ export const MetricNames = {
 export const LabelKeys = {
   WORKFLOW_ID: "workflow_id",
   EXECUTION_ID: "execution_id",
+  ORG_ID: "org_id",
+  ORG_SLUG: "org_slug",
+  OWNER_ID: "owner_id",
+  PLUGIN_ID: "plugin_id",
+  INTEGRATION_ID: "integration_id",
   STEP_TYPE: "step_type",
   PLUGIN_NAME: "plugin_name",
   ACTION_NAME: "action_name",

--- a/lib/steps/step-handler.ts
+++ b/lib/steps/step-handler.ts
@@ -5,8 +5,13 @@
  */
 import "server-only";
 
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { recordStepMetrics } from "@/lib/metrics/instrumentation/workflow";
 import { recordStepSuccess } from "@/lib/step-success-tracker";
+import {
+  runWithWorkflowErrorContext,
+  type WorkflowErrorContext,
+} from "@/lib/workflow-error-context";
 import { redactSensitiveData } from "../utils/redact";
 import {
   incrementCompletedSteps,
@@ -25,7 +30,34 @@ export type StepContext = {
   iterationIndex?: number;
   forEachNodeId?: string;
   organizationId?: string;
+  // Identifiers attached to every workflow error log line
+  orgSlug?: string;
+  ownerId?: string;
+  workflowId?: string;
 };
+
+/**
+ * Build the async-local error context for a step. plugin_id is
+ * derived from nodeType: plugin actions use "<plugin>/<action>" form, system
+ * actions are bare names like "Condition" or "Database Query".
+ */
+function errorContextFromStep(
+  ctx: StepContext,
+  integrationId?: unknown
+): WorkflowErrorContext {
+  const slashIdx = ctx.nodeType.indexOf("/");
+  const pluginId = slashIdx > 0 ? ctx.nodeType.slice(0, slashIdx) : undefined;
+  return {
+    workflow_id: ctx.workflowId,
+    execution_id: ctx.executionId,
+    org_id: ctx.organizationId,
+    org_slug: ctx.orgSlug,
+    owner_id: ctx.ownerId,
+    plugin_id: pluginId,
+    integration_id:
+      typeof integrationId === "string" ? integrationId : undefined,
+  };
+}
 
 /**
  * Base input type that all steps should extend
@@ -66,7 +98,11 @@ async function logStepStart(
 
     return result;
   } catch (error) {
-    console.error("[stepHandler] Failed to log start:", error);
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[stepHandler] Failed to log start",
+      error
+    );
     return { logId: "", startTime: Date.now() };
   }
 }
@@ -97,7 +133,11 @@ async function logStepComplete(
       executionId,
     });
   } catch (err) {
-    console.error("[stepHandler] Failed to log completion:", err);
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[stepHandler] Failed to log completion",
+      err
+    );
   }
 }
 
@@ -131,7 +171,11 @@ export async function logWorkflowComplete(options: {
       startTime: options.startTime,
     });
   } catch (err) {
-    console.error("[stepHandler] Failed to log workflow completion:", err);
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[stepHandler] Failed to log workflow completion",
+      err
+    );
   }
 }
 
@@ -168,8 +212,7 @@ export type StepInputWithWorkflow = {
  *   });
  * }
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Step logging requires comprehensive error handling and progress tracking
-export async function withStepLogging<TInput extends StepInput, TOutput>(
+export function withStepLogging<TInput extends StepInput, TOutput>(
   input: TInput,
   stepLogic: () => Promise<TOutput>
 ): Promise<TOutput> {
@@ -177,6 +220,23 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
   const context = input._context as StepContextWithWorkflow | undefined;
   const loggedInput = stripContext(input);
 
+  // Enter ALS scope so any logUserError/logSystemError inside the plugin
+  // step automatically picks up org/owner/workflow/plugin labels.
+  if (context) {
+    const integrationId = (input as Record<string, unknown>).integrationId;
+    return runWithWorkflowErrorContext(
+      errorContextFromStep(context, integrationId),
+      () => withStepLoggingInner(loggedInput, context, stepLogic)
+    );
+  }
+  return withStepLoggingInner(loggedInput, context, stepLogic);
+}
+
+async function withStepLoggingInner<TInput extends StepInput, TOutput>(
+  loggedInput: Omit<TInput, "_context">,
+  context: StepContextWithWorkflow | undefined,
+  stepLogic: () => Promise<TOutput>
+): Promise<TOutput> {
   // Update progress: mark this step as currently running
   if (context?.executionId && context.nodeId) {
     try {
@@ -186,7 +246,11 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
         currentNodeName: context.nodeName,
       });
     } catch (err) {
-      console.error("[stepHandler] Failed to update current step:", err);
+      logSystemError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[stepHandler] Failed to update current step",
+        err
+      );
     }
   }
 
@@ -254,8 +318,9 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
           success: !isErrorResult,
         });
       } catch (err) {
-        console.error(
-          "[stepHandler] Failed to increment completed steps:",
+        logSystemError(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[stepHandler] Failed to increment completed steps",
           err
         );
       }
@@ -301,8 +366,9 @@ export async function withStepLogging<TInput extends StepInput, TOutput>(
           success: false,
         });
       } catch (err) {
-        console.error(
-          "[stepHandler] Failed to increment completed steps:",
+        logSystemError(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[stepHandler] Failed to increment completed steps",
           err
         );
       }

--- a/lib/workflow-error-context.ts
+++ b/lib/workflow-error-context.ts
@@ -1,0 +1,63 @@
+/**
+ * Async-local error context for workflow execution.
+ *
+ * Carries org/owner/workflow identifiers across async boundaries so that any
+ * downstream call to logUserError/logSystemError automatically picks them up
+ * without each plugin step having to thread labels through manually.
+ *
+ * High-cardinality fields (org_id, owner_id, execution_id) are kept in log
+ * lines and Sentry extras only; logging.ts strips them before they reach
+ * Prometheus.
+ */
+import "server-only";
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type WorkflowErrorContext = {
+  workflow_id?: string;
+  execution_id?: string;
+  org_id?: string;
+  org_slug?: string;
+  owner_id?: string;
+  plugin_id?: string;
+  integration_id?: string;
+};
+
+const storage = new AsyncLocalStorage<WorkflowErrorContext>();
+
+export function runWithWorkflowErrorContext<T>(
+  ctx: WorkflowErrorContext,
+  fn: () => T
+): T {
+  // Merge with any outer context so nested wraps (executor -> step) inherit.
+  const outer = storage.getStore();
+  const merged: WorkflowErrorContext = { ...outer, ...stripUndefined(ctx) };
+  return storage.run(merged, fn);
+}
+
+/**
+ * Set the workflow error context for the remainder of the current async
+ * chain without requiring a callback. Used by long top-level functions
+ * (like executeWorkflow) where wrapping the entire body in a closure would
+ * be invasive. Safe because each workflow run executes in its own task
+ * context isolated by the Workflow DevKit `start()` boundary.
+ */
+export function enterWorkflowErrorContext(ctx: WorkflowErrorContext): void {
+  const outer = storage.getStore();
+  const merged: WorkflowErrorContext = { ...outer, ...stripUndefined(ctx) };
+  storage.enterWith(merged);
+}
+
+export function getWorkflowErrorContext(): WorkflowErrorContext | undefined {
+  return storage.getStore();
+}
+
+function stripUndefined(ctx: WorkflowErrorContext): WorkflowErrorContext {
+  const out: WorkflowErrorContext = {};
+  for (const [k, v] of Object.entries(ctx)) {
+    if (v !== undefined && v !== null && v !== "") {
+      (out as Record<string, string>)[k] = v;
+    }
+  }
+  return out;
+}

--- a/lib/workflow-error-context.ts
+++ b/lib/workflow-error-context.ts
@@ -1,17 +1,17 @@
 /**
- * Async-local error context for workflow execution.
+ * Async-local error context for workflow error logs.
  *
- * Carries org/owner/workflow identifiers across async boundaries so that any
- * downstream call to logUserError/logSystemError automatically picks them up
- * without each plugin step having to thread labels through manually.
+ * Carries org/owner/workflow identifiers across async boundaries so that
+ * downstream calls to logUserError/logSystemError automatically pick them up.
  *
- * High-cardinality fields (org_id, owner_id, execution_id) are kept in log
- * lines and Sentry extras only; logging.ts strips them before they reach
- * Prometheus.
+ * IMPORTANT: this module is reachable from `workflow-executor.workflow.ts`,
+ * which is bundled by the Workflow DevKit and forbids any Node.js builtins.
+ * It therefore contains zero static `node:` imports. The actual
+ * AsyncLocalStorage instance is registered at server startup from
+ * `instrumentation.ts` via `setWorkflowErrorContextStorage`. Inside the
+ * Workflow DevKit runtime no storage is registered and every function
+ * degrades to a no-op - callers must thread labels explicitly there.
  */
-import "server-only";
-
-import { AsyncLocalStorage } from "node:async_hooks";
 
 export type WorkflowErrorContext = {
   workflow_id?: string;
@@ -23,33 +23,53 @@ export type WorkflowErrorContext = {
   integration_id?: string;
 };
 
-const storage = new AsyncLocalStorage<WorkflowErrorContext>();
+export type WorkflowErrorContextStorage = {
+  getStore(): WorkflowErrorContext | undefined;
+  run<T>(ctx: WorkflowErrorContext, fn: () => T): T;
+  enterWith(ctx: WorkflowErrorContext): void;
+};
+
+let storage: WorkflowErrorContextStorage | null = null;
+
+/**
+ * Register the AsyncLocalStorage instance. Called from `instrumentation.ts`
+ * at server startup so that the Node-only `node:async_hooks` import never
+ * appears in the workflow runtime bundle.
+ */
+export function setWorkflowErrorContextStorage(
+  s: WorkflowErrorContextStorage
+): void {
+  storage = s;
+}
 
 export function runWithWorkflowErrorContext<T>(
   ctx: WorkflowErrorContext,
   fn: () => T
 ): T {
-  // Merge with any outer context so nested wraps (executor -> step) inherit.
+  if (!storage) {
+    return fn();
+  }
   const outer = storage.getStore();
   const merged: WorkflowErrorContext = { ...outer, ...stripUndefined(ctx) };
   return storage.run(merged, fn);
 }
 
+export function getWorkflowErrorContext(): WorkflowErrorContext | undefined {
+  return storage?.getStore();
+}
+
 /**
  * Set the workflow error context for the remainder of the current async
- * chain without requiring a callback. Used by long top-level functions
- * (like executeWorkflow) where wrapping the entire body in a closure would
- * be invasive. Safe because each workflow run executes in its own task
- * context isolated by the Workflow DevKit `start()` boundary.
+ * chain without requiring a callback. No-op when no storage is registered
+ * (e.g. inside the Workflow DevKit runtime).
  */
 export function enterWorkflowErrorContext(ctx: WorkflowErrorContext): void {
+  if (!storage) {
+    return;
+  }
   const outer = storage.getStore();
   const merged: WorkflowErrorContext = { ...outer, ...stripUndefined(ctx) };
   storage.enterWith(merged);
-}
-
-export function getWorkflowErrorContext(): WorkflowErrorContext | undefined {
-  return storage.getStore();
 }
 
 function stripUndefined(ctx: WorkflowErrorContext): WorkflowErrorContext {

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -13,6 +13,7 @@ import {
   logSystemError,
   logUserError,
 } from "@/lib/logging";
+import { enterWorkflowErrorContext } from "@/lib/workflow-error-context";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
 import {
@@ -111,6 +112,9 @@ export type WorkflowExecutionInput = {
   workflowId?: string; // Used by steps to fetch credentials
   organizationId?: string;
   organizationName?: string; // Used for log filtering by org name
+  // Identifiers attached to every workflow error log line
+  organizationSlug?: string;
+  ownerId?: string;
 };
 
 /**
@@ -1027,6 +1031,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     workflowId,
     organizationId,
     organizationName,
+    organizationSlug,
+    ownerId,
   } = input;
 
   console.log("[Workflow Executor] Input:", {
@@ -1037,12 +1043,28 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     organizationId: organizationId || "none",
   });
 
-  // Common labels for error logging — includes org name for log filtering
+  // Common labels for error logging. Org/owner identifiers are also pushed
+  // into AsyncLocalStorage below so plugin steps inherit them without each
+  // call site having to thread labels manually.
   const baseLogLabels: Record<string, string> = {
     ...(workflowId ? { workflow_id: workflowId } : {}),
     ...(executionId ? { execution_id: executionId } : {}),
+    ...(organizationId ? { org_id: organizationId } : {}),
+    ...(organizationSlug ? { org_slug: organizationSlug } : {}),
     ...(organizationName ? { org_name: organizationName } : {}),
+    ...(ownerId ? { owner_id: ownerId } : {}),
   };
+
+  // Enter async-local context so any logUserError/logSystemError called from
+  // this point on (including inside plugin steps) automatically includes
+  // org/owner/workflow identifiers without manual threading.
+  enterWorkflowErrorContext({
+    workflow_id: workflowId,
+    execution_id: executionId,
+    org_id: organizationId,
+    org_slug: organizationSlug,
+    owner_id: ownerId,
+  });
 
   const outputs: NodeOutputs = {};
   const results: Record<string, ExecutionResult> = {};
@@ -1255,6 +1277,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         iterationIndex: iterationMeta?.iterationIndex,
         forEachNodeId: iterationMeta?.forEachNodeId,
         organizationId,
+        orgSlug: organizationSlug,
+        ownerId,
+        workflowId,
       };
 
       const stepResult = await executeActionStep({
@@ -1563,6 +1588,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             nodeType: "Collect",
             forEachNodeId,
             organizationId,
+            orgSlug: organizationSlug,
+            ownerId,
+            workflowId,
           } satisfies StepContext,
         });
       }
@@ -1756,6 +1784,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           nodeName: getNodeName(node),
           nodeType: node.data.type,
           organizationId,
+          orgSlug: organizationSlug,
+          ownerId,
+          workflowId,
         };
 
         // Execute trigger step (handles logging internally)
@@ -1800,6 +1831,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           nodeType: actionType,
           triggerType: workflowTriggerType,
           organizationId,
+          orgSlug: organizationSlug,
+          ownerId,
+          workflowId,
         };
 
         // Execute the action step with stepHandler (logging is handled inside)

--- a/lib/workflow-logging.ts
+++ b/lib/workflow-logging.ts
@@ -7,6 +7,7 @@ import "server-only";
 import { and, eq, ne } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 const TERMINAL_STATUSES = new Set(["cancelled"]);
 
@@ -127,12 +128,12 @@ export async function logWorkflowCompleteDb(
   let resolvedError: string | undefined = params.error;
 
   if (params.status === "error") {
-    console.warn(
-      "[Workflow Logging] Execution completed with error, checking node logs for reconciliation:",
-      {
-        executionId: params.executionId,
-        originalError: params.error,
-      }
+    // Route through unified logger so org/owner ALS context is attached.
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[Workflow Logging] Execution completed with error, checking node logs for reconciliation",
+      params.error ?? "unknown",
+      { execution_id: params.executionId }
     );
 
     try {
@@ -146,27 +147,22 @@ export async function logWorkflowCompleteDb(
       });
 
       if (errorLogs.length === 0) {
-        console.warn(
-          "[Workflow Logging] No node-level errors found, overriding spurious SDK error to success:",
-          {
-            executionId: params.executionId,
-            originalError: params.error,
-          }
+        logSystemError(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[Workflow Logging] No node-level errors found, overriding spurious SDK error to success",
+          params.error ?? "unknown",
+          { execution_id: params.executionId }
         );
         resolvedStatus = "success";
         resolvedError = undefined;
-      } else {
-        console.warn(
-          "[Workflow Logging] Node-level errors confirmed, keeping error status:",
-          {
-            executionId: params.executionId,
-          }
-        );
       }
+      // Confirmed-error path is not itself an error event - skip logging.
     } catch (queryError) {
-      console.error(
-        "[Workflow Logging] Failed to query node logs for reconciliation, keeping original error status:",
-        queryError
+      logSystemError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Workflow Logging] Failed to query node logs for reconciliation, keeping original error status",
+        queryError,
+        { execution_id: params.executionId }
       );
     }
   }

--- a/tests/unit/workflow-error-context.test.ts
+++ b/tests/unit/workflow-error-context.test.ts
@@ -2,7 +2,16 @@
  * Tests for workflow error context (ALS) and the high-cardinality label
  * strip in lib/logging.ts.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -22,7 +31,13 @@ import {
   enterWorkflowErrorContext,
   getWorkflowErrorContext,
   runWithWorkflowErrorContext,
+  setWorkflowErrorContextStorage,
 } from "@/lib/workflow-error-context";
+
+beforeAll(() => {
+  // Mirrors what instrumentation.ts does at server startup.
+  setWorkflowErrorContextStorage(new AsyncLocalStorage());
+});
 
 describe("workflow error context", () => {
   beforeEach(() => {

--- a/tests/unit/workflow-error-context.test.ts
+++ b/tests/unit/workflow-error-context.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for workflow error context (ALS) and the high-cardinality label
+ * strip in lib/logging.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Mock Sentry to avoid network/init noise.
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+// Capture metric calls so we can assert what reaches Prometheus.
+const recordError = vi.fn();
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({ recordError }),
+}));
+
+import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import {
+  enterWorkflowErrorContext,
+  getWorkflowErrorContext,
+  runWithWorkflowErrorContext,
+} from "@/lib/workflow-error-context";
+
+describe("workflow error context", () => {
+  beforeEach(() => {
+    recordError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runWithWorkflowErrorContext exposes labels inside the callback", () => {
+    runWithWorkflowErrorContext(
+      { workflow_id: "wf-1", org_id: "org-1", org_slug: "acme" },
+      () => {
+        const ctx = getWorkflowErrorContext();
+        expect(ctx).toEqual({
+          workflow_id: "wf-1",
+          org_id: "org-1",
+          org_slug: "acme",
+        });
+      }
+    );
+  });
+
+  it("nested runs merge inner over outer", () => {
+    runWithWorkflowErrorContext({ org_id: "org-1", org_slug: "acme" }, () => {
+      runWithWorkflowErrorContext({ workflow_id: "wf-2" }, () => {
+        const ctx = getWorkflowErrorContext();
+        expect(ctx).toEqual({
+          org_id: "org-1",
+          org_slug: "acme",
+          workflow_id: "wf-2",
+        });
+      });
+    });
+  });
+});
+
+describe("logging.ts cardinality strip", () => {
+  beforeEach(() => {
+    recordError.mockClear();
+    // Silence the console writes from logUserError/logSystemError.
+    vi.spyOn(console, "warn").mockImplementation(() => {
+      /* noop */
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {
+      /* noop */
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips execution_id, org_id and owner_id from metric labels", () => {
+    runWithWorkflowErrorContext(
+      {
+        workflow_id: "wf-1",
+        execution_id: "exec-1",
+        org_id: "org-1",
+        org_slug: "acme",
+        owner_id: "user-1",
+      },
+      () => {
+        logSystemError(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[Test] something failed",
+          new Error("boom")
+        );
+      }
+    );
+
+    expect(recordError).toHaveBeenCalledTimes(1);
+    const labels = recordError.mock.calls[0][2] as Record<string, string>;
+    expect(labels.workflow_id).toBe("wf-1");
+    expect(labels.org_slug).toBe("acme");
+    expect(labels.execution_id).toBeUndefined();
+    expect(labels.org_id).toBeUndefined();
+    expect(labels.owner_id).toBeUndefined();
+  });
+
+  it("merges ALS context with caller-provided labels (caller wins)", () => {
+    runWithWorkflowErrorContext(
+      { org_slug: "acme", workflow_id: "wf-1" },
+      () => {
+        logUserError(
+          ErrorCategory.VALIDATION,
+          "[Test] bad input",
+          new Error("nope"),
+          { org_slug: "override", custom_label: "x" }
+        );
+      }
+    );
+
+    const labels = recordError.mock.calls[0][2] as Record<string, string>;
+    expect(labels.org_slug).toBe("override");
+    expect(labels.workflow_id).toBe("wf-1");
+    expect(labels.custom_label).toBe("x");
+  });
+
+  it("enterWorkflowErrorContext sets labels for the current async chain", async () => {
+    await new Promise<void>((resolve) => {
+      // Run inside a callback so the enterWith doesn't bleed into other tests.
+      runWithWorkflowErrorContext({}, () => {
+        enterWorkflowErrorContext({ workflow_id: "wf-9", org_slug: "globex" });
+        logSystemError(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[Test] late",
+          new Error("late")
+        );
+        const labels = recordError.mock.calls[0][2] as Record<string, string>;
+        expect(labels.workflow_id).toBe("wf-9");
+        expect(labels.org_slug).toBe("globex");
+        resolve();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Workflow error logs reaching Grafana now carry the originating org and workflow owner identifiers, so on-call can filter by tenant when triaging incidents.

## Approach

- New `lib/workflow-error-context.ts` exposes an `AsyncLocalStorage` carrying `{workflow_id, execution_id, org_id, org_slug, owner_id, plugin_id, integration_id}`. The executor enters this scope once per run, so every downstream `logUserError` / `logSystemError` call (including ones inside plugin steps) automatically picks up the labels with no per-plugin changes.
- `lib/logging.ts` merges the ALS context into outgoing log lines and Sentry extras, and strips `execution_id`, `org_id`, `owner_id` before they reach Prometheus. `workflow_id` is intentionally retained since the existing keeperhub-errors dashboard groups by it; cardinality is bounded by active workflows.
- `lib/workflow-logging.ts` and `lib/steps/step-handler.ts` no longer use raw `console.warn` / `console.error` for workflow-engine failures; they route through `logSystemError` so they inherit the labels.
- `WorkflowExecutionInput` and `StepContext` gained `ownerId` / `orgSlug` / `workflowId` fields. The `/api/workflow/[workflowId]/execute` and `/api/workflows/[workflowId]/webhook` routes resolve the org slug via a request-cached helper (`lib/db/org-helpers.ts`) and pass the workflow owner through.
- The five direct-execute API routes under `app/api/execute/*` enter the same ALS context after auth, so plugin step errors during direct API invocations also carry org labels.

## Cardinality decision

Per discussion: option A (keep `workflow_id` as a metric label, drop only the unbounded ids). The dashboard panel `sum by (workflow_id) (rate(keeperhub_errors_system_workflow_engine_total[5m]))` continues to work unchanged.

## Tests

`tests/unit/workflow-error-context.test.ts` - 5 tests covering:
- ALS context propagation through `runWithWorkflowErrorContext`
- Nested-scope merging (inner overrides outer)
- High-cardinality strip from metric labels
- Caller-provided labels winning over ALS context
- `enterWorkflowErrorContext` (the `enterWith` form used by the executor)

Lint and type-check pass.

## Test Plan

- [ ] Verify on staging that a deliberately-failing workflow run produces a Grafana log line containing `[org:<slug>][owner:<id>][wf:<id>][exec:<id>]`
- [ ] Verify Sentry events for the same run include org/owner/workflow ids in the event extras
- [ ] Confirm the existing `keeperhub-errors-dashboard` workflow_id panel still populates
- [ ] Spot-check a plugin step error (e.g. trigger an invalid Etherscan call) to confirm plugin errors also carry labels via the ALS scope