### PR TITLE
ci: KEEP-283 split COPY into granular COPYs and add COPY --link

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,21 @@ Dockerfile
 docker-compose.yml
 docker-compose.*.yml
 
+# Directories not needed by any Docker stage
+tests/
+docs/
+docs-site/
+specs/
+analysis/
+.claude/
+.cursor/
+.probes/
+
+# Dev-only config files
+playwright.config.ts
+vitest.config.mts
+biome.jsonc
+
 # IDE files
 .vscode
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,28 @@ WORKDIR /app
 RUN npm install -g pnpm@9
 
 # Copy dependencies from deps stage
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY --link --from=deps /app/node_modules ./node_modules
+
+# Source files split into granular COPYs so BuildKit caches each
+# directory independently. A PR touching only plugins/ invalidates
+# only that layer; unchanged directories stay cached.
+COPY app/ ./app/
+COPY components/ ./components/
+COPY deploy/scripts/ ./deploy/scripts/
+COPY drizzle/ ./drizzle/
+COPY hooks/ ./hooks/
+COPY keeperhub-events/ ./keeperhub-events/
+COPY keeperhub-executor/ ./keeperhub-executor/
+COPY keeperhub-scheduler/ ./keeperhub-scheduler/
+COPY lib/ ./lib/
+COPY plugins/ ./plugins/
+COPY protocols/ ./protocols/
+COPY public/ ./public/
+COPY scripts/ ./scripts/
+COPY next.config.ts tsconfig.json package.json drizzle.config.ts ./
+COPY instrumentation.ts instrumentation-client.ts ./
+COPY sentry.server.config.ts sentry.edge.config.ts ./
+COPY postcss.config.mjs components.json ./
 
 # Stage 2.5: Builder (runs Next.js build, only needed for runner stage)
 FROM source AS builder
@@ -74,17 +94,17 @@ RUN if [ -n "$SENTRY_AUTH_TOKEN" ]; then \
 FROM node:24-alpine AS migrator
 WORKDIR /app
 RUN npm install -g pnpm@9 tsx@4
-COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Copy dependencies, migration files, and seed scripts
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=source /app/drizzle ./drizzle
-COPY --from=source /app/drizzle.config.ts ./drizzle.config.ts
-COPY --from=source /app/lib ./lib
-COPY --from=source /app/plugins ./plugins
-COPY --from=source /app/scripts ./scripts
-COPY --from=source /app/package.json ./package.json
-COPY --from=source /app/tsconfig.json ./tsconfig.json
+COPY --link --from=deps /app/node_modules ./node_modules
+COPY --link --from=source /app/drizzle ./drizzle
+COPY --link --from=source /app/drizzle.config.ts ./drizzle.config.ts
+COPY --link --from=source /app/lib ./lib
+COPY --link --from=source /app/plugins ./plugins
+COPY --link --from=source /app/scripts ./scripts
+COPY --link --from=source /app/package.json ./package.json
+COPY --link --from=source /app/tsconfig.json ./tsconfig.json
 
 # This stage runs migrations and seeds default data
 # Build with: docker build --target migrator -t keeperhub-migrator .
@@ -115,18 +135,18 @@ RUN addgroup -g 1001 -S scheduler && \
     adduser -S scheduler -u 1001
 WORKDIR /app
 RUN npm install -g tsx@4
-COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
-COPY --from=scheduler-deps /app/node_modules ./node_modules
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+COPY --link --from=scheduler-deps /app/node_modules ./node_modules
 ENV NODE_ENV=production
 
 # Stage 2.7c: Schedule Dispatcher
 FROM scheduler-base AS schedule-dispatcher
-COPY --from=source /app/keeperhub-scheduler/schedule-dispatcher/ ./schedule-dispatcher/
-COPY --from=source /app/keeperhub-scheduler/lib/ ./lib/
-COPY --from=source /app/keeperhub-scheduler/package.json ./keeperhub-scheduler/package.json
-COPY --from=source /app/keeperhub-scheduler/tsconfig.json ./keeperhub-scheduler/tsconfig.json
-COPY --from=source /app/keeperhub-scheduler/package.json ./package.json
-COPY --from=source /app/keeperhub-scheduler/tsconfig.json ./tsconfig.json
+COPY --link --from=source /app/keeperhub-scheduler/schedule-dispatcher/ ./schedule-dispatcher/
+COPY --link --from=source /app/keeperhub-scheduler/lib/ ./lib/
+COPY --link --from=source /app/keeperhub-scheduler/package.json ./keeperhub-scheduler/package.json
+COPY --link --from=source /app/keeperhub-scheduler/tsconfig.json ./keeperhub-scheduler/tsconfig.json
+COPY --link --from=source /app/keeperhub-scheduler/package.json ./package.json
+COPY --link --from=source /app/keeperhub-scheduler/tsconfig.json ./tsconfig.json
 RUN chown -R scheduler:scheduler /app
 USER scheduler
 EXPOSE 3000
