### PR TITLE
fix(bazaar): emit discoverable/category/tags + fix resource URL for CDP Bazaar indexing

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -4,7 +4,7 @@ import { start } from "workflow/api";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { db } from "@/lib/db";
-import { workflowExecutions, workflows } from "@/lib/db/schema";
+import { tags, workflowExecutions, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { hashMppCredential } from "@/lib/mpp/server";
@@ -166,8 +166,9 @@ async function createAndStartExecution(
 
 async function lookupWorkflow(slug: string): Promise<CallRouteWorkflow | null> {
   const rows = await db
-    .select(CALL_ROUTE_COLUMNS)
+    .select({ ...CALL_ROUTE_COLUMNS, tagName: tags.name })
     .from(workflows)
+    .leftJoin(tags, eq(workflows.tagId, tags.id))
     .where(and(eq(workflows.listedSlug, slug), eq(workflows.isListed, true)))
     .limit(1);
   return rows[0] ?? null;

--- a/lib/payments/router.ts
+++ b/lib/payments/router.ts
@@ -41,6 +41,8 @@ type Dual402Params = {
   workflowName: string;
   resourceUrl: string;
   inputSchema?: Record<string, unknown> | null;
+  category?: string | null;
+  tagName?: string | null;
 };
 
 type PaymentRequiredV2 = {
@@ -81,6 +83,8 @@ function buildPaymentRequired(params: Dual402Params): PaymentRequiredV2 {
     workflowName,
     resourceUrl,
     inputSchema,
+    category,
+    tagName,
   } = params;
   const amountSmallestUnit = String(
     Math.round(Number(price) * 10 ** USDC_DECIMALS)
@@ -106,18 +110,24 @@ function buildPaymentRequired(params: Dual402Params): PaymentRequiredV2 {
     ],
   };
 
+  // CDP Bazaar discovery: `discoverable: true` opts the resource into the
+  // marketplace index. The schema subtree feeds agentcash / x402scan probers.
+  const bazaar: Record<string, unknown> = { discoverable: true };
+  if (category) {
+    bazaar.category = category;
+  }
+  if (tagName) {
+    bazaar.tags = [tagName];
+  }
   if (inputSchema) {
-    payload.extensions = {
-      bazaar: {
-        schema: {
-          properties: {
-            input: { properties: { body: inputSchema } },
-            output: { properties: { example: WORKFLOW_OUTPUT_EXAMPLE } },
-          },
-        },
+    bazaar.schema = {
+      properties: {
+        input: { properties: { body: inputSchema } },
+        output: { properties: { example: WORKFLOW_OUTPUT_EXAMPLE } },
       },
     };
   }
+  payload.extensions = { bazaar };
 
   return payload;
 }
@@ -362,14 +372,24 @@ export function gatePayment(
     return handleMpp(request, workflow, creatorWalletAddress, createHandler);
   }
 
-  // No payment header -- return dual 402 challenge
+  // No payment header -- return dual 402 challenge.
+  // Resource URL must use the public hostname (not request.url, which can be
+  // the internal pod bind `0.0.0.0:3000` inside K8s) or the CDP Bazaar
+  // crawler and any other caller will fail to resolve the endpoint.
+  const publicHost =
+    process.env.NEXT_PUBLIC_APP_URL ?? "https://app.keeperhub.com";
+  const resourceUrl = workflow.listedSlug
+    ? `${publicHost}/api/mcp/workflows/${workflow.listedSlug}/call`
+    : request.url;
   return Promise.resolve(
     buildDual402Response({
       price: workflow.priceUsdcPerCall ?? "0",
       creatorWalletAddress,
       workflowName: workflow.name,
-      resourceUrl: request.url,
+      resourceUrl,
       inputSchema: workflow.inputSchema,
+      category: workflow.category,
+      tagName: workflow.tagName,
     }) as NextResponse
   );
 }

--- a/lib/x402/types.ts
+++ b/lib/x402/types.ts
@@ -4,6 +4,7 @@ import { workflows } from "@/lib/db/schema";
  * Exact columns the call route needs from the workflows table.
  * priceUsdcPerCall returns string | null from Drizzle (numeric column).
  * nodes and edges are needed for execution; userId for creating the execution record.
+ * category/tagId feed the x402 Bazaar extensions for marketplace discovery.
  */
 export type CallRouteWorkflow = {
   id: string;
@@ -19,6 +20,8 @@ export type CallRouteWorkflow = {
   nodes: unknown[];
   edges: unknown[];
   userId: string;
+  category: string | null;
+  tagName: string | null;
 };
 
 /**
@@ -40,4 +43,5 @@ export const CALL_ROUTE_COLUMNS = {
   nodes: workflows.nodes,
   edges: workflows.edges,
   userId: workflows.userId,
+  category: workflows.category,
 } as const;

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -420,8 +420,14 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
   }));
 
   vi.mock("@/lib/db/schema", () => ({
-    workflows: { id: "id", listedSlug: "listed_slug", isListed: "is_listed" },
+    workflows: {
+      id: "id",
+      listedSlug: "listed_slug",
+      isListed: "is_listed",
+      tagId: "tag_id",
+    },
     workflowExecutions: { id: "id" },
+    tags: { id: "id", name: "name" },
   }));
 
   vi.mock("@/lib/x402/server", () => ({
@@ -501,10 +507,15 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
   };
 
   function setupDbSelectWorkflow(row: unknown) {
+    // lookupWorkflow joins the tags table to project tagName into the row;
+    // the real chain is select().from().leftJoin().where().limit(). Mirror
+    // that shape here or the real code throws on the missing .leftJoin().
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue(row ? [row] : []),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(row ? [row] : []),
+          }),
         }),
       }),
     });

--- a/tests/unit/payment-router.test.ts
+++ b/tests/unit/payment-router.test.ts
@@ -252,7 +252,7 @@ describe("buildDual402Response", () => {
     ).toEqual({ executionId: "exec_abc123", status: "running" });
   });
 
-  it("omits extensions block when inputSchema is absent", async () => {
+  it("always emits extensions.bazaar.discoverable:true so CDP Bazaar indexes the resource", async () => {
     const response = buildDual402Response({
       price: "0.01",
       creatorWalletAddress: "0xCreator",
@@ -260,6 +260,25 @@ describe("buildDual402Response", () => {
       resourceUrl: "https://example.com/api/mcp/workflows/test/call",
     });
     const body = await response.json();
-    expect(body.extensions).toBeUndefined();
+    expect(body.extensions.bazaar.discoverable).toBe(true);
+    // schema subtree is only populated when inputSchema is provided
+    expect(body.extensions.bazaar.schema).toBeUndefined();
+    expect(body.extensions.bazaar.category).toBeUndefined();
+    expect(body.extensions.bazaar.tags).toBeUndefined();
+  });
+
+  it("emits extensions.bazaar.category and tags when provided", async () => {
+    const response = buildDual402Response({
+      price: "0.01",
+      creatorWalletAddress: "0xCreator",
+      workflowName: "Test Workflow",
+      resourceUrl: "https://example.com/api/mcp/workflows/test/call",
+      category: "web3",
+      tagName: "defi",
+    });
+    const body = await response.json();
+    expect(body.extensions.bazaar.discoverable).toBe(true);
+    expect(body.extensions.bazaar.category).toBe("web3");
+    expect(body.extensions.bazaar.tags).toEqual(["defi"]);
   });
 });

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -53,8 +53,14 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/db/schema", () => ({
-  workflows: { id: "id", listedSlug: "listed_slug", isListed: "is_listed" },
+  workflows: {
+    id: "id",
+    listedSlug: "listed_slug",
+    isListed: "is_listed",
+    tagId: "tag_id",
+  },
   workflowExecutions: { id: "id" },
+  tags: { id: "id", name: "name" },
 }));
 
 vi.mock("@/lib/x402/payment-gate", () => ({
@@ -128,10 +134,15 @@ const FREE_WORKFLOW_NULL_PRICE = { ...LISTED_WORKFLOW, priceUsdcPerCall: null };
 const CREATOR_WALLET = "0xCREATOR_WALLET";
 
 function setupDbSelectWorkflow(row: unknown) {
+  // lookupWorkflow joins the tags table to project tagName into the row, so
+  // the chain is: select().from().leftJoin().where().limit(). Mirror that
+  // shape here or the real code throws on the missing .leftJoin().
   mockDbSelect.mockReturnValue({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(row ? [row] : []),
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(row ? [row] : []),
+        }),
       }),
     }),
   });


### PR DESCRIPTION
## Summary

Two fixes so the Coinbase CDP Bazaar (agentic.market) can index our paid workflow endpoints:

1. **Missing discovery metadata.** The Bazaar crawler looks for `extensions.bazaar.discoverable:true` plus optional `category` and `tags` in the `PAYMENT-REQUIRED` body. Prior work (KEEP-176, PRs #835 #837 #840) populated `extensions.bazaar.schema` for agentcash/x402scan/mppscan but none of the Bazaar-specific fields. Without `discoverable:true` the Bazaar sees us as x402-compliant but does not surface us in the marketplace.

2. **Resource URL uses internal pod host.** Prod probe today returned `resource.url: https://0.0.0.0:3000/api/mcp/workflows/mcp-test/call`. PR #837 threaded `request.url` through, which resolves to the internal pod bind (`0.0.0.0:3000`) in K8s. `buildPaymentConfig()` in `lib/x402/payment-gate.ts` already uses `NEXT_PUBLIC_APP_URL` correctly; `buildDual402Response()` now does too.

## Evidence

Before, against prod:

```
$ curl -X POST https://app.keeperhub.com/api/mcp/workflows/mcp-test/call -d '{}'
{"x402Version":2,"error":"Payment required",
 "resource":{"url":"https://0.0.0.0:3000/api/mcp/workflows/mcp-test/call",...},
 "accepts":[...],
 "extensions":{"bazaar":{"schema":{...}}}}
```

After, with the change applied locally:

```
resource.url = https://app.keeperhub.com/api/mcp/workflows/mcp-test/call
extensions.bazaar = { discoverable: true, schema: {...} }
// when category/tag are set on the workflow:
extensions.bazaar = { discoverable: true, category, tags: [tagName], schema }
```

## What changed

- `lib/payments/router.ts` -- extended `Dual402Params` with `category`/`tagName`; `buildPaymentRequired` always emits `extensions.bazaar.discoverable:true`, and adds `category`/`tags`/`schema` only when their inputs are populated; `gatePayment` builds `resource.url` from `NEXT_PUBLIC_APP_URL` (fallback `https://app.keeperhub.com`) instead of `request.url`.
- `lib/x402/types.ts` -- added `category` and `tagName` to `CallRouteWorkflow`; added `category` to `CALL_ROUTE_COLUMNS`.
- `app/api/mcp/workflows/[slug]/call/route.ts` -- `lookupWorkflow` now `leftJoin`s the `tags` table to project `tagName`.
- `tests/unit/payment-router.test.ts` -- replaced the "omits extensions when inputSchema absent" case with "always emits discoverable:true"; added case covering `category`/`tags` emission.

## Test plan

- [x] `pnpm vitest run tests/unit/payment-router.test.ts` -- 16/16 passing
- [x] `pnpm type-check` clean
- [ ] After deploy, re-probe `mcp-test` in prod: `resource.url` shows `app.keeperhub.com`, `extensions.bazaar.discoverable === true`
- [ ] Backfill `category` on listed workflows so the marketplace listing has real metadata (currently `null` on `mcp-test`)
- [ ] Confirm listing appears on https://agentic.market (CDP Bazaar crawls via the CDP facilitator, which we already use -- `X402_FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402` in staging + prod values.yaml)
- [ ] Re-run `pnpm tsx scripts/test-payments-prod.ts` full suite against prod

## Not in scope

- No registration form/endpoint -- Coinbase Bazaar discovery is automatic via the CDP facilitator.
- KEEP-264 (`x-discovery.ownershipProofs` on `/openapi.json`) -- separate trust-tier signaling, deferred.
- KEEP-261 Tempo chain ID audit -- deliberately separate; this PR stays focused on Bazaar indexing.

Closes KEEP-294. Related: KEEP-176, KEEP-264.