### PR TITLE
fix: coerce "true"/"false" strings to bool in web3 action args

### DIFF
--- a/lib/abi-struct-args.ts
+++ b/lib/abi-struct-args.ts
@@ -8,6 +8,7 @@
  */
 
 const TEMPLATE_VARIABLE_RE = /^\{\{.+\}\}$/;
+const ARRAY_SUFFIX_RE = /\[\d*\]$/;
 
 type AbiComponent = {
   name: string;
@@ -141,28 +142,43 @@ function coerceValue(
   if (isTemplateVariable(value)) {
     return value;
   }
-  if (type.endsWith("[]")) {
-    if (!Array.isArray(value)) {
-      return value;
-    }
-    const baseType = type.slice(0, -2);
-    return value.map((item) => coerceValue(item, baseType, components));
+  if (isArrayType(type)) {
+    return coerceArray(value, type, components);
   }
   if (type === "tuple") {
-    if (value === null || typeof value !== "object" || Array.isArray(value)) {
-      return value;
-    }
-    const obj = value as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    for (const comp of components ?? []) {
-      out[comp.name] = coerceValue(obj[comp.name], comp.type, comp.components);
-    }
-    return out;
+    return coerceTuple(value, components);
   }
   if (type === "bool") {
     return coerceBool(value);
   }
   return value;
+}
+
+function coerceArray(
+  value: unknown,
+  arrayType: string,
+  components: AbiComponent[] | undefined
+): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const elementType = stripArraySuffix(arrayType);
+  return value.map((item) => coerceValue(item, elementType, components));
+}
+
+function coerceTuple(
+  value: unknown,
+  components: AbiComponent[] | undefined
+): unknown {
+  if (!isPreStructuredObject(value)) {
+    return value;
+  }
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const comp of components ?? []) {
+    out[comp.name] = coerceValue(obj[comp.name], comp.type, comp.components);
+  }
+  return out;
 }
 
 function coerceBool(value: unknown): unknown {
@@ -177,6 +193,14 @@ function coerceBool(value: unknown): unknown {
     return false;
   }
   return value;
+}
+
+function isArrayType(type: string): boolean {
+  return type.endsWith("]");
+}
+
+function stripArraySuffix(type: string): string {
+  return type.replace(ARRAY_SUFFIX_RE, "");
 }
 
 function isTemplateVariable(value: unknown): boolean {

--- a/lib/abi-struct-args.ts
+++ b/lib/abi-struct-args.ts
@@ -114,11 +114,17 @@ export function reshapeArgsForAbi(
 
 /**
  * Coerce stringly-typed args to their ABI-native types where a string would
- * silently corrupt encoding. Currently scoped to `bool`, because ethers v6
- * encodes any non-empty string as `true` -- so the literal string `"false"`
- * becomes `true` without warning. Numeric and bytes types are safe as strings
- * and are left untouched. Template variables (`{{...}}`) are passed through
- * and resolved later in the pipeline.
+ * silently corrupt encoding.
+ *
+ * Scoped to `bool` on purpose: ethers v6 encodes booleans via JS truthiness
+ * (`value ? 1 : 0`), so any non-empty string -- including the literal
+ * `"false"` -- becomes `true` without warning. Every other ABI leaf type
+ * fails loudly on a malformed string: numerics go through `BigInt()` and
+ * throw on non-numeric input or out-of-range values, `address` runs EIP-55
+ * checksum validation, and `bytes`/`bytesN` reject wrong lengths or missing
+ * `0x` prefixes. Extending coercion beyond `bool` would hide those errors
+ * instead of fixing them. Template variables (`{{...}}`) pass through and
+ * are resolved later in the pipeline.
  */
 export function coerceArgsForAbi(
   args: unknown[],
@@ -173,8 +179,12 @@ function coerceTuple(
   if (!isPreStructuredObject(value)) {
     return value;
   }
+  // Start from a shallow copy so keys the user set outside the ABI are
+  // preserved. Then overwrite known components with their coerced values.
+  // The validator downstream flags typos; silently dropping them here
+  // would mask that signal.
   const obj = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
+  const out: Record<string, unknown> = { ...obj };
   for (const comp of components ?? []) {
     out[comp.name] = coerceValue(obj[comp.name], comp.type, comp.components);
   }

--- a/lib/abi-struct-args.ts
+++ b/lib/abi-struct-args.ts
@@ -7,9 +7,12 @@
  * ethers.js expects a single object argument -- this utility rebuilds it.
  */
 
+const TEMPLATE_VARIABLE_RE = /^\{\{.+\}\}$/;
+
 type AbiComponent = {
   name: string;
   type: string;
+  components?: AbiComponent[];
 };
 
 type AbiInput = {
@@ -106,4 +109,76 @@ export function reshapeArgsForAbi(
   }
 
   return reshaped;
+}
+
+/**
+ * Coerce stringly-typed args to their ABI-native types where a string would
+ * silently corrupt encoding. Currently scoped to `bool`, because ethers v6
+ * encodes any non-empty string as `true` -- so the literal string `"false"`
+ * becomes `true` without warning. Numeric and bytes types are safe as strings
+ * and are left untouched. Template variables (`{{...}}`) are passed through
+ * and resolved later in the pipeline.
+ */
+export function coerceArgsForAbi(
+  args: unknown[],
+  functionAbi: FunctionAbiEntry
+): unknown[] {
+  const inputs = functionAbi.inputs ?? [];
+  return args.map((arg, i) => {
+    const input = inputs[i];
+    if (!input) {
+      return arg;
+    }
+    return coerceValue(arg, input.type, input.components);
+  });
+}
+
+function coerceValue(
+  value: unknown,
+  type: string,
+  components: AbiComponent[] | undefined
+): unknown {
+  if (isTemplateVariable(value)) {
+    return value;
+  }
+  if (type.endsWith("[]")) {
+    if (!Array.isArray(value)) {
+      return value;
+    }
+    const baseType = type.slice(0, -2);
+    return value.map((item) => coerceValue(item, baseType, components));
+  }
+  if (type === "tuple") {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return value;
+    }
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const comp of components ?? []) {
+      out[comp.name] = coerceValue(obj[comp.name], comp.type, comp.components);
+    }
+    return out;
+  }
+  if (type === "bool") {
+    return coerceBool(value);
+  }
+  return value;
+}
+
+function coerceBool(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return true;
+  }
+  if (normalized === "false") {
+    return false;
+  }
+  return value;
+}
+
+function isTemplateVariable(value: unknown): boolean {
+  return typeof value === "string" && TEMPLATE_VARIABLE_RE.test(value.trim());
 }

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -9,7 +9,7 @@ import "server-only";
 
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
-import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi-struct-args";
 import { validateArgsForAbi } from "@/lib/abi-validate-args";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
@@ -149,6 +149,7 @@ export async function readContractCore(
         return parsedArgs.slice(index + 1).some((a) => a !== "");
       });
       args = reshapeArgsForAbi(args, functionAbi);
