### PR TITLE
ci: KEEP-266 parallelize PR checks into 5 independent jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -80,40 +80,30 @@ jobs:
           path: /tmp/drizzle-generate-output.txt
           retention-days: 7
 
-  lint-typecheck:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '22'
+          discover-plugins: "true"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+      - name: Run check
+        run: pnpm check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 9
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate plugin registry
-        run: pnpm discover-plugins
+          discover-plugins: "true"
 
       - name: Cache TypeScript build info
         uses: actions/cache@v5
@@ -124,40 +114,19 @@ jobs:
             ${{ runner.os }}-tsbuildinfo-${{ hashFiles('**/pnpm-lock.yaml') }}-
             ${{ runner.os }}-tsbuildinfo-
 
-      - name: Run check
-        run: pnpm check
-
       - name: Run type check
         run: pnpm type-check
 
-  build-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '22'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 9
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          discover-plugins: "true"
 
       - name: Cache Next.js build
         uses: actions/cache@v5
@@ -168,17 +137,33 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
             ${{ runner.os }}-nextjs-
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate plugin registry
-        run: pnpm discover-plugins
-
       - name: Run build
         run: pnpm build
 
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          discover-plugins: "true"
+
       - name: Run unit tests
         run: pnpm test:unit
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          discover-plugins: "true"
 
       - name: Run integration tests
         env:


### PR DESCRIPTION
## Summary

- Split `lint-typecheck` into `lint` and `typecheck` parallel jobs
- Split `build-test` into `build`, `test-unit`, `test-integration` parallel jobs
- Uses existing `setup-node-pnpm` composite action for setup boilerplate
- `migrate-check` job unchanged

All 5 jobs run independently with no `needs:` dependencies, maximizing parallelism.

## Blocker

The `staging` branch has a required-status-checks ruleset (ID 14211237) that requires the old job names (`lint-typecheck`, `build-test`). Before merging, either:
1. A repo admin updates the ruleset to require the new names (`lint`, `typecheck`, `build`, `test-unit`, `test-integration`)
2. Or we add empty umbrella jobs with the old names that gate on the new jobs

## Test plan

- [ ] Verify all 5 jobs appear and run in parallel on this PR
- [ ] Confirm pnpm store cache is shared across jobs
- [ ] Resolve required-status-checks blocker before merge
- [ ] Measure wall-time before/after (expected: 1-2 min savings)

Ref: [KEEP-266](https://linear.app/keeperhubapp/issue/KEEP-266)