### PR TITLE
fix: guard Selection.getRangeAt in template badge input

### DIFF
--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -7,6 +7,14 @@ import { cn } from "@/lib/utils";
 import { nodesAtom, selectedNodeAtom } from "@/lib/workflow-store";
 import { TemplateAutocomplete } from "./template-autocomplete";
 
+// Guards `selection.getRangeAt(0)`, which throws IndexSizeError when
+// rangeCount is 0 (e.g. focus moved off the editable before keydown fired).
+export function hasUsableSelection(
+  selection: Selection | null
+): selection is Selection {
+  return selection !== null && selection.rangeCount > 0;
+}
+
 export interface TemplateBadgeInputProps {
   value?: string;
   onChange?: (value: string) => void;
@@ -576,7 +584,7 @@ export function TemplateBadgeInput({
     // Handle Backspace/Delete for badge removal
     if (e.key === "Backspace" || e.key === "Delete") {
       const selection = window.getSelection();
-      if (!selection || !contentRef.current) return;
+      if (!hasUsableSelection(selection) || !contentRef.current) return;
 
       // Case 1: Range selection containing a badge
       if (!selection.isCollapsed) {

--- a/tests/unit/template-badge-input-selection-guard.test.ts
+++ b/tests/unit/template-badge-input-selection-guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { hasUsableSelection } from "@/components/ui/template-badge-input";
+
+describe("hasUsableSelection", () => {
+  it("returns false for null", () => {
+    expect(hasUsableSelection(null)).toBe(false);
+  });
+
+  it("returns false when rangeCount is 0", () => {
+    const selection = { rangeCount: 0 } as unknown as Selection;
+    expect(hasUsableSelection(selection)).toBe(false);
+  });
+
+  it("returns true when rangeCount is >= 1", () => {
+    const selection = { rangeCount: 1 } as unknown as Selection;
+    expect(hasUsableSelection(selection)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes Sentry `IndexSizeError` (issue 112091969) in `components/ui/template-badge-input.tsx`: `selection.getRangeAt(0)` was called in the Backspace/Delete handler without checking `rangeCount`.
- `Selection` can be non-null with `rangeCount === 0` when focus has moved off the contenteditable before keydown fires (observed breadcrumb: user clicked a Radix tab trigger, then pressed a key).
- Extracted guard into a pure helper `hasUsableSelection()` and added unit tests.

## Root cause

Line 579 previously only checked `!selection`. The second collapsed-cursor branch on line 595 (now the narrowed call site) then called `selection.getRangeAt(0)`, which throws `IndexSizeError` when `rangeCount` is 0.

## Changes

- `components/ui/template-badge-input.tsx`: new exported `hasUsableSelection(selection)` type guard; replaced inline check in the Backspace/Delete handler.
- `tests/unit/template-badge-input-selection-guard.test.ts`: covers null, `rangeCount: 0`, and `rangeCount: 1`.

## Caveat on test coverage

The unit test verifies the helper's logic in isolation but does not verify that the component actually calls it. A future regression that removes the call at the keydown site would not be caught by this test. Tradeoff chosen for minimal scope; component-level test would require adding `@testing-library/react` to the project.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm vitest run tests/unit/template-badge-input-selection-guard.test.ts` (3/3 pass)
- [ ] Manual verification in staging: click a Radix tab trigger adjacent to a TemplateBadgeInput, then press Backspace -- no Sentry error