@@ -134,10 +154,10 @@ CMD ["tsx", "schedule-dispatcher/index.ts"]
 
 # Stage 2.7d: Block Dispatcher
 FROM scheduler-base AS block-dispatcher
-COPY --from=source /app/keeperhub-scheduler/block-dispatcher/ ./block-dispatcher/
-COPY --from=source /app/keeperhub-scheduler/lib/ ./lib/
-COPY --from=source /app/keeperhub-scheduler/package.json ./package.json
-COPY --from=source /app/keeperhub-scheduler/tsconfig.json ./tsconfig.json
+COPY --link --from=source /app/keeperhub-scheduler/block-dispatcher/ ./block-dispatcher/
+COPY --link --from=source /app/keeperhub-scheduler/lib/ ./lib/
+COPY --link --from=source /app/keeperhub-scheduler/package.json ./package.json
+COPY --link --from=source /app/keeperhub-scheduler/tsconfig.json ./tsconfig.json
 RUN chown -R scheduler:scheduler /app
 USER scheduler
 EXPOSE 3000
@@ -147,24 +167,24 @@ CMD ["tsx", "block-dispatcher/index.ts"]
 FROM node:24-alpine AS workflow-runner
 WORKDIR /app
 RUN npm install -g pnpm@9 tsx@4
-COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Copy dependencies and workflow execution files
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=source /app/keeperhub-executor ./keeperhub-executor
-COPY --from=source /app/lib ./lib
-COPY --from=source /app/plugins ./plugins
-COPY --from=source /app/protocols ./protocols
-COPY --from=source /app/package.json ./package.json
-COPY --from=source /app/tsconfig.json ./tsconfig.json
+COPY --link --from=deps /app/node_modules ./node_modules
+COPY --link --from=source /app/keeperhub-executor ./keeperhub-executor
+COPY --link --from=source /app/lib ./lib
+COPY --link --from=source /app/plugins ./plugins
+COPY --link --from=source /app/protocols ./protocols
+COPY --link --from=source /app/package.json ./package.json
+COPY --link --from=source /app/tsconfig.json ./tsconfig.json
 
 # Copy auto-generated files from builder stage (step-registry.ts, etc. are in .gitignore)
-COPY --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
-COPY --from=builder /app/lib/codegen-registry.ts ./lib/codegen-registry.ts
-COPY --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
-COPY --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
-COPY --from=builder /app/plugins/index.ts ./plugins/index.ts
-COPY --from=builder /app/protocols/index.ts ./protocols/index.ts
+COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
+COPY --link --from=builder /app/lib/codegen-registry.ts ./lib/codegen-registry.ts
+COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
+COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
+COPY --link --from=builder /app/plugins/index.ts ./plugins/index.ts
+COPY --link --from=builder /app/protocols/index.ts ./protocols/index.ts
 
 # Create a shim for 'server-only' package - the runner runs outside Next.js
 # so we replace the package with an empty module that doesn't throw
@@ -185,24 +205,24 @@ CMD ["tsx", "keeperhub-executor/workflow-runner.ts"]
 FROM node:24-alpine AS executor
 WORKDIR /app
 RUN npm install -g pnpm@9 tsx@4
-COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Full deps needed for in-process workflow execution + @kubernetes/client-node
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=source /app/keeperhub-executor ./keeperhub-executor
-COPY --from=source /app/lib ./lib
-COPY --from=source /app/plugins ./plugins
-COPY --from=source /app/protocols ./protocols
-COPY --from=source /app/package.json ./package.json
-COPY --from=source /app/tsconfig.json ./tsconfig.json
+COPY --link --from=deps /app/node_modules ./node_modules
+COPY --link --from=source /app/keeperhub-executor ./keeperhub-executor
+COPY --link --from=source /app/lib ./lib
+COPY --link --from=source /app/plugins ./plugins
+COPY --link --from=source /app/protocols ./protocols
+COPY --link --from=source /app/package.json ./package.json
+COPY --link --from=source /app/tsconfig.json ./tsconfig.json
 
 # Copy auto-generated files from builder stage