+      args = coerceArgsForAbi(args, functionAbi);
       const validation = validateArgsForAbi(args, functionAbi);
       if (!validation.ok) {
         return {

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -9,7 +9,7 @@ import "server-only";
 
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
-import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi-struct-args";
 import { validateArgsForAbi } from "@/lib/abi-validate-args";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
@@ -144,6 +144,7 @@ export async function writeContractCore(
         return parsedArgs.slice(index + 1).some((a) => a !== "");
       });
       args = reshapeArgsForAbi(args, functionAbi);
+      args = coerceArgsForAbi(args, functionAbi);
       const validation = validateArgsForAbi(args, functionAbi);
       if (!validation.ok) {
         return {

--- a/tests/unit/abi-struct-args.test.ts
+++ b/tests/unit/abi-struct-args.test.ts
@@ -269,4 +269,200 @@ describe("coerceArgsForAbi", () => {
     });
     expect(result).toEqual(["yes"]);
   });
+
+  it("preserves real booleans untouched", () => {
+    const result = coerceArgsForAbi([true, false], {
+      inputs: [
+        { name: "a", type: "bool" },
+        { name: "b", type: "bool" },
+      ],
+    });
+    expect(result).toEqual([true, false]);
+  });
+
+  it("is case-insensitive and trims whitespace on bool strings", () => {
+    const result = coerceArgsForAbi(["  TRUE ", "False"], {
+      inputs: [
+        { name: "a", type: "bool" },
+        { name: "b", type: "bool" },
+      ],
+    });
+    expect(result).toEqual([true, false]);
+  });
+
+  it("leaves extra args (beyond ABI length) untouched", () => {
+    const result = coerceArgsForAbi(["true", "false"], {
+      inputs: [{ name: "a", type: "bool" }],
+    });
+    expect(result).toEqual([true, "false"]);
+  });
+
+  it("coerces bool inside a fixed-size array", () => {
+    const result = coerceArgsForAbi([["true", "false", "true"]], {
+      inputs: [{ name: "flags", type: "bool[3]" }],
+    });
+    expect(result).toEqual([[true, false, true]]);
+  });
+
+  it("coerces bool deeply inside nested tuples", () => {
+    const result = coerceArgsForAbi(
+      [
+        {
+          outer: {
+            flag: "false",
+            inner: { flag: "true", amount: "42" },
+          },
+          tag: "0xabcd",
+        },
+      ],
+      {
+        inputs: [
+          {
+            name: "root",
+            type: "tuple",
+            components: [
+              {
+                name: "outer",
+                type: "tuple",
+                components: [
+                  { name: "flag", type: "bool" },
+                  {
+                    name: "inner",
+                    type: "tuple",
+                    components: [
+                      { name: "flag", type: "bool" },
+                      { name: "amount", type: "uint256" },
+                    ],
+                  },
+                ],
+              },
+              { name: "tag", type: "bytes32" },
+            ],
+          },
+        ],
+      }
+    );
+    expect(result).toEqual([
+      {
+        outer: {
+          flag: false,
+          inner: { flag: true, amount: "42" },
+        },
+        tag: "0xabcd",
+      },
+    ]);
+  });
+
+  it("coerces bool in arrays of tuples", () => {
+    const result = coerceArgsForAbi(
+      [
+        [
+          { addr: "0xaaa", enabled: "true" },
+          { addr: "0xbbb", enabled: "false" },
+        ],
+      ],
+      {
+        inputs: [
+          {
+            name: "entries",
+            type: "tuple[]",
+            components: [
+              { name: "addr", type: "address" },
+              { name: "enabled", type: "bool" },
+            ],
+          },
+        ],
+      }
+    );
+    expect(result).toEqual([
+      [
+        { addr: "0xaaa", enabled: true },
+        { addr: "0xbbb", enabled: false },
+      ],
+    ]);
+  });
+
+  it("coerces bool inside arrays of arrays", () => {
+    const result = coerceArgsForAbi(
+      [
+        [
+          ["true", "false"],
+          ["false", "false"],
+        ],
+      ],
+      {
+        inputs: [{ name: "matrix", type: "bool[][]" }],
+      }
+    );
+    expect(result).toEqual([
+      [
+        [true, false],
+        [false, false],
+      ],
+    ]);
+  });
+
+  it("preserves tuple shape when inner bool coercion fails (unknown string)", () => {
+    const result = coerceArgsForAbi([{ flag: "maybe", amount: "10" }], {
+      inputs: [
+        {
+          name: "p",
+          type: "tuple",
+          components: [
+            { name: "flag", type: "bool" },
+            { name: "amount", type: "uint256" },
+          ],
+        },
+      ],
+    });
+    expect(result).toEqual([{ flag: "maybe", amount: "10" }]);
+  });
+
+  it("does not touch non-bool types even when they look boolean-ish", () => {
+    // "true"/"false" on a string param must NOT be coerced.
+    const result = coerceArgsForAbi(["false", "true"], {
+      inputs: [
+        { name: "label", type: "string" },
+        { name: "data", type: "bytes" },
+      ],
+    });
+    expect(result).toEqual(["false", "true"]);
+  });
+
+  it("passes templates through bools inside tuples and arrays", () => {
+    const result = coerceArgsForAbi(
+      [{ flag: "{{@prev.out}}" }, ["{{@prev.a}}", "false"]],
+      {
+        inputs: [
+          {
+            name: "p",
+            type: "tuple",
+            components: [{ name: "flag", type: "bool" }],
+          },
+          { name: "flags", type: "bool[]" },
+        ],
+      }
+    );
+    expect(result).toEqual([{ flag: "{{@prev.out}}" }, ["{{@prev.a}}", false]]);
+  });
+
+  it("handles empty arrays and empty tuples without errors", () => {
+    const result = coerceArgsForAbi([[], {}], {
+      inputs: [
+        { name: "flags", type: "bool[]" },
+        { name: "empty", type: "tuple", components: [] },
+      ],
+    });
+    expect(result).toEqual([[], {}]);
+  });
+
+  it("returns array with null/undefined preserved for non-matching shapes", () => {
+    const result = coerceArgsForAbi([null, undefined], {
+      inputs: [
+        { name: "p", type: "tuple", components: [{ name: "f", type: "bool" }] },
+        { name: "flags", type: "bool[]" },
+      ],
+    });
+    expect(result).toEqual([null, undefined]);
+  });
 });

