### PR TITLE
fix(payments): embed bazaar schema extensions in PaymentRequired payload

### DIFF
--- a/lib/payments/router.ts
+++ b/lib/payments/router.ts
@@ -40,14 +40,10 @@ type Dual402Params = {
   creatorWalletAddress: string;
   workflowName: string;
   resourceUrl: string;
+  inputSchema?: Record<string, unknown> | null;
 };
 
-/**
- * Builds the spec-compliant x402 v2 PaymentRequired payload (matches the
- * `PaymentRequired` type from `@x402/core/types`). Discovery scanners like
- * x402scan and the `@agentcash/discovery` prober parse this exact shape.
- */
-function buildPaymentRequired(params: Dual402Params): {
+type PaymentRequiredV2 = {
   x402Version: 2;
   error: string;
   resource: { url: string; description: string; mimeType: string };
@@ -60,12 +56,36 @@ function buildPaymentRequired(params: Dual402Params): {
     maxTimeoutSeconds: number;
     extra: Record<string, unknown>;
   }>;
-} {
-  const { price, creatorWalletAddress, workflowName, resourceUrl } = params;
+  extensions?: Record<string, unknown>;
+};
+
+// Agentcash discovery's `extractSchemas2` drills the PaymentRequired body
+// at `extensions.bazaar.schema.properties.input.properties.body` for the
+// input JSON schema and at `.output.properties.example` for an output
+// sample. Emitting both lets x402scan / mppscan surface full request and
+// response metadata for the resource.
+const WORKFLOW_OUTPUT_EXAMPLE = {
+  executionId: "exec_abc123",
+  status: "running",
+} as const;
+
+/**
+ * Builds the spec-compliant x402 v2 PaymentRequired payload (matches the
+ * `PaymentRequired` type from `@x402/core/types`). Discovery scanners like
+ * x402scan and the `@agentcash/discovery` prober parse this exact shape.
+ */
+function buildPaymentRequired(params: Dual402Params): PaymentRequiredV2 {
+  const {
+    price,
+    creatorWalletAddress,
+    workflowName,
+    resourceUrl,
+    inputSchema,
+  } = params;
   const amountSmallestUnit = String(
     Math.round(Number(price) * 10 ** USDC_DECIMALS)
   );
-  return {
+  const payload: PaymentRequiredV2 = {
     x402Version: 2,
     error: "Payment required",
     resource: {
@@ -85,6 +105,21 @@ function buildPaymentRequired(params: Dual402Params): {
       },
     ],
   };
+
+  if (inputSchema) {
+    payload.extensions = {
+      bazaar: {
+        schema: {
+          properties: {
+            input: { properties: { body: inputSchema } },
+            output: { properties: { example: WORKFLOW_OUTPUT_EXAMPLE } },
+          },
+        },
+      },
+    };
+  }
+
+  return payload;
 }
 
 export function buildDual402Response(params: Dual402Params): Response {
@@ -334,6 +369,7 @@ export function gatePayment(
       creatorWalletAddress,
       workflowName: workflow.name,
       resourceUrl: request.url,
+      inputSchema: workflow.inputSchema,
     }) as NextResponse
   );
 }

--- a/tests/unit/payment-router.test.ts
+++ b/tests/unit/payment-router.test.ts
@@ -223,4 +223,43 @@ describe("buildDual402Response", () => {
       response.headers.get("PAYMENT-REQUIRED")
     );
   });
+
+  it("embeds extensions.bazaar.schema at the path agentcash probes when inputSchema is present", async () => {
+    const inputSchema = {
+      type: "object",
+      required: ["address"],
+      properties: {
+        address: { type: "string", description: "eth address" },
+      },
+    };
+    const response = buildDual402Response({
+      price: "0.01",
+      creatorWalletAddress: "0xCreator",
+      workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
+      inputSchema,
+    });
+    const body = await response.json();
+    // Agentcash's extractSchemas2 drills
+    // extensions.bazaar.schema.properties.input.properties.body and
+    // extensions.bazaar.schema.properties.output.properties.example -- see
+    // @agentcash/discovery dist/index.js extractSchemas2.
+    expect(body.extensions.bazaar.schema.properties.input.properties.body).toEqual(
+      inputSchema
+    );
+    expect(
+      body.extensions.bazaar.schema.properties.output.properties.example
+    ).toEqual({ executionId: "exec_abc123", status: "running" });
+  });
+
+  it("omits extensions block when inputSchema is absent", async () => {
+    const response = buildDual402Response({
+      price: "0.01",
+      creatorWalletAddress: "0xCreator",
+      workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
+    });
+    const body = await response.json();
+    expect(body.extensions).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

When you register `https://app.keeperhub.com` on mppscan or x402scan, the scanners successfully parse our openapi and find the paid route, but surface two non-blocking errors: `SCHEMA_INPUT_MISSING` and `SCHEMA_OUTPUT_MISSING`. You have to click "Confirm and continue anyway" to register through them. This PR clears both so the listing lands clean on first try.

The scanners use `@agentcash/discovery`'s prober. Its `extractSchemas2` function walks the 402 response body at a very specific path:

```
extensions.bazaar.schema.properties.input.properties.body
extensions.bazaar.schema.properties.output.properties.example
```

We weren't populating that shape anywhere, so the input/output schema extraction returned empty and the warnings fired.

This PR threads `workflow.inputSchema` (already populated from the DB) through `gatePayment` into `buildDual402Response`, which now emits the `extensions.bazaar.schema` block with the workflow's real input schema at `input.properties.body` and a fixed output example at `output.properties.example`. The output example -- `{ executionId: "exec_abc123", status: "running" }` -- matches what the workflow call route actually returns on success.

The new extensions block is only emitted when `inputSchema` is present, so free workflows and workflows without a declared schema still produce a lean 402 response.

## Verification

Before this PR, local `npx @agentcash/discovery discover http://localhost:3000` reported:

```
Warnings (2):
  [error] SCHEMA_INPUT_MISSING (extensions.bazaar.schema.properties.input)
  [error] SCHEMA_OUTPUT_MISSING (extensions.bazaar.schema.properties.output)
```

After this PR:

```
Routes:   2
  POST    /api/mcp/workflows/x402-echo-test/call  paid  0.01 USD  [x402, mpp]
  POST    /api/mcp/workflows/mcp-test/call        paid  0.01 USD  [x402, mpp]

Guidance: 64 tokens
```

Zero warnings.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm vitest run tests/unit/payment-router.test.ts tests/unit/x402-call-route.test.ts tests/unit/openapi-route.test.ts` -- 34/34 passing (2 new cases)
- [x] Local agentcash discover reports zero warnings against a dev server with the seeded workflows
- [ ] After deploy to prod, re-run agentcash discover against `https://app.keeperhub.com` and confirm the two SCHEMA warnings stay gone
- [ ] Refresh the mppscan and x402scan registration pages and confirm the "Input/Output schema missing" errors are no longer shown
- [ ] Full `scripts/test-payments-prod.ts` still passes 8/8

Part of KEEP-176.
