### PR TITLE
feat: KEEP-185 add RPC latency, error breakdown, and chain initialization metrics

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -448,6 +448,25 @@ const rpcHealthState = getOrCreateGauge(
   RPC_LABELS
 );
 
+const RPC_PROVIDER_LABELS = ["chain", "provider"];
+
+const rpcLatency = getOrCreateHistogram(
+  apiRegistry,
+  "keeperhub_rpc_latency_ms",
+  "RPC request latency in milliseconds per chain and provider",
+  RPC_PROVIDER_LABELS,
+  [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10_000, 30_000]
+);
+
+const RPC_ERROR_LABELS = ["chain", "provider", "error_type"];
+
+const rpcErrorsByType = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_errors_by_type_total",
+  "RPC errors broken down by type (timeout, rate_limit, connection, rpc_error)",
+  RPC_ERROR_LABELS
+);
+
 // API-process metrics → apiRegistry (per-pod in-memory, scrape all pods)
 const webhookLatency = getOrCreateHistogram(
   apiRegistry,
@@ -1027,9 +1046,31 @@ export async function getDbMetrics(): Promise<string> {
 }
 
 /**
+ * Initialize RPC health gauges for all enabled chains so they appear in
+ * Grafana immediately (with healthy/0 defaults) instead of only after
+ * first traffic. Called before each API metrics scrape.
+ */
+async function initRpcMetricsForAllChains(): Promise<void> {
+  try {
+    const { getEnabledChainNamesFromDb } = await import("../db-metrics");
+    const chainNames = await getEnabledChainNamesFromDb();
+
+    for (const chain of chainNames) {
+      // Initialize gauges with defaults; counters auto-appear once
+      // their gauge siblings exist for the same label set
+      rpcHealthState.labels({ chain }).inc(0);
+      rpcCurrentProvider.labels({ chain }).inc(0);
+    }
+  } catch {
+    // Non-fatal: metrics will still populate on first RPC traffic
+  }
+}
+
+/**
  * Get API-process metrics only (/api/metrics/api)
  */
 export async function getApiProcessMetrics(): Promise<string> {
+  await initRpcMetricsForAllChains();
   return await apiRegistry.metrics();
 }
 
@@ -1053,4 +1094,6 @@ export const rpcMetrics = {
   bothFailedEvents: rpcBothFailedEvents,
   currentProvider: rpcCurrentProvider,
   healthState: rpcHealthState,
+  latency: rpcLatency,
+  errorsByType: rpcErrorsByType,
 };

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1053,14 +1053,15 @@ const initializedChains = new Set<string>();
  * first traffic. Each chain is initialized at most once per pod lifetime.
  */
 async function initRpcMetricsForAllChains(): Promise<void> {
+  if (initializedChains.size > 0) {
+    return;
+  }
+
   try {
     const { getEnabledChainNamesFromDb } = await import("../db-metrics");
     const chainNames = await getEnabledChainNamesFromDb();
 
     for (const chain of chainNames) {
-      if (initializedChains.has(chain)) {
-        continue;
-      }
       rpcHealthState.labels({ chain }).inc(0);
       rpcCurrentProvider.labels({ chain }).inc(0);
       initializedChains.add(chain);

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1045,10 +1045,12 @@ export async function getDbMetrics(): Promise<string> {
   return await dbRegistry.metrics();
 }
 
+const initializedChains = new Set<string>();
+
 /**
  * Initialize RPC health gauges for all enabled chains so they appear in
  * Grafana immediately (with healthy/0 defaults) instead of only after
- * first traffic. Called before each API metrics scrape.
+ * first traffic. Each chain is initialized at most once per pod lifetime.
  */
 async function initRpcMetricsForAllChains(): Promise<void> {
   try {
@@ -1056,10 +1058,12 @@ async function initRpcMetricsForAllChains(): Promise<void> {
     const chainNames = await getEnabledChainNamesFromDb();
 
     for (const chain of chainNames) {
-      // Initialize gauges with defaults; counters auto-appear once
-      // their gauge siblings exist for the same label set
+      if (initializedChains.has(chain)) {
+        continue;
+      }
       rpcHealthState.labels({ chain }).inc(0);
       rpcCurrentProvider.labels({ chain }).inc(0);
+      initializedChains.add(chain);
     }
   } catch {
     // Non-fatal: metrics will still populate on first RPC traffic

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -689,3 +689,21 @@ export async function getInfraStatsFromDb(): Promise<InfraStats> {
     };
   }
 }
+
+/**
+ * Query names of all enabled chains from the database.
+ * Used to pre-initialize RPC metrics so every chain appears in Grafana.
+ */
+export async function getEnabledChainNamesFromDb(): Promise<string[]> {
+  try {
+    const results = await db
+      .select({ name: chains.name })
+      .from(chains)
+      .where(eq(chains.isEnabled, true));
+
+    return results.map((r) => r.name);
+  } catch (error) {
+    console.error("[Metrics] Failed to query enabled chain names:", error);
+    return [];
+  }
+}

--- a/lib/metrics/rpc-metrics.ts
+++ b/lib/metrics/rpc-metrics.ts
@@ -10,7 +10,7 @@
 
 import "server-only";
 
-import type { RpcMetricsCollector } from "@/lib/rpc-provider";
+import type { RpcErrorType, RpcMetricsCollector } from "@/lib/rpc-provider";
 import type { SolanaRpcMetricsCollector } from "@/lib/rpc-provider/solana";
 import { rpcMetrics } from "./collectors/prometheus";
 
@@ -43,6 +43,24 @@ const prometheusCollector: RpcMetricsCollector & SolanaRpcMetricsCollector = {
   },
   recordSuccess(chain: string, provider: "primary" | "fallback"): void {
     rpcMetrics.healthState.set({ chain }, provider === "primary" ? 0 : 1);
+  },
+  recordLatency(
+    chain: string,
+    provider: "primary" | "fallback",
+    durationMs: number
+  ): void {
+    rpcMetrics.latency.observe({ chain, provider }, durationMs);
+  },
+  recordErrorType(
+    chain: string,
+    provider: "primary" | "fallback",
+    errorType: RpcErrorType
+  ): void {
+    rpcMetrics.errorsByType.inc({
+      chain,
+      provider,
+      error_type: errorType,
+    });
   },
 };
 

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -110,6 +110,13 @@ export const consoleMetricsCollector: RpcMetricsCollector = {
     console.debug(`[RPC Metrics] Error ${errorType} on ${provider}: ${chain}`),
 };
 
+export const RPC_CONNECTION_ERROR_PATTERNS: ReadonlyArray<string> = [
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "fetch failed",
+];
+
 export type RpcProviderConfig = {
   primaryRpcUrl: string;
   fallbackRpcUrl?: string;
@@ -444,21 +451,14 @@ export class RpcProviderManager {
         return "rate_limit";
       }
     }
-
-    const CONNECTION_ERRORS = [
-      "ECONNREFUSED",
-      "ENOTFOUND",
-      "ETIMEDOUT",
-      "fetch failed",
-    ];
-
     if (
       error instanceof Error &&
-      CONNECTION_ERRORS.some((err) => error.message.includes(err))
+      RPC_CONNECTION_ERROR_PATTERNS.some((pattern) =>
+        error.message.includes(pattern)
+      )
     ) {
       return "connection";
     }
-
     return "rpc_error";
   }
 

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -10,6 +10,12 @@ export {
  * Interface for metrics collection - allows dependency injection
  * so both server-side (console/structured) and frontend (no-op) can use this
  */
+export type RpcErrorType =
+  | "timeout"
+  | "rate_limit"
+  | "connection"
+  | "rpc_error";
+
 export type RpcMetricsCollector = {
   recordPrimaryAttempt(chainName: string): void;
   recordPrimaryFailure(chainName: string): void;
@@ -19,6 +25,16 @@ export type RpcMetricsCollector = {
   recordRecoveryEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
   recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
+  recordLatency(
+    chainName: string,
+    provider: "primary" | "fallback",
+    durationMs: number
+  ): void;
+  recordErrorType(
+    chainName: string,
+    provider: "primary" | "fallback",
+    errorType: RpcErrorType
+  ): void;
 };
 
 /**
@@ -58,6 +74,12 @@ export const noopMetricsCollector: RpcMetricsCollector = {
   recordSuccess: () => {
     /* noop */
   },
+  recordLatency: () => {
+    /* noop */
+  },
+  recordErrorType: () => {
+    /* noop */
+  },
 };
 
 /**
@@ -80,6 +102,12 @@ export const consoleMetricsCollector: RpcMetricsCollector = {
     console.debug(`[RPC Metrics] Both endpoints failed: ${chain}`),
   recordSuccess: (chain, provider) =>
     console.debug(`[RPC Metrics] Success on ${provider}: ${chain}`),
+  recordLatency: (chain, provider, durationMs) =>
+    console.debug(
+      `[RPC Metrics] Latency ${provider} ${chain}: ${durationMs}ms`
+    ),
+  recordErrorType: (chain, provider, errorType) =>
+    console.debug(`[RPC Metrics] Error ${errorType} on ${provider}: ${chain}`),
 };
 
 export type RpcProviderConfig = {
@@ -404,6 +432,36 @@ export class RpcProviderManager {
     return this.getRetryDelayMs(error, attempt);
   }
 
+  private classifyError(error: unknown): RpcErrorType {
+    if (error instanceof Error && error.message.startsWith("Timeout after ")) {
+      return "timeout";
+    }
+    if (isError(error, "SERVER_ERROR")) {
+      const serverErr = error as ethers.EthersError & {
+        response?: { statusCode?: number };
+      };
+      if (serverErr.response?.statusCode === 429) {
+        return "rate_limit";
+      }
+    }
+
+    const CONNECTION_ERRORS = [
+      "ECONNREFUSED",
+      "ENOTFOUND",
+      "ETIMEDOUT",
+      "fetch failed",
+    ];
+
+    if (
+      error instanceof Error &&
+      CONNECTION_ERRORS.some((err) => error.message.includes(err))
+    ) {
+      return "connection";
+    }
+
+    return "rpc_error";
+  }
+
   private async tryProvider<T>(
     provider: ethers.JsonRpcProvider,
     operation: (p: ethers.JsonRpcProvider) => Promise<T>,
@@ -413,6 +471,7 @@ export class RpcProviderManager {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const startTime = performance.now();
       try {
         this.recordAttempt(providerType);
 
@@ -421,10 +480,29 @@ export class RpcProviderManager {
           this.config.timeoutMs
         );
 
+        const durationMs = performance.now() - startTime;
+        this.metricsCollector.recordLatency(
+          this.config.chainName,
+          providerType,
+          durationMs
+        );
+
         return { success: true, result };
       } catch (error: unknown) {
+        const durationMs = performance.now() - startTime;
+        this.metricsCollector.recordLatency(
+          this.config.chainName,
+          providerType,
+          durationMs
+        );
+
         lastError = error instanceof Error ? error : new Error(String(error));
         this.recordFailure(providerType);
+        this.metricsCollector.recordErrorType(
+          this.config.chainName,
+          providerType,
+          this.classifyError(error)
+        );
 
         const delayMs = this.evaluateRetryAction(
           error,

--- a/lib/rpc-provider/solana.ts
+++ b/lib/rpc-provider/solana.ts
@@ -1,4 +1,5 @@
 import { type Commitment, Connection } from "@solana/web3.js";
+import { type RpcErrorType, RPC_CONNECTION_ERROR_PATTERNS } from "./index";
 
 /**
  * Solana RPC Provider Manager
@@ -6,12 +7,6 @@ import { type Commitment, Connection } from "@solana/web3.js";
  * Similar to the EVM RpcProviderManager but uses @solana/web3.js Connection
  * instead of ethers.JsonRpcProvider.
  */
-
-export type SolanaRpcErrorType =
-  | "timeout"
-  | "rate_limit"
-  | "connection"
-  | "rpc_error";
 
 export type SolanaRpcMetricsCollector = {
   recordPrimaryAttempt(chainName: string): void;
@@ -30,7 +25,7 @@ export type SolanaRpcMetricsCollector = {
   recordErrorType(
     chainName: string,
     provider: "primary" | "fallback",
-    errorType: SolanaRpcErrorType
+    errorType: RpcErrorType
   ): void;
 };
 
@@ -321,7 +316,7 @@ export class SolanaProviderManager {
     );
   }
 
-  private classifyError(error: unknown): SolanaRpcErrorType {
+  private classifyError(error: unknown): RpcErrorType {
     if (error instanceof Error && error.message.startsWith("Timeout after ")) {
       return "timeout";
     }
@@ -334,10 +329,9 @@ export class SolanaProviderManager {
     }
     if (
       error instanceof Error &&
-      (error.message.includes("ECONNREFUSED") ||
-        error.message.includes("ENOTFOUND") ||
-        error.message.includes("ETIMEDOUT") ||
-        error.message.includes("fetch failed"))
+      RPC_CONNECTION_ERROR_PATTERNS.some((pattern) =>
+        error.message.includes(pattern)
+      )
     ) {
       return "connection";
     }

--- a/lib/rpc-provider/solana.ts
+++ b/lib/rpc-provider/solana.ts
@@ -7,6 +7,12 @@ import { type Commitment, Connection } from "@solana/web3.js";
  * instead of ethers.JsonRpcProvider.
  */
 
+export type SolanaRpcErrorType =
+  | "timeout"
+  | "rate_limit"
+  | "connection"
+  | "rpc_error";
+
 export type SolanaRpcMetricsCollector = {
   recordPrimaryAttempt(chainName: string): void;
   recordPrimaryFailure(chainName: string): void;
@@ -16,6 +22,16 @@ export type SolanaRpcMetricsCollector = {
   recordRecoveryEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
   recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
+  recordLatency(
+    chainName: string,
+    provider: "primary" | "fallback",
+    durationMs: number
+  ): void;
+  recordErrorType(
+    chainName: string,
+    provider: "primary" | "fallback",
+    errorType: SolanaRpcErrorType
+  ): void;
 };
 
 export type SolanaFailoverStateChangeCallback = (
@@ -49,6 +65,12 @@ export const noopSolanaMetricsCollector: SolanaRpcMetricsCollector = {
   recordSuccess: () => {
     /* noop */
   },
+  recordLatency: () => {
+    /* noop */
+  },
+  recordErrorType: () => {
+    /* noop */
+  },
 };
 
 export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
@@ -68,6 +90,14 @@ export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
     console.debug(`[Solana RPC Metrics] Both endpoints failed: ${chain}`),
   recordSuccess: (chain, provider) =>
     console.debug(`[Solana RPC Metrics] Success on ${provider}: ${chain}`),
+  recordLatency: (chain, provider, durationMs) =>
+    console.debug(
+      `[Solana RPC Metrics] Latency ${provider} ${chain}: ${durationMs}ms`
+    ),
+  recordErrorType: (chain, provider, errorType) =>
+    console.debug(
+      `[Solana RPC Metrics] Error ${errorType} on ${provider}: ${chain}`
+    ),
 };
 
 export type SolanaProviderConfig = {
@@ -291,6 +321,29 @@ export class SolanaProviderManager {
     );
   }
 
+  private classifyError(error: unknown): SolanaRpcErrorType {
+    if (error instanceof Error && error.message.startsWith("Timeout after ")) {
+      return "timeout";
+    }
+    if (
+      error instanceof Error &&
+      (error.message.includes("429") ||
+        error.message.includes("Too Many Requests"))
+    ) {
+      return "rate_limit";
+    }
+    if (
+      error instanceof Error &&
+      (error.message.includes("ECONNREFUSED") ||
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ETIMEDOUT") ||
+        error.message.includes("fetch failed"))
+    ) {
+      return "connection";
+    }
+    return "rpc_error";
+  }
+
   private async tryConnection<T>(
     connection: Connection,
     operation: (c: Connection) => Promise<T>,
@@ -300,6 +353,7 @@ export class SolanaProviderManager {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const startTime = performance.now();
       try {
         if (connectionType === "primary") {
           this.metrics.primaryAttempts += 1;
@@ -314,8 +368,22 @@ export class SolanaProviderManager {
           this.config.timeoutMs
         );
 
+        const durationMs = performance.now() - startTime;
+        this.metricsCollector.recordLatency(
+          this.config.chainName,
+          connectionType,
+          durationMs
+        );
+
         return { success: true, result };
       } catch (error: unknown) {
+        const durationMs = performance.now() - startTime;
+        this.metricsCollector.recordLatency(
+          this.config.chainName,
+          connectionType,
+          durationMs
+        );
+
         lastError = error instanceof Error ? error : new Error(String(error));
 
         if (connectionType === "primary") {
@@ -325,6 +393,12 @@ export class SolanaProviderManager {
           this.metrics.fallbackFailures += 1;
           this.metricsCollector.recordFallbackFailure(this.config.chainName);
         }
+
+        this.metricsCollector.recordErrorType(
+          this.config.chainName,
+          connectionType,
+          this.classifyError(error)
+        );
 
         if (attempt === maxRetries - 1) {
           break;

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -96,6 +96,8 @@ describe("RpcProviderManager", () => {
       recordRecoveryEvent: vi.fn(),
       recordBothFailed: vi.fn(),
       recordSuccess: vi.fn(),
+      recordLatency: vi.fn(),
+      recordErrorType: vi.fn(),
     };
   });
 

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -39,6 +39,8 @@ describe("SolanaProviderManager", () => {
       recordRecoveryEvent: vi.fn(),
       recordBothFailed: vi.fn(),
       recordSuccess: vi.fn(),
+      recordLatency: vi.fn(),
+      recordErrorType: vi.fn(),
     };
   });
 


### PR DESCRIPTION
## Summary

- Add `keeperhub_rpc_latency_ms` histogram (10ms-30s buckets, labels: chain + provider) to track RPC call duration for both EVM and Solana providers
- Add `keeperhub_rpc_errors_by_type_total` counter (labels: chain + provider + error_type) classifying failures as timeout, rate_limit, connection, or rpc_error
- Pre-initialize `keeperhub_rpc_health_state` and `keeperhub_rpc_using_fallback` gauges for all enabled chains on every `/api/metrics/api` scrape, so all networks appear in Grafana immediately instead of only after first traffic
- Add `getEnabledChainNamesFromDb()` to query enabled chain names from the DB for metric initialization
- Extend `RpcMetricsCollector` and `SolanaRpcMetricsCollector` interfaces with `recordLatency` and `recordErrorType`
- Instrument `tryProvider` (EVM) and `tryConnection` (Solana) with `performance.now()` timing on both success and failure paths