### PR TITLE
feat(billing): landing-style redesign, billing details, nav reorg

### DIFF
--- a/app/api/billing/billing-details/route.ts
+++ b/app/api/billing/billing-details/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { isBillingEnabled } from "@/lib/billing/feature-flag";
+import { getOrgSubscription } from "@/lib/billing/plans-server";
+import { getBillingProvider } from "@/lib/billing/providers";
+import { requireOrgOwner } from "@/lib/billing/require-org-owner";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
+export async function GET(): Promise<NextResponse> {
+  if (!isBillingEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  try {
+    const authResult = await requireOrgOwner();
+    if ("error" in authResult) {
+      return authResult.error;
+    }
+    const { orgId: activeOrgId } = authResult;
+
+    const sub = await getOrgSubscription(activeOrgId);
+    if (!sub?.providerCustomerId) {
+      return NextResponse.json({
+        paymentMethod: null,
+        billingEmail: null,
+      });
+    }
+
+    const provider = getBillingProvider();
+    const details = await provider.getBillingDetails(sub.providerCustomerId);
+
+    return NextResponse.json(details);
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Billing] Billing details error",
+      error,
+      { endpoint: "/api/billing/billing-details", operation: "get" }
+    );
+    return NextResponse.json(
+      { error: "Failed to load billing details" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Provider } from "jotai";
 import { type ReactNode, Suspense } from "react";
+import { AppBanner } from "@/components/app-banner";
 import { AuthProvider } from "@/components/auth/provider";
 import { KeeperHubExtensionLoader } from "@/components/extension-loader";
 import { GitHubStarsLoader } from "@/components/github-stars-loader";
@@ -76,6 +77,7 @@ const RootLayout = ({ children }: RootLayoutProps) => (
               <Suspense fallback={<GitHubStarsProvider stars={null} />}>
                 <GitHubStarsLoader />
               </Suspense>
+              <AppBanner />
               <LayoutContent>{children}</LayoutContent>
               <Toaster />
               <GlobalModals />

--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -880,7 +880,7 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
       {/* Right panel overlay (desktop only) - only show if trigger exists */}
       {!isMobile && hasTriggerNode && (
         <div
-          className="pointer-events-auto absolute top-24 right-0 bottom-0 z-20 border-l bg-background transition-transform duration-300 ease-out lg:top-[60px]"
+          className="pointer-events-auto absolute top-[calc(6rem+var(--app-banner-height,0px))] right-0 bottom-0 z-20 border-l bg-background transition-transform duration-300 ease-out lg:top-[calc(60px+var(--app-banner-height,0px))]"
           style={{
             width: `${panelWidth}%`,
             transform:

--- a/components/analytics/analytics-page.tsx
+++ b/components/analytics/analytics-page.tsx
@@ -106,7 +106,7 @@ export function AnalyticsPage(): ReactNode {
     return (
       <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
         <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-          <div className="flex flex-col gap-6 p-6 pt-20">
+          <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
             <AnalyticsHeader onRefetch={refetch} />
             <EmptyState />
           </div>

--- a/components/app-banner.tsx
+++ b/components/app-banner.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Info, X } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "kh-billing-announce-v1";
+
+export function AppBanner(): React.ReactElement | null {
+  const [mounted, setMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    setMounted(true);
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      setDismissed(stored === "1");
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+    if (dismissed) {
+      document.documentElement.style.removeProperty("--app-banner-height");
+    } else {
+      document.documentElement.style.setProperty("--app-banner-height", "36px");
+    }
+    return (): void => {
+      document.documentElement.style.removeProperty("--app-banner-height");
+    };
+  }, [mounted, dismissed]);
+
+  function handleDismiss(): void {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // localStorage unavailable; dismissal only lasts this session
+    }
+    setDismissed(true);
+  }
+
+  if (!mounted || dismissed) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-auto fixed top-0 right-0 left-0 z-[55] flex h-9 items-center justify-center border-b border-keeperhub-green/30 bg-keeperhub-green/10 px-12 text-sm backdrop-blur-sm"
+      data-testid="app-banner"
+    >
+      <p className="flex items-center gap-2 truncate text-foreground">
+        <Info
+          aria-hidden="true"
+          className="size-4 shrink-0 text-keeperhub-green-dark"
+        />
+        <span className="truncate">
+          New Pro and Business plans unlock higher execution limits and gas
+          credits. Free stays free forever.{" "}
+          <Link
+            className="font-medium text-keeperhub-green-dark underline-offset-4 hover:underline"
+            href="/billing#plans-section"
+          >
+            See plans
+          </Link>
+        </span>
+      </p>
+      <button
+        aria-label="Dismiss announcement"
+        className="absolute right-3 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-keeperhub-green/10 hover:text-foreground"
+        onClick={handleDismiss}
+        type="button"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/components/billing/billing-details.tsx
+++ b/components/billing/billing-details.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Loader2, Pencil } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BILLING_API } from "@/lib/billing/constants";
+import { useOrganization } from "@/lib/hooks/use-organization";
+
+type PaymentMethod = {
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+};
+
+type BillingDetailsResponse = {
+  paymentMethod: PaymentMethod | null;
+  billingEmail: string | null;
+};
+
+function formatBrand(brand: string): string {
+  const map: Record<string, string> = {
+    visa: "Visa",
+    mastercard: "Mastercard",
+    amex: "American Express",
+    discover: "Discover",
+    jcb: "JCB",
+    diners: "Diners Club",
+    unionpay: "UnionPay",
+  };
+  return map[brand] ?? brand.charAt(0).toUpperCase() + brand.slice(1);
+}
+
+export function BillingDetails(): React.ReactElement {
+  const { organization } = useOrganization();
+  const orgId = organization?.id;
+  const [data, setData] = useState<BillingDetailsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [portalLoading, setPortalLoading] = useState(false);
+
+  const fetchDetails = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const response = await fetch(BILLING_API.BILLING_DETAILS);
+      if (response.ok) {
+        const json = (await response.json()) as BillingDetailsResponse;
+        setData(json);
+      } else {
+        setData({ paymentMethod: null, billingEmail: null });
+      }
+    } catch {
+      setData({ paymentMethod: null, billingEmail: null });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: orgId drives re-fetch on org switch
+  useEffect(() => {
+    fetchDetails().catch(() => undefined);
+  }, [fetchDetails, orgId]);
+
+  async function openPortal(): Promise<void> {
+    setPortalLoading(true);
+    try {
+      const response = await fetch(BILLING_API.PORTAL, { method: "POST" });
+      const json = (await response.json()) as { url?: string; error?: string };
+      if (response.ok && json.url) {
+        window.location.href = json.url;
+        return;
+      }
+      toast.error(json.error ?? "Could not open billing portal");
+    } catch {
+      toast.error("Could not open billing portal");
+    } finally {
+      setPortalLoading(false);
+    }
+  }
+
+  const paymentMethod = data?.paymentMethod ?? null;
+  const billingEmail = data?.billingEmail ?? null;
+  const hasPaymentMethod = paymentMethod !== null;
+
+  return (
+    <Card className="bg-sidebar">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <span>Billing Details</span>
+          {hasPaymentMethod && (
+            <Button
+              aria-label="Edit billing details"
+              className="size-7 text-muted-foreground hover:text-foreground"
+              disabled={portalLoading}
+              onClick={() => {
+                openPortal().catch(() => undefined);
+              }}
+              size="icon"
+              variant="ghost"
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {loading && (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="size-4 animate-spin" />
+            Loading...
+          </div>
+        )}
+
+        {!(loading || hasPaymentMethod) && (
+          <p className="text-muted-foreground text-sm">
+            No card on file. Subscribe to a paid plan to add a payment method.
+          </p>
+        )}
+
+        {!loading && hasPaymentMethod && (
+          <div>
+            <p className="text-sm">
+              <span className="text-muted-foreground">
+                {formatBrand(paymentMethod.brand)} ending in
+              </span>{" "}
+              <span className="font-medium tracking-wider">
+                •••• {paymentMethod.last4}
+              </span>
+            </p>
+            <p className="text-muted-foreground text-xs mt-1">
+              Expires {String(paymentMethod.expMonth).padStart(2, "0")}/
+              {String(paymentMethod.expYear).slice(-2)}
+            </p>
+          </div>
+        )}
+
+        {!loading && (
+          <div className="border-t border-border/50 pt-3">
+            <p className="text-sm">
+              <span className="text-muted-foreground">Invoice Email:</span>{" "}
+              {billingEmail ? (
+                <span className="font-medium">{billingEmail}</span>
+              ) : (
+                <span className="text-muted-foreground italic">
+                  Not on file
+                </span>
+              )}
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/billing/billing-history.tsx
+++ b/components/billing/billing-history.tsx
@@ -216,7 +216,7 @@ export function BillingHistory(): React.ReactElement {
                 <TableCell className="space-x-2">
                   {invoice.invoiceUrl && (
                     <a
-                      className="text-sm text-blue-500 underline underline-offset-2 hover:text-blue-600"
+                      className="text-sm text-keeperhub-green-dark underline underline-offset-2 hover:text-keeperhub-green"
                       href={invoice.invoiceUrl}
                       rel="noopener"
                       target="_blank"
@@ -226,7 +226,7 @@ export function BillingHistory(): React.ReactElement {
                   )}
                   {invoice.pdfUrl && (
                     <a
-                      className="text-sm text-blue-500 underline underline-offset-2 hover:text-blue-600"
+                      className="text-sm text-keeperhub-green-dark underline underline-offset-2 hover:text-keeperhub-green"
                       href={invoice.pdfUrl}
                       rel="noopener"
                       target="_blank"

--- a/components/billing/billing-page.tsx
+++ b/components/billing/billing-page.tsx
@@ -167,7 +167,7 @@ export function BillingPage(): React.ReactElement {
       data-testid="billing-page"
     >
       <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-        <div className="container mx-auto max-w-7xl space-y-8 px-4 py-8 pt-20">
+        <div className="container mx-auto max-w-7xl space-y-8 px-4 py-8 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <div>
             <h1 className="text-2xl font-bold">Billing</h1>
             <p className="text-muted-foreground mt-1">

--- a/components/billing/billing-page.tsx
+++ b/components/billing/billing-page.tsx
@@ -97,7 +97,12 @@ export function BillingPage(): React.ReactElement {
     if (checkout === "success") {
       toast.success("Subscription activated successfully!");
       window.history.replaceState({}, "", window.location.pathname);
-      // Re-fetch after Stripe finishes attaching the payment method (~2s delay)
+      // Heuristic delay: Stripe needs a moment after Checkout to attach the
+      // payment method where getBillingDetails can read it back via the API
+      // cascade. 2s works in practice but is a race, not a guarantee. The
+      // robust fix is to persist payment method details in our DB on the
+      // checkout.session.completed webhook and read from DB instead of
+      // hitting Stripe here.
       const timer = setTimeout(() => setRefreshKey((k) => k + 1), 2000);
       return () => clearTimeout(timer);
     }

--- a/components/billing/billing-page.tsx
+++ b/components/billing/billing-page.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { CreditCard, LogIn } from "lucide-react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useSession } from "@/lib/auth-client";
 import { BILLING_API } from "@/lib/billing/constants";
 import {
   type BillingInterval,
@@ -12,6 +16,7 @@ import {
   type TierKey,
 } from "@/lib/billing/plans";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { BillingDetails } from "./billing-details";
 import { BillingHistory } from "./billing-history";
 import { BillingStatus } from "./billing-status";
 import { PricingTable } from "./pricing-table";
@@ -26,8 +31,54 @@ type SubscriptionResponse = {
   gasCreditCaps?: GasCreditCapsMap;
 };
 
+function AuthGate({
+  error,
+}: {
+  error: "AUTH_REQUIRED" | "ORG_REQUIRED";
+}): React.ReactElement {
+  const isAuthRequired = error === "AUTH_REQUIRED";
+
+  return (
+    <div
+      className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar"
+      data-page-state="ready"
+      data-testid="billing-page-auth-gate"
+    >
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
+          <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
+            {isAuthRequired ? (
+              <LogIn className="size-10 text-muted-foreground" />
+            ) : (
+              <CreditCard className="size-10 text-muted-foreground" />
+            )}
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold tracking-tight">
+              {isAuthRequired
+                ? "Sign in to view billing"
+                : "Organization required"}
+            </h2>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              {isAuthRequired
+                ? "Sign in to your account to manage your subscription and view billing history."
+                : "Create or join an organization to manage billing."}
+            </p>
+          </div>
+          {!isAuthRequired && (
+            <Button asChild>
+              <Link href="/">Get Started</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function BillingPage(): React.ReactElement {
   const searchParams = useSearchParams();
+  const { data: session, isPending: sessionPending } = useSession();
   const { organization } = useOrganization();
   const orgId = organization?.id;
   const [currentPlan, setCurrentPlan] = useState<PlanName>("free");
@@ -39,13 +90,18 @@ export function BillingPage(): React.ReactElement {
   >(undefined);
   const [refreshKey, setRefreshKey] = useState(0);
   const [planLoaded, setPlanLoaded] = useState(false);
+  const isAnonymous = !session?.user || session.user.isAnonymous;
 
   useEffect(() => {
     const checkout = searchParams.get("checkout");
     if (checkout === "success") {
       toast.success("Subscription activated successfully!");
       window.history.replaceState({}, "", window.location.pathname);
-    } else if (checkout === "canceled") {
+      // Re-fetch after Stripe finishes attaching the payment method (~2s delay)
+      const timer = setTimeout(() => setRefreshKey((k) => k + 1), 2000);
+      return () => clearTimeout(timer);
+    }
+    if (checkout === "canceled") {
       toast.info("Checkout was canceled.");
       window.history.replaceState({}, "", window.location.pathname);
     }
@@ -88,6 +144,20 @@ export function BillingPage(): React.ReactElement {
     setRefreshKey((k) => k + 1);
   }
 
+  if (sessionPending) {
+    return (
+      <div
+        className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar"
+        data-page-state="loading"
+        data-testid="billing-page"
+      />
+    );
+  }
+
+  if (isAnonymous) {
+    return <AuthGate error="AUTH_REQUIRED" />;
+  }
+
   // data-page-state tracks subscription plan fetch only.
   // BillingStatus and BillingHistory have independent async loads.
   return (
@@ -107,7 +177,10 @@ export function BillingPage(): React.ReactElement {
 
           <BillingStatus key={`status-${String(refreshKey)}`} />
 
-          <BillingHistory key={`history-${String(refreshKey)}`} />
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
+            <BillingHistory key={`history-${String(refreshKey)}`} />
+            <BillingDetails key={`details-${String(refreshKey)}`} />
+          </div>
 
           <div className="border-t border-border/50 pt-8" id="plans-section">
             <h2 className="text-xl font-semibold mb-4">Plans</h2>
@@ -119,6 +192,17 @@ export function BillingPage(): React.ReactElement {
               key={`${currentPlan}-${currentTier ?? "none"}-${currentInterval ?? "none"}-${String(refreshKey)}`}
               onPlanUpdated={handlePlanUpdated}
             />
+          </div>
+
+          <div className="flex justify-center border-t border-border/50 pt-8">
+            <a
+              className="text-muted-foreground text-sm underline-offset-4 hover:text-foreground hover:underline"
+              href="https://keeperhub.com/pricing"
+              rel="noopener"
+              target="_blank"
+            >
+              Pricing FAQ and comparison -&gt;
+            </a>
           </div>
         </div>
       </div>

--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BILLING_ALERTS, BILLING_API } from "@/lib/billing/constants";
-import { PLANS, type PlanName, type TierKey } from "@/lib/billing/plans";
+import { PLANS, type PlanName } from "@/lib/billing/plans";
 
 type OverageCharge = {
   periodStart: string;
@@ -371,13 +371,13 @@ function ExecutionUsageBar({
   const overageRate = PLANS[plan].overage.ratePerThousand;
 
   function resolveBarColor(): string {
-    if (isOverLimit) {
-      return hasOverage ? "bg-muted-foreground" : "bg-destructive";
+    if (isOverLimit && !hasOverage) {
+      return "bg-destructive";
     }
-    if (isNearLimit) {
+    if (isNearLimit && !isOverLimit) {
       return "bg-yellow-500";
     }
-    return "bg-keeperhub-green";
+    return "bg-keeperhub-green-dark";
   }
   const barColor = resolveBarColor();
 
@@ -393,7 +393,7 @@ function ExecutionUsageBar({
         </span>
       </div>
       {!(isUnlimited || isOverLimit) && (
-        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-keeperhub-green-dark/15">
           <div
             className={`h-full rounded-full transition-all ${barColor}`}
             style={{ width: `${percent}%` }}
@@ -402,14 +402,14 @@ function ExecutionUsageBar({
       )}
       {!isUnlimited && isOverLimit && (
         <div className="flex h-2 w-full gap-0.5">
-          <div className="h-full flex-1 overflow-hidden rounded-l-full bg-muted">
-            <div className="h-full w-full rounded-l-full bg-muted-foreground" />
+          <div className="h-full flex-1 overflow-hidden rounded-l-full bg-keeperhub-green-dark/15">
+            <div className="h-full w-full rounded-l-full bg-keeperhub-green-dark" />
           </div>
           <div
-            className="h-full overflow-hidden rounded-r-full bg-muted"
+            className="h-full overflow-hidden rounded-r-full bg-keeperhub-green-dark/15"
             style={{ width: `${Math.min((overageCount / limit) * 100, 50)}%` }}
           >
-            <div className="h-full w-full rounded-r-full bg-destructive/50 transition-all" />
+            <div className="h-full w-full rounded-r-full bg-yellow-500 transition-all" />
           </div>
         </div>
       )}
@@ -456,7 +456,7 @@ function GasCreditsBar({
     if (isNearLimit) {
       return "bg-yellow-500";
     }
-    return "bg-keeperhub-green";
+    return "bg-keeperhub-green-dark";
   }
   const barColor = resolveBarColor();
 
@@ -469,7 +469,7 @@ function GasCreditsBar({
           {(gasCredits.totalCents / 100).toFixed(2)}
         </span>
       </div>
-      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-keeperhub-green-dark/15">
         <div
           className={`h-full rounded-full transition-all ${barColor}`}
           style={{ width: `${percent}%` }}
@@ -582,8 +582,6 @@ function BillingStatusContent({
 }): React.ReactElement {
   const plan = (sub?.plan ?? "free") as PlanName;
   const planDef = PLANS[plan];
-  const tier = sub?.tier as TierKey | null;
-  const activeTier = tier ? planDef.tiers.find((t) => t.key === tier) : null;
   const statusVariant = STATUS_VARIANT[sub?.status ?? "active"] ?? "outline";
 
   const renewalMessage = getRenewalMessage(
@@ -607,14 +605,14 @@ function BillingStatusContent({
         <UpgradeSuggestionBanner suggestion={suggestion} />
       )}
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
         <span className="text-2xl font-bold">{planDef.name}</span>
-        {activeTier && (
-          <Badge variant="outline">
-            {activeTier.executions.toLocaleString()} executions
-          </Badge>
-        )}
         <Badge variant={statusVariant}>{sub?.status ?? "active"}</Badge>
+        {renewalMessage && (
+          <p className={`text-sm ${renewalMessage.className}`}>
+            {renewalMessage.text}
+          </p>
+        )}
       </div>
 
       {usage && (
@@ -628,12 +626,6 @@ function BillingStatusContent({
       {gasCredits && <GasCreditsBar gasCredits={gasCredits} />}
 
       <OverageChargesSection charges={overageCharges} />
-
-      {renewalMessage && (
-        <p className={`text-sm ${renewalMessage.className}`}>
-          {renewalMessage.text}
-        </p>
-      )}
     </CardContent>
   );
 }

--- a/components/billing/confirm-plan-change-dialog.tsx
+++ b/components/billing/confirm-plan-change-dialog.tsx
@@ -567,7 +567,7 @@ export function ConfirmPlanChangeDialog({
                 )}
                 <span className="text-muted-foreground">
                   {" "}
-                  -- changes take effect immediately with prorated billing.
+                  Changes take effect immediately with prorated billing.
                 </span>
               </p>
 

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -1,11 +1,157 @@
 "use client";
 
+import { ChevronDown } from "lucide-react";
 import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import type { BillingInterval } from "@/lib/billing/plans";
 import { PLANS } from "@/lib/billing/plans";
 import { cn } from "@/lib/utils";
 import { PlanCard } from "./plan-card";
 import type { PricingTableProps } from "./types";
+
+const COMPARISON_ROWS = [
+  {
+    label: "Workflows",
+    free: "Unlimited",
+    pro: "Unlimited",
+    business: "Unlimited",
+    enterprise: "Unlimited",
+  },
+  {
+    label: "Chains",
+    free: "All EVM",
+    pro: "All EVM",
+    business: "All EVM",
+    enterprise: "Custom",
+  },
+  {
+    label: "Triggers",
+    free: "Standard",
+    pro: "Advanced",
+    business: "Advanced + Custom",
+    enterprise: "Custom",
+  },
+  {
+    label: "API",
+    free: "Rate-limited",
+    pro: "Full",
+    business: "Full",
+    enterprise: "Full",
+  },
+  {
+    label: "Logs",
+    free: "7 days",
+    pro: "30 days",
+    business: "90 days",
+    enterprise: "Custom",
+  },
+  {
+    label: "Support",
+    free: "Community",
+    pro: "Email",
+    business: "Dedicated",
+    enterprise: "Dedicated (1h)",
+  },
+  {
+    label: "SLA",
+    free: "\u2014",
+    pro: "\u2014",
+    business: "99.9%",
+    enterprise: "99.999%",
+  },
+  {
+    label: "Builder",
+    free: "Visual + AI",
+    pro: "Visual + AI",
+    business: "Visual + AI",
+    enterprise: "Visual + AI",
+  },
+  {
+    label: "MCP Server",
+    free: "Included",
+    pro: "Included",
+    business: "Included",
+    enterprise: "Included",
+  },
+  {
+    label: "Ops team",
+    free: "\u2014",
+    pro: "\u2014",
+    business: "\u2014",
+    enterprise: "Dedicated",
+  },
+] as const;
+
+function ComparisonTable(): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="mx-auto mt-6 max-w-7xl">
+      <button
+        className="mx-auto flex cursor-pointer items-center gap-2 text-keeperhub-green-dark text-sm transition-colors hover:text-keeperhub-green"
+        onClick={() => setIsOpen((v) => !v)}
+        type="button"
+      >
+        <span>{isOpen ? "Hide comparison" : "Compare all features"}</span>
+        <ChevronDown
+          className={cn(
+            "size-4 transition-transform duration-200",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="mt-6 overflow-x-auto rounded-2xl border border-border/60 bg-sidebar">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60">
+                <th className="w-[20%] px-5 py-3.5 text-left font-medium text-muted-foreground">
+                  Feature
+                </th>
+                <th className="w-[20%] px-5 py-3.5 text-center font-medium">
+                  Free
+                </th>
+                <th className="w-[20%] px-5 py-3.5 text-center font-medium">
+                  Pro
+                </th>
+                <th className="w-[20%] px-5 py-3.5 text-center font-medium">
+                  Business
+                </th>
+                <th className="w-[20%] px-5 py-3.5 text-center font-medium text-keeperhub-green-dark">
+                  Enterprise
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {COMPARISON_ROWS.map((row, i) => (
+                <tr
+                  className={cn(
+                    "border-b border-border/30 last:border-b-0",
+                    i % 2 === 0 && "bg-muted/20"
+                  )}
+                  key={row.label}
+                >
+                  <td className="px-5 py-3 font-medium text-muted-foreground">
+                    {row.label}
+                  </td>
+                  <td className="px-5 py-3 text-center text-muted-foreground">
+                    {row.free}
+                  </td>
+                  <td className="px-5 py-3 text-center">{row.pro}</td>
+                  <td className="px-5 py-3 text-center">{row.business}</td>
+                  <td className="px-5 py-3 text-center text-keeperhub-green-dark/90">
+                    {row.enterprise}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function PricingTable({
   currentPlan = "free",
@@ -18,14 +164,13 @@ export function PricingTable({
 
   return (
     <div className="space-y-8">
-      {/* Interval toggle */}
-      <div className="flex justify-center">
-        <div className="inline-flex items-center rounded-full border border-border/50 bg-sidebar p-1">
+      <div className="flex items-center justify-center gap-3">
+        <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-sidebar p-1">
           <button
             className={cn(
-              "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+              "rounded-full px-5 py-2 font-medium text-sm transition-colors",
               interval === "monthly"
-                ? "bg-background text-foreground shadow-sm"
+                ? "bg-keeperhub-green-dark text-white shadow-sm"
                 : "text-muted-foreground hover:text-foreground"
             )}
             onClick={() => setInterval("monthly")}
@@ -35,9 +180,9 @@ export function PricingTable({
           </button>
           <button
             className={cn(
-              "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+              "flex items-center gap-2 rounded-full px-5 py-2 font-medium text-sm transition-colors",
               interval === "yearly"
-                ? "bg-background text-foreground shadow-sm"
+                ? "bg-keeperhub-green-dark text-white shadow-sm"
                 : "text-muted-foreground hover:text-foreground"
             )}
             onClick={() => setInterval("yearly")}
@@ -46,10 +191,12 @@ export function PricingTable({
             Annual
           </button>
         </div>
+        <Badge className="border border-keeperhub-green-dark/20 bg-keeperhub-green-dark/10 text-keeperhub-green-dark text-xs font-medium">
+          Save 20%
+        </Badge>
       </div>
 
-      {/* Plan cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
         <PlanCard
           currentInterval={currentInterval}
           currentPlan={currentPlan}
@@ -66,7 +213,6 @@ export function PricingTable({
           currentTier={currentTier}
           gasCreditCaps={gasCreditCaps}
           interval={interval}
-          isPopular
           onPlanUpdated={onPlanUpdated}
           plan={PLANS.pro}
           planName="pro"
@@ -93,37 +239,12 @@ export function PricingTable({
         />
       </div>
 
-      {/* Overage callout */}
-      <div className="border-l-4 border-yellow-500/50 bg-yellow-500/5 rounded-r-lg p-4">
-        <h4 className="text-sm font-medium mb-3">
-          When users reach their execution limit
-        </h4>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-          <div className="rounded-lg border border-border/50 bg-sidebar p-3">
-            <p className="text-sm font-medium">Pay per execution (default)</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              On paid tiers, overages billed at end of cycle
-            </p>
-          </div>
-          <div className="rounded-lg border border-border/50 bg-sidebar p-3">
-            <p className="text-sm font-medium">Bump executions</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Select a higher tier from the dropdown
-            </p>
-          </div>
-          <div className="rounded-lg border border-border/50 bg-sidebar p-3">
-            <p className="text-sm font-medium">Upgrade their plan</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Move to a higher plan for more features
-            </p>
-          </div>
-        </div>
-        <p className="text-xs text-muted-foreground mt-3">
-          On paid tiers, overages are billed at end of cycle. Unpaid overage
-          invoices may result in reduced execution limits. Free tier: hard cap,
-          must upgrade.
-        </p>
-      </div>
+      <ComparisonTable />
+
+      <p className="text-center text-muted-foreground text-xs">
+        Paid tiers bill overage at the end of the cycle. Free tier caps at its
+        limit with no overage.
+      </p>
     </div>
   );
 }

--- a/components/billing/pricing-table/plan-card-parts.tsx
+++ b/components/billing/pricing-table/plan-card-parts.tsx
@@ -1,152 +1,180 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CardFooter } from "@/components/ui/card";
-import { SUPPORT_LABELS } from "@/lib/billing/constants";
 import type { BillingInterval, PLANS, PlanName } from "@/lib/billing/plans";
 import { cn } from "@/lib/utils";
 import type { PlanTierItem } from "./types";
-import { formatPrice, getButtonLabel, getExecutionsDisplay } from "./utils";
-
-export function FeatureRow({
-  label,
-  value,
-  highlight = false,
-}: {
-  label: string;
-  value: string;
-  highlight?: boolean;
-}): React.ReactElement {
-  return (
-    <div className="flex items-center justify-between py-1.5 text-sm">
-      <span className="text-muted-foreground">{label}</span>
-      <span
-        className={cn(highlight && "text-keeperhub-green-dark font-medium")}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
+import { formatPrice, getButtonLabel, getTierPrice } from "./utils";
 
 export function PlanCardBadge({
   isActive,
-  isPopular,
 }: {
   isActive: boolean;
-  isPopular: boolean;
 }): React.ReactElement | null {
-  if (isActive) {
-    return (
-      <div className="absolute top-6 right-3">
-        <Badge className="bg-keeperhub-green-dark text-white border-0 text-xs px-3">
-          ACTIVE
-        </Badge>
-      </div>
-    );
-  }
-  if (!isPopular) {
+  if (!isActive) {
     return null;
   }
   return (
-    <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-      <Badge className="bg-keeperhub-green-dark text-white border-0 text-xs px-3">
-        POPULAR
+    <div className="absolute top-4 right-4">
+      <Badge className="border-0 bg-keeperhub-green-dark text-white text-xs px-2.5">
+        CURRENT
       </Badge>
     </div>
   );
 }
 
-export function PlanCardFeatures({
-  plan,
-  planName,
-  activeTier,
-  gasCreditCentsCap,
+export function PlanHeader({
+  name,
+  price,
+  isEnterprise,
 }: {
-  plan: (typeof PLANS)[PlanName];
-  planName: PlanName;
-  activeTier: PlanTierItem | undefined;
-  gasCreditCentsCap?: number;
+  name: string;
+  price: number | null;
+  isEnterprise: boolean;
 }): React.ReactElement {
-  const isEnterprise = planName === "enterprise";
-  const executionsDisplay = getExecutionsDisplay(planName, activeTier);
-
-  const capCents = gasCreditCentsCap ?? plan.features.gasCreditsCents;
-  const gasCredits = isEnterprise
-    ? `$${(capCents / 100).toFixed(0)}+/mo`
-    : `$${(capCents / 100).toFixed(0)}/mo`;
-
-  const logRetention =
-    plan.features.logRetentionDays >= 365
-      ? "1 year"
-      : `${plan.features.logRetentionDays} days`;
-
   return (
-    <div className="space-y-0.5 border-t border-border/50 pt-3">
-      {executionsDisplay && (
-        <FeatureRow
-          highlight
-          label="Executions"
-          value={`${executionsDisplay}/mo`}
-        />
-      )}
-      <FeatureRow highlight label="Gas credits" value={gasCredits} />
-
-      <div className="border-t border-border/30 my-2" />
-
-      <FeatureRow label="Workflows" value="Unlimited" />
-      <FeatureRow
-        label="Chains"
-        value={isEnterprise ? "All + Custom" : "All"}
-      />
-      <FeatureRow
-        label="Triggers"
-        value={isEnterprise ? "All + Custom" : "All"}
-      />
-      <FeatureRow
-        label="API"
-        value={plan.features.apiAccess === "full" ? "Full" : "Rate-limited"}
-      />
-      <FeatureRow label="Logs" value={logRetention} />
-      <FeatureRow
-        label="Support"
-        value={SUPPORT_LABELS[plan.features.supportLevel] ?? "Community"}
-      />
-      {plan.features.sla && (
-        <FeatureRow label="SLA" value={plan.features.sla} />
-      )}
+    <div className="text-center">
+      <h3 className="mb-3 font-bold text-2xl tracking-tight">{name}</h3>
+      <div>
+        {isEnterprise || price === null ? (
+          <span className="font-bold text-5xl text-keeperhub-green-dark">
+            Custom
+          </span>
+        ) : (
+          <>
+            <span className="font-bold text-5xl text-keeperhub-green-dark">
+              {formatPrice(price)}
+            </span>
+            <span className="text-muted-foreground text-xl ml-1">/mo</span>
+          </>
+        )}
+      </div>
     </div>
   );
 }
 
-export function PriceDisplay({
-  price,
-  annualTotal,
+export function HeroMetrics({
+  executions,
+  gas,
+}: {
+  executions: string;
+  gas: string;
+}): React.ReactElement {
+  return (
+    <div className="mt-3 mb-3 grid grid-cols-2 gap-2 rounded-xl bg-background/60 px-5 py-4">
+      <div className="text-center">
+        <p className="mb-1.5 whitespace-nowrap text-muted-foreground text-xs">
+          Executions /mo
+        </p>
+        <p className="font-bold text-2xl leading-tight">{executions}</p>
+      </div>
+      <div className="text-center">
+        <p className="mb-1.5 whitespace-nowrap text-muted-foreground text-xs">
+          Gas credits /mo
+        </p>
+        <p className="font-bold text-2xl leading-tight">{gas}</p>
+      </div>
+    </div>
+  );
+}
+
+export function TierSelect({
+  options,
+  value,
+  onChange,
   interval,
 }: {
-  price: number | null;
-  annualTotal: number | null;
+  options: PlanTierItem[];
+  value: string;
+  onChange: (key: string) => void;
   interval: BillingInterval;
 }): React.ReactElement {
-  if (price === null) {
-    return (
-      <div>
-        <span className="text-3xl font-bold text-keeperhub-green-dark">
-          {interval === "yearly" ? "$1,999+" : "$2,499+"}
-        </span>
-        <span className="text-muted-foreground text-sm">/mo</span>
-      </div>
-    );
-  }
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    function handleClickOutside(event: MouseEvent): void {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return (): void =>
+      document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const selected = options.find((opt) => opt.key === value) ?? options[0];
+
   return (
-    <div>
-      <span className="text-3xl font-bold text-keeperhub-green-dark">
-        {formatPrice(price)}
-      </span>
-      <span className="text-muted-foreground text-sm">/mo</span>
-      {annualTotal !== null && (
-        <p className="text-muted-foreground text-xs mt-1">
-          {formatPrice(annualTotal)}/year billed annually
-        </p>
+    <div className="relative mb-4" ref={containerRef}>
+      <button
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        className="flex w-full cursor-pointer items-center justify-between rounded-lg border border-border/60 bg-background/60 px-4 py-2.5 text-sm transition-colors hover:border-keeperhub-green-dark/60"
+        onClick={() => setIsOpen((prev) => !prev)}
+        type="button"
+      >
+        <span className="font-medium">
+          {selected.executions.toLocaleString()} executions
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-4 text-muted-foreground transition-transform duration-200",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute top-full right-0 left-0 z-20 mt-1 overflow-hidden rounded-lg border border-border/60 bg-popover shadow-xl shadow-black/10"
+          role="listbox"
+        >
+          {options.map((opt) => {
+            const isSelected = opt.key === value;
+            return (
+              <button
+                aria-selected={isSelected}
+                className={cn(
+                  "flex w-full cursor-pointer items-center justify-between px-4 py-2.5 text-sm transition-colors",
+                  isSelected
+                    ? "bg-keeperhub-green-dark/10 text-keeperhub-green-dark"
+                    : "text-foreground hover:bg-muted"
+                )}
+                key={opt.key}
+                onClick={() => {
+                  onChange(opt.key);
+                  setIsOpen(false);
+                }}
+                role="option"
+                type="button"
+              >
+                <span className={isSelected ? "font-medium" : ""}>
+                  {opt.executions.toLocaleString()} executions
+                </span>
+                <span
+                  className={
+                    isSelected
+                      ? "text-keeperhub-green-dark"
+                      : "text-muted-foreground"
+                  }
+                >
+                  {formatPrice(getTierPrice(opt, interval))}/mo
+                </span>
+              </button>
+            );
+          })}
+        </div>
       )}
     </div>
   );
@@ -157,7 +185,6 @@ export function PlanCardFooter({
   plan,
   isCurrent,
   loading,
-  isPopular,
   currentPlan,
   hasSubscription,
   onSubscribe,
@@ -166,7 +193,6 @@ export function PlanCardFooter({
   plan: (typeof PLANS)[PlanName];
   isCurrent: boolean;
   loading: boolean;
-  isPopular: boolean;
   currentPlan?: PlanName;
   hasSubscription: boolean;
   onSubscribe: () => void;
@@ -174,33 +200,30 @@ export function PlanCardFooter({
   const isFree = planName === "free";
   const isEnterprise = planName === "enterprise";
 
+  let overageLabel: string | null = null;
+  if (plan.overage.enabled) {
+    overageLabel = `$${plan.overage.ratePerThousand}/1K additional executions`;
+  } else if (isFree) {
+    overageLabel = "No overage. Hard cap at limit.";
+  } else if (isEnterprise) {
+    overageLabel = "Custom overage terms";
+  }
+
   return (
-    <CardFooter className="flex-col gap-3">
-      <div className="w-full text-center">
-        {isFree && (
-          <span className="text-xs text-muted-foreground">No overage</span>
-        )}
-        {plan.overage.enabled && (
-          <Badge className="text-xs" variant="outline">
-            ${plan.overage.ratePerThousand}/1K additional executions
-          </Badge>
-        )}
-        {isEnterprise && (
-          <span className="text-xs text-muted-foreground">Custom pricing</span>
-        )}
-      </div>
+    <CardFooter className="mt-auto flex-col gap-3">
       <Button
-        className={cn(
-          "w-full",
-          isPopular &&
-            "bg-keeperhub-green-dark hover:bg-keeperhub-green-dark/90 text-white"
-        )}
+        className="w-full rounded-full"
         disabled={isCurrent || (isFree && currentPlan === "free") || loading}
         onClick={onSubscribe}
-        variant={isPopular ? "default" : "outline"}
+        variant="outline"
       >
         {getButtonLabel(planName, isCurrent, loading, hasSubscription)}
       </Button>
+      {overageLabel && (
+        <span className="rounded-full border border-border/50 bg-muted/40 px-3 py-1 text-muted-foreground text-xs">
+          {overageLabel}
+        </span>
+      )}
     </CardFooter>
   );
 }

--- a/components/billing/pricing-table/plan-card.tsx
+++ b/components/billing/pricing-table/plan-card.tsx
@@ -2,15 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { CONTACT_EMAIL } from "@/lib/billing/constants";
+import { Card, CardContent } from "@/components/ui/card";
 import type {
   BillingInterval,
   PLANS,
@@ -20,17 +12,16 @@ import type {
 import { cn } from "@/lib/utils";
 import { ConfirmPlanChangeDialog } from "../confirm-plan-change-dialog";
 import {
+  HeroMetrics,
   PlanCardBadge,
-  PlanCardFeatures,
   PlanCardFooter,
-  PriceDisplay,
+  PlanHeader,
+  TierSelect,
 } from "./plan-card-parts";
 import type { GasCreditCapsMap } from "./types";
 import {
   cancelSubscription,
   computeDisplayPrice,
-  formatPrice,
-  getTierPrice,
   isCurrentPlan,
   resolveExecutions,
   startCheckout,
@@ -44,7 +35,6 @@ export function PlanCard({
   currentTier,
   currentInterval,
   gasCreditCaps,
-  isPopular = false,
   onPlanUpdated,
 }: {
   plan: (typeof PLANS)[PlanName];
@@ -54,7 +44,6 @@ export function PlanCard({
   currentTier?: TierKey | null;
   currentInterval?: BillingInterval | null;
   gasCreditCaps?: GasCreditCapsMap;
-  isPopular?: boolean;
   onPlanUpdated?: () => Promise<void>;
 }): React.ReactElement {
   const [selectedTier, setSelectedTier] = useState<TierKey | null>(
@@ -64,9 +53,10 @@ export function PlanCard({
   );
   const [loading, setLoading] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [selectOpen, setSelectOpen] = useState(false);
 
   const hasSubscription = currentPlan !== undefined && currentPlan !== "free";
+  const isEnterprise = planName === "enterprise";
+  const isFree = planName === "free";
 
   const isCurrent = isCurrentPlan(
     planName,
@@ -80,15 +70,28 @@ export function PlanCard({
   const activeTier = plan.tiers.find((t) => t.key === selectedTier);
   const price = computeDisplayPrice(planName, activeTier, interval);
 
-  const annualTotal =
-    activeTier && interval === "yearly"
-      ? activeTier.monthlyPriceAnnual * 12
-      : null;
+  const capCents = gasCreditCaps?.[planName] ?? plan.features.gasCreditsCents;
+  const gasDisplay = isEnterprise
+    ? "Custom"
+    : `$${(capCents / 100).toFixed(0)}`;
+
+  const executionsDisplay = (() => {
+    if (isEnterprise) {
+      return "Custom";
+    }
+    if (isFree) {
+      return plan.features.maxExecutionsPerMonth.toLocaleString();
+    }
+    if (activeTier) {
+      return activeTier.executions.toLocaleString();
+    }
+    return "-";
+  })();
 
   async function executeCheckout(): Promise<void> {
     setLoading(true);
     try {
-      if (planName === "free") {
+      if (isFree) {
         const result = await cancelSubscription();
         if (!result.success) {
           return;
@@ -122,35 +125,30 @@ export function PlanCard({
   }
 
   function handleSubscribe(): void {
-    if (planName === "enterprise") {
+    if (isEnterprise) {
       window.open(
-        `mailto:${CONTACT_EMAIL}?subject=Enterprise%20Plan`,
+        "mailto:human@keeperhub.com?subject=Enterprise%20Plan",
         "_blank",
         "noopener"
       );
       return;
     }
-
     if (isCurrent) {
       return;
     }
-
-    if (planName === "free" && hasSubscription) {
+    if (isFree && hasSubscription) {
       setConfirmOpen(true);
       return;
     }
-
-    if (planName === "free") {
+    if (isFree) {
       return;
     }
-
     if (hasSubscription) {
       setConfirmOpen(true);
       return;
     }
-
     executeCheckout().catch(() => {
-      // error handled inside executeCheckout
+      // handled inside executeCheckout
     });
   }
 
@@ -180,63 +178,35 @@ export function PlanCard({
       />
       <Card
         className={cn(
-          "group relative flex flex-col bg-sidebar border-border/50 transition-transform duration-200 hover:-translate-y-2.5",
-          selectOpen && "-translate-y-2.5",
-          isPopular &&
-            "border-keeperhub-green-dark/50 shadow-keeperhub-green-dark/10 shadow-lg"
+          "group relative flex flex-col border border-border/50 bg-sidebar p-2 transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(0,255,100,0.08)]",
+          currentPlan === planName && "border-keeperhub-green-dark/60"
         )}
       >
-        <PlanCardBadge
-          isActive={currentPlan === planName}
-          isPopular={isPopular}
-        />
+        <PlanCardBadge isActive={currentPlan === planName} />
 
-        <CardHeader className="pb-2">
-          <CardTitle className="text-lg">{plan.name}</CardTitle>
-          <p className="text-muted-foreground text-sm">{plan.description}</p>
-        </CardHeader>
-
-        <CardContent className="flex-1 space-y-4">
-          <PriceDisplay
-            annualTotal={annualTotal}
-            interval={interval}
+        <CardContent className="flex flex-1 flex-col gap-0 pt-6">
+          <PlanHeader
+            isEnterprise={isEnterprise}
+            name={plan.name}
             price={price}
           />
 
-          {plan.tiers.length > 0 && (
-            <Select
-              onOpenChange={setSelectOpen}
-              onValueChange={(val) => setSelectedTier(val as TierKey)}
-              open={selectOpen}
-              value={selectedTier ?? undefined}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select executions" />
-              </SelectTrigger>
-              <SelectContent>
-                {plan.tiers.map((tier) => (
-                  <SelectItem key={tier.key} value={tier.key}>
-                    {tier.executions.toLocaleString()} executions -{" "}
-                    {formatPrice(getTierPrice(tier, interval))}/mo
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
+          <HeroMetrics executions={executionsDisplay} gas={gasDisplay} />
 
-          <PlanCardFeatures
-            activeTier={activeTier}
-            gasCreditCentsCap={gasCreditCaps?.[planName]}
-            plan={plan}
-            planName={planName}
-          />
+          {plan.tiers.length > 0 && (
+            <TierSelect
+              interval={interval}
+              onChange={(key) => setSelectedTier(key as TierKey)}
+              options={plan.tiers}
+              value={selectedTier ?? plan.tiers[0].key}
+            />
+          )}
         </CardContent>
 
         <PlanCardFooter
           currentPlan={currentPlan}
           hasSubscription={hasSubscription}
           isCurrent={isCurrent}
-          isPopular={isPopular}
           loading={loading}
           onSubscribe={handleSubscribe}
           plan={plan}

--- a/components/billing/pricing-table/utils.ts
+++ b/components/billing/pricing-table/utils.ts
@@ -52,12 +52,9 @@ export function getButtonLabel(
     return hasSubscription ? "Downgrade to Free" : "Free";
   }
   if (planName === "enterprise") {
-    return "Contact Sales";
+    return "Talk to us";
   }
-  if (hasSubscription) {
-    return "Change Plan";
-  }
-  return "Subscribe";
+  return "Change plan";
 }
 
 export function getExecutionsDisplay(

--- a/components/earnings/earnings-page.tsx
+++ b/components/earnings/earnings-page.tsx
@@ -122,7 +122,7 @@ export function EarningsPage(): ReactNode {
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
       <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-        <div className="flex flex-col gap-6 p-6 pt-20">
+        <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <EarningsHeader onRefetch={refetch} />
           <EarningsKpiCards />
           <WorkflowEarningsTable onPageChange={setPage} page={page} />

--- a/components/flyout-panel.tsx
+++ b/components/flyout-panel.tsx
@@ -46,7 +46,7 @@ export function FlyoutPanel({
       <Tooltip>
         <TooltipTrigger asChild>
           <button
-            className="pointer-events-auto fixed top-[60px] bottom-0 z-30 flex items-start justify-center border-r bg-background pt-3 transition-[left] duration-200 ease-out hover:bg-muted/50"
+            className="pointer-events-auto fixed top-[calc(60px+var(--app-banner-height,0px))] bottom-0 z-30 flex items-start justify-center border-r bg-background pt-3 transition-[left] duration-200 ease-out hover:bg-muted/50"
             data-flyout
             onClick={onExpand}
             style={{ left: leftOffset, width: STRIP_WIDTH }}
@@ -91,7 +91,7 @@ export function FlyoutPanel({
   return (
     <div
       className={cn(
-        "pointer-events-auto fixed top-[60px] bottom-0 z-30 border-r bg-background shadow-lg transition-[left] duration-200 ease-out",
+        "pointer-events-auto fixed top-[calc(60px+var(--app-banner-height,0px))] bottom-0 z-30 border-r bg-background shadow-lg transition-[left] duration-200 ease-out",
         "animate-[flyout-in_150ms_ease-out_forwards]"
       )}
       data-flyout

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -817,7 +817,7 @@ export function NavigationSidebar(): React.ReactNode {
     <>
       <div
         className={cn(
-          "pointer-events-auto fixed top-[60px] bottom-0 left-0 z-40 flex flex-col bg-background",
+          "pointer-events-auto fixed top-[calc(60px+var(--app-banner-height,0px))] bottom-0 left-0 z-40 flex flex-col bg-background",
           dragWidth === null && "transition-[width] duration-200 ease-out"
         )}
         ref={sidebarRef}

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -2,11 +2,12 @@
 
 import {
   BarChart3,
+  Bookmark,
   Check,
   ChevronLeft,
   ChevronRight,
-  CreditCard,
   DollarSign,
+  Github,
   Globe,
   Info,
   List,
@@ -17,6 +18,9 @@ import {
 import { useParams, usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DiscordIcon } from "@/components/icons/discord-icon";
+import { AddressBookOverlay } from "@/components/overlays/address-book-overlay";
+import { FeedbackOverlay } from "@/components/overlays/feedback-overlay";
+import { useOverlay } from "@/components/overlays/overlay-provider";
 import {
   Tooltip,
   TooltipContent,
@@ -26,8 +30,6 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { Project, SavedWorkflow, Tag } from "@/lib/api-client";
 import { api } from "@/lib/api-client";
 import { authClient, useSession } from "@/lib/auth-client";
-import { isBillingEnabled } from "@/lib/billing/feature-flag";
-import { useActiveMember } from "@/lib/hooks/use-organization";
 import type { NavPanelStates } from "@/lib/hooks/use-persisted-nav-state";
 import { usePersistedNavState } from "@/lib/hooks/use-persisted-nav-state";
 import { isAnonymousUser } from "@/lib/is-anonymous";
@@ -404,6 +406,11 @@ function SidebarHeader({
   );
 }
 
+const ACTION_ITEM_IDS: ReadonlySet<string> = new Set([
+  "workflows",
+  "address-book",
+]);
+
 function NavItem({
   item,
   active,
@@ -415,7 +422,7 @@ function NavItem({
   showLabels: boolean;
   onClick: () => void;
 }): React.ReactNode {
-  const disabled = item.href === null && item.id !== "workflows";
+  const disabled = item.href === null && !ACTION_ITEM_IDS.has(item.id);
   const layoutClass = showLabels ? "gap-3 px-2" : "justify-center";
 
   if (disabled) {
@@ -492,18 +499,17 @@ const NAV_ITEMS = [
     href: "/earnings" as string | null,
   },
   {
-    id: "billing",
-    icon: CreditCard,
-    label: "Billing",
-    href: "/billing" as string | null,
+    id: "address-book",
+    icon: Bookmark,
+    label: "Address Book",
+    href: null as string | null,
   },
 ];
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large component with many panel interactions, further extraction would hurt readability
 export function NavigationSidebar(): React.ReactNode {
   const isMobile = useIsMobile();
   const { data: session } = useSession();
-  const { isOwner } = useActiveMember();
+  const { open: openOverlay } = useOverlay();
   const router = useRouter();
   const pathname = usePathname();
   const params = useParams();
@@ -570,7 +576,6 @@ export function NavigationSidebar(): React.ReactNode {
   const isHubPage = pathname === "/hub";
   const isAnalyticsPage = pathname === "/analytics";
   const isEarningsPage = pathname === "/earnings";
-  const isBillingPage = pathname === "/billing";
 
   const expanded = navState.state.sidebar;
   const setExpanded = navState.setSidebar;
@@ -698,9 +703,6 @@ export function NavigationSidebar(): React.ReactNode {
     if (id === "earnings") {
       return isEarningsPage;
     }
-    if (id === "billing") {
-      return isBillingPage;
-    }
     return false;
   }
 
@@ -755,6 +757,11 @@ export function NavigationSidebar(): React.ReactNode {
       }
       return;
     }
+    if (id === "address-book") {
+      navState.closeAll();
+      openOverlay(AddressBookOverlay);
+      return;
+    }
     navState.closeAll();
     if (href) {
       router.push(href);
@@ -800,8 +807,8 @@ export function NavigationSidebar(): React.ReactNode {
     if (item.id === "earnings") {
       return !isAnonymous;
     }
-    if (item.id === "billing") {
-      return isOwner && isBillingEnabled();
+    if (item.id === "address-book") {
+      return !isAnonymous;
     }
     return true;
   });
@@ -886,6 +893,36 @@ export function NavigationSidebar(): React.ReactNode {
               </Tooltip>
             );
           })}
+          {(() => {
+            const reportButton = (
+              <button
+                aria-label="Report an issue"
+                className={cn(
+                  "flex h-9 w-full items-center rounded-md transition-colors hover:bg-muted",
+                  showLabels ? "gap-3 px-2" : "justify-center"
+                )}
+                data-testid="nav-report-issue"
+                onClick={() => openOverlay(FeedbackOverlay)}
+                type="button"
+              >
+                <Github className="size-4 shrink-0" />
+                {showLabels && (
+                  <span className="truncate text-sm">Report an issue</span>
+                )}
+              </button>
+            );
+
+            if (showLabels) {
+              return reportButton;
+            }
+
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>{reportButton}</TooltipTrigger>
+                <TooltipContent side="right">Report an issue</TooltipContent>
+              </Tooltip>
+            );
+          })()}
         </div>
 
         {/* Resize handle */}

--- a/components/overlays/projects-and-tags-overlay.tsx
+++ b/components/overlays/projects-and-tags-overlay.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { FolderOpen, Plus, Tag as TagIcon, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ConfirmOverlay } from "@/components/overlays/confirm-overlay";
+import { Overlay } from "@/components/overlays/overlay";
+import { useOverlay } from "@/components/overlays/overlay-provider";
+import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
+import { TagFormDialog } from "@/components/tags/tag-form-dialog";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { api, type Project, type Tag as TagType } from "@/lib/api-client";
+
+type ProjectsAndTagsOverlayProps = {
+  overlayId: string;
+  initialTab?: "projects" | "tags";
+};
+
+export function ProjectsAndTagsOverlay({
+  overlayId,
+  initialTab = "projects",
+}: ProjectsAndTagsOverlayProps): React.ReactElement {
+  const { open: openOverlay } = useOverlay();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [tags, setTags] = useState<TagType[]>([]);
+  const [loadingProjects, setLoadingProjects] = useState(true);
+  const [loadingTags, setLoadingTags] = useState(true);
+  const [showProjectDialog, setShowProjectDialog] = useState(false);
+  const [showTagDialog, setShowTagDialog] = useState(false);
+
+  const loadProjects = useCallback(async (): Promise<void> => {
+    try {
+      const result = await api.project.getAll();
+      setProjects(result);
+    } catch {
+      toast.error("Failed to load projects");
+    } finally {
+      setLoadingProjects(false);
+    }
+  }, []);
+
+  const loadTags = useCallback(async (): Promise<void> => {
+    try {
+      const result = await api.tag.getAll();
+      setTags(result);
+    } catch {
+      toast.error("Failed to load tags");
+    } finally {
+      setLoadingTags(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadProjects().catch(() => undefined);
+    loadTags().catch(() => undefined);
+  }, [loadProjects, loadTags]);
+
+  const handleDeleteProject = (project: Project): void => {
+    openOverlay(ConfirmOverlay, {
+      title: "Delete Project",
+      message: `Are you sure you want to delete "${project.name}"? This cannot be undone.`,
+      confirmLabel: "Delete",
+      confirmVariant: "destructive" as const,
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.project.delete(project.id);
+          setProjects((prev) => prev.filter((p) => p.id !== project.id));
+          toast.success(`Project "${project.name}" deleted`);
+        } catch {
+          toast.error("Failed to delete project");
+        }
+      },
+    });
+  };
+
+  const handleDeleteTag = (tag: TagType): void => {
+    openOverlay(ConfirmOverlay, {
+      title: "Delete Tag",
+      message: `Are you sure you want to delete "${tag.name}"? This cannot be undone.`,
+      confirmLabel: "Delete",
+      confirmVariant: "destructive" as const,
+      destructive: true,
+      onConfirm: async () => {
+        try {
+          await api.tag.delete(tag.id);
+          setTags((prev) => prev.filter((t) => t.id !== tag.id));
+          toast.success(`Tag "${tag.name}" deleted`);
+        } catch {
+          toast.error("Failed to delete tag");
+        }
+      },
+    });
+  };
+
+  const handleProjectCreated = (project: Project): void => {
+    setProjects((prev) => [...prev, project]);
+  };
+
+  const handleTagCreated = (tag: TagType): void => {
+    setTags((prev) => [...prev, tag]);
+  };
+
+  return (
+    <>
+      <Overlay
+        description="Organize and categorize your workflows"
+        overlayId={overlayId}
+        title="Projects and Tags"
+      >
+        <Tabs className="w-full" defaultValue={initialTab}>
+          <TabsList className="mb-4 w-full">
+            <TabsTrigger value="projects">Projects</TabsTrigger>
+            <TabsTrigger value="tags">Tags</TabsTrigger>
+          </TabsList>
+
+          <TabsContent className="space-y-4" value="projects">
+            <div className="flex justify-end">
+              <Button onClick={() => setShowProjectDialog(true)} size="sm">
+                <Plus className="mr-2 size-4" />
+                New Project
+              </Button>
+            </div>
+
+            {loadingProjects && (
+              <div className="flex items-center justify-center py-8">
+                <Spinner />
+              </div>
+            )}
+            {!loadingProjects && projects.length === 0 && (
+              <div className="flex flex-col items-center gap-2 py-8 text-center text-muted-foreground">
+                <FolderOpen className="size-8" />
+                <p className="text-sm">No projects yet</p>
+                <p className="text-xs">
+                  Create a project to organize your workflows.
+                </p>
+              </div>
+            )}
+            {!loadingProjects && projects.length > 0 && (
+              <div className="space-y-1">
+                {projects.map((project) => (
+                  <div
+                    className="flex items-center justify-between rounded-md border px-4 py-3"
+                    key={project.id}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span
+                        className="inline-block size-3 shrink-0 rounded-full"
+                        style={{
+                          backgroundColor:
+                            project.color ?? "var(--color-text-muted)",
+                        }}
+                      />
+                      <div>
+                        <p className="font-medium text-sm">{project.name}</p>
+                        {project.description && (
+                          <p className="text-muted-foreground text-xs">
+                            {project.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-muted-foreground text-xs">
+                        {project.workflowCount}{" "}
+                        {project.workflowCount === 1
+                          ? "workflow"
+                          : "workflows"}
+                      </span>
+                      {project.workflowCount === 0 && (
+                        <Button
+                          className="text-muted-foreground hover:text-destructive"
+                          onClick={() => handleDeleteProject(project)}
+                          size="icon"
+                          variant="ghost"
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+
+          <TabsContent className="space-y-4" value="tags">
+            <div className="flex justify-end">
+              <Button onClick={() => setShowTagDialog(true)} size="sm">
+                <Plus className="mr-2 size-4" />
+                New Tag
+              </Button>
+            </div>
+
+            {loadingTags && (
+              <div className="flex items-center justify-center py-8">
+                <Spinner />
+              </div>
+            )}
+            {!loadingTags && tags.length === 0 && (
+              <div className="flex flex-col items-center gap-2 py-8 text-center text-muted-foreground">
+                <TagIcon className="size-8" />
+                <p className="text-sm">No tags yet</p>
+                <p className="text-xs">
+                  Create a tag to categorize your workflows.
+                </p>
+              </div>
+            )}
+            {!loadingTags && tags.length > 0 && (
+              <div className="space-y-1">
+                {tags.map((tag) => (
+                  <div
+                    className="flex items-center justify-between rounded-md border px-4 py-3"
+                    key={tag.id}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span
+                        className="inline-block size-3 shrink-0 rounded-full"
+                        style={{ backgroundColor: tag.color }}
+                      />
+                      <p className="font-medium text-sm">{tag.name}</p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-muted-foreground text-xs">
+                        {tag.workflowCount}{" "}
+                        {tag.workflowCount === 1 ? "workflow" : "workflows"}
+                      </span>
+                      {tag.workflowCount === 0 && (
+                        <Button
+                          className="text-muted-foreground hover:text-destructive"
+                          onClick={() => handleDeleteTag(tag)}
+                          size="icon"
+                          variant="ghost"
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+      </Overlay>
+      <ProjectFormDialog
+        onCreated={handleProjectCreated}
+        onOpenChange={setShowProjectDialog}
+        open={showProjectDialog}
+      />
+      <TagFormDialog
+        onCreated={handleTagCreated}
+        onOpenChange={setShowTagDialog}
+        open={showTagDialog}
+      />
+    </>
+  );
+}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1803,7 +1803,7 @@ export const WorkflowToolbar = ({
 
   // If persistent mode, use fixed positioning
   const containerClassName = persistent
-    ? "pointer-events-auto fixed top-0 right-0 left-0 z-50 flex items-center justify-between border-b bg-background px-4 py-3"
+    ? "pointer-events-auto fixed top-[var(--app-banner-height,0px)] right-0 left-0 z-50 flex items-center justify-between border-b bg-background px-4 py-3"
     : "";
 
   const leftSectionClassName = persistent

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -1,31 +1,27 @@
 "use client";
 
 import {
-  Bookmark,
-  FolderOpen,
-  Github,
+  CreditCard,
+  FolderTree,
   Key,
   LogOut,
   Plug,
   Settings,
-  Tag,
   Users,
   Wallet,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import {
   AuthDialog,
   isSingleProviderSignInInitiated,
 } from "@/components/auth/dialog";
 import { ManageOrgsModal } from "@/components/organization/manage-orgs-modal";
-import { AddressBookOverlay } from "@/components/overlays/address-book-overlay";
 import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
-import { FeedbackOverlay } from "@/components/overlays/feedback-overlay";
 import { IntegrationsOverlay } from "@/components/overlays/integrations-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
-import { ProjectsOverlay } from "@/components/overlays/projects-overlay";
+import { ProjectsAndTagsOverlay } from "@/components/overlays/projects-and-tags-overlay";
 import { SettingsOverlay } from "@/components/overlays/settings-overlay";
-import { TagsOverlay } from "@/components/overlays/tags-overlay";
 import { WalletOverlay } from "@/components/overlays/wallet-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -38,13 +34,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { signOut, useSession } from "@/lib/auth-client";
-import { useOrganization } from "@/lib/hooks/use-organization";
+import { isBillingEnabled } from "@/lib/billing/feature-flag";
+import { useActiveMember, useOrganization } from "@/lib/hooks/use-organization";
 
-export const UserMenu = () => {
+export const UserMenu = (): React.ReactElement => {
   const { data: session, isPending } = useSession();
   const { open: openOverlay } = useOverlay();
   const [orgModalOpen, setOrgModalOpen] = useState(false);
   const { organization } = useOrganization();
+  const { isOwner } = useActiveMember();
+  const router = useRouter();
+  const showBilling = isOwner && isBillingEnabled();
 
   const handleLogout = async () => {
     await signOut();
@@ -144,9 +144,9 @@ export const UserMenu = () => {
             </DropdownMenuItem>
             <DropdownMenuSeparator />
           </div>
-          <DropdownMenuItem onClick={() => openOverlay(FeedbackOverlay)}>
-            <Github className="size-4" />
-            <span>Report an issue</span>
+          <DropdownMenuItem onClick={() => openOverlay(WalletOverlay)}>
+            <Wallet className="size-4" />
+            <span>Wallet</span>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => openOverlay(SettingsOverlay)}>
             <Settings className="size-4" />
@@ -160,21 +160,15 @@ export const UserMenu = () => {
             <Key className="size-4" />
             <span>API Keys</span>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => openOverlay(WalletOverlay)}>
-            <Wallet className="size-4" />
-            <span>Wallet</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => openOverlay(AddressBookOverlay)}>
-            <Bookmark className="size-4" />
-            <span>Address Book</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => openOverlay(ProjectsOverlay)}>
-            <FolderOpen className="size-4" />
-            <span>Projects</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => openOverlay(TagsOverlay)}>
-            <Tag className="size-4" />
-            <span>Tags</span>
+          {showBilling && (
+            <DropdownMenuItem onClick={() => router.push("/billing")}>
+              <CreditCard className="size-4" />
+              <span>Billing</span>
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem onClick={() => openOverlay(ProjectsAndTagsOverlay)}>
+            <FolderTree className="size-4" />
+            <span>Projects and Tags</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleLogout}>

--- a/lib/billing/constants.ts
+++ b/lib/billing/constants.ts
@@ -6,6 +6,7 @@ export const BILLING_API = {
   CHECKOUT: "/api/billing/checkout",
   CANCEL: "/api/billing/cancel",
   USAGE_SUGGESTION: "/api/billing/usage-suggestion",
+  BILLING_DETAILS: "/api/billing/billing-details",
 } as const;
 
 export const BILLING_ALERTS = {

--- a/lib/billing/provider.ts
+++ b/lib/billing/provider.ts
@@ -93,6 +93,16 @@ export type ProrationPreview = {
   }[];
 };
 
+export type BillingDetails = {
+  paymentMethod: {
+    brand: string;
+    last4: string;
+    expMonth: number;
+    expYear: number;
+  } | null;
+  billingEmail: string | null;
+};
+
 export interface BillingProvider {
   readonly name: string;
 
@@ -104,6 +114,8 @@ export interface BillingProvider {
     customerId: string,
     returnUrl: string
   ): Promise<{ url: string }>;
+
+  getBillingDetails(customerId: string): Promise<BillingDetails>;
 
   verifyWebhook(body: string, signature: string): Promise<BillingWebhookEvent>;
 

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -1,6 +1,7 @@
 import type Stripe from "stripe";
 import { stripe } from "@/lib/stripe";
 import type {
+  BillingDetails,
   BillingProvider,
   BillingWebhookEvent,
   CreateCheckoutParams,
@@ -261,6 +262,67 @@ export class StripeBillingProvider implements BillingProvider {
       return_url: returnUrl,
     });
     return { url: session.url };
+  }
+
+  async getBillingDetails(customerId: string): Promise<BillingDetails> {
+    const s = getStripe();
+    const customer = await s.customers.retrieve(customerId, {
+      expand: ["invoice_settings.default_payment_method"],
+    });
+
+    if (customer.deleted) {
+      return { paymentMethod: null, billingEmail: null };
+    }
+
+    const defaultPaymentMethod =
+      customer.invoice_settings?.default_payment_method;
+    let card: Stripe.PaymentMethod.Card | null =
+      defaultPaymentMethod &&
+      typeof defaultPaymentMethod === "object" &&
+      defaultPaymentMethod.type === "card"
+        ? (defaultPaymentMethod.card ?? null)
+        : null;
+
+    // Stripe Checkout stores the default payment method on the subscription,
+    // not on the customer. Fall back to the most recent subscription's default,
+    // then to any card attached to the customer.
+    if (!card) {
+      const subs = await s.subscriptions.list({
+        customer: customerId,
+        status: "all",
+        limit: 1,
+        expand: ["data.default_payment_method"],
+      });
+      const subDefault = subs.data[0]?.default_payment_method;
+      if (
+        subDefault &&
+        typeof subDefault === "object" &&
+        subDefault.type === "card"
+      ) {
+        card = subDefault.card ?? null;
+      }
+    }
+
+    if (!card) {
+      const methods = await s.paymentMethods.list({
+        customer: customerId,
+        type: "card",
+        limit: 1,
+      });
+      card = methods.data[0]?.card ?? null;
+    }
+
+    return {
+      paymentMethod: card
+        ? {
+            brand: card.brand,
+            last4: card.last4,
+            expMonth: card.exp_month,
+            expYear: card.exp_year,
+          }
+        : null,
+      billingEmail: customer.email ?? null,
+    };
   }
 
   // biome-ignore lint/suspicious/useAwait: must be async to satisfy BillingProvider interface contract

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -284,15 +284,25 @@ export class StripeBillingProvider implements BillingProvider {
         : null;
 
     // Stripe Checkout stores the default payment method on the subscription,
-    // not on the customer. Fall back to the most recent subscription's default,
-    // then to any card attached to the customer.
+    // not on the customer. Prefer the active subscription's default PM, since
+    // that's the card actually being charged. Fall back to any status only if
+    // there is no active sub, to preserve data for past_due / canceled users
+    // viewing billing history.
     if (!card) {
-      const subs = await s.subscriptions.list({
+      let subs = await s.subscriptions.list({
         customer: customerId,
-        status: "all",
+        status: "active",
         limit: 1,
         expand: ["data.default_payment_method"],
       });
+      if (subs.data.length === 0) {
+        subs = await s.subscriptions.list({
+          customer: customerId,
+          status: "all",
+          limit: 1,
+          expand: ["data.default_payment_method"],
+        });
+      }
       const subDefault = subs.data[0]?.default_payment_method;
       if (
         subDefault &&

--- a/tests/unit/billing-handle-event.test.ts
+++ b/tests/unit/billing-handle-event.test.ts
@@ -66,6 +66,9 @@ function createMockProvider(
     createCustomer: vi.fn(),
     createCheckoutSession: vi.fn(),
     createPortalSession: vi.fn(),
+    getBillingDetails: vi
+      .fn()
+      .mockResolvedValue({ paymentMethod: null, billingEmail: null }),
     verifyWebhook: vi.fn(),
     getSubscriptionDetails: vi.fn().mockResolvedValue({
       priceId: process.env.STRIPE_PRICE_PRO_25K_MONTHLY,

--- a/tests/unit/billing-stripe-provider.test.ts
+++ b/tests/unit/billing-stripe-provider.test.ts
@@ -2,14 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/stripe", () => ({
   stripe: {
-    customers: { create: vi.fn() },
+    customers: { create: vi.fn(), retrieve: vi.fn() },
     checkout: { sessions: { create: vi.fn() } },
     billingPortal: { sessions: { create: vi.fn() } },
     webhooks: { constructEvent: vi.fn() },
     invoiceItems: { create: vi.fn() },
     invoices: { list: vi.fn(), createPreview: vi.fn() },
-    subscriptions: { retrieve: vi.fn(), update: vi.fn() },
+    subscriptions: { retrieve: vi.fn(), update: vi.fn(), list: vi.fn() },
     prices: { retrieve: vi.fn() },
+    paymentMethods: { list: vi.fn() },
   },
 }));
 
@@ -774,6 +775,145 @@ describe("StripeBillingProvider", () => {
       const callArgs = vi.mocked(s.invoiceItems.create).mock
         .calls[0][0] as Record<string, unknown>;
       expect(callArgs.metadata).toBeUndefined();
+    });
+  });
+
+  describe("getBillingDetails", () => {
+    const customerBase = {
+      id: "cus_1",
+      deleted: false,
+      email: "user@test.com",
+      invoice_settings: { default_payment_method: null },
+    };
+
+    function makeCard(last4: string): Record<string, unknown> {
+      return {
+        id: `pm_${last4}`,
+        type: "card",
+        card: {
+          brand: "visa",
+          last4,
+          exp_month: 12,
+          exp_year: 2030,
+        },
+      };
+    }
+
+    type CustomerResponse = Awaited<ReturnType<typeof s.customers.retrieve>>;
+    type SubsListResponse = Awaited<ReturnType<typeof s.subscriptions.list>>;
+    type PMListResponse = Awaited<ReturnType<typeof s.paymentMethods.list>>;
+
+    it("tier 1: returns the customer's default payment method", async () => {
+      vi.mocked(s.customers.retrieve).mockResolvedValue({
+        ...customerBase,
+        invoice_settings: { default_payment_method: makeCard("1111") },
+      } as unknown as CustomerResponse);
+
+      const result = await provider.getBillingDetails("cus_1");
+
+      expect(result).toEqual({
+        paymentMethod: {
+          brand: "visa",
+          last4: "1111",
+          expMonth: 12,
+          expYear: 2030,
+        },
+        billingEmail: "user@test.com",
+      });
+      expect(s.subscriptions.list).not.toHaveBeenCalled();
+      expect(s.paymentMethods.list).not.toHaveBeenCalled();
+    });
+
+    it("tier 2: returns the active subscription's default PM when customer has none", async () => {
+      vi.mocked(s.customers.retrieve).mockResolvedValue(
+        customerBase as unknown as CustomerResponse
+      );
+      vi.mocked(s.subscriptions.list).mockResolvedValueOnce({
+        data: [{ default_payment_method: makeCard("2222") }],
+      } as unknown as SubsListResponse);
+
+      const result = await provider.getBillingDetails("cus_1");
+
+      expect(result.paymentMethod?.last4).toBe("2222");
+      expect(s.subscriptions.list).toHaveBeenCalledTimes(1);
+      expect(s.subscriptions.list).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "active" })
+      );
+      expect(s.paymentMethods.list).not.toHaveBeenCalled();
+    });
+
+    it("tier 2 fallback: queries status=all only when the active list is empty", async () => {
+      vi.mocked(s.customers.retrieve).mockResolvedValue(
+        customerBase as unknown as CustomerResponse
+      );
+      vi.mocked(s.subscriptions.list)
+        .mockResolvedValueOnce({ data: [] } as unknown as SubsListResponse)
+        .mockResolvedValueOnce({
+          data: [{ default_payment_method: makeCard("3333") }],
+        } as unknown as SubsListResponse);
+
+      const result = await provider.getBillingDetails("cus_1");
+
+      expect(result.paymentMethod?.last4).toBe("3333");
+      expect(s.subscriptions.list).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(s.subscriptions.list).mock.calls[0][0]).toMatchObject({
+        status: "active",
+      });
+      expect(vi.mocked(s.subscriptions.list).mock.calls[1][0]).toMatchObject({
+        status: "all",
+      });
+      expect(s.paymentMethods.list).not.toHaveBeenCalled();
+    });
+
+    it("tier 3: falls back to paymentMethods.list when no subscription has a PM", async () => {
+      vi.mocked(s.customers.retrieve).mockResolvedValue(
+        customerBase as unknown as CustomerResponse
+      );
+      vi.mocked(s.subscriptions.list).mockResolvedValue({
+        data: [],
+      } as unknown as SubsListResponse);
+      vi.mocked(s.paymentMethods.list).mockResolvedValue({
+        data: [makeCard("4444")],
+      } as unknown as PMListResponse);
+
+      const result = await provider.getBillingDetails("cus_1");
+
+      expect(result.paymentMethod?.last4).toBe("4444");
+      expect(s.paymentMethods.list).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "card", limit: 1 })
+      );
+    });
+
+    it("returns null paymentMethod when no card is found anywhere", async () => {
+      vi.mocked(s.customers.retrieve).mockResolvedValue(
+        customerBase as unknown as CustomerResponse
+      );
+      vi.mocked(s.subscriptions.list).mockResolvedValue({
+        data: [],
+      } as unknown as SubsListResponse);
+      vi.mocked(s.paymentMethods.list).mockResolvedValue({
+        data: [],
+      } as unknown as PMListResponse);
+
+      const result = await provider.getBillingDetails("cus_1");
+
+      expect(result).toEqual({
+        paymentMethod: null,
+        billingEmail: "user@test.com",
+      });
+    });
+
+    it("returns both nulls for a deleted customer and skips the cascade", async () => {
+      vi.mocked(s.customers.retrieve).mockResolvedValue({
+        id: "cus_1",
+        deleted: true,
+      } as unknown as CustomerResponse);
+
+      const result = await provider.getBillingDetails("cus_1");
+
+      expect(result).toEqual({ paymentMethod: null, billingEmail: null });
+      expect(s.subscriptions.list).not.toHaveBeenCalled();
+      expect(s.paymentMethods.list).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Redesign `/billing` Plans section to mirror the landing page `/pricing` aesthetic and add a new Billing Details card next to Billing History
- Add an owner-auth GET `/api/billing/billing-details` endpoint and `BillingProvider.getBillingDetails()` that cascades customer default → subscription default → first customer payment method (Stripe Checkout attaches cards to subscription, not customer)
- Fix `/billing` exposure to anonymous users (AuthGate mirroring analytics page pattern)
- Reorganize left nav + user menu; consolidate Projects + Tags into a single tabbed overlay

## Changes

### Nav & user menu
- Billing moved from left nav → user menu dropdown (gated on `isOwner && isBillingEnabled()`; navigates to `/billing`)
- Address Book moved to left nav (Billing's former slot); opens overlay on click
- Report an issue added to left nav bottom section under Documentation; opens `FeedbackOverlay`
- User menu order: Wallet → Settings → Connections → API Keys → Billing → Projects and Tags → Logout
- New `ProjectsAndTagsOverlay` replaces the two separate overlays (mirrors `SettingsOverlay` tabbed pattern)
- `NavItem` gains an `ACTION_ITEM_IDS` allowlist so `href: null` items that open overlays are not marked "Coming Soon"

### Billing page (`/billing`)
- Pricing table uses landing aesthetic: pill Monthly/Annual toggle with inline "Save 20%" badge; centered 4-col grid at xl; HeroMetrics stat panel per card; custom `TierSelect` dropdown with green highlight for the selected tier
- Outline the current plan with a thin `keeperhub-green-dark` border + `CURRENT` badge (removed the old `POPULAR` Pro highlight)
- Enterprise card consistent with the others ("Custom" price, "Talk to us" CTA, `mailto:human@keeperhub.com`)
- Shared "Compare all features" toggle below the grid reveals a 10-row striped `ComparisonTable` with the Enterprise column accented in green
- CTA label normalized to "Change plan" for all paid plan changes
- Removed subheadings under price and the redundant executions pill on the Current Plan card
- Renewal message ("Your plan ends on …") rendered inline with the plan name + status pill
- Usage + gas credit bars restyled on keeperhub-green tokens with a `/15` track; overage tail in yellow
- FAQ link footer routes to `https://keeperhub.com/pricing`

### Billing Details card (new)
- Rendered next to BillingHistory in a `lg:grid-cols-[2fr_1fr]` layout
- Shows card brand + last4 + expiry and invoice email
- Pencil inline next to the title opens the Stripe portal (`/api/billing/portal`); empty state when no card on file

### Data plumbing
- `BillingDetails` type + `getBillingDetails(customerId)` on `BillingProvider` interface
- Stripe provider implementation cascades through three sources (customer default → subscription default → first customer payment method) because Stripe Checkout attaches the card to the subscription, not the customer, by default
- `BILLING_DETAILS` added to `BILLING_API` constants
- New `GET /api/billing/billing-details` route (owner-auth, same pattern as existing billing endpoints)
- `/billing` bumps `refreshKey` 2s after `?checkout=success` so BillingDetails remounts once Stripe has attached the payment method

### Fixes & copy
- Anonymous users visiting `/billing` now see a "Sign in to view billing" AuthGate (was rendering the pricing table to unauthenticated users)
- Confirm plan change dialog: removed leading `--` before the prorated billing note
- Billing history View / PDF links recolored to keeperhub green

### Tests
- `tests/unit/billing-handle-event.test.ts` mock provider stubs `getBillingDetails`

## UAT — Phase 31 Stripe Billing (11/11 passed, 0 issues)

Driven interactively over a live dev environment (`localhost:3000`, Docker Postgres, Stripe CLI listener, test-mode customer).

| # | Test | Result |
|---|---|---|
| 1 | Cold Start Smoke + Billing Auth Gate | pass — fixed local env DB port (5432 → `127.0.0.1:5433`), added AuthGate |
| 2 | Billing Page Renders Pricing + Current Plan | pass after redesign landed in this PR |
| 3 | New Subscription via Checkout (Pro 25k Monthly, `4242 …`) | pass — card attached to subscription, UI picks it up via cascade |
| 4 | Plan Upgrade with Proration (25k → 50k) | pass |
| 5 | Cancel at Period End | pass |
| 6 | Customer Portal Opens | pass |
| 7 | Webhook Idempotency | pass — two back-to-back `stripe trigger invoice.paid`, all 200s, zero duplicate `billing_events` rows |
| 8 | Overage Billing | pass — drove 100,050 synthetic executions, `/api/billing/overage` returned `{billed:true, overageCount:50, totalChargeCents:10}` (Pro $2/1K), idempotent re-call returned `already billed for this period` |
| 9 | Execution Debt 15-day Grace | pass — backdated overage, finalized unpaid Stripe invoice, `/api/billing/debt-scan` created debt, workflow execution returned 429 "Executions suspended due to unpaid overage invoice", `stripe invoices pay` fired `invoice.paid` webhook, `clearDebtForInvoice` flipped status to `cleared`, workflow ran again |
| 10 | Invoice Listing + Pagination | pass |
| 11 | Usage Suggestion Recommends Upgrade | pass — initial 100k@day21 correctly returned `shouldUpgrade: false` (Pro 100k + projected overage still cheaper than Business 250k); once pushed to 130k actual (projected 185k), blue `UpgradeSuggestionBanner` rendered at top of Current Plan card |

### Notes for reviewers

- Initial testing guide (shared at session start) listed overage rates as Pro $0.20/1K and Business $0.15/1K. **Code is authoritative at $2/1K (Pro) and $1.50/1K (Business)** per `lib/billing/plans.ts`. UI already renders the correct rates. Verified with whoever owns pricing; guide was stale.
- Test 8 used a temporary local `HUB_SERVICE_API_KEY` for `/api/billing/overage` and `/api/billing/debt-scan` endpoint auth. Don't forward that value — production/staging should have its own service key rotation.
- Test 8/9 left synthetic rows in the dev DB (~130k `workflow_executions`, 1 `overage_billing_records`, 1 cleared `execution_debt`). Harmless but clean up if you reuse that local DB:
  ```sql
  DELETE FROM workflow_executions WHERE id LIKE 'exec_ovtest%';
  DELETE FROM execution_debt WHERE organization_id='<dev org id>';
  DELETE FROM overage_billing_records WHERE organization_id='<dev org id>';
  ```

## Test plan

- [x] `pnpm check` and `pnpm type-check` pass locally
- [ ] `/billing` renders correctly for Free org (pricing table, no Billing Details / no Overage section)
- [ ] `/billing` renders correctly for Pro org with active subscription (Billing Details shows card, renewal message inline)
- [ ] Anonymous `/billing` visit renders AuthGate, not pricing table
- [ ] Avatar → Billing link routes to `/billing` only for owners
- [ ] Left nav Address Book opens overlay; Report an issue opens feedback overlay
- [ ] Projects and Tags user-menu item opens a tabbed overlay; both tabs CRUD correctly
- [ ] Stripe Checkout → Billing Details card picks up the card within a few seconds of redirect
- [ ] Plan upgrade triggers proration dialog; confirm updates subscription without new Checkout session
- [ ] Existing billing unit + integration tests still pass (`pnpm test billing`)

---

### Addendum: announcement banner (added 2026-04-21)

Third commit adds a skinny (36px) dismissible banner at the top of the app to introduce paid plans to existing users.

- `components/app-banner.tsx` — fixed 36px strip, keeperhub-green tint with border, centered info icon + body + "See plans" link, close (X) at right edge
- Copy: *"New Pro and Business plans unlock higher execution limits and gas credits. Free stays free forever. See plans"*
- Dismissal is permanent-per-browser via `localStorage` key `kh-billing-announce-v1` (version suffix lets us introduce a new banner later without wiping other prefs)
- Banner height exposed via `--app-banner-height` CSS var on `<html>` so fixed overlays shift down and snap back cleanly. Touches: workflow-toolbar, navigation-sidebar, flyout-panel, workflow page side-panel, and the `pt-20` of `/billing`, `/analytics`, `/earnings`
- No hydration flash: component renders null until mounted to avoid SSR/client localStorage mismatch

To re-trigger the banner in dev (for QA): `localStorage.removeItem("kh-billing-announce-v1")` + refresh.