### PR TITLE
chore: group github-actions dependabot updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,5 +61,9 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "staging"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

- Adds grouping config to the github-actions dependabot ecosystem entry so all action updates are bundled into a single PR instead of one per dependency

## Test plan

- [ ] Verify next monthly dependabot run produces a single grouped PR for github-actions updates