### PR TITLE
fix: drop --turbopack from production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "A template for building your own AI-driven workflow automation platform",
   "scripts": {
     "dev": "pnpm discover-plugins && next dev",
-    "build": "tsx scripts/migrate-prod.ts && pnpm discover-plugins && next build --turbopack",
+    "build": "tsx scripts/migrate-prod.ts && pnpm discover-plugins && next build",
     "start": "next start",
     "type-check": "tsc --noEmit",
     "check": "ultracite check",


### PR DESCRIPTION
## Summary

Reverts the `--turbopack` flag on the `build` script added by KEEP-284 (`00f01ce4`). Keeps the `RUN --mount=type=cache,target=/app/.next/cache` line in the Dockerfile (it's harmless with webpack and leaves scaffolding for a future re-enable).

## Why

Next.js 16.1.x ships Turbopack as stable for production, but its `output: "standalone"` tracer has an active regression: it silently omits packages listed in `serverExternalPackages` from `.next/standalone/node_modules/` ([vercel/next.js#88844](https://github.com/vercel/next.js/issues/88844)). Our `next.config.ts` has a large `serverExternalPackages` list covering `@workflow/*`, `pg`, `drizzle-orm`, etc., so the Turbopack standalone output is effectively incomplete.

The bug manifests non-deterministically: a fresh build sometimes produces a working standalone, but as soon as BuildKit reuses a cached layer containing a bad Turbopack state, the runner image fails at startup. Symptoms in the container logs:

```
Error: Cannot find module 'next'
Require stack: /app/server.js
```

## Evidence this is what's happening

1. Staging CI on `main` (post-merge) has been failing at the `e2e-vitest-ephemeral / Start application` step since Turbopack was enabled ([last failed run](https://github.com/KeeperHub/keeperhub/actions/runs/24586051255)). The build job reports `#40 [app builder 2/2] RUN ... pnpm build` as `CACHED`, then the runner stage can't resolve `next`.
2. The previous green staging run ([24577197990](https://github.com/KeeperHub/keeperhub/actions/runs/24577197990)) had the same Dockerfile/package.json but a fresh (non-cached) `pnpm build`. Turbopack happened to emit a complete standalone that time, so the app booted.
3. Prod deploys don't catch it because `ENABLE_E2E_EPHEMERAL_TESTS` is only `true` on staging; on prod the runtime e2e job is skipped. Any broken image produced on prod would ship silently and surface only via pod CrashLoopBackOff.
4. Local repro confirmed: a Docker build of the `runner` target with `--turbopack` removed boots cleanly (`Next.js 16.2.2 Ready in 0ms`).

## Scope of revert

- `package.json`: `next build --turbopack` -> `next build`. One line.
- `Dockerfile`: unchanged.
- `next.config.ts`: unchanged (its `outputFileTracingIncludes` + `serverExternalPackages` lists are still correct for webpack).

## Follow-up

- Track [vercel/next.js#88844](https://github.com/vercel/next.js/issues/88844). Re-enable `--turbopack` once the standalone omission is fixed upstream.
- Consider enabling runtime e2e (`ENABLE_E2E_EPHEMERAL_TESTS=true`) on the prod CI gate so image-start regressions are caught before they reach pods.