### PR TITLE
fix: KEEP-291 config panel retains previous node's field inputs

### DIFF
--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -1084,7 +1084,10 @@ export const PanelInner = () => {
             !selectedNode.data.config?.actionType &&
             isOwner
           ) && (
-            <div className="flex-1 space-y-4 overflow-y-auto p-4">
+            <div
+              className="flex-1 space-y-4 overflow-y-auto p-4"
+              key={selectedNode.id}
+            >
               {selectedNode.data.type === "trigger" && (
                 <TriggerConfig
                   config={selectedNode.data.config || {}}

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -1084,6 +1084,9 @@ export const PanelInner = () => {
             !selectedNode.data.config?.actionType &&
             isOwner
           ) && (
+            // key forces this subtree to remount when the selected node
+            // changes, resetting local useState in leaf field components so
+            // the previous node's inputs don't leak into the new node's panel.
             <div
               className="flex-1 space-y-4 overflow-y-auto p-4"
               key={selectedNode.id}


### PR DESCRIPTION
## Summary

- Adds `key={selectedNode.id}` on the per-node config wrapper in `components/workflow/node-config-panel.tsx` so the subtree fully unmounts and remounts when a different node is selected.
- Root cause: React preserved leaf-component state across prop changes (e.g. `AbiFunctionArgsField.localArgValues`, `FieldGroup.isExpanded`) because the components stayed at the same tree position. Result was old node's field inputs persisting after clicking a new node.
- This replaces the per-field workaround pattern (the existing `category` resync effect in `action-config.tsx`) with a structural fix that holds for any future field component that uses local state.

## Test plan

- [x] Open a workflow with two or more configured action nodes
- [x] Click node A, confirm its field inputs render
- [x] Click node B, confirm its field inputs replace A's (no stale values)
- [x] Repeat with trigger + action pair
- [x] Repeat with two nodes calling the same ABI function name (e.g. both `transfer`) - the arg values in `AbiFunctionArgsField` should reflect the newly-selected node
- [x] Verify expand/collapse state of `FieldGroup` doesn't leak across nodes
- [x] Spot-check that editing a field on one node still updates correctly (no regression in the within-node edit path)