### PR TITLE
feat: KEEP-230 disable new Para wallet creation

### DIFF
--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -15,12 +15,10 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { createTurnkeyWallet } from "@/lib/turnkey/turnkey-client";
-import type { WalletProvider } from "@/lib/wallet/types";
 
 const PARA_API_KEY = process.env.PARA_API_KEY ?? "";
 const PARA_ENV = process.env.PARA_ENVIRONMENT ?? "beta";
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const VALID_PROVIDERS: WalletProvider[] = ["turnkey"];
 
 // Helper: Validate user authentication, organization membership, and admin permissions
 async function validateUserAndOrganization(request: Request) {
@@ -264,9 +262,8 @@ export async function POST(request: Request) {
     const { user, organizationId } = validation;
 
     // 3. Parse request body
-    const body: { email?: string; provider?: string } = await request.json();
+    const body: { email?: string } = await request.json();
     const walletEmail = body.email;
-    const provider = (body.provider ?? "turnkey") as WalletProvider;
 
     if (!walletEmail || typeof walletEmail !== "string") {
       return NextResponse.json(
@@ -278,15 +275,6 @@ export async function POST(request: Request) {
     if (!EMAIL_REGEX.test(walletEmail)) {
       return NextResponse.json(
         { error: "Invalid email format" },
-        { status: 400 }
-      );
-    }
-
-    if (!VALID_PROVIDERS.includes(provider)) {
-      return NextResponse.json(
-        {
-          error: `Invalid provider. Must be one of: ${VALID_PROVIDERS.join(", ")}`,
-        },
         { status: 400 }
       );
     }

--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -11,7 +11,6 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { createIntegration } from "@/lib/db/integrations";
 import { integrations, organizationWallets } from "@/lib/db/schema";
-import { encryptUserShare } from "@/lib/encryption";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
@@ -106,46 +105,6 @@ async function checkExistingWallet(
   return { valid: true };
 }
 
-// Helper: Create wallet via Para SDK
-async function createParaWallet(email: string) {
-  if (!PARA_API_KEY) {
-    logSystemError(
-      ErrorCategory.INFRASTRUCTURE,
-      "[Para] PARA_API_KEY not configured",
-      new Error("PARA_API_KEY not configured"),
-      { endpoint: "/api/user/wallet", operation: "post" }
-    );
-    throw new Error("Para API key not configured");
-  }
-
-  const environment = PARA_ENV === "prod" ? Environment.PROD : Environment.BETA;
-  console.log(
-    `[Para] Initializing SDK with environment: ${PARA_ENV} (${environment})`
-  );
-  console.log(`[Para] API key: ${PARA_API_KEY.slice(0, 8)}...`);
-
-  const paraClient = new ParaServer(environment, PARA_API_KEY);
-
-  console.log(`[Para] Creating wallet for email: ${email}`);
-
-  const wallet = await paraClient.createPregenWallet({
-    type: "EVM",
-    pregenId: { email },
-  });
-
-  const userShare = await paraClient.getUserShare();
-
-  if (!userShare) {
-    throw new Error("Failed to get user share from Para");
-  }
-
-  if (!(wallet.id && wallet.address)) {
-    throw new Error("Invalid wallet data from Para");
-  }
-
-  return { wallet, userShare };
-}
-
 // Helper: Get user-friendly error response for wallet creation failures
 function getErrorResponse(error: unknown): NextResponse {
   // Catch DB unique constraint violation (race condition: wallet already exists)
@@ -198,48 +157,6 @@ function getErrorResponse(error: unknown): NextResponse {
   }
 
   return NextResponse.json({ error: errorMessage }, { status: statusCode });
-}
-
-// Helper: Store Para wallet in database and create integration
-async function storeParaWalletAndIntegration(options: {
-  userId: string;
-  organizationId: string;
-  email: string;
-  paraWalletId: string;
-  walletAddress: string;
-  userShare: string;
-}): Promise<{ walletAddress: string; walletId: string }> {
-  const {
-    userId,
-    organizationId,
-    email,
-    paraWalletId,
-    walletAddress,
-    userShare,
-  } = options;
-
-  const normalizedWalletAddress = normalizeAddressForStorage(walletAddress);
-
-  await db.insert(organizationWallets).values({
-    userId,
-    organizationId,
-    provider: "para",
-    email,
-    walletAddress: normalizedWalletAddress,
-    paraWalletId,
-    userShare: encryptUserShare(userShare),
-  });
-
-  const truncatedAddress = truncateAddress(normalizedWalletAddress);
-  await createIntegration({
-    userId,
-    organizationId,
-    name: truncatedAddress,
-    type: "web3",
-    config: {},
-  });
-
-  return { walletAddress: normalizedWalletAddress, walletId: paraWalletId };
 }
 
 // Helper: Store Turnkey wallet in database and create integration
@@ -383,58 +300,29 @@ export async function POST(request: Request) {
       );
     }
 
-    // 5. Create wallet via selected provider
-    if (provider === "turnkey") {
-      const orgName = `org-${organizationId.slice(0, 8)}`;
-      const turnkeyResult = await createTurnkeyWallet(walletEmail, orgName);
+    // 5. Create wallet via Turnkey
+    const orgName = `org-${organizationId.slice(0, 8)}`;
+    const turnkeyResult = await createTurnkeyWallet(walletEmail, orgName);
 
-      const { walletAddress: storedAddress, walletId } =
-        await storeTurnkeyWalletAndIntegration({
-          userId: user.id,
-          organizationId,
-          email: walletEmail,
-          walletAddress: turnkeyResult.walletAddress,
-          turnkeySubOrgId: turnkeyResult.subOrgId,
-          turnkeyWalletId: turnkeyResult.walletId,
-          turnkeyPrivateKeyId: turnkeyResult.privateKeyId,
-        });
-
-      return NextResponse.json({
-        success: true,
-        wallet: {
-          address: storedAddress,
-          walletId,
-          email: walletEmail,
-          organizationId,
-          provider: "turnkey",
-        },
-      });
-    }
-
-    // Para wallet creation (default)
-    const { wallet: paraWallet, userShare } =
-      await createParaWallet(walletEmail);
-    const paraWalletId = paraWallet.id as string;
-    const paraAddress = paraWallet.address as string;
-
-    const { walletAddress: paraStoredAddress } =
-      await storeParaWalletAndIntegration({
+    const { walletAddress: storedAddress, walletId } =
+      await storeTurnkeyWalletAndIntegration({
         userId: user.id,
         organizationId,
         email: walletEmail,
-        paraWalletId,
-        walletAddress: paraAddress,
-        userShare,
+        walletAddress: turnkeyResult.walletAddress,
+        turnkeySubOrgId: turnkeyResult.subOrgId,
+        turnkeyWalletId: turnkeyResult.walletId,
+        turnkeyPrivateKeyId: turnkeyResult.privateKeyId,
       });
 
     return NextResponse.json({
       success: true,
       wallet: {
-        address: paraStoredAddress,
-        walletId: paraWalletId,
+        address: storedAddress,
+        walletId,
         email: walletEmail,
         organizationId,
-        provider: "para",
+        provider: "turnkey",
       },
     });
   } catch (error) {

--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -21,7 +21,7 @@ import type { WalletProvider } from "@/lib/wallet/types";
 const PARA_API_KEY = process.env.PARA_API_KEY ?? "";
 const PARA_ENV = process.env.PARA_ENVIRONMENT ?? "beta";
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const VALID_PROVIDERS: WalletProvider[] = ["para", "turnkey"];
+const VALID_PROVIDERS: WalletProvider[] = ["turnkey"];
 
 // Helper: Validate user authentication, organization membership, and admin permissions
 async function validateUserAndOrganization(request: Request) {
@@ -349,7 +349,7 @@ export async function POST(request: Request) {
     // 3. Parse request body
     const body: { email?: string; provider?: string } = await request.json();
     const walletEmail = body.email;
-    const provider = (body.provider ?? "para") as WalletProvider;
+    const provider = (body.provider ?? "turnkey") as WalletProvider;
 
     if (!walletEmail || typeof walletEmail !== "string") {
       return NextResponse.json(

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -513,17 +513,14 @@ function AddTokenForm({
   );
 }
 
-type WalletProviderOption = "para" | "turnkey";
-
 function CreateWalletForm({
   initialEmail,
   onSubmit,
 }: {
   initialEmail: string;
-  onSubmit: (email: string, provider: WalletProviderOption) => Promise<void>;
+  onSubmit: (email: string) => Promise<void>;
 }) {
   const [email, setEmail] = useState(initialEmail);
-  const [provider, setProvider] = useState<WalletProviderOption>("turnkey");
   const [creating, setCreating] = useState(false);
 
   const handleCreate = async (): Promise<void> => {
@@ -533,7 +530,7 @@ function CreateWalletForm({
     }
     setCreating(true);
     try {
-      await onSubmit(email, provider);
+      await onSubmit(email);
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to create wallet"
@@ -715,7 +712,7 @@ function NoWalletSection({
 }: {
   isAdmin: boolean;
   initialEmail: string;
-  onCreateWallet: (email: string, provider: WalletProviderOption) => Promise<void>;
+  onCreateWallet: (email: string) => Promise<void>;
 }) {
   if (!isAdmin) {
     return (
@@ -1290,14 +1287,11 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     }
   };
 
-  const handleCreateWallet = async (
-    email: string,
-    provider: WalletProviderOption
-  ): Promise<void> => {
+  const handleCreateWallet = async (email: string): Promise<void> => {
     const response = await fetch("/api/user/wallet", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, provider }),
+      body: JSON.stringify({ email, provider: "turnkey" }),
     });
 
     const data: { error?: string } = await response.json();

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -5,12 +5,10 @@ import {
   Eye,
   EyeOff,
   ExternalLink,
-  Info,
   KeyRound,
   Plus,
   RefreshCw,
   SendHorizontal,
-  Shield,
   ShieldCheck,
   Trash2,
 } from "lucide-react";
@@ -37,12 +35,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
 import { useSession } from "@/lib/auth-client";
 import { useActiveMember } from "@/lib/hooks/use-organization";
@@ -553,139 +545,33 @@ function CreateWalletForm({
 
   return (
     <div className="space-y-4">
-      <div className="space-y-4 rounded-lg border bg-muted/50 p-4">
-        <div>
-          <h3 className="mb-2 font-medium text-sm">
-            Create Organization Wallet
-          </h3>
-          <p className="mb-4 text-muted-foreground text-xs">
-            This wallet will be shared by all members of your organization. Only
-            admins and owners can manage it.
-          </p>
-        </div>
+      <p className="text-muted-foreground text-xs">
+        This wallet will be shared by all members of your organization.
+        Only admins and owners can manage it.
+      </p>
 
-        <div className="space-y-2">
-          <Label>Wallet Provider</Label>
-          <div className="grid grid-cols-2 gap-2">
-            <button
-              className={`flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors ${
-                provider === "turnkey"
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-border/80"
-              }`}
-              disabled={creating}
-              onClick={() => setProvider("turnkey")}
-              type="button"
-            >
-              <div className="flex items-center gap-1.5">
-                <ShieldCheck className="h-3.5 w-3.5 text-primary" />
-                <span className="font-medium text-xs">Turnkey</span>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger
-                      asChild
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Info className="size-3 text-muted-foreground" />
-                    </TooltipTrigger>
-                    <TooltipContent className="text-xs" side="top">
-                      <a
-                        className="underline"
-                        href="https://www.turnkey.com"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Website
-                      </a>
-                      {" · "}
-                      <a
-                        className="underline"
-                        href="https://docs.keeperhub.com/wallet-management/turnkey"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Docs
-                      </a>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-              <span className="text-muted-foreground text-[10px] leading-tight">
-                Secure enclave. Supports private key export.
-              </span>
-            </button>
-            <button
-              className={`flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors ${
-                provider === "para"
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-border/80"
-              }`}
-              disabled={creating}
-              onClick={() => setProvider("para")}
-              type="button"
-            >
-              <div className="flex items-center gap-1.5">
-                <Shield className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="font-medium text-xs">Para</span>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger
-                      asChild
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Info className="size-3 text-muted-foreground" />
-                    </TooltipTrigger>
-                    <TooltipContent className="text-xs" side="top">
-                      <a
-                        className="underline"
-                        href="https://www.getpara.com"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Website
-                      </a>
-                      {" · "}
-                      <a
-                        className="underline"
-                        href="https://docs.keeperhub.com/wallet-management/para"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Docs
-                      </a>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-              <span className="text-muted-foreground text-[10px] leading-tight">
-                MPC-based signing. No key export.
-              </span>
-            </button>
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="wallet-email">Email Address</Label>
-          <Input
-            disabled={creating}
-            id="wallet-email"
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@example.com"
-            type="email"
-            value={email}
-          />
-          <p className="text-muted-foreground text-xs">
-            This email will be associated with the organization's wallet for
-            identification purposes.
-          </p>
-        </div>
+      <div className="space-y-2">
+        <Label htmlFor="wallet-email">Email Address</Label>
+        <Input
+          disabled={creating}
+          id="wallet-email"
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          type="email"
+          value={email}
+        />
+        <p className="text-muted-foreground text-xs">
+          This email will be associated with the wallet for identification
+          purposes.
+        </p>
       </div>
-      <div className="flex gap-2">
-        <Button
-          className="flex-1"
-          disabled={creating || !email}
-          onClick={handleCreate}
-        >
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-muted-foreground text-xs">
+          <ShieldCheck className="h-3.5 w-3.5" />
+          <span>Secured by Turnkey</span>
+        </div>
+        <Button disabled={creating || !email} onClick={handleCreate}>
           {creating ? (
             <>
               <Spinner className="mr-2 h-4 w-4" />

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -1291,7 +1291,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     const response = await fetch("/api/user/wallet", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, provider: "turnkey" }),
+      body: JSON.stringify({ email }),
     });
 
     const data: { error?: string } = await response.json();

--- a/components/settings/web3-wallet-section.tsx
+++ b/components/settings/web3-wallet-section.tsx
@@ -81,7 +81,7 @@ export function Web3WalletSection({
       const response = await fetch("/api/user/wallet", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: userEmail }),
+        body: JSON.stringify({ email: userEmail, provider: "turnkey" }),
       });
 
       const data = await response.json();
@@ -157,9 +157,9 @@ export function Web3WalletSection({
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="font-medium text-sm">Para Wallet</h3>
+        <h3 className="font-medium text-sm">Organization Wallet</h3>
         <p className="text-muted-foreground text-sm">
-          Use your email address to pre-generate a wallet for Web3 automations.
+          Create a secure wallet for Web3 automations.
         </p>
       </div>
 

--- a/components/settings/web3-wallet-section.tsx
+++ b/components/settings/web3-wallet-section.tsx
@@ -81,7 +81,7 @@ export function Web3WalletSection({
       const response = await fetch("/api/user/wallet", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: userEmail, provider: "turnkey" }),
+        body: JSON.stringify({ email: userEmail }),
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary

- Remove Para from valid wallet providers, making Turnkey the only option for new wallet creation
- Simplify wallet creation UI by removing provider selection (single provider)
- Fix web3-wallet-section to explicitly send `provider: "turnkey"` instead of relying on server default
- Existing Para wallets remain fully operational (signing, share retrieval, refresh)