### PR TITLE
fix(payments): emit spec-compliant x402 v2 PaymentRequired header

### DIFF
--- a/lib/payments/router.ts
+++ b/lib/payments/router.ts
@@ -19,7 +19,10 @@ export type PaymentProtocol = "x402" | "mpp";
 
 const TEMPO_USDC_ADDRESS = "0x20c000000000000000000000b9537d11c60e8b50";
 const TEMPO_CHAIN_ID = 4217;
+const BASE_USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const BASE_NETWORK = "eip155:8453";
 const USDC_DECIMALS = 6;
+const PAYMENT_MAX_TIMEOUT_SECONDS = 300;
 const RE_PROTOCOL = /^https?:\/\//;
 const RE_TRAILING_SLASH = /\/$/;
 
@@ -28,34 +31,76 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, PAYMENT-SIGNATURE",
-  "Access-Control-Expose-Headers": "Payment-Receipt",
+  "Access-Control-Expose-Headers":
+    "Payment-Receipt, PAYMENT-REQUIRED, X-PAYMENT-REQUIREMENTS, WWW-Authenticate",
 } as const;
 
 type Dual402Params = {
   price: string;
   creatorWalletAddress: string;
   workflowName: string;
+  resourceUrl: string;
 };
 
-export function buildDual402Response(params: Dual402Params): Response {
-  const { price, creatorWalletAddress, workflowName } = params;
-
-  const x402Requirements = {
-    accepts: {
-      scheme: "exact",
-      network: "eip155:8453",
-      payTo: creatorWalletAddress,
-      price: `$${Number(price).toFixed(2)}`,
+/**
+ * Builds the spec-compliant x402 v2 PaymentRequired payload (matches the
+ * `PaymentRequired` type from `@x402/core/types`). Discovery scanners like
+ * x402scan and the `@agentcash/discovery` prober parse this exact shape.
+ */
+function buildPaymentRequired(params: Dual402Params): {
+  x402Version: 2;
+  error: string;
+  resource: { url: string; description: string; mimeType: string };
+  accepts: Array<{
+    scheme: string;
+    network: string;
+    asset: string;
+    amount: string;
+    payTo: string;
+    maxTimeoutSeconds: number;
+    extra: Record<string, unknown>;
+  }>;
+} {
+  const { price, creatorWalletAddress, workflowName, resourceUrl } = params;
+  const amountSmallestUnit = String(
+    Math.round(Number(price) * 10 ** USDC_DECIMALS)
+  );
+  return {
+    x402Version: 2,
+    error: "Payment required",
+    resource: {
+      url: resourceUrl,
+      description: `Pay to run workflow: ${workflowName}`,
+      mimeType: "application/json",
     },
-    description: `Pay to run workflow: ${workflowName}`,
+    accepts: [
+      {
+        scheme: "exact",
+        network: BASE_NETWORK,
+        asset: BASE_USDC_ADDRESS,
+        amount: amountSmallestUnit,
+        payTo: creatorWalletAddress,
+        maxTimeoutSeconds: PAYMENT_MAX_TIMEOUT_SECONDS,
+        extra: { name: "USD Coin", version: "2" },
+      },
+    ],
   };
+}
 
-  const x402Header = Buffer.from(JSON.stringify(x402Requirements)).toString(
+export function buildDual402Response(params: Dual402Params): Response {
+  const { price, creatorWalletAddress } = params;
+  const paymentRequired = buildPaymentRequired(params);
+  const encoded = Buffer.from(JSON.stringify(paymentRequired)).toString(
     "base64"
   );
 
   const headers = new Headers(CORS_HEADERS);
-  headers.set("X-PAYMENT-REQUIREMENTS", x402Header);
+  // Canonical header name from `@x402/core/http` -- this is what
+  // `@agentcash/discovery` and x402scan probe for.
+  headers.set("PAYMENT-REQUIRED", encoded);
+  // Legacy alias kept for in-flight clients that read the old name. Same
+  // payload, safe to remove once nothing depends on it.
+  headers.set("X-PAYMENT-REQUIREMENTS", encoded);
   headers.set("Cache-Control", "no-store");
 
   const mppSecretKey = process.env.MPP_SECRET_KEY;
@@ -84,13 +129,10 @@ export function buildDual402Response(params: Dual402Params): Response {
     headers.set("WWW-Authenticate", Challenge.serialize(challenge));
   }
 
-  return new Response(
-    JSON.stringify({
-      error: "Payment Required",
-      x402: x402Requirements,
-    }),
-    { status: 402, headers }
-  );
+  return new Response(JSON.stringify(paymentRequired), {
+    status: 402,
+    headers,
+  });
 }
 
 export type PaymentMeta = {
@@ -291,6 +333,7 @@ export function gatePayment(
       price: workflow.priceUsdcPerCall ?? "0",
       creatorWalletAddress,
       workflowName: workflow.name,
+      resourceUrl: request.url,
     }) as NextResponse
   );
 }

--- a/scripts/test-payments-prod.ts
+++ b/scripts/test-payments-prod.ts
@@ -20,7 +20,6 @@ import { registerExactEvmScheme } from "@x402/evm/exact/client";
 import { Mppx, tempo } from "mppx/client";
 import { privateKeyToAccount } from "viem/accounts";
 
-const BASE_USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 const BASE_USDC_DECIMALS = 6;
 
 const SLUG = "mcp-test";
@@ -91,36 +90,22 @@ function fetch402(): Promise<Response> {
   });
 }
 
