### PR TITLE
ci: KEEP-280 separate Sentry source map upload from builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Multi-stage Dockerfile for Next.js application
 # Stage 1: Dependencies
 FROM node:24-alpine AS deps
-RUN apk add --no-cache libc6-compat
-RUN wget -O /etc/ssl/certs/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+RUN apk add --no-cache libc6-compat && \
+    wget --progress=dot:giga -O /etc/ssl/certs/rds-combined-ca-bundle.pem \
+      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 WORKDIR /app
 
 # Install pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,12 +58,14 @@ ARG SENTRY_PROJECT
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_RELEASE
 RUN if [ -n "$SENTRY_AUTH_TOKEN" ]; then \
-      npx @sentry/cli sourcemaps upload \
+      ./node_modules/.bin/sentry-cli releases new "$SENTRY_RELEASE" \
+        --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" && \
+      ./node_modules/.bin/sentry-cli sourcemaps upload \
         --org "$SENTRY_ORG" \
         --project "$SENTRY_PROJECT" \
         --release "$SENTRY_RELEASE" \
         .next && \
-      npx @sentry/cli releases finalize "$SENTRY_RELEASE" \
+      ./node_modules/.bin/sentry-cli releases finalize "$SENTRY_RELEASE" \
         --org "$SENTRY_ORG" --project "$SENTRY_PROJECT"; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,24 +41,31 @@ ENV NEXT_PUBLIC_GITHUB_CLIENT_ID=$NEXT_PUBLIC_GITHUB_CLIENT_ID
 ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID
 ENV NEXT_PUBLIC_BILLING_ENABLED=$NEXT_PUBLIC_BILLING_ENABLED
 
-# Sentry (DSN baked into client bundle, rest for source map upload)
+# Sentry DSN baked into client bundle for error reporting.
+# SENTRY_ORG/PROJECT/AUTH_TOKEN/RELEASE are intentionally NOT set here
+# so this stage is cache-deterministic across commits (see sentry-upload stage).
 ARG NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV CI=true
+
+# Build the application (source maps generated but not uploaded)
+RUN pnpm build
+
+# Stage 2.5b: Sentry source map upload (side-effect only, not consumed by other stages)
+FROM builder AS sentry-upload
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_RELEASE
-ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
-ENV SENTRY_ORG=$SENTRY_ORG
-ENV SENTRY_PROJECT=$SENTRY_PROJECT
-ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-ENV SENTRY_RELEASE=$SENTRY_RELEASE
-ENV CI=true
-
-# Build the application
-RUN pnpm build
-
-# Remove source maps after upload (they should not ship in the final image)
-RUN find .next -name '*.map' -delete
+RUN if [ -n "$SENTRY_AUTH_TOKEN" ]; then \
+      npx @sentry/cli sourcemaps upload \
+        --org "$SENTRY_ORG" \
+        --project "$SENTRY_PROJECT" \
+        --release "$SENTRY_RELEASE" \
+        .next && \
+      npx @sentry/cli releases finalize "$SENTRY_RELEASE" \
+        --org "$SENTRY_ORG" --project "$SENTRY_PROJECT"; \
+    fi
 
 # Stage 2.6: Migration stage (for running migrations and seeding)
 FROM node:24-alpine AS migrator
@@ -217,10 +224,11 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \
     apk add --no-cache curl
 
