### PR TITLE
hotfix: pass signer address in preflight staticCall and estimateGas

### DIFF
--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -124,7 +124,11 @@ export class EvmChainAdapter implements ChainAdapter {
       );
     }
 
-    const valueOverride = request.value ? { value: request.value } : {};
+    const signerAddress = await signer.getAddress();
+    const callOverrides = {
+      ...(request.value ? { value: request.value } : {}),
+      from: signerAddress,
+    };
 
     if (options.rpcManager) {
       await options.rpcManager.executeWithFailover((rpcProvider) => {
@@ -135,13 +139,13 @@ export class EvmChainAdapter implements ChainAdapter {
         );
         return readContract[request.functionKey].staticCall(
           ...request.args,
-          valueOverride
+          callOverrides
         );
       }, "preflight");
     } else {
       await contract[request.functionKey].staticCall(
         ...request.args,
-        valueOverride
+        callOverrides
       );
     }
 
@@ -156,12 +160,12 @@ export class EvmChainAdapter implements ChainAdapter {
           );
           return readContract[request.functionKey].estimateGas(
             ...request.args,
-            valueOverride
+            callOverrides
           );
         }, "preflight")
       : await contract[request.functionKey].estimateGas(
           ...request.args,
-          valueOverride
+          callOverrides
         );
 
     const gasConfig = await this.gasStrategy.getGasConfig(
@@ -178,7 +182,7 @@ export class EvmChainAdapter implements ChainAdapter {
       gasLimit: gasConfig.gasLimit,
       maxFeePerGas: gasConfig.maxFeePerGas,
       maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
-      ...valueOverride,
+      ...(request.value ? { value: request.value } : {}),
     });
 
     return this.confirmTransaction(tx, session, nonce, gasConfig, options);

