### PR TITLE
fix: correct executor metrics ingest URL service name

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -96,7 +96,7 @@ env:
     value: "prometheus"
   EXECUTOR_METRICS_INGEST_URL:
     type: kv
-    value: "http://keeperhub-executor-prod.keeperhub.svc.cluster.local:3080"
+    value: "http://keeperhub-executor-common:3080"
   METRICS_INGEST_TOKEN:
     type: parameterStore
     name: metrics-ingest-token

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -96,7 +96,7 @@ env:
     value: "prometheus"
   EXECUTOR_METRICS_INGEST_URL:
     type: kv
-    value: "http://keeperhub-executor-staging.keeperhub.svc.cluster.local:3080"
+    value: "http://keeperhub-executor-common:3080"
   METRICS_INGEST_TOKEN:
     type: parameterStore
     name: metrics-ingest-token


### PR DESCRIPTION
## Summary

- Update EXECUTOR_METRICS_INGEST_URL in staging and prod values.yaml to use keeperhub-executor-common:3080 instead of per-environment svc.cluster.local addresses