### PR TITLE
test: KEEP-219 add on-chain integration tests for Chainlink CCIP

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -181,4 +181,11 @@ jobs:
         run: pnpm test:unit
 
       - name: Run integration tests
+        env:
+          # Shared staging RPC config (AWS Parameter Store -> Helm -> this secret).
+          # Integration tests use the same 3-tier resolution
+          # (CHAIN_RPC_CONFIG -> individual env vars -> public RPC defaults)
+          # as deployed services. Absent secrets fall back to public RPCs
+          # via PUBLIC_RPCS defaults in lib/rpc/rpc-config.ts.
+          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
         run: pnpm test:integration

--- a/tests/integration/protocol-chainlink-onchain.test.ts
+++ b/tests/integration/protocol-chainlink-onchain.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Chainlink CCIP On-Chain Integration Tests
+ *
+ * Verifies that the Chainlink protocol's CCIP action definitions produce
+ * calldata the real Sepolia CCIP router and CCIP-BnM token accept. Runs
+ * against a live RPC endpoint.
+ *
+ * Gated on INTEGRATION_TEST_RPC_URL env var (Sepolia) - skipped in CI
+ * without it. Matches the pattern established by WETH in
+ * protocol-weth-onchain.test.ts.
+ *
+ * Coverage: 6 of 9 CCIP actions. The non-covered three
+ * (ccip-check-fee-balance, ccip-check-fee-allowance, ccip-approve-fee-token)
+ * are structurally identical to their bridge-token siblings; one each is
+ * enough to validate the ABI path.
+ */
+
+import { ethers } from "ethers";
+import { describe, expect, it } from "vitest";
+import { reshapeArgsForAbi } from "@/lib/abi-struct-args";
+import type {
+  ProtocolAction,
+  ProtocolContract,
+  ProtocolDefinition,
+} from "@/lib/protocol-registry";
+import chainlinkDef from "@/protocols/chainlink";
+
+const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
+const CHAIN_ID = "11155111"; // Sepolia
+const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
+const CCIP_BNM_SEPOLIA = "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05";
+const BASE_SEPOLIA_CHAIN_SELECTOR = "10344971235874465080";
+// Chainlink's extra args V1 encoding with gasLimit=0 (EOA token transfer default).
+const EXTRA_ARGS_V1_GAS_LIMIT_ZERO =
+  "0x97a657c90000000000000000000000000000000000000000000000000000000000000000";
+
+// Canonical CCIP message inputs for getFee and ccipSend. Reused across tests
+// so a business revert in one call isn't caused by a shape drift from another.
+const CCIP_MESSAGE_SAMPLE: Record<string, string> = {
+  destinationChainSelector: BASE_SEPOLIA_CHAIN_SELECTOR,
+  // `receiver` is `bytes`, set to the abi-encoded TEST_ADDRESS.
+  receiver: ethers.zeroPadValue(TEST_ADDRESS, 32),
+  data: "0x",
+  tokenAmounts: "[]",
+  feeToken: ethers.ZeroAddress,
+  extraArgs: EXTRA_ARGS_V1_GAS_LIMIT_ZERO,
+};
+
+type Calldata = {
+  to: string;
+  data: string;
+  action: ProtocolAction;
+  contract: ProtocolContract;
+};
+
+// Builds calldata from a protocol action. For contracts with
+// userSpecifiedAddress: true, pass `toOverride` so the request targets a real
+// runtime token address rather than the reference address baked into the
+// protocol definition.
+function buildCalldata(
+  protocol: ProtocolDefinition,
+  actionSlug: string,
+  sampleInputs: Record<string, string>,
+  toOverride?: string
+): Calldata {
+  const action = protocol.actions.find((a) => a.slug === actionSlug);
+  if (!action) {
+    throw new Error(`Action ${actionSlug} not found`);
+  }
+
+  const contract = protocol.contracts[action.contract];
+  if (!contract.abi) {
+    throw new Error(`Contract ${action.contract} has no ABI`);
+  }
+
+  const to = toOverride ?? contract.addresses[CHAIN_ID];
+  if (!to) {
+    throw new Error(
+      `No address for contract ${action.contract} on chain ${CHAIN_ID}`
+    );
+  }
+
+  const rawArgs = action.inputs.map(
+    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
+  );
+
+  const abi = JSON.parse(contract.abi);
+  const functionAbi = abi.find(
+    (f: { name: string; type: string }) =>
+      f.type === "function" && f.name === action.function
+  );
+  const args = reshapeArgsForAbi(rawArgs, functionAbi);
+  const iface = new ethers.Interface(abi);
+  const data = iface.encodeFunctionData(action.function, args);
+
+  return { to, data, action, contract };
+}
+
+describe.skipIf(!RPC_URL)(
+  "Chainlink CCIP on-chain integration (Sepolia)",
+  () => {
+    const getProvider = (): ethers.JsonRpcProvider =>
+      new ethers.JsonRpcProvider(RPC_URL);
+
+    it("ccip-get-fee: eth_call returns decodable uint256", async () => {
+      const { to, data, contract } = buildCalldata(
+        chainlinkDef,
+        "ccip-get-fee",
+        CCIP_MESSAGE_SAMPLE
+      );
+
+      const provider = getProvider();
+      try {
+        const result = await provider.call({ to, data });
+        const abi = JSON.parse(contract.abi as string);
+        const iface = new ethers.Interface(abi);
+        const decoded = iface.decodeFunctionResult("getFee", result);
+        expect(decoded).toBeDefined();
+        expect(typeof decoded[0]).toBe("bigint");
+      } catch (error) {
+        // getFee can revert for business reasons (e.g. unsupported lane),
+        // but the error must not be an ABI-level encoding/decoding failure.
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    }, 15_000);
+
+    it("ccip-check-bridge-balance: eth_call returns decodable uint256", async () => {
+      const { to, data, contract } = buildCalldata(
+        chainlinkDef,
+        "ccip-check-bridge-balance",
+        { account: TEST_ADDRESS },
+        CCIP_BNM_SEPOLIA
+      );
+
+      const provider = getProvider();
+      const result = await provider.call({ to, data });
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("balanceOf", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    }, 15_000);
+
+    it("ccip-check-bridge-allowance: eth_call returns decodable uint256", async () => {
+      const { to, data, contract } = buildCalldata(
+        chainlinkDef,
+        "ccip-check-bridge-allowance",
+        { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
+        CCIP_BNM_SEPOLIA
+      );
+
+      const provider = getProvider();
+      const result = await provider.call({ to, data });
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("allowance", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    }, 15_000);
+
+    it("ccip-approve-bridge-token: calldata encodes (business revert expected)", async () => {
+      const { to, data } = buildCalldata(
+        chainlinkDef,
+        "ccip-approve-bridge-token",
+        { spender: ethers.ZeroAddress, amount: "1000000000000000000" },
+        CCIP_BNM_SEPOLIA
+      );
+
+      const provider = getProvider();
+      try {
+        await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    }, 15_000);
+
+    it("ccip-send: calldata encodes (business revert expected)", async () => {
+      const { to, data } = buildCalldata(
+        chainlinkDef,
+        "ccip-send",
+        CCIP_MESSAGE_SAMPLE
+      );
+
+      const provider = getProvider();
+      try {
+        await provider.estimateGas({
+          to,
+          data,
+          // Pay native for fee; any non-zero value is fine - estimateGas will
+          // revert for real-world reasons (fee mismatch, no balance) but the
+          // calldata itself must be ABI-valid.
+          value: ethers.parseEther("0.01"),
+          from: TEST_ADDRESS,
+        });
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    }, 15_000);
+
+    it("ccip-bnm-drip: calldata encodes (business revert expected)", async () => {
+      const { to, data } = buildCalldata(chainlinkDef, "ccip-bnm-drip", {
+        to: TEST_ADDRESS,
+      });
+
+      const provider = getProvider();
+      try {
+        await provider.estimateGas({ to, data, from: TEST_ADDRESS });
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    }, 15_000);
+  }
+);

--- a/tests/integration/protocol-chainlink-onchain.test.ts
+++ b/tests/integration/protocol-chainlink-onchain.test.ts
@@ -5,14 +5,19 @@
  * calldata the real Sepolia CCIP router and CCIP-BnM token accept. Runs
  * against a live RPC endpoint.
  *
- * Gated on INTEGRATION_TEST_RPC_URL env var (Sepolia) - skipped in CI
- * without it. Matches the pattern established by WETH in
- * protocol-weth-onchain.test.ts.
+ * RPC URL resolution (shared with the rest of the codebase):
+ *   1. CHAIN_RPC_CONFIG JSON (Helm/AWS Parameter Store, set in CI + deployed
+ *      environments)
+ *   2. Individual CHAIN_SEPOLIA_*_RPC env vars (dev override)
+ *   3. Public Sepolia RPC default (last resort)
  *
- * Coverage: 6 of 9 CCIP actions. The non-covered three
- * (ccip-check-fee-balance, ccip-check-fee-allowance, ccip-approve-fee-token)
- * are structurally identical to their bridge-token siblings; one each is
- * enough to validate the ABI path.
+ * Uses getRpcProviderFromUrls + executeWithFailover so primary RPC failures
+ * transparently fail over to the fallback URL - same failover machinery
+ * deployed services use.
+ *
+ * Ungated. Always runs. Public RPC backs every tier so the test is never
+ * blocked by missing env vars. CI uses the paid staging endpoints via
+ * CHAIN_RPC_CONFIG.
  */
 
 import { ethers } from "ethers";
@@ -23,16 +28,39 @@ import type {
   ProtocolContract,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import {
+  createRpcUrlResolver,
+  PUBLIC_RPCS,
+  parseRpcConfig,
+} from "@/lib/rpc/rpc-config";
 import chainlinkDef from "@/protocols/chainlink";
 
-const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
 const CHAIN_ID = "11155111"; // Sepolia
+const CHAIN_ID_NUMBER = 11_155_111;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 const CCIP_BNM_SEPOLIA = "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05";
 const BASE_SEPOLIA_CHAIN_SELECTOR = "10344971235874465080";
 // Chainlink's extra args V1 encoding with gasLimit=0 (EOA token transfer default).
 const EXTRA_ARGS_V1_GAS_LIMIT_ZERO =
   "0x97a657c90000000000000000000000000000000000000000000000000000000000000000";
+
+// Resolve Sepolia RPC URLs via the shared config pipeline: CHAIN_RPC_CONFIG
+// first, individual env vars second, public default last.
+const rpcConfig = parseRpcConfig(process.env.CHAIN_RPC_CONFIG);
+const resolveRpcUrl = createRpcUrlResolver(rpcConfig);
+const SEPOLIA_PRIMARY_URL = resolveRpcUrl(
+  "eth-sepolia",
+  "CHAIN_SEPOLIA_PRIMARY_RPC",
+  PUBLIC_RPCS.SEPOLIA,
+  "primary"
+);
+const SEPOLIA_FALLBACK_URL = resolveRpcUrl(
+  "eth-sepolia",
+  "CHAIN_SEPOLIA_FALLBACK_RPC",
+  PUBLIC_RPCS.SEPOLIA,
+  "fallback"
+);
 
 // Canonical CCIP message inputs for getFee and ccipSend. Reused across tests
 // so a business revert in one call isn't caused by a shape drift from another.
@@ -96,130 +124,145 @@ function buildCalldata(
   return { to, data, action, contract };
 }
 
-describe.skipIf(!RPC_URL)(
-  "Chainlink CCIP on-chain integration (Sepolia)",
-  () => {
-    const getProvider = (): ethers.JsonRpcProvider =>
-      new ethers.JsonRpcProvider(RPC_URL);
+describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
+  const makeProvider = () =>
+    getRpcProviderFromUrls(
+      SEPOLIA_PRIMARY_URL,
+      SEPOLIA_FALLBACK_URL,
+      CHAIN_ID_NUMBER,
+      "Sepolia (CCIP integration test)"
+    );
 
-    it("ccip-get-fee: eth_call returns decodable uint256", async () => {
-      const { to, data, contract } = buildCalldata(
-        chainlinkDef,
-        "ccip-get-fee",
-        CCIP_MESSAGE_SAMPLE
+  it("ccip-get-fee: eth_call returns decodable uint256", async () => {
+    const { to, data, contract } = buildCalldata(
+      chainlinkDef,
+      "ccip-get-fee",
+      CCIP_MESSAGE_SAMPLE
+    );
+
+    const provider = await makeProvider();
+    try {
+      const result = await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
       );
-
-      const provider = getProvider();
-      try {
-        const result = await provider.call({ to, data });
-        const abi = JSON.parse(contract.abi as string);
-        const iface = new ethers.Interface(abi);
-        const decoded = iface.decodeFunctionResult("getFee", result);
-        expect(decoded).toBeDefined();
-        expect(typeof decoded[0]).toBe("bigint");
-      } catch (error) {
-        // getFee can revert for business reasons (e.g. unsupported lane),
-        // but the error must not be an ABI-level encoding/decoding failure.
-        const msg = String(error);
-        expect(msg).not.toContain("INVALID_ARGUMENT");
-        expect(msg).not.toContain("could not decode");
-        expect(msg).not.toContain("invalid function");
-      }
-    }, 15_000);
-
-    it("ccip-check-bridge-balance: eth_call returns decodable uint256", async () => {
-      const { to, data, contract } = buildCalldata(
-        chainlinkDef,
-        "ccip-check-bridge-balance",
-        { account: TEST_ADDRESS },
-        CCIP_BNM_SEPOLIA
-      );
-
-      const provider = getProvider();
-      const result = await provider.call({ to, data });
       const abi = JSON.parse(contract.abi as string);
       const iface = new ethers.Interface(abi);
-      const decoded = iface.decodeFunctionResult("balanceOf", result);
+      const decoded = iface.decodeFunctionResult("getFee", result);
       expect(decoded).toBeDefined();
       expect(typeof decoded[0]).toBe("bigint");
-    }, 15_000);
+    } catch (error) {
+      // getFee can revert for business reasons (e.g. unsupported lane),
+      // but the error must not be an ABI-level encoding/decoding failure.
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
+    }
+  }, 30_000);
 
-    it("ccip-check-bridge-allowance: eth_call returns decodable uint256", async () => {
-      const { to, data, contract } = buildCalldata(
-        chainlinkDef,
-        "ccip-check-bridge-allowance",
-        { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
-        CCIP_BNM_SEPOLIA
+  it("ccip-check-bridge-balance: eth_call returns decodable uint256", async () => {
+    const { to, data, contract } = buildCalldata(
+      chainlinkDef,
+      "ccip-check-bridge-balance",
+      { account: TEST_ADDRESS },
+      CCIP_BNM_SEPOLIA
+    );
+
+    const provider = await makeProvider();
+    const result = await provider.executeWithFailover(
+      async (p) => await p.call({ to, data })
+    );
+    const abi = JSON.parse(contract.abi as string);
+    const iface = new ethers.Interface(abi);
+    const decoded = iface.decodeFunctionResult("balanceOf", result);
+    expect(decoded).toBeDefined();
+    expect(typeof decoded[0]).toBe("bigint");
+  }, 30_000);
+
+  it("ccip-check-bridge-allowance: eth_call returns decodable uint256", async () => {
+    const { to, data, contract } = buildCalldata(
+      chainlinkDef,
+      "ccip-check-bridge-allowance",
+      { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
+      CCIP_BNM_SEPOLIA
+    );
+
+    const provider = await makeProvider();
+    const result = await provider.executeWithFailover(
+      async (p) => await p.call({ to, data })
+    );
+    const abi = JSON.parse(contract.abi as string);
+    const iface = new ethers.Interface(abi);
+    const decoded = iface.decodeFunctionResult("allowance", result);
+    expect(decoded).toBeDefined();
+    expect(typeof decoded[0]).toBe("bigint");
+  }, 30_000);
+
+  it("ccip-approve-bridge-token: calldata encodes (business revert expected)", async () => {
+    const { to, data } = buildCalldata(
+      chainlinkDef,
+      "ccip-approve-bridge-token",
+      { spender: ethers.ZeroAddress, amount: "1000000000000000000" },
+      CCIP_BNM_SEPOLIA
+    );
+
+    const provider = await makeProvider();
+    try {
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
       );
+    } catch (error) {
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
+    }
+  }, 30_000);
 
-      const provider = getProvider();
-      const result = await provider.call({ to, data });
-      const abi = JSON.parse(contract.abi as string);
-      const iface = new ethers.Interface(abi);
-      const decoded = iface.decodeFunctionResult("allowance", result);
-      expect(decoded).toBeDefined();
-      expect(typeof decoded[0]).toBe("bigint");
-    }, 15_000);
+  it("ccip-send: calldata encodes (business revert expected)", async () => {
+    const { to, data } = buildCalldata(
+      chainlinkDef,
+      "ccip-send",
+      CCIP_MESSAGE_SAMPLE
+    );
 
-    it("ccip-approve-bridge-token: calldata encodes (business revert expected)", async () => {
-      const { to, data } = buildCalldata(
-        chainlinkDef,
-        "ccip-approve-bridge-token",
-        { spender: ethers.ZeroAddress, amount: "1000000000000000000" },
-        CCIP_BNM_SEPOLIA
+    const provider = await makeProvider();
+    try {
+      await provider.executeWithFailover(
+        async (p) =>
+          await p.estimateGas({
+            to,
+            data,
+            // Pay native for fee; any non-zero value is fine - estimateGas
+            // will revert for real-world reasons (fee mismatch, no balance)
+            // but the calldata itself must be ABI-valid.
+            value: ethers.parseEther("0.01"),
+            from: TEST_ADDRESS,
+          })
       );
+    } catch (error) {
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
+    }
+  }, 30_000);
 
-      const provider = getProvider();
-      try {
-        await provider.estimateGas({ to, data, from: TEST_ADDRESS });
-      } catch (error) {
-        const msg = String(error);
-        expect(msg).not.toContain("INVALID_ARGUMENT");
-        expect(msg).not.toContain("could not decode");
-        expect(msg).not.toContain("invalid function");
-      }
-    }, 15_000);
+  it("ccip-bnm-drip: calldata encodes (business revert expected)", async () => {
+    const { to, data } = buildCalldata(chainlinkDef, "ccip-bnm-drip", {
+      to: TEST_ADDRESS,
+    });
 
-    it("ccip-send: calldata encodes (business revert expected)", async () => {
-      const { to, data } = buildCalldata(
-        chainlinkDef,
-        "ccip-send",
-        CCIP_MESSAGE_SAMPLE
+    const provider = await makeProvider();
+    try {
+      await provider.executeWithFailover(
+        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
       );
-
-      const provider = getProvider();
-      try {
-        await provider.estimateGas({
-          to,
-          data,
-          // Pay native for fee; any non-zero value is fine - estimateGas will
-          // revert for real-world reasons (fee mismatch, no balance) but the
-          // calldata itself must be ABI-valid.
-          value: ethers.parseEther("0.01"),
-          from: TEST_ADDRESS,
-        });
-      } catch (error) {
-        const msg = String(error);
-        expect(msg).not.toContain("INVALID_ARGUMENT");
-        expect(msg).not.toContain("could not decode");
-        expect(msg).not.toContain("invalid function");
-      }
-    }, 15_000);
-
-    it("ccip-bnm-drip: calldata encodes (business revert expected)", async () => {
-      const { to, data } = buildCalldata(chainlinkDef, "ccip-bnm-drip", {
-        to: TEST_ADDRESS,
-      });
-
-      const provider = getProvider();
-      try {
-        await provider.estimateGas({ to, data, from: TEST_ADDRESS });
-      } catch (error) {
-        const msg = String(error);
-        expect(msg).not.toContain("INVALID_ARGUMENT");
-        expect(msg).not.toContain("could not decode");
-        expect(msg).not.toContain("invalid function");
-      }
-    }, 15_000);
-  }
-);
+    } catch (error) {
+      const msg = String(error);
+      expect(msg).not.toContain("INVALID_ARGUMENT");
+      expect(msg).not.toContain("could not decode");
+      expect(msg).not.toContain("invalid function");
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Adds `tests/integration/protocol-chainlink-onchain.test.ts` to close the gap flagged in PR #869 review: CCIP was the only ABI-derived protocol shipping without on-chain integration tests.

Follows the WETH pattern from PR #820 (`tests/integration/protocol-weth-onchain.test.ts`) for action/test coverage, but uses the shared RPC pipeline (`CHAIN_RPC_CONFIG` + `RpcProviderManager`) rather than the standalone `INTEGRATION_TEST_RPC_URL` env var.

## What the test validates

Against the live Sepolia CCIP router (`0x0BF3...A59`) and CCIP-BnM token (`0xFd57...a05`):

| # | Test | Validates |
|---|---|---|
| 1 | `ccip-get-fee` | Router address is live; tuple-argument getFee encodes correctly and returns a decodable uint256 |
| 2 | `ccip-check-bridge-balance` | `userSpecifiedAddress` ERC-20 path: balanceOf against CCIP-BnM as the runtime token |
| 3 | `ccip-check-bridge-allowance` | Same path with a 2-input allowance signature |
| 4 | `ccip-approve-bridge-token` | approve() calldata encodes; estimateGas runs (business revert OK, no ABI errors) |
| 5 | `ccip-send` | Payable ccipSend with native fee; estimateGas runs with value; tuple flattening works for writes |
| 6 | `ccip-bnm-drip` | Faucet call on CCIP-BnM testnet contract |

## RPC resolution and CI wiring

Uses the same 3-tier resolution the rest of the codebase uses:

1. `CHAIN_RPC_CONFIG` JSON (AWS Parameter Store via Helm, now also available as a GitHub Actions secret)
2. Individual `CHAIN_SEPOLIA_{PRIMARY,FALLBACK}_RPC` env vars (dev override)
3. `PUBLIC_RPCS.SEPOLIA` default (`ethereum-sepolia-rpc.publicnode.com`) as last resort

Calls go through `RpcProviderManager.executeWithFailover()` so primary RPC failures transparently fail over to the fallback URL - same failover machinery deployed services use.

### Ungated

No `describe.skipIf` gate. Public Sepolia RPC is baked into tier 3, so the test always has a working URL:

- In CI: uses paid staging endpoints via `CHAIN_RPC_CONFIG` secret
- Locally with `CHAIN_RPC_CONFIG` in `.env`: same paid endpoints
- Locally without: public Sepolia RPC

### CI change

`.github/workflows/pr-checks.yml` now passes `CHAIN_RPC_CONFIG` to the `pnpm test:integration` step. Repo secret was added 2026-04-16 for all environments (dev/staging/prod).

## Coverage and skipped actions

6 of 9 CCIP actions. The three not covered (`ccip-check-fee-balance`, `ccip-check-fee-allowance`, `ccip-approve-fee-token`) are structurally identical to their bridge-token siblings - one each is enough to validate the ABI path.

## Key implementation detail

The `buildCalldata` helper extends the WETH version with an optional `toOverride` parameter. `userSpecifiedAddress` contracts (`ccipBridgeToken`, `ccipFeeToken`) carry reference addresses in the protocol definition but at runtime the user passes a real token address via the `contractAddress` config field. The test mirrors that by targeting the CCIP-BnM Sepolia address directly.

## Test plan

- [x] `pnpm test tests/integration/protocol-chainlink-onchain.test.ts` (no env vars) - 6/6 pass against public Sepolia via fallback tier
- [x] Same tests pass with `CHAIN_RPC_CONFIG` populated (staging RPC pipeline)
- [x] `pnpm check` - clean
- [x] `pnpm type-check` - clean
- [x] Verified `CHAIN_RPC_CONFIG` repo secret exists (`gh secret list`)

## Known tradeoffs of removing the gate

Acknowledged and accepted with this PR:

1. Developer running `pnpm test` offline sees the CCIP test fail. Workaround: `pnpm test:unit` skips `tests/integration/`.
2. Public Sepolia occasionally flakes - mitigated by primary/fallback failover via `RpcProviderManager`.
3. CI run time adds ~5s per protocol with on-chain tests.

## Follow-ups (out of scope for this PR)

- `tests/integration/protocol-weth-onchain.test.ts` still uses the old `INTEGRATION_TEST_RPC_URL` gate. Should be migrated to the same shared-pipeline pattern in a separate PR.
- Price feed actions on the Chainlink protocol (`eth-usd-latest-round-data` etc., 8 named feeds) are unexercised. Separate PR could add integration coverage if deemed necessary.
- The `add-protocol` skill (`fix/add-protocol` branch, PR #868) documents the old `INTEGRATION_TEST_RPC_URL` pattern. Should be updated to reflect the shared-pipeline approach before merging.
