### PR TITLE
feat: subscribe new signups to MailerLite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,5 +83,8 @@ X402_FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402
 BASE_RPC_URL=https://mainnet.base.org
 PLATFORM_FEE_PERCENT=30
 
+# MailerLite (signup subscriber sync)
+MAILERLITE_API_KEY=
+
 # ERC-8004 Agent Registration (one-time mainnet registration script)
 REGISTRATION_PRIVATE_KEY=

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -158,6 +158,10 @@ env:
     type: parameterStore
     name: discord-webhook-signups
     parameter_name: /eks/techops-prod/keeperhub/discord-webhook-signups
+  MAILERLITE_API_KEY:
+    type: parameterStore
+    name: mailerlite-api-key
+    parameter_name: /eks/techops-prod/keeperhub/mailerlite-api-key
   # Auth and social providers (GitHub, Google)
   NEXT_PUBLIC_AUTH_PROVIDERS:
     type: kv

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -360,7 +360,10 @@ async function notifyDiscordSignup(user: {
   email?: string | null;
   image?: string | null;
 }): Promise<void> {
-  await fetch(process.env.DISCORD_WEBHOOK_SIGNUPS as string, {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_SIGNUPS;
+  if (!webhookUrl) return;
+
+  await fetch(webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -450,12 +453,7 @@ export const auth = betterAuth({
 
           // Notify external services for OAuth signups (already verified at creation)
           if (user.emailVerified) {
-            if (process.env.DISCORD_WEBHOOK_SIGNUPS) {
-              console.log("[Auth] Notifying Discord for OAuth signup", {
-                email: user.email,
-              });
-              await notifyDiscordSignup(user);
-            }
+            await notifyDiscordSignup(user);
             await subscribeToMailerLite(user);
           }
         },
@@ -513,9 +511,7 @@ export const auth = betterAuth({
   emailVerification: {
     afterEmailVerification: async (user) => {
       console.log("[Auth] afterEmailVerification fired", { email: user.email });
-      if (process.env.DISCORD_WEBHOOK_SIGNUPS) {
-        await notifyDiscordSignup(user);
-      }
+      await notifyDiscordSignup(user);
       await subscribeToMailerLite(user);
     },
   },

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -324,6 +324,37 @@ const plugins = [
     : []),
 ];
 
+async function subscribeToMailerLite(user: {
+  name?: string | null;
+  email?: string | null;
+}): Promise<void> {
+  const apiKey = process.env.MAILERLITE_API_KEY;
+  if (!apiKey || !user.email) return;
+
+  await fetch("https://connect.mailerlite.com/api/subscribers", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email: user.email,
+      groups: ["184355071771804948", "184358071395419781"],
+      status: "active",
+    }),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        console.error(
+          `[MailerLite] Subscribe failed: ${res.status} ${res.statusText}`
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      console.error("[MailerLite] Subscribe request error:", err);
+    });
+}
+
 async function notifyDiscordSignup(user: {
   name?: string | null;
   email?: string | null;
@@ -417,12 +448,15 @@ export const auth = betterAuth({
             console.error(error);
           }
 
-          // Notify Discord for OAuth signups (already verified at creation)
-          if (user.emailVerified && process.env.DISCORD_WEBHOOK_SIGNUPS) {
-            console.log("[Auth] Notifying Discord for OAuth signup", {
-              email: user.email,
-            });
-            await notifyDiscordSignup(user);
+          // Notify external services for OAuth signups (already verified at creation)
+          if (user.emailVerified) {
+            if (process.env.DISCORD_WEBHOOK_SIGNUPS) {
+              console.log("[Auth] Notifying Discord for OAuth signup", {
+                email: user.email,
+              });
+              await notifyDiscordSignup(user);
+            }
+            await subscribeToMailerLite(user);
           }
         },
       },
@@ -482,6 +516,7 @@ export const auth = betterAuth({
       if (process.env.DISCORD_WEBHOOK_SIGNUPS) {
         await notifyDiscordSignup(user);
       }
+      await subscribeToMailerLite(user);
     },
   },
   socialProviders: {


### PR DESCRIPTION
## Summary

- Add fire-and-forget POST to MailerLite subscriber API after successful signup (GTM-68)
- Subscribes new users to App Signups group (welcome email automation) and Newsletter group
- Called for both OAuth signups (on user creation) and email/password signups (after email verification)
- No-ops gracefully if `MAILERLITE_API_KEY` env var is unset
- Adds SSM parameter reference to prod deploy values

## Test plan

- [ ] Deploy to staging without `MAILERLITE_API_KEY` set -- verify signup still works normally
- [ ] Set `MAILERLITE_API_KEY` in prod SSM, verify new signups appear in MailerLite App Signups and Newsletter groups
- [ ] Verify MailerLite welcome automation triggers after subscriber lands in App Signups group