### PR TITLE
ci: add ALLOW_TEST_ENDPOINTS to staging Helm values

### DIFF
--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -392,6 +392,9 @@ env:
     type: parameterStore
     name: test-api-key
     parameter_name: /eks/techops-staging/keeperhub/test-api-key
+  ALLOW_TEST_ENDPOINTS:
+    type: kv
+    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-staging


### PR DESCRIPTION
## Summary

Adds `ALLOW_TEST_ENDPOINTS=true` as a `kv` env var in the staging Helm values. This enables the admin test endpoints (`/api/admin/test/cleanup`, `/api/admin/test/enable-workflow`, `/api/admin/test/otp`) on staging permanently, so k6 load tests can run via GitHub Actions without manual `kubectl set env` patching after each deploy.

Not added to production values -- the `authenticateAdmin()` function blocks these endpoints when `NODE_ENV=production` unless this flag is explicitly set.

## Test plan

- [x] Verified staging values.yaml syntax
- [x] Confirmed not added to prod values
- [ ] After merge + deploy, verify: `curl -X POST .../api/admin/test/cleanup -H "Authorization: Bearer $TEST_API_KEY"` returns 200 instead of 403