### PR TITLE
feat(executor): add monitoring exclusion for workflow runner pods

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -76,6 +76,9 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
+  WORKFLOW_RUNNER_COLLECT_MONITORING:
+    type: kv
+    value: "true"
   PARA_API_KEY:
     type: parameterStore
     name: para-api-key

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -76,6 +76,9 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
+  WORKFLOW_RUNNER_COLLECT_MONITORING:
+    type: kv
+    value: "false"
   PARA_API_KEY:
     type: parameterStore
     name: para-api-key

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -32,6 +32,9 @@ export const CONFIG = {
   chainRpcConfig: process.env.CHAIN_RPC_CONFIG || "",
   etherscanApiKey: process.env.ETHERSCAN_API_KEY || "",
 
+  workflowRunnerCollectMonitoring:
+    process.env.WORKFLOW_RUNNER_COLLECT_MONITORING !== "false",
+
   visibilityTimeout: 300,
   waitTimeSeconds: 20,
   maxMessages: 10,

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -104,6 +104,11 @@ export async function createWorkflowJob(params: {
             "workflow-id": workflowId,
             "execution-id": executionId,
           },
+          ...(!CONFIG.workflowRunnerCollectMonitoring && {
+            annotations: {
+              "keeperhub.com/monitoring.exclude": "true",
+            },
+          }),
         },
         spec: {
           restartPolicy: "Never",


### PR DESCRIPTION
## Summary
- Add `WORKFLOW_RUNNER_COLLECT_MONITORING` env var to control whether workflow runner pods have their metrics/logs collected by Grafana Alloy
- When set to `"false"`, the executor adds `keeperhub.com/monitoring.exclude: "true"` annotation to the pod template of K8s Jobs, which Alloy's discovery.relabel rules drop before scraping/tailing
- Defaults to `true` (collect) when the env var is unset, so prod behavior is unchanged
- Staging values.yaml sets it to `"false"` to reduce monitoring noise from short-lived runner pods

## Files changed
- `keeperhub-executor/config.ts` -- new `workflowRunnerCollectMonitoring` config field
- `keeperhub-executor/k8s-job.ts` -- conditionally adds annotation to pod template metadata
- `deploy/executor/staging/values.yaml` -- sets `WORKFLOW_RUNNER_COLLECT_MONITORING=false`

## Test plan
- [ ] Deploy to staging, verify new workflow runner pods have the `keeperhub.com/monitoring.exclude: "true"` annotation
- [ ] Confirm Alloy stops collecting logs/metrics from those pods
- [ ] Verify prod is unaffected (env var not set, defaults to collect)