### PR TITLE
fix: replace ethers JsonRpcProvider with raw fetch in RPC health probe

### DIFF
--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -12,7 +12,6 @@
 import "server-only";
 
 import { Connection } from "@solana/web3.js";
-import { ethers } from "ethers";
 import { classifyRpcError } from "@/lib/rpc-provider";
 import { rpcProbeMetrics } from "./collectors/prometheus";
 import type { ProbeChainConfig } from "./db-metrics";
@@ -60,7 +59,8 @@ async function runProbeAllChains(): Promise<void> {
   try {
     const { getEnabledChainConfigsForProbe } = await import("./db-metrics");
     chainConfigs = await getEnabledChainConfigsForProbe();
-  } catch {
+  } catch (error: unknown) {
+    console.error("RPC health probe: failed to load chain configs", error);
     return;
   }
 
@@ -118,13 +118,25 @@ async function probeEndpoint(target: ProbeTarget): Promise<void> {
 }
 
 async function probeEvm(url: string): Promise<void> {
-  const provider = new ethers.JsonRpcProvider(url, ethers.Network.from(1), {
-    staticNetwork: true,
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_blockNumber",
+      params: [],
+      id: 1,
+    }),
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
   });
-  try {
-    await withTimeout(provider.getBlockNumber(), PROBE_TIMEOUT_MS);
-  } finally {
-    provider.destroy();
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data: { error?: { message?: string } } = await response.json();
+  if (data.error) {
+    throw new Error(data.error.message ?? "RPC error");
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace ethers `JsonRpcProvider` with raw `fetch` in the RPC health probe to eliminate persistent "failed to detect network" log spam in production
- Use direct `eth_blockNumber` JSON-RPC call with `AbortSignal.timeout` for cleaner, dependency-free health probing
- Log chain config DB query failures instead of silently swallowing them