### PR TITLE
refactor: KEEP-268 extract e2e DB setup into composite action

### DIFF
--- a/.github/actions/setup-e2e-db/action.yml
+++ b/.github/actions/setup-e2e-db/action.yml
@@ -1,0 +1,47 @@
+name: Setup E2E Database
+description: Run workflow engine setup, migrations, and seed data for E2E tests
+
+inputs:
+  database_url:
+    description: 'PostgreSQL connection string'
+    required: true
+  test_para_user_share:
+    description: 'TEST_PARA_USER_SHARE secret for wallet seeding'
+    required: true
+  wallet_encryption_key:
+    description: 'WALLET_ENCRYPTION_KEY secret for wallet seeding'
+    required: true
+  chain_rpc_config:
+    description: 'CHAIN_RPC_CONFIG for RPC endpoint resolution'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup workflow engine schema
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database_url }}
+      run: pnpm db:setup-workflow
+
+    - name: Run migrations
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database_url }}
+      run: pnpm db:migrate
+
+    - name: Seed default data
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database_url }}
+        CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}
+      run: pnpm db:seed
+
+    - name: Seed test wallet
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database_url }}
+        TEST_PARA_USER_SHARE: ${{ inputs.test_para_user_share }}
+        WALLET_ENCRYPTION_KEY: ${{ inputs.wallet_encryption_key }}
+      run: pnpm db:seed-test-wallet

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -178,16 +178,12 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
 
       - name: Setup database
-        run: |
-          pnpm db:setup-workflow
-          pnpm db:migrate
-          pnpm db:seed
-          pnpm db:seed-test-wallet
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
-          WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
-          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
+        uses: ./.github/actions/setup-e2e-db
+        with:
+          database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
+          test_para_user_share: ${{ secrets.TEST_PARA_USER_SHARE }}
+          wallet_encryption_key: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
+          chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Start application
         uses: ./.github/actions/start-app
@@ -274,16 +270,12 @@ jobs:
           discover-plugins: "true"
 
       - name: Setup database
-        run: |
-          pnpm db:setup-workflow
-          pnpm db:migrate
-          pnpm db:seed
-          pnpm db:seed-test-wallet
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          TEST_PARA_USER_SHARE: ${{ secrets.TEST_PARA_USER_SHARE }}
-          WALLET_ENCRYPTION_KEY: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
-          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
+        uses: ./.github/actions/setup-e2e-db
+        with:
+          database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
+          test_para_user_share: ${{ secrets.TEST_PARA_USER_SHARE }}
+          wallet_encryption_key: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
+          chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
 
       - name: Start application
         uses: ./.github/actions/start-app


### PR DESCRIPTION
## Summary

- Create `.github/actions/setup-e2e-db/` composite action for shared DB setup
- Replace duplicate inline DB setup in both vitest and playwright e2e jobs

## What changed

The 4-step DB setup (db:setup-workflow, db:migrate, db:seed, db:seed-test-wallet) was duplicated identically in both `e2e-vitest-ephemeral` and `e2e-playwright-ephemeral` jobs. Extracted into a shared composite action.

No behavioral change - same commands, same env vars, same ordering.

## Test plan

- [x] E2e tests pass (when enabled via ENABLE_E2E_EPHEMERAL_TESTS)
- [x] Composite action correctly passes secrets to each step

Ref: [KEEP-268](https://linear.app/keeperhubapp/issue/KEEP-268)