--- a/tests/unit/evm-chain-adapter-preflight.test.ts
+++ b/tests/unit/evm-chain-adapter-preflight.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/db/schema", () => ({ explorerConfigs: {} }));
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+vi.mock("@/lib/explorer", () => ({
+  getAddressUrl: () => "",
+  getTransactionUrl: () => "",
+}));
+
+const SIGNER_ADDRESS = "0x2c9F694183A4240B6431771F6c714a8106179dF5";
+const SPENDER = "0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59";
+const AMOUNT = BigInt(1000);
+
+const mockStaticCall = vi.fn().mockResolvedValue(true);
+const mockEstimateGas = vi.fn().mockResolvedValue(BigInt(50_000));
+const mockSendTx = Object.assign(
+  vi.fn().mockResolvedValue({
+    hash: "0xtxhash",
+    wait: vi.fn().mockResolvedValue({
+      hash: "0xtxhash",
+      gasUsed: BigInt(21_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+      blockNumber: 100,
+    }),
+  }),
+  { staticCall: mockStaticCall, estimateGas: mockEstimateGas }
+);
+
+vi.mock("ethers", () => {
+  function MockContract(): Record<string, unknown> {
+    return { approve: mockSendTx };
+  }
+  return {
+    ethers: {
+      Contract: MockContract,
+    },
+  };
+});
+
+import { EvmChainAdapter } from "@/lib/web3/chain-adapter/evm";
+
+const APPROVE_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+];
+
+function createMockSigner(): unknown {
+  return {
+    getAddress: vi.fn().mockResolvedValue(SIGNER_ADDRESS),
+    provider: {
+      getNetwork: vi.fn().mockResolvedValue({ chainId: BigInt(11_155_111) }),
+    },
+  };
+}
+
+function createAdapter(): EvmChainAdapter {
+  const gasStrategy = {
+    getGasConfig: vi.fn().mockResolvedValue({
+      gasLimit: BigInt(100_000),
+      maxFeePerGas: BigInt(1_000_000_000),
+      maxPriorityFeePerGas: BigInt(1_000_000),
+    }),
+  };
+  const nonceManager = { getNextNonce: vi.fn().mockReturnValue(5) };
+
+  return new EvmChainAdapter(
+    11_155_111,
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    gasStrategy as any,
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    nonceManager as any
+  );
+}
+
+describe("EvmChainAdapter preflight signer address", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes signer address as from in staticCall and estimateGas", async () => {
+    const adapter = createAdapter();
+    const signer = createMockSigner();
+
+    try {
+      await adapter.executeContractCall(
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        signer as any,
+        {
+          contractAddress: "0x779877A7B0D9E8603169DdbD7836e478b4624789",
+          abi: APPROVE_ABI as unknown as import("ethers").InterfaceAbi,
+          functionKey: "approve",
+          args: [SPENDER, AMOUNT],
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        { currentNonce: 5 } as any,
+        { triggerType: "manual", gasOverrides: {} }
+      );
+    } catch (err) {
+      // confirmTransaction fails with mocks - expected
+      // But if staticCall wasn't called, re-throw to see the real error
+      if (mockStaticCall.mock.calls.length === 0) {
+        throw err;
+      }
+    }
+
+    expect(mockStaticCall).toHaveBeenCalledTimes(1);
+    const staticOverrides =
+      mockStaticCall.mock.calls[0][mockStaticCall.mock.calls[0].length - 1];
+    expect(staticOverrides.from).toBe(SIGNER_ADDRESS);
+
+    expect(mockEstimateGas).toHaveBeenCalledTimes(1);
+    const gasOverrides =
+      mockEstimateGas.mock.calls[0][
+        mockEstimateGas.mock.calls[0].length - 1
+      ];
+    expect(gasOverrides.from).toBe(SIGNER_ADDRESS);
+  });
+
+  it("includes value alongside from for payable calls", async () => {
+    const adapter = createAdapter();
+    const signer = createMockSigner();
+    const ethValue = BigInt("1000000000000000000");
+
+    try {
+      await adapter.executeContractCall(
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        signer as any,
+        {
+          contractAddress: "0x779877A7B0D9E8603169DdbD7836e478b4624789",
+          abi: APPROVE_ABI as unknown as import("ethers").InterfaceAbi,
+          functionKey: "approve",
+          args: [SPENDER, AMOUNT],
+          value: ethValue,
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        { currentNonce: 5 } as any,
+        { triggerType: "manual", gasOverrides: {} }
+      );
+    } catch {
+      // confirmTransaction fails with mocks - expected
+    }
+
+    const staticOverrides =
+      mockStaticCall.mock.calls[0][mockStaticCall.mock.calls[0].length - 1];
+    expect(staticOverrides.from).toBe(SIGNER_ADDRESS);
+    expect(staticOverrides.value).toBe(ethValue);
+
+    const gasOverrides =
+      mockEstimateGas.mock.calls[0][
+        mockEstimateGas.mock.calls[0].length - 1
+      ];
+    expect(gasOverrides.from).toBe(SIGNER_ADDRESS);
+    expect(gasOverrides.value).toBe(ethValue);
+  });
+});


### PR DESCRIPTION
## Summary

Pass the signer's address as `from` in the EVM chain adapter's preflight `staticCall` and `estimateGas` calls.

## Root cause

PR #786 added RPC failover support to the write transaction preflight path. When `rpcManager` is available, it creates a new `readContract` connected to a plain `rpcProvider` (no signer) for `staticCall` and `estimateGas`. This means `from = address(0)` in the simulation.

For state-changing functions that check `msg.sender` (e.g. ERC-20 `approve` checks `require(owner != address(0))`), the simulation reverts with "approve from the zero address" before the transaction is ever sent.

The non-rpcManager fallback path (which uses the signer-connected contract) does not have this issue, which is why it was not caught - the bug only surfaces when rpcManager is passed, which writeContractCore always does.

## Fix

Resolve the signer address once with `signer.getAddress()` and pass it as `from` in the call overrides for both `staticCall` and `estimateGas`. The actual transaction send (line 180) already uses the signer-connected contract, so it is unaffected.

## Test plan

- [ ] Manual: execute ERC-20 approve on Sepolia - should succeed instead of reverting with "approve from the zero address"
- [ ] Manual: execute a payable write with ETH value - verify value is still passed correctly in overrides