-type DualAccepts = { scheme: string; network: string; payTo: string; price: string };
-type Dual402Header = { accepts: DualAccepts; description: string };
-
-function parseDual402Header(headerValue: string): Dual402Header {
+/**
+ * Parses the canonical `PAYMENT-REQUIRED` header (base64-encoded JSON of a
+ * `PaymentRequired` from `@x402/core/types`). Falls back to the legacy
+ * `X-PAYMENT-REQUIREMENTS` header for transitional compatibility -- both
+ * carry the same payload after the discovery-fix release.
+ */
+function parsePaymentRequiredHeader(res: Response): PaymentRequired | null {
+  const header =
+    res.headers.get("PAYMENT-REQUIRED") ??
+    res.headers.get("X-PAYMENT-REQUIREMENTS");
+  if (!header) {
+    return null;
+  }
   return JSON.parse(
-    Buffer.from(headerValue, "base64").toString("utf-8")
-  ) as Dual402Header;
-}
-
-function priceToAtomicUnits(price: string): string {
-  const numeric = price.replace(/^\$/, "");
-  return String(Math.round(Number(numeric) * 10 ** BASE_USDC_DECIMALS));
-}
-
-function toPaymentRequired(header: Dual402Header, url: string): PaymentRequired {
-  return {
-    x402Version: 2,
-    resource: { url },
-    accepts: [
-      {
-        scheme: header.accepts.scheme,
-        network: header.accepts.network as `${string}:${string}`,
-        payTo: header.accepts.payTo,
-        amount: priceToAtomicUnits(header.accepts.price),
-        asset: BASE_USDC_ADDRESS,
-        maxTimeoutSeconds: 300,
-        extra: { name: "USD Coin", version: "2" },
-      },
-    ],
-  };
+    Buffer.from(header, "base64").toString("utf-8")
+  ) as PaymentRequired;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,26 +131,26 @@ async function testDual402(): Promise<TestResult> {
     return { pass: false, detail: `expected 402, got ${res.status}` };
   }
 
-  const x402Header = res.headers.get("X-PAYMENT-REQUIREMENTS");
   const mppHeader = res.headers.get("WWW-Authenticate");
 
-  if (!x402Header) {
-    return { pass: false, detail: "missing X-PAYMENT-REQUIREMENTS header" };
-  }
-
+  let parsed: PaymentRequired | null;
   try {
-    const parsed = parseDual402Header(x402Header);
-    const hasAccepts = parsed.accepts?.scheme && parsed.accepts?.payTo;
-    return {
-      pass: Boolean(hasAccepts),
-      detail: [
-        `x402: scheme=${parsed.accepts?.scheme} payTo=${parsed.accepts?.payTo?.slice(0, 10)}...`,
-        `MPP WWW-Authenticate: ${mppHeader ? "present" : "absent"}`,
-      ].join(" | "),
-    };
+    parsed = parsePaymentRequiredHeader(res);
   } catch {
-    return { pass: false, detail: `X-PAYMENT-REQUIREMENTS not valid base64 JSON` };
+    return { pass: false, detail: "PAYMENT-REQUIRED not valid base64 JSON" };
   }
+  if (!parsed) {
+    return { pass: false, detail: "missing PAYMENT-REQUIRED header" };
+  }
+  const accept = parsed.accepts?.[0];
+  const hasAccepts = Boolean(accept?.scheme && accept?.payTo);
+  return {
+    pass: hasAccepts,
+    detail: [
+      `x402: v${parsed.x402Version} scheme=${accept?.scheme} payTo=${accept?.payTo?.slice(0, 10)}...`,
+      `MPP WWW-Authenticate: ${mppHeader ? "present" : "absent"}`,
+    ].join(" | "),
+  };
 }
 
 async function testInputValidation(): Promise<TestResult> {
@@ -209,13 +194,10 @@ async function testX402PaidCall(): Promise<TestResult> {
     return { pass: false, detail: `expected 402, got ${initialRes.status}` };
   }
 
-  const x402Header = initialRes.headers.get("X-PAYMENT-REQUIREMENTS");
-  if (!x402Header) {
-    return { pass: false, detail: "no X-PAYMENT-REQUIREMENTS header" };
+  const paymentRequired = parsePaymentRequiredHeader(initialRes);
+  if (!paymentRequired) {
+    return { pass: false, detail: "no PAYMENT-REQUIRED header" };
   }
-
-  const dual402 = parseDual402Header(x402Header);
-  const paymentRequired = toPaymentRequired(dual402, callUrl);
   const firstAccept = paymentRequired.accepts[0];
   const amountUsdc = Number(firstAccept.amount) / 10 ** BASE_USDC_DECIMALS;
   console.log(`\n    x402: $${amountUsdc.toFixed(2)} USDC on ${firstAccept.network} to ${firstAccept.payTo}`);

--- a/tests/unit/payment-router.test.ts
+++ b/tests/unit/payment-router.test.ts
@@ -89,6 +89,7 @@ describe("buildDual402Response", () => {
       price: "0.01",
       creatorWalletAddress: "0xCreator",
       workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
     });
     expect(response.status).toBe(402);
   });
