### PR TITLE
fix(block-dispatcher): await async eth_subscribe on reconnection

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.test.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.test.ts
@@ -1,0 +1,520 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChainMonitor } from "./chain-monitor.js";
+import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock SQS enqueue - prevent real AWS calls
+// ---------------------------------------------------------------------------
+
+vi.mock("./sqs-enqueue.js", () => ({
+  enqueueBlockTrigger: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket that supports ping/pong and close events
+// ---------------------------------------------------------------------------
+
+class MockWebSocket extends EventEmitter {
+  readyState = 1;
+  ping(): void {
+    setTimeout(() => this.emit("pong"), 0);
+  }
+  removeListener(event: string, cb: () => void): this {
+    return super.removeListener(event, cb);
+  }
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+  send(): void {}
+}
+
+// ---------------------------------------------------------------------------
+// Mock ethers.WebSocketProvider
+// ---------------------------------------------------------------------------
+
+type BlockListener = (blockNumber: number) => void;
+
+class MockProvider {
+  readonly websocket: MockWebSocket;
+  destroyed = false;
+  private blockListeners: BlockListener[] = [];
+
+  ready: Promise<unknown>;
+
+  constructor(readonly url: string) {
+    this.websocket = new MockWebSocket();
+    this.ready = Promise.resolve(true);
+  }
+
+  async getBlockNumber(): Promise<number> {
+    return 100;
+  }
+
+  async getBlock(
+    blockNumber: number
+  ): Promise<{
+    hash: string;
+    timestamp: number;
+    parentHash: string;
+  }> {
+    return {
+      hash: `0x${blockNumber.toString(16).padStart(64, "0")}`,
+      timestamp: Math.floor(Date.now() / 1000),
+      parentHash: `0x${(blockNumber - 1).toString(16).padStart(64, "0")}`,
+    };
+  }
+
+  async on(event: string, listener: BlockListener): Promise<this> {
+    if (event === "block") {
+      this.blockListeners.push(listener);
+    }
+    return this;
+  }
+
+  async removeAllListeners(): Promise<this> {
+    this.blockListeners = [];
+    return this;
+  }
+
+  async destroy(): Promise<void> {
+    this.destroyed = true;
+    this.websocket.close();
+  }
+
+  emitBlock(blockNumber: number): void {
+    for (const listener of this.blockListeners) {
+      listener(blockNumber);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Patch ethers.WebSocketProvider at module level
+// ---------------------------------------------------------------------------
+
+let providerInstances: MockProvider[] = [];
+let providerFactory: (url: string) => MockProvider = (url) => new MockProvider(url);
+
+vi.mock("ethers", () => ({
+  ethers: {
+    WebSocketProvider: class {
+      constructor(url: string) {
+        const instance = providerFactory(url);
+        providerInstances.push(instance);
+        return instance;
+      }
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeChain(overrides?: Partial<ChainConfig>): ChainConfig {
+  return {
+    chainId: 1,
+    name: "TestChain",
+    defaultPrimaryWss: "wss://primary.test",
+    defaultFallbackWss: "wss://fallback.test",
+    ...overrides,
+  };
+}
+
+function makeWorkflow(overrides?: Partial<BlockWorkflow>): BlockWorkflow {
+  return {
+    id: "wf-1",
+    name: "Test Workflow",
+    userId: "user-1",
+    organizationId: null,
+    network: "1",
+    blockInterval: 10,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChainMonitor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.clearAllMocks();
+    providerInstances = [];
+    providerFactory = (url) => new MockProvider(url);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function latestProvider(): MockProvider {
+    return providerInstances[providerInstances.length - 1];
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("start / stop", () => {
+    it("connects, subscribes, and reports alive after start", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      expect(monitor.isAlive()).toBe(true);
+      expect(providerInstances).toHaveLength(1);
+      expect(latestProvider().url).toBe("wss://primary.test");
+    });
+
+    it("reports not alive before start", () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      expect(monitor.isAlive()).toBe(false);
+    });
+
+    it("reports not alive after stop", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      await monitor.stop();
+
+      expect(monitor.isAlive()).toBe(false);
+    });
+
+    it("throws and resets isRunning if connect fails with no WSS urls", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain({
+          defaultPrimaryWss: null,
+          defaultFallbackWss: null,
+        }),
+        workflows: [makeWorkflow()],
+      });
+
+      await expect(monitor.start()).rejects.toThrow("No WSS URLs configured");
+      expect(monitor.isAlive()).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Block subscription
+  // -------------------------------------------------------------------------
+
+  describe("block subscription", () => {
+    it("awaits provider.on and sets hasActiveSubscription", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      expect(monitor.isAlive()).toBe(true);
+      const provider = latestProvider();
+      // Verify the on() was called - provider has block listeners
+      // Emit a block to confirm the listener was wired up
+      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      provider.emitBlock(10);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(enqueueBlockTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowId: "wf-1",
+          triggerData: expect.objectContaining({ blockNumber: 10 }),
+        })
+      );
+    });
+
+    it("only enqueues for blocks matching the interval", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow({ blockInterval: 12 })],
+      });
+
+      await monitor.start();
+
+      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      const provider = latestProvider();
+
+      provider.emitBlock(11);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).not.toHaveBeenCalled();
+
+      provider.emitBlock(12);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(1);
+
+      provider.emitBlock(13);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(1);
+
+      provider.emitBlock(24);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(2);
+    });
+
+    it("deduplicates blocks with the same or lower number", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow({ blockInterval: 1 })],
+      });
+
+      await monitor.start();
+
+      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      const provider = latestProvider();
+
+      provider.emitBlock(10);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(1);
+
+      // Same block again
+      provider.emitBlock(10);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(1);
+
+      // Lower block
+      provider.emitBlock(9);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WebSocket close and reconnection
+  // -------------------------------------------------------------------------
+
+  describe("reconnection", () => {
+    it("reconnects when WebSocket closes", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(providerInstances).toHaveLength(1);
+
+      // Simulate WebSocket close
+      latestProvider().websocket.emit("close");
+
+      // Advance past the reconnection delay (1s for first attempt)
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(providerInstances).toHaveLength(2);
+      expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("clears hasActiveSubscription on WebSocket close", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(monitor.isAlive()).toBe(true);
+
+      // Close the WebSocket - isAlive should still be true because
+      // isReconnecting becomes true
+      latestProvider().websocket.emit("close");
+      expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("reports alive during reconnection (isReconnecting guard)", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      // Trigger disconnect
+      latestProvider().websocket.emit("close");
+
+      // During the backoff delay, monitor should report alive
+      // (isReconnecting = true)
+      expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("removes stale WebSocket close handler during destroyProvider", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      const firstProvider = latestProvider();
+      const closeListenerCount = firstProvider.websocket.listenerCount("close");
+
+      // Trigger reconnection
+      firstProvider.websocket.emit("close");
+      await vi.advanceTimersByTimeAsync(1500);
+
+      // Old provider's close handler should have been removed
+      expect(firstProvider.websocket.listenerCount("close")).toBeLessThan(
+        closeListenerCount
+      );
+    });
+
+    it("re-subscribes to blocks after reconnection", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow({ blockInterval: 10 })],
+      });
+
+      await monitor.start();
+
+      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+
+      // First provider delivers a matching block
+      latestProvider().emitBlock(10);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(1);
+
+      // Disconnect and reconnect
+      latestProvider().websocket.emit("close");
+      await vi.advanceTimersByTimeAsync(1500);
+
+      // Second provider delivers a matching block
+      // Use block 20 (10 blocks later, within MAX_BACKFILL but only
+      // block 20 matches interval=10)
+      latestProvider().emitBlock(20);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueueBlockTrigger).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not double-trigger handleDisconnect when already reconnecting", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      // Trigger disconnect
+      latestProvider().websocket.emit("close");
+
+      // Trigger another close event while reconnecting
+      latestProvider().websocket.emit("close");
+
+      // Should only create one new provider
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(providerInstances).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isAlive
+  // -------------------------------------------------------------------------
+
+  describe("isAlive", () => {
+    it("returns false when not started", () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+      expect(monitor.isAlive()).toBe(false);
+    });
+
+    it("returns true when running with active subscription", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+      await monitor.start();
+      expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("returns true when reconnecting (not dead, just recovering)", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+      await monitor.start();
+      latestProvider().websocket.emit("close");
+      // Now isReconnecting=true, hasActiveSubscription=false
+      expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("returns false after stop", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+      await monitor.start();
+      await monitor.stop();
+      expect(monitor.isAlive()).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Config changes
+  // -------------------------------------------------------------------------
+
+  describe("hasConfigChanged", () => {
+    it("detects primary WSS change", async () => {
+      const chain = makeChain();
+      const monitor = new ChainMonitor({
+        chain,
+        workflows: [makeWorkflow()],
+      });
+
+      expect(
+        monitor.hasConfigChanged({
+          ...chain,
+          defaultPrimaryWss: "wss://new-primary.test",
+        })
+      ).toBe(true);
+    });
+
+    it("returns false when config unchanged", () => {
+      const chain = makeChain();
+      const monitor = new ChainMonitor({
+        chain,
+        workflows: [makeWorkflow()],
+      });
+
+      expect(monitor.hasConfigChanged(chain)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fallback connection
+  // -------------------------------------------------------------------------
+
+  describe("fallback connection", () => {
+    it("uses fallback WSS when primary fails", async () => {
+      let callCount = 0;
+      providerFactory = (url: string) => {
+        callCount++;
+        const instance = new MockProvider(url);
+        if (callCount === 1) {
+          instance.ready = Promise.reject(new Error("Primary down"));
+        }
+        return instance;
+      };
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      expect(providerInstances).toHaveLength(2);
+      expect(latestProvider().url).toBe("wss://fallback.test");
+      expect(monitor.isAlive()).toBe(true);
+    });
+  });
+});

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -168,8 +168,8 @@ export class ChainMonitor {
       } catch (error) {
         // Destroy the provider if it was created but failed/timed out
         if (provider) {
-          provider.removeAllListeners();
-          provider.destroy().catch(() => {});
+          await provider.removeAllListeners();
+          await provider.destroy().catch(() => {});
         }
         console.warn(
           `[BlockMonitor:${this.chainName}] Failed to connect to ${label} WSS:`,

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -105,6 +105,30 @@ export class ChainMonitor {
     return this.isRunning && (this.hasActiveSubscription || this.isReconnecting);
   }
 
+  getStatus(): {
+    chainId: number;
+    chainName: string;
+    alive: boolean;
+    reconnecting: boolean;
+    hasSubscription: boolean;
+    lastBlock: number | null;
+    blocksReceived: number;
+    blocksMatched: number;
+    workflows: number;
+  } {
+    return {
+      chainId: this.chainId,
+      chainName: this.chainName,
+      alive: this.isAlive(),
+      reconnecting: this.isReconnecting,
+      hasSubscription: this.hasActiveSubscription,
+      lastBlock: this.lastProcessedBlock,
+      blocksReceived: this.blocksReceived,
+      blocksMatched: this.blocksMatched,
+      workflows: this.workflows.length,
+    };
+  }
+
   // ---------------------------------------------------------------------------
   // Provider lifecycle
   // ---------------------------------------------------------------------------

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -102,7 +102,7 @@ export class ChainMonitor {
   }
 
   isAlive(): boolean {
-    return this.isRunning && this.hasActiveSubscription;
+    return this.isRunning && (this.hasActiveSubscription || this.isReconnecting);
   }
 
   // ---------------------------------------------------------------------------

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -4,11 +4,11 @@
  * Monitors a single blockchain chain via ethers.js WebSocketProvider.
  * When a block matches a workflow's interval, enqueues a trigger to SQS.
  *
- * ethers.js polls eth_blockNumber internally (~4s) in addition to receiving
- * newHeads notifications, so it detects new blocks even when the RPC provider
- * fails to push subscription events. A WebSocket-level ping/pong runs every
- * 30s to verify the connection is alive, and a no-block timeout forces
- * reconnection if the provider goes silent.
+ * ethers v6 WebSocketProvider uses eth_subscribe ("newHeads") over the
+ * WebSocket to receive block notifications (SocketBlockSubscriber, not
+ * polling). A WebSocket-level ping/pong runs every 30s to verify the
+ * connection is alive, and a no-block timeout forces reconnection if the
+ * provider goes silent.
  */
 
 import { ethers } from "ethers";
@@ -50,6 +50,8 @@ export class ChainMonitor {
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private pongTimer: ReturnType<typeof setTimeout> | null = null;
   private noBlockTimer: ReturnType<typeof setTimeout> | null = null;
+  private hasActiveSubscription = false;
+  private wsCloseHandler: (() => void) | null = null;
 
   constructor(config: ChainMonitorConfig) {
     this.chainId = config.chain.chainId;
@@ -68,7 +70,7 @@ export class ChainMonitor {
     try {
       await this.connect();
       await this.validateConnection();
-      this.subscribeToBlocks();
+      await this.subscribeToBlocks();
       this.startPingPong();
       this.resetNoBlockTimer();
     } catch (error) {
@@ -100,7 +102,7 @@ export class ChainMonitor {
   }
 
   isAlive(): boolean {
-    return this.isRunning;
+    return this.isRunning && this.hasActiveSubscription;
   }
 
   // ---------------------------------------------------------------------------
@@ -108,8 +110,20 @@ export class ChainMonitor {
   // ---------------------------------------------------------------------------
 
   private async destroyProvider(): Promise<void> {
+    this.hasActiveSubscription = false;
+
     if (this.provider) {
-      this.provider.removeAllListeners();
+      // Remove the raw WebSocket close handler before destroying to prevent
+      // stale handlers from firing handleDisconnect during teardown
+      if (this.wsCloseHandler) {
+        const ws = this.provider.websocket as unknown as {
+          removeListener?: (event: string, cb: () => void) => void;
+        };
+        ws?.removeListener?.("close", this.wsCloseHandler);
+        this.wsCloseHandler = null;
+      }
+
+      await this.provider.removeAllListeners();
       try {
         await this.provider.destroy();
       } catch {
@@ -192,7 +206,7 @@ export class ChainMonitor {
   // Block subscription
   // ---------------------------------------------------------------------------
 
-  private subscribeToBlocks(): void {
+  private async subscribeToBlocks(): Promise<void> {
     if (!this.provider) {
       return;
     }
@@ -201,7 +215,10 @@ export class ChainMonitor {
       `[BlockMonitor:${this.chainName}] Subscribing to block events`
     );
 
-    this.provider.on("block", (blockNumber: number) => {
+    // ethers v6 provider.on() is async - it sends eth_subscribe over the
+    // WebSocket and waits for the subscription ID. Must be awaited or the
+    // subscription silently fails on reconnection.
+    await this.provider.on("block", (blockNumber: number) => {
       this.onBlock(blockNumber).catch((error: unknown) => {
         console.error(
           `[BlockMonitor:${this.chainName}] Error processing block ${blockNumber}:`,
@@ -210,15 +227,22 @@ export class ChainMonitor {
       });
     });
 
-    // Handle WebSocket close for reconnection
+    this.hasActiveSubscription = true;
+    console.log(
+      `[BlockMonitor:${this.chainName}] Block subscription active`
+    );
+
+    // Handle WebSocket close for reconnection - store reference for cleanup
     const ws = this.provider.websocket as unknown as {
       on?: (event: string, cb: () => void) => void;
     };
     if (ws?.on) {
-      ws.on("close", () => {
+      this.wsCloseHandler = () => {
         console.warn(`[BlockMonitor:${this.chainName}] WebSocket closed`);
+        this.hasActiveSubscription = false;
         this.handleDisconnect();
-      });
+      };
+      ws.on("close", this.wsCloseHandler);
     }
   }
 
@@ -546,9 +570,9 @@ export class ChainMonitor {
       try {
         await this.connect();
         await this.validateConnection();
+        await this.subscribeToBlocks();
         this.reconnectAttempts = 0;
         this.isReconnecting = false;
-        this.subscribeToBlocks();
         this.startPingPong();
         this.resetNoBlockTimer();
         return;
@@ -557,6 +581,8 @@ export class ChainMonitor {
           `[BlockMonitor:${this.chainName}] Reconnect attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS} failed:`,
           error instanceof Error ? error.message : error
         );
+        // Clean up the provider if connect succeeded but subscribe failed
+        await this.destroyProvider();
       }
     }
   }

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -75,6 +75,15 @@ class BlockMonitorService {
     console.log("[BlockMonitorService] Stopped");
   }
 
+  getHealth(): {
+    healthy: boolean;
+    monitors: ReturnType<ChainMonitor["getStatus"]>[];
+  } {
+    const monitors = [...this.monitors.values()].map((m) => m.getStatus());
+    const healthy = monitors.length === 0 || monitors.every((m) => m.alive);
+    return { healthy, monitors };
+  }
+
   private async reconcile(): Promise<void> {
     if (this.isShuttingDown) {
       return;
@@ -177,10 +186,13 @@ async function main(): Promise<void> {
   const HEALTH_PORT = process.env.HEALTH_PORT || 3050;
 
   healthApp.get("/health", (_req, res) => {
-    res.status(200).json({
-      status: "ok",
+    const health = service.getHealth();
+    const statusCode = health.healthy ? 200 : 503;
+    res.status(statusCode).json({
+      status: health.healthy ? "ok" : "degraded",
       service: "block-dispatcher",
       timestamp: new Date().toISOString(),
+      monitors: health.monitors,
     });
   });
 


### PR DESCRIPTION
## Summary

- Block-based triggered keepers stopped running in production because the ethers v6 `provider.on("block")` call was not awaited during WebSocket reconnection. This caused the `eth_subscribe` setup to silently fail, leaving the monitor in a zombie state - alive (health check passing, reconcile loop running) but receiving zero blocks.
- The fix awaits the async subscription, tracks subscription health so the reconcile loop can detect and restart zombie monitors, and cleans up stale WebSocket close handlers to prevent spurious disconnects.

## Root cause

ethers v6 `WebSocketProvider` uses `SocketBlockSubscriber` (not polling) for the `"block"` event. `provider.on("block", callback)` is async - it sends `eth_subscribe ["newHeads"]` over the WebSocket and waits for the subscription ID. The old code called this without `await`, so:

1. On initial startup it usually worked (fresh connection, responsive WebSocket)
2. On reconnection after a WebSocket drop, the fire-and-forget `eth_subscribe` could silently fail
3. The monitor appeared healthy (`isAlive()` only checked `isRunning`, ping/pong kept the WebSocket alive at the transport level)
4. The no-block timeout triggered reconnection every 5 minutes, but each reconnection re-entered the same broken state

## Changes

- `subscribeToBlocks()` is now async, awaits `provider.on("block")`
- `destroyProvider()` awaits `removeAllListeners()`, removes raw WebSocket close handler before destroy
- `isAlive()` checks `hasActiveSubscription` flag (set after confirmed `eth_subscribe`)
- `reconnectWithBackoff()` awaits subscription and cleans up provider on partial failure

## Test plan

- [ ] Deploy to staging, verify block-triggered workflow fires on expected interval
- [ ] Kill the block-dispatcher pod, verify it recovers and resumes block processing
- [ ] Monitor logs for "Block subscription active" confirmation after reconnection
- [ ] Verify reconcile detects dead monitors via `isAlive()` check