### PR TITLE
fix: KEEP-280 build sentry-upload separately without push

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -127,6 +127,25 @@ jobs:
           files: docker-bake.hcl
           push: true
 
+      - name: Upload Sentry source maps
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPO: ${{ env.AWS_ECR_NAME }}
+          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
+          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+          NEXT_PUBLIC_BILLING_ENABLED: ${{ env.NEXT_PUBLIC_BILLING_ENABLED }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ env.NEXT_PUBLIC_SENTRY_DSN }}
+          SENTRY_ORG: ${{ env.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN }}
+          SENTRY_RELEASE: ${{ steps.vars.outputs.sha_short }}
+        with:
+          files: docker-bake.hcl
+          targets: sentry-upload
+
       # ── Copy images to TechOps ECR ──
       - name: Configure TechOps AWS credentials
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,7 +24,7 @@ variable "SCHEDULER_ECR_REPO" { default = "" }
 variable "EXECUTOR_ECR_REPO" { default = "" }
 
 group "default" {
-  targets = ["app", "migrator", "workflow-runner", "sentry-upload"]
+  targets = ["app", "migrator", "workflow-runner"]
 }
 
 group "events" {
@@ -36,7 +36,7 @@ group "scheduler" {
 }
 
 group "all" {
-  targets = ["app", "migrator", "workflow-runner", "sentry-upload", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor"]
+  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor"]
 }
 
 target "app" {


### PR DESCRIPTION
## Summary

Hotfix for the staging build failure caused by #881.

The `sentry-upload` bake target has no tags (it's a side-effect-only stage that uploads source maps). Including it in the `default` group with `push: true` caused `ERROR: tag is needed when pushing to registry`.

## Changes

- Remove `sentry-upload` from `default` and `all` bake groups
- Add a separate bake step in `build-images.yml` targeting `sentry-upload` without push
- Builder layer cache is shared between both bake calls via registry cache-from

## Why not `output = ["type=cacheonly"]`?

BuildKit has a known bug (docker/buildx#2338) where `--push` overrides `type=cacheonly`. The separate bake step is the reliable workaround.

## Test plan

- [ ] Staging CI pipeline passes (build-images job completes)
- [ ] Sentry source maps uploaded (check Sentry releases dashboard)
- [ ] App, migrator, workflow-runner images pushed to ECR

Ref: [KEEP-280](https://linear.app/keeperhubapp/issue/KEEP-280)