--- a/tests/unit/abi-struct-args.test.ts
+++ b/tests/unit/abi-struct-args.test.ts
@@ -446,6 +446,25 @@ describe("coerceArgsForAbi", () => {
     expect(result).toEqual([{ flag: "{{@prev.out}}" }, ["{{@prev.a}}", false]]);
   });
 
+  it("preserves keys outside the ABI so typos stay visible to the validator", () => {
+    const result = coerceArgsForAbi(
+      [{ flag: "false", typo: "extra", amount: "10" }],
+      {
+        inputs: [
+          {
+            name: "p",
+            type: "tuple",
+            components: [
+              { name: "flag", type: "bool" },
+              { name: "amount", type: "uint256" },
+            ],
+          },
+        ],
+      }
+    );
+    expect(result).toEqual([{ flag: false, typo: "extra", amount: "10" }]);
+  });
+
   it("handles empty arrays and empty tuples without errors", () => {
     const result = coerceArgsForAbi([[], {}], {
       inputs: [

--- a/tests/unit/abi-struct-args.test.ts
+++ b/tests/unit/abi-struct-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi-struct-args";
 
 describe("reshapeArgsForAbi", () => {
   it("returns empty array unchanged", () => {
@@ -197,5 +197,76 @@ describe("reshapeArgsForAbi", () => {
     const obj = result[0] as Record<string, unknown>;
     expect(obj.items).toBe(items);
     expect(obj.target).toBe("0xAddr");
+  });
+});
+
+describe("coerceArgsForAbi", () => {
+  it('coerces string "false" to boolean false on bool inputs', () => {
+    const result = coerceArgsForAbi(["0xABC", "false"], {
+      inputs: [
+        { name: "target", type: "address" },
+        { name: "flag", type: "bool" },
+      ],
+    });
+    expect(result).toEqual(["0xABC", false]);
+  });
+
+  it('coerces string "true" to boolean true on bool inputs', () => {
+    const result = coerceArgsForAbi(["true"], {
+      inputs: [{ name: "flag", type: "bool" }],
+    });
+    expect(result).toEqual([true]);
+  });
+
+  it("leaves numeric and address strings untouched", () => {
+    const result = coerceArgsForAbi(["30106", "0xABC", "0xdeadbeef"], {
+      inputs: [
+        { name: "eid", type: "uint32" },
+        { name: "addr", type: "address" },
+        { name: "data", type: "bytes" },
+      ],
+    });
+    expect(result).toEqual(["30106", "0xABC", "0xdeadbeef"]);
+  });
+
+  it("passes template variables through unchanged", () => {
+    const result = coerceArgsForAbi(["{{@node.flag}}"], {
+      inputs: [{ name: "flag", type: "bool" }],
+    });
+    expect(result).toEqual(["{{@node.flag}}"]);
+  });
+
+  it("coerces bool leaves inside tuples", () => {
+    const result = coerceArgsForAbi(
+      [{ dstEid: "30106", payInLzToken: "false" }, "false"],
+      {
+        inputs: [
+          {
+            name: "param",
+            type: "tuple",
+            components: [
+              { name: "dstEid", type: "uint32" },
+              { name: "payInLzToken", type: "bool" },
+            ],
+          },
+          { name: "simulate", type: "bool" },
+        ],
+      }
+    );
+    expect(result).toEqual([{ dstEid: "30106", payInLzToken: false }, false]);
+  });
+
+  it("coerces bool elements inside arrays", () => {
+    const result = coerceArgsForAbi([["true", "false", "true"]], {
+      inputs: [{ name: "flags", type: "bool[]" }],
+    });
+    expect(result).toEqual([[true, false, true]]);
+  });
+
+  it("leaves unrecognized bool strings unchanged so validation can reject them", () => {
+    const result = coerceArgsForAbi(["yes"], {
+      inputs: [{ name: "flag", type: "bool" }],
+    });
+    expect(result).toEqual(["yes"]);
   });
 });


### PR DESCRIPTION
## Summary

The web3 `read-contract` and `write-contract` step handlers `JSON.parse` the user-supplied `functionArgs` and hand the array to ethers without any type coercion. ethers v6 encodes booleans via truthiness, so any non-empty string becomes `true`. That includes the literal string `"false"`, which silently encodes as `true` and surfaces as unrelated on-chain reverts (e.g. `LZ_LzTokenUnavailable()` on a LayerZero OFT `quoteSend(..., "false")` that the user intended as a native-fee quote).

## Fix

New `coerceArgsForAbi()` in `lib/abi-struct-args.ts` walks the ABI after `reshapeArgsForAbi` and converts `"true"` / `"false"` strings to real booleans on `bool` leaves, including inside tuples and arrays. Template variables (`{{...}}`) and non-bool types pass through untouched.

Wired into both `plugins/web3/steps/read-contract-core.ts` and `plugins/web3/steps/write-contract-core.ts`.

## Tests

Seven new cases in `tests/unit/abi-struct-args.test.ts` covering top-level bools, tuples, arrays, template passthrough, non-bool passthrough, and unrecognized strings (left for the validator to reject). All 17 tests in the file pass.