### PR TITLE
ci: KEEP-267 replace pnpm build with docker buildx bake in PR CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -130,7 +130,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
-            --paginate --per-page 100 -q '.[].filename')
+            --paginate -q '.[].filename')
           RELEVANT=$(echo "$FILES" | grep -vE '^(docs/|specs/|\.github/|.*\.md$)' | head -1 || true)
           if [ -n "$RELEVANT" ]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -168,6 +168,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
         with:
           files: docker-bake.hcl
+          targets: app
           push: false
 
   test-unit:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -119,26 +119,56 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    environment: staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js + pnpm
-        uses: ./.github/actions/setup-node-pnpm
-        with:
-          discover-plugins: "true"
+      - name: Check for build-relevant changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --paginate --per-page 100 -q '.[].filename')
+          RELEVANT=$(echo "$FILES" | grep -vE '^(docs/|specs/|\.github/|.*\.md$)' | head -1 || true)
+          if [ -n "$RELEVANT" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Cache Next.js build
-        uses: actions/cache@v5
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.relevant == 'true'
+        uses: docker/setup-buildx-action@v4
 
-      - name: Run build
-        run: pnpm build
+      - name: Configure AWS credentials
+        if: steps.changes.outputs.relevant == 'true'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.TO_REGION }}
+
+      - name: Login to AWS ECR
+        if: steps.changes.outputs.relevant == 'true'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build images (validate + prime cache)
+        if: steps.changes.outputs.relevant == 'true'
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPO: ${{ vars.TO_ECR_NAME }}
+          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ vars.NEXT_PUBLIC_AUTH_PROVIDERS }}
+          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+          NEXT_PUBLIC_BILLING_ENABLED: ${{ vars.NEXT_PUBLIC_BILLING_ENABLED }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+        with:
+          files: docker-bake.hcl
+          push: false
 
   test-unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Replace bare-metal `pnpm build` in the PR `build` job with `docker buildx bake`
- Builds the same `default` group (`app`, `migrator`, `workflow-runner`) using the same Dockerfile and `docker-bake.hcl` as post-merge builds
- Add `environment: staging` for ECR credentials and `NEXT_PUBLIC_*` vars
- Add path-based skip for docs/specs/markdown-only PRs
- No push (`push: false`) - PR CI validates only, images are not pushed to ECR

## Why

Previously the app was built twice: once with `pnpm build` in PR CI (bare-metal), once with `docker buildx bake` after merge. These builds shared nothing. Now PR CI validates the same Docker build that ships, catching Dockerfile-specific issues at PR time (missing COPY, arg mismatches, case-sensitive imports on Linux).

With KEEP-280 merged (builder stage is cache-deterministic), the BuildKit registry cache is fully shared between PR and post-merge builds. `cache-to` and `push` are independent operations in BuildKit - PR builds write cache layers to ECR via `cache-to` without pushing images.

## Cache flow

1. PR build writes cache layers to `ECR:cache-app` via `cache-to` in `docker-bake.hcl`
2. Post-merge build reads those layers via `cache-from`
3. `pnpm build` layer cache-hits because builder stage has no commit-specific args (KEEP-280)
4. Post-merge build time drops to image packaging + push (~30-60s)

## Path filter

The Docker build is skipped when a PR only changes files matching `docs/`, `specs/`, `.github/`, or `*.md`. These paths cannot affect build artifacts.

## Test plan

- [ ] Verify `build` job runs `docker buildx bake` on this PR (check logs for BuildKit output)
- [ ] Verify path filter: create a docs-only PR and confirm `build` job skips with "relevant=false"
- [ ] Verify AWS/ECR auth works with `environment: staging` on a PR workflow
- [ ] Measure build job wall time vs previous `pnpm build` approach
- [ ] Verify other jobs (lint, typecheck, test-unit, test-integration) are unaffected

Ref: [KEEP-267](https://linear.app/keeperhubapp/issue/KEEP-267)
Depends on: [KEEP-280](https://linear.app/keeperhubapp/issue/KEEP-280) (merged)