### PR TITLE
chore: add 3-day minimum release age to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,6 @@
+# Reject packages published less than 3 days ago to mitigate supply chain attacks
+minimum-release-age=3d
+
 # Force-hoist the full transitive dependency tree of @workflow/world-postgres.
 # Next.js standalone output tracing cannot follow the dynamic
 # require(process.env.WORKFLOW_TARGET_WORLD) in the workflow SDK.


### PR DESCRIPTION
## Summary

- Adds `minimum-release-age=3d` to `.npmrc`, which tells pnpm to reject any package version published less than 3 days ago
- Provides a quarantine window against supply chain attacks - compromised publishes get caught before reaching CI/prod

## Test plan

- [ ] Verify `pnpm install` still succeeds (all current deps are older than 3 days)
- [ ] Confirm CI passes