### PR TITLE
fix: suppress ethers network detection and reduce probe timeout

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -121,7 +121,7 @@ env:
     value: "30000"
   RPC_PROBE_TIMEOUT_MS:
     type: kv
-    value: "15000"
+    value: "5000"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -121,7 +121,7 @@ env:
     value: "30000"
   RPC_PROBE_TIMEOUT_MS:
     type: kv
-    value: "15000"
+    value: "5000"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps --trace-warnings --trace-uncaught --trace-exit"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -140,7 +140,7 @@ env:
     value: "30000"
   RPC_PROBE_TIMEOUT_MS:
     type: kv
-    value: "15000"
+    value: "5000"
   NODE_OPTIONS:
     type: kv
     value: "--enable-source-maps --trace-warnings --trace-uncaught --trace-exit"

--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -21,7 +21,7 @@ function noop(): void {
 }
 
 const PROBE_INTERVAL_MS = Number(process.env.RPC_PROBE_INTERVAL_MS) || 30_000;
-const PROBE_TIMEOUT_MS = Number(process.env.RPC_PROBE_TIMEOUT_MS) || 15_000;
+const PROBE_TIMEOUT_MS = Number(process.env.RPC_PROBE_TIMEOUT_MS) || 5_000;
 
 type ProbeTarget = {
   chain: string;

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -243,8 +243,9 @@ export class RpcProviderManager {
     const fetchRequest = new ethers.FetchRequest(url);
     fetchRequest.timeout = 5000;
 
-    const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
+    const provider = new ethers.JsonRpcProvider(fetchRequest, "any", {
       cacheTimeout: -1,
+      staticNetwork: true,
       // Disable JSON-RPC batching: ethers v6 batches concurrent calls into one
       // HTTP request by default. When the RPC proxy returns an incomplete batch
       // response, ethers throws BAD_DATA "missing response for request". Sending

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -245,7 +245,6 @@ export class RpcProviderManager {
 
     const provider = new ethers.JsonRpcProvider(fetchRequest, "any", {
       cacheTimeout: -1,
-      staticNetwork: true,
       // Disable JSON-RPC batching: ethers v6 batches concurrent calls into one
       // HTTP request by default. When the RPC proxy returns an incomplete batch
       // response, ethers throws BAD_DATA "missing response for request". Sending

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -177,6 +177,7 @@ export type RpcProviderConfig = {
   maxRetries?: number;
   timeoutMs?: number;
   chainName?: string;
+  chainId?: number;
 };
 
 export type RpcProviderMetrics = {
@@ -225,6 +226,7 @@ export class RpcProviderManager {
       maxRetries: config.maxRetries ?? RpcProviderManager.DEFAULT_MAX_RETRIES,
       timeoutMs: config.timeoutMs ?? RpcProviderManager.DEFAULT_TIMEOUT_MS,
       chainName: config.chainName ?? "unknown",
+      chainId: config.chainId ?? 1,
     };
 
     this.metricsCollector = metricsCollector;
@@ -243,8 +245,9 @@ export class RpcProviderManager {
     const fetchRequest = new ethers.FetchRequest(url);
     fetchRequest.timeout = 5000;
 
-    const provider = new ethers.JsonRpcProvider(fetchRequest, "any", {
+    const provider = new ethers.JsonRpcProvider(fetchRequest, ethers.Network.from(this.config.chainId), {
       cacheTimeout: -1,
+      staticNetwork: true,
       // Disable JSON-RPC batching: ethers v6 batches concurrent calls into one
       // HTTP request by default. When the RPC proxy returns an incomplete batch
       // response, ethers throws BAD_DATA "missing response for request". Sending
@@ -670,6 +673,7 @@ export type CreateRpcProviderManagerOptions = {
   maxRetries?: number;
   timeoutMs?: number;
   chainName?: string;
+  chainId?: number;
   metricsCollector?: RpcMetricsCollector;
   onFailoverStateChange?: FailoverStateChangeCallback;
 };
@@ -688,6 +692,7 @@ export function createRpcProviderManager(
         maxRetries: options.maxRetries,
         timeoutMs: options.timeoutMs,
         chainName: options.chainName,
+        chainId: options.chainId,
       },
       metricsCollector: options.metricsCollector,
       onFailoverStateChange: options.onFailoverStateChange,

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -139,6 +139,7 @@ export async function getRpcProvider(
     primaryRpcUrl: config.primaryRpcUrl,
     fallbackRpcUrl: config.fallbackRpcUrl,
     chainName: config.chainName,
+    chainId,
     metricsCollector,
     onFailoverStateChange: (chain, isUsingFallback, reason) => {
       try {

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -37,6 +37,7 @@ vi.mock("ethers", () => {
     ethers: {
       JsonRpcProvider: MockJsonRpcProvider,
       FetchRequest: MockFetchRequest,
+      Network: { from: (_chainId: number) => ({}) },
     },
     isError: (error: unknown, code: string): boolean =>
       typeof error === "object" &&


### PR DESCRIPTION
## Summary

- Replace ethers JsonRpcProvider with raw fetch in the RPC health probe to eliminate "failed to detect network" log spam
- Use eth_blockNumber JSON-RPC call with AbortSignal.timeout for dependency-free health probing
- Pass real chainId through RpcProviderConfig and use Network.from(chainId) with staticNetwork: true in RpcProviderManager to skip ethers network auto-detection per chain
- Reduce probe timeout from 15s to 5s in code default and all deploy values (staging, prod, PR environments)
- Log chain config DB query failures instead of silently swallowing them