@@ -98,6 +99,7 @@ describe("buildDual402Response", () => {
       price: "0.01",
       creatorWalletAddress: "0xCreator",
       workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
     });
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
@@ -109,6 +111,7 @@ describe("buildDual402Response", () => {
         price: "0.01",
         creatorWalletAddress: "0xCreator",
         workflowName: "Test Workflow",
+        resourceUrl: "https://example.com/api/mcp/workflows/test/call",
       });
       const wwwAuth = response.headers.get("WWW-Authenticate");
       expect(wwwAuth).toBeTruthy();
@@ -127,6 +130,7 @@ describe("buildDual402Response", () => {
         price: "0.01",
         creatorWalletAddress: "0xCreator",
         workflowName: "Test Workflow",
+        resourceUrl: "https://example.com/api/mcp/workflows/test/call",
       });
       expect(Expires.minutes).toHaveBeenCalledWith(5);
       expect(Challenge.from).toHaveBeenCalledWith(
@@ -146,6 +150,7 @@ describe("buildDual402Response", () => {
         price: "0.01",
         creatorWalletAddress: "0xCreator",
         workflowName: "Test Workflow",
+        resourceUrl: "https://example.com/api/mcp/workflows/test/call",
       });
       expect(Challenge.from).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -166,7 +171,56 @@ describe("buildDual402Response", () => {
       price: "0.01",
       creatorWalletAddress: "0xCreator",
       workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
     });
     expect(response.headers.get("WWW-Authenticate")).toBeNull();
+  });
+
+  it("emits the canonical PAYMENT-REQUIRED header with x402 v2 shape", async () => {
+    const response = buildDual402Response({
+      price: "0.01",
+      creatorWalletAddress: "0xCreator",
+      workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
+    });
+    const header = response.headers.get("PAYMENT-REQUIRED");
+    expect(header).toBeTruthy();
+    const decoded = JSON.parse(
+      Buffer.from(header as string, "base64").toString("utf8")
+    );
+    expect(decoded.x402Version).toBe(2);
+    expect(decoded.error).toBe("Payment required");
+    expect(decoded.resource).toEqual({
+      url: "https://example.com/api/mcp/workflows/test/call",
+      description: "Pay to run workflow: Test Workflow",
+      mimeType: "application/json",
+    });
+    expect(Array.isArray(decoded.accepts)).toBe(true);
+    expect(decoded.accepts).toHaveLength(1);
+    expect(decoded.accepts[0]).toEqual({
+      scheme: "exact",
+      network: "eip155:8453",
+      asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      amount: "10000",
+      payTo: "0xCreator",
+      maxTimeoutSeconds: 300,
+      extra: { name: "USD Coin", version: "2" },
+    });
+    // Body mirrors the header payload so probers that read the body still
+    // see the canonical shape.
+    const body = await response.json();
+    expect(body).toEqual(decoded);
+  });
+
+  it("also emits X-PAYMENT-REQUIREMENTS as a legacy alias with the same payload", () => {
+    const response = buildDual402Response({
+      price: "0.01",
+      creatorWalletAddress: "0xCreator",
+      workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
+    });
+    expect(response.headers.get("X-PAYMENT-REQUIREMENTS")).toBe(
+      response.headers.get("PAYMENT-REQUIRED")
+    );
   });
 });


