### PR TITLE
feat: KEEP-221 add RPC failover and metrics to write transaction path

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -116,6 +116,12 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  RPC_PROBE_INTERVAL_MS:
+    type: kv
+    value: "30000"
+  RPC_PROBE_TIMEOUT_MS:
+    type: kv
+    value: "15000"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -116,6 +116,12 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  RPC_PROBE_INTERVAL_MS:
+    type: kv
+    value: "30000"
+  RPC_PROBE_TIMEOUT_MS:
+    type: kv
+    value: "15000"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps --trace-warnings --trace-uncaught --trace-exit"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -135,6 +135,12 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  RPC_PROBE_INTERVAL_MS:
+    type: kv
+    value: "30000"
+  RPC_PROBE_TIMEOUT_MS:
+    type: kv
+    value: "15000"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps --trace-warnings --trace-uncaught --trace-exit"

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1171,7 +1171,7 @@ async function initRpcMetricsForAllChains(): Promise<void> {
       rpcHealthState.labels({ chain }).inc(0);
       rpcCurrentProvider.labels({ chain }).inc(0);
       // Initialize per-operation counters so both read/write appear in Grafana
-      for (const operation of ["read", "write"]) {
+      for (const operation of ["read", "write", "preflight"]) {
         rpcPrimaryAttempts.labels({ chain, operation }).inc(0);
         rpcPrimaryFailures.labels({ chain, operation }).inc(0);
       }

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -412,88 +412,130 @@ const hubUserVotesTotal = getOrCreateGauge(
 );
 
 // RPC failover metrics → apiRegistry (per-pod in-memory, scrape all pods)
-const RPC_LABELS = ["chain"];
+// Per-request counters include "operation" label (read/write)
+const RPC_CHAIN_LABELS = ["chain"];
+const RPC_OPERATION_LABELS = ["chain", "operation"];
 
 const rpcPrimaryAttempts = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_primary_attempts_total",
   "Total RPC requests attempted against primary endpoint",
-  RPC_LABELS
+  RPC_OPERATION_LABELS
 );
 
 const rpcPrimaryFailures = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_primary_failures_total",
   "Total RPC request failures on primary endpoint",
-  RPC_LABELS
+  RPC_OPERATION_LABELS
 );
 
 const rpcFallbackAttempts = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_fallback_attempts_total",
   "Total RPC requests attempted against fallback endpoint",
-  RPC_LABELS
+  RPC_OPERATION_LABELS
 );
 
 const rpcFallbackFailures = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_fallback_failures_total",
   "Total RPC request failures on fallback endpoint",
-  RPC_LABELS
+  RPC_OPERATION_LABELS
 );
 
 const rpcFailoverEvents = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_failover_events_total",
   "Total times primary failed and traffic switched to fallback",
-  RPC_LABELS
+  RPC_CHAIN_LABELS
 );
 
 const rpcRecoveryEvents = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_recovery_events_total",
   "Total times primary recovered and traffic switched back from fallback",
-  RPC_LABELS
+  RPC_CHAIN_LABELS
 );
 
 const rpcBothFailedEvents = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_both_failed_total",
   "Total times both primary and fallback endpoints failed",
-  RPC_LABELS
+  RPC_CHAIN_LABELS
 );
 
 const rpcCurrentProvider = getOrCreateGauge(
   apiRegistry,
   "keeperhub_rpc_using_fallback",
   "Whether the chain is currently using the fallback RPC (1=fallback, 0=primary)",
-  RPC_LABELS
+  RPC_CHAIN_LABELS
 );
 
 const rpcHealthState = getOrCreateGauge(
   apiRegistry,
   "keeperhub_rpc_health_state",
   "RPC health state per chain (0=primary/healthy, 1=fallback/degraded, 2=both_failed/down)",
-  RPC_LABELS
+  RPC_CHAIN_LABELS
 );
 
-const RPC_PROVIDER_LABELS = ["chain", "provider"];
+const RPC_PROVIDER_OPERATION_LABELS = ["chain", "provider", "operation"];
 
 const rpcLatency = getOrCreateHistogram(
   apiRegistry,
   "keeperhub_rpc_latency_ms",
   "RPC request latency in milliseconds per chain and provider",
-  RPC_PROVIDER_LABELS,
+  RPC_PROVIDER_OPERATION_LABELS,
   [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10_000, 30_000]
 );
 
-const RPC_ERROR_LABELS = ["chain", "provider", "error_type"];
+const RPC_ERROR_OPERATION_LABELS = [
+  "chain",
+  "provider",
+  "error_type",
+  "operation",
+];
 
 const rpcErrorsByType = getOrCreateCounter(
   apiRegistry,
   "keeperhub_rpc_errors_by_type_total",
   "RPC errors broken down by type (timeout, rate_limit, connection, rpc_error)",
-  RPC_ERROR_LABELS
+  RPC_ERROR_OPERATION_LABELS
+);
+
+// Active RPC health probe metrics → apiRegistry
+const RPC_PROBE_LABELS = ["chain", "provider"];
+const RPC_PROBE_ERROR_LABELS = ["chain", "provider", "error_type"];
+
+const RPC_PROBE_UP_LABELS = ["chain", "provider", "endpoint"];
+
+const rpcProbeUp = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_rpc_probe_up",
+  "Whether the RPC endpoint responded to the health probe (1=up, 0=down)",
+  RPC_PROBE_UP_LABELS
+);
+
+const rpcProbeLatency = getOrCreateHistogram(
+  apiRegistry,
+  "keeperhub_rpc_probe_latency_ms",
+  "Active health probe latency in milliseconds",
+  RPC_PROBE_LABELS,
+  [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10_000, 15_000]
+);
+
+const rpcProbeErrorsTotal = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_rpc_probe_errors_total",
+  "Active health probe errors by type",
+  RPC_PROBE_ERROR_LABELS
+);
+
+const rpcProbeLastSuccess = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_rpc_probe_last_success_timestamp",
+  "Unix timestamp of last successful probe per endpoint",
+  RPC_PROBE_LABELS
 );
 
 // API-process metrics → apiRegistry (per-pod in-memory, scrape all pods)
