### PR TITLE
feat: KEEP-281 add Avalanche and Plasma stablecoins to wallet

### DIFF
--- a/.claude/commands/add-chain.md
+++ b/.claude/commands/add-chain.md
@@ -1,0 +1,139 @@
+---
+description: Add a new blockchain and its stablecoins to the wallet modal end-to-end
+argument-hint: <chain-name-or-chain-id>
+---
+
+<objective>
+Standardise onboarding a new EVM chain into KeeperHub's wallet modal. `$ARGUMENTS` is the chain name (e.g. "Ethereum", "Avalanche", "Plasma") or chain ID (e.g. `1`, `43114`, `9745`). If empty, ask the user.
+
+End state: the chain is seeded in `chains` + `explorer_configs`, has at least one `supported_tokens` entry per mainnet asset (verified on-chain), and the wallet modal renders it correctly.
+</objective>
+
+<context>
+Chain seed script: @scripts/seed/seed-chains.ts
+Stablecoin seed script: @scripts/seed/seed-tokens.ts
+RPC config (chain ID to RPC URL mapping): @lib/rpc/rpc-config.ts
+Wallet modal (consumes supported_tokens via /api/supported-tokens): @components/overlays/wallet-overlay.tsx
+Supported tokens API (master-list logic, TEMPO carve-outs): @app/api/supported-tokens/route.ts
+Schema: @lib/db/schema-extensions.ts (supportedTokens), @lib/db/schema.ts (chains, explorerConfigs)
+Project conventions: @CLAUDE.md
+</context>
+
+<process>
+
+### 1. Parse arguments and identify the chain
+
+From `$ARGUMENTS`, resolve to a canonical `(chainId, jsonKey, symbol)` tuple. Look up the chain on chainlist.org or the protocol's official docs. Confirm with the user before proceeding if ambiguous.
+
+Needed facts (ask the user for anything missing):
+- Chain ID (integer).
+- Human name (e.g. "Avalanche").
+- Native symbol (e.g. "AVAX").
+- `jsonKey` for env/Helm config (kebab-case, e.g. `avax-mainnet`, `plasma-testnet`).
+- Is testnet? (boolean).
+- Primary + fallback public RPC URLs.
+- Block explorer URL + API type (`etherscan` for Etherscan V2 family, `blockscout` otherwise).
+- List of stablecoin contract addresses to track in the wallet modal (mainnet chains only need this; testnets often have one faucet USDC).
+
+### 2. Check what already exists
+
+Idempotency matters. For the target chain ID, check:
+
+- `lib/rpc/rpc-config.ts`: does `CHAIN_CONFIG[<id>]` exist? Does `PUBLIC_RPCS` have entries?
+- `scripts/seed/seed-chains.ts`: is there an entry in `DEFAULT_CHAINS`? An entry in `EXPLORER_CONFIG_TEMPLATES`? An entry in `chainToDefaultIdMap`?
+- `scripts/seed/seed-tokens.ts`: any `TOKEN_CONFIGS` rows?
+- Database (dev): `SELECT chain_id, name FROM chains WHERE chain_id = <id>`; `SELECT COUNT(*) FROM supported_tokens WHERE chain_id = <id>`.
+
+Report which pieces exist and which are missing. Only modify what needs modifying.
+
+### 3. Wire up RPC config (if missing)
+
+Edit [lib/rpc/rpc-config.ts](lib/rpc/rpc-config.ts):
+- Add primary + fallback URLs to the `PUBLIC_RPCS` constant.
+- Add a `CHAIN_CONFIG[<id>]` entry with `jsonKey`, `envKey`, `fallbackEnvKey`, `publicDefault`, `publicFallback`.
+
+### 4. Wire up chain seed (if missing)
+
+Edit [scripts/seed/seed-chains.ts](scripts/seed/seed-chains.ts):
+- Append a `NewChain` entry to `DEFAULT_CHAINS` following the existing pattern (use `getChainConfigValue`, `getRpcUrlByChainId`, `getWssUrl`, `getUsePrivateMempoolRpc`, `getPrivateRpcUrl`).
+- Add the chain to `chainToDefaultIdMap` (name to default chainId).
+- Add an entry to `EXPLORER_CONFIG_TEMPLATES` keyed by chain ID. Etherscan V2 chains use `explorerApiUrl: "https://api.etherscan.io/v2/api"`; Blockscout chains use their own endpoint.
+
+### 5. Verify stablecoins on-chain
+
+**Before editing `seed-tokens.ts`**, validate every proposed token address. For each `(chainId, tokenAddress)`:
+
+Run:
+```bash
+pnpm tsx scripts/verify-token.ts <chainId> <tokenAddress>
+```
+
+This calls `symbol()`, `name()`, `decimals()` via the chain's configured primary RPC (falls back to public RPC on failure). It prints the resolved metadata and exits non-zero on failure.
+
+Record each `(chainId, tokenAddress, symbol, name, decimals)`. Reject any address that reverts, times out, or returns a symbol that doesn't match what the user expects (a common sign of a wrong address or a proxy to a different impl).
+
+### 6. Update seed-tokens.ts
+
+Edit [scripts/seed/seed-tokens.ts](scripts/seed/seed-tokens.ts). Append `TOKEN_CONFIGS` rows under a new comment block matching the existing format:
+
+```ts
+// ==========================================================================
+// <Chain Name> (chainId: <id>)
+// ==========================================================================
+{
+  chainId: <id>,
+  tokenAddress: "0x...", // <SYMBOL>
+  logoUrl: LOGOS.<SYMBOL> ?? null,
+  isStablecoin: true,
+  sortOrder: 1,
+},
+```
+
+Rules:
+- Addresses MUST be lowercase (the `supported_tokens_chain_address` unique index + wallet modal lookups assume this).
+- `sortOrder` starts at 1 for the primary stablecoin on the chain and increments.
+- If no `LOGOS.<SYMBOL>` entry exists and you have a canonical logo URL, add it to the `LOGOS` constant; otherwise use `null`.
+- Do NOT hardcode `symbol`, `name`, or `decimals` in `TOKEN_CONFIGS`; the seed script fetches them on-chain.
+
+### 7. Seed locally and verify
+
+```bash
+pnpm tsx scripts/seed/seed-chains.ts
+pnpm tsx scripts/seed/seed-tokens.ts
+```
+
+Then confirm:
+- `SELECT chain_id, symbol, name, decimals FROM supported_tokens WHERE chain_id = <id>` returns the expected rows.
+- `curl 'http://localhost:3000/api/supported-tokens?chainId=<id>'` returns the tokens with resolved `explorerUrl`.
+- Open the wallet modal in the app, switch to the new chain's card, and verify the stablecoins render (balances may be zero).
+
+### 8. Lint, type-check, and commit
+
+```bash
+pnpm check
+pnpm type-check
+pnpm fix
+```
+
+Fix any failures before committing. Commit message format (no ticket numbers per repo convention):
+
+```
+feat: add <chain-name> to wallet with <symbols> stablecoins
+```
+
+### 9. Staging and prod rollout
+
+The seed scripts are idempotent (update-on-conflict by `(chain_id, token_address)`). They run on deploy via `scripts/migrate-prod.ts`; no manual DB edits are needed in staging or prod.
+
+If the chain requires env vars (private RPC, API keys), coordinate the Helm/Parameter Store `CHAIN_RPC_CONFIG` update with the infra owner before the PR merges.
+
+</process>
+
+<success_criteria>
+- `lib/rpc/rpc-config.ts` has `CHAIN_CONFIG[<id>]` and public RPC entries.
+- `scripts/seed/seed-chains.ts` has the chain in `DEFAULT_CHAINS`, `chainToDefaultIdMap`, and `EXPLORER_CONFIG_TEMPLATES`.
+- `scripts/seed/seed-tokens.ts` has at least one `TOKEN_CONFIGS` row per tracked stablecoin, all addresses lowercase and verified on-chain by `scripts/verify-token.ts`.
+- Local seed runs complete without errors; `/api/supported-tokens?chainId=<id>` returns the expected payload; wallet modal renders the new chain card.
+- `pnpm check`, `pnpm type-check` and `pnpm fix` pass.
+- Commit follows conventional-commit format, PR targets `staging`.
+</success_criteria>

