### PR TITLE
chore: retire maker-staging and maker-prod cluster references

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -149,7 +149,7 @@ jobs:
       - name: Fetch TEST_API_KEY from Parameter Store
         run: |
           TEST_API_KEY=$(aws ssm get-parameter \
-            --name "/eks/maker-staging/keeperhub/test-api-key" \
+            --name "/eks/techops-staging/keeperhub/test-api-key" \
             --with-decryption --query "Parameter.Value" --output text \
             --region us-east-2)
           echo "::add-mask::$TEST_API_KEY"

--- a/docs/featured-workflows.md
+++ b/docs/featured-workflows.md
@@ -6,10 +6,10 @@ Keys are stored in AWS SSM Parameter Store. Retrieve with:
 
 ```
 # Prod
-"/eks/maker-prod/keeperhub-hub/keeperhub-api-key"
+"/eks/techops-prod/keeperhub-hub/keeperhub-api-key"
 
 # Staging
-"/eks/maker-staging/keeperhub-hub/keeperhub-api-key"
+"/eks/techops-staging/keeperhub-hub/keeperhub-api-key"
 ```
 
 ## Endpoint

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,12 +28,12 @@ Retrieve the hub service API key from AWS SSM:
 ```bash
 # Production
 aws ssm get-parameter \
-  --name "/eks/maker-prod/keeperhub-hub/keeperhub-api-key" \
+  --name "/eks/techops-prod/keeperhub-hub/keeperhub-api-key" \
   --with-decryption --query "Parameter.Value" --output text
 
 # Staging
 aws ssm get-parameter \
-  --name "/eks/maker-staging/keeperhub-hub/keeperhub-api-key" \
+  --name "/eks/techops-staging/keeperhub-hub/keeperhub-api-key" \
   --with-decryption --query "Parameter.Value" --output text
 ```
 

--- a/scripts/feature-workflows.sh
+++ b/scripts/feature-workflows.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Get API key from SSM:
-# Prod: aws ssm get-parameter --name "/eks/maker-prod/keeperhub-hub/keeperhub-api-key" --with-decryption --query "Parameter.Value" --output text
-# Staging: aws ssm get-parameter --name "/eks/maker-staging/keeperhub-hub/keeperhub-api-key" --with-decryption --query "Parameter.Value" --output text
+# Prod: aws ssm get-parameter --name "/eks/techops-prod/keeperhub-hub/keeperhub-api-key" --with-decryption --query "Parameter.Value" --output text
+# Staging: aws ssm get-parameter --name "/eks/techops-staging/keeperhub-hub/keeperhub-api-key" --with-decryption --query "Parameter.Value" --output text
 
 if [[ -z "$HUB_SERVICE_API_KEY" ]]; then
   echo "Error: HUB_SERVICE_API_KEY env var not found"

--- a/scripts/pr-test/pr-connect.sh
+++ b/scripts/pr-test/pr-connect.sh
@@ -23,7 +23,7 @@ for cmd in aws-vault kubectl; do
   fi
 done
 
-export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/maker-staging}"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/techops-staging}"
 
 NAMESPACE="pr-${PR_NUMBER}"
 

--- a/scripts/pr-test/pr-exec-sql.sh
+++ b/scripts/pr-test/pr-exec-sql.sh
@@ -24,7 +24,7 @@ for cmd in aws-vault kubectl; do
   fi
 done
 
-export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/maker-staging}"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/techops-staging}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 

--- a/scripts/pr-test/pr-logs.sh
+++ b/scripts/pr-test/pr-logs.sh
@@ -29,7 +29,7 @@ for cmd in aws-vault kubectl; do
   fi
 done
 
-export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/maker-staging}"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/techops-staging}"
 
 shift
 NAMESPACE="pr-${PR_NUMBER}"

--- a/scripts/pr-test/pr-preflight.sh
+++ b/scripts/pr-test/pr-preflight.sh
@@ -23,7 +23,7 @@ for cmd in aws-vault kubectl curl; do
   fi
 done
 
-export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/maker-staging}"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/techops-staging}"
 
 NAMESPACE="pr-${PR_NUMBER}"
 ENV_FILE="/tmp/pr-test-${PR_NUMBER}.env"

--- a/scripts/pr-test/pr-seed.sh
+++ b/scripts/pr-test/pr-seed.sh
@@ -23,7 +23,7 @@ for cmd in aws-vault kubectl; do
   fi
 done
 
-export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/maker-staging}"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/techops-staging}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 


### PR DESCRIPTION
## Summary

- Replace all stale `maker-staging` / `maker-prod` cluster references with `techops-staging` / `techops-prod`
- The Helm values files were migrated during the original cluster rename; 9 other files were missed

## Changed files (9)

| File | Change |
|---|---|
| `.github/workflows/deploy-keeperhub.yaml:152` | SSM path for `TEST_API_KEY` |
| `scripts/pr-test/pr-seed.sh` | Default KUBECONFIG path |
| `scripts/pr-test/pr-preflight.sh` | Same |
| `scripts/pr-test/pr-connect.sh` | Same |
| `scripts/pr-test/pr-exec-sql.sh` | Same |
| `scripts/pr-test/pr-logs.sh` | Same |
| `scripts/feature-workflows.sh` | SSM path comments |
| `scripts/README.md` | Internal docs |
| `docs/featured-workflows.md` | Published docs |

No behaviour change beyond the rename. `git grep` confirms zero remaining `maker-staging`, `maker-prod`, or `/eks/maker` references (excluding `analysis/` docs about the unrelated MakerDAO protocol).

## Test plan

- [x] `git grep maker-staging` returns no matches
- [x] `git grep maker-prod` returns no matches
- [x] `git grep /eks/maker` returns no matches
- [ ] Staging deploy succeeds after merge (confirms SSM path `/eks/techops-staging/keeperhub/test-api-key` is valid)
- [ ] `pr-seed.sh` runs against a PR environment without KUBECONFIG override