### PR TITLE
fix: pass CHAIN_RPC_CONFIG to e2e app for reliable RPCs

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'TEST_API_KEY for rate limit bypass via X-Test-API-Key header'
     required: false
     default: ''
+  chain_rpc_config:
+    description: 'CHAIN_RPC_CONFIG JSON for reliable RPC endpoints (avoids flaky public RPCs)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -66,6 +70,7 @@ runs:
         IMAGE_TAG: ${{ inputs.image_tag }}
         DATABASE_URL: ${{ inputs.database_url }}
         TEST_API_KEY: ${{ inputs.test_api_key }}
+        CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}
       run: |
         IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
@@ -79,6 +84,7 @@ runs:
           "CI=true" \
           "TEST_API_KEY=${TEST_API_KEY}" \
           "WORKFLOW_TARGET_WORLD=@workflow/world-postgres" \
+          "CHAIN_RPC_CONFIG=${CHAIN_RPC_CONFIG}" \
           > /tmp/keeperhub-app.env
 
         docker run -d --name keeperhub-app --network host \
@@ -142,3 +148,4 @@ runs:
         CI: true
         TEST_API_KEY: ${{ inputs.test_api_key }}
         WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
+        CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -201,6 +201,7 @@ jobs:
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
           test_api_key: ${{ secrets.TEST_API_KEY }}
+          chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -296,6 +297,7 @@ jobs:
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
           test_api_key: ${{ secrets.TEST_API_KEY }}
+          chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e


### PR DESCRIPTION
The start-app action never passed CHAIN_RPC_CONFIG to the running app, forcing it to use unreliable public RPCs. Adds chain_rpc_config input and passes it in both Docker and bare-metal paths. Fixes flaky e2e failures when public RPCs (Base Sepolia, BNB, Polygon, Arbitrum Sepolia) are unreachable from GH runners.