### PR TITLE
refactor: KEEP-277 migrate Uniswap V3 to defineAbiProtocol

### DIFF
--- a/protocols/abis/uniswap-factory.json
+++ b/protocols/abis/uniswap-factory.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "function",
+    "name": "getPool",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "tokenA", "type": "address" },
+      { "name": "tokenB", "type": "address" },
+      { "name": "fee", "type": "uint24" }
+    ],
+    "outputs": [{ "name": "pool", "type": "address" }]
+  }
+]

--- a/protocols/abis/uniswap-position-manager.json
+++ b/protocols/abis/uniswap-position-manager.json
@@ -1,0 +1,64 @@
+[
+  {
+    "type": "function",
+    "name": "positions",
+    "stateMutability": "view",
+    "inputs": [{ "name": "tokenId", "type": "uint256" }],
+    "outputs": [
+      { "name": "nonce", "type": "uint96" },
+      { "name": "operator", "type": "address" },
+      { "name": "token0", "type": "address" },
+      { "name": "token1", "type": "address" },
+      { "name": "fee", "type": "uint24" },
+      { "name": "tickLower", "type": "int24" },
+      { "name": "tickUpper", "type": "int24" },
+      { "name": "liquidity", "type": "uint128" },
+      { "name": "feeGrowthInside0LastX128", "type": "uint256" },
+      { "name": "feeGrowthInside1LastX128", "type": "uint256" },
+      { "name": "tokensOwed0", "type": "uint128" },
+      { "name": "tokensOwed1", "type": "uint128" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "stateMutability": "view",
+    "inputs": [{ "name": "owner", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "stateMutability": "view",
+    "inputs": [{ "name": "tokenId", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "to", "type": "address" },
+      { "name": "tokenId", "type": "uint256" }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "tokenId", "type": "uint256" }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "stateMutability": "nonpayable",
+    "inputs": [{ "name": "tokenId", "type": "uint256" }],
+    "outputs": []
+  }
+]

--- a/protocols/abis/uniswap-quoter.json
+++ b/protocols/abis/uniswap-quoter.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "function",
+    "name": "quoteExactInputSingle",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "components": [
+          { "name": "tokenIn", "type": "address" },
+          { "name": "tokenOut", "type": "address" },
+          { "name": "amountIn", "type": "uint256" },
+          { "name": "fee", "type": "uint24" },
+          { "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ]
+      }
+    ],
+    "outputs": [
+      { "name": "amountOut", "type": "uint256" },
+      { "name": "sqrtPriceX96After", "type": "uint160" },
+      { "name": "initializedTicksCrossed", "type": "uint32" },
+      { "name": "gasEstimate", "type": "uint256" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "quoteExactOutputSingle",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "components": [
+          { "name": "tokenIn", "type": "address" },
+          { "name": "tokenOut", "type": "address" },
+          { "name": "amount", "type": "uint256" },
+          { "name": "fee", "type": "uint24" },
+          { "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ]
+      }
+    ],
+    "outputs": [
+      { "name": "amountIn", "type": "uint256" },
+      { "name": "sqrtPriceX96After", "type": "uint160" },
+      { "name": "initializedTicksCrossed", "type": "uint32" },
+      { "name": "gasEstimate", "type": "uint256" }
+    ]
+  }
+]

--- a/protocols/abis/uniswap-swap-router.json
+++ b/protocols/abis/uniswap-swap-router.json
@@ -1,0 +1,44 @@
+[
+  {
+    "type": "function",
+    "name": "exactInputSingle",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "components": [
+          { "name": "tokenIn", "type": "address" },
+          { "name": "tokenOut", "type": "address" },
+          { "name": "fee", "type": "uint24" },
+          { "name": "recipient", "type": "address" },
+          { "name": "amountIn", "type": "uint256" },
+          { "name": "amountOutMinimum", "type": "uint256" },
+          { "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "amountOut", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "exactOutputSingle",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "components": [
+          { "name": "tokenIn", "type": "address" },
+          { "name": "tokenOut", "type": "address" },
+          { "name": "fee", "type": "uint24" },
+          { "name": "recipient", "type": "address" },
+          { "name": "amountOut", "type": "uint256" },
+          { "name": "amountInMaximum", "type": "uint256" },
+          { "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "amountIn", "type": "uint256" }]
+  }
+]

--- a/protocols/uniswap-v3.ts
+++ b/protocols/uniswap-v3.ts
@@ -1,16 +1,33 @@
-import { defineProtocol } from "@/lib/protocol-registry";
+import { defineAbiProtocol } from "@/lib/protocol-registry";
+import factoryAbi from "./abis/uniswap-factory.json";
+import positionManagerAbi from "./abis/uniswap-position-manager.json";
+import quoterAbi from "./abis/uniswap-quoter.json";
+import swapRouterAbi from "./abis/uniswap-swap-router.json";
 
-export default defineProtocol({
+// QuoterV2 is declared as `view` in the reduced ABI even though the on-chain
+// contract is `nonpayable`. QuoterV2 uses a revert-to-return pattern (calls
+// pool.swap inside a try/catch), so the true mutability is nonpayable, but
+// every client invokes these via eth_call. Declaring `view` keeps the action
+// classified as a read step - no credentials, no gas, no state change.
+//
+// SwapRouter02 and NonfungiblePositionManager have several `payable` functions
+// upstream (exactInputSingle, exactOutputSingle, burn) to support multicall
+// composition. They are marked `nonpayable` in the reduced ABI because we do
+// not expose the ETH-value path through these actions; callers wrap ETH via
+// the WETH protocol first.
+
+export default defineAbiProtocol({
   name: "Uniswap V3",
   slug: "uniswap",
   description:
-    "Uniswap V3 -- pool discovery, liquidity positions, swaps, and quotes",
+    "Uniswap V3 - pool discovery, liquidity positions, swaps, and quotes",
   website: "https://uniswap.org",
   icon: "/protocols/uniswap.png",
 
   contracts: {
     factory: {
       label: "Uniswap V3 Factory",
+      abi: JSON.stringify(factoryAbi),
       addresses: {
         "1": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
         "8453": "0x33128a8fC17869897dcE68Ed026d694621f6FDfD",
@@ -18,9 +35,26 @@ export default defineProtocol({
         "10": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
         "11155111": "0x0227628f3F023bb0B980b67D528571c95c6DaC1c",
       },
+      overrides: {
+        getPool: {
+          slug: "get-pool",
+          label: "Get Pool Address",
+          description:
+            "Find the Uniswap V3 pool address for a token pair and fee tier",
+          inputs: {
+            tokenA: { label: "Token A Address" },
+            tokenB: { label: "Token B Address" },
+            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+          },
+          outputs: {
+            pool: { label: "Pool Address" },
+          },
+        },
+      },
     },
     positionManager: {
       label: "NonfungiblePositionManager",
+      abi: JSON.stringify(positionManagerAbi),
       addresses: {
         "1": "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
         "8453": "0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1",
@@ -28,9 +62,86 @@ export default defineProtocol({
         "10": "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
         "11155111": "0x1238536071E1c677A632429e3655c799b22cDA52",
       },
+      overrides: {
+        positions: {
+          slug: "get-position",
+          label: "Get Position Details",
+          description:
+            "Get full details of a liquidity position by NFT token ID",
+          inputs: {
+            tokenId: { label: "Position Token ID" },
+          },
+          outputs: {
+            nonce: { label: "Nonce" },
+            operator: { label: "Operator Address" },
+            token0: { label: "Token 0 Address" },
+            token1: { label: "Token 1 Address" },
+            fee: { label: "Fee Tier" },
+            tickLower: { label: "Lower Tick" },
+            tickUpper: { label: "Upper Tick" },
+            liquidity: { label: "Liquidity" },
+            feeGrowthInside0LastX128: { label: "Fee Growth Inside 0 (X128)" },
+            feeGrowthInside1LastX128: { label: "Fee Growth Inside 1 (X128)" },
+            tokensOwed0: { label: "Tokens Owed 0" },
+            tokensOwed1: { label: "Tokens Owed 1" },
+          },
+        },
+        balanceOf: {
+          slug: "balance-of",
+          label: "Get Position Count",
+          description: "Check how many LP position NFTs an address owns",
+          inputs: {
+            owner: { label: "Wallet Address" },
+          },
+          outputs: {
+            result: { name: "balance", label: "Position Count" },
+          },
+        },
+        ownerOf: {
+          slug: "owner-of",
+          label: "Get Position Owner",
+          description: "Get the owner address of a liquidity position NFT",
+          inputs: {
+            tokenId: { label: "Position Token ID" },
+          },
+          outputs: {
+            result: { name: "owner", label: "Owner Address" },
+          },
+        },
+        approve: {
+          slug: "approve-position",
+          label: "Approve Position Transfer",
+          description:
+            "Approve an address to manage a specific liquidity position NFT",
+          inputs: {
+            to: { label: "Approved Address" },
+            tokenId: { label: "Position Token ID" },
+          },
+        },
+        transferFrom: {
+          slug: "transfer-position",
+          label: "Transfer Position NFT",
+          description: "Transfer a liquidity position NFT to another address",
+          inputs: {
+            from: { label: "From Address" },
+            to: { label: "To Address" },
+            tokenId: { label: "Position Token ID" },
+          },
+        },
+        burn: {
+          slug: "burn-position",
+          label: "Burn Empty Position",
+          description:
+            "Burn an empty liquidity position NFT (position must have zero liquidity and zero owed tokens)",
+          inputs: {
+            tokenId: { label: "Position Token ID" },
+          },
+        },
+      },
     },
     swapRouter: {
       label: "SwapRouter02",
+      abi: JSON.stringify(swapRouterAbi),
       addresses: {
         "1": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
         "8453": "0x2626664c2603336E57B271c5C0b26F421741e481",
@@ -38,9 +149,54 @@ export default defineProtocol({
         "10": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
         "11155111": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E",
       },
+      overrides: {
+        exactInputSingle: {
+          slug: "swap-exact-input",
+          label: "Swap Exact Input",
+          description:
+            "Swap an exact amount of input tokens for as many output tokens as possible (single-hop)",
+          inputs: {
+            tokenIn: { label: "Input Token Address" },
+            tokenOut: { label: "Output Token Address" },
+            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            recipient: { label: "Recipient Address" },
+            amountIn: { label: "Amount In (wei)" },
+            amountOutMinimum: { label: "Minimum Output Amount (wei)" },
+            sqrtPriceLimitX96: {
+              label: "Price Limit (0 for none)",
+              default: "0",
+            },
+          },
+          outputs: {
+            amountOut: { label: "Amount Out (wei)" },
+          },
+        },
+        exactOutputSingle: {
+          slug: "swap-exact-output",
+          label: "Swap Exact Output",
+          description:
+            "Swap as few input tokens as possible for an exact amount of output tokens (single-hop)",
+          inputs: {
+            tokenIn: { label: "Input Token Address" },
+            tokenOut: { label: "Output Token Address" },
+            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            recipient: { label: "Recipient Address" },
+            amountOut: { label: "Desired Output Amount (wei)" },
+            amountInMaximum: { label: "Maximum Input Amount (wei)" },
+            sqrtPriceLimitX96: {
+              label: "Price Limit (0 for none)",
+              default: "0",
+            },
+          },
+          outputs: {
+            amountIn: { label: "Amount In (wei)" },
+          },
+        },
+      },
     },
     quoter: {
       label: "QuoterV2",
+      abi: JSON.stringify(quoterAbi),
       addresses: {
         "1": "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
         "8453": "0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a",
@@ -48,283 +204,52 @@ export default defineProtocol({
         "10": "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
         "11155111": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
       },
+      overrides: {
+        quoteExactInputSingle: {
+          slug: "quote-exact-input",
+          label: "Quote Exact Input",
+          description:
+            "Get the expected output amount for a single-hop exact-input swap",
+          inputs: {
+            tokenIn: { label: "Input Token Address" },
+            tokenOut: { label: "Output Token Address" },
+            amountIn: { label: "Amount In (wei)" },
+            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            sqrtPriceLimitX96: {
+              label: "Price Limit (0 for none)",
+              default: "0",
+            },
+          },
+          outputs: {
+            amountOut: { label: "Amount Out (wei)" },
+            sqrtPriceX96After: { label: "Price After Swap" },
+            initializedTicksCrossed: { label: "Ticks Crossed" },
+            gasEstimate: { label: "Gas Estimate" },
+          },
+        },
+        quoteExactOutputSingle: {
+          slug: "quote-exact-output",
+          label: "Quote Exact Output",
+          description:
+            "Get the required input amount for a single-hop exact-output swap",
+          inputs: {
+            tokenIn: { label: "Input Token Address" },
+            tokenOut: { label: "Output Token Address" },
+            amount: { label: "Desired Output Amount (wei)" },
+            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            sqrtPriceLimitX96: {
+              label: "Price Limit (0 for none)",
+              default: "0",
+            },
+          },
+          outputs: {
+            amountIn: { label: "Amount In (wei)" },
+            sqrtPriceX96After: { label: "Price After Swap" },
+            initializedTicksCrossed: { label: "Ticks Crossed" },
+            gasEstimate: { label: "Gas Estimate" },
+          },
+        },
+      },
     },
   },
-
-  actions: [
-    // Pool Discovery
-
-    {
-      slug: "get-pool",
-      label: "Get Pool Address",
-      description:
-        "Find the Uniswap V3 pool address for a token pair and fee tier",
-      type: "read",
-      contract: "factory",
-      function: "getPool",
-      inputs: [
-        { name: "tokenA", type: "address", label: "Token A Address" },
-        { name: "tokenB", type: "address", label: "Token B Address" },
-        {
-          name: "fee",
-          type: "uint24",
-          label: "Fee Tier (100, 500, 3000, or 10000)",
-        },
-      ],
-      outputs: [{ name: "pool", type: "address", label: "Pool Address" }],
-    },
-
-    // Position Reads
-
-    {
-      slug: "get-position",
-      label: "Get Position Details",
-      description: "Get full details of a liquidity position by NFT token ID",
-      type: "read",
-      contract: "positionManager",
-      function: "positions",
-      inputs: [
-        { name: "tokenId", type: "uint256", label: "Position Token ID" },
-      ],
-      outputs: [
-        { name: "nonce", type: "uint96", label: "Nonce" },
-        { name: "operator", type: "address", label: "Operator Address" },
-        { name: "token0", type: "address", label: "Token 0 Address" },
-        { name: "token1", type: "address", label: "Token 1 Address" },
-        { name: "fee", type: "uint24", label: "Fee Tier" },
-        { name: "tickLower", type: "int24", label: "Lower Tick" },
-        { name: "tickUpper", type: "int24", label: "Upper Tick" },
-        { name: "liquidity", type: "uint128", label: "Liquidity" },
-        {
-          name: "feeGrowthInside0LastX128",
-          type: "uint256",
-          label: "Fee Growth Inside 0 (X128)",
-        },
-        {
-          name: "feeGrowthInside1LastX128",
-          type: "uint256",
-          label: "Fee Growth Inside 1 (X128)",
-        },
-        { name: "tokensOwed0", type: "uint128", label: "Tokens Owed 0" },
-        { name: "tokensOwed1", type: "uint128", label: "Tokens Owed 1" },
-      ],
-    },
-    {
-      slug: "balance-of",
-      label: "Get Position Count",
-      description: "Check how many LP position NFTs an address owns",
-      type: "read",
-      contract: "positionManager",
-      function: "balanceOf",
-      inputs: [{ name: "owner", type: "address", label: "Wallet Address" }],
-      outputs: [{ name: "balance", type: "uint256", label: "Position Count" }],
-    },
-    {
-      slug: "owner-of",
-      label: "Get Position Owner",
-      description: "Get the owner address of a liquidity position NFT",
-      type: "read",
-      contract: "positionManager",
-      function: "ownerOf",
-      inputs: [
-        { name: "tokenId", type: "uint256", label: "Position Token ID" },
-      ],
-      outputs: [{ name: "owner", type: "address", label: "Owner Address" }],
-    },
-
-    // Quotes (read-only, struct params)
-
-    {
-      slug: "quote-exact-input",
-      label: "Quote Exact Input",
-      description:
-        "Get the expected output amount for a single-hop exact-input swap",
-      type: "read",
-      contract: "quoter",
-      function: "quoteExactInputSingle",
-      inputs: [
-        { name: "tokenIn", type: "address", label: "Input Token Address" },
-        { name: "tokenOut", type: "address", label: "Output Token Address" },
-        { name: "amountIn", type: "uint256", label: "Amount In (wei)" },
-        {
-          name: "fee",
-          type: "uint24",
-          label: "Fee Tier (100, 500, 3000, or 10000)",
-        },
-        {
-          name: "sqrtPriceLimitX96",
-          type: "uint160",
-          label: "Price Limit (0 for none)",
-          default: "0",
-        },
-      ],
-      outputs: [
-        { name: "amountOut", type: "uint256", label: "Amount Out (wei)" },
-        {
-          name: "sqrtPriceX96After",
-          type: "uint160",
-          label: "Price After Swap",
-        },
-        {
-          name: "initializedTicksCrossed",
-          type: "uint32",
-          label: "Ticks Crossed",
-        },
-        { name: "gasEstimate", type: "uint256", label: "Gas Estimate" },
-      ],
-    },
-    {
-      slug: "quote-exact-output",
-      label: "Quote Exact Output",
-      description:
-        "Get the required input amount for a single-hop exact-output swap",
-      type: "read",
-      contract: "quoter",
-      function: "quoteExactOutputSingle",
-      inputs: [
-        { name: "tokenIn", type: "address", label: "Input Token Address" },
-        { name: "tokenOut", type: "address", label: "Output Token Address" },
-        {
-          name: "amount",
-          type: "uint256",
-          label: "Desired Output Amount (wei)",
-        },
-        {
-          name: "fee",
-          type: "uint24",
-          label: "Fee Tier (100, 500, 3000, or 10000)",
-        },
-        {
-          name: "sqrtPriceLimitX96",
-          type: "uint160",
-          label: "Price Limit (0 for none)",
-          default: "0",
-        },
-      ],
-      outputs: [
-        { name: "amountIn", type: "uint256", label: "Amount In (wei)" },
-        {
-          name: "sqrtPriceX96After",
-          type: "uint160",
-          label: "Price After Swap",
-        },
-        {
-          name: "initializedTicksCrossed",
-          type: "uint32",
-          label: "Ticks Crossed",
-        },
-        { name: "gasEstimate", type: "uint256", label: "Gas Estimate" },
-      ],
-    },
-
-    // Swaps (write, struct params)
-
-    {
-      slug: "swap-exact-input",
-      label: "Swap Exact Input",
-      description:
-        "Swap an exact amount of input tokens for as many output tokens as possible (single-hop)",
-      type: "write",
-      contract: "swapRouter",
-      function: "exactInputSingle",
-      inputs: [
-        { name: "tokenIn", type: "address", label: "Input Token Address" },
-        { name: "tokenOut", type: "address", label: "Output Token Address" },
-        {
-          name: "fee",
-          type: "uint24",
-          label: "Fee Tier (100, 500, 3000, or 10000)",
-        },
-        { name: "recipient", type: "address", label: "Recipient Address" },
-        { name: "amountIn", type: "uint256", label: "Amount In (wei)" },
-        {
-          name: "amountOutMinimum",
-          type: "uint256",
-          label: "Minimum Output Amount (wei)",
-        },
-        {
-          name: "sqrtPriceLimitX96",
-          type: "uint160",
-          label: "Price Limit (0 for none)",
-          default: "0",
-        },
-      ],
-    },
-    {
-      slug: "swap-exact-output",
-      label: "Swap Exact Output",
-      description:
-        "Swap as few input tokens as possible for an exact amount of output tokens (single-hop)",
-      type: "write",
-      contract: "swapRouter",
-      function: "exactOutputSingle",
-      inputs: [
-        { name: "tokenIn", type: "address", label: "Input Token Address" },
-        { name: "tokenOut", type: "address", label: "Output Token Address" },
-        {
-          name: "fee",
-          type: "uint24",
-          label: "Fee Tier (100, 500, 3000, or 10000)",
-        },
-        { name: "recipient", type: "address", label: "Recipient Address" },
-        {
-          name: "amountOut",
-          type: "uint256",
-          label: "Desired Output Amount (wei)",
-        },
-        {
-          name: "amountInMaximum",
-          type: "uint256",
-          label: "Maximum Input Amount (wei)",
-        },
-        {
-          name: "sqrtPriceLimitX96",
-          type: "uint160",
-          label: "Price Limit (0 for none)",
-          default: "0",
-        },
-      ],
-    },
-
-    // Position Writes
-
-    {
-      slug: "approve-position",
-      label: "Approve Position Transfer",
-      description:
-        "Approve an address to manage a specific liquidity position NFT",
-      type: "write",
-      contract: "positionManager",
-      function: "approve",
-      inputs: [
-        { name: "to", type: "address", label: "Approved Address" },
-        { name: "tokenId", type: "uint256", label: "Position Token ID" },
-      ],
-    },
-    {
-      slug: "transfer-position",
-      label: "Transfer Position NFT",
-      description: "Transfer a liquidity position NFT to another address",
-      type: "write",
-      contract: "positionManager",
-      function: "transferFrom",
-      inputs: [
-        { name: "from", type: "address", label: "From Address" },
-        { name: "to", type: "address", label: "To Address" },
-        { name: "tokenId", type: "uint256", label: "Position Token ID" },
-      ],
-    },
-    {
-      slug: "burn-position",
-      label: "Burn Empty Position",
-      description:
-        "Burn an empty liquidity position NFT (position must have zero liquidity and zero owed tokens)",
-      type: "write",
-      contract: "positionManager",
-      function: "burn",
-      inputs: [
-        { name: "tokenId", type: "uint256", label: "Position Token ID" },
-      ],
-    },
-  ],
 });

--- a/protocols/uniswap-v3.ts
+++ b/protocols/uniswap-v3.ts
@@ -4,6 +4,17 @@ import positionManagerAbi from "./abis/uniswap-position-manager.json";
 import quoterAbi from "./abis/uniswap-quoter.json";
 import swapRouterAbi from "./abis/uniswap-swap-router.json";
 
+const UNISWAP_DOCS = "https://docs.uniswap.org/contracts/v3/reference";
+
+const FEE_TIER_TIP =
+  "Pool fee tier in hundredths of a basis point. Common values: 100 (0.01% - stablecoin pairs), 500 (0.05% - correlated pairs), 3000 (0.3% - most pairs), 10000 (1% - exotic pairs).";
+
+const SQRT_PRICE_LIMIT_TIP =
+  "Square-root price limit encoded as a Q64.96 fixed-point number. Constrains how far the pool price can move during the swap. Set to 0 for no limit (most common). Non-zero values act as a slippage guard at the pool level.";
+
+const POSITION_TOKEN_ID_TIP =
+  "The NFT token ID representing a Uniswap V3 liquidity position. Each position minted via the NonfungiblePositionManager receives a unique uint256 ID. Find it from the Mint event or via the balanceOf + tokenOfOwnerByIndex pattern.";
+
 // QuoterV2 is declared as `view` in the reduced ABI even though the on-chain
 // contract is `nonpayable`. QuoterV2 uses a revert-to-return pattern (calls
 // pool.swap inside a try/catch), so the true mutability is nonpayable, but
@@ -44,7 +55,11 @@ export default defineAbiProtocol({
           inputs: {
             tokenA: { label: "Token A Address" },
             tokenB: { label: "Token B Address" },
-            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            fee: {
+              label: "Fee Tier (100, 500, 3000, or 10000)",
+              helpTip: FEE_TIER_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
           },
           outputs: {
             pool: { label: "Pool Address" },
@@ -69,7 +84,11 @@ export default defineAbiProtocol({
           description:
             "Get full details of a liquidity position by NFT token ID",
           inputs: {
-            tokenId: { label: "Position Token ID" },
+            tokenId: {
+              label: "Position Token ID",
+              helpTip: POSITION_TOKEN_ID_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
           },
           outputs: {
             nonce: { label: "Nonce" },
@@ -102,7 +121,11 @@ export default defineAbiProtocol({
           label: "Get Position Owner",
           description: "Get the owner address of a liquidity position NFT",
           inputs: {
-            tokenId: { label: "Position Token ID" },
+            tokenId: {
+              label: "Position Token ID",
+              helpTip: POSITION_TOKEN_ID_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
           },
           outputs: {
             result: { name: "owner", label: "Owner Address" },
@@ -115,7 +138,11 @@ export default defineAbiProtocol({
             "Approve an address to manage a specific liquidity position NFT",
           inputs: {
             to: { label: "Approved Address" },
-            tokenId: { label: "Position Token ID" },
+            tokenId: {
+              label: "Position Token ID",
+              helpTip: POSITION_TOKEN_ID_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
           },
         },
         transferFrom: {
@@ -125,7 +152,11 @@ export default defineAbiProtocol({
           inputs: {
             from: { label: "From Address" },
             to: { label: "To Address" },
-            tokenId: { label: "Position Token ID" },
+            tokenId: {
+              label: "Position Token ID",
+              helpTip: POSITION_TOKEN_ID_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
           },
         },
         burn: {
@@ -134,7 +165,11 @@ export default defineAbiProtocol({
           description:
             "Burn an empty liquidity position NFT (position must have zero liquidity and zero owed tokens)",
           inputs: {
-            tokenId: { label: "Position Token ID" },
+            tokenId: {
+              label: "Position Token ID",
+              helpTip: POSITION_TOKEN_ID_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
           },
         },
       },
@@ -158,13 +193,24 @@ export default defineAbiProtocol({
           inputs: {
             tokenIn: { label: "Input Token Address" },
             tokenOut: { label: "Output Token Address" },
-            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            fee: {
+              label: "Fee Tier (100, 500, 3000, or 10000)",
+              helpTip: FEE_TIER_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
             recipient: { label: "Recipient Address" },
             amountIn: { label: "Amount In (wei)" },
-            amountOutMinimum: { label: "Minimum Output Amount (wei)" },
+            amountOutMinimum: {
+              label: "Minimum Output Amount (wei)",
+              helpTip:
+                "Minimum tokens to receive after the swap. The transaction reverts if the output would be less. Set to 0 only for testing - in production, calculate from a quote minus your slippage tolerance to avoid sandwich attacks.",
+              docUrl: UNISWAP_DOCS,
+            },
             sqrtPriceLimitX96: {
               label: "Price Limit (0 for none)",
               default: "0",
+              helpTip: SQRT_PRICE_LIMIT_TIP,
+              docUrl: UNISWAP_DOCS,
             },
           },
           outputs: {
@@ -179,13 +225,24 @@ export default defineAbiProtocol({
           inputs: {
             tokenIn: { label: "Input Token Address" },
             tokenOut: { label: "Output Token Address" },
-            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            fee: {
+              label: "Fee Tier (100, 500, 3000, or 10000)",
+              helpTip: FEE_TIER_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
             recipient: { label: "Recipient Address" },
             amountOut: { label: "Desired Output Amount (wei)" },
-            amountInMaximum: { label: "Maximum Input Amount (wei)" },
+            amountInMaximum: {
+              label: "Maximum Input Amount (wei)",
+              helpTip:
+                "Maximum tokens you are willing to spend. The transaction reverts if the required input exceeds this. Calculate from a quote plus your slippage tolerance.",
+              docUrl: UNISWAP_DOCS,
+            },
             sqrtPriceLimitX96: {
               label: "Price Limit (0 for none)",
               default: "0",
+              helpTip: SQRT_PRICE_LIMIT_TIP,
+              docUrl: UNISWAP_DOCS,
             },
           },
           outputs: {
@@ -214,10 +271,16 @@ export default defineAbiProtocol({
             tokenIn: { label: "Input Token Address" },
             tokenOut: { label: "Output Token Address" },
             amountIn: { label: "Amount In (wei)" },
-            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            fee: {
+              label: "Fee Tier (100, 500, 3000, or 10000)",
+              helpTip: FEE_TIER_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
             sqrtPriceLimitX96: {
               label: "Price Limit (0 for none)",
               default: "0",
+              helpTip: SQRT_PRICE_LIMIT_TIP,
+              docUrl: UNISWAP_DOCS,
             },
           },
           outputs: {
@@ -236,10 +299,16 @@ export default defineAbiProtocol({
             tokenIn: { label: "Input Token Address" },
             tokenOut: { label: "Output Token Address" },
             amount: { label: "Desired Output Amount (wei)" },
-            fee: { label: "Fee Tier (100, 500, 3000, or 10000)" },
+            fee: {
+              label: "Fee Tier (100, 500, 3000, or 10000)",
+              helpTip: FEE_TIER_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
             sqrtPriceLimitX96: {
               label: "Price Limit (0 for none)",
               default: "0",
+              helpTip: SQRT_PRICE_LIMIT_TIP,
+              docUrl: UNISWAP_DOCS,
             },
           },
           outputs: {

--- a/tests/integration/protocol-uniswap-onchain.test.ts
+++ b/tests/integration/protocol-uniswap-onchain.test.ts
@@ -2,15 +2,26 @@
  * Uniswap V3 On-Chain Integration Tests
  *
  * Verifies that the ABI-driven Uniswap V3 protocol definition produces
- * valid calldata that real contracts accept. Runs against a live Sepolia
- * RPC endpoint.
+ * calldata that real Sepolia Uniswap V3 contracts accept.
  *
- * Gated on INTEGRATION_TEST_RPC_URL env var - skipped in CI without it.
+ * RPC URL resolution (shared with the rest of the codebase):
+ *   1. CHAIN_RPC_CONFIG JSON (Helm/AWS Parameter Store, set in CI + deployed
+ *      environments)
+ *   2. Individual CHAIN_SEPOLIA_*_RPC env vars (dev override)
+ *   3. Public Sepolia RPC default (last resort)
  *
- * Test philosophy: verify the derived calldata is valid ABI, not that
- * business operations succeed. Pools may lack liquidity on Sepolia and
- * position token IDs may not exist; the try/catch paths accept those
- * reverts as long as the error is not an ABI encoding failure.
+ * Uses getRpcProviderFromUrls + executeWithFailover so primary RPC failures
+ * transparently fail over to the fallback URL - same failover machinery
+ * deployed services use.
+ *
+ * Ungated. Always runs. Public RPC backs every tier so the test is never
+ * blocked by missing env vars. CI uses the paid staging endpoints via
+ * CHAIN_RPC_CONFIG.
+ *
+ * Test philosophy: verify derived calldata is valid ABI, not that business
+ * operations succeed. Pools may lack liquidity on Sepolia and position
+ * token IDs may not exist; the try/catch paths accept those reverts as
+ * long as the error is not an ABI encoding failure.
  */
 
 import { ethers } from "ethers";
@@ -21,32 +32,63 @@ import type {
   ProtocolContract,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import {
+  createRpcUrlResolver,
+  PUBLIC_RPCS,
+  parseRpcConfig,
+} from "@/lib/rpc/rpc-config";
 import uniswapDef from "@/protocols/uniswap-v3";
 
-const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
-const CHAIN_ID = "11155111";
+const CHAIN_ID = "11155111"; // Sepolia
+const CHAIN_ID_NUMBER = 11_155_111;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 const HEX_ADDRESS_REGEX = /^0x[\dA-Fa-f]{40}$/;
 
-// Sepolia token addresses used for read-path tests. The WETH/USDC 0.3%
-// pool on Sepolia has had liquidity historically; if it does not at test
-// time, the quote calls revert with a business error and we still assert
+// Sepolia token addresses used for read-path tests. The WETH/USDC 0.3% pool
+// has had liquidity historically; if it lacks liquidity at test time the
+// quote calls revert with a business error and the try/catch still asserts
 // the calldata was well-formed.
 const SEPOLIA_WETH = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14";
 const SEPOLIA_USDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
 const FEE_TIER_030 = "3000";
 const ONE_ETH = "1000000000000000000";
 
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>
-): {
+// Resolve Sepolia RPC URLs via the shared config pipeline: CHAIN_RPC_CONFIG
+// first, individual env vars second, public default last.
+const rpcConfig = parseRpcConfig(process.env.CHAIN_RPC_CONFIG);
+const resolveRpcUrl = createRpcUrlResolver(rpcConfig);
+const SEPOLIA_PRIMARY_URL = resolveRpcUrl(
+  "eth-sepolia",
+  "CHAIN_SEPOLIA_PRIMARY_RPC",
+  PUBLIC_RPCS.SEPOLIA,
+  "primary"
+);
+const SEPOLIA_FALLBACK_URL = resolveRpcUrl(
+  "eth-sepolia",
+  "CHAIN_SEPOLIA_FALLBACK_RPC",
+  PUBLIC_RPCS.SEPOLIA,
+  "fallback"
+);
+
+type Calldata = {
   to: string;
   data: string;
   action: ProtocolAction;
   contract: ProtocolContract;
-} {
+};
+
+// Builds calldata from a protocol action. For contracts with
+// userSpecifiedAddress: true, pass `toOverride` so the request targets a
+// real runtime token address rather than the reference address baked into
+// the protocol definition. (Uniswap V3 has no userSpecifiedAddress
+// contracts today, but the hook is preserved to match the CCIP helper.)
+function buildCalldata(
+  protocol: ProtocolDefinition,
+  actionSlug: string,
+  sampleInputs: Record<string, string>,
+  toOverride?: string
+): Calldata {
   const action = protocol.actions.find((a) => a.slug === actionSlug);
   if (!action) {
     throw new Error(`Action ${actionSlug} not found`);
@@ -57,15 +99,16 @@ function buildCalldata(
     throw new Error(`Contract ${action.contract} has no ABI`);
   }
 
-  const contractAddress = contract.addresses[CHAIN_ID];
-  if (!contractAddress) {
-    throw new Error(`Contract ${action.contract} not on chain ${CHAIN_ID}`);
+  const to = toOverride ?? contract.addresses[CHAIN_ID];
+  if (!to) {
+    throw new Error(
+      `No address for contract ${action.contract} on chain ${CHAIN_ID}`
+    );
   }
 
-  const rawArgs = action.inputs.map((inp) => {
-    const val = sampleInputs[inp.name] ?? inp.default ?? "";
-    return val;
-  });
+  const rawArgs = action.inputs.map(
+    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
+  );
 
   const abi = JSON.parse(contract.abi);
   const functionAbi = abi.find(
@@ -76,26 +119,17 @@ function buildCalldata(
   const iface = new ethers.Interface(abi);
   const data = iface.encodeFunctionData(action.function, args);
 
-  return { to: contractAddress, data, action, contract };
+  return { to, data, action, contract };
 }
 
-function isAbiEncodingError(error: unknown): string | null {
-  const msg = String(error);
-  if (msg.includes("INVALID_ARGUMENT")) {
-    return "INVALID_ARGUMENT";
-  }
-  if (msg.includes("could not decode")) {
-    return "could not decode";
-  }
-  if (msg.includes("invalid function")) {
-    return "invalid function";
-  }
-  return null;
-}
-
-describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
-  const getProvider = (): ethers.JsonRpcProvider =>
-    new ethers.JsonRpcProvider(RPC_URL);
+describe("Uniswap V3 on-chain integration (Sepolia)", () => {
+  const makeProvider = () =>
+    getRpcProviderFromUrls(
+      SEPOLIA_PRIMARY_URL,
+      SEPOLIA_FALLBACK_URL,
+      CHAIN_ID_NUMBER,
+      "Sepolia (Uniswap V3 integration test)"
+    );
 
   // -- factory ---------------------------------------------------------------
 
@@ -106,15 +140,16 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       fee: FEE_TIER_030,
     });
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
-
+    const provider = await makeProvider();
+    const result = await provider.executeWithFailover(
+      async (p) => await p.call({ to, data })
+    );
     const iface = new ethers.Interface(JSON.parse(contract.abi as string));
     const decoded = iface.decodeFunctionResult("getPool", result);
     expect(decoded).toBeDefined();
     expect(typeof decoded[0]).toBe("string");
     expect(decoded[0]).toMatch(HEX_ADDRESS_REGEX);
-  }, 15_000);
+  }, 30_000);
 
   // -- positionManager -------------------------------------------------------
 
@@ -123,40 +158,51 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       owner: TEST_ADDRESS,
     });
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
-
+    const provider = await makeProvider();
+    const result = await provider.executeWithFailover(
+      async (p) => await p.call({ to, data })
+    );
     const iface = new ethers.Interface(JSON.parse(contract.abi as string));
     const decoded = iface.decodeFunctionResult("balanceOf", result);
     expect(decoded).toBeDefined();
     expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+  }, 30_000);
 
-  it("owner-of: calldata encodes correctly (business revert expected for invalid tokenId)", async () => {
+  it("owner-of: calldata encodes (business revert expected for invalid tokenId)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "owner-of", {
       tokenId: "1",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.call({ to, data });
+      await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
-  it("get-position: calldata encodes correctly (business revert expected for invalid tokenId)", async () => {
+  it("get-position: calldata encodes (business revert expected for invalid tokenId)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "get-position", {
       tokenId: "1",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.call({ to, data });
+      await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
   it("approve-position: estimateGas calldata is valid (business revert expected)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "approve-position", {
@@ -164,13 +210,18 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       tokenId: "1",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
   it("transfer-position: estimateGas calldata is valid (business revert expected)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "transfer-position", {
@@ -179,30 +230,40 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       tokenId: "1",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
   it("burn-position: estimateGas calldata is valid (business revert expected)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "burn-position", {
       tokenId: "1",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
   // -- quoter (tuple-flattened inputs) ---------------------------------------
 
-  it("quote-exact-input: calldata encodes correctly (business revert OK if pool lacks liquidity)", async () => {
+  it("quote-exact-input: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "quote-exact-input", {
       tokenIn: SEPOLIA_WETH,
       tokenOut: SEPOLIA_USDC,
@@ -211,15 +272,20 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       sqrtPriceLimitX96: "0",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.call({ to, data });
+      await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
-  it("quote-exact-output: calldata encodes correctly (business revert OK if pool lacks liquidity)", async () => {
+  it("quote-exact-output: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "quote-exact-output", {
       tokenIn: SEPOLIA_WETH,
       tokenOut: SEPOLIA_USDC,
@@ -228,13 +294,18 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       sqrtPriceLimitX96: "0",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.call({ to, data });
+      await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
   // -- swapRouter (tuple-flattened inputs) -----------------------------------
 
@@ -249,13 +320,18 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       sqrtPriceLimitX96: "0",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 
   it("swap-exact-output: estimateGas calldata is valid (business revert expected - no approval)", async () => {
     const { to, data } = buildCalldata(uniswapDef, "swap-exact-output", {
@@ -268,11 +344,16 @@ describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
       sqrtPriceLimitX96: "0",
     });
 
-    const provider = getProvider();
+    const provider = await makeProvider();
     try {
-      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+      );
     } catch (error) {
-      expect(isAbiEncodingError(error)).toBeNull();
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
     }
-  }, 15_000);
+  }, 30_000);
 });

--- a/tests/integration/protocol-uniswap-onchain.test.ts
+++ b/tests/integration/protocol-uniswap-onchain.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Uniswap V3 On-Chain Integration Tests
+ *
+ * Verifies that the ABI-driven Uniswap V3 protocol definition produces
+ * valid calldata that real contracts accept. Runs against a live Sepolia
+ * RPC endpoint.
+ *
+ * Gated on INTEGRATION_TEST_RPC_URL env var - skipped in CI without it.
+ *
+ * Test philosophy: verify the derived calldata is valid ABI, not that
+ * business operations succeed. Pools may lack liquidity on Sepolia and
+ * position token IDs may not exist; the try/catch paths accept those
+ * reverts as long as the error is not an ABI encoding failure.
+ */
+
+import { ethers } from "ethers";
+import { describe, expect, it } from "vitest";
+import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import type {
+  ProtocolAction,
+  ProtocolContract,
+  ProtocolDefinition,
+} from "@/lib/protocol-registry";
+import uniswapDef from "@/protocols/uniswap-v3";
+
+const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
+const CHAIN_ID = "11155111";
+const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
+const HEX_ADDRESS_REGEX = /^0x[\dA-Fa-f]{40}$/;
+
+// Sepolia token addresses used for read-path tests. The WETH/USDC 0.3%
+// pool on Sepolia has had liquidity historically; if it does not at test
+// time, the quote calls revert with a business error and we still assert
+// the calldata was well-formed.
+const SEPOLIA_WETH = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14";
+const SEPOLIA_USDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
+const FEE_TIER_030 = "3000";
+const ONE_ETH = "1000000000000000000";
+
+function buildCalldata(
+  protocol: ProtocolDefinition,
+  actionSlug: string,
+  sampleInputs: Record<string, string>
+): {
+  to: string;
+  data: string;
+  action: ProtocolAction;
+  contract: ProtocolContract;
+} {
+  const action = protocol.actions.find((a) => a.slug === actionSlug);
+  if (!action) {
+    throw new Error(`Action ${actionSlug} not found`);
+  }
+
+  const contract = protocol.contracts[action.contract];
+  if (!contract.abi) {
+    throw new Error(`Contract ${action.contract} has no ABI`);
+  }
+
+  const contractAddress = contract.addresses[CHAIN_ID];
+  if (!contractAddress) {
+    throw new Error(`Contract ${action.contract} not on chain ${CHAIN_ID}`);
+  }
+
+  const rawArgs = action.inputs.map((inp) => {
+    const val = sampleInputs[inp.name] ?? inp.default ?? "";
+    return val;
+  });
+
+  const abi = JSON.parse(contract.abi);
+  const functionAbi = abi.find(
+    (f: { name: string; type: string }) =>
+      f.type === "function" && f.name === action.function
+  );
+  const args = reshapeArgsForAbi(rawArgs, functionAbi);
+  const iface = new ethers.Interface(abi);
+  const data = iface.encodeFunctionData(action.function, args);
+
+  return { to: contractAddress, data, action, contract };
+}
+
+function isAbiEncodingError(error: unknown): string | null {
+  const msg = String(error);
+  if (msg.includes("INVALID_ARGUMENT")) {
+    return "INVALID_ARGUMENT";
+  }
+  if (msg.includes("could not decode")) {
+    return "could not decode";
+  }
+  if (msg.includes("invalid function")) {
+    return "invalid function";
+  }
+  return null;
+}
+
+describe.skipIf(!RPC_URL)("Uniswap V3 on-chain integration", () => {
+  const getProvider = (): ethers.JsonRpcProvider =>
+    new ethers.JsonRpcProvider(RPC_URL);
+
+  // -- factory ---------------------------------------------------------------
+
+  it("get-pool: eth_call returns a decodable address", async () => {
+    const { to, data, contract } = buildCalldata(uniswapDef, "get-pool", {
+      tokenA: SEPOLIA_WETH,
+      tokenB: SEPOLIA_USDC,
+      fee: FEE_TIER_030,
+    });
+
+    const provider = getProvider();
+    const result = await provider.call({ to, data });
+
+    const iface = new ethers.Interface(JSON.parse(contract.abi as string));
+    const decoded = iface.decodeFunctionResult("getPool", result);
+    expect(decoded).toBeDefined();
+    expect(typeof decoded[0]).toBe("string");
+    expect(decoded[0]).toMatch(HEX_ADDRESS_REGEX);
+  }, 15_000);
+
+  // -- positionManager -------------------------------------------------------
+
+  it("balance-of: eth_call returns a decodable uint256", async () => {
+    const { to, data, contract } = buildCalldata(uniswapDef, "balance-of", {
+      owner: TEST_ADDRESS,
+    });
+
+    const provider = getProvider();
+    const result = await provider.call({ to, data });
+
+    const iface = new ethers.Interface(JSON.parse(contract.abi as string));
+    const decoded = iface.decodeFunctionResult("balanceOf", result);
+    expect(decoded).toBeDefined();
+    expect(typeof decoded[0]).toBe("bigint");
+  }, 15_000);
+
+  it("owner-of: calldata encodes correctly (business revert expected for invalid tokenId)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "owner-of", {
+      tokenId: "1",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.call({ to, data });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  it("get-position: calldata encodes correctly (business revert expected for invalid tokenId)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "get-position", {
+      tokenId: "1",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.call({ to, data });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  it("approve-position: estimateGas calldata is valid (business revert expected)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "approve-position", {
+      to: TEST_ADDRESS,
+      tokenId: "1",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  it("transfer-position: estimateGas calldata is valid (business revert expected)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "transfer-position", {
+      from: TEST_ADDRESS,
+      to: TEST_ADDRESS,
+      tokenId: "1",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  it("burn-position: estimateGas calldata is valid (business revert expected)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "burn-position", {
+      tokenId: "1",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  // -- quoter (tuple-flattened inputs) ---------------------------------------
+
+  it("quote-exact-input: calldata encodes correctly (business revert OK if pool lacks liquidity)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "quote-exact-input", {
+      tokenIn: SEPOLIA_WETH,
+      tokenOut: SEPOLIA_USDC,
+      amountIn: ONE_ETH,
+      fee: FEE_TIER_030,
+      sqrtPriceLimitX96: "0",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.call({ to, data });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  it("quote-exact-output: calldata encodes correctly (business revert OK if pool lacks liquidity)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "quote-exact-output", {
+      tokenIn: SEPOLIA_WETH,
+      tokenOut: SEPOLIA_USDC,
+      amount: ONE_ETH,
+      fee: FEE_TIER_030,
+      sqrtPriceLimitX96: "0",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.call({ to, data });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  // -- swapRouter (tuple-flattened inputs) -----------------------------------
+
+  it("swap-exact-input: estimateGas calldata is valid (business revert expected - no approval)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "swap-exact-input", {
+      tokenIn: SEPOLIA_WETH,
+      tokenOut: SEPOLIA_USDC,
+      fee: FEE_TIER_030,
+      recipient: TEST_ADDRESS,
+      amountIn: ONE_ETH,
+      amountOutMinimum: "0",
+      sqrtPriceLimitX96: "0",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+
+  it("swap-exact-output: estimateGas calldata is valid (business revert expected - no approval)", async () => {
+    const { to, data } = buildCalldata(uniswapDef, "swap-exact-output", {
+      tokenIn: SEPOLIA_WETH,
+      tokenOut: SEPOLIA_USDC,
+      fee: FEE_TIER_030,
+      recipient: TEST_ADDRESS,
+      amountOut: ONE_ETH,
+      amountInMaximum: ONE_ETH,
+      sqrtPriceLimitX96: "0",
+    });
+
+    const provider = getProvider();
+    try {
+      await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+    } catch (error) {
+      expect(isAbiEncodingError(error)).toBeNull();
+    }
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Refactors `protocols/uniswap-v3.ts` from hand-coded action definitions to the ABI-driven pattern already used by WETH (`defineAbiProtocol`) and Chainlink/CCIP (`deriveActionsFromAbi`).

- Splits each contract's ABI into a reduced JSON under `protocols/abis/` (factory, position manager, quoter, swap router).
- Replaces ~280 lines of hand-coded inputs/outputs with ~75 lines of editorial overrides.
- Tuple inputs for quoter and swap router are flattened via the shared derive path, same mechanism CCIP's `message` struct uses.

## Behaviour preserved

- All 11 action slugs (`get-pool`, `get-position`, `balance-of`, `owner-of`, `quote-exact-input`, `quote-exact-output`, `swap-exact-input`, `swap-exact-output`, `approve-position`, `transfer-position`, `burn-position`).
- 4 contracts, same 5 chains each (mainnet, Base, Arbitrum, Optimism, Sepolia).
- All existing labels, descriptions, and default values.
- 6 read / 5 write classification.

## Minor gain

- `swap-exact-input` and `swap-exact-output` now expose `amountOut` / `amountIn` as output fields (ABI-derived). The hand-coded version silently dropped these.

## Non-obvious ABI declarations (documented inline in `uniswap-v3.ts`)

- **QuoterV2 marked `view`** even though the on-chain contract is `nonpayable`. QuoterV2 uses a revert-to-return pattern (invokes `pool.swap` inside try/catch), so clients always call via `eth_call`. Declaring `view` keeps these classified as read steps.
- **SwapRouter02 and PositionManager marked `nonpayable`** even though `exactInputSingle`, `exactOutputSingle`, and `burn` are `payable` upstream for multicall composition. Matches existing behaviour; the ETH-value path is not exposed through these actions.

## Test plan

- [x] `pnpm vitest run tests/unit/protocol-uniswap.test.ts` - 14/14 pass (all pre-existing assertions: 11 actions, 6 read / 5 write, 4 contracts, 5 chains each, 12 outputs on `get-position`)
- [x] `pnpm check` on changed files - clean
- [x] `pnpm type-check` - clean (after `pnpm discover-plugins` regenerates `step-registry.ts` and related files)
- [ ] Manual verification in UI: swap, quote, position actions still render correctly with the derived fields