-# Copy built application
+# Copy built application (source maps removed - uploaded by sentry-upload stage)
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+RUN find .next -name '*.map' -delete 2>/dev/null || true
 
 # Copy OG image fonts for server-side image generation
 COPY --from=source --chown=nextjs:nodejs /app/app/api/og/fonts ./app/api/og/fonts

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -36,7 +36,7 @@ group "scheduler" {
 }
 
 group "all" {
-  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor"]
+  targets = ["app", "migrator", "workflow-runner", "sentry-upload", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor"]
 }
 
 target "app" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,7 +24,7 @@ variable "SCHEDULER_ECR_REPO" { default = "" }
 variable "EXECUTOR_ECR_REPO" { default = "" }
 
 group "default" {
-  targets = ["app", "migrator", "workflow-runner"]
+  targets = ["app", "migrator", "workflow-runner", "sentry-upload"]
 }
 
 group "events" {
@@ -49,10 +49,6 @@ target "app" {
     NEXT_PUBLIC_GOOGLE_CLIENT_ID = NEXT_PUBLIC_GOOGLE_CLIENT_ID
     NEXT_PUBLIC_BILLING_ENABLED  = NEXT_PUBLIC_BILLING_ENABLED
     NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
-    SENTRY_ORG                   = SENTRY_ORG
-    SENTRY_PROJECT               = SENTRY_PROJECT
-    SENTRY_AUTH_TOKEN            = SENTRY_AUTH_TOKEN
-    SENTRY_RELEASE               = SENTRY_RELEASE
   }
   tags = compact([
     "${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}",
@@ -61,6 +57,27 @@ target "app" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app,mode=max"]
+}
+
+target "sentry-upload" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "sentry-upload"
+  args = {
+    # NEXT_PUBLIC_* args must match the app target so BuildKit reuses
+    # the cached builder layer instead of rebuilding with empty defaults
+    NEXT_PUBLIC_AUTH_PROVIDERS    = NEXT_PUBLIC_AUTH_PROVIDERS
+    NEXT_PUBLIC_GITHUB_CLIENT_ID = NEXT_PUBLIC_GITHUB_CLIENT_ID
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID = NEXT_PUBLIC_GOOGLE_CLIENT_ID
+    NEXT_PUBLIC_BILLING_ENABLED  = NEXT_PUBLIC_BILLING_ENABLED
+    NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    SENTRY_ORG                   = SENTRY_ORG
+    SENTRY_PROJECT               = SENTRY_PROJECT
+    SENTRY_AUTH_TOKEN            = SENTRY_AUTH_TOKEN
+    SENTRY_RELEASE               = SENTRY_RELEASE
+  }
+  tags       = []
+  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"]
 }
 
 target "migrator" {

--- a/next.config.ts
+++ b/next.config.ts
@@ -250,7 +250,8 @@ export default withSentryConfig(withWorkflow(nextConfig), {
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
 
-  // Delete source maps after uploading to Sentry so they don't ship in the bundle
+  // No-op: source map upload moved to sentry-upload Docker stage (KEEP-280).
+  // Kept for safety in case SENTRY_AUTH_TOKEN is ever set during build.
   sourcemaps: {
     deleteSourcemapsAfterUpload: true,
   },


### PR DESCRIPTION
## Summary

- Extract Sentry source map upload from the `builder` Docker stage into a dedicated `sentry-upload` stage
- Remove `SENTRY_ORG/PROJECT/AUTH_TOKEN/RELEASE` build args from the `builder` stage, keeping only `NEXT_PUBLIC_SENTRY_DSN`
- Add `sentry-upload` target to `docker-bake.hcl` with its own args and no tags (side-effect only)
- Move `.map` file deletion from `builder` to `runner` stage

## Why

`SENTRY_RELEASE` is the commit SHA, which changes on every build. Having it as a build arg in the `builder` stage invalidated the BuildKit layer cache on the most expensive step (`pnpm build`, ~2-4 min). After this change, the `builder` stage is keyed only on source files + `NEXT_PUBLIC_*` args, which are stable across builds targeting the same environment. This is a prerequisite for KEEP-267 (sharing BuildKit cache between PR CI and post-merge builds).

## How it works

- `builder` stage runs `pnpm build` without Sentry - source maps are generated but not uploaded
- `sentry-upload` stage (FROM builder) uploads maps via `@sentry/cli` if `SENTRY_AUTH_TOKEN` is present, no-op otherwise
- `runner` stage copies from `builder` and deletes `.map` files so they don't ship
- `sentry-upload` bake target passes `NEXT_PUBLIC_*` args to match `app` target, ensuring BuildKit reuses the cached builder layer

## Test plan

- [ ] Verify staging deploy: Sentry source maps uploaded correctly (check Sentry releases dashboard)
- [ ] Verify prod deploy: same
- [ ] Verify no `.map` files in final `runner` image: `docker run --rm <image> find .next -name '*.map'`
- [ ] Verify builder cache-hit on consecutive builds with same source: check BuildKit output for "CACHED" on pnpm build layer
- [ ] Verify `@sentry/cli` is available in the sentry-upload stage (transitive dep of @sentry/nextjs)

## Risk

- If `@sentry/cli` is not in node_modules (unlikely, it's a dep of @sentry/nextjs), the upload step will fail. This only affects `sentry-upload`, not the app build or deployment.
- Client-side Sentry errors will use auto-detected release names instead of the commit SHA. Server-side uses runtime `SENTRY_RELEASE` env var (unchanged).

Ref: [KEEP-280](https://linear.app/keeperhubapp/issue/KEEP-280)
Prerequisite for: [KEEP-267](https://linear.app/keeperhubapp/issue/KEEP-267)