### PR TITLE
fix: KEEP-230 expose Turnkey env vars to migrator init container

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -14,6 +14,18 @@ shared_env: &shared_env
     type: parameterStore
     name: chain-rpc-config
     parameter_name: /eks/techops-prod/keeperhub/chain-rpc-config
+  TURNKEY_API_PUBLIC_KEY:
+    type: parameterStore
+    name: turnkey-api-public-key
+    parameter_name: /eks/techops-prod/keeperhub/turnkey-api-public-key
+  TURNKEY_API_PRIVATE_KEY:
+    type: parameterStore
+    name: turnkey-api-private-key
+    parameter_name: /eks/techops-prod/keeperhub/turnkey-api-private-key
+  TURNKEY_ORGANIZATION_ID:
+    type: parameterStore
+    name: turnkey-organization-id
+    parameter_name: /eks/techops-prod/keeperhub/turnkey-organization-id
 
 replicaCount: 2
 

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -14,6 +14,18 @@ shared_env: &shared_env
     type: parameterStore
     name: chain-rpc-config
     parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+  TURNKEY_API_PUBLIC_KEY:
+    type: parameterStore
+    name: turnkey-api-public-key
+    parameter_name: /eks/techops-staging/keeperhub/turnkey-api-public-key
+  TURNKEY_API_PRIVATE_KEY:
+    type: parameterStore
+    name: turnkey-api-private-key
+    parameter_name: /eks/techops-staging/keeperhub/turnkey-api-private-key
+  TURNKEY_ORGANIZATION_ID:
+    type: parameterStore
+    name: turnkey-organization-id
+    parameter_name: /eks/techops-staging/keeperhub/turnkey-organization-id
 
 replicaCount: 1
 


### PR DESCRIPTION
## Summary

Follow-up to #897. The `server-only` issue in the provisioning script is fixed, but the current staging deploy logs show the next barrier:

```
[provision-turnkey] 11 Para-only orgs to process
[provision-turnkey] Failed for org=…: TURNKEY_API_PUBLIC_KEY, TURNKEY_API_PRIVATE_KEY, and TURNKEY_ORGANIZATION_ID must be set
…
[provision-turnkey] Done. provisioned=0 skipped=0 failed=11
```

The main app container already has those vars via its explicit `env:` block, but the migrator init container uses `env: *shared_env` and `shared_env` didn't include the Turnkey credentials. Every `createTurnkeyWallet` call inside the init container fails immediately.

## What this PR does

- Adds the three Turnkey parameterStore entries (`TURNKEY_API_PUBLIC_KEY`, `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ORGANIZATION_ID`) into `shared_env` in both `deploy/keeperhub/staging/values.yaml` and `deploy/keeperhub/prod/values.yaml`.
- Leaves the existing duplicates in the main app container's `env:` block alone. The merged result is identical (same parameterStore lookup, same values) so no app-container behavior change.

## Effect

Next deploy's migrator init container gets the Turnkey credentials, the provisioning script creates Turnkey sub-orgs for the 11 Para-only orgs, and the 11-failed summary becomes `provisioned=11 skipped=0 failed=0`. Subsequent deploys find `0 Para-only orgs to process` and exit in under a second.
