### PR TITLE
perf: KEEP-284 enable Turbopack production builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,10 @@ ARG NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV CI=true
 
-# Build the application (source maps generated but not uploaded)
-RUN pnpm build
+# Build the application with Turbopack (source maps generated but not uploaded).
+# Cache mount persists .next/cache across builds on the same BuildKit instance,
+# enabling Turbopack's incremental compilation.
+RUN --mount=type=cache,target=/app/.next/cache pnpm build
 
 # Stage 2.5b: Sentry source map upload (side-effect only, not consumed by other stages)
 FROM builder AS sentry-upload

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "A template for building your own AI-driven workflow automation platform",
   "scripts": {
     "dev": "pnpm discover-plugins && next dev",
-    "build": "tsx scripts/migrate-prod.ts && pnpm discover-plugins && next build",
+    "build": "tsx scripts/migrate-prod.ts && pnpm discover-plugins && next build --turbopack",
     "start": "next start",
     "type-check": "tsc --noEmit",
     "check": "ultracite check",


### PR DESCRIPTION
## Summary

- Switch `next build` to `next build --turbopack` for production builds
- Add BuildKit cache mount for `.next/cache` in the builder Dockerfile stage

## Why

The `pnpm build` step (specifically `next build`) takes ~4 min and is the single most expensive step in the Docker build. Turbopack is stable in Next.js 16 and offers 2-5x faster production builds with function-level incremental compilation.

## Compatibility

Verified against `next.config.ts`:

| Dependency | Turbopack support |
|---|---|
| `withWorkflow` (workflow/next) | Yes - has explicit `nextConfig.turbopack.rules` config |
| `@sentry/nextjs` (v10.47) | Yes - detects `process.turbopack` at runtime |
| `output: "standalone"` | Yes |
| `serverExternalPackages` | Yes (Next.js core) |
| `outputFileTracingIncludes` | Yes (Next.js core) |

**Known gaps (non-blocking):**
- `withSentryConfig({ webpack: { automaticVercelMonitors } })` - webpack-only, silently ignored. Not relevant for K8s deployment.
- `withSentryConfig({ webpack: { treeshake: { removeDebugLogging } } })` - webpack-only, silently ignored. Minor bundle size impact.

## .next/cache mount

```dockerfile
RUN --mount=type=cache,target=/app/.next/cache pnpm build
```

Turbopack stores compilation cache in `.next/cache`. The BuildKit cache mount persists this across builds on the same instance. On GHA (ephemeral runners), the mount is cold each run - but on persistent BuildKit instances or within multi-bake sessions, it enables incremental builds.

## Test plan

- [ ] PR CI `build` job succeeds with Turbopack (this PR validates it)
- [ ] Staging deploy succeeds and app works correctly
- [ ] Sentry error tracking works (client + server)
- [ ] Workflow engine functions correctly
- [ ] Measure: `next build` wall time in build logs (before ~4 min, target ~1-2 min)

## Risk

This is a bundler change. Turbopack is stable in Next.js 16 but is newer than webpack. If any runtime issues surface on staging, revert is a one-line change (remove `--turbopack`).

Ref: [KEEP-284](https://linear.app/keeperhubapp/issue/KEEP-284)