### PR TITLE
chore: add explicit dependabot config for sub-services

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,42 @@ updates:
     labels:
       - "dependencies"
 
+  - package-ecosystem: "npm"
+    directory: "/keeperhub-events"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "staging"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/keeperhub-scheduler"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "staging"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 version: 2
+# Sub-services with their own lockfiles need explicit entries.
+# keeperhub-executor has no lockfile (part of root workspace) so "/" covers it.
 updates:
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Summary

- Adds dedicated dependabot entries for `/keeperhub-events` and `/keeperhub-scheduler` which have their own pnpm lockfiles
- Previously only `directory: "/"` was configured, relying on implicit auto-discovery which is not guaranteed
- `keeperhub-executor` is excluded as it has no lockfile (part of root workspace)
- All entries share the same policy: weekly on Monday, minor/patch only, grouped PRs

## Test plan

- [ ] Verify dependabot picks up the new directories (check Security > Dependabot tab after merge)