### PR TITLE
hotfix: nonce lock chainId, preflight from, retry budget

### DIFF
--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -152,11 +152,19 @@ export async function POST(request: Request) {
 
     // 2. Parse request body
     const body = await request.json();
-    const { chainId, tokenAddress, amount, recipient } = body;
+    const { chainId: rawChainId, tokenAddress, amount, recipient } = body;
 
-    if (!(chainId && amount && recipient)) {
+    if (!(rawChainId && amount && recipient)) {
       return NextResponse.json(
         { error: "Missing required fields: chainId, amount, recipient" },
+        { status: 400 }
+      );
+    }
+
+    const chainId = Number.parseInt(String(rawChainId), 10);
+    if (Number.isNaN(chainId)) {
+      return NextResponse.json(
+        { error: "Invalid chainId" },
         { status: 400 }
       );
     }
@@ -219,7 +227,7 @@ export async function POST(request: Request) {
         console.log(
           `[Withdraw] Initializing signer for org ${organizationId} on chain ${chain.name}`
         );
-        const signer = await initializeWalletSigner(organizationId, rpcUrl, Number(chainId));
+        const signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
         const provider = signer.provider;
 
         if (!provider) {

--- a/lib/rpc-provider/index.ts
+++ b/lib/rpc-provider/index.ts
@@ -685,7 +685,7 @@ export type CreateRpcProviderManagerOptions = {
 export function createRpcProviderManager(
   options: CreateRpcProviderManagerOptions
 ): RpcProviderManager {
-  const cacheKey = `${options.primaryRpcUrl}|${options.fallbackRpcUrl || ""}`;
+  const cacheKey = `${options.primaryRpcUrl}|${options.fallbackRpcUrl || ""}|${options.chainId ?? ""}`;
 
   let manager = managerCache.get(cacheKey);
   if (!manager) {

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -49,10 +49,13 @@ export type NonceManagerOptions = {
   lockRetryDelayMs?: number;
 };
 
+// Retry budget must outwait one full RPC failover round (up to ~90s per
+// provider including 30s timeouts + exponential backoff) since preflight
+// failover runs while the nonce lock is held.
 const DEFAULT_OPTIONS: Required<NonceManagerOptions> = {
   lockTimeoutMs: 60_000,
-  maxLockRetries: 50,
-  lockRetryDelayMs: 100,
+  maxLockRetries: 600,
+  lockRetryDelayMs: 200,
 };
 
 const getConnectionString = () => getDatabaseUrl();

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -372,7 +372,7 @@ export async function executeTransaction(
  */
 export async function executeContractTransaction(
   context: TransactionContext,
-  _walletAddress: string,
+  walletAddress: string,
   contract: ethers.Contract,
   method: string,
   args: unknown[],
@@ -394,7 +394,7 @@ export async function executeContractTransaction(
           (rpcProvider) =>
             (contract.connect(rpcProvider) as typeof contract)[
               method
-            ].estimateGas(...args),
+            ].estimateGas(...args, { from: walletAddress }),
           "preflight"
         )
       : await contract[method].estimateGas(...args);
@@ -462,7 +462,12 @@ export async function withNonceSession<T>(
 ): Promise<T> {
   const nonceManager = getNonceManager();
   const rpcManager =
-    context.rpcManager ?? (await getRpcProviderFromUrls(context.rpcUrl));
+    context.rpcManager ??
+    (await getRpcProviderFromUrls(
+      context.rpcUrl,
+      undefined,
+      context.chainId
+    ));
   const provider = rpcManager.getProvider();
 
   const { session, validation } = await nonceManager.startSession(
@@ -492,9 +497,10 @@ export async function withNonceSession<T>(
  */
 export async function getCurrentNonce(
   walletAddress: string,
-  rpcUrl: string
+  rpcUrl: string,
+  chainId: number
 ): Promise<number> {
-  const rpcManager = await getRpcProviderFromUrls(rpcUrl);
+  const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, chainId);
   return await rpcManager.executeWithFailover(
     (provider) => provider.getTransactionCount(walletAddress, "pending"),
     "write"


### PR DESCRIPTION
## Summary

Fixes three same-pattern bugs missed by #842 and #843, and stops Poker Keeper's "Failed to acquire nonce lock for 0x...:1 after 50 attempts" failures caused by preflight failover retries holding the nonce lock longer than the retry budget.

## Live bugs fixed

- **withNonceSession chainId omission** (same class as #842) -- fell back to `getRpcProviderFromUrls(context.rpcUrl)` with no chainId, defaulting to mainnet. Broke `/api/user/wallet/withdraw` on any non-mainnet chain with NETWORK_ERROR at `nonceManager.startSession`.
- **Poker Keeper nonce lock starvation** -- the nonce lock retry budget (50x100ms = 5s) could not outwait a single preflight failover round (3 retries x 30s timeout x 2 providers + backoff = up to ~190s worst case) while the lock is held. Bumped to 600x200ms (120s) as a band-aid. A structural fix (scope lock to nonce-assignment + broadcast only, release before `tx.wait`) will follow in a separate PR.
- **Withdraw route chainId type lie** -- `TransactionContext.chainId: number` but the route was passing the raw value from JSON body. Now coerced and validated at the boundary.

## Dormant bugs fixed (same patterns, no live callers)

- `executeContractTransaction` preflight `estimateGas` now passes `from: walletAddress` (same class as #843).
- `getCurrentNonce` now takes chainId.

## Defense in depth

- `RpcProviderManager` cache key now includes chainId, so a wrong-chainId entry cannot poison subsequent calls on the same URL.