--- a/app/api/supported-tokens/route.ts
+++ b/app/api/supported-tokens/route.ts
@@ -8,8 +8,11 @@ import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 // Mainnet chain ID - used as the "master list" of supported tokens
 const MAINNET_CHAIN_ID = 1;
 
-// TEMPO chain IDs - excluded from master list logic (have their own tokens)
-const TEMPO_CHAIN_IDS = [42_429, 4217];
+// Chains with their own stablecoin lineup that doesn't mirror Ethereum mainnet
+// (TEMPO mainnet/testnet, Plasma mainnet). These bypass the master-list overlay
+// and return only their own supported_tokens rows, avoiding misleading
+// "Not available" entries for assets that don't exist on the chain.
+const INDEPENDENT_TOKEN_LIST_CHAIN_IDS = [42_429, 4217, 9745];
 
 /**
  * Build explorer URL for a token address
@@ -120,8 +123,9 @@ export async function GET(request: Request) {
       ),
     });
 
-    // For TEMPO chains, just return their own tokens (no master list logic)
-    if (TEMPO_CHAIN_IDS.includes(chainId)) {
+    // For chains with independent stablecoin lineups (TEMPO, Plasma), return
+    // only their own tokens; no master-list overlay.
+    if (INDEPENDENT_TOKEN_LIST_CHAIN_IDS.includes(chainId)) {
       const tokens = await db
         .select()
         .from(supportedTokens)

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -58,6 +58,16 @@ type WalletOverlayProps = {
 // TEMPO uses stablecoins for gas, so we display stablecoins only (no native token)
 const TEMPO_CHAIN_IDS = new Set([42_429, 4217]);
 const isTempoChain = (chainId: number): boolean => TEMPO_CHAIN_IDS.has(chainId);
+
+// Chains whose token lineup doesn't mirror Ethereum mainnet's stablecoin set
+// (e.g. Plasma ships USDT0, no Circle USDC, no Sky USDS). For these chains we
+// render the chain's own supported_tokens rows directly instead of overlaying
+// them on the mainnet master list, which would otherwise produce misleading
+// "Not available" entries for assets that simply don't exist on the chain.
+const INDEPENDENT_TOKEN_LIST_CHAIN_IDS = new Set([42_429, 4217, 9745]);
+const hasIndependentTokenList = (chainId: number): boolean =>
+  INDEPENDENT_TOKEN_LIST_CHAIN_IDS.has(chainId);
+
 const MAINNET_CHAIN_ID = 1;
 
 // ============================================================================
@@ -249,11 +259,13 @@ function ChainBalanceItem({
 
   const isTempo = isTempoChain(balance.chainId);
   const isMainnet = balance.chainId === MAINNET_CHAIN_ID;
+  const isIndependentTokenList = hasIndependentTokenList(balance.chainId);
 
-  // For TEMPO chains, just show their own tokens
-  // For other chains, use mainnet tokens as the master list
+  // For chains with their own stablecoin lineup (TEMPO, Plasma, etc.), render
+  // their tokens directly. For other chains, use mainnet tokens as the master
+  // list and overlay availability per-chain.
   const chainSupportedTokens = (() => {
-    if (isTempo) {
+    if (isIndependentTokenList) {
       return supportedTokenBalances.filter(
         (t) => t.chainId === balance.chainId
       );

--- a/scripts/seed/seed-tokens.ts
+++ b/scripts/seed/seed-tokens.ts
@@ -247,6 +247,49 @@ const TOKEN_CONFIGS: TokenConfig[] = [
     isStablecoin: true,
     sortOrder: 3,
   },
+
+  // ==========================================================================
+  // Avalanche C-Chain (chainId: 43114)
+  // ==========================================================================
+  {
+    chainId: 43_114,
+    tokenAddress: "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e", // USDC (Circle native)
+    logoUrl: LOGOS.USDC,
+    isStablecoin: true,
+    sortOrder: 1,
+  },
+  {
+    chainId: 43_114,
+    tokenAddress: "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7", // USDt (Tether native, symbol is lowercase 't')
+    logoUrl: LOGOS.USDT,
+    isStablecoin: true,
+    sortOrder: 2,
+  },
+
+  // ==========================================================================
+  // Avalanche Fuji Testnet (chainId: 43113)
+  // ==========================================================================
+  {
+    chainId: 43_113,
+    tokenAddress: "0x5425890298aed601595a70ab815c96711a31bc65", // USDC (Circle testnet)
+    logoUrl: LOGOS.USDC,
+    isStablecoin: true,
+    sortOrder: 1,
+  },
+
+  // ==========================================================================
+  // Plasma Mainnet (chainId: 9745)
+  // ==========================================================================
+  // Only USDT0 is tracked: Circle has not deployed native USDC on Plasma, and
+  // Sky's USDS has not been deployed on Plasma. Add new stablecoins here once
+  // issuers deploy natively.
+  {
+    chainId: 9745,
+    tokenAddress: "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb", // USDT0 (Tether omnichain via LayerZero)
+    logoUrl: LOGOS.USDT,
+    isStablecoin: true,
+    sortOrder: 1,
+  },
 ];
 
 /**

--- a/scripts/verify-token.ts
+++ b/scripts/verify-token.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env tsx
+
+/**
+ * verify-token.ts
+ *
+ * Verifies an ERC-20 token contract on a given chain by calling `symbol()`,
+ * `name()`, and `decimals()` via the chain's configured primary RPC (with
+ * fallback on failure). Prints a row compatible with the `TOKEN_CONFIGS`
+ * format in `scripts/seed/seed-tokens.ts`.
+ *
+ * Exits 1 if any metadata call reverts, times out, or the response is not
+ * a valid ERC-20 shape.
+ *
+ * Usage:
+ *   pnpm tsx scripts/verify-token.ts <chainId> <tokenAddress>
+ *
+ * Example:
+ *   pnpm tsx scripts/verify-token.ts 43114 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E
+ */
+
+import "dotenv/config";
+import { ethers } from "ethers";
+import ERC20_ABI from "../lib/contracts/abis/erc20.json";
+import { getRpcUrlByChainId } from "../lib/rpc/rpc-config";
+
+type TokenMetadata = {
+  symbol: string;
+  name: string;
+  decimals: number;
+};
+
+async function fetchMetadata(
+  rpcUrl: string,
+  tokenAddress: string
+): Promise<TokenMetadata> {
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+
+  const [symbol, name, decimals] = await Promise.all([
+    contract.symbol() as Promise<string>,
+    contract.name() as Promise<string>,
+    contract.decimals() as Promise<bigint>,
+  ]);
+
+  return { symbol, name, decimals: Number(decimals) };
+}
+
+async function main(): Promise<void> {
+  const [chainIdArg, tokenAddress] = process.argv.slice(2);
+
+  if (!(chainIdArg && tokenAddress)) {
+    console.error("Usage: pnpm tsx scripts/verify-token.ts <chainId> <tokenAddress>");
+    process.exit(1);
+  }
+
+  const chainId = Number.parseInt(chainIdArg, 10);
+  if (!Number.isFinite(chainId)) {
+    console.error(`Invalid chainId: ${chainIdArg}`);
+    process.exit(1);
+  }
+
+  if (!ethers.isAddress(tokenAddress)) {
+    console.error(`Invalid address: ${tokenAddress}`);
+    process.exit(1);
+  }
+
+  const lower = tokenAddress.toLowerCase();
+  const primaryUrl = getRpcUrlByChainId(chainId, "primary");
+
+  console.log(`Verifying ${lower} on chain ${chainId}`);
+  console.log(`  primary RPC: ${primaryUrl}`);
+
+  let metadata: TokenMetadata;
+  try {
+    metadata = await fetchMetadata(primaryUrl, lower);
+  } catch (primaryError) {
+    const fallbackUrl = getRpcUrlByChainId(chainId, "fallback");
+    if (fallbackUrl === primaryUrl) {
+      console.error(
+        `  primary RPC failed and no distinct fallback is configured: ${(primaryError as Error).message}`
+      );
+      process.exit(1);
+    }
+    console.warn(
+      `  primary RPC failed, trying fallback: ${fallbackUrl}`
+    );
+    try {
+      metadata = await fetchMetadata(fallbackUrl, lower);
+    } catch (fallbackError) {
+      console.error(
+        `  fallback RPC also failed: ${(fallbackError as Error).message}`
+      );
+      process.exit(1);
+    }
+  }
+
+  console.log("");
+  console.log(`  symbol:   ${metadata.symbol}`);
+  console.log(`  name:     ${metadata.name}`);
+  console.log(`  decimals: ${metadata.decimals}`);
+  console.log("");
+  console.log("TOKEN_CONFIGS entry:");
+  console.log("");
+  console.log("  {");
+  console.log(`    chainId: ${chainId},`);
+  console.log(`    tokenAddress: "${lower}", // ${metadata.symbol}`);
+  console.log(`    logoUrl: LOGOS.${metadata.symbol} ?? null,`);
+  console.log("    isStablecoin: true,");
+  console.log("    sortOrder: 1,");
+  console.log("  },");
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Seeds supported_tokens rows for Avalanche C-Chain (USDC, USDt), Avalanche Fuji (USDC), and Plasma mainnet (USDT0). Chain + explorer config for Avalanche and Plasma already landed in a prior PR.
- Introduces `INDEPENDENT_TOKEN_LIST_CHAIN_IDS` in the wallet modal and the `/api/supported-tokens` endpoint. Chains whose stablecoin lineup doesn't mirror Ethereum mainnet (TEMPO, Plasma) now render their own tokens directly instead of being overlaid on the mainnet USDC/USDT/USDS master list. Plasma's USDT0 was previously invisible because of symbol-match against `USDT` and the card showed three "Not available" rows.
- Adds `scripts/verify-token.ts` (calls `symbol()`/`name()`/`decimals()` over RPC and emits a paste-ready TOKEN_CONFIGS row) and a `/add-chain` slash command that standardises end-to-end onboarding of future chains.

## Scope notes

- USDC and USDS on Plasma: Circle has not deployed USDC on Plasma; Sky's USDS isn't on Plasma. Only USDT0 exists and is included.
- Avalanche USDS: Sky's native USDS landed on Avalanche on 2026-04-13 via SkyLink; address not yet authoritatively discoverable. Deferred to a follow-up.