### PR DESCRIPTION
## Summary

x402scan's URL validator uses `@agentcash/discovery`'s `checkEndpointSchema` to probe paid endpoints and filters the returned advisories for ones containing `paymentOptions` with `protocol === 'x402'`. Our hand-rolled `buildDual402Response` emitted a non-standard header name and body shape, so agentcash could not extract a valid `X402PaymentOption` from the probe response and x402scan rejected the resource with "No valid x402 response found".

Three things were wrong:

1. **Header name was `X-PAYMENT-REQUIREMENTS`**. The canonical name used by `@x402/core`'s encoder (`encodePaymentRequiredHeader`) and by the agentcash prober is `PAYMENT-REQUIRED`. Both names now carry the same payload so any in-flight legacy clients keep working while the prober gets the header it expects.

2. **`accepts` was an object**. The `@x402/core` spec is `PaymentRequirements[]` (an array).

3. **Missing required fields** per `PaymentRequirementsV2`: `asset` (token contract), `amount` (in token units, not the display string `"$0.01"`), `maxTimeoutSeconds`, `extra`, plus `x402Version: 2` at the top level and a proper `resource: { url, description, mimeType }` block.

## Evidence

Before this PR, calling `checkEndpointSchema` directly on our prod 402 response returned a probe result where `advisory.paymentOptions` did not contain any `protocol === 'x402'` entry. x402scan's filter then rejected the resource.

After this PR, the same call returns:

```json
{
  "protocol": "x402",
  "version": 2,
  "network": "eip155:8453",
  "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
  "amount": "10000",
  "scheme": "exact",
  "payTo": "0xAA70...8Fee",
  "maxTimeoutSeconds": 300
}
```

which is exactly the shape x402scan's `probe.ts` filter expects.

Also verified locally:
- `curl -X POST ... -d '{}' http://localhost:3000/api/mcp/workflows/mcp-test/call` returns HTTP 402 with `payment-required` + `x-payment-requirements` + `www-authenticate` headers, all pointing at the same canonical payload.
- `npx @agentcash/discovery discover http://localhost:3000` source is `openapi`, both routes resolve as `paid 0.01 USD [x402, mpp]`, and the previous `OPENAPI_PARSE_ERROR` / `L2_PRICE_MISSING_ON_PAID` warnings are gone.

## What changed

- `lib/payments/router.ts` -- rewrote `buildDual402Response` to build the canonical `PaymentRequired` v2 payload, emit it under both `PAYMENT-REQUIRED` (canonical) and `X-PAYMENT-REQUIREMENTS` (legacy alias) headers, put the same payload in the response body, and thread the request URL in as `resource.url`.
- `scripts/test-payments-prod.ts` -- dropped the legacy-to-canonical adapter (`toPaymentRequired`, `parseDual402Header`, `priceToAtomicUnits`). The script now parses `PAYMENT-REQUIRED` directly and falls back to the legacy header for transitional compatibility.
- `tests/unit/payment-router.test.ts` -- added two new cases covering the canonical payload shape and the legacy-alias equality. Updated the existing cases to pass the new required `resourceUrl` param.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm vitest run tests/unit/payment-router.test.ts tests/unit/x402-call-route.test.ts tests/unit/openapi-route.test.ts` -- 32/32 passing
- [x] `pnpm check` clean on the touched files
- [x] Local dev server probe via `@agentcash/discovery.checkEndpointSchema` returns `paymentOptions[0].protocol === "x402"`
- [ ] After deploy to prod, re-register the resource on `x402scan.com/resources/register` and confirm the "1 failed resource" error is gone
- [ ] Re-run `pnpm tsx scripts/test-payments-prod.ts` against prod -- should still be 8/8
- [ ] Re-run agentcash discover on prod and confirm `OPENAPI_PARSE_ERROR` stays gone

Part of KEEP-176.
