### PR TITLE
hotfix: pass chainId to wallet signer provider

### DIFF
--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -219,7 +219,7 @@ export async function POST(request: Request) {
         console.log(
           `[Withdraw] Initializing signer for org ${organizationId} on chain ${chain.name}`
         );
-        const signer = await initializeWalletSigner(organizationId, rpcUrl);
+        const signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
         const provider = signer.provider;
 
         if (!provider) {

--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -219,7 +219,7 @@ export async function POST(request: Request) {
         console.log(
           `[Withdraw] Initializing signer for org ${organizationId} on chain ${chain.name}`
         );
-        const signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+        const signer = await initializeWalletSigner(organizationId, rpcUrl, Number(chainId));
         const provider = signer.provider;
 
         if (!provider) {

--- a/lib/para/wallet-helpers.ts
+++ b/lib/para/wallet-helpers.ts
@@ -55,10 +55,11 @@ export async function getUserWallet(userId: string) {
  */
 export async function initializeWalletSigner(
   organizationId: string,
-  rpcUrl: string
+  rpcUrl: string,
+  chainId?: number
 ): Promise<ethers.Signer> {
   const wallet = await getOrganizationWallet(organizationId);
-  const rpcManager = await getRpcProviderFromUrls(rpcUrl);
+  const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, undefined, chainId);
   const provider = rpcManager.getProvider();
 
   if (wallet.provider === "turnkey") {

--- a/lib/para/wallet-helpers.ts
+++ b/lib/para/wallet-helpers.ts
@@ -59,7 +59,7 @@ export async function initializeWalletSigner(
   chainId?: number
 ): Promise<ethers.Signer> {
   const wallet = await getOrganizationWallet(organizationId);
-  const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, undefined, chainId);
+  const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, chainId);
   const provider = rpcManager.getProvider();
 
   if (wallet.provider === "turnkey") {

--- a/lib/para/wallet-helpers.ts
+++ b/lib/para/wallet-helpers.ts
@@ -56,7 +56,7 @@ export async function getUserWallet(userId: string) {
 export async function initializeWalletSigner(
   organizationId: string,
   rpcUrl: string,
-  chainId?: number
+  chainId: number
 ): Promise<ethers.Signer> {
   const wallet = await getOrganizationWallet(organizationId);
   const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, chainId);

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -204,8 +204,8 @@ export async function getSolanaProvider(
 export async function getRpcProviderFromUrls(
   primaryRpcUrl: string,
   fallbackRpcUrl?: string,
-  chainName = "unknown",
-  chainId?: number
+  chainId?: number,
+  chainName = "unknown"
 ): Promise<RpcProviderManager> {
   const [metricsCollector, failoverCallback] = await Promise.all([
     getEvmMetricsCollector(),

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -204,7 +204,8 @@ export async function getSolanaProvider(
 export async function getRpcProviderFromUrls(
   primaryRpcUrl: string,
   fallbackRpcUrl?: string,
-  chainName = "unknown"
+  chainName = "unknown",
+  chainId?: number
 ): Promise<RpcProviderManager> {
   const [metricsCollector, failoverCallback] = await Promise.all([
     getEvmMetricsCollector(),
@@ -215,6 +216,7 @@ export async function getRpcProviderFromUrls(
     primaryRpcUrl,
     fallbackRpcUrl,
     chainName,
+    chainId,
     metricsCollector,
     onFailoverStateChange: failoverCallback,
   });

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -296,7 +296,8 @@ export async function executeTransaction(
 
     const signer = await initializeWalletSigner(
       context.organizationId,
-      context.rpcUrl
+      context.rpcUrl,
+      context.chainId
     );
     const provider = signer.provider;
 

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -282,7 +282,7 @@ export async function approveTokenCore(
     // Initialize Para signer
     let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
     try {
-      signer = await initializeWalletSigner(organizationId, rpcUrl);
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
     } catch (error) {
       return {
         success: false,

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -227,7 +227,7 @@ export async function transferFundsCore(
   return withNonceSession(txContext, walletAddress, async (session) => {
     let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
     try {
-      signer = await initializeWalletSigner(organizationId, rpcUrl);
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
     } catch (error) {
       return {
         success: false,

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -382,7 +382,7 @@ export async function transferTokenCore(
     let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
     let signerAddress: string;
     try {
-      signer = await initializeWalletSigner(organizationId, rpcUrl);
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
       signerAddress = await signer.getAddress();
     } catch (error) {
       return {

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -329,7 +329,7 @@ export async function writeContractCore(
     // Initialize Para signer
     let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
     try {
-      signer = await initializeWalletSigner(organizationId, rpcUrl);
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
     } catch (error) {
       return {
         success: false,

--- a/tests/e2e/vitest/check-balance.test.ts
+++ b/tests/e2e/vitest/check-balance.test.ts
@@ -124,6 +124,7 @@ describe("Check Balance E2E", () => {
       const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_MAINNET.primary,
         RPC_URLS.ETH_MAINNET.fallback,
+        1,
         "Ethereum Mainnet"
       );
 
@@ -142,6 +143,7 @@ describe("Check Balance E2E", () => {
       const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_SEPOLIA.primary,
         RPC_URLS.ETH_SEPOLIA.fallback,
+        11155111,
         "Sepolia Testnet"
       );
 
@@ -159,6 +161,7 @@ describe("Check Balance E2E", () => {
       const provider = await getRpcProviderFromUrls(
         RPC_URLS.BASE_MAINNET.primary,
         RPC_URLS.BASE_MAINNET.fallback,
+        8453,
         "Base Mainnet"
       );
 
@@ -176,6 +179,7 @@ describe("Check Balance E2E", () => {
       const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_MAINNET.primary,
         RPC_URLS.ETH_MAINNET.fallback,
+        1,
         "Ethereum Mainnet (Zero Address)"
       );
 
@@ -287,6 +291,7 @@ describe("Check Balance E2E", () => {
       const provider = await getRpcProviderFromUrls(
         "https://invalid-rpc-url-that-does-not-exist.example.com",
         RPC_URLS.ETH_MAINNET.fallback,
+        1,
         "Ethereum Mainnet (Failover Test)"
       );
 
@@ -324,6 +329,7 @@ describe("Check Balance E2E", () => {
       const provider = await getRpcProviderFromUrls(
         RPC_URLS.ETH_MAINNET.primary,
         RPC_URLS.ETH_MAINNET.fallback,
+        1,
         "Ethereum Mainnet"
       );
 

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -150,6 +150,10 @@ vi.mock("@/lib/web3/transaction-manager", () => ({
   ),
 }));
 
+// Import mocks for assertion
+import { initializeWalletSigner } from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+
 // Import SUT after all mocks
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
 
@@ -199,5 +203,48 @@ describe("writeContractCore unique execution ID", () => {
 
     expect(capturedTxContext).not.toBeNull();
     expect(capturedTxContext?.executionId).toBe("wf-exec-123");
+  });
+});
+
+describe("writeContractCore signer chain ID", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTxContext = null;
+  });
+
+  it("should pass resolved chainId to initializeWalletSigner", async () => {
+    vi.mocked(getChainIdFromNetwork).mockReturnValue(11155111);
+
+    await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "11155111",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(initializeWalletSigner).toHaveBeenCalledWith(
+      "org-1",
+      "https://rpc.example.com",
+      11155111
+    );
+  });
+
+  it("should pass mainnet chainId when network is mainnet", async () => {
+    vi.mocked(getChainIdFromNetwork).mockReturnValue(1);
+
+    await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "1",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(initializeWalletSigner).toHaveBeenCalledWith(
+      "org-1",
+      "https://rpc.example.com",
+      1
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Pass chainId through initializeWalletSigner and getRpcProviderFromUrls so the wallet signer provider uses the correct chain
- Fix all callers: write-contract, transfer-funds, approve-token, transfer-token, transaction-manager, withdraw route

## Root cause

PR #791 added staticNetwork: true with Network.from(chainId) to the RPC provider to suppress ethers network auto-detection log spam. The chainId was wired through getRpcProvider (the read path) but not through getRpcProviderFromUrls (the signer path). When chainId is undefined, the config defaults to chainId ?? 1 (mainnet). Every non-mainnet write operation signed transactions with chain ID 1, which the target chain RPC rejects with "invalid chain ID".

Before #791, the provider used network "any" which auto-detected from the RPC. After #791, it locks to the configured chainId - but the signer path was never given one.

## Test plan

- [x] 2 new unit tests: writeContractCore forwards chainId to initializeWalletSigner for both Sepolia (11155111) and mainnet (1)
- [x] All 4 write-contract-core tests pass
- [x] Manual: execute a write operation on Sepolia to verify chain ID is correct in the signed transaction