### PR TITLE
fix: KEEP-293 tolerate missing ECR credentials for Dependabot PR builds

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -143,7 +143,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Configure AWS credentials
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
@@ -151,7 +151,7 @@ jobs:
           aws-region: ${{ vars.TO_REGION }}
 
       - name: Login to AWS ECR
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -50,13 +50,13 @@ target "app" {
     NEXT_PUBLIC_BILLING_ENABLED  = NEXT_PUBLIC_BILLING_ENABLED
     NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
   }
-  tags = compact([
+  tags = ECR_REGISTRY != "" ? compact([
     "${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}",
     "${ECR_REGISTRY}/${ECR_REPO}:app-latest",
     ENVIRONMENT_TAG != "" ? "${ECR_REGISTRY}/${ECR_REPO}:${ENVIRONMENT_TAG}" : "",
-  ])
-  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"]
-  cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app,mode=max"]
+  ]) : []
+  cache-from = ECR_REGISTRY != "" ? ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"] : []
+  cache-to   = ECR_REGISTRY != "" ? ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app,mode=max"] : []
 }
 
 target "sentry-upload" {


### PR DESCRIPTION
## Summary

The `build` job in `pr-checks.yml` has failed on every Dependabot-authored PR since KEEP-266 + KEEP-267 landed (2026-04-17) because the job requires AWS/ECR credentials that Dependabot workflow runs cannot access.

Fix:
- `.github/workflows/pr-checks.yml`: skip `Configure AWS credentials` and `Login to AWS ECR` steps when `github.actor == 'dependabot[bot]'`. ECR_REGISTRY env var then arrives empty at the bake step.
- `docker-bake.hcl`: guard `tags`, `cache-from`, `cache-to` on the `app` target with `ECR_REGISTRY != ""`. Empty registry -> no tags, no cache, pure Dockerfile validation build.

Only the `app` target is modified because the PR CI build job only builds the `app` target. Deploy/release workflows that build the other targets (`migrator`, `workflow-runner`, etc.) always have ECR credentials, so those targets are untouched.

## Root cause

Before KEEP-267, PR CI ran `pnpm build` (no AWS needed) and Dependabot PRs worked. KEEP-267 replaced it with `docker buildx bake` + ECR cache, which requires `secrets.TO_AWS_ACCESS_KEY_ID` / `TO_AWS_SECRET_ACCESS_KEY` — both scoped to the `staging` environment. GitHub deliberately does not expose Actions secrets or environment secrets to Dependabot workflow runs, so both references resolve to empty strings, `aws-actions/configure-aws-credentials@v6` exhausts its provider chain, and the job fails with `Could not load credentials from any providers`.

Regular (human-authored) PRs are unaffected — they have normal environment access and the `build` job passes (e.g., #905).

First visible failure: #889 (dompurify bump in docs-site). Ticket: KEEP-293.

## Tradeoff

Dependabot validation runs without registry build cache -- full cold build, ~5-10 min. Acceptable for correctness.

## Test plan

- [x] Merge this PR to `staging`
- [x] Rebase PR #889 (Dependabot dompurify bump) onto updated `staging`
- [x] Confirm #889's `build` check passes without any AWS creds being granted to Dependabot
- [x] Verify a regular (human-authored) PR still exercises the ECR cache path as before