-COPY --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
-COPY --from=builder /app/lib/codegen-registry.ts ./lib/codegen-registry.ts
-COPY --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
-COPY --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
-COPY --from=builder /app/plugins/index.ts ./plugins/index.ts
-COPY --from=builder /app/protocols/index.ts ./protocols/index.ts
+COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
+COPY --link --from=builder /app/lib/codegen-registry.ts ./lib/codegen-registry.ts
+COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
+COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
+COPY --link --from=builder /app/plugins/index.ts ./plugins/index.ts
+COPY --link --from=builder /app/protocols/index.ts ./protocols/index.ts
 
 # Shim server-only (runs outside Next.js)
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
@@ -220,7 +240,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-COPY --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
 # Create non-root user and install curl (used by healthcheck and cronjob scripts)
 RUN addgroup --system --gid 1001 nodejs && \
@@ -228,16 +248,16 @@ RUN addgroup --system --gid 1001 nodejs && \
     apk add --no-cache curl
 
 # Copy built application (source maps removed - uploaded by sentry-upload stage)
-COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --link --from=builder /app/public ./public
+COPY --link --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --link --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 RUN find .next -name '*.map' -delete 2>/dev/null || true
 
 # Copy OG image fonts for server-side image generation
-COPY --from=source --chown=nextjs:nodejs /app/app/api/og/fonts ./app/api/og/fonts
+COPY --link --from=source --chown=nextjs:nodejs /app/app/api/og/fonts ./app/api/og/fonts
 
 # Copy deploy scripts (used by cronjobs)
-COPY --from=source /app/deploy/scripts ./deploy/scripts
+COPY --link --from=source /app/deploy/scripts ./deploy/scripts
 
 # Switch to non-root user
 USER nextjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -249,12 +249,12 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 # Copy built application (source maps removed - uploaded by sentry-upload stage)
 COPY --link --from=builder /app/public ./public
-COPY --link --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --link --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --link --from=builder --chown=1001:1001 /app/.next/standalone ./
+COPY --link --from=builder --chown=1001:1001 /app/.next/static ./.next/static
 RUN find .next -name '*.map' -delete 2>/dev/null || true
 
 # Copy OG image fonts for server-side image generation
-COPY --link --from=source --chown=nextjs:nodejs /app/app/api/og/fonts ./app/api/og/fonts
+COPY --link --from=source --chown=1001:1001 /app/app/api/og/fonts ./app/api/og/fonts
 
 # Copy deploy scripts (used by cronjobs)
 COPY --link --from=source /app/deploy/scripts ./deploy/scripts


### PR DESCRIPTION
## Summary

- Replace `COPY . .` in the source stage with per-directory COPY instructions
- Add `COPY --link` to all cross-stage COPY instructions
- Update `.dockerignore` to exclude non-build directories
- Narrow `deploy/` to `deploy/scripts/` only

## Why

The source stage's `COPY . .` checksums all files in the build context. Any commit that touches any file invalidates this layer and cascades to `builder` (`pnpm build`, ~4 min) and all downstream stages.

From the KEEP-267 post-merge build analysis, the `COPY . .` invalidation was the single biggest contributor to rebuild time. The sentry-upload bake step (same run) showed all layers CACHED including `pnpm build`, proving the cache machinery works - the problem was `COPY . .`.

## How it works

Each directory gets its own COPY instruction:
```dockerfile
COPY app/ ./app/
COPY lib/ ./lib/
COPY plugins/ ./plugins/
...
```

BuildKit caches each independently. A PR that only touches `plugins/` invalidates that one COPY layer. Other directories cache-hit. The builder `pnpm build` still re-runs if any input changed, but the cache-hit surface increases significantly for most PRs.

`COPY --link` breaks parent-layer dependency chains on cross-stage COPYs, improving image push speed (unchanged layers skip re-upload).

## .dockerignore additions

Excluded from build context (not needed by any Docker stage):
- `tests/`, `docs/`, `docs-site/`, `specs/`, `analysis/`
- `.claude/`, `.cursor/`, `.probes/`
- `playwright.config.ts`, `vitest.config.mts`, `biome.jsonc`

## Risk

If a new top-level directory is added to the project and not included in the source stage COPY list, the build will fail (missing files). This is a maintenance burden but fails loudly rather than silently.

## Test plan

- [ ] All bake targets build successfully (app, migrator, workflow-runner, executor, scheduler, event-tracker)
- [ ] Verify no `.dockerignore`-excluded files are needed by the build
- [ ] Measure cache-hit rate on consecutive builds where only one directory changed
- [ ] Verify `COPY --link` doesn't affect runtime behavior (it shouldn't - same filesystem, just different layer structure)

Ref: [KEEP-283](https://linear.app/keeperhubapp/issue/KEEP-283)