### PR TITLE
fix: KEEP-280 use wget -q for BusyBox compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Dependencies
 FROM node:24-alpine AS deps
 RUN apk add --no-cache libc6-compat && \
-    wget --progress=dot:giga -O /etc/ssl/certs/rds-combined-ca-bundle.pem \
+    wget -q -O /etc/ssl/certs/rds-combined-ca-bundle.pem \
       https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Hotfix for staging build failure. Alpine's BusyBox wget does not support `--progress=dot:giga` (GNU wget only). Use `-q` (quiet) which BusyBox supports and satisfies hadolint DL3047.

## Context

The `--progress=dot:giga` flag was added in #881 to satisfy a hadolint warning (DL3047: avoid wget without progress bar). BusyBox wget in Alpine doesn't support this flag, causing the deps stage to fail.

Ref: [KEEP-280](https://linear.app/keeperhubapp/issue/KEEP-280)