### PR TITLE
fix: cast user IDs in cleanup endpoint for UUID FK compatibility

### DIFF
--- a/app/api/admin/test/cleanup/route.ts
+++ b/app/api/admin/test/cleanup/route.ts
@@ -103,7 +103,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       await tx.execute(sql`
         DELETE FROM workflow_execution_logs
         WHERE execution_id IN (
-          SELECT id FROM workflow_executions WHERE user_id = ANY(${userIds})
+          SELECT id FROM workflow_executions WHERE user_id::text = ANY(${userIds}::text[])
         )
       `);
 
@@ -130,7 +130,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         }
         await tx.execute(sql`
           DELETE FROM ${sql.identifier(row.table_name)}
-          WHERE ${sql.identifier(row.column_name)} = ANY(${userIds})
+          WHERE ${sql.identifier(row.column_name)}::text = ANY(${userIds}::text[])
         `);
       }
 

--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -73,6 +73,9 @@ env:
   HEALTH_PORT:
     type: kv
     value: "3080"
+  JOB_TTL_SECONDS:
+    type: kv
+    value: "300"
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -73,6 +73,9 @@ env:
   HEALTH_PORT:
     type: kv
     value: "3080"
+  JOB_TTL_SECONDS:
+    type: kv
+    value: "120"
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"


### PR DESCRIPTION
## Summary

- Fixes `42809` PostgreSQL error in `/api/admin/test/cleanup` when FK columns use UUID type but user IDs are text — casts both sides of `= ANY()` comparisons to `text`
- Sets explicit `JOB_TTL_SECONDS` on the workflow executor to auto-cleanup completed K8s Jobs (120s staging, 300s prod). Without this, completed Jobs lingered with the 1h code default, causing Karpenter to keep 18 nodes alive on staging for 60+ idle pods

## Test plan

- [x] Reproduced `42809` error on staging (`app-staging.keeperhub.com`)
- [ ] Verify cleanup works after deploy
- [ ] After deploy to staging, confirm workflow runner pods are cleaned up within ~2 minutes of completion