### PR TITLE
fix: KEEP-230 resolve overloaded ABI functions and fix tuple selector computation

### DIFF
--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi-cache";
+import { type AbiItem, findAbiFunction } from "@/lib/abi-utils";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
@@ -18,16 +19,10 @@ import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { validateContractCallInput } from "../_lib/validate";
 import { requireWallet } from "../_lib/wallet-check";
 
-type AbiEntry = {
-  type: string;
-  name?: string;
-  stateMutability?: string;
-};
-
 function findFunctionInAbi(
   abi: string,
   functionName: string
-): { entry: AbiEntry } | { error: string } {
+): { entry: AbiItem } | { error: string } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(abi);
@@ -39,9 +34,7 @@ function findFunctionInAbi(
     return { error: "ABI must be a JSON array" };
   }
 
-  const entry = parsed.find(
-    (item: AbiEntry) => item.type === "function" && item.name === functionName
-  ) as AbiEntry | undefined;
+  const entry = findAbiFunction(parsed, functionName);
 
   if (!entry) {
     return { error: `Function '${functionName}' not found in ABI` };

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -22,7 +22,7 @@ import { SaveAddressBookmark } from "@/components/address-book/save-address-book
 import type { AbiComponent } from "@/components/workflow/config/abi-types";
 import { ArrayInputField } from "@/components/workflow/config/array-input-field";
 import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
-import { computeSelector } from "@/lib/abi-utils";
+import { computeSelector, findAbiFunction } from "@/lib/abi-utils";
 import { evaluateShowWhen } from "@/lib/workflow/show-when";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
 import { toChecksumAddress } from "@/lib/address-utils";
@@ -203,7 +203,15 @@ export function AbiFunctionSelectField({
               (item.stateMutability === "view" ||
                 item.stateMutability === "pure");
 
-      return abi.filter(filterFn).map((func) => {
+      const filtered = abi.filter(filterFn);
+
+      // Count how many times each function name appears to detect overloads
+      const nameCounts = new Map<string, number>();
+      for (const func of filtered) {
+        nameCounts.set(func.name, (nameCounts.get(func.name) ?? 0) + 1);
+      }
+
+      return filtered.map((func) => {
         const inputs = func.inputs || [];
         const params = inputs
           .map(
@@ -212,9 +220,13 @@ export function AbiFunctionSelectField({
           )
           .join(", ");
         const inputTypes = inputs.map((input: { type: string }) => input.type);
-        const selector = computeSelector(func.name, inputTypes);
+        const selector = computeSelector(func.name, inputs);
+        const isOverloaded = (nameCounts.get(func.name) ?? 0) > 1;
+        const key = isOverloaded
+          ? `${func.name}(${inputTypes.join(",")})`
+          : func.name;
         return {
-          name: func.name,
+          key,
           label: `${func.name}(${params})`,
           stateMutability: func.stateMutability || "nonpayable",
           selector,
@@ -242,7 +254,7 @@ export function AbiFunctionSelectField({
       </SelectTrigger>
       <SelectContent>
         {functions.map((func) => (
-          <SelectItem key={func.label} value={func.name}>
+          <SelectItem key={func.key} value={func.key}>
             <div className="flex flex-col items-start">
               <span>
                 {func.label}{" "}
@@ -290,21 +302,17 @@ export function AbiFunctionArgsField({
         return [];
       }
 
-      const func = abi.find(
-        (item) => item.type === "function" && item.name === functionValue
-      );
+      const func = findAbiFunction(abi, functionValue);
 
       if (!func?.inputs) {
         return [];
       }
 
-      return func.inputs.map(
-        (input: { name: string; type: string; components?: AbiComponent[] }) => ({
-          name: input.name || "unnamed",
-          type: input.type,
-          components: input.components,
-        })
-      );
+      return func.inputs.map((input) => ({
+        name: input.name || "unnamed",
+        type: input.type,
+        components: input.components,
+      }));
     } catch {
       return [];
     }

--- a/components/workflow/config/args-list-field.tsx
+++ b/components/workflow/config/args-list-field.tsx
@@ -7,6 +7,7 @@ import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import type { AbiComponent } from "@/components/workflow/config/abi-types";
 import { ArrayInputField } from "@/components/workflow/config/array-input-field";
 import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
+import { findAbiFunction } from "@/lib/abi-utils";
 import type { ActionConfigFieldBase } from "@/plugins/registry";
 
 type FunctionInput = {
@@ -34,22 +35,17 @@ export function parseFunctionInputs(
       return [];
     }
 
-    const func = abi.find(
-      (item: Record<string, unknown>) =>
-        item.type === "function" && item.name === functionValue
-    );
+    const func = findAbiFunction(abi, functionValue);
 
     if (!(func?.inputs && Array.isArray(func.inputs))) {
       return [];
     }
 
-    return func.inputs.map(
-      (input: { name: string; type: string; components?: AbiComponent[] }) => ({
-        name: input.name || "unnamed",
-        type: input.type,
-        components: input.components,
-      })
-    );
+    return func.inputs.map((input) => ({
+      name: input.name || "unnamed",
+      type: input.type,
+      components: input.components,
+    }));
   } catch {
     return [];
   }

--- a/lib/abi-utils.ts
+++ b/lib/abi-utils.ts
@@ -1,10 +1,92 @@
 import { ethers } from "ethers";
 
+export type AbiItemComponent = {
+  name: string;
+  type: string;
+  components?: AbiItemComponent[];
+};
+
+type AbiInput = {
+  type: string;
+  components?: AbiItemComponent[];
+};
+
 /**
- * Compute the 4-byte function selector from a name and its input types.
+ * Build the canonical type string for an ABI input, recursively
+ * expanding tuple types into their component types.
+ *
+ * e.g. a tuple with (uint32, bytes32) becomes "(uint32,bytes32)"
+ * and a tuple[] becomes "(uint32,bytes32)[]"
+ */
+function canonicalType(input: AbiInput): string {
+  if (!input.type.startsWith("tuple") || !input.components) {
+    return input.type;
+  }
+  const inner = input.components.map((c) => canonicalType(c)).join(",");
+  const suffix = input.type.slice("tuple".length);
+  return `(${inner})${suffix}`;
+}
+
+/**
+ * Compute the 4-byte function selector from a name and its inputs.
+ * Accepts either full ABI input objects (expands tuples correctly)
+ * or plain type strings (for simple non-tuple functions).
  * Returns a hex string like "0xcdffacc6".
  */
-export function computeSelector(name: string, inputTypes: string[]): string {
-  const signature = `${name}(${inputTypes.join(",")})`;
+export function computeSelector(
+  name: string,
+  inputs: Array<AbiInput | string>
+): string {
+  const types = inputs.map((input) =>
+    typeof input === "string" ? input : canonicalType(input)
+  );
+  const signature = `${name}(${types.join(",")})`;
   return ethers.id(signature).slice(0, 10);
+}
+
+export type AbiItem = {
+  type: string;
+  name?: string;
+  inputs?: Array<{
+    type: string;
+    name: string;
+    components?: AbiItemComponent[];
+  }>;
+  outputs?: Array<{ type: string; name?: string }>;
+  stateMutability?: string;
+};
+
+/** ABI entry narrowed to a function (name is always present). */
+export type AbiFunctionItem = AbiItem & { name: string };
+
+/**
+ * Find a function in a parsed ABI by key.
+ *
+ * The key can be a plain name (`"send"`) or a qualified signature
+ * (`"send(address,uint256,bytes)"`).  Plain names match when the ABI
+ * contains at most one function with that name.  Qualified signatures
+ * are used for overloaded functions.
+ */
+export function findAbiFunction(
+  abi: AbiItem[],
+  key: string
+): AbiFunctionItem | undefined {
+  const parenIdx = key.indexOf("(");
+  if (parenIdx === -1) {
+    return abi.find(
+      (item): item is AbiFunctionItem =>
+        item.type === "function" && item.name === key
+    );
+  }
+
+  const name = key.slice(0, parenIdx);
+  const typesStr = key.slice(parenIdx + 1, -1);
+  const targetTypes = typesStr === "" ? [] : typesStr.split(",");
+
+  return abi.find((item): item is AbiFunctionItem => {
+    if (item.type !== "function" || item.name !== name) return false;
+    const inputTypes = (item.inputs ?? []).map((i) => i.type);
+    if (inputTypes.length !== targetTypes.length) return false;
+    return inputTypes.every((t, idx) => t === targetTypes[idx]);
+  });
 }

--- a/lib/abi-utils.ts
+++ b/lib/abi-utils.ts
@@ -75,7 +75,7 @@ export function findAbiFunction(
   if (parenIdx === -1) {
     return abi.find(
       (item): item is AbiFunctionItem =>
-        item.type === "function" && item.name === key
+        item != null && item.type === "function" && item.name === key
     );
   }
 
@@ -84,7 +84,8 @@ export function findAbiFunction(
   const targetTypes = typesStr === "" ? [] : typesStr.split(",");
 
   return abi.find((item): item is AbiFunctionItem => {
-    if (item.type !== "function" || item.name !== name) return false;
+    if (item == null || item.type !== "function" || item.name !== name)
+      return false;
     const inputTypes = (item.inputs ?? []).map((i) => i.type);
     if (inputTypes.length !== targetTypes.length) return false;
     return inputTypes.every((t, idx) => t === targetTypes[idx]);

--- a/lib/action-output-fields.ts
+++ b/lib/action-output-fields.ts
@@ -3,6 +3,7 @@
  * Defines dynamic output fields for plugin actions based on their configuration
  */
 
+import { findAbiFunction } from "@/lib/abi-utils";
 import type { OutputField } from "@/plugins/registry";
 
 /**
@@ -30,11 +31,7 @@ export function getReadContractOutputFields(
       return defaultFields;
     }
 
-    // Find the function in the ABI
-    const functionAbi = abiArray.find(
-      (item: { type: string; name?: string }) =>
-        item.type === "function" && item.name === functionName
-    );
+    const functionAbi = findAbiFunction(abiArray, functionName);
 
     if (!functionAbi?.outputs) {
       return defaultFields;
@@ -65,13 +62,13 @@ export function getReadContractOutputFields(
       // Unnamed single output: just use result directly (already added)
     } else if (outputs.length > 1) {
       // Multiple outputs: result is an object with named fields
-      outputs.forEach((output, index) => {
+      for (const [index, output] of outputs.entries()) {
         const fieldName = output.name?.trim() || `unnamedOutput${index}`;
         outputFields.push({
           field: `result.${fieldName}`,
           description: `Return value: ${output.type} (${getDeserializedType(output.type)})`,
         });
-      });
+      }
     }
 
     // Add standard fields

--- a/lib/web3/abi-mutability.ts
+++ b/lib/web3/abi-mutability.ts
@@ -8,7 +8,7 @@
  * value -- this helper is intended for UI gating and lightweight checks,
  * not as the sole authority on whether a transfer is safe.
  */
-import { findAbiFunction } from "@/lib/abi-utils";
+import { type AbiItem, findAbiFunction } from "@/lib/abi-utils";
 
 export function deriveStateMutability(
   abiJson: string,
@@ -25,7 +25,7 @@ export function deriveStateMutability(
     return "nonpayable";
   }
 
-  const func = findAbiFunction(parsed, funcKey);
+  const func = findAbiFunction(parsed as AbiItem[], funcKey);
 
   return typeof func?.stateMutability === "string"
     ? func.stateMutability

--- a/lib/web3/abi-mutability.ts
+++ b/lib/web3/abi-mutability.ts
@@ -8,15 +8,11 @@
  * value -- this helper is intended for UI gating and lightweight checks,
  * not as the sole authority on whether a transfer is safe.
  */
-type AbiItem = {
-  type?: unknown;
-  name?: unknown;
-  stateMutability?: unknown;
-};
+import { findAbiFunction } from "@/lib/abi-utils";
 
 export function deriveStateMutability(
   abiJson: string,
-  funcName: string
+  funcKey: string
 ): string {
   let parsed: unknown;
   try {
@@ -29,13 +25,7 @@ export function deriveStateMutability(
     return "nonpayable";
   }
 
-  const func = (parsed as AbiItem[]).find(
-    (item) =>
-      item != null &&
-      typeof item === "object" &&
-      item.type === "function" &&
-      item.name === funcName
-  );
+  const func = findAbiFunction(parsed, funcKey);
 
   return typeof func?.stateMutability === "string"
     ? func.stateMutability

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -1180,17 +1180,10 @@ const web3Plugin: IntegrationPlugin = {
           required: true,
         },
         {
-          key: "functionArgs",
-          label: "Function Arguments",
-          type: "abi-function-args",
-          abiField: "abi",
-          abiFunctionField: "abiFunction",
-        },
-        {
           key: "ethValue",
           label: "Payable Value",
           type: "protocol-eth-value",
-          placeholder: "0.0",
+          placeholder: "payableAmount",
           helpTip:
             "Amount of native token (e.g. ETH, MATIC) to send with this payable function call. Specified in whole units, not wei.",
           showWhen: {
@@ -1199,6 +1192,13 @@ const web3Plugin: IntegrationPlugin = {
             functionField: "abiFunction",
             equals: "payable",
           },
+        },
+        {
+          key: "functionArgs",
+          label: "Function Arguments",
+          type: "abi-function-args",
+          abiField: "abi",
+          abiFunctionField: "abiFunction",
         },
         {
           type: "group",

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -16,6 +16,7 @@ import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { findAbiFunction } from "@/lib/abi-utils";
 import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/web3/abi-function-key";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
@@ -107,11 +108,7 @@ export async function readContractCore(
     return { success: false, error: "ABI must be a JSON array" };
   }
 
-  // Find the selected function in the ABI to get output structure
-  const functionAbi = parsedAbi.find(
-    (item: { type: string; name: string; stateMutability?: string }) =>
-      item.type === "function" && item.name === abiFunction
-  );
+  const functionAbi = findAbiFunction(parsedAbi, abiFunction);
 
   if (!functionAbi) {
     logUserError(

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -21,6 +21,7 @@ import {
 } from "@/lib/para/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { findAbiFunction } from "@/lib/abi-utils";
 import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/web3/abi-function-key";
 import { generateId } from "@/lib/utils/id";
@@ -111,11 +112,7 @@ export async function writeContractCore(
     };
   }
 
-  // Find the selected function in the ABI
-  const functionAbi = parsedAbi.find(
-    (item: { type: string; name: string }) =>
-      item.type === "function" && item.name === abiFunction
-  );
+  const functionAbi = findAbiFunction(parsedAbi, abiFunction);
 
   if (!functionAbi) {
     return {

--- a/tests/unit/abi-utils.test.ts
+++ b/tests/unit/abi-utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { computeSelector } from "@/lib/abi-utils";
+import {
+  type AbiItem,
+  computeSelector,
+  findAbiFunction,
+} from "@/lib/abi-utils";
 
 const SELECTOR_PATTERN = /^0x[\da-f]{8}$/;
 
@@ -28,5 +32,181 @@ describe("computeSelector", () => {
   it("returns a 10-character hex string (0x + 8 hex digits)", () => {
     const result = computeSelector("foo", ["uint256"]);
     expect(result).toMatch(SELECTOR_PATTERN);
+  });
+
+  it("expands tuple inputs to canonical component types", () => {
+    const inputs = [
+      {
+        type: "tuple",
+        components: [
+          { name: "dstEid", type: "uint32" },
+          { name: "to", type: "bytes32" },
+          { name: "amountLD", type: "uint256" },
+          { name: "minAmountLD", type: "uint256" },
+          { name: "extraOptions", type: "bytes" },
+          { name: "composeMsg", type: "bytes" },
+          { name: "oftCmd", type: "bytes" },
+        ],
+      },
+      {
+        type: "tuple",
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" },
+        ],
+      },
+      { type: "address" },
+    ];
+    // send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)
+    expect(computeSelector("send", inputs)).toBe("0xc7c7f5b3");
+  });
+
+  it("handles tuple[] arrays correctly", () => {
+    const inputs = [
+      {
+        type: "tuple[]",
+        components: [
+          { name: "target", type: "address" },
+          { name: "value", type: "uint256" },
+        ],
+      },
+    ];
+    // execute((address,uint256)[])
+    const result = computeSelector("execute", inputs);
+    expect(result).toMatch(SELECTOR_PATTERN);
+  });
+
+  it("handles nested tuples", () => {
+    const inputs = [
+      {
+        type: "tuple",
+        components: [
+          { name: "id", type: "uint256" },
+          {
+            name: "inner",
+            type: "tuple",
+            components: [
+              { name: "a", type: "address" },
+              { name: "b", type: "uint256" },
+            ],
+          },
+        ],
+      },
+    ];
+    // fn((uint256,(address,uint256)))
+    const result = computeSelector("fn", inputs);
+    expect(result).toMatch(SELECTOR_PATTERN);
+  });
+
+  it("mixes string types and ABI input objects", () => {
+    const inputs = [
+      "address",
+      {
+        type: "tuple",
+        components: [
+          { name: "a", type: "uint256" },
+          { name: "b", type: "uint256" },
+        ],
+      },
+    ];
+    const result = computeSelector("mixed", inputs);
+    expect(result).toMatch(SELECTOR_PATTERN);
+  });
+});
+
+const OVERLOADED_ABI: AbiItem[] = [
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "payable",
+    inputs: [
+      {
+        type: "tuple",
+        name: "_sendParam",
+        components: [
+          { name: "dstEid", type: "uint32" },
+          { name: "to", type: "bytes32" },
+        ],
+      },
+      { type: "address", name: "_refundAddress" },
+    ],
+  },
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "nonpayable",
+    inputs: [
+      { type: "address", name: "_to" },
+      { type: "uint256", name: "_amount" },
+    ],
+  },
+  {
+    type: "function",
+    name: "transfer",
+    stateMutability: "nonpayable",
+    inputs: [
+      { type: "address", name: "to" },
+      { type: "uint256", name: "amount" },
+    ],
+  },
+];
+
+describe("findAbiFunction", () => {
+  it("finds a function by plain name when unambiguous", () => {
+    const result = findAbiFunction(OVERLOADED_ABI, "transfer");
+    expect(result).toBeDefined();
+    expect(result?.name).toBe("transfer");
+  });
+
+  it("returns first match for plain name on overloaded functions", () => {
+    const result = findAbiFunction(OVERLOADED_ABI, "send");
+    expect(result).toBeDefined();
+    expect(result?.name).toBe("send");
+    expect(result?.stateMutability).toBe("payable");
+  });
+
+  it("finds the correct overload by qualified signature", () => {
+    const result = findAbiFunction(OVERLOADED_ABI, "send(address,uint256)");
+    expect(result).toBeDefined();
+    expect(result?.stateMutability).toBe("nonpayable");
+    expect(result?.inputs).toHaveLength(2);
+  });
+
+  it("finds the other overload by qualified signature", () => {
+    const result = findAbiFunction(OVERLOADED_ABI, "send(tuple,address)");
+    expect(result).toBeDefined();
+    expect(result?.stateMutability).toBe("payable");
+  });
+
+  it("returns undefined for non-existent function", () => {
+    expect(findAbiFunction(OVERLOADED_ABI, "nonexistent")).toBeUndefined();
+  });
+
+  it("returns undefined for qualified signature with wrong types", () => {
+    expect(
+      findAbiFunction(OVERLOADED_ABI, "send(uint256,uint256)")
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for qualified signature with wrong arity", () => {
+    expect(findAbiFunction(OVERLOADED_ABI, "send(address)")).toBeUndefined();
+  });
+
+  it("handles empty ABI array", () => {
+    expect(findAbiFunction([], "transfer")).toBeUndefined();
+  });
+
+  it("ignores non-function entries", () => {
+    const abi: AbiItem[] = [
+      { type: "event", name: "Transfer" },
+      {
+        type: "function",
+        name: "Transfer",
+        inputs: [{ type: "address", name: "to" }],
+      },
+    ];
+    const result = findAbiFunction(abi, "Transfer");
+    expect(result).toBeDefined();
+    expect(result?.type).toBe("function");
   });
 });


### PR DESCRIPTION
## Summary

- Use qualified signatures (e.g. `send(address,uint256,bytes)`) as the stored function key when a contract has overloaded functions, so every overload appears in the dropdown and resolves correctly at execution time
- Fix `computeSelector` to expand tuple parameters into their canonical component types, producing correct 4-byte selectors that match Etherscan (e.g. `0xc7c7f5b3` instead of incorrect `0xccfc9451`)
- Move the payable value field above function arguments to match Etherscan layout
- Update `deriveStateMutability` to handle qualified function keys so the payable field shows correctly for overloaded payable functions
- Extract shared `findAbiFunction` helper in `lib/abi-utils.ts` used across all ABI lookup sites (UI, execution, output fields)