### PR TITLE
fix: KEEP-290 hide delete option on trigger nodes

### DIFF
--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -1178,15 +1178,17 @@ export const PanelInner = () => {
                         )}
                       </Button>
                     )}
-                    <Button
-                      className="text-muted-foreground"
-                      onClick={() => setShowDeleteNodeAlert(true)}
-                      size="sm"
-                      variant="ghost"
-                    >
-                      <Trash2 className="mr-2 size-4" />
-                      Delete
-                    </Button>
+                    {selectedNode.data.type !== "trigger" && (
+                      <Button
+                        className="text-muted-foreground"
+                        onClick={() => setShowDeleteNodeAlert(true)}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        <Trash2 className="mr-2 size-4" />
+                        Delete
+                      </Button>
+                    )}
                   </div>
                 </div>
               )}

--- a/components/workflow/workflow-context-menu.tsx
+++ b/components/workflow/workflow-context-menu.tsx
@@ -144,12 +144,6 @@ export function WorkflowContextMenu({
     return null;
   }
 
-  // Check if the node is a trigger (can't be deleted)
-  const isTriggerNode = Boolean(
-    menuState.nodeId &&
-      nodes.find((n) => n.id === menuState.nodeId)?.data.type === "trigger"
-  );
-
   const getNodeLabel = () => {
     if (!menuState.nodeId) {
       return "Step";
@@ -169,7 +163,6 @@ export function WorkflowContextMenu({
     >
       {menuState.type === "node" && (
         <MenuItem
-          disabled={isTriggerNode}
           icon={<Trash2 className="size-4" />}
           label={`Delete ${getNodeLabel()}`}
           onClick={handleDeleteNode}
@@ -239,6 +232,10 @@ export function useContextMenuHandlers(
   const onNodeContextMenu = useCallback(
     (event: React.MouseEvent, node: Node) => {
       event.preventDefault();
+      const data = node.data as WorkflowNode["data"] | undefined;
+      if (data?.type === "trigger") {
+        return;
+      }
       setMenuState({
         type: "node",
         position: { x: event.clientX, y: event.clientY },


### PR DESCRIPTION
## Summary
- Trigger node is the workflow anchor and cannot be deleted. Previously both the node properties tab and the right-click context menu offered a delete affordance (non-functional for triggers). This removes them on trigger nodes only.
- `components/workflow/node-config-panel.tsx`: hide the Delete button on trigger nodes.
- `components/workflow/workflow-context-menu.tsx`: early-return in `onNodeContextMenu` for trigger nodes so the menu never opens; dead `disabled={isTriggerNode}` branch removed from the Delete `MenuItem`.

## Test plan
- [x] Open a workflow. Click the trigger node — properties panel shows no Delete button. Delete / Backspace still no-op on trigger (pre-existing behavior, verified unaffected).
- [x] Right-click the trigger node — no context menu opens.
- [x] Click a non-trigger step — properties panel still shows Delete; clicking Delete + confirm removes the node.
- [x] Right-click a non-trigger step — context menu opens with "Delete {label}" and works.
- [x] Right-click empty canvas and right-click an edge still work as before.