@@ -1128,6 +1170,11 @@ async function initRpcMetricsForAllChains(): Promise<void> {
     for (const chain of chainNames) {
       rpcHealthState.labels({ chain }).inc(0);
       rpcCurrentProvider.labels({ chain }).inc(0);
+      // Initialize per-operation counters so both read/write appear in Grafana
+      for (const operation of ["read", "write"]) {
+        rpcPrimaryAttempts.labels({ chain, operation }).inc(0);
+        rpcPrimaryFailures.labels({ chain, operation }).inc(0);
+      }
       initializedChains.add(chain);
     }
   } catch {
@@ -1140,6 +1187,8 @@ async function initRpcMetricsForAllChains(): Promise<void> {
  */
 export async function getApiProcessMetrics(): Promise<string> {
   await initRpcMetricsForAllChains();
+  const { startRpcHealthProbe } = await import("../rpc-health-probe");
+  startRpcHealthProbe();
   return await apiRegistry.metrics();
 }
 
@@ -1165,4 +1214,11 @@ export const rpcMetrics = {
   healthState: rpcHealthState,
   latency: rpcLatency,
   errorsByType: rpcErrorsByType,
+};
+
+export const rpcProbeMetrics = {
+  up: rpcProbeUp,
+  latency: rpcProbeLatency,
+  errorsTotal: rpcProbeErrorsTotal,
+  lastSuccess: rpcProbeLastSuccess,
 };

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -799,3 +799,34 @@ export async function getEnabledChainNamesFromDb(): Promise<string[]> {
     return [];
   }
 }
+
+export type ProbeChainConfig = {
+  chainId: number;
+  name: string;
+  chainType: string;
+  defaultPrimaryRpc: string;
+  defaultFallbackRpc: string | null;
+};
+
+/**
+ * Query all enabled chain configs for the active RPC health probe.
+ * Returns chain metadata + default RPC URLs for both primary and fallback.
+ */
+export async function getEnabledChainConfigsForProbe(): Promise<
+  ProbeChainConfig[]
+> {
+  try {
+    return await db
+      .select({
+        chainId: chains.chainId,
+        name: chains.name,
+        chainType: chains.chainType,
+        defaultPrimaryRpc: chains.defaultPrimaryRpc,
+        defaultFallbackRpc: chains.defaultFallbackRpc,
+      })
+      .from(chains)
+      .where(eq(chains.isEnabled, true));
+  } catch {
+    return [];
+  }
+}

--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -1,0 +1,154 @@
+/**
+ * Active RPC Health Probe
+ *
+ * Periodically pings every RPC endpoint (primary + fallback) with a
+ * lightweight call (eth_blockNumber for EVM, getSlot for Solana) and
+ * records up/down, latency, and error classification independent of
+ * workflow traffic.
+ *
+ * Started lazily on first /api/metrics/api scrape via startRpcHealthProbe().
+ */
+
+import "server-only";
+
+import { Connection } from "@solana/web3.js";
+import { ethers } from "ethers";
+import { classifyRpcError } from "@/lib/rpc-provider";
+import { rpcProbeMetrics } from "./collectors/prometheus";
+import type { ProbeChainConfig } from "./db-metrics";
+
+function noop(): void {
+  // intentional no-op for unhandled probe promise rejections
+}
+
+const PROBE_INTERVAL_MS = Number(process.env.RPC_PROBE_INTERVAL_MS) || 30_000;
+const PROBE_TIMEOUT_MS =
+  Number(process.env.RPC_PROBE_TIMEOUT_MS) || 15_000;
+
+type ProbeTarget = {
+  chain: string;
+  provider: "primary" | "fallback";
+  url: string;
+  chainType: string;
+};
+
+// Hot-reload safe: store timer on globalThis so restarts don't spawn duplicates
+const globalForProbe = globalThis as unknown as {
+  rpcProbeTimer: ReturnType<typeof setInterval> | undefined;
+};
+
+export function startRpcHealthProbe(): void {
+  if (globalForProbe.rpcProbeTimer !== undefined) {
+    return;
+  }
+
+  runProbeAllChains().catch(noop);
+  globalForProbe.rpcProbeTimer = setInterval(() => {
+    runProbeAllChains().catch(noop);
+  }, PROBE_INTERVAL_MS);
+}
+
+export function stopRpcHealthProbe(): void {
+  if (globalForProbe.rpcProbeTimer !== undefined) {
+    clearInterval(globalForProbe.rpcProbeTimer);
+    globalForProbe.rpcProbeTimer = undefined;
+  }
+}
+
+async function runProbeAllChains(): Promise<void> {
+  let chainConfigs: ProbeChainConfig[];
+  try {
+    const { getEnabledChainConfigsForProbe } = await import("./db-metrics");
+    chainConfigs = await getEnabledChainConfigsForProbe();
+  } catch {
+    return;
+  }
+
+  const targets: ProbeTarget[] = [];
+
+  for (const config of chainConfigs) {
+    targets.push({
+      chain: config.name,
+      provider: "primary",
+      url: config.defaultPrimaryRpc,
+      chainType: config.chainType,
+    });
+    if (config.defaultFallbackRpc) {
+      targets.push({
+        chain: config.name,
+        provider: "fallback",
+        url: config.defaultFallbackRpc,
+        chainType: config.chainType,
+      });
+    }
+  }
+
+  await Promise.allSettled(targets.map((t) => probeEndpoint(t)));
+}
+
+async function probeEndpoint(target: ProbeTarget): Promise<void> {
+  const { chain, provider, url, chainType } = target;
+  const start = performance.now();
+
+  try {
+    if (chainType === "solana") {
+      await probeSolana(url);
+    } else {
+      await probeEvm(url);
+    }
+
+    const durationMs = performance.now() - start;
+    const endpoint = extractHostname(url);
+    rpcProbeMetrics.up.set({ chain, provider, endpoint }, 1);
+    rpcProbeMetrics.latency.observe({ chain, provider }, durationMs);
+    rpcProbeMetrics.lastSuccess.set({ chain, provider }, Date.now());
+  } catch (error: unknown) {
+    const durationMs = performance.now() - start;
+    const endpoint = extractHostname(url);
+    rpcProbeMetrics.up.set({ chain, provider, endpoint }, 0);
+    rpcProbeMetrics.latency.observe({ chain, provider }, durationMs);
+
+    const errorType = classifyRpcError(error);
+    rpcProbeMetrics.errorsTotal.inc({
+      chain,
+      provider,
+      error_type: errorType,
+    });
+  }
+}
+
+async function probeEvm(url: string): Promise<void> {
+  const provider = new ethers.JsonRpcProvider(url, undefined, {
+    staticNetwork: true,
+  });
+  try {
+    await withTimeout(provider.getBlockNumber(), PROBE_TIMEOUT_MS);
+  } finally {
+    provider.destroy();
+  }
+}
+
+async function probeSolana(url: string): Promise<void> {
+  const connection = new Connection(url, { commitment: "confirmed" });
+  await withTimeout(connection.getSlot(), PROBE_TIMEOUT_MS);
+}
+
+function extractHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Timeout after ${timeoutMs}ms`)),
+        timeoutMs
+      )
+    ),
+  ]);
+}

--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -22,8 +22,7 @@ function noop(): void {
 }
 
 const PROBE_INTERVAL_MS = Number(process.env.RPC_PROBE_INTERVAL_MS) || 30_000;
-const PROBE_TIMEOUT_MS =
-  Number(process.env.RPC_PROBE_TIMEOUT_MS) || 15_000;
+const PROBE_TIMEOUT_MS = Number(process.env.RPC_PROBE_TIMEOUT_MS) || 15_000;
 
 type ProbeTarget = {
   chain: string;
@@ -142,13 +141,17 @@ function extractHostname(url: string): string {
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
-    promise,
-    new Promise<T>((_, reject) =>
-      setTimeout(
+    promise.then((v) => {
+      clearTimeout(timer);
+      return v;
+    }),
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(
         () => reject(new Error(`Timeout after ${timeoutMs}ms`)),
         timeoutMs
-      )
-    ),
+      );
+    }),
   ]);
 }

--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -45,6 +45,7 @@ export function startRpcHealthProbe(): void {
   globalForProbe.rpcProbeTimer = setInterval(() => {
     runProbeAllChains().catch(noop);
   }, PROBE_INTERVAL_MS);
+  globalForProbe.rpcProbeTimer.unref();
 }
 
 export function stopRpcHealthProbe(): void {
@@ -143,10 +144,16 @@ function extractHostname(url: string): string {
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
-    promise.then((v) => {
-      clearTimeout(timer);
-      return v;
-    }),
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        return v;
+      },
+      (e: unknown) => {
+        clearTimeout(timer);
+        throw e;
+      }
+    ),
     new Promise<T>((_, reject) => {
       timer = setTimeout(
         () => reject(new Error(`Timeout after ${timeoutMs}ms`)),

--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -118,7 +118,7 @@ async function probeEndpoint(target: ProbeTarget): Promise<void> {
 }
 
 async function probeEvm(url: string): Promise<void> {
-  const provider = new ethers.JsonRpcProvider(url, undefined, {
+  const provider = new ethers.JsonRpcProvider(url, ethers.Network.from(1), {
     staticNetwork: true,
   });
   try {

--- a/lib/metrics/rpc-metrics.ts
+++ b/lib/metrics/rpc-metrics.ts
@@ -10,7 +10,11 @@
 
 import "server-only";
 
-import type { RpcErrorType, RpcMetricsCollector } from "@/lib/rpc-provider";
+import type {
+  RpcErrorType,
+  RpcMetricsCollector,
+  RpcOperationType,
+} from "@/lib/rpc-provider";
 import type { SolanaRpcMetricsCollector } from "@/lib/rpc-provider/solana";
 import { rpcMetrics } from "./collectors/prometheus";
 
@@ -19,17 +23,29 @@ import { rpcMetrics } from "./collectors/prometheus";
  * Both interfaces are structurally identical, so a single implementation serves both.
  */
 const prometheusCollector: RpcMetricsCollector & SolanaRpcMetricsCollector = {
-  recordPrimaryAttempt(chain: string): void {
-    rpcMetrics.primaryAttempts.inc({ chain });
+  recordPrimaryAttempt(
+    chain: string,
+    operation: RpcOperationType = "read"
+  ): void {
+    rpcMetrics.primaryAttempts.inc({ chain, operation });
   },
-  recordPrimaryFailure(chain: string): void {
-    rpcMetrics.primaryFailures.inc({ chain });
+  recordPrimaryFailure(
+    chain: string,
+    operation: RpcOperationType = "read"
+  ): void {
+    rpcMetrics.primaryFailures.inc({ chain, operation });
   },
-  recordFallbackAttempt(chain: string): void {
-    rpcMetrics.fallbackAttempts.inc({ chain });
+  recordFallbackAttempt(
+    chain: string,
+    operation: RpcOperationType = "read"
+  ): void {
+    rpcMetrics.fallbackAttempts.inc({ chain, operation });
   },
-  recordFallbackFailure(chain: string): void {
-    rpcMetrics.fallbackFailures.inc({ chain });
+  recordFallbackFailure(
+    chain: string,
+    operation: RpcOperationType = "read"
+  ): void {
+    rpcMetrics.fallbackFailures.inc({ chain, operation });
   },
   recordFailoverEvent(chain: string): void {
     rpcMetrics.failoverEvents.inc({ chain });
@@ -41,25 +57,32 @@ const prometheusCollector: RpcMetricsCollector & SolanaRpcMetricsCollector = {
     rpcMetrics.bothFailedEvents.inc({ chain });
     rpcMetrics.healthState.set({ chain }, 2);
   },
-  recordSuccess(chain: string, provider: "primary" | "fallback"): void {
+  recordSuccess(
+    chain: string,
+    provider: "primary" | "fallback",
+    _operation?: RpcOperationType
+  ): void {
     rpcMetrics.healthState.set({ chain }, provider === "primary" ? 0 : 1);
   },
   recordLatency(
     chain: string,
     provider: "primary" | "fallback",
-    durationMs: number
+    durationMs: number,
+    operation: RpcOperationType = "read"
   ): void {
-    rpcMetrics.latency.observe({ chain, provider }, durationMs);
+    rpcMetrics.latency.observe({ chain, provider, operation }, durationMs);
   },
   recordErrorType(
     chain: string,
     provider: "primary" | "fallback",
-    errorType: RpcErrorType
+    errorType: RpcErrorType,
+    operation: RpcOperationType = "read"
   ): void {
     rpcMetrics.errorsByType.inc({
       chain,
       provider,
       error_type: errorType,
+      operation,
     });
   },
 };

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -117,6 +117,34 @@ export const RPC_CONNECTION_ERROR_PATTERNS: ReadonlyArray<string> = [
   "fetch failed",
 ];
 
+/**
+ * Classify an RPC error into a category for metrics tracking.
+ * Standalone version for use outside of executeWithFailover
+ * (e.g., write transaction send paths).
+ */
+export function classifyRpcError(error: unknown): RpcErrorType {
+  if (error instanceof Error && error.message.startsWith("Timeout after ")) {
+    return "timeout";
+  }
+  if (isError(error, "SERVER_ERROR")) {
+    const serverErr = error as ethers.EthersError & {
+      response?: { statusCode?: number };
+    };
+    if (serverErr.response?.statusCode === 429) {
+      return "rate_limit";
+    }
+  }
+  if (
+    error instanceof Error &&
+    RPC_CONNECTION_ERROR_PATTERNS.some((pattern) =>
+      error.message.includes(pattern)
+    )
+  ) {
+    return "connection";
+  }
+  return "rpc_error";
+}
+
 export type RpcProviderConfig = {
   primaryRpcUrl: string;
   fallbackRpcUrl?: string;
@@ -440,26 +468,7 @@ export class RpcProviderManager {
   }
 
   private classifyError(error: unknown): RpcErrorType {
-    if (error instanceof Error && error.message.startsWith("Timeout after ")) {
-      return "timeout";
-    }
-    if (isError(error, "SERVER_ERROR")) {
-      const serverErr = error as ethers.EthersError & {
-        response?: { statusCode?: number };
-      };
-      if (serverErr.response?.statusCode === 429) {
-        return "rate_limit";
-      }
-    }
-    if (
-      error instanceof Error &&
-      RPC_CONNECTION_ERROR_PATTERNS.some((pattern) =>
-        error.message.includes(pattern)
-      )
-    ) {
-      return "connection";
-    }
-    return "rpc_error";
+    return classifyRpcError(error);
   }
 
   private async tryProvider<T>(
@@ -587,6 +596,10 @@ export class RpcProviderManager {
    */
   getChainName(): string {
     return this.config.chainName;
+  }
+
+  getMetricsCollector(): RpcMetricsCollector {
+    return this.metricsCollector;
   }
 }
 

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -16,24 +16,32 @@ export type RpcErrorType =
   | "connection"
   | "rpc_error";
 
+export type RpcOperationType = "read" | "write";
+
 export type RpcMetricsCollector = {
-  recordPrimaryAttempt(chainName: string): void;
-  recordPrimaryFailure(chainName: string): void;
-  recordFallbackAttempt(chainName: string): void;
-  recordFallbackFailure(chainName: string): void;
+  recordPrimaryAttempt(chainName: string, operation?: RpcOperationType): void;
+  recordPrimaryFailure(chainName: string, operation?: RpcOperationType): void;
+  recordFallbackAttempt(chainName: string, operation?: RpcOperationType): void;
+  recordFallbackFailure(chainName: string, operation?: RpcOperationType): void;
   recordFailoverEvent(chainName: string): void;
   recordRecoveryEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
-  recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
+  recordSuccess(
+    chainName: string,
+    provider: "primary" | "fallback",
+    operation?: RpcOperationType
+  ): void;
   recordLatency(
     chainName: string,
     provider: "primary" | "fallback",
-    durationMs: number
+    durationMs: number,
+    operation?: RpcOperationType
   ): void;
   recordErrorType(
     chainName: string,
     provider: "primary" | "fallback",
-    errorType: RpcErrorType
+    errorType: RpcErrorType,
+    operation?: RpcOperationType
   ): void;
 };
 
@@ -50,16 +58,16 @@ export type FailoverStateChangeCallback = (
  * No-op metrics collector for environments without metrics (e.g., frontend)
  */
 export const noopMetricsCollector: RpcMetricsCollector = {
-  recordPrimaryAttempt: () => {
+  recordPrimaryAttempt: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
-  recordPrimaryFailure: () => {
+  recordPrimaryFailure: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
-  recordFallbackAttempt: () => {
+  recordFallbackAttempt: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
-  recordFallbackFailure: () => {
+  recordFallbackFailure: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
   recordFailoverEvent: () => {
@@ -71,13 +79,27 @@ export const noopMetricsCollector: RpcMetricsCollector = {
   recordBothFailed: () => {
     /* noop */
   },
-  recordSuccess: () => {
+  recordSuccess: (
+    _chain: string,
+    _provider: "primary" | "fallback",
+    _operation?: RpcOperationType
+  ) => {
     /* noop */
   },
-  recordLatency: () => {
+  recordLatency: (
+    _chain: string,
+    _provider: "primary" | "fallback",
+    _durationMs: number,
+    _operation?: RpcOperationType
+  ) => {
     /* noop */
   },
-  recordErrorType: () => {
+  recordErrorType: (
+    _chain: string,
+    _provider: "primary" | "fallback",
+    _errorType: RpcErrorType,
+    _operation?: RpcOperationType
+  ) => {
     /* noop */
   },
 };
@@ -86,28 +108,32 @@ export const noopMetricsCollector: RpcMetricsCollector = {
  * Console-based metrics collector for debugging
  */
 export const consoleMetricsCollector: RpcMetricsCollector = {
-  recordPrimaryAttempt: (chain) =>
-    console.debug(`[RPC Metrics] Primary attempt: ${chain}`),
-  recordPrimaryFailure: (chain) =>
-    console.debug(`[RPC Metrics] Primary failure: ${chain}`),
-  recordFallbackAttempt: (chain) =>
-    console.debug(`[RPC Metrics] Fallback attempt: ${chain}`),
-  recordFallbackFailure: (chain) =>
-    console.debug(`[RPC Metrics] Fallback failure: ${chain}`),
+  recordPrimaryAttempt: (chain, operation = "read") =>
+    console.debug(`[RPC Metrics] Primary attempt: ${chain} [${operation}]`),
+  recordPrimaryFailure: (chain, operation = "read") =>
+    console.debug(`[RPC Metrics] Primary failure: ${chain} [${operation}]`),
+  recordFallbackAttempt: (chain, operation = "read") =>
+    console.debug(`[RPC Metrics] Fallback attempt: ${chain} [${operation}]`),
+  recordFallbackFailure: (chain, operation = "read") =>
+    console.debug(`[RPC Metrics] Fallback failure: ${chain} [${operation}]`),
   recordFailoverEvent: (chain) =>
     console.debug(`[RPC Metrics] Failover event: ${chain}`),
   recordRecoveryEvent: (chain) =>
     console.debug(`[RPC Metrics] Recovery event: ${chain}`),
   recordBothFailed: (chain) =>
     console.debug(`[RPC Metrics] Both endpoints failed: ${chain}`),
-  recordSuccess: (chain, provider) =>
-    console.debug(`[RPC Metrics] Success on ${provider}: ${chain}`),
-  recordLatency: (chain, provider, durationMs) =>
+  recordSuccess: (chain, provider, operation = "read") =>
     console.debug(
-      `[RPC Metrics] Latency ${provider} ${chain}: ${durationMs}ms`
+      `[RPC Metrics] Success on ${provider}: ${chain} [${operation}]`
     ),
-  recordErrorType: (chain, provider, errorType) =>
-    console.debug(`[RPC Metrics] Error ${errorType} on ${provider}: ${chain}`),
+  recordLatency: (chain, provider, durationMs, operation = "read") =>
+    console.debug(
+      `[RPC Metrics] Latency ${provider} ${chain}: ${durationMs}ms [${operation}]`
+    ),
+  recordErrorType: (chain, provider, errorType, operation = "read") =>
+    console.debug(
+      `[RPC Metrics] Error ${errorType} on ${provider}: ${chain} [${operation}]`
+    ),
 };
 
 export const RPC_CONNECTION_ERROR_PATTERNS: ReadonlyArray<string> = [
@@ -253,7 +279,8 @@ export class RpcProviderManager {
   }
 
   async executeWithFailover<T>(
-    operation: (provider: ethers.JsonRpcProvider) => Promise<T>
+    operation: (provider: ethers.JsonRpcProvider) => Promise<T>,
+    operationType: RpcOperationType = "read"
   ): Promise<T> {
     this.metrics.totalRequests += 1;
 
@@ -265,13 +292,15 @@ export class RpcProviderManager {
           fallbackProvider,
           operation,
           "fallback",
-          this.config.maxRetries
+          this.config.maxRetries,
+          operationType
         );
 
         if (fallbackResult.success) {
           this.metricsCollector.recordSuccess(
             this.config.chainName,
-            "fallback"
+            "fallback",
+            operationType
           );
           return fallbackResult.result as T;
         }
@@ -292,7 +321,8 @@ export class RpcProviderManager {
           primaryProvider,
           operation,
           "primary",
-          this.config.maxRetries
+          this.config.maxRetries,
+          operationType
         );
 
         if (primaryResult.success) {
@@ -342,11 +372,16 @@ export class RpcProviderManager {
       primaryProvider,
       operation,
       "primary",
-      this.config.maxRetries
+      this.config.maxRetries,
+      operationType
     );
 
     if (primaryResult.success) {
-      this.metricsCollector.recordSuccess(this.config.chainName, "primary");
+      this.metricsCollector.recordSuccess(
+        this.config.chainName,
+        "primary",
+        operationType
+      );
       return primaryResult.result as T;
     }
 
@@ -359,7 +394,8 @@ export class RpcProviderManager {
         fallbackProvider,
         operation,
         "fallback",
-        this.config.maxRetries
+        this.config.maxRetries,
+        operationType
       );
 
       if (fallbackResult.success) {
@@ -400,23 +436,41 @@ export class RpcProviderManager {
     throw new Error(`RPC failed on primary endpoint: ${primaryResult.error}`);
   }
 
-  private recordAttempt(providerType: "primary" | "fallback"): void {
+  private recordAttempt(
+    providerType: "primary" | "fallback",
+    operationType: RpcOperationType = "read"
+  ): void {
     if (providerType === "primary") {
       this.metrics.primaryAttempts += 1;
-      this.metricsCollector.recordPrimaryAttempt(this.config.chainName);
+      this.metricsCollector.recordPrimaryAttempt(
+        this.config.chainName,
+        operationType
+      );
     } else {
       this.metrics.fallbackAttempts += 1;
-      this.metricsCollector.recordFallbackAttempt(this.config.chainName);
+      this.metricsCollector.recordFallbackAttempt(
+        this.config.chainName,
+        operationType
+      );
     }
   }
 
-  private recordFailure(providerType: "primary" | "fallback"): void {
+  private recordFailure(
+    providerType: "primary" | "fallback",
+    operationType: RpcOperationType = "read"
+  ): void {
     if (providerType === "primary") {
       this.metrics.primaryFailures += 1;
-      this.metricsCollector.recordPrimaryFailure(this.config.chainName);
+      this.metricsCollector.recordPrimaryFailure(
+        this.config.chainName,
+        operationType
+      );
     } else {
       this.metrics.fallbackFailures += 1;
-      this.metricsCollector.recordFallbackFailure(this.config.chainName);
+      this.metricsCollector.recordFallbackFailure(
+        this.config.chainName,
+        operationType
+      );
     }
   }
 
@@ -475,14 +529,15 @@ export class RpcProviderManager {
     provider: ethers.JsonRpcProvider,
     operation: (p: ethers.JsonRpcProvider) => Promise<T>,
     providerType: "primary" | "fallback",
-    maxRetries: number
+    maxRetries: number,
+    operationType: RpcOperationType = "read"
   ): Promise<{ success: boolean; result?: T; error?: string }> {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       const startTime = performance.now();
       try {
-        this.recordAttempt(providerType);
+        this.recordAttempt(providerType, operationType);
 
         const result = await this.withTimeout(
           operation(provider),
@@ -493,7 +548,8 @@ export class RpcProviderManager {
         this.metricsCollector.recordLatency(
           this.config.chainName,
           providerType,
-          durationMs
+          durationMs,
+          operationType
         );
 
         return { success: true, result };
@@ -502,15 +558,17 @@ export class RpcProviderManager {
         this.metricsCollector.recordLatency(
           this.config.chainName,
           providerType,
-          durationMs
+          durationMs,
+          operationType
         );
 
         lastError = error instanceof Error ? error : new Error(String(error));
-        this.recordFailure(providerType);
+        this.recordFailure(providerType, operationType);
         this.metricsCollector.recordErrorType(
           this.config.chainName,
           providerType,
-          this.classifyError(error)
+          this.classifyError(error),
+          operationType
         );
 
         const delayMs = this.evaluateRetryAction(

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -16,7 +16,7 @@ export type RpcErrorType =
   | "connection"
   | "rpc_error";
 
-export type RpcOperationType = "read" | "write";
+export type RpcOperationType = "read" | "write" | "preflight";
 
 export type RpcMetricsCollector = {
   recordPrimaryAttempt(chainName: string, operation?: RpcOperationType): void;

--- a/lib/rpc-provider/solana.ts
+++ b/lib/rpc-provider/solana.ts
@@ -1,5 +1,9 @@
 import { type Commitment, Connection } from "@solana/web3.js";
-import { type RpcErrorType, RPC_CONNECTION_ERROR_PATTERNS } from "./index";
+import {
+  RPC_CONNECTION_ERROR_PATTERNS,
+  type RpcErrorType,
+  type RpcOperationType,
+} from "./index";
 
 /**
  * Solana RPC Provider Manager
@@ -9,23 +13,29 @@ import { type RpcErrorType, RPC_CONNECTION_ERROR_PATTERNS } from "./index";
  */
 
 export type SolanaRpcMetricsCollector = {
-  recordPrimaryAttempt(chainName: string): void;
-  recordPrimaryFailure(chainName: string): void;
-  recordFallbackAttempt(chainName: string): void;
-  recordFallbackFailure(chainName: string): void;
+  recordPrimaryAttempt(chainName: string, operation?: RpcOperationType): void;
+  recordPrimaryFailure(chainName: string, operation?: RpcOperationType): void;
+  recordFallbackAttempt(chainName: string, operation?: RpcOperationType): void;
+  recordFallbackFailure(chainName: string, operation?: RpcOperationType): void;
   recordFailoverEvent(chainName: string): void;
   recordRecoveryEvent(chainName: string): void;
   recordBothFailed(chainName: string): void;
-  recordSuccess(chainName: string, provider: "primary" | "fallback"): void;
+  recordSuccess(
+    chainName: string,
+    provider: "primary" | "fallback",
+    operation?: RpcOperationType
+  ): void;
   recordLatency(
     chainName: string,
     provider: "primary" | "fallback",
-    durationMs: number
+    durationMs: number,
+    operation?: RpcOperationType
   ): void;
   recordErrorType(
     chainName: string,
     provider: "primary" | "fallback",
-    errorType: RpcErrorType
+    errorType: RpcErrorType,
+    operation?: RpcOperationType
   ): void;
 };
 
@@ -36,16 +46,16 @@ export type SolanaFailoverStateChangeCallback = (
 ) => void;
 
 export const noopSolanaMetricsCollector: SolanaRpcMetricsCollector = {
-  recordPrimaryAttempt: () => {
+  recordPrimaryAttempt: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
-  recordPrimaryFailure: () => {
+  recordPrimaryFailure: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
-  recordFallbackAttempt: () => {
+  recordFallbackAttempt: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
-  recordFallbackFailure: () => {
+  recordFallbackFailure: (_chain: string, _operation?: RpcOperationType) => {
     /* noop */
   },
   recordFailoverEvent: () => {
@@ -57,41 +67,65 @@ export const noopSolanaMetricsCollector: SolanaRpcMetricsCollector = {
   recordBothFailed: () => {
     /* noop */
   },
-  recordSuccess: () => {
+  recordSuccess: (
+    _chain: string,
+    _provider: "primary" | "fallback",
+    _operation?: RpcOperationType
+  ) => {
     /* noop */
   },
-  recordLatency: () => {
+  recordLatency: (
+    _chain: string,
+    _provider: "primary" | "fallback",
+    _durationMs: number,
+    _operation?: RpcOperationType
+  ) => {
     /* noop */
   },
-  recordErrorType: () => {
+  recordErrorType: (
+    _chain: string,
+    _provider: "primary" | "fallback",
+    _errorType: RpcErrorType,
+    _operation?: RpcOperationType
+  ) => {
     /* noop */
   },
 };
 
 export const consoleSolanaMetricsCollector: SolanaRpcMetricsCollector = {
-  recordPrimaryAttempt: (chain) =>
-    console.debug(`[Solana RPC Metrics] Primary attempt: ${chain}`),
-  recordPrimaryFailure: (chain) =>
-    console.debug(`[Solana RPC Metrics] Primary failure: ${chain}`),
-  recordFallbackAttempt: (chain) =>
-    console.debug(`[Solana RPC Metrics] Fallback attempt: ${chain}`),
-  recordFallbackFailure: (chain) =>
-    console.debug(`[Solana RPC Metrics] Fallback failure: ${chain}`),
+  recordPrimaryAttempt: (chain, operation = "read") =>
+    console.debug(
+      `[Solana RPC Metrics] Primary attempt: ${chain} [${operation}]`
+    ),
+  recordPrimaryFailure: (chain, operation = "read") =>
+    console.debug(
+      `[Solana RPC Metrics] Primary failure: ${chain} [${operation}]`
+    ),
+  recordFallbackAttempt: (chain, operation = "read") =>
+    console.debug(
+      `[Solana RPC Metrics] Fallback attempt: ${chain} [${operation}]`
+    ),
+  recordFallbackFailure: (chain, operation = "read") =>
+    console.debug(
+      `[Solana RPC Metrics] Fallback failure: ${chain} [${operation}]`
+    ),
   recordFailoverEvent: (chain) =>
     console.debug(`[Solana RPC Metrics] Failover event: ${chain}`),
   recordRecoveryEvent: (chain) =>
     console.debug(`[Solana RPC Metrics] Recovery event: ${chain}`),
   recordBothFailed: (chain) =>
     console.debug(`[Solana RPC Metrics] Both endpoints failed: ${chain}`),
-  recordSuccess: (chain, provider) =>
-    console.debug(`[Solana RPC Metrics] Success on ${provider}: ${chain}`),
-  recordLatency: (chain, provider, durationMs) =>
+  recordSuccess: (chain, provider, operation = "read") =>
     console.debug(
-      `[Solana RPC Metrics] Latency ${provider} ${chain}: ${durationMs}ms`
+      `[Solana RPC Metrics] Success on ${provider}: ${chain} [${operation}]`
     ),
-  recordErrorType: (chain, provider, errorType) =>
+  recordLatency: (chain, provider, durationMs, operation = "read") =>
     console.debug(
-      `[Solana RPC Metrics] Error ${errorType} on ${provider}: ${chain}`
+      `[Solana RPC Metrics] Latency ${provider} ${chain}: ${durationMs}ms [${operation}]`
+    ),
+  recordErrorType: (chain, provider, errorType, operation = "read") =>
+    console.debug(
+      `[Solana RPC Metrics] Error ${errorType} on ${provider}: ${chain} [${operation}]`
     ),
 };
 
@@ -197,7 +231,8 @@ export class SolanaProviderManager {
   }
 
   async executeWithFailover<T>(
-    operation: (connection: Connection) => Promise<T>
+    operation: (connection: Connection) => Promise<T>,
+    operationType: RpcOperationType = "read"
   ): Promise<T> {
     this.metrics.totalRequests += 1;
 
@@ -209,13 +244,15 @@ export class SolanaProviderManager {
           fallbackConnection,
           operation,
           "fallback",
-          this.config.maxRetries
+          this.config.maxRetries,
+          operationType
         );
 
         if (fallbackResult.success) {
           this.metricsCollector.recordSuccess(
             this.config.chainName,
-            "fallback"
+            "fallback",
+            operationType
           );
           return fallbackResult.result as T;
         }
@@ -237,11 +274,16 @@ export class SolanaProviderManager {
       primaryConnection,
       operation,
       "primary",
-      this.config.maxRetries
+      this.config.maxRetries,
+      operationType
     );
 
     if (primaryResult.success) {
-      this.metricsCollector.recordSuccess(this.config.chainName, "primary");
+      this.metricsCollector.recordSuccess(
+        this.config.chainName,
+        "primary",
+        operationType
+      );
       if (this.isUsingFallback) {
         console.info(
           JSON.stringify({
@@ -270,11 +312,16 @@ export class SolanaProviderManager {
         fallbackConnection,
         operation,
         "fallback",
-        this.config.maxRetries
+        this.config.maxRetries,
+        operationType
       );
 
       if (fallbackResult.success) {
-        this.metricsCollector.recordSuccess(this.config.chainName, "fallback");
+        this.metricsCollector.recordSuccess(
+          this.config.chainName,
+          "fallback",
+          operationType
+        );
         if (!this.isUsingFallback) {
           console.warn(
             JSON.stringify({
@@ -342,7 +389,8 @@ export class SolanaProviderManager {
     connection: Connection,
     operation: (c: Connection) => Promise<T>,
     connectionType: "primary" | "fallback",
-    maxRetries: number
+    maxRetries: number,
+    operationType: RpcOperationType = "read"
   ): Promise<{ success: boolean; result?: T; error?: string }> {
     let lastError: Error | undefined;
 
@@ -351,10 +399,16 @@ export class SolanaProviderManager {
       try {
         if (connectionType === "primary") {
           this.metrics.primaryAttempts += 1;
-          this.metricsCollector.recordPrimaryAttempt(this.config.chainName);
+          this.metricsCollector.recordPrimaryAttempt(
+            this.config.chainName,
+            operationType
+          );
         } else {
           this.metrics.fallbackAttempts += 1;
-          this.metricsCollector.recordFallbackAttempt(this.config.chainName);
+          this.metricsCollector.recordFallbackAttempt(
+            this.config.chainName,
+            operationType
+          );
         }
 
         const result = await this.withTimeout(
@@ -366,7 +420,8 @@ export class SolanaProviderManager {
         this.metricsCollector.recordLatency(
           this.config.chainName,
           connectionType,
-          durationMs
+          durationMs,
+          operationType
         );
 
         return { success: true, result };
@@ -375,23 +430,31 @@ export class SolanaProviderManager {
         this.metricsCollector.recordLatency(
           this.config.chainName,
           connectionType,
-          durationMs
+          durationMs,
+          operationType
         );
 
         lastError = error instanceof Error ? error : new Error(String(error));
 
         if (connectionType === "primary") {
           this.metrics.primaryFailures += 1;
-          this.metricsCollector.recordPrimaryFailure(this.config.chainName);
+          this.metricsCollector.recordPrimaryFailure(
+            this.config.chainName,
+            operationType
+          );
         } else {
           this.metrics.fallbackFailures += 1;
-          this.metricsCollector.recordFallbackFailure(this.config.chainName);
+          this.metricsCollector.recordFallbackFailure(
+            this.config.chainName,
+            operationType
+          );
         }
 
         this.metricsCollector.recordErrorType(
           this.config.chainName,
           connectionType,
-          this.classifyError(error)
+          this.classifyError(error),
+          operationType
         );
 
         if (attempt === maxRetries - 1) {

--- a/lib/rpc-provider/with-rpc-metrics.ts
+++ b/lib/rpc-provider/with-rpc-metrics.ts
@@ -1,22 +1,29 @@
-import type { RpcMetricsCollector, RpcProviderManager } from "./index";
+import type {
+  RpcMetricsCollector,
+  RpcOperationType,
+  RpcProviderManager,
+} from "./index";
 import { classifyRpcError } from "./index";
 
 export type RpcMetricsContext = {
   metricsCollector: RpcMetricsCollector;
   chainName: string;
   providerType: "primary" | "fallback";
+  operationType: RpcOperationType;
 };
 
 /**
  * Build an RpcMetricsContext from an RpcProviderManager instance.
  */
 export function rpcMetricsCtx(
-  rpcManager: RpcProviderManager
+  rpcManager: RpcProviderManager,
+  operationType: RpcOperationType = "write"
 ): RpcMetricsContext {
   return {
     metricsCollector: rpcManager.getMetricsCollector(),
     chainName: rpcManager.getChainName(),
     providerType: rpcManager.getCurrentProviderType(),
+    operationType,
   };
 }
 
@@ -30,33 +37,44 @@ export async function withRpcMetrics<T>(
   ctx: RpcMetricsContext,
   operation: () => Promise<T>
 ): Promise<T> {
-  const { metricsCollector, chainName, providerType } = ctx;
+  const { metricsCollector, chainName, providerType, operationType } = ctx;
 
   if (providerType === "primary") {
-    metricsCollector.recordPrimaryAttempt(chainName);
+    metricsCollector.recordPrimaryAttempt(chainName, operationType);
   } else {
-    metricsCollector.recordFallbackAttempt(chainName);
+    metricsCollector.recordFallbackAttempt(chainName, operationType);
   }
 
   const startTime = performance.now();
   try {
     const result = await operation();
     const durationMs = performance.now() - startTime;
-    metricsCollector.recordLatency(chainName, providerType, durationMs);
-    metricsCollector.recordSuccess(chainName, providerType);
+    metricsCollector.recordLatency(
+      chainName,
+      providerType,
+      durationMs,
+      operationType
+    );
+    metricsCollector.recordSuccess(chainName, providerType, operationType);
     return result;
   } catch (error: unknown) {
     const durationMs = performance.now() - startTime;
-    metricsCollector.recordLatency(chainName, providerType, durationMs);
+    metricsCollector.recordLatency(
+      chainName,
+      providerType,
+      durationMs,
+      operationType
+    );
     if (providerType === "primary") {
-      metricsCollector.recordPrimaryFailure(chainName);
+      metricsCollector.recordPrimaryFailure(chainName, operationType);
     } else {
-      metricsCollector.recordFallbackFailure(chainName);
+      metricsCollector.recordFallbackFailure(chainName, operationType);
     }
     metricsCollector.recordErrorType(
       chainName,
       providerType,
-      classifyRpcError(error)
+      classifyRpcError(error),
+      operationType
     );
     throw error;
   }

--- a/lib/rpc-provider/with-rpc-metrics.ts
+++ b/lib/rpc-provider/with-rpc-metrics.ts
@@ -1,0 +1,63 @@
+import type { RpcMetricsCollector, RpcProviderManager } from "./index";
+import { classifyRpcError } from "./index";
+
+export type RpcMetricsContext = {
+  metricsCollector: RpcMetricsCollector;
+  chainName: string;
+  providerType: "primary" | "fallback";
+};
+
+/**
+ * Build an RpcMetricsContext from an RpcProviderManager instance.
+ */
+export function rpcMetricsCtx(
+  rpcManager: RpcProviderManager
+): RpcMetricsContext {
+  return {
+    metricsCollector: rpcManager.getMetricsCollector(),
+    chainName: rpcManager.getChainName(),
+    providerType: rpcManager.getCurrentProviderType(),
+  };
+}
+
+/**
+ * Wrap an RPC operation with metrics recording.
+ * Records attempt, latency, success/failure, and error type.
+ * Does NOT add failover or retries -- use executeWithFailover for that.
+ * Re-throws the original error on failure.
+ */
+export async function withRpcMetrics<T>(
+  ctx: RpcMetricsContext,
+  operation: () => Promise<T>
+): Promise<T> {
+  const { metricsCollector, chainName, providerType } = ctx;
+
+  if (providerType === "primary") {
+    metricsCollector.recordPrimaryAttempt(chainName);
+  } else {
+    metricsCollector.recordFallbackAttempt(chainName);
+  }
+
+  const startTime = performance.now();
+  try {
+    const result = await operation();
+    const durationMs = performance.now() - startTime;
+    metricsCollector.recordLatency(chainName, providerType, durationMs);
+    metricsCollector.recordSuccess(chainName, providerType);
+    return result;
+  } catch (error: unknown) {
+    const durationMs = performance.now() - startTime;
+    metricsCollector.recordLatency(chainName, providerType, durationMs);
+    if (providerType === "primary") {
+      metricsCollector.recordPrimaryFailure(chainName);
+    } else {
+      metricsCollector.recordFallbackFailure(chainName);
+    }
+    metricsCollector.recordErrorType(
+      chainName,
+      providerType,
+      classifyRpcError(error)
+    );
+    throw error;
+  }
+}

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -58,7 +58,7 @@ export class EvmChainAdapter implements ChainAdapter {
     if (options.rpcManager) {
       await options.rpcManager.executeWithFailover(
         (rpcProvider) => rpcProvider.call({ ...baseTx, from: walletAddress }),
-        "write"
+        "preflight"
       );
     } else {
       await provider.call({ ...baseTx, from: walletAddress });
@@ -70,7 +70,7 @@ export class EvmChainAdapter implements ChainAdapter {
       ? await options.rpcManager.executeWithFailover(
           (rpcProvider) =>
             rpcProvider.estimateGas({ ...baseTx, from: walletAddress }),
-          "write"
+          "preflight"
         )
       : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
@@ -137,7 +137,7 @@ export class EvmChainAdapter implements ChainAdapter {
           ...request.args,
           valueOverride
         );
-      }, "write");
+      }, "preflight");
     } else {
       await contract[request.functionKey].staticCall(
         ...request.args,
@@ -158,7 +158,7 @@ export class EvmChainAdapter implements ChainAdapter {
             ...request.args,
             valueOverride
           );
-        }, "write")
+        }, "preflight")
       : await contract[request.functionKey].estimateGas(
           ...request.args,
           valueOverride

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -56,8 +56,9 @@ export class EvmChainAdapter implements ChainAdapter {
     };
 
     if (options.rpcManager) {
-      await options.rpcManager.executeWithFailover((rpcProvider) =>
-        rpcProvider.call({ ...baseTx, from: walletAddress })
+      await options.rpcManager.executeWithFailover(
+        (rpcProvider) => rpcProvider.call({ ...baseTx, from: walletAddress }),
+        "write"
       );
     } else {
       await provider.call({ ...baseTx, from: walletAddress });
@@ -66,8 +67,10 @@ export class EvmChainAdapter implements ChainAdapter {
     const nonce = this.nonceManager.getNextNonce(session);
 
     const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover((rpcProvider) =>
-          rpcProvider.estimateGas({ ...baseTx, from: walletAddress })
+      ? await options.rpcManager.executeWithFailover(
+          (rpcProvider) =>
+            rpcProvider.estimateGas({ ...baseTx, from: walletAddress }),
+          "write"
         )
       : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
@@ -134,7 +137,7 @@ export class EvmChainAdapter implements ChainAdapter {
           ...request.args,
           valueOverride
         );
-      });
+      }, "write");
     } else {
       await contract[request.functionKey].staticCall(
         ...request.args,
@@ -155,7 +158,7 @@ export class EvmChainAdapter implements ChainAdapter {
             ...request.args,
             valueOverride
           );
-        })
+        }, "write")
       : await contract[request.functionKey].estimateGas(
           ...request.args,
           valueOverride
@@ -215,9 +218,10 @@ export class EvmChainAdapter implements ChainAdapter {
 
   async executeWithFailover<T>(
     rpcManager: RpcProviderManager,
-    operation: (provider: ethers.JsonRpcProvider) => Promise<T>
+    operation: (provider: ethers.JsonRpcProvider) => Promise<T>,
+    operationType?: "read" | "write"
   ): Promise<T> {
-    return await rpcManager.executeWithFailover(operation);
+    return await rpcManager.executeWithFailover(operation, operationType);
   }
 
   async getTransactionUrl(txHash: string): Promise<string> {

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -56,8 +56,8 @@ export class EvmChainAdapter implements ChainAdapter {
     };
 
     if (options.rpcManager) {
-      await options.rpcManager.executeWithFailover((p) =>
-        p.call({ ...baseTx, from: walletAddress })
+      await options.rpcManager.executeWithFailover((rpcProvider) =>
+        rpcProvider.call({ ...baseTx, from: walletAddress })
       );
     } else {
       await provider.call({ ...baseTx, from: walletAddress });
@@ -66,8 +66,8 @@ export class EvmChainAdapter implements ChainAdapter {
     const nonce = this.nonceManager.getNextNonce(session);
 
     const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover((p) =>
-          p.estimateGas({ ...baseTx, from: walletAddress })
+      ? await options.rpcManager.executeWithFailover((rpcProvider) =>
+          rpcProvider.estimateGas({ ...baseTx, from: walletAddress })
         )
       : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
@@ -124,11 +124,11 @@ export class EvmChainAdapter implements ChainAdapter {
     const valueOverride = request.value ? { value: request.value } : {};
 
     if (options.rpcManager) {
-      await options.rpcManager.executeWithFailover((p) => {
+      await options.rpcManager.executeWithFailover((rpcProvider) => {
         const readContract = new ethers.Contract(
           request.contractAddress,
           request.abi,
-          p
+          rpcProvider
         );
         return readContract[request.functionKey].staticCall(
           ...request.args,
@@ -145,11 +145,11 @@ export class EvmChainAdapter implements ChainAdapter {
     const nonce = this.nonceManager.getNextNonce(session);
 
     const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover((p) => {
+      ? await options.rpcManager.executeWithFailover((rpcProvider) => {
           const readContract = new ethers.Contract(
             request.contractAddress,
             request.abi,
-            p
+            rpcProvider
           );
           return readContract[request.functionKey].estimateGas(
             ...request.args,

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -55,14 +55,21 @@ export class EvmChainAdapter implements ChainAdapter {
       data: request.data,
     };
 
-    await provider.call({ ...baseTx, from: walletAddress });
+    if (options.rpcManager) {
+      await options.rpcManager.executeWithFailover((p) =>
+        p.call({ ...baseTx, from: walletAddress })
+      );
+    } else {
+      await provider.call({ ...baseTx, from: walletAddress });
+    }
 
     const nonce = this.nonceManager.getNextNonce(session);
 
-    const estimatedGas = await provider.estimateGas({
-      ...baseTx,
-      from: walletAddress,
-    });
+    const estimatedGas = options.rpcManager
+      ? await options.rpcManager.executeWithFailover((p) =>
+          p.estimateGas({ ...baseTx, from: walletAddress })
+        )
+      : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
     const gasConfig = await this.gasStrategy.getGasConfig(
       provider,
@@ -116,17 +123,43 @@ export class EvmChainAdapter implements ChainAdapter {
 
     const valueOverride = request.value ? { value: request.value } : {};
 
-    await contract[request.functionKey].staticCall(
-      ...request.args,
-      valueOverride
-    );
+    if (options.rpcManager) {
+      await options.rpcManager.executeWithFailover((p) => {
+        const readContract = new ethers.Contract(
+          request.contractAddress,
+          request.abi,
+          p
+        );
+        return readContract[request.functionKey].staticCall(
+          ...request.args,
+          valueOverride
+        );
+      });
+    } else {
+      await contract[request.functionKey].staticCall(
+        ...request.args,
+        valueOverride
+      );
+    }
 
     const nonce = this.nonceManager.getNextNonce(session);
 
-    const estimatedGas = await contract[request.functionKey].estimateGas(
-      ...request.args,
-      valueOverride
-    );
+    const estimatedGas = options.rpcManager
+      ? await options.rpcManager.executeWithFailover((p) => {
+          const readContract = new ethers.Contract(
+            request.contractAddress,
+            request.abi,
+            p
+          );
+          return readContract[request.functionKey].estimateGas(
+            ...request.args,
+            valueOverride
+          );
+        })
+      : await contract[request.functionKey].estimateGas(
+          ...request.args,
+          valueOverride
+        );
 
     const gasConfig = await this.gasStrategy.getGasConfig(
       provider,

--- a/lib/web3/chain-adapter/types.ts
+++ b/lib/web3/chain-adapter/types.ts
@@ -67,7 +67,8 @@ export interface ChainAdapter {
 
   executeWithFailover<T>(
     rpcManager: RpcProviderManager,
-    operation: (provider: ethers.JsonRpcProvider) => Promise<T>
+    operation: (provider: ethers.JsonRpcProvider) => Promise<T>,
+    operationType?: "read" | "write"
   ): Promise<T>;
 
   // ---- Explorer ----

--- a/lib/web3/chain-adapter/types.ts
+++ b/lib/web3/chain-adapter/types.ts
@@ -81,4 +81,5 @@ export type TransactionOptions = {
   triggerType: TriggerType;
   gasOverrides: GasOverrides;
   workflowId?: string;
+  rpcManager?: RpcProviderManager;
 };

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -305,8 +305,8 @@ export async function executeTransaction(
     }
 
     const estimatedGas = context.rpcManager
-      ? await context.rpcManager.executeWithFailover((p) =>
-          p.estimateGas({ ...baseTx, from: walletAddress })
+      ? await context.rpcManager.executeWithFailover((rpcProvider) =>
+          rpcProvider.estimateGas({ ...baseTx, from: walletAddress })
         )
       : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
@@ -387,8 +387,10 @@ export async function executeContractTransaction(
     }
 
     const estimatedGas = context.rpcManager
-      ? await context.rpcManager.executeWithFailover((p) =>
-          (contract.connect(p) as typeof contract)[method].estimateGas(...args)
+      ? await context.rpcManager.executeWithFailover((rpcProvider) =>
+          (contract.connect(rpcProvider) as typeof contract)[method].estimateGas(
+            ...args
+          )
         )
       : await contract[method].estimateGas(...args);
 

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -308,7 +308,7 @@ export async function executeTransaction(
       ? await context.rpcManager.executeWithFailover(
           (rpcProvider) =>
             rpcProvider.estimateGas({ ...baseTx, from: walletAddress }),
-          "write"
+          "preflight"
         )
       : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
@@ -394,7 +394,7 @@ export async function executeContractTransaction(
             (contract.connect(rpcProvider) as typeof contract)[
               method
             ].estimateGas(...args),
-          "write"
+          "preflight"
         )
       : await contract[method].estimateGas(...args);
 

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -27,6 +27,11 @@ import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { isNonRetryableError } from "@/lib/rpc-provider/error-classification";
 import {
+  withRpcMetrics,
+  rpcMetricsCtx,
+  type RpcMetricsContext,
+} from "@/lib/rpc-provider/with-rpc-metrics";
+import {
   type TriggerType as GasTriggerType,
   getGasStrategy,
 } from "./gas-strategy";
@@ -87,10 +92,13 @@ export async function submitAndConfirm(
   const { rpcManager, session, nonce, workflowId, chainId, maxFeePerGas } =
     options;
   const nonceManager = getNonceManager();
+  const primaryCtx = rpcMetricsCtx(rpcManager);
 
   let tx: ethers.TransactionResponse;
   try {
-    tx = await signer.sendTransaction(txRequest);
+    tx = await withRpcMetrics(primaryCtx, () =>
+      signer.sendTransaction(txRequest)
+    );
   } catch (primaryError) {
     if (isNonRetryableError(primaryError)) {
       throw primaryError;
@@ -100,6 +108,10 @@ export async function submitAndConfirm(
     if (!fallbackProvider) {
       throw primaryError;
     }
+
+    rpcManager.getMetricsCollector().recordFailoverEvent(
+      rpcManager.getChainName()
+    );
 
     console.warn(
       JSON.stringify({
@@ -115,8 +127,14 @@ export async function submitAndConfirm(
       })
     );
 
+    const fallbackCtx: RpcMetricsContext = {
+      ...primaryCtx,
+      providerType: "fallback",
+    };
     const reconnectedSigner = signer.connect(fallbackProvider) as typeof signer;
-    tx = await reconnectedSigner.sendTransaction(txRequest);
+    tx = await withRpcMetrics(fallbackCtx, () =>
+      reconnectedSigner.sendTransaction(txRequest)
+    );
   }
 
   return await confirmAndBuildResult(
@@ -149,10 +167,13 @@ export async function submitContractCallAndConfirm(
   const { rpcManager, session, nonce, workflowId, chainId, maxFeePerGas } =
     options;
   const nonceManager = getNonceManager();
+  const primaryCtx = rpcMetricsCtx(rpcManager);
 
   let tx: ethers.TransactionResponse;
   try {
-    tx = await contract[method](...args, overrides);
+    tx = await withRpcMetrics(primaryCtx, () =>
+      contract[method](...args, overrides)
+    );
   } catch (primaryError) {
     if (isNonRetryableError(primaryError)) {
       throw primaryError;
@@ -162,6 +183,10 @@ export async function submitContractCallAndConfirm(
     if (!fallbackProvider) {
       throw primaryError;
     }
+
+    rpcManager.getMetricsCollector().recordFailoverEvent(
+      rpcManager.getChainName()
+    );
 
     console.warn(
       JSON.stringify({
@@ -178,11 +203,17 @@ export async function submitContractCallAndConfirm(
       })
     );
 
+    const fallbackCtx: RpcMetricsContext = {
+      ...primaryCtx,
+      providerType: "fallback",
+    };
     const reconnectedSigner = signer.connect(fallbackProvider) as typeof signer;
     const reconnectedContract = contract.connect(
       reconnectedSigner
     ) as typeof contract;
-    tx = await reconnectedContract[method](...args, overrides);
+    tx = await withRpcMetrics(fallbackCtx, () =>
+      reconnectedContract[method](...args, overrides)
+    );
   }
 
   return await confirmAndBuildResult(
@@ -273,10 +304,11 @@ export async function executeTransaction(
       throw new Error("Signer has no provider");
     }
 
-    const estimatedGas = await provider.estimateGas({
-      ...baseTx,
-      from: walletAddress,
-    });
+    const estimatedGas = context.rpcManager
+      ? await context.rpcManager.executeWithFailover((p) =>
+          p.estimateGas({ ...baseTx, from: walletAddress })
+        )
+      : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider,
@@ -354,7 +386,11 @@ export async function executeContractTransaction(
       throw new Error("Contract has no provider");
     }
 
-    const estimatedGas = await contract[method].estimateGas(...args);
+    const estimatedGas = context.rpcManager
+      ? await context.rpcManager.executeWithFailover((p) =>
+          (contract.connect(p) as typeof contract)[method].estimateGas(...args)
+        )
+      : await contract[method].estimateGas(...args);
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider as ethers.Provider,

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -305,8 +305,10 @@ export async function executeTransaction(
     }
 
     const estimatedGas = context.rpcManager
-      ? await context.rpcManager.executeWithFailover((rpcProvider) =>
-          rpcProvider.estimateGas({ ...baseTx, from: walletAddress })
+      ? await context.rpcManager.executeWithFailover(
+          (rpcProvider) =>
+            rpcProvider.estimateGas({ ...baseTx, from: walletAddress }),
+          "write"
         )
       : await provider.estimateGas({ ...baseTx, from: walletAddress });
 
@@ -387,10 +389,12 @@ export async function executeContractTransaction(
     }
 
     const estimatedGas = context.rpcManager
-      ? await context.rpcManager.executeWithFailover((rpcProvider) =>
-          (contract.connect(rpcProvider) as typeof contract)[
-            method
-          ].estimateGas(...args)
+      ? await context.rpcManager.executeWithFailover(
+          (rpcProvider) =>
+            (contract.connect(rpcProvider) as typeof contract)[
+              method
+            ].estimateGas(...args),
+          "write"
         )
       : await contract[method].estimateGas(...args);
 
@@ -490,7 +494,8 @@ export async function getCurrentNonce(
   rpcUrl: string
 ): Promise<number> {
   const rpcManager = await getRpcProviderFromUrls(rpcUrl);
-  return await rpcManager.executeWithFailover((provider) =>
-    provider.getTransactionCount(walletAddress, "pending")
+  return await rpcManager.executeWithFailover(
+    (provider) => provider.getTransactionCount(walletAddress, "pending"),
+    "write"
   );
 }

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -27,9 +27,9 @@ import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { isNonRetryableError } from "@/lib/rpc-provider/error-classification";
 import {
-  withRpcMetrics,
-  rpcMetricsCtx,
   type RpcMetricsContext,
+  rpcMetricsCtx,
+  withRpcMetrics,
 } from "@/lib/rpc-provider/with-rpc-metrics";
 import {
   type TriggerType as GasTriggerType,
@@ -109,9 +109,9 @@ export async function submitAndConfirm(
       throw primaryError;
     }
 
-    rpcManager.getMetricsCollector().recordFailoverEvent(
-      rpcManager.getChainName()
-    );
+    rpcManager
+      .getMetricsCollector()
+      .recordFailoverEvent(rpcManager.getChainName());
 
     console.warn(
       JSON.stringify({
@@ -184,9 +184,9 @@ export async function submitContractCallAndConfirm(
       throw primaryError;
     }
 
-    rpcManager.getMetricsCollector().recordFailoverEvent(
-      rpcManager.getChainName()
-    );
+    rpcManager
+      .getMetricsCollector()
+      .recordFailoverEvent(rpcManager.getChainName());
 
     console.warn(
       JSON.stringify({
@@ -388,9 +388,9 @@ export async function executeContractTransaction(
 
     const estimatedGas = context.rpcManager
       ? await context.rpcManager.executeWithFailover((rpcProvider) =>
-          (contract.connect(rpcProvider) as typeof contract)[method].estimateGas(
-            ...args
-          )
+          (contract.connect(rpcProvider) as typeof contract)[
+            method
+          ].estimateGas(...args)
         )
       : await contract[method].estimateGas(...args);
 

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -198,12 +198,15 @@ export async function approveTokenCore(
   // Try gas-sponsored execution first (ERC-4337 via Pimlico)
   if (isSponsorshipSupported(chainId)) {
     try {
-      const signer = await initializeWalletSigner(organizationId, rpcUrl);
-      const readContract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
-      const [decimals, symbol] = await Promise.all([
-        readContract.decimals() as Promise<bigint>,
-        readContract.symbol() as Promise<string>,
-      ]);
+      const [decimals, symbol] = await rpcManager.executeWithFailover(
+        (p) => {
+          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          return Promise.all([
+            c.decimals() as Promise<bigint>,
+            c.symbol() as Promise<string>,
+          ]);
+        }
+      );
 
       let amountRaw: bigint;
       let approvedAmountDisplay: string;
@@ -287,15 +290,20 @@ export async function approveTokenCore(
       };
     }
 
-    // Create contract instance for pre-flight checks (decimals, symbol)
+    // Keep contract instance for error formatting in catch block
     const contract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
 
     try {
-      // Get token decimals and symbol
-      const [decimals, symbol] = await Promise.all([
-        contract.decimals() as Promise<bigint>,
-        contract.symbol() as Promise<string>,
-      ]);
+      // Get token decimals and symbol via failover
+      const [decimals, symbol] = await rpcManager.executeWithFailover(
+        (p) => {
+          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          return Promise.all([
+            c.decimals() as Promise<bigint>,
+            c.symbol() as Promise<string>,
+          ]);
+        }
+      );
 
       const decimalsNum = Number(decimals);
 
@@ -326,6 +334,7 @@ export async function approveTokenCore(
         triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
+        rpcManager,
       });
 
       const gasUsedUnits = receipt.gasUsed.toString();

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -200,10 +200,10 @@ export async function approveTokenCore(
     try {
       const [decimals, symbol] = await rpcManager.executeWithFailover(
         (p) => {
-          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          const tokenContract = new ethers.Contract(tokenAddress, ERC20_ABI, p);
           return Promise.all([
-            c.decimals() as Promise<bigint>,
-            c.symbol() as Promise<string>,
+            tokenContract.decimals() as Promise<bigint>,
+            tokenContract.symbol() as Promise<string>,
           ]);
         }
       );
@@ -297,10 +297,10 @@ export async function approveTokenCore(
       // Get token decimals and symbol via failover
       const [decimals, symbol] = await rpcManager.executeWithFailover(
         (p) => {
-          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          const tokenContract = new ethers.Contract(tokenAddress, ERC20_ABI, p);
           return Promise.all([
-            c.decimals() as Promise<bigint>,
-            c.symbol() as Promise<string>,
+            tokenContract.decimals() as Promise<bigint>,
+            tokenContract.symbol() as Promise<string>,
           ]);
         }
       );

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -243,6 +243,7 @@ export async function transferFundsCore(
         triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
+        rpcManager,
       });
 
       const gasUsedUnits = receipt.gasUsed.toString();

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -306,12 +306,15 @@ export async function transferTokenCore(
   // Try gas-sponsored execution first (ERC-4337 via Pimlico)
   if (isSponsorshipSupported(chainId)) {
     try {
-      const signer = await initializeWalletSigner(organizationId, rpcUrl);
-      const readContract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
-      const [decimals, symbol] = await Promise.all([
-        readContract.decimals() as Promise<bigint>,
-        readContract.symbol() as Promise<string>,
-      ]);
+      const [decimals, symbol] = await rpcManager.executeWithFailover(
+        (p) => {
+          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          return Promise.all([
+            c.decimals() as Promise<bigint>,
+            c.symbol() as Promise<string>,
+          ]);
+        }
+      );
       const amountRaw = ethers.parseUnits(amount, Number(decimals));
 
       const sponsoredResult = await executeSponsoredContractTransaction({
@@ -388,15 +391,20 @@ export async function transferTokenCore(
       };
     }
 
-    // Create contract instance for pre-flight checks (decimals, symbol, balance)
+    // Create contract instance for the actual write (needs signer)
     const contract = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
 
     try {
-      // Get token decimals and symbol
-      const [decimals, symbol] = await Promise.all([
-        contract.decimals() as Promise<bigint>,
-        contract.symbol() as Promise<string>,
-      ]);
+      // Get token decimals, symbol, and balance via failover
+      const [decimals, symbol, balance] =
+        await rpcManager.executeWithFailover((p) => {
+          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          return Promise.all([
+            c.decimals() as Promise<bigint>,
+            c.symbol() as Promise<string>,
+            c.balanceOf(signerAddress) as Promise<bigint>,
+          ]);
+        });
 
       const decimalsNum = Number(decimals);
 
@@ -412,7 +420,6 @@ export async function transferTokenCore(
       }
 
       // Check balance before transfer
-      const balance = (await contract.balanceOf(signerAddress)) as bigint;
       if (balance < amountRaw) {
         const balanceFormatted = ethers.formatUnits(balance, decimalsNum);
         return {
@@ -430,6 +437,7 @@ export async function transferTokenCore(
         triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
+        rpcManager,
       });
 
       const gasUsedUnits = receipt.gasUsed.toString();

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -308,10 +308,10 @@ export async function transferTokenCore(
     try {
       const [decimals, symbol] = await rpcManager.executeWithFailover(
         (p) => {
-          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          const tokenContract = new ethers.Contract(tokenAddress, ERC20_ABI, p);
           return Promise.all([
-            c.decimals() as Promise<bigint>,
-            c.symbol() as Promise<string>,
+            tokenContract.decimals() as Promise<bigint>,
+            tokenContract.symbol() as Promise<string>,
           ]);
         }
       );
@@ -398,11 +398,11 @@ export async function transferTokenCore(
       // Get token decimals, symbol, and balance via failover
       const [decimals, symbol, balance] =
         await rpcManager.executeWithFailover((p) => {
-          const c = new ethers.Contract(tokenAddress, ERC20_ABI, p);
+          const tokenContract = new ethers.Contract(tokenAddress, ERC20_ABI, p);
           return Promise.all([
-            c.decimals() as Promise<bigint>,
-            c.symbol() as Promise<string>,
-            c.balanceOf(signerAddress) as Promise<bigint>,
+            tokenContract.decimals() as Promise<bigint>,
+            tokenContract.symbol() as Promise<string>,
+            tokenContract.balanceOf(signerAddress) as Promise<bigint>,
           ]);
         });
 

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -356,6 +356,7 @@ export async function writeContractCore(
         triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
+        rpcManager,
       });
 
       const gasUsedUnits = receipt.gasUsed.toString();

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -225,6 +225,10 @@ function setupMocks(): void {
   mockGetChainIdFromNetwork.mockReturnValue(1);
   mockGetRpcProvider.mockResolvedValue({
     resolveActiveRpcUrl: () => Promise.resolve("https://rpc.example.com"),
+    executeWithFailover: (fn: (p: unknown) => unknown) =>
+      fn({
+        // biome-ignore lint/suspicious/noExplicitAny: test mock for ethers Contract constructor
+      } as any),
   });
   mockResolveOrgContext.mockResolvedValue({
     success: true,

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -172,7 +172,8 @@ describe("RpcProviderManager", () => {
       expect(result).toBe("success");
       expect(mockOperation).toHaveBeenCalledTimes(1);
       expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledWith(
-        "Ethereum"
+        "Ethereum",
+        "read"
       );
       expect(manager.getMetrics().totalRequests).toBe(1);
       expect(manager.getMetrics().primaryAttempts).toBe(1);
@@ -808,12 +809,12 @@ describe("consoleMetricsCollector", () => {
 
     consoleMetricsCollector.recordPrimaryAttempt("Ethereum");
     expect(debugSpy).toHaveBeenCalledWith(
-      "[RPC Metrics] Primary attempt: Ethereum"
+      "[RPC Metrics] Primary attempt: Ethereum [read]"
     );
 
     consoleMetricsCollector.recordPrimaryFailure("Ethereum");
     expect(debugSpy).toHaveBeenCalledWith(
-      "[RPC Metrics] Primary failure: Ethereum"
+      "[RPC Metrics] Primary failure: Ethereum [read]"
     );
 
     debugSpy.mockRestore();

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -116,7 +116,8 @@ describe("SolanaProviderManager", () => {
       expect(result).toBe(12_345);
       expect(mockOperation).toHaveBeenCalledTimes(1);
       expect(metricsCollector.recordPrimaryAttempt).toHaveBeenCalledWith(
-        "Solana"
+        "Solana",
+        "read"
       );
       expect(manager.getMetrics().totalRequests).toBe(1);
       expect(manager.getMetrics().primaryAttempts).toBe(1);
@@ -458,12 +459,12 @@ describe("consoleSolanaMetricsCollector", () => {
 
     consoleSolanaMetricsCollector.recordPrimaryAttempt("Solana");
     expect(debugSpy).toHaveBeenCalledWith(
-      "[Solana RPC Metrics] Primary attempt: Solana"
+      "[Solana RPC Metrics] Primary attempt: Solana [read]"
     );
 
     consoleSolanaMetricsCollector.recordPrimaryFailure("Solana");
     expect(debugSpy).toHaveBeenCalledWith(
-      "[Solana RPC Metrics] Primary failure: Solana"
+      "[Solana RPC Metrics] Primary failure: Solana [read]"
     );
 
     debugSpy.mockRestore();

--- a/tests/unit/write-failover.test.ts
+++ b/tests/unit/write-failover.test.ts
@@ -111,6 +111,19 @@ function makeOptions(
     rpcManager: {
       getFallbackProvider: vi.fn().mockReturnValue(null),
       getChainName: vi.fn().mockReturnValue("ethereum"),
+      getCurrentProviderType: vi.fn().mockReturnValue("primary"),
+      getMetricsCollector: vi.fn().mockReturnValue({
+        recordPrimaryAttempt: vi.fn(),
+        recordPrimaryFailure: vi.fn(),
+        recordFallbackAttempt: vi.fn(),
+        recordFallbackFailure: vi.fn(),
+        recordFailoverEvent: vi.fn(),
+        recordRecoveryEvent: vi.fn(),
+        recordBothFailed: vi.fn(),
+        recordSuccess: vi.fn(),
+        recordLatency: vi.fn(),
+        recordErrorType: vi.fn(),
+      }),
     } as unknown as SubmitAndConfirmOptions["rpcManager"],
     session: makeSession(),
     nonce: 42,
@@ -190,6 +203,19 @@ describe("submitAndConfirm", () => {
     const rpcManager = {
       getFallbackProvider: vi.fn().mockReturnValue(fallbackProvider),
       getChainName: vi.fn().mockReturnValue("ethereum"),
+      getCurrentProviderType: vi.fn().mockReturnValue("primary"),
+      getMetricsCollector: vi.fn().mockReturnValue({
+        recordPrimaryAttempt: vi.fn(),
+        recordPrimaryFailure: vi.fn(),
+        recordFallbackAttempt: vi.fn(),
+        recordFallbackFailure: vi.fn(),
+        recordFailoverEvent: vi.fn(),
+        recordRecoveryEvent: vi.fn(),
+        recordBothFailed: vi.fn(),
+        recordSuccess: vi.fn(),
+        recordLatency: vi.fn(),
+        recordErrorType: vi.fn(),
+      }),
     };
 
     const result = await submitAndConfirm(
@@ -274,6 +300,19 @@ describe("submitContractCallAndConfirm", () => {
     const rpcManager = {
       getFallbackProvider: vi.fn().mockReturnValue(fallbackProvider),
       getChainName: vi.fn().mockReturnValue("ethereum"),
+      getCurrentProviderType: vi.fn().mockReturnValue("primary"),
+      getMetricsCollector: vi.fn().mockReturnValue({
+        recordPrimaryAttempt: vi.fn(),
+        recordPrimaryFailure: vi.fn(),
+        recordFallbackAttempt: vi.fn(),
+        recordFallbackFailure: vi.fn(),
+        recordFailoverEvent: vi.fn(),
+        recordRecoveryEvent: vi.fn(),
+        recordBothFailed: vi.fn(),
+        recordSuccess: vi.fn(),
+        recordLatency: vi.fn(),
+        recordErrorType: vi.fn(),
+      }),
     };
 
     const result = await submitContractCallAndConfirm(


### PR DESCRIPTION
## Summary

Write transaction pre-flight operations (static calls, gas estimation, ERC20 reads) previously went through the signer's raw provider with no failover, no retries, and no metrics. If the primary RPC failed during gas estimation, the entire transaction failed immediately with no recovery.

This PR routes all pre-flight operations through `rpcManager.executeWithFailover()`, which provides retries with exponential backoff, automatic failover to the fallback RPC, and full Prometheus metrics (latency, error types, attempt counts).

## What changed

**Core infrastructure:**
- `lib/rpc-provider/index.ts` - Export `classifyRpcError()` as standalone function (extracted from private method), add `getMetricsCollector()` public getter
- `lib/rpc-provider/with-rpc-metrics.ts` - New utility for wrapping signer send operations with metrics recording (used by submitAndConfirm failover)
- `lib/web3/chain-adapter/types.ts` - Add optional `rpcManager` to `TransactionOptions`

**Pre-flight failover (read-only operations now use executeWithFailover):**
- `lib/web3/chain-adapter/evm.ts` - `sendTransaction()`: provider.call + estimateGas; `executeContractCall()`: staticCall + estimateGas
- `lib/web3/transaction-manager.ts` - Legacy `executeTransaction` + `executeContractTransaction` gas estimation
- `plugins/web3/steps/transfer-token-core.ts` - ERC20 decimals/symbol/balanceOf reads (both sponsored and direct paths)
- `plugins/web3/steps/approve-token-core.ts` - ERC20 decimals/symbol reads (both sponsored and direct paths)

**Send metrics (signer operations now have Prometheus instrumentation):**
- `lib/web3/transaction-manager.ts` - `submitAndConfirm` and `submitContractCallAndConfirm` record attempt/latency/failure/failover metrics for both primary and fallback sends

**rpcManager threaded through write steps:**
- `plugins/web3/steps/write-contract-core.ts`
- `plugins/web3/steps/transfer-funds-core.ts`
- `plugins/web3/steps/transfer-token-core.ts`
- `plugins/web3/steps/approve-token-core.ts`

## Before vs After

| Operation | Before | After |
|---|---|---|
| Static call (simulation) | No failover, no metrics | Failover + retries + metrics |
| Gas estimation | No failover, no metrics | Failover + retries + metrics |
| ERC20 reads (decimals, symbol, balanceOf) | No failover, no metrics | Failover + retries + metrics |
| sendTransaction | Manual failover, no metrics | Manual failover + metrics |
| contract method call (write) | Manual failover, no metrics | Manual failover + metrics |

## Not changed (by design)

- `tx.wait()` - receipt polling latency is chain-level, not RPC health
- `gasStrategy.getGasConfig()` internals - deeper refactor needed (follow-up)
- All changes are backward-compatible: `rpcManager` is optional, falls back to direct provider calls when absent

## Verification

- 2122 unit tests pass
- No lint errors