### PR TITLE
fix: KEEP-288 guard onConnectEnd node creation with connectionState.isValid

### DIFF
--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -2,6 +2,7 @@
 
 import {
   ConnectionMode,
+  type FinalConnectionState,
   MiniMap,
   type Node,
   type NodeMouseHandler,
@@ -562,30 +563,16 @@ export function WorkflowCanvas() {
   );
 
   const onConnectEnd = useCallback(
-    (event: MouseEvent | TouchEvent) => {
+    (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
       if (!connectingNodeId.current) {
         return;
       }
 
-      // Get client position first
-      const { clientX, clientY } = getClientPosition(event);
-
-      // For touch events, use elementFromPoint to get the actual element at the touch position
-      // For mouse events, use event.target as before
-      const target =
-        "changedTouches" in event
-          ? document.elementFromPoint(clientX, clientY)
-          : (event.target as Element);
-
-      if (!target) {
-        connectingNodeId.current = null;
-        return;
-      }
-
-      const isNode = target.closest(".react-flow__node");
-      const isHandle = target.closest(".react-flow__handle");
-
-      if (!(isNode || isHandle)) {
+      // isValid === null: pointer never entered a handle's connection radius (pane drop).
+      // true: valid connection -- onConnect already created the edge.
+      // false: over a handle that rejected the drop -- do nothing.
+      if (connectionState.isValid === null) {
+        const { clientX, clientY } = getClientPosition(event);
         const { adjustedX, adjustedY } = calculateMenuPosition(
           event,
           clientX,


### PR DESCRIPTION
## Summary

In the workflow canvas, dragging a connection from one node's handle to another node's handle successfully created the edge *and* spawned a spurious extra node with its own spurious edge.

Root cause: `onConnectEnd` used a DOM hit-test (`event.target.closest('.react-flow__node' | '.react-flow__handle')`) to decide whether the drop landed on empty pane. During an xyflow connection drag, `event.target` on mouseup can be the connection-line SVG overlay rather than the target handle, so the pane-drop branch fired even on successful handle-to-handle drops -- creating a node in addition to the edge that `onConnect` already made.

Fix: replace the DOM hit-test with xyflow's own `FinalConnectionState.isValid`. Only `isValid === null` (pointer never entered a handle's connection radius) is treated as a true pane drop.

- `true`: valid connection -- onConnect handled it, skip.
- `false`: over an invalid handle -- skip (preserves prior behavior where the DOM check also skipped).
- `null`: genuine pane drop -- create fallback node + edge.

File touched: `components/workflow/workflow-canvas.tsx`.

## Test plan

- [x] Drag from one node's handle to another node's handle -> only one edge is created, no extra node.
- [x] Drag from a handle to empty canvas -> new action node is created and auto-connected (existing pane-drop feature preserved).
- [x] Drop on an invalid handle (e.g. source-to-source) -> nothing happens.
- [x] For Each / Condition connection auto-handle assignment still works (unchanged path).