### PR TITLE
fix(payments): make paid workflows discoverable by x402/mpp scanners

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -8,7 +8,11 @@ import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { hashMppCredential } from "@/lib/mpp/server";
-import { gatePayment, type PaymentMeta } from "@/lib/payments/router";
+import {
+  detectProtocol,
+  gatePayment,
+  type PaymentMeta,
+} from "@/lib/payments/router";
 import { executeWorkflow } from "@/lib/workflow-executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow-store";
 import {
@@ -342,6 +346,17 @@ async function handleReadWorkflow(
   request: Request,
   workflow: CallRouteWorkflow
 ): Promise<NextResponse> {
+  const price = Number(workflow.priceUsdcPerCall ?? "0");
+  const isPaid = price > 0;
+
+  // Scanner discoverability: on a paid workflow, emit 402 before parsing or
+  // validating the body. Scanners probe paid endpoints with empty/invalid
+  // bodies and rely on the 402 response (with X-PAYMENT-REQUIREMENTS and
+  // WWW-Authenticate: Payment headers) to catalog the resource.
+  if (isPaid && detectProtocol(request) === null) {
+    return handlePaidWorkflow(request, workflow, {});
+  }
+
   const parsed = await parseJsonBody(request);
   if ("error" in parsed) {
     return parsed.error;
@@ -353,12 +368,10 @@ async function handleReadWorkflow(
     return bodyError;
   }
 
-  const price = Number(workflow.priceUsdcPerCall ?? "0");
-  if (price <= 0) {
-    return createAndStartExecution(workflow, body);
+  if (isPaid) {
+    return handlePaidWorkflow(request, workflow, body);
   }
-
-  return handlePaidWorkflow(request, workflow, body);
+  return createAndStartExecution(workflow, body);
 }
 
 export async function POST(

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -63,7 +63,7 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
       price: {
         mode: "fixed",
         amount: workflow.priceUsdcPerCall,
-        currency: "USDC",
+        currency: "USD",
       },
       protocols: [
         { x402: { network: "eip155:8453" } },

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -13,6 +13,7 @@ const {
   mockRecordPayment,
   mockResolveCreatorWallet,
   mockGatePayment,
+  mockDetectProtocol,
   mockStart,
   mockExecuteWorkflow,
   mockEnforceExecutionLimit,
@@ -29,6 +30,7 @@ const {
   mockRecordPayment: vi.fn(),
   mockResolveCreatorWallet: vi.fn(),
   mockGatePayment: vi.fn(),
+  mockDetectProtocol: vi.fn(),
   mockStart: vi.fn(),
   mockExecuteWorkflow: vi.fn(),
   mockEnforceExecutionLimit: vi.fn(),
@@ -67,6 +69,7 @@ vi.mock("@/lib/mpp/server", () => ({
 
 vi.mock("@/lib/payments/router", () => ({
   gatePayment: mockGatePayment,
+  detectProtocol: mockDetectProtocol,
 }));
 
 vi.mock("@/lib/api-key-auth", () => ({
@@ -226,6 +229,22 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
       authenticated: true,
       organizationId: "caller-org-1",
       apiKeyId: "key-1",
+    });
+    // Mirror the real detectProtocol: inspect the request for payment headers
+    // so individual tests don't need to stub this manually.
+    mockDetectProtocol.mockImplementation((req: Request) => {
+      const hasAuth = req.headers.get("authorization")?.startsWith("Payment ");
+      const hasSig = Boolean(req.headers.get("PAYMENT-SIGNATURE"));
+      if (hasAuth && hasSig) {
+        return "error";
+      }
+      if (hasAuth) {
+        return "mpp";
+      }
+      if (hasSig) {
+        return "x402";
+      }
+      return null;
     });
   });
 
@@ -513,5 +532,27 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     );
     // The workflow itself was never started.
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("Test 16: paid workflow probe with empty body returns 402 before body validation", async () => {
+    const workflowWithRequiredField = {
+      ...LISTED_WORKFLOW,
+      inputSchema: {
+        type: "object",
+        required: ["address"],
+        properties: { address: { type: "string" } },
+      },
+    };
+    setupDbSelectWorkflow(workflowWithRequiredField);
+    make402GatePayment();
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    // Empty body: under the old flow this would return 400 (missing required
+    // field). The 402-first ordering ensures scanners probing paid endpoints
+    // without a valid body still see the payment challenge.
+    const request = makeRequest("test-workflow", { body: {} });
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(402);
+    expect(mockGatePayment).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Two issues were blocking agentcash, x402scan, and mppscan from cataloging our paid workflow endpoint:

1. **OpenAPI schema error** -- `x-payment-info.price.currency: "USDC"` fails the agentcash discovery spec, which requires ISO-4217 (three uppercase letters). The whole OpenAPI document gets rejected during schema validation, which is why mppscan shows "No description available" and labels the paid route as "FREE" (fallback with no metadata). Changed to `"USD"` (the pegged fiat unit); left the `mpp` protocol object's `currency: "USDC"` alone since it's a protocol-specific extension, not the spec-validated `price.currency` field.

2. **Body validation before 402** -- `handleReadWorkflow` parsed and validated the JSON body before dispatching to `handlePaidWorkflow`, so scanners probing paid endpoints with empty/missing bodies got HTTP 400 ("Missing required field: address") instead of the expected 402 with `X-PAYMENT-REQUIREMENTS` and `WWW-Authenticate: Payment` headers. Reordered so paid workflows without payment headers hit `handlePaidWorkflow` first -- scanners get a clean 402, paying clients still go through full body validation after payment is verified.

## Diagnostic

Before this PR, `npx -y @agentcash/discovery@latest discover "https://app.keeperhub.com"` reported:

```
[warn] OPENAPI_PARSE_ERROR
         paths./api/mcp/workflows/mcp-test/call.post.x-payment-info.price.currency:
         Invalid string: must match pattern /^[A-Z]{3}$/
[warn] L2_PRICE_MISSING_ON_PAID (/api/mcp/workflows/mcp-test/call)
         Paid route POST /api/mcp/workflows/mcp-test/call has no price hint.
```

And probing the endpoint directly:

```
POST empty body   -> 400  (should be 402)
POST no body      -> 400  (should be 402)
GET               -> 405  (acceptable; POST is the canonical shape)
```

## Test plan

- [x] Unit test covers "paid workflow probe with empty body returns 402 before body validation"
- [x] `pnpm type-check` clean
- [ ] After deploy, re-run agentcash discovery and confirm zero `OPENAPI_PARSE_ERROR` warnings
- [ ] After deploy, `curl -X POST https://app.keeperhub.com/api/mcp/workflows/mcp-test/call -H 'content-type: application/json' -d '{}'` returns 402 with both headers
- [ ] Refresh mppscan listing and confirm the server description populates and the route renders its DB price (not FREE). Same goes for any future listed workflows -- one registration covers them all via `/openapi.json`.
- [ ] Re-run `pnpm tsx scripts/test-payments-prod.ts` full suite (should still be 8/8)

Part of KEEP-176.
