### PR TITLE
fix: condition routing leak in For Each body when taken handle has no edges

### DIFF
--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -838,6 +838,39 @@ export type LoopBodyInfo = {
 };
 
 /**
+ * Determine which downstream node IDs a condition node should dispatch to
+ * within a For Each body. Mirrors the two-phase routing in executeBodyNode:
+ *
+ * 1. If the node has handle-based edges (bodyHandleMap entry), route
+ *    exclusively via the taken handle. The not-taken handle is dead.
+ * 2. Otherwise (legacy edges without sourceHandle), gate on conditionValue:
+ *    true -> all bodyEdgesBySource targets, false -> nothing.
+ *
+ * Extracted so the routing decision is testable independently of the
+ * async executeBodyNode closure.
+ */
+export function resolveBodyConditionTargets(
+  conditionValue: boolean,
+  nodeId: string,
+  bodyHandleMap: EdgesBySourceHandle | undefined,
+  bodyEdgesBySource: Map<string, string[]>
+): string[] {
+  const nodeHandles = bodyHandleMap?.get(nodeId);
+
+  if (nodeHandles) {
+    const handleId = conditionValue === true ? "true" : "false";
+    return nodeHandles.get(handleId) ?? [];
+  }
+
+  // Legacy fallback: no handle map entry, gate on condition value
+  if (conditionValue !== true) {
+    return [];
+  }
+
+  return bodyEdgesBySource.get(nodeId) ?? [];
+}
+
+/**
  * Compute the next BFS depth when traversing loop body nodes.
  * Inner For Each increments depth, inner Collect decrements it.
  */
@@ -1344,43 +1377,29 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       } else if (actionType === "Condition") {
         const conditionValue = (result.data as { condition?: boolean })
           ?.condition;
-        const nodeHandles = bodyHandleMap?.get(nodeId);
-        if (nodeHandles) {
-          const handleId = conditionValue === true ? "true" : "false";
-          const handleTargets = nodeHandles.get(handleId) ?? [];
-          if (handleTargets.length > 0) {
-            for (const next of handleTargets) {
-              await executeBodyNode(
-                next,
-                bodyVisited,
-                scopedOutputs,
-                bodyResults,
-                bodyEdgesBySource,
-                collectNodeId,
-                iterationMeta,
-                bodyHandleMap
-              );
-            }
-          }
-        } else if (conditionValue !== true) {
-          // Legacy fallback: gate behavior
-          return;
+        const conditionTargets = resolveBodyConditionTargets(
+          conditionValue === true,
+          nodeId,
+          bodyHandleMap,
+          bodyEdgesBySource
+        );
+        for (const next of conditionTargets) {
+          await executeBodyNode(
+            next,
+            bodyVisited,
+            scopedOutputs,
+            bodyResults,
+            bodyEdgesBySource,
+            collectNodeId,
+            iterationMeta,
+            bodyHandleMap
+          );
         }
+        // Condition routing is fully handled; skip the generic downstream pass
       }
 
-      // Continue to downstream body nodes.
-      // Skip only when condition routed via handles AND the chosen handle had targets.
-      const conditionRoutedViaHandles =
-        actionType === "Condition" &&
-        bodyHandleMap?.has(nodeId) &&
-        (bodyHandleMap
-          .get(nodeId)
-          ?.get(
-            (result.data as { condition?: boolean })?.condition === true
-              ? "true"
-              : "false"
-          )?.length ?? 0) > 0;
-      if (!conditionRoutedViaHandles) {
+      // Continue to downstream body nodes for non-condition actions.
+      if (actionType !== "Condition") {
         const nextNodes = bodyEdgesBySource.get(nodeId) ?? [];
         for (const next of nextNodes) {
           await executeBodyNode(

--- a/tests/unit/condition-foreach-body-routing.test.ts
+++ b/tests/unit/condition-foreach-body-routing.test.ts
@@ -1,0 +1,666 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { buildEdgesBySourceHandle } from "@/lib/edge-handle-utils";
+import {
+  evaluateConditionExpression,
+  resolveBodyConditionTargets,
+} from "@/lib/workflow-executor.workflow";
+
+type EdgeLike = {
+  source: string;
+  target: string;
+  sourceHandle?: string | null;
+};
+
+function createEdge(
+  source: string,
+  target: string,
+  sourceHandle?: string
+): EdgeLike {
+  return { source, target, sourceHandle };
+}
+
+/**
+ * Build bodyEdgesBySource (handle-agnostic) from edges, same as the executor
+ * does for the For Each body subgraph.
+ */
+function buildBodyEdgesBySource(edges: EdgeLike[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!map.has(edge.source)) {
+      map.set(edge.source, []);
+    }
+    map.get(edge.source)!.push(edge.target);
+  }
+  return map;
+}
+
+/**
+ * Simulates the executor's bodyEdgesBySourceHandle filtering
+ * (workflow-executor.workflow.ts identifyLoopBody, lines 935-953).
+ * Only keeps handle entries whose targets are in the body node set.
+ */
+function filterHandleMapToBody(
+  fullHandleMap: ReturnType<typeof buildEdgesBySourceHandle>,
+  bodyNodeIds: string[]
+): ReturnType<typeof buildEdgesBySourceHandle> {
+  const bodyNodeSet = new Set(bodyNodeIds);
+  const filtered = new Map<string, Map<string, string[]>>();
+  for (const nodeId of bodyNodeIds) {
+    const nodeHandleMap = fullHandleMap.get(nodeId);
+    if (!nodeHandleMap) {
+      continue;
+    }
+    const filteredHandleMap = new Map<string, string[]>();
+    for (const [handle, targets] of nodeHandleMap) {
+      const filteredTargets = targets.filter((t) => bodyNodeSet.has(t));
+      if (filteredTargets.length > 0) {
+        filteredHandleMap.set(handle, filteredTargets);
+      }
+    }
+    if (filteredHandleMap.size > 0) {
+      filtered.set(nodeId, filteredHandleMap);
+    }
+  }
+  return filtered;
+}
+
+describe("condition routing inside For Each body", () => {
+  describe("one-sided condition: only true-handle edge, false result", () => {
+    // Reproduces the exact bug: condition with only a true-handle edge,
+    // condition evaluates false, but downstream nodes still execute
+    const edges: EdgeLike[] = [
+      createEdge("compare-tokens", "already-cast", "true"),
+    ];
+    const bodyNodeIds = ["compare-tokens", "already-cast", "search-db"];
+    const bodyEdges: EdgeLike[] = [
+      createEdge("compare-tokens", "already-cast", "true"),
+      createEdge("already-cast", "search-db", "false"),
+    ];
+
+    it("should NOT route to true-branch target when condition is false", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(bodyEdges);
+
+      const targets = resolveBodyConditionTargets(
+        false,
+        "compare-tokens",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual([]);
+    });
+
+    it("should route to true-branch target when condition is true", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(bodyEdges);
+
+      const targets = resolveBodyConditionTargets(
+        true,
+        "compare-tokens",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual(["already-cast"]);
+    });
+  });
+
+  describe("one-sided condition: only false-handle edge", () => {
+    const edges: EdgeLike[] = [
+      createEdge("cond-check", "error-handler", "false"),
+    ];
+    const bodyNodeIds = ["cond-check", "error-handler"];
+
+    it("should route to false-branch target when condition is false", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        false,
+        "cond-check",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual(["error-handler"]);
+    });
+
+    it("should NOT route to false-branch target when condition is true", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        true,
+        "cond-check",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("both handles present", () => {
+    const edges: EdgeLike[] = [
+      createEdge("cond-1", "action-a", "true"),
+      createEdge("cond-1", "action-b", "false"),
+    ];
+    const bodyNodeIds = ["cond-1", "action-a", "action-b"];
+
+    it("should route to true target when true", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        true,
+        "cond-1",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual(["action-a"]);
+    });
+
+    it("should route to false target when false", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        false,
+        "cond-1",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual(["action-b"]);
+    });
+  });
+
+  describe("multiple downstream conditions in For Each body", () => {
+    //   forEach -> action-read -> cond-1 (true-only) -> cond-2 (both) -> action-true / action-false
+    const allEdges: EdgeLike[] = [
+      createEdge("action-read", "cond-1", undefined),
+      createEdge("cond-1", "cond-2", "true"),
+      createEdge("cond-2", "action-true", "true"),
+      createEdge("cond-2", "action-false", "false"),
+    ];
+    const bodyNodeIds = [
+      "action-read",
+      "cond-1",
+      "cond-2",
+      "action-true",
+      "action-false",
+    ];
+
+    it("cond-1=false should stop the chain entirely", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(allEdges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(allEdges);
+
+      const targets = resolveBodyConditionTargets(
+        false,
+        "cond-1",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+
+      expect(targets).toEqual([]);
+    });
+
+    it("cond-1=true, cond-2=true should reach action-true", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(allEdges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(allEdges);
+
+      const cond1Targets = resolveBodyConditionTargets(
+        true,
+        "cond-1",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(cond1Targets).toEqual(["cond-2"]);
+
+      const cond2Targets = resolveBodyConditionTargets(
+        true,
+        "cond-2",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(cond2Targets).toEqual(["action-true"]);
+    });
+
+    it("cond-1=true, cond-2=false should reach action-false", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(allEdges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(allEdges);
+
+      const cond1Targets = resolveBodyConditionTargets(
+        true,
+        "cond-1",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(cond1Targets).toEqual(["cond-2"]);
+
+      const cond2Targets = resolveBodyConditionTargets(
+        false,
+        "cond-2",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(cond2Targets).toEqual(["action-false"]);
+    });
+  });
+
+  describe("chained one-sided conditions (all true-only)", () => {
+    // cond-a (true) -> cond-b (true) -> cond-c (true) -> final-action
+    const edges: EdgeLike[] = [
+      createEdge("cond-a", "cond-b", "true"),
+      createEdge("cond-b", "cond-c", "true"),
+      createEdge("cond-c", "final-action", "true"),
+    ];
+    const bodyNodeIds = ["cond-a", "cond-b", "cond-c", "final-action"];
+
+    it("all true should reach final-action", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(true, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      expect(aTargets).toEqual(["cond-b"]);
+
+      const bTargets = resolveBodyConditionTargets(true, "cond-b", bodyHandleMap, bodyEdgesBySource);
+      expect(bTargets).toEqual(["cond-c"]);
+
+      const cTargets = resolveBodyConditionTargets(true, "cond-c", bodyHandleMap, bodyEdgesBySource);
+      expect(cTargets).toEqual(["final-action"]);
+    });
+
+    it("first condition false should stop entire chain", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(false, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      expect(targets).toEqual([]);
+    });
+
+    it("middle condition false should stop chain at that point", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(true, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      expect(aTargets).toEqual(["cond-b"]);
+
+      const bTargets = resolveBodyConditionTargets(false, "cond-b", bodyHandleMap, bodyEdgesBySource);
+      expect(bTargets).toEqual([]);
+    });
+
+    it("last condition false should not reach final-action", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(true, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      expect(aTargets).toEqual(["cond-b"]);
+
+      const bTargets = resolveBodyConditionTargets(true, "cond-b", bodyHandleMap, bodyEdgesBySource);
+      expect(bTargets).toEqual(["cond-c"]);
+
+      const cTargets = resolveBodyConditionTargets(false, "cond-c", bodyHandleMap, bodyEdgesBySource);
+      expect(cTargets).toEqual([]);
+    });
+  });
+
+  describe("condition with multiple targets on true, none on false", () => {
+    const edges: EdgeLike[] = [
+      createEdge("cond-fan", "action-1", "true"),
+      createEdge("cond-fan", "action-2", "true"),
+      createEdge("cond-fan", "action-3", "true"),
+    ];
+    const bodyNodeIds = ["cond-fan", "action-1", "action-2", "action-3"];
+
+    it("true should fan out to all targets", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(true, "cond-fan", bodyHandleMap, bodyEdgesBySource);
+      expect(targets).toEqual(["action-1", "action-2", "action-3"]);
+    });
+
+    it("false should not execute any of the fan-out targets", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(false, "cond-fan", bodyHandleMap, bodyEdgesBySource);
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("parallel conditions in For Each body", () => {
+    // action-read -> cond-a (true-only) + cond-b (true-only)
+    const edges: EdgeLike[] = [
+      createEdge("action-read", "cond-a", undefined),
+      createEdge("action-read", "cond-b", undefined),
+      createEdge("cond-a", "notify-a", "true"),
+      createEdge("cond-b", "notify-b", "true"),
+    ];
+    const bodyNodeIds = ["action-read", "cond-a", "cond-b", "notify-a", "notify-b"];
+
+    it("cond-a=true, cond-b=false: only notify-a executes", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(true, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      expect(aTargets).toEqual(["notify-a"]);
+
+      const bTargets = resolveBodyConditionTargets(false, "cond-b", bodyHandleMap, bodyEdgesBySource);
+      expect(bTargets).toEqual([]);
+    });
+
+    it("cond-a=false, cond-b=true: only notify-b executes", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(false, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      expect(aTargets).toEqual([]);
+
+      const bTargets = resolveBodyConditionTargets(true, "cond-b", bodyHandleMap, bodyEdgesBySource);
+      expect(bTargets).toEqual(["notify-b"]);
+    });
+
+    it("both false: nothing executes downstream", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(false, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      const bTargets = resolveBodyConditionTargets(false, "cond-b", bodyHandleMap, bodyEdgesBySource);
+
+      expect(aTargets).toEqual([]);
+      expect(bTargets).toEqual([]);
+    });
+
+    it("both true: both notify nodes execute", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const aTargets = resolveBodyConditionTargets(true, "cond-a", bodyHandleMap, bodyEdgesBySource);
+      const bTargets = resolveBodyConditionTargets(true, "cond-b", bodyHandleMap, bodyEdgesBySource);
+
+      expect(aTargets).toEqual(["notify-a"]);
+      expect(bTargets).toEqual(["notify-b"]);
+    });
+  });
+
+  describe("condition with BigInt web3 values in For Each context", () => {
+    it("should correctly evaluate false when loop item has 0 tokens vs large hat balance", () => {
+      const outputs = {
+        f48AH_PyqHFNYeob6NhcC: {
+          label: "Amount of tockens locked in the spell",
+          data: { amt: "0" },
+        },
+        F_b1_FDBQeghz8bCkFjn8: {
+          label: "Get amount of SKY token on the current hat",
+          data: { amt: "6577716159627818993901156981" },
+        },
+      };
+
+      const { result } = evaluateConditionExpression(
+        "{{@f48AH_PyqHFNYeob6NhcC:Amount of tockens locked in the spell.amt}} > {{@F_b1_FDBQeghz8bCkFjn8:Get amount of SKY token on the current hat.amt}}",
+        outputs
+      );
+      expect(result).toBe(false);
+
+      const edges: EdgeLike[] = [
+        createEdge("compare-tokens", "already-cast", "true"),
+      ];
+      const bodyNodeIds = ["compare-tokens", "already-cast"];
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        result,
+        "compare-tokens",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(targets).toEqual([]);
+    });
+
+    it("should correctly evaluate true when loop item has more tokens than hat", () => {
+      const outputs = {
+        f48AH_PyqHFNYeob6NhcC: {
+          label: "Amount of tockens locked in the spell",
+          data: { amt: "9999999999999999999999999999" },
+        },
+        F_b1_FDBQeghz8bCkFjn8: {
+          label: "Get amount of SKY token on the current hat",
+          data: { amt: "6577716159627818993901156981" },
+        },
+      };
+
+      const { result } = evaluateConditionExpression(
+        "{{@f48AH_PyqHFNYeob6NhcC:Amount of tockens locked in the spell.amt}} > {{@F_b1_FDBQeghz8bCkFjn8:Get amount of SKY token on the current hat.amt}}",
+        outputs
+      );
+      expect(result).toBe(true);
+
+      const edges: EdgeLike[] = [
+        createEdge("compare-tokens", "already-cast", "true"),
+      ];
+      const bodyNodeIds = ["compare-tokens", "already-cast"];
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        result,
+        "compare-tokens",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(targets).toEqual(["already-cast"]);
+    });
+  });
+
+  describe("legacy body edges (no sourceHandle)", () => {
+    it("should use bodyEdgesBySource when no handle map entry exists", () => {
+      const edges: EdgeLike[] = [
+        createEdge("cond-legacy", "next-action", undefined),
+      ];
+      const bodyNodeIds = ["cond-legacy", "next-action"];
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      // No handle map entry, so legacy fallback applies
+      expect(bodyHandleMap.has("cond-legacy")).toBe(false);
+
+      const trueTargets = resolveBodyConditionTargets(
+        true,
+        "cond-legacy",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(trueTargets).toEqual(["next-action"]);
+
+      const falseTargets = resolveBodyConditionTargets(
+        false,
+        "cond-legacy",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(falseTargets).toEqual([]);
+    });
+  });
+
+  describe("complex body: condition -> fan-out -> nested condition", () => {
+    //   cond-gate (true-only) -> action-1
+    //                         -> action-2
+    //                         -> cond-nested (true/false)
+    //                              true  -> notify-ok
+    //                              false -> notify-fail
+    const edges: EdgeLike[] = [
+      createEdge("cond-gate", "action-1", "true"),
+      createEdge("cond-gate", "action-2", "true"),
+      createEdge("cond-gate", "cond-nested", "true"),
+      createEdge("cond-nested", "notify-ok", "true"),
+      createEdge("cond-nested", "notify-fail", "false"),
+    ];
+    const bodyNodeIds = [
+      "cond-gate",
+      "action-1",
+      "action-2",
+      "cond-nested",
+      "notify-ok",
+      "notify-fail",
+    ];
+
+    it("gate=false should block everything downstream", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        false,
+        "cond-gate",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(targets).toEqual([]);
+    });
+
+    it("gate=true should fan out, nested=true routes to notify-ok", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const gateTargets = resolveBodyConditionTargets(
+        true,
+        "cond-gate",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(gateTargets).toEqual(["action-1", "action-2", "cond-nested"]);
+
+      const nestedTargets = resolveBodyConditionTargets(
+        true,
+        "cond-nested",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(nestedTargets).toEqual(["notify-ok"]);
+    });
+
+    it("gate=true, nested=false routes to notify-fail", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const gateTargets = resolveBodyConditionTargets(
+        true,
+        "cond-gate",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(gateTargets).toEqual(["action-1", "action-2", "cond-nested"]);
+
+      const nestedTargets = resolveBodyConditionTargets(
+        false,
+        "cond-nested",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(nestedTargets).toEqual(["notify-fail"]);
+    });
+  });
+
+  describe("mixed: one-sided condition followed by two-sided condition", () => {
+    // cond-filter (true-only) -> cond-route (true + false)
+    //                              true  -> path-a, path-b
+    //                              false -> path-c
+    const edges: EdgeLike[] = [
+      createEdge("cond-filter", "cond-route", "true"),
+      createEdge("cond-route", "path-a", "true"),
+      createEdge("cond-route", "path-b", "true"),
+      createEdge("cond-route", "path-c", "false"),
+    ];
+    const bodyNodeIds = ["cond-filter", "cond-route", "path-a", "path-b", "path-c"];
+
+    it("filter=false blocks everything", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const targets = resolveBodyConditionTargets(
+        false,
+        "cond-filter",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(targets).toEqual([]);
+    });
+
+    it("filter=true, route=true reaches path-a and path-b", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const filterTargets = resolveBodyConditionTargets(
+        true,
+        "cond-filter",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(filterTargets).toEqual(["cond-route"]);
+
+      const routeTargets = resolveBodyConditionTargets(
+        true,
+        "cond-route",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(routeTargets).toEqual(["path-a", "path-b"]);
+    });
+
+    it("filter=true, route=false reaches path-c", () => {
+      const fullHandleMap = buildEdgesBySourceHandle(edges);
+      const bodyHandleMap = filterHandleMapToBody(fullHandleMap, bodyNodeIds);
+      const bodyEdgesBySource = buildBodyEdgesBySource(edges);
+
+      const filterTargets = resolveBodyConditionTargets(
+        true,
+        "cond-filter",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(filterTargets).toEqual(["cond-route"]);
+
+      const routeTargets = resolveBodyConditionTargets(
+        false,
+        "cond-route",
+        bodyHandleMap,
+        bodyEdgesBySource
+      );
+      expect(routeTargets).toEqual(["path-c"]);
+    });
+  });
+});

--- a/tests/unit/condition-foreach-multi-loop.test.ts
+++ b/tests/unit/condition-foreach-multi-loop.test.ts
@@ -1,0 +1,1349 @@
+/**
+ * Comprehensive tests for condition routing inside multiple For Each loops.
+ *
+ * Tests the real exported functions:
+ *   - identifyLoopBody: builds body subgraph (bodyEdgesBySource, bodyEdgesBySourceHandle)
+ *   - resolveBodyConditionTargets: determines which nodes a condition dispatches to
+ *
+ * Topologies tested:
+ *   1. Five parallel For Each loops, each with a condition that fans out to 5 true + 5 false
+ *   2. Five parallel For Each loops with chained conditions (3 deep) inside each body
+ *   3. For Each with 5 parallel conditions, each having 5 true + 5 false branches
+ *   4. For Each with nested conditions: outer -> 5 inner conditions on true, 5 on false
+ *   5. Mixed: some conditions one-sided, varied branch counts, chained and parallel
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { buildEdgesBySourceHandle } from "@/lib/edge-handle-utils";
+import {
+  identifyLoopBody,
+  resolveBodyConditionTargets,
+} from "@/lib/workflow-executor.workflow";
+
+// Minimal WorkflowNode shape that identifyLoopBody actually reads
+type TestNode = {
+  id: string;
+  data: {
+    label: string;
+    type: "trigger" | "action" | "add";
+    config?: Record<string, unknown>;
+  };
+  position: { x: number; y: number };
+};
+
+type TestEdge = {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle?: string | null;
+};
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+let edgeCounter = 0;
+
+function edge(
+  source: string,
+  target: string,
+  sourceHandle?: string
+): TestEdge {
+  edgeCounter++;
+  return {
+    id: `e-${edgeCounter}`,
+    source,
+    target,
+    sourceHandle: sourceHandle ?? null,
+  };
+}
+
+function actionNode(id: string, actionType?: string): TestNode {
+  return {
+    id,
+    data: {
+      label: id,
+      type: "action",
+      config: actionType ? { actionType } : undefined,
+    },
+    position: { x: 0, y: 0 },
+  };
+}
+
+function conditionNode(id: string): TestNode {
+  return actionNode(id, "Condition");
+}
+
+function forEachNode(id: string): TestNode {
+  return actionNode(id, "For Each");
+}
+
+function collectNode(id: string): TestNode {
+  return actionNode(id, "Collect");
+}
+
+/**
+ * Build all the maps needed for testing from raw nodes and edges.
+ * Returns the full-workflow edgesBySource, edgesBySourceHandle,
+ * and a nodeMap, ready for identifyLoopBody.
+ */
+function buildMaps(nodes: TestNode[], edges: TestEdge[]): {
+  edgesBySource: Map<string, string[]>;
+  edgesBySourceHandle: ReturnType<typeof buildEdgesBySourceHandle>;
+  // biome-ignore lint/suspicious/noExplicitAny: TestNode is a minimal stand-in for WorkflowNode from xyflow
+  nodeMap: Map<string, any>;
+} {
+  const edgesBySource = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!edgesBySource.has(e.source)) {
+      edgesBySource.set(e.source, []);
+    }
+    edgesBySource.get(e.source)!.push(e.target);
+  }
+
+  const edgesBySourceHandle = buildEdgesBySourceHandle(edges);
+
+  const nodeMap = new Map<string, TestNode>();
+  for (const n of nodes) {
+    nodeMap.set(n.id, n);
+  }
+
+  return { edgesBySource, edgesBySourceHandle, nodeMap };
+}
+
+/**
+ * Generate N target node IDs with a prefix and handle, plus edges.
+ * Returns { nodes, edges, ids } for the generated targets.
+ */
+function fanOut(
+  sourceId: string,
+  handle: "true" | "false",
+  prefix: string,
+  count: number
+): { nodes: TestNode[]; edges: TestEdge[]; ids: string[] } {
+  const nodes: TestNode[] = [];
+  const edges: TestEdge[] = [];
+  const ids: string[] = [];
+  for (let i = 1; i <= count; i++) {
+    const id = `${prefix}-${handle[0]}${i}`;
+    ids.push(id);
+    nodes.push(actionNode(id));
+    edges.push(edge(sourceId, id, handle));
+  }
+  return { nodes, edges, ids };
+}
+
+// -----------------------------------------------------------------------
+// Topology 1: Five parallel For Each loops, each with condition (5t + 5f)
+// -----------------------------------------------------------------------
+
+describe("topology 1: five parallel For Each loops with branching conditions", () => {
+  // Build the full workflow once
+  const allNodes: TestNode[] = [];
+  const allEdges: TestEdge[] = [];
+
+  // For each loop index 1..5
+  const loops: Array<{
+    feId: string;
+    collectId: string;
+    condId: string;
+    readId: string;
+    trueIds: string[];
+    falseIds: string[];
+  }> = [];
+
+  for (let i = 1; i <= 5; i++) {
+    const feId = `fe-${i}`;
+    const readId = `read-${i}`;
+    const condId = `cond-${i}`;
+    const collectId = `collect-${i}`;
+
+    allNodes.push(forEachNode(feId));
+    allNodes.push(actionNode(readId));
+    allNodes.push(conditionNode(condId));
+    allNodes.push(collectNode(collectId));
+
+    // fe -> read -> cond -> collect
+    allEdges.push(edge(feId, readId));
+    allEdges.push(edge(readId, condId));
+
+    // cond -> 5 true targets
+    const trueFan = fanOut(condId, "true", `loop${i}`, 5);
+    allNodes.push(...trueFan.nodes);
+    allEdges.push(...trueFan.edges);
+
+    // cond -> 5 false targets
+    const falseFan = fanOut(condId, "false", `loop${i}`, 5);
+    allNodes.push(...falseFan.nodes);
+    allEdges.push(...falseFan.edges);
+
+    // All body nodes -> collect
+    for (const tid of trueFan.ids) {
+      allEdges.push(edge(tid, collectId));
+    }
+    for (const fid of falseFan.ids) {
+      allEdges.push(edge(fid, collectId));
+    }
+
+    loops.push({
+      feId,
+      collectId,
+      condId,
+      readId,
+      trueIds: trueFan.ids,
+      falseIds: falseFan.ids,
+    });
+  }
+
+  const { edgesBySource, edgesBySourceHandle, nodeMap } = buildMaps(
+    allNodes,
+    allEdges
+  );
+
+  for (const loop of loops) {
+    describe(`${loop.feId}: condition with 5 true + 5 false branches`, () => {
+      it("should identify correct body nodes and collect boundary", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+        expect(body.collectNodeId).toBe(loop.collectId);
+        // Body should contain: read + cond + 5 true + 5 false = 12 nodes
+        expect(body.bodyNodeIds).toHaveLength(12);
+        expect(body.bodyNodeIds).toContain(loop.readId);
+        expect(body.bodyNodeIds).toContain(loop.condId);
+        for (const id of loop.trueIds) {
+          expect(body.bodyNodeIds).toContain(id);
+        }
+        for (const id of loop.falseIds) {
+          expect(body.bodyNodeIds).toContain(id);
+        }
+      });
+
+      it("condition=true routes to all 5 true-branch targets", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        const targets = resolveBodyConditionTargets(
+          true,
+          loop.condId,
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+
+        expect(targets).toHaveLength(5);
+        expect(targets).toEqual(loop.trueIds);
+        for (const fid of loop.falseIds) {
+          expect(targets).not.toContain(fid);
+        }
+      });
+
+      it("condition=false routes to all 5 false-branch targets", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        const targets = resolveBodyConditionTargets(
+          false,
+          loop.condId,
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+
+        expect(targets).toHaveLength(5);
+        expect(targets).toEqual(loop.falseIds);
+        for (const tid of loop.trueIds) {
+          expect(targets).not.toContain(tid);
+        }
+      });
+
+      it("conditions in different loops are fully isolated", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        // Other loops' condition IDs should not be in this body
+        for (const other of loops) {
+          if (other.feId === loop.feId) {
+            continue;
+          }
+          expect(body.bodyNodeIds).not.toContain(other.condId);
+          for (const tid of other.trueIds) {
+            expect(body.bodyNodeIds).not.toContain(tid);
+          }
+        }
+      });
+    });
+  }
+});
+
+// -----------------------------------------------------------------------
+// Topology 2: Five parallel For Each loops, each with 3 chained conditions
+//   fe -> read -> cond-a (5t/5f) -> cond-b (5t/5f) -> cond-c (5t/5f) -> collect
+// Only the true branch of each condition leads to the next condition.
+// -----------------------------------------------------------------------
+
+describe("topology 2: five For Each loops with chained conditions (3 deep, 5 branches each)", () => {
+  const allNodes: TestNode[] = [];
+  const allEdges: TestEdge[] = [];
+
+  const loops: Array<{
+    feId: string;
+    condIds: string[];
+    trueFans: string[][];
+    falseFans: string[][];
+  }> = [];
+
+  for (let i = 1; i <= 5; i++) {
+    const feId = `fe-${i}`;
+    const readId = `read-${i}`;
+    const collectId = `collect-${i}`;
+    const condIds = [`cond-${i}a`, `cond-${i}b`, `cond-${i}c`];
+
+    allNodes.push(forEachNode(feId));
+    allNodes.push(actionNode(readId));
+    allNodes.push(collectNode(collectId));
+    for (const cid of condIds) {
+      allNodes.push(conditionNode(cid));
+    }
+
+    // fe -> read -> cond-a
+    allEdges.push(edge(feId, readId));
+    allEdges.push(edge(readId, condIds[0]));
+
+    const trueFans: string[][] = [];
+    const falseFans: string[][] = [];
+
+    for (let c = 0; c < condIds.length; c++) {
+      const condId = condIds[c];
+
+      // 5 false-branch targets
+      const ff = fanOut(condId, "false", `l${i}c${c}`, 5);
+      allNodes.push(...ff.nodes);
+      allEdges.push(...ff.edges);
+      falseFans.push(ff.ids);
+      for (const fid of ff.ids) {
+        allEdges.push(edge(fid, collectId));
+      }
+
+      if (c < condIds.length - 1) {
+        // True branch of non-final conditions: 4 action targets + next condition
+        const tf = fanOut(condId, "true", `l${i}c${c}`, 4);
+        allNodes.push(...tf.nodes);
+        allEdges.push(...tf.edges);
+        // Also connect true handle to the next condition
+        allEdges.push(edge(condId, condIds[c + 1], "true"));
+        trueFans.push([...tf.ids, condIds[c + 1]]);
+        for (const tid of tf.ids) {
+          allEdges.push(edge(tid, collectId));
+        }
+      } else {
+        // Final condition: 5 true-branch targets
+        const tf = fanOut(condId, "true", `l${i}c${c}`, 5);
+        allNodes.push(...tf.nodes);
+        allEdges.push(...tf.edges);
+        trueFans.push(tf.ids);
+        for (const tid of tf.ids) {
+          allEdges.push(edge(tid, collectId));
+        }
+      }
+    }
+
+    loops.push({ feId, condIds, trueFans, falseFans });
+  }
+
+  const { edgesBySource, edgesBySourceHandle, nodeMap } = buildMaps(
+    allNodes,
+    allEdges
+  );
+
+  for (const loop of loops) {
+    describe(`${loop.feId}: three chained conditions`, () => {
+      it("all conditions true: walks the full chain", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        for (let c = 0; c < loop.condIds.length; c++) {
+          const targets = resolveBodyConditionTargets(
+            true,
+            loop.condIds[c],
+            body.bodyEdgesBySourceHandle,
+            body.bodyEdgesBySource
+          );
+          expect(targets).toEqual(loop.trueFans[c]);
+        }
+      });
+
+      it("first condition false: nothing beyond first condition executes", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        const targets = resolveBodyConditionTargets(
+          false,
+          loop.condIds[0],
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+        expect(targets).toEqual(loop.falseFans[0]);
+
+        // Second and third conditions should not be in the dispatched set
+        for (let c = 1; c < loop.condIds.length; c++) {
+          expect(targets).not.toContain(loop.condIds[c]);
+        }
+      });
+
+      it("first true, second false: chain stops at second condition", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        const firstTargets = resolveBodyConditionTargets(
+          true,
+          loop.condIds[0],
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+        // Should include next condition
+        expect(firstTargets).toContain(loop.condIds[1]);
+
+        const secondTargets = resolveBodyConditionTargets(
+          false,
+          loop.condIds[1],
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+        expect(secondTargets).toEqual(loop.falseFans[1]);
+        expect(secondTargets).not.toContain(loop.condIds[2]);
+      });
+
+      it("first true, second true, third false: only third false branch", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        const t1 = resolveBodyConditionTargets(
+          true,
+          loop.condIds[0],
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+        expect(t1).toContain(loop.condIds[1]);
+
+        const t2 = resolveBodyConditionTargets(
+          true,
+          loop.condIds[1],
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+        expect(t2).toContain(loop.condIds[2]);
+
+        const t3 = resolveBodyConditionTargets(
+          false,
+          loop.condIds[2],
+          body.bodyEdgesBySourceHandle,
+          body.bodyEdgesBySource
+        );
+        expect(t3).toEqual(loop.falseFans[2]);
+      });
+
+      it("each false branch has exactly 5 targets", () => {
+        const body = identifyLoopBody(
+          loop.feId,
+          edgesBySource,
+          nodeMap,
+          edgesBySourceHandle
+        );
+
+        for (let c = 0; c < loop.condIds.length; c++) {
+          const targets = resolveBodyConditionTargets(
+            false,
+            loop.condIds[c],
+            body.bodyEdgesBySourceHandle,
+            body.bodyEdgesBySource
+          );
+          expect(targets).toHaveLength(5);
+        }
+      });
+    });
+  }
+});
+
+// -----------------------------------------------------------------------
+// Topology 3: Single For Each with 5 parallel conditions (each 5t + 5f)
+//   fe -> read -> cond-1..cond-5 (all from read, each with 5t + 5f) -> collect
+// -----------------------------------------------------------------------
+
+describe("topology 3: For Each with 5 parallel conditions, each 5t + 5f", () => {
+  const nodes: TestNode[] = [];
+  const edges: TestEdge[] = [];
+
+  const feId = "fe-parallel";
+  const readId = "read-all";
+  const collectId = "collect-all";
+
+  nodes.push(forEachNode(feId));
+  nodes.push(actionNode(readId));
+  nodes.push(collectNode(collectId));
+
+  edges.push(edge(feId, readId));
+
+  const condData: Array<{
+    condId: string;
+    trueIds: string[];
+    falseIds: string[];
+  }> = [];
+
+  for (let c = 1; c <= 5; c++) {
+    const condId = `pcond-${c}`;
+    nodes.push(conditionNode(condId));
+    edges.push(edge(readId, condId));
+
+    const tf = fanOut(condId, "true", `p${c}`, 5);
+    const ff = fanOut(condId, "false", `p${c}`, 5);
+
+    nodes.push(...tf.nodes, ...ff.nodes);
+    edges.push(...tf.edges, ...ff.edges);
+
+    for (const id of [...tf.ids, ...ff.ids]) {
+      edges.push(edge(id, collectId));
+    }
+
+    condData.push({ condId, trueIds: tf.ids, falseIds: ff.ids });
+  }
+
+  const { edgesBySource, edgesBySourceHandle, nodeMap } = buildMaps(
+    nodes,
+    edges
+  );
+
+  it("body contains all 5 conditions and all 50 branch targets", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    // read + 5 conditions + 25 true targets + 25 false targets = 56
+    expect(body.bodyNodeIds).toHaveLength(56);
+    for (const cd of condData) {
+      expect(body.bodyNodeIds).toContain(cd.condId);
+    }
+  });
+
+  it("each condition routes independently: alternating true/false pattern", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    // Odd conditions true, even conditions false
+    for (let i = 0; i < condData.length; i++) {
+      const isTrue = i % 2 === 0;
+      const targets = resolveBodyConditionTargets(
+        isTrue,
+        condData[i].condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+
+      if (isTrue) {
+        expect(targets).toEqual(condData[i].trueIds);
+        expect(targets).toHaveLength(5);
+      } else {
+        expect(targets).toEqual(condData[i].falseIds);
+        expect(targets).toHaveLength(5);
+      }
+    }
+  });
+
+  it("all conditions false: no true targets reached", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const allDispatched: string[] = [];
+    for (const cd of condData) {
+      const targets = resolveBodyConditionTargets(
+        false,
+        cd.condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+      allDispatched.push(...targets);
+      expect(targets).toEqual(cd.falseIds);
+    }
+
+    // No true target should appear in dispatched set
+    for (const cd of condData) {
+      for (const tid of cd.trueIds) {
+        expect(allDispatched).not.toContain(tid);
+      }
+    }
+  });
+
+  it("all conditions true: no false targets reached", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const allDispatched: string[] = [];
+    for (const cd of condData) {
+      const targets = resolveBodyConditionTargets(
+        true,
+        cd.condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+      allDispatched.push(...targets);
+      expect(targets).toEqual(cd.trueIds);
+    }
+
+    for (const cd of condData) {
+      for (const fid of cd.falseIds) {
+        expect(allDispatched).not.toContain(fid);
+      }
+    }
+  });
+
+  it("one condition true, rest false: only that condition's true branch fires", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const activeIndex = 2;
+    const allDispatched: string[] = [];
+
+    for (let i = 0; i < condData.length; i++) {
+      const isTrue = i === activeIndex;
+      const targets = resolveBodyConditionTargets(
+        isTrue,
+        condData[i].condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+      allDispatched.push(...targets);
+    }
+
+    // Only the active condition's true targets should be present
+    for (const tid of condData[activeIndex].trueIds) {
+      expect(allDispatched).toContain(tid);
+    }
+    // All other true targets should be absent
+    for (let i = 0; i < condData.length; i++) {
+      if (i === activeIndex) {
+        continue;
+      }
+      for (const tid of condData[i].trueIds) {
+        expect(allDispatched).not.toContain(tid);
+      }
+    }
+  });
+});
+
+// -----------------------------------------------------------------------
+// Topology 4: For Each with nested conditions
+//   fe -> cond-outer (true-only)
+//           true -> 5 inner conditions (each 5t + 5f)
+//   collect
+// When outer is false, all 5 inner conditions and their 50 targets are dead.
+// -----------------------------------------------------------------------
+
+describe("topology 4: For Each with outer gate + 5 nested inner conditions", () => {
+  const nodes: TestNode[] = [];
+  const edges: TestEdge[] = [];
+
+  const feId = "fe-nested";
+  const outerId = "cond-outer";
+  const collectId = "collect-nested";
+
+  nodes.push(forEachNode(feId));
+  nodes.push(conditionNode(outerId));
+  nodes.push(collectNode(collectId));
+
+  edges.push(edge(feId, outerId));
+
+  const innerConds: Array<{
+    condId: string;
+    trueIds: string[];
+    falseIds: string[];
+  }> = [];
+
+  for (let c = 1; c <= 5; c++) {
+    const condId = `inner-${c}`;
+    nodes.push(conditionNode(condId));
+    // Outer true -> inner condition
+    edges.push(edge(outerId, condId, "true"));
+
+    const tf = fanOut(condId, "true", `n${c}`, 5);
+    const ff = fanOut(condId, "false", `n${c}`, 5);
+
+    nodes.push(...tf.nodes, ...ff.nodes);
+    edges.push(...tf.edges, ...ff.edges);
+
+    for (const id of [...tf.ids, ...ff.ids]) {
+      edges.push(edge(id, collectId));
+    }
+
+    innerConds.push({ condId, trueIds: tf.ids, falseIds: ff.ids });
+  }
+
+  // Inner condition nodes also need edges to collect
+  for (const ic of innerConds) {
+    // Collect reachable from the inner condition nodes' children (already added above)
+  }
+
+  const { edgesBySource, edgesBySourceHandle, nodeMap } = buildMaps(
+    nodes,
+    edges
+  );
+
+  it("outer=false blocks all 5 inner conditions and all 50 targets", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const outerTargets = resolveBodyConditionTargets(
+      false,
+      outerId,
+      body.bodyEdgesBySourceHandle,
+      body.bodyEdgesBySource
+    );
+
+    expect(outerTargets).toEqual([]);
+  });
+
+  it("outer=true dispatches all 5 inner conditions", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const outerTargets = resolveBodyConditionTargets(
+      true,
+      outerId,
+      body.bodyEdgesBySourceHandle,
+      body.bodyEdgesBySource
+    );
+
+    expect(outerTargets).toHaveLength(5);
+    for (const ic of innerConds) {
+      expect(outerTargets).toContain(ic.condId);
+    }
+  });
+
+  it("outer=true, all inner=true: only true targets fire", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const allDispatched: string[] = [];
+    for (const ic of innerConds) {
+      const targets = resolveBodyConditionTargets(
+        true,
+        ic.condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+      expect(targets).toEqual(ic.trueIds);
+      expect(targets).toHaveLength(5);
+      allDispatched.push(...targets);
+    }
+
+    // 25 true targets total
+    expect(allDispatched).toHaveLength(25);
+    for (const ic of innerConds) {
+      for (const fid of ic.falseIds) {
+        expect(allDispatched).not.toContain(fid);
+      }
+    }
+  });
+
+  it("outer=true, all inner=false: only false targets fire", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    const allDispatched: string[] = [];
+    for (const ic of innerConds) {
+      const targets = resolveBodyConditionTargets(
+        false,
+        ic.condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+      expect(targets).toEqual(ic.falseIds);
+      expect(targets).toHaveLength(5);
+      allDispatched.push(...targets);
+    }
+
+    expect(allDispatched).toHaveLength(25);
+    for (const ic of innerConds) {
+      for (const tid of ic.trueIds) {
+        expect(allDispatched).not.toContain(tid);
+      }
+    }
+  });
+
+  it("outer=true, mixed inner results: each condition routes independently", () => {
+    const body = identifyLoopBody(
+      feId,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+
+    // Pattern: true, false, true, false, true
+    const pattern = [true, false, true, false, true];
+    const allDispatched: string[] = [];
+
+    for (let i = 0; i < innerConds.length; i++) {
+      const targets = resolveBodyConditionTargets(
+        pattern[i],
+        innerConds[i].condId,
+        body.bodyEdgesBySourceHandle,
+        body.bodyEdgesBySource
+      );
+
+      const expected = pattern[i]
+        ? innerConds[i].trueIds
+        : innerConds[i].falseIds;
+      expect(targets).toEqual(expected);
+      expect(targets).toHaveLength(5);
+      allDispatched.push(...targets);
+
+      // Verify the opposite branch is not dispatched
+      const notExpected = pattern[i]
+        ? innerConds[i].falseIds
+        : innerConds[i].trueIds;
+      for (const id of notExpected) {
+        expect(targets).not.toContain(id);
+      }
+    }
+
+    // 25 total: 3 conditions * 5 true + 2 conditions * 5 false
+    expect(allDispatched).toHaveLength(25);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Topology 5: Mixed topology - one-sided gates, varied branch counts,
+// chained and parallel conditions inside 5 For Each loops
+//
+// Each loop has a different internal structure:
+//   Loop 1: one-sided true gate -> 5 action targets (no false branch)
+//   Loop 2: one-sided false gate -> 5 error handlers (no true branch)
+//   Loop 3: chain of 5 one-sided true conditions, each with 1 side action
+//   Loop 4: parallel: 3 one-sided (true-only) + 2 two-sided conditions
+//   Loop 5: nested: two-sided outer (5t/5f), true side has one-sided inner (5t)
+// -----------------------------------------------------------------------
+
+describe("topology 5: mixed structures across 5 For Each loops", () => {
+  // -- Loop 1: one-sided true gate -> 5 targets --
+  const l1Nodes: TestNode[] = [
+    forEachNode("fe-1"),
+    conditionNode("l1-gate"),
+    ...Array.from({ length: 5 }, (_, i) => actionNode(`l1-t${i + 1}`)),
+    collectNode("collect-1"),
+  ];
+  const l1Edges: TestEdge[] = [
+    edge("fe-1", "l1-gate"),
+    ...Array.from({ length: 5 }, (_, i) =>
+      edge("l1-gate", `l1-t${i + 1}`, "true")
+    ),
+    ...Array.from({ length: 5 }, (_, i) =>
+      edge(`l1-t${i + 1}`, "collect-1")
+    ),
+  ];
+
+  // -- Loop 2: one-sided false gate -> 5 error handlers --
+  const l2Nodes: TestNode[] = [
+    forEachNode("fe-2"),
+    conditionNode("l2-gate"),
+    ...Array.from({ length: 5 }, (_, i) => actionNode(`l2-f${i + 1}`)),
+    collectNode("collect-2"),
+  ];
+  const l2Edges: TestEdge[] = [
+    edge("fe-2", "l2-gate"),
+    ...Array.from({ length: 5 }, (_, i) =>
+      edge("l2-gate", `l2-f${i + 1}`, "false")
+    ),
+    ...Array.from({ length: 5 }, (_, i) =>
+      edge(`l2-f${i + 1}`, "collect-2")
+    ),
+  ];
+
+  // -- Loop 3: chain of 5 one-sided true conditions, each with a side action --
+  const l3CondIds = Array.from({ length: 5 }, (_, i) => `l3-c${i + 1}`);
+  const l3ActionIds = Array.from({ length: 5 }, (_, i) => `l3-a${i + 1}`);
+  const l3Nodes: TestNode[] = [
+    forEachNode("fe-3"),
+    ...l3CondIds.map((id) => conditionNode(id)),
+    ...l3ActionIds.map((id) => actionNode(id)),
+    collectNode("collect-3"),
+  ];
+  const l3Edges: TestEdge[] = [
+    edge("fe-3", l3CondIds[0]),
+    ...l3CondIds.map((id, i) => edge(id, l3ActionIds[i], "true")),
+    ...l3CondIds.slice(0, -1).map((id, i) => edge(id, l3CondIds[i + 1], "true")),
+    ...l3ActionIds.map((id) => edge(id, "collect-3")),
+    edge(l3CondIds[4], "collect-3"),
+  ];
+
+  // -- Loop 4: 3 one-sided (true) + 2 two-sided conditions in parallel --
+  const l4Nodes: TestNode[] = [
+    forEachNode("fe-4"),
+    actionNode("l4-read"),
+    ...Array.from({ length: 5 }, (_, i) => conditionNode(`l4-c${i + 1}`)),
+    // 3 one-sided: 5 true targets each = 15
+    ...Array.from({ length: 15 }, (_, i) => actionNode(`l4-os-t${i + 1}`)),
+    // 2 two-sided: 5 true + 5 false each = 20
+    ...Array.from({ length: 10 }, (_, i) => actionNode(`l4-ts-t${i + 1}`)),
+    ...Array.from({ length: 10 }, (_, i) => actionNode(`l4-ts-f${i + 1}`)),
+    collectNode("collect-4"),
+  ];
+  const l4Edges: TestEdge[] = [
+    edge("fe-4", "l4-read"),
+    ...Array.from({ length: 5 }, (_, i) => edge("l4-read", `l4-c${i + 1}`)),
+  ];
+  // One-sided conditions (c1-c3): 5 true targets each
+  for (let c = 0; c < 3; c++) {
+    for (let t = 0; t < 5; t++) {
+      const targetId = `l4-os-t${c * 5 + t + 1}`;
+      l4Edges.push(edge(`l4-c${c + 1}`, targetId, "true"));
+      l4Edges.push(edge(targetId, "collect-4"));
+    }
+  }
+  // Two-sided conditions (c4-c5): 5 true + 5 false targets each
+  for (let c = 0; c < 2; c++) {
+    for (let t = 0; t < 5; t++) {
+      const trueId = `l4-ts-t${c * 5 + t + 1}`;
+      const falseId = `l4-ts-f${c * 5 + t + 1}`;
+      l4Edges.push(edge(`l4-c${c + 4}`, trueId, "true"));
+      l4Edges.push(edge(`l4-c${c + 4}`, falseId, "false"));
+      l4Edges.push(edge(trueId, "collect-4"));
+      l4Edges.push(edge(falseId, "collect-4"));
+    }
+  }
+
+  // -- Loop 5: two-sided outer (5t/5f), true branch has one-sided inner (5 true targets) --
+  const l5Nodes: TestNode[] = [
+    forEachNode("fe-5"),
+    conditionNode("l5-outer"),
+    conditionNode("l5-inner"),
+    ...Array.from({ length: 5 }, (_, i) => actionNode(`l5-ot${i + 1}`)),
+    ...Array.from({ length: 5 }, (_, i) => actionNode(`l5-of${i + 1}`)),
+    ...Array.from({ length: 5 }, (_, i) => actionNode(`l5-it${i + 1}`)),
+    collectNode("collect-5"),
+  ];
+  const l5Edges: TestEdge[] = [
+    edge("fe-5", "l5-outer"),
+    // outer true: 4 actions + inner condition
+    ...Array.from({ length: 4 }, (_, i) =>
+      edge("l5-outer", `l5-ot${i + 1}`, "true")
+    ),
+    edge("l5-outer", "l5-inner", "true"),
+    // outer false: 5 actions
+    ...Array.from({ length: 5 }, (_, i) =>
+      edge("l5-outer", `l5-of${i + 1}`, "false")
+    ),
+    // inner true: 5 actions (one-sided, no false branch)
+    ...Array.from({ length: 5 }, (_, i) =>
+      edge("l5-inner", `l5-it${i + 1}`, "true")
+    ),
+    // Connect everything to collect
+    ...Array.from({ length: 5 }, (_, i) => edge(`l5-ot${i + 1}`, "collect-5")),
+    ...Array.from({ length: 5 }, (_, i) => edge(`l5-of${i + 1}`, "collect-5")),
+    ...Array.from({ length: 5 }, (_, i) => edge(`l5-it${i + 1}`, "collect-5")),
+    edge("l5-inner", "collect-5"),
+  ];
+
+  const allNodes = [...l1Nodes, ...l2Nodes, ...l3Nodes, ...l4Nodes, ...l5Nodes];
+  const allEdges = [...l1Edges, ...l2Edges, ...l3Edges, ...l4Edges, ...l5Edges];
+  const { edgesBySource, edgesBySourceHandle, nodeMap } = buildMaps(
+    allNodes,
+    allEdges
+  );
+
+  describe("loop 1: one-sided true gate", () => {
+    it("true dispatches all 5 targets", () => {
+      const body = identifyLoopBody("fe-1", edgesBySource, nodeMap, edgesBySourceHandle);
+      const targets = resolveBodyConditionTargets(
+        true, "l1-gate", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(targets).toHaveLength(5);
+      for (let i = 1; i <= 5; i++) {
+        expect(targets).toContain(`l1-t${i}`);
+      }
+    });
+
+    it("false dispatches nothing", () => {
+      const body = identifyLoopBody("fe-1", edgesBySource, nodeMap, edgesBySourceHandle);
+      const targets = resolveBodyConditionTargets(
+        false, "l1-gate", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("loop 2: one-sided false gate", () => {
+    it("false dispatches all 5 error handlers", () => {
+      const body = identifyLoopBody("fe-2", edgesBySource, nodeMap, edgesBySourceHandle);
+      const targets = resolveBodyConditionTargets(
+        false, "l2-gate", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(targets).toHaveLength(5);
+      for (let i = 1; i <= 5; i++) {
+        expect(targets).toContain(`l2-f${i}`);
+      }
+    });
+
+    it("true dispatches nothing", () => {
+      const body = identifyLoopBody("fe-2", edgesBySource, nodeMap, edgesBySourceHandle);
+      const targets = resolveBodyConditionTargets(
+        true, "l2-gate", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("loop 3: chain of 5 one-sided true conditions", () => {
+    it("all true: every condition dispatches its side action and next condition", () => {
+      const body = identifyLoopBody("fe-3", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      for (let i = 0; i < 5; i++) {
+        const targets = resolveBodyConditionTargets(
+          true, l3CondIds[i], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+        );
+        expect(targets).toContain(l3ActionIds[i]);
+        if (i < 4) {
+          expect(targets).toContain(l3CondIds[i + 1]);
+        }
+      }
+    });
+
+    it("false at position 0: entire chain is dead", () => {
+      const body = identifyLoopBody("fe-3", edgesBySource, nodeMap, edgesBySourceHandle);
+      const targets = resolveBodyConditionTargets(
+        false, l3CondIds[0], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(targets).toEqual([]);
+    });
+
+    it("false at position 2: first two conditions dispatch, rest dead", () => {
+      const body = identifyLoopBody("fe-3", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const t0 = resolveBodyConditionTargets(
+        true, l3CondIds[0], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(t0).toContain(l3CondIds[1]);
+
+      const t1 = resolveBodyConditionTargets(
+        true, l3CondIds[1], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(t1).toContain(l3CondIds[2]);
+
+      const t2 = resolveBodyConditionTargets(
+        false, l3CondIds[2], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(t2).toEqual([]);
+    });
+
+    it("false at position 4 (last): first four dispatch, last blocks", () => {
+      const body = identifyLoopBody("fe-3", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      for (let i = 0; i < 4; i++) {
+        const t = resolveBodyConditionTargets(
+          true, l3CondIds[i], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+        );
+        expect(t).toContain(l3ActionIds[i]);
+        expect(t).toContain(l3CondIds[i + 1]);
+      }
+
+      const tLast = resolveBodyConditionTargets(
+        false, l3CondIds[4], body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(tLast).toEqual([]);
+    });
+  });
+
+  describe("loop 4: 3 one-sided + 2 two-sided conditions in parallel", () => {
+    it("all one-sided conditions false: no one-sided targets fire", () => {
+      const body = identifyLoopBody("fe-4", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      for (let c = 1; c <= 3; c++) {
+        const targets = resolveBodyConditionTargets(
+          false, `l4-c${c}`, body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+        );
+        expect(targets).toEqual([]);
+      }
+    });
+
+    it("all one-sided conditions true: 15 targets fire", () => {
+      const body = identifyLoopBody("fe-4", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const allTargets: string[] = [];
+      for (let c = 1; c <= 3; c++) {
+        const targets = resolveBodyConditionTargets(
+          true, `l4-c${c}`, body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+        );
+        expect(targets).toHaveLength(5);
+        allTargets.push(...targets);
+      }
+      expect(allTargets).toHaveLength(15);
+    });
+
+    it("two-sided c4=true, c5=false: correct targets for each", () => {
+      const body = identifyLoopBody("fe-4", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const c4Targets = resolveBodyConditionTargets(
+        true, "l4-c4", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(c4Targets).toHaveLength(5);
+      for (let t = 1; t <= 5; t++) {
+        expect(c4Targets).toContain(`l4-ts-t${t}`);
+      }
+
+      const c5Targets = resolveBodyConditionTargets(
+        false, "l4-c5", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(c5Targets).toHaveLength(5);
+      for (let t = 6; t <= 10; t++) {
+        expect(c5Targets).toContain(`l4-ts-f${t}`);
+      }
+    });
+
+    it("two-sided c4=false, c5=true: correct targets for each", () => {
+      const body = identifyLoopBody("fe-4", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const c4Targets = resolveBodyConditionTargets(
+        false, "l4-c4", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(c4Targets).toHaveLength(5);
+      for (let t = 1; t <= 5; t++) {
+        expect(c4Targets).toContain(`l4-ts-f${t}`);
+      }
+
+      const c5Targets = resolveBodyConditionTargets(
+        true, "l4-c5", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(c5Targets).toHaveLength(5);
+      for (let t = 6; t <= 10; t++) {
+        expect(c5Targets).toContain(`l4-ts-t${t}`);
+      }
+    });
+
+    it("mixed: one-sided all false, two-sided all true: only two-sided true branches fire", () => {
+      const body = identifyLoopBody("fe-4", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const allDispatched: string[] = [];
+
+      for (let c = 1; c <= 3; c++) {
+        const targets = resolveBodyConditionTargets(
+          false, `l4-c${c}`, body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+        );
+        expect(targets).toEqual([]);
+      }
+
+      for (let c = 4; c <= 5; c++) {
+        const targets = resolveBodyConditionTargets(
+          true, `l4-c${c}`, body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+        );
+        expect(targets).toHaveLength(5);
+        allDispatched.push(...targets);
+      }
+
+      expect(allDispatched).toHaveLength(10);
+      // Verify no false targets from two-sided conditions
+      for (let i = 1; i <= 10; i++) {
+        expect(allDispatched).not.toContain(`l4-ts-f${i}`);
+      }
+    });
+  });
+
+  describe("loop 5: two-sided outer + one-sided inner on true branch", () => {
+    it("outer=false: 5 false targets, inner never reached", () => {
+      const body = identifyLoopBody("fe-5", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const outerTargets = resolveBodyConditionTargets(
+        false, "l5-outer", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(outerTargets).toHaveLength(5);
+      for (let i = 1; i <= 5; i++) {
+        expect(outerTargets).toContain(`l5-of${i}`);
+      }
+      expect(outerTargets).not.toContain("l5-inner");
+    });
+
+    it("outer=true: 4 true actions + inner condition dispatched", () => {
+      const body = identifyLoopBody("fe-5", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const outerTargets = resolveBodyConditionTargets(
+        true, "l5-outer", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(outerTargets).toHaveLength(5);
+      for (let i = 1; i <= 4; i++) {
+        expect(outerTargets).toContain(`l5-ot${i}`);
+      }
+      expect(outerTargets).toContain("l5-inner");
+
+      // No false targets
+      for (let i = 1; i <= 5; i++) {
+        expect(outerTargets).not.toContain(`l5-of${i}`);
+      }
+    });
+
+    it("outer=true, inner=true: inner dispatches 5 targets", () => {
+      const body = identifyLoopBody("fe-5", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const innerTargets = resolveBodyConditionTargets(
+        true, "l5-inner", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(innerTargets).toHaveLength(5);
+      for (let i = 1; i <= 5; i++) {
+        expect(innerTargets).toContain(`l5-it${i}`);
+      }
+    });
+
+    it("outer=true, inner=false: inner dispatches nothing (one-sided)", () => {
+      const body = identifyLoopBody("fe-5", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const innerTargets = resolveBodyConditionTargets(
+        false, "l5-inner", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      expect(innerTargets).toEqual([]);
+    });
+
+    it("full walk outer=true inner=true: correct total dispatched set", () => {
+      const body = identifyLoopBody("fe-5", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const outerTargets = resolveBodyConditionTargets(
+        true, "l5-outer", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+      const innerTargets = resolveBodyConditionTargets(
+        true, "l5-inner", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+
+      const allDispatched = new Set([...outerTargets, ...innerTargets]);
+      // 4 outer-true actions + inner condition + 5 inner-true actions = 10
+      expect(allDispatched.size).toBe(10);
+
+      // No outer-false targets
+      for (let i = 1; i <= 5; i++) {
+        expect(allDispatched.has(`l5-of${i}`)).toBe(false);
+      }
+    });
+
+    it("full walk outer=false: zero nodes beyond outer false targets", () => {
+      const body = identifyLoopBody("fe-5", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      const outerTargets = resolveBodyConditionTargets(
+        false, "l5-outer", body.bodyEdgesBySourceHandle, body.bodyEdgesBySource
+      );
+
+      const allDispatched = new Set(outerTargets);
+      expect(allDispatched.size).toBe(5);
+
+      // No true targets, no inner targets
+      for (let i = 1; i <= 5; i++) {
+        expect(allDispatched.has(`l5-ot${i}`)).toBe(false);
+        expect(allDispatched.has(`l5-it${i}`)).toBe(false);
+      }
+      expect(allDispatched.has("l5-inner")).toBe(false);
+    });
+  });
+
+  describe("cross-loop isolation", () => {
+    it("each loop body contains only its own nodes", () => {
+      const feIds = ["fe-1", "fe-2", "fe-3", "fe-4", "fe-5"];
+      const bodies = feIds.map((feId) =>
+        identifyLoopBody(feId, edgesBySource, nodeMap, edgesBySourceHandle)
+      );
+
+      for (let i = 0; i < bodies.length; i++) {
+        const bodySet = new Set(bodies[i].bodyNodeIds);
+        for (let j = 0; j < bodies.length; j++) {
+          if (i === j) {
+            continue;
+          }
+          for (const nodeId of bodies[j].bodyNodeIds) {
+            expect(bodySet.has(nodeId)).toBe(false);
+          }
+        }
+      }
+    });
+
+    it("condition decisions in one loop do not affect another loop's routing", () => {
+      const body1 = identifyLoopBody("fe-1", edgesBySource, nodeMap, edgesBySourceHandle);
+      const body2 = identifyLoopBody("fe-2", edgesBySource, nodeMap, edgesBySourceHandle);
+
+      // Loop 1 gate = false (nothing dispatched)
+      const l1Targets = resolveBodyConditionTargets(
+        false, "l1-gate", body1.bodyEdgesBySourceHandle, body1.bodyEdgesBySource
+      );
+      expect(l1Targets).toEqual([]);
+
+      // Loop 2 gate = false (5 error handlers dispatched)
+      const l2Targets = resolveBodyConditionTargets(
+        false, "l2-gate", body2.bodyEdgesBySourceHandle, body2.bodyEdgesBySource
+      );
+      expect(l2Targets).toHaveLength(5);
+
+      // They should share zero node IDs
+      const l1Set = new Set(l1Targets);
+      for (const id of l2Targets) {
+        expect(l1Set.has(id)).toBe(false);
+      }
+    });
+  });
+});

--- a/tests/unit/condition-foreach-workflow-topology.test.ts
+++ b/tests/unit/condition-foreach-workflow-topology.test.ts
@@ -1,0 +1,657 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { buildEdgesBySourceHandle } from "@/lib/edge-handle-utils";
+import {
+  evaluateConditionExpression,
+  identifyLoopBody,
+  resolveBodyConditionTargets,
+} from "@/lib/workflow-executor.workflow";
+
+type TestNode = {
+  id: string;
+  data: {
+    label: string;
+    type: "trigger" | "action" | "add";
+    config?: Record<string, unknown>;
+  };
+  position: { x: number; y: number };
+};
+
+type TestEdge = {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle?: string | null;
+};
+
+let edgeCounter = 0;
+
+function te(source: string, target: string, sourceHandle?: string): TestEdge {
+  edgeCounter++;
+  return {
+    id: `e-${edgeCounter}`,
+    source,
+    target,
+    sourceHandle: sourceHandle ?? null,
+  };
+}
+
+function action(id: string, actionType?: string): TestNode {
+  return {
+    id,
+    data: {
+      label: id,
+      type: "action",
+      config: actionType ? { actionType } : undefined,
+    },
+    position: { x: 0, y: 0 },
+  };
+}
+
+function condition(id: string): TestNode {
+  return action(id, "Condition");
+}
+
+const FE_ID = "for-each";
+const COLLECT_ID = "collect";
+
+const nodes: TestNode[] = [
+  action(FE_ID, "For Each"),
+  action(COLLECT_ID, "Collect"),
+  action("read-tokens"),
+  condition("compare-tokens"),
+  condition("already-done"),
+  action("search-db"),
+  condition("exists-in-db"),
+  condition("is-valid"),
+  action("send-alert-1"),
+  action("send-alert-2"),
+  action("query-history"),
+  action("transform-data"),
+  condition("has-prior-action"),
+  action("execute-action-a"),
+  action("check-state"),
+  condition("state-ready"),
+  action("execute-action-b"),
+  action("notify-1"),
+  condition("meets-threshold"),
+  action("execute-action-c"),
+  action("get-receipt"),
+  action("notify-2"),
+];
+
+const edges: TestEdge[] = [
+  te(FE_ID, "read-tokens", "loop"),
+  te(FE_ID, COLLECT_ID, "done"),
+  te("read-tokens", "compare-tokens"),
+  te("compare-tokens", "already-done", "true"),
+  te("already-done", "search-db", "false"),
+  te("search-db", "exists-in-db"),
+  te("exists-in-db", "is-valid", "true"),
+  te("exists-in-db", "send-alert-2", "false"),
+  te("is-valid", "query-history", "true"),
+  te("is-valid", "send-alert-1", "false"),
+  te("send-alert-1", "query-history"),
+  te("send-alert-2", "query-history"),
+  te("query-history", "transform-data"),
+  te("transform-data", "has-prior-action"),
+  te("has-prior-action", "check-state", "true"),
+  te("has-prior-action", "execute-action-a", "false"),
+  te("execute-action-a", "check-state"),
+  te("check-state", "state-ready"),
+  te("state-ready", "meets-threshold", "true"),
+  te("state-ready", "execute-action-b", "false"),
+  te("execute-action-b", "notify-1"),
+  te("execute-action-b", "meets-threshold"),
+  te("meets-threshold", "execute-action-c", "true"),
+  te("execute-action-c", "get-receipt"),
+  te("get-receipt", "notify-2"),
+];
+
+const edgesBySource = new Map<string, string[]>();
+for (const edge of edges) {
+  if (!edgesBySource.has(edge.source)) {
+    edgesBySource.set(edge.source, []);
+  }
+  edgesBySource.get(edge.source)!.push(edge.target);
+}
+
+const edgesBySourceHandle = buildEdgesBySourceHandle(edges);
+
+// biome-ignore lint/suspicious/noExplicitAny: TestNode is a minimal stand-in for WorkflowNode from xyflow
+const nodeMap = new Map<string, any>();
+for (const n of nodes) {
+  nodeMap.set(n.id, n);
+}
+
+const body = identifyLoopBody(FE_ID, edgesBySource, nodeMap, edgesBySourceHandle);
+
+function route(conditionValue: boolean, nodeId: string): string[] {
+  return resolveBodyConditionTargets(
+    conditionValue,
+    nodeId,
+    body.bodyEdgesBySourceHandle,
+    body.bodyEdgesBySource
+  );
+}
+
+function evaluateAndRoute(
+  expression: string,
+  outputs: Record<string, { label: string; data: unknown }>,
+  nodeId: string
+): { result: boolean; targets: string[] } {
+  const { result } = evaluateConditionExpression(expression, outputs);
+  const targets = route(result, nodeId);
+  return { result, targets };
+}
+
+const SPELL_ZERO_TOKENS = {
+  spellTokens: { label: "Spell Tokens", data: { amt: "0" } },
+};
+
+const SPELL_HIGH_TOKENS = {
+  spellTokens: {
+    label: "Spell Tokens",
+    data: { amt: "8291047382917492837461029384" },
+  },
+};
+
+const HAT_TOKENS = {
+  hatTokens: {
+    label: "Hat Tokens",
+    data: { amt: "6577716159627818993901156981" },
+  },
+};
+
+const BATCH_CAST_TRUE = {
+  batchRead: { label: "Batch Read", data: { results: [true, "1749820800", "1749907200"] } },
+};
+
+const BATCH_CAST_FALSE = {
+  batchRead: { label: "Batch Read", data: { results: [false, "1749820800", "1749907200"] } },
+};
+
+const DB_FOUND = {
+  dbResult: { label: "DB Result", data: { count: 1 } },
+};
+
+const DB_NOT_FOUND = {
+  dbResult: { label: "DB Result", data: { count: 0 } },
+};
+
+const DB_WHITELISTED = {
+  dbRow: { label: "DB Row", data: { success: true } },
+};
+
+const DB_NOT_WHITELISTED = {
+  dbRow: { label: "DB Row", data: { success: false } },
+};
+
+const LIFT_EVENTS_FOUND = {
+  liftFilter: { label: "Lift Filter", data: { matchCount: 3 } },
+};
+
+const LIFT_EVENTS_NONE = {
+  liftFilter: { label: "Lift Filter", data: { matchCount: 0 } },
+};
+
+const SCHEDULE_FOUND = {
+  scheduleTxns: { label: "Schedule Txns", data: { matchCount: 2 } },
+};
+
+const SCHEDULE_NOT_FOUND = {
+  scheduleTxns: { label: "Schedule Txns", data: { matchCount: 0 } },
+};
+
+const CAN_CAST = {
+  execStatus: {
+    label: "Exec Status",
+    data: { expiration: "1749993600", nextCastTime: "1749820800" },
+  },
+  systemTime: { label: "System Time", data: { unixTimestamp: 1749907200 } },
+};
+
+const CANNOT_CAST = {
+  execStatus: {
+    label: "Exec Status",
+    data: { expiration: "1749993600", nextCastTime: "1749993700" },
+  },
+  systemTime: { label: "System Time", data: { unixTimestamp: 1749907200 } },
+};
+
+const EXPR_COMPARE = "{{@spellTokens:Spell Tokens.amt}} > {{@hatTokens:Hat Tokens.amt}}";
+const EXPR_CAST_STATUS = "{{@batchRead:Batch Read.results[0]}} === true";
+const EXPR_DB_COUNT = "{{@dbResult:DB Result.count}} === 1";
+const EXPR_WHITELIST = "{{@dbRow:DB Row.success}} === true";
+const EXPR_LIFT_COUNT = "{{@liftFilter:Lift Filter.matchCount}} > 0";
+const EXPR_SCHEDULE_COUNT = "{{@scheduleTxns:Schedule Txns.matchCount}} !== 0";
+const EXPR_CAN_CAST =
+  "{{@execStatus:Exec Status.expiration}} >= {{@systemTime:System Time.unixTimestamp}} && {{@systemTime:System Time.unixTimestamp}} >= {{@execStatus:Exec Status.nextCastTime}}";
+
+describe("For Each body: 7 chained conditions with real web3 values", () => {
+  describe("body identification", () => {
+    it("collects 20 body nodes with correct boundary", () => {
+      expect(body.collectNodeId).toBe(COLLECT_ID);
+      expect(body.bodyNodeIds).toHaveLength(20);
+      expect(body.bodyNodeIds).not.toContain(FE_ID);
+      expect(body.bodyNodeIds).not.toContain(COLLECT_ID);
+    });
+
+    it("includes all 7 condition nodes", () => {
+      for (const id of [
+        "compare-tokens", "already-done", "exists-in-db", "is-valid",
+        "has-prior-action", "state-ready", "meets-threshold",
+      ]) {
+        expect(body.bodyNodeIds).toContain(id);
+      }
+    });
+  });
+
+  describe("C1 compare-tokens: 0 tokens vs 6.5e27 hat -> nothing runs", () => {
+    it("evaluates false, dispatches nothing", () => {
+      const { result, targets } = evaluateAndRoute(
+        EXPR_COMPARE, { ...SPELL_ZERO_TOKENS, ...HAT_TOKENS }, "compare-tokens"
+      );
+      expect(result).toBe(false);
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("C1 compare-tokens: 8.2e27 spell vs 6.5e27 hat -> already-done runs", () => {
+    it("evaluates true, dispatches to already-done", () => {
+      const { result, targets } = evaluateAndRoute(
+        EXPR_COMPARE, { ...SPELL_HIGH_TOKENS, ...HAT_TOKENS }, "compare-tokens"
+      );
+      expect(result).toBe(true);
+      expect(targets).toEqual(["already-done"]);
+    });
+  });
+
+  describe("C1 compare-tokens: equal amounts -> nothing runs", () => {
+    it("not strictly greater, dispatches nothing", () => {
+      const { result, targets } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: { label: "Spell Tokens", data: { amt: "6577716159627818993901156981" } },
+          ...HAT_TOKENS,
+        },
+        "compare-tokens"
+      );
+      expect(result).toBe(false);
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("C1 compare-tokens: spell exceeds hat by 1 wei -> already-done runs", () => {
+    it("evaluates true at 1 wei difference", () => {
+      const { result, targets } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: { label: "Spell Tokens", data: { amt: "6577716159627818993901156982" } },
+          ...HAT_TOKENS,
+        },
+        "compare-tokens"
+      );
+      expect(result).toBe(true);
+      expect(targets).toEqual(["already-done"]);
+    });
+  });
+
+  describe("C1 compare-tokens: above MAX_SAFE_INTEGER boundary -> correct BigInt comparison", () => {
+    it("9007199254740993 > 9007199254740992 evaluates true", () => {
+      const { result } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: { label: "Spell Tokens", data: { amt: "9007199254740993" } },
+          hatTokens: { label: "Hat Tokens", data: { amt: "9007199254740992" } },
+        },
+        "compare-tokens"
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("C1 compare-tokens: uint256 max range -> correct comparison", () => {
+    it("max-1 < max evaluates correctly", () => {
+      const { result } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: {
+            label: "Spell Tokens",
+            data: { amt: "115792089237316195423570985008687907853269984665640564039457584007913129639935" },
+          },
+          hatTokens: {
+            label: "Hat Tokens",
+            data: { amt: "115792089237316195423570985008687907853269984665640564039457584007913129639934" },
+          },
+        },
+        "compare-tokens"
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("C1 compare-tokens: both zero -> nothing runs", () => {
+    it("0 is not > 0", () => {
+      const { result, targets } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: { label: "Spell Tokens", data: { amt: "0" } },
+          hatTokens: { label: "Hat Tokens", data: { amt: "0" } },
+        },
+        "compare-tokens"
+      );
+      expect(result).toBe(false);
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("C2 already-done: cast=true -> nothing runs (already handled)", () => {
+    it("evaluates true, dispatches nothing", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_CAST_STATUS, BATCH_CAST_TRUE, "already-done");
+      expect(result).toBe(true);
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("C2 already-done: cast=false -> search-db runs", () => {
+    it("evaluates false, dispatches to search-db", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_CAST_STATUS, BATCH_CAST_FALSE, "already-done");
+      expect(result).toBe(false);
+      expect(targets).toEqual(["search-db"]);
+    });
+  });
+
+  describe("C3 exists-in-db: count=1 -> is-valid runs, send-alert-2 does not", () => {
+    it("evaluates true, dispatches to is-valid", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_DB_COUNT, DB_FOUND, "exists-in-db");
+      expect(result).toBe(true);
+      expect(targets).toEqual(["is-valid"]);
+    });
+  });
+
+  describe("C3 exists-in-db: count=0 -> send-alert-2 runs, is-valid does not", () => {
+    it("evaluates false, dispatches to send-alert-2", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_DB_COUNT, DB_NOT_FOUND, "exists-in-db");
+      expect(result).toBe(false);
+      expect(targets).toEqual(["send-alert-2"]);
+    });
+  });
+
+  describe("C4 is-valid: whitelisted -> query-history runs, send-alert-1 does not", () => {
+    it("evaluates true, dispatches to query-history", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_WHITELIST, DB_WHITELISTED, "is-valid");
+      expect(result).toBe(true);
+      expect(targets).toEqual(["query-history"]);
+    });
+  });
+
+  describe("C4 is-valid: not whitelisted -> send-alert-1 runs, query-history does not", () => {
+    it("evaluates false, dispatches to send-alert-1", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_WHITELIST, DB_NOT_WHITELISTED, "is-valid");
+      expect(result).toBe(false);
+      expect(targets).toEqual(["send-alert-1"]);
+    });
+  });
+
+  describe("C5 has-prior-action: 3 events -> check-state runs, execute-action-a does not", () => {
+    it("evaluates true, dispatches to check-state", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_LIFT_COUNT, LIFT_EVENTS_FOUND, "has-prior-action");
+      expect(result).toBe(true);
+      expect(targets).toEqual(["check-state"]);
+    });
+  });
+
+  describe("C5 has-prior-action: 0 events -> execute-action-a runs, check-state does not", () => {
+    it("evaluates false, dispatches to execute-action-a", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_LIFT_COUNT, LIFT_EVENTS_NONE, "has-prior-action");
+      expect(result).toBe(false);
+      expect(targets).toEqual(["execute-action-a"]);
+    });
+  });
+
+  describe("C6 state-ready: 2 txns -> meets-threshold runs, execute-action-b does not", () => {
+    it("evaluates true, dispatches to meets-threshold", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_SCHEDULE_COUNT, SCHEDULE_FOUND, "state-ready");
+      expect(result).toBe(true);
+      expect(targets).toEqual(["meets-threshold"]);
+    });
+  });
+
+  describe("C6 state-ready: 0 txns -> execute-action-b runs, meets-threshold does not", () => {
+    it("evaluates false, dispatches to execute-action-b", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_SCHEDULE_COUNT, SCHEDULE_NOT_FOUND, "state-ready");
+      expect(result).toBe(false);
+      expect(targets).toEqual(["execute-action-b"]);
+    });
+  });
+
+  describe("C7 meets-threshold: expiration valid + past cast time -> execute-action-c runs", () => {
+    it("evaluates true, dispatches to execute-action-c", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_CAN_CAST, CAN_CAST, "meets-threshold");
+      expect(result).toBe(true);
+      expect(targets).toEqual(["execute-action-c"]);
+    });
+  });
+
+  describe("C7 meets-threshold: cast time in future -> nothing runs", () => {
+    it("evaluates false, dispatches nothing", () => {
+      const { result, targets } = evaluateAndRoute(EXPR_CAN_CAST, CANNOT_CAST, "meets-threshold");
+      expect(result).toBe(false);
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("full path: all gates pass -> executes through to notify-2", () => {
+    it("C1-C7 all favorable: every node in the happy path runs", () => {
+      const c1 = evaluateAndRoute(EXPR_COMPARE, { ...SPELL_HIGH_TOKENS, ...HAT_TOKENS }, "compare-tokens");
+      expect(c1.targets).toEqual(["already-done"]);
+
+      const c2 = evaluateAndRoute(EXPR_CAST_STATUS, BATCH_CAST_FALSE, "already-done");
+      expect(c2.targets).toEqual(["search-db"]);
+
+      const c3 = evaluateAndRoute(EXPR_DB_COUNT, DB_FOUND, "exists-in-db");
+      expect(c3.targets).toEqual(["is-valid"]);
+
+      const c4 = evaluateAndRoute(EXPR_WHITELIST, DB_WHITELISTED, "is-valid");
+      expect(c4.targets).toEqual(["query-history"]);
+
+      const c5 = evaluateAndRoute(EXPR_LIFT_COUNT, LIFT_EVENTS_FOUND, "has-prior-action");
+      expect(c5.targets).toEqual(["check-state"]);
+
+      const c6 = evaluateAndRoute(EXPR_SCHEDULE_COUNT, SCHEDULE_FOUND, "state-ready");
+      expect(c6.targets).toEqual(["meets-threshold"]);
+
+      const c7 = evaluateAndRoute(EXPR_CAN_CAST, CAN_CAST, "meets-threshold");
+      expect(c7.targets).toEqual(["execute-action-c"]);
+    });
+  });
+
+  describe("full path: 0 tokens -> nothing beyond C1 runs", () => {
+    it("C1 false: search-db, exists-in-db, all downstream nodes are dead", () => {
+      const c1 = evaluateAndRoute(EXPR_COMPARE, { ...SPELL_ZERO_TOKENS, ...HAT_TOKENS }, "compare-tokens");
+      expect(c1.result).toBe(false);
+      expect(c1.targets).toEqual([]);
+    });
+  });
+
+  describe("full path: already cast -> nothing beyond C2 runs", () => {
+    it("C1 true, C2 true: search-db never reached", () => {
+      const c1 = evaluateAndRoute(EXPR_COMPARE, { ...SPELL_HIGH_TOKENS, ...HAT_TOKENS }, "compare-tokens");
+      expect(c1.targets).toEqual(["already-done"]);
+
+      const c2 = evaluateAndRoute(EXPR_CAST_STATUS, BATCH_CAST_TRUE, "already-done");
+      expect(c2.targets).toEqual([]);
+    });
+  });
+
+  describe("full path: not in DB -> send-alert-2 runs, is-valid does not run", () => {
+    it("C3 false dispatches alert, convergence continues to query-history", () => {
+      const c3 = evaluateAndRoute(EXPR_DB_COUNT, DB_NOT_FOUND, "exists-in-db");
+      expect(c3.targets).toEqual(["send-alert-2"]);
+    });
+  });
+
+  describe("full path: in DB but not whitelisted -> send-alert-1 runs, query-history does not run directly", () => {
+    it("C3 true then C4 false dispatches alert", () => {
+      const c3 = evaluateAndRoute(EXPR_DB_COUNT, DB_FOUND, "exists-in-db");
+      expect(c3.targets).toEqual(["is-valid"]);
+
+      const c4 = evaluateAndRoute(EXPR_WHITELIST, DB_NOT_WHITELISTED, "is-valid");
+      expect(c4.targets).toEqual(["send-alert-1"]);
+    });
+  });
+
+  describe("full path: no lift, no schedule, cannot cast -> lifts, schedules, then stops at C7", () => {
+    it("C5 false, C6 false, C7 false: execute-action-a and execute-action-b run, execute-action-c does not", () => {
+      const c5 = evaluateAndRoute(EXPR_LIFT_COUNT, LIFT_EVENTS_NONE, "has-prior-action");
+      expect(c5.targets).toEqual(["execute-action-a"]);
+
+      const c6 = evaluateAndRoute(EXPR_SCHEDULE_COUNT, SCHEDULE_NOT_FOUND, "state-ready");
+      expect(c6.targets).toEqual(["execute-action-b"]);
+
+      const c7 = evaluateAndRoute(EXPR_CAN_CAST, CANNOT_CAST, "meets-threshold");
+      expect(c7.targets).toEqual([]);
+    });
+  });
+
+  describe("exhaustive C5 x C6 x C7: all 8 combinations", () => {
+    const combos: Array<{
+      c5Events: typeof LIFT_EVENTS_FOUND;
+      c6Txns: typeof SCHEDULE_FOUND;
+      c7Status: typeof CAN_CAST;
+      desc: string;
+      c5Runs: string;
+      c6Runs: string;
+      c7Runs: string[];
+    }> = [
+      {
+        c5Events: LIFT_EVENTS_FOUND, c6Txns: SCHEDULE_FOUND, c7Status: CAN_CAST,
+        desc: "lifted + scheduled + castable -> check-state, meets-threshold, execute-action-c all run",
+        c5Runs: "check-state", c6Runs: "meets-threshold", c7Runs: ["execute-action-c"],
+      },
+      {
+        c5Events: LIFT_EVENTS_FOUND, c6Txns: SCHEDULE_FOUND, c7Status: CANNOT_CAST,
+        desc: "lifted + scheduled + not castable -> check-state, meets-threshold run, execute-action-c does not",
+        c5Runs: "check-state", c6Runs: "meets-threshold", c7Runs: [],
+      },
+      {
+        c5Events: LIFT_EVENTS_FOUND, c6Txns: SCHEDULE_NOT_FOUND, c7Status: CAN_CAST,
+        desc: "lifted + not scheduled + castable -> check-state, execute-action-b, execute-action-c run",
+        c5Runs: "check-state", c6Runs: "execute-action-b", c7Runs: ["execute-action-c"],
+      },
+      {
+        c5Events: LIFT_EVENTS_FOUND, c6Txns: SCHEDULE_NOT_FOUND, c7Status: CANNOT_CAST,
+        desc: "lifted + not scheduled + not castable -> check-state, execute-action-b run, execute-action-c does not",
+        c5Runs: "check-state", c6Runs: "execute-action-b", c7Runs: [],
+      },
+      {
+        c5Events: LIFT_EVENTS_NONE, c6Txns: SCHEDULE_FOUND, c7Status: CAN_CAST,
+        desc: "not lifted + scheduled + castable -> execute-action-a, meets-threshold, execute-action-c run",
+        c5Runs: "execute-action-a", c6Runs: "meets-threshold", c7Runs: ["execute-action-c"],
+      },
+      {
+        c5Events: LIFT_EVENTS_NONE, c6Txns: SCHEDULE_FOUND, c7Status: CANNOT_CAST,
+        desc: "not lifted + scheduled + not castable -> execute-action-a, meets-threshold run, execute-action-c does not",
+        c5Runs: "execute-action-a", c6Runs: "meets-threshold", c7Runs: [],
+      },
+      {
+        c5Events: LIFT_EVENTS_NONE, c6Txns: SCHEDULE_NOT_FOUND, c7Status: CAN_CAST,
+        desc: "not lifted + not scheduled + castable -> execute-action-a, execute-action-b, execute-action-c all run",
+        c5Runs: "execute-action-a", c6Runs: "execute-action-b", c7Runs: ["execute-action-c"],
+      },
+      {
+        c5Events: LIFT_EVENTS_NONE, c6Txns: SCHEDULE_NOT_FOUND, c7Status: CANNOT_CAST,
+        desc: "not lifted + not scheduled + not castable -> execute-action-a, execute-action-b run, execute-action-c does not",
+        c5Runs: "execute-action-a", c6Runs: "execute-action-b", c7Runs: [],
+      },
+    ];
+
+    for (const combo of combos) {
+      it(combo.desc, () => {
+        const c5 = evaluateAndRoute(EXPR_LIFT_COUNT, combo.c5Events, "has-prior-action");
+        expect(c5.targets).toEqual([combo.c5Runs]);
+
+        const c6 = evaluateAndRoute(EXPR_SCHEDULE_COUNT, combo.c6Txns, "state-ready");
+        expect(c6.targets).toEqual([combo.c6Runs]);
+
+        const c7 = evaluateAndRoute(EXPR_CAN_CAST, combo.c7Status, "meets-threshold");
+        expect(c7.targets).toEqual(combo.c7Runs);
+      });
+    }
+  });
+
+  describe("exhaustive C3 x C4: all convergence paths", () => {
+    it("found + whitelisted -> is-valid runs, query-history runs, no alerts", () => {
+      const c3 = evaluateAndRoute(EXPR_DB_COUNT, DB_FOUND, "exists-in-db");
+      expect(c3.targets).toEqual(["is-valid"]);
+
+      const c4 = evaluateAndRoute(EXPR_WHITELIST, DB_WHITELISTED, "is-valid");
+      expect(c4.targets).toEqual(["query-history"]);
+    });
+
+    it("found + not whitelisted -> is-valid runs, send-alert-1 runs, query-history does not run directly", () => {
+      const c3 = evaluateAndRoute(EXPR_DB_COUNT, DB_FOUND, "exists-in-db");
+      expect(c3.targets).toEqual(["is-valid"]);
+
+      const c4 = evaluateAndRoute(EXPR_WHITELIST, DB_NOT_WHITELISTED, "is-valid");
+      expect(c4.targets).toEqual(["send-alert-1"]);
+    });
+
+    it("not found -> send-alert-2 runs, is-valid does not run", () => {
+      const c3 = evaluateAndRoute(EXPR_DB_COUNT, DB_NOT_FOUND, "exists-in-db");
+      expect(c3.targets).toEqual(["send-alert-2"]);
+    });
+  });
+
+  describe("one-sided gates never leak to wrong targets", () => {
+    it("C1 false: already-done, search-db, exists-in-db never dispatched", () => {
+      const { targets } = evaluateAndRoute(
+        EXPR_COMPARE, { ...SPELL_ZERO_TOKENS, ...HAT_TOKENS }, "compare-tokens"
+      );
+      expect(targets).not.toContain("already-done");
+      expect(targets).not.toContain("search-db");
+      expect(targets).not.toContain("exists-in-db");
+    });
+
+    it("C2 true: search-db, exists-in-db, query-history never dispatched", () => {
+      const { targets } = evaluateAndRoute(EXPR_CAST_STATUS, BATCH_CAST_TRUE, "already-done");
+      expect(targets).not.toContain("search-db");
+      expect(targets).not.toContain("exists-in-db");
+      expect(targets).not.toContain("query-history");
+    });
+
+    it("C7 false: execute-action-c, get-receipt, notify-2 never dispatched", () => {
+      const { targets } = evaluateAndRoute(EXPR_CAN_CAST, CANNOT_CAST, "meets-threshold");
+      expect(targets).not.toContain("execute-action-c");
+      expect(targets).not.toContain("get-receipt");
+      expect(targets).not.toContain("notify-2");
+    });
+  });
+
+  describe("BigInt edge cases at token comparison boundary", () => {
+    it("28-digit values differing by 1: lower does not pass, higher passes", () => {
+      const { result: r1 } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: { label: "Spell Tokens", data: { amt: "1000000000000000000000000000" } },
+          hatTokens: { label: "Hat Tokens", data: { amt: "1000000000000000000000000001" } },
+        },
+        "compare-tokens"
+      );
+      expect(r1).toBe(false);
+
+      const { result: r2 } = evaluateAndRoute(
+        EXPR_COMPARE,
+        {
+          spellTokens: { label: "Spell Tokens", data: { amt: "1000000000000000000000000002" } },
+          hatTokens: { label: "Hat Tokens", data: { amt: "1000000000000000000000000001" } },
+        },
+        "compare-tokens"
+      );
+      expect(r2).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Condition nodes inside For Each bodies with only one handle edge (e.g., only a `true` branch, no `false` branch) were leaking execution to the true-branch targets even when the condition evaluated to false
- Extracted `resolveBodyConditionTargets` from the `executeBodyNode` closure so the routing decision is unit-testable
- The old inline logic checked whether the *taken* handle had targets to determine if handle-based routing was active; when a one-sided condition evaluated to the empty side, the fallthrough dispatched all downstream nodes via `bodyEdgesBySource`, ignoring handle gating
- The fix checks whether the condition node exists in `bodyHandleMap` at all, rather than whether the specific taken handle produced targets

## Tests

- `condition-foreach-body-routing.test.ts` (27 tests): one-sided gates, both-handle routing, chained conditions, parallel conditions, BigInt web3 values, legacy edges
- `condition-foreach-multi-loop.test.ts` (76 tests): 5 topologies across multiple For Each loops with `identifyLoopBody` + `resolveBodyConditionTargets`
- `condition-foreach-workflow-topology.test.ts` (43 tests): real-world 7-condition topology with BigInt token amounts, exhaustive C3xC4 and C5xC6xC7 combinations, leak prevention assertions