### PR TITLE
ci: add k6 Cloud output for load test results visualization

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -133,6 +133,10 @@ jobs:
       - name: Run execution load test
         if: inputs.test_mode == 'execution'
         run: |
+          K6_CLOUD_ARGS=""
+          if [ -n "${K6_CLOUD_TOKEN:-}" ]; then
+            K6_CLOUD_ARGS="--out cloud"
+          fi
           k6 run tests/k6/execution-load-test.js \
             -e BASE_URL="${BASE_URL}" \
             -e TEST_API_KEY="${TEST_API_KEY}" \
@@ -144,12 +148,14 @@ jobs:
             -e DURATION="${{ inputs.duration }}" \
             -e RAMP_INTERVAL="${{ inputs.ramp_interval }}" \
             --summary-export /tmp/k6-results/summary.json \
-            --no-usage-report
+            --no-usage-report \
+            $K6_CLOUD_ARGS
         env:
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
           SERVICE_KEY: ${{ secrets.SCHEDULER_SERVICE_API_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
+          K6_CLOUD_TOKEN: ${{ secrets.K6_CLOUD_TOKEN }}
 
       # ── HTTP ramp mode: VU ramp-until-breach ──
       - name: Run HTTP ramp load test


### PR DESCRIPTION
## Summary

Adds `--out cloud` to k6 load test runs when `K6_CLOUD_TOKEN` secret is set. This pushes test metrics to Grafana Cloud for long-term visualization and week-over-week performance tracking.

Gracefully skipped when the token is not set (no breaking change).

## Test plan

- [ ] Trigger smoke test and verify results appear in Grafana Cloud