### PR TITLE
fix: pre-seed condition skip-arrival at direct-skip convergence targets

### DIFF
--- a/lib/convergence-barrier.ts
+++ b/lib/convergence-barrier.ts
@@ -169,6 +169,10 @@ export function propagateConvergenceSkips(
         }
         continue;
       }
+      // Convergence node not fully resolved: stop BFS here. It is still
+      // awaiting arrivals from the real execution path and should not
+      // propagate skip signals to its downstream.
+      continue;
     }
 
     const downstream = edgesBySource.get(currentId) ?? [];

--- a/lib/workflow-executor.workflow.ts
+++ b/lib/workflow-executor.workflow.ts
@@ -1979,6 +1979,18 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             // nodes downstream receive arrival signals from skipped sources
             const skippedTargets = handleMap.get(notTakenHandle) ?? [];
             if (skippedTargets.length > 0) {
+              // Register the condition's skip-arrival at direct skipped targets
+              // that are themselves convergence nodes. Without this, a pattern
+              // like `Cond -> (skipped) -> nodeB` and `Cond -> (taken) -> X -> nodeB`
+              // stalls nodeB: the condition's not-taken edge never signals
+              // arrival, so nodeB only ever sees X's arrival (1/2).
+              const preSeedUnblocked = signalConvergenceArrival(
+                nodeId,
+                skippedTargets,
+                edgesByTarget,
+                convergenceArrivals,
+                visited
+              );
               const unblockedIds = propagateConvergenceSkips(
                 skippedTargets,
                 edgesBySource,
@@ -1986,11 +1998,14 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 convergenceArrivals,
                 visited
               );
-              if (unblockedIds.length > 0) {
+              const allUnblocked = [
+                ...new Set([...preSeedUnblocked, ...unblockedIds]),
+              ];
+              if (allUnblocked.length > 0) {
                 const settled = await Promise.allSettled(
-                  unblockedIds.map((id) => executeNode(id, visited))
+                  allUnblocked.map((id) => executeNode(id, visited))
                 );
-                processSettledResults(settled, unblockedIds);
+                processSettledResults(settled, allUnblocked);
               }
             }
           } else {

--- a/tests/unit/convergence-barrier.test.ts
+++ b/tests/unit/convergence-barrier.test.ts
@@ -284,6 +284,382 @@ describe("convergence barrier", () => {
     });
   });
 
+  describe("direct-skip edge into convergence node", () => {
+    // Models the prod stall pattern:
+    //   Cond -> true  -> X -> nodeB
+    //   Cond -> false ------> nodeB   (direct skipped edge into convergence)
+    // The direct not-taken edge from the condition must register a skip-arrival
+    // at nodeB, otherwise nodeB stalls at 1/2 arrivals once X completes.
+    const edges = [
+      { source: "Cond", target: "X" },
+      { source: "Cond", target: "nodeB" },
+      { source: "X", target: "nodeB" },
+    ];
+
+    it("signals skip-arrival when condition's not-taken edge targets convergence directly", () => {
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
+
+      // Condition=true: X is taken (runs), nodeB is the direct skipped target.
+      // Caller pre-seeds condition's skip-arrival at direct skipped targets.
+      signalConvergenceArrival(
+        "Cond",
+        ["nodeB"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      const unblocked = propagateConvergenceSkips(
+        ["nodeB"],
+        sourceMap,
+        targetMap,
+        arrivals,
+        visited
+      );
+
+      expect(unblocked).toEqual([]);
+      expect(arrivals.get("nodeB")?.has("Cond")).toBe(true);
+      expect(arrivals.get("nodeB")?.size).toBe(1);
+
+      // X completes and arrives at nodeB -- barrier should now release.
+      const ready = getReadyDownstreamIds(
+        "X",
+        ["nodeB"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(ready).toEqual(["nodeB"]);
+    });
+
+    it("releases convergence when condition=false takes direct edge and intermediate arrives via skip", () => {
+      // Mirror case:
+      //   Cond -> true  ------> nodeB   (direct taken edge into convergence)
+      //   Cond -> false -> X -> nodeB
+      const mirrorEdges = [
+        { source: "Cond", target: "nodeB" },
+        { source: "Cond", target: "X" },
+        { source: "X", target: "nodeB" },
+      ];
+      const sourceMap = buildEdgesBySource(mirrorEdges);
+      const targetMap = buildEdgesByTarget(mirrorEdges);
+      const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
+
+      // Cond takes direct edge to nodeB -- signalConvergenceArrival seeds
+      // arrivals[nodeB] = {Cond}; nodeB not yet unblocked (1/2).
+      const readyFromTake = getReadyDownstreamIds(
+        "Cond",
+        ["nodeB"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(readyFromTake).toEqual([]);
+      expect(arrivals.get("nodeB")?.size).toBe(1);
+
+      // X is skipped; propagation walks X -> nodeB, adds X to arrivals.
+      signalConvergenceArrival("Cond", ["X"], targetMap, arrivals, visited);
+      const unblocked = propagateConvergenceSkips(
+        ["X"],
+        sourceMap,
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(unblocked).toEqual(["nodeB"]);
+    });
+
+    it("does not corrupt deeper convergence when direct-skip target is still pending", () => {
+      // Cond -> true  -> X -> nodeB -> J -> K
+      // Cond -> false ------> nodeB
+      // Y -----------------------------> K
+      // nodeB is waiting on X. BFS must not walk through nodeB and falsely
+      // register J as an arrival at K, otherwise Y's real arrival would
+      // unblock K prematurely (before J has actually run).
+      const deeperEdges = [
+        { source: "Cond", target: "X" },
+        { source: "Cond", target: "nodeB" },
+        { source: "X", target: "nodeB" },
+        { source: "nodeB", target: "J" },
+        { source: "J", target: "K" },
+        { source: "Y", target: "K" },
+      ];
+      const sourceMap = buildEdgesBySource(deeperEdges);
+      const targetMap = buildEdgesByTarget(deeperEdges);
+      const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
+
+      signalConvergenceArrival(
+        "Cond",
+        ["nodeB"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      propagateConvergenceSkips(
+        ["nodeB"],
+        sourceMap,
+        targetMap,
+        arrivals,
+        visited
+      );
+
+      // BFS must stop at the not-fully-resolved nodeB; K's arrivals stay empty.
+      expect(arrivals.get("K")).toBeUndefined();
+
+      // Y arrives first -- K must remain blocked until J (after nodeB, X) runs.
+      const readyFromY = getReadyDownstreamIds(
+        "Y",
+        ["K"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(readyFromY).toEqual([]);
+      expect(arrivals.get("K")?.size).toBe(1);
+    });
+  });
+
+  describe("chained conditions, each with a 5-node post-convergence chain", () => {
+    // Realistic workflow shape that mirrors the production stall and verifies
+    // that a long post-convergence chain drains all the way to the next
+    // condition (and eventually End):
+    //
+    //   Cond1 -> true  -> Allow1 -> M1 (conv) -> D1a -> D2a -> D3a -> D4a -> Cond2
+    //   Cond1 -> false ------------> M1
+    //   Cond2 -> true  -> Allow2 -> M2 (conv) -> D1b -> D2b -> D3b -> D4b -> Cond3
+    //   Cond2 -> false ------------> M2
+    //   Cond3 -> true  -> Allow3 -> M3 (conv) -> D1c -> D2c -> D3c -> D4c -> End
+    //   Cond3 -> false ------------> M3
+    //
+    // Each Mi has exactly 2 incoming edges (the condition's false handle +
+    // the Allow_i "taken" node). After each convergence there is a chain of
+    // five nodes (Mi, D1, D2, D3, D4) before the next condition -- this is
+    // the topology the user explicitly asked to verify.
+    const edges = [
+      { source: "Cond1", target: "Allow1" },
+      { source: "Cond1", target: "M1" },
+      { source: "Allow1", target: "M1" },
+      { source: "M1", target: "D1a" },
+      { source: "D1a", target: "D2a" },
+      { source: "D2a", target: "D3a" },
+      { source: "D3a", target: "D4a" },
+      { source: "D4a", target: "Cond2" },
+
+      { source: "Cond2", target: "Allow2" },
+      { source: "Cond2", target: "M2" },
+      { source: "Allow2", target: "M2" },
+      { source: "M2", target: "D1b" },
+      { source: "D1b", target: "D2b" },
+      { source: "D2b", target: "D3b" },
+      { source: "D3b", target: "D4b" },
+      { source: "D4b", target: "Cond3" },
+
+      { source: "Cond3", target: "Allow3" },
+      { source: "Cond3", target: "M3" },
+      { source: "Allow3", target: "M3" },
+      { source: "M3", target: "D1c" },
+      { source: "D1c", target: "D2c" },
+      { source: "D2c", target: "D3c" },
+      { source: "D3c", target: "D4c" },
+      { source: "D4c", target: "End" },
+    ];
+
+    type ConditionSpec = {
+      id: string;
+      value: boolean;
+      trueTargets: string[];
+      falseTargets: string[];
+    };
+
+    // End-to-end simulator that mirrors the executor's control flow:
+    //   - For condition nodes: signal taken arrival, pre-seed skip arrivals at
+    //     direct skipped convergence targets, propagate skip through not-taken
+    //     subtree.
+    //   - For non-condition nodes: getReadyDownstreamIds over downstream.
+    // Returns the set of executed nodes in discovery order.
+    function runSimulatedWorkflow(
+      triggerReady: string[],
+      conditions: Map<string, ConditionSpec>,
+      edgesBySource: Map<string, string[]>,
+      edgesByTarget: Map<string, string[]>
+    ): { executed: string[]; visited: Set<string> } {
+      const arrivals = new Map<string, Set<string>>();
+      const visited = new Set<string>();
+      const executed: string[] = [];
+      const queue: string[] = [...triggerReady];
+
+      while (queue.length > 0) {
+        const nodeId = queue.shift() as string;
+        if (visited.has(nodeId)) {
+          continue;
+        }
+        visited.add(nodeId);
+        executed.push(nodeId);
+
+        const condSpec = conditions.get(nodeId);
+        if (condSpec !== undefined) {
+          const taken = condSpec.value
+            ? condSpec.trueTargets
+            : condSpec.falseTargets;
+          const skipped = condSpec.value
+            ? condSpec.falseTargets
+            : condSpec.trueTargets;
+          const readyFromTaken = getReadyDownstreamIds(
+            nodeId,
+            taken,
+            edgesByTarget,
+            arrivals,
+            visited
+          );
+          const preSeed = signalConvergenceArrival(
+            nodeId,
+            skipped,
+            edgesByTarget,
+            arrivals,
+            visited
+          );
+          const unblockedFromSkip = propagateConvergenceSkips(
+            skipped,
+            edgesBySource,
+            edgesByTarget,
+            arrivals,
+            visited
+          );
+          for (const next of [
+            ...readyFromTaken,
+            ...preSeed,
+            ...unblockedFromSkip,
+          ]) {
+            if (!visited.has(next)) {
+              queue.push(next);
+            }
+          }
+          continue;
+        }
+
+        const downstream = edgesBySource.get(nodeId) ?? [];
+        const ready = getReadyDownstreamIds(
+          nodeId,
+          downstream,
+          edgesByTarget,
+          arrivals,
+          visited
+        );
+        for (const next of ready) {
+          if (!visited.has(next)) {
+            queue.push(next);
+          }
+        }
+      }
+
+      return { executed, visited };
+    }
+
+    type Scenario = {
+      name: string;
+      cond1: boolean;
+      cond2: boolean;
+      cond3: boolean;
+    };
+
+    const scenarios: Scenario[] = [
+      { name: "TTT", cond1: true, cond2: true, cond3: true },
+      { name: "TTF", cond1: true, cond2: true, cond3: false },
+      { name: "TFT", cond1: true, cond2: false, cond3: true },
+      { name: "TFF", cond1: true, cond2: false, cond3: false },
+      { name: "FTT", cond1: false, cond2: true, cond3: true },
+      { name: "FTF", cond1: false, cond2: true, cond3: false },
+      { name: "FFT", cond1: false, cond2: false, cond3: true },
+      { name: "FFF", cond1: false, cond2: false, cond3: false },
+    ];
+
+    for (const scenario of scenarios) {
+      it(`reaches End for scenario ${scenario.name} (Cond1=${scenario.cond1}, Cond2=${scenario.cond2}, Cond3=${scenario.cond3})`, () => {
+        const sourceMap = buildEdgesBySource(edges);
+        const targetMap = buildEdgesByTarget(edges);
+        const conditions = new Map<string, ConditionSpec>([
+          [
+            "Cond1",
+            {
+              id: "Cond1",
+              value: scenario.cond1,
+              trueTargets: ["Allow1"],
+              falseTargets: ["M1"],
+            },
+          ],
+          [
+            "Cond2",
+            {
+              id: "Cond2",
+              value: scenario.cond2,
+              trueTargets: ["Allow2"],
+              falseTargets: ["M2"],
+            },
+          ],
+          [
+            "Cond3",
+            {
+              id: "Cond3",
+              value: scenario.cond3,
+              trueTargets: ["Allow3"],
+              falseTargets: ["M3"],
+            },
+          ],
+        ]);
+
+        const { executed, visited } = runSimulatedWorkflow(
+          ["Cond1"],
+          conditions,
+          sourceMap,
+          targetMap
+        );
+
+        // End must be reached in every scenario -- this is the core correctness
+        // claim: the stall bug is fixed and the graph drains to its sink.
+        expect(visited.has("End")).toBe(true);
+        expect(visited.has("M1")).toBe(true);
+        expect(visited.has("M2")).toBe(true);
+        expect(visited.has("M3")).toBe(true);
+
+        // Each condition ran exactly once.
+        expect(executed.filter((id) => id === "Cond1")).toHaveLength(1);
+        expect(executed.filter((id) => id === "Cond2")).toHaveLength(1);
+        expect(executed.filter((id) => id === "Cond3")).toHaveLength(1);
+
+        // The 4-node post-convergence chain after each Mi must drain fully
+        // in every scenario -- this is the core thing the user asked to
+        // verify: the workflow keeps running all the way to the next
+        // condition (and ultimately End) regardless of which branch each
+        // condition took.
+        for (const id of [
+          "D1a",
+          "D2a",
+          "D3a",
+          "D4a",
+          "D1b",
+          "D2b",
+          "D3b",
+          "D4b",
+          "D1c",
+          "D2c",
+          "D3c",
+          "D4c",
+        ]) {
+          expect(visited.has(id)).toBe(true);
+        }
+
+        // Allowance nodes (taken chain) run iff their condition was true.
+        expect(visited.has("Allow1")).toBe(scenario.cond1);
+        expect(visited.has("Allow2")).toBe(scenario.cond2);
+        expect(visited.has("Allow3")).toBe(scenario.cond3);
+      });
+    }
+  });
+
   describe("all-skip convergence should not execute", () => {
     it("should not unblock convergence node when all inputs are from skipped subtree", () => {
       // Cond -> [false: A -> B, false: A -> C] -> D (convergence)


### PR DESCRIPTION
## Summary

Fixes a workflow execution stall where the execution halted after a condition node whose not-taken edge pointed directly at a convergence node, and whose taken branch reached that same convergence through one or more intermediate steps.

## Root cause

A convergence node `M` with two incoming edges (`Cond` via the false handle, and `X` on the taken path through `Cond -> X -> M`) would only ever see the arrival from `X`. The taken-side arrival from the condition is pre-seeded in `getReadyDownstreamIds` via `signalConvergenceArrival`, but the skipped-side had no equivalent seed. When the condition evaluated true, the skipped direct edge `Cond -> M` never signaled the barrier, so `M` stayed at 1 of 2 arrivals forever.

## Fix

- `lib/workflow-executor.workflow.ts`: call `signalConvergenceArrival(conditionNodeId, skippedTargets, ...)` before `propagateConvergenceSkips`, mirroring the pre-seed already done for the taken side.
- `lib/convergence-barrier.ts`: in `propagateConvergenceSkips`, when the BFS reaches a convergence node whose arrivals are not yet full, stop instead of falling through to push its downstream. Otherwise a pending-but-not-skipped node would corrupt arrivals at deeper convergence nodes.

## Tests

- Three direct-skip cases (the minimal reproducer, its mirror, and a deep-convergence guard).
- Eight-scenario truth table (`(Cond1, Cond2, Cond3)` in `{true, false}^3`) over a realistic topology: three sequential conditions, each with a 1-node taken chain meeting a direct-skip at a convergence, followed by a 4-node linear chain before the next condition. Every scenario must drain to `End`.