### PR TITLE
feat: add Plasma chain support

### DIFF
--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -49,6 +49,8 @@ export const PUBLIC_RPCS = {
   AVAX_MAINNET_FALLBACK: "https://avalanche-c-chain-rpc.publicnode.com",
   AVAX_FUJI: "https://api.avax-test.network/ext/bc/C/rpc",
   AVAX_FUJI_FALLBACK: "https://avalanche-fuji-c-chain-rpc.publicnode.com",
+  PLASMA_MAINNET: "https://rpc.plasma.to",
+  PLASMA_TESTNET: "https://testnet-rpc.plasma.to",
   SOLANA_MAINNET: "https://api.mainnet-beta.solana.com",
   SOLANA_DEVNET: "https://api.devnet.solana.com",
 } as const;
@@ -177,6 +179,20 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     fallbackEnvKey: "CHAIN_AVAX_FUJI_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.AVAX_FUJI,
     publicFallback: PUBLIC_RPCS.AVAX_FUJI_FALLBACK,
+  },
+  // Plasma Mainnet
+  9745: {
+    jsonKey: "plasma-mainnet",
+    envKey: "CHAIN_PLASMA_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_PLASMA_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.PLASMA_MAINNET,
+  },
+  // Plasma Testnet
+  9746: {
+    jsonKey: "plasma-testnet",
+    envKey: "CHAIN_PLASMA_TESTNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_PLASMA_TESTNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.PLASMA_TESTNET,
   },
   // Solana Mainnet
   101: {

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -50,7 +50,9 @@ export const PUBLIC_RPCS = {
   AVAX_FUJI: "https://api.avax-test.network/ext/bc/C/rpc",
   AVAX_FUJI_FALLBACK: "https://avalanche-fuji-c-chain-rpc.publicnode.com",
   PLASMA_MAINNET: "https://rpc.plasma.to",
+  PLASMA_MAINNET_FALLBACK: "https://plasma.drpc.org",
   PLASMA_TESTNET: "https://testnet-rpc.plasma.to",
+  PLASMA_TESTNET_FALLBACK: "https://9746.rpc.thirdweb.com",
   SOLANA_MAINNET: "https://api.mainnet-beta.solana.com",
   SOLANA_DEVNET: "https://api.devnet.solana.com",
 } as const;
@@ -186,6 +188,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_PLASMA_MAINNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_PLASMA_MAINNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.PLASMA_MAINNET,
+    publicFallback: PUBLIC_RPCS.PLASMA_MAINNET_FALLBACK,
   },
   // Plasma Testnet
   9746: {
@@ -193,6 +196,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_PLASMA_TESTNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_PLASMA_TESTNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.PLASMA_TESTNET,
+    publicFallback: PUBLIC_RPCS.PLASMA_TESTNET_FALLBACK,
   },
   // Solana Mainnet
   101: {

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -339,6 +339,47 @@ const DEFAULT_CHAINS: NewChain[] = [
     isTestnet: getChainConfigValue("avax-fuji", "isTestnet", true),
     isEnabled: getChainConfigValue("avax-fuji", "isEnabled", true),
   },
+  // Plasma chains
+  {
+    chainId: getChainConfigValue("plasma-mainnet", "chainId", 9745),
+    name: "Plasma",
+    symbol: getChainConfigValue("plasma-mainnet", "symbol", "XPL"),
+    chainType: "evm",
+    defaultPrimaryRpc: getRpcUrlByChainId(9745, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(9745, "fallback"),
+    defaultPrimaryWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[9745].jsonKey,
+      type: "primary",
+    }),
+    defaultFallbackWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[9745].jsonKey,
+      type: "fallback",
+    }),
+    isTestnet: getChainConfigValue("plasma-mainnet", "isTestnet", false),
+    isEnabled: getChainConfigValue("plasma-mainnet", "isEnabled", true),
+  },
+  {
+    chainId: getChainConfigValue("plasma-testnet", "chainId", 9746),
+    name: "Plasma Testnet",
+    symbol: getChainConfigValue("plasma-testnet", "symbol", "XPL"),
+    chainType: "evm",
+    defaultPrimaryRpc: getRpcUrlByChainId(9746, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(9746, "fallback"),
+    defaultPrimaryWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[9746].jsonKey,
+      type: "primary",
+    }),
+    defaultFallbackWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[9746].jsonKey,
+      type: "fallback",
+    }),
+    isTestnet: getChainConfigValue("plasma-testnet", "isTestnet", true),
+    isEnabled: getChainConfigValue("plasma-testnet", "isEnabled", true),
+  },
   // Solana chains (non-EVM - uses SolanaProviderManager)
   {
     chainId: getChainConfigValue("solana-mainnet", "chainId", 101),
@@ -530,6 +571,26 @@ const EXPLORER_CONFIG_TEMPLATES: Record<
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}#code",
   },
+  // Plasma Mainnet - Etherscan V2 (Plasmascan)
+  9745: {
+    chainType: "evm",
+    explorerUrl: "https://plasmascan.to",
+    explorerApiType: "etherscan",
+    explorerApiUrl: "https://api.etherscan.io/v2/api",
+    explorerTxPath: "/tx/{hash}",
+    explorerAddressPath: "/address/{address}",
+    explorerContractPath: "/address/{address}#code",
+  },
+  // Plasma Testnet - Etherscan V2 (Plasmascan)
+  9746: {
+    chainType: "evm",
+    explorerUrl: "https://testnet.plasmascan.to",
+    explorerApiType: "etherscan",
+    explorerApiUrl: "https://api.etherscan.io/v2/api",
+    explorerTxPath: "/tx/{hash}",
+    explorerAddressPath: "/address/{address}",
+    explorerContractPath: "/address/{address}#code",
+  },
   // Solana Mainnet - Solscan
   101: {
     chainType: "solana",
@@ -614,6 +675,8 @@ async function seedChains() {
     "Arbitrum Sepolia": 421_614,
     Avalanche: 43_114,
     "Avalanche Fuji": 43_113,
+    Plasma: 9745,
+    "Plasma Testnet": 9746,
     Solana: 101,
     "Solana Devnet": 103,
   };


### PR DESCRIPTION
## Summary

- Register Plasma mainnet (9745) and Plasma testnet (9746) in `CHAIN_CONFIG`.
- Seed chains and explorer configs for both networks.
- Public RPC defaults route to `rpc.plasma.to` and `testnet-rpc.plasma.to`; explorers use Plasmascan via the unified Etherscan V2 API.