### PR TITLE
fix: remove duplicate statements from migration 0046

### DIFF
--- a/drizzle/0046_first_phalanx.sql
+++ b/drizzle/0046_first_phalanx.sql
@@ -1,16 +1,2 @@
-CREATE TABLE "workflow_ratings" (
-	"id" text PRIMARY KEY NOT NULL,
-	"workflow_id" text NOT NULL,
-	"user_id" text NOT NULL,
-	"rating" integer NOT NULL,
-	"created_at" timestamp DEFAULT now() NOT NULL,
-	"updated_at" timestamp DEFAULT now() NOT NULL,
-	CONSTRAINT "uq_workflow_ratings_workflow_user" UNIQUE("workflow_id","user_id")
-);
---> statement-breakpoint
 DROP INDEX "idx_workflows_org_slug";--> statement-breakpoint
-ALTER TABLE "workflows" ADD COLUMN "source_workflow_id" text;--> statement-breakpoint
-ALTER TABLE "workflow_ratings" ADD CONSTRAINT "workflow_ratings_workflow_id_workflows_id_fk" FOREIGN KEY ("workflow_id") REFERENCES "public"."workflows"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "workflow_ratings" ADD CONSTRAINT "workflow_ratings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "idx_workflow_ratings_workflow" ON "workflow_ratings" USING btree ("workflow_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "idx_workflows_listed_slug" ON "workflows" USING btree ("listed_slug") WHERE "workflows"."listed_slug" is not null;

--- a/drizzle/meta/0046_snapshot.json
+++ b/drizzle/meta/0046_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "43ae9c0b-df70-4f45-b76a-e219941f016f",
+  "id": "938bd798-ff45-46dc-b530-ed2525c04666",
   "prevId": "f771846d-359a-4fdd-9c81-4a4a90abbb47",
   "version": "7",
   "dialect": "postgresql",

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -327,7 +327,7 @@
     {
       "idx": 46,
       "version": "7",
-      "when": 1775800029485,
+      "when": 1775806152381,
       "tag": "0046_first_phalanx",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

- Migration 0041 already creates the `workflow_ratings` table, both FK constraints, the index, and `source_workflow_id` column
- Migration 0046 (introduced in #807) duplicated all of these statements, causing `drizzle-kit migrate` to fail with `relation "workflow_ratings" already exists`
- This broke the ephemeral DB setup in CI e2e tests
- Fix: strip the duplicate statements, keeping only the two genuinely new operations (drop old per-org slug index, create new global unique slug index)

## Test plan

- [x] CI ephemeral e2e tests pass (the failing check from #808)
- [x] `pnpm db:migrate` succeeds on a fresh database