### PR TITLE
feat(earnings): per-chain revenue breakdown + docs tooltip (KEEP-259 part 2)

### DIFF
--- a/components/earnings/earnings-kpi-cards.tsx
+++ b/components/earnings/earnings-kpi-cards.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useAtomValue } from "jotai";
-import { Activity, DollarSign, TrendingUp } from "lucide-react";
+import { Activity, DollarSign, HelpCircle, TrendingUp } from "lucide-react";
+import Link from "next/link";
 import type { ReactNode } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { earningsDataAtom, earningsLoadingAtom } from "@/lib/atoms/earnings";
@@ -28,6 +29,8 @@ type KpiCardProps = {
   label: string;
   value: string;
   subtext?: string;
+  helpHref?: string;
+  helpTitle?: string;
   iconClassName?: string;
 };
 
@@ -36,6 +39,8 @@ function KpiCard({
   label,
   value,
   subtext,
+  helpHref,
+  helpTitle,
   iconClassName,
 }: KpiCardProps): ReactNode {
   return (
@@ -43,7 +48,21 @@ function KpiCard({
       <CardContent className="pt-0">
         <div className="flex items-center justify-between">
           <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">{label}</p>
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm text-muted-foreground">{label}</p>
+              {helpHref ? (
+                <Link
+                  aria-label={helpTitle ?? `Learn more about ${label}`}
+                  className="text-muted-foreground/70 hover:text-foreground"
+                  href={helpHref}
+                  rel="noopener"
+                  target="_blank"
+                  title={helpTitle}
+                >
+                  <HelpCircle className="size-3.5" />
+                </Link>
+              ) : null}
+            </div>
             <p className="text-2xl font-semibold tracking-tight">{value}</p>
             {subtext ? (
               <p className="text-xs text-muted-foreground">{subtext}</p>
@@ -88,18 +107,30 @@ export function EarningsKpiCards(): ReactNode {
     totalCreatorEarnings,
     totalInvocations,
     creatorSharePercent,
+    perChain,
   } = data;
+
+  // Revenue arrives on Base (x402/USDC) or Tempo (MPP/USDC.e) depending on
+  // which protocol the calling agent used. Showing the split inline prevents
+  // creators from treating a zero on one chain as a bug.
+  const revenueChainSplit = `Base ${perChain.base.grossRevenue} -- Tempo ${perChain.tempo.grossRevenue}`;
+  const invocationChainSplit = `Base ${perChain.base.invocationCount.toLocaleString()} -- Tempo ${perChain.tempo.invocationCount.toLocaleString()}`;
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <KpiCard
+          helpHref="https://docs.keeperhub.com/workflows/paid-workflows"
+          helpTitle="How dual-chain revenue works"
           icon={<DollarSign className="size-5" />}
           iconClassName="bg-green-500/10 text-green-600 dark:text-green-400"
           label="Total Revenue"
+          subtext={revenueChainSplit}
           value={totalGrossRevenue}
         />
         <KpiCard
+          helpHref="https://docs.keeperhub.com/workflows/paid-workflows"
+          helpTitle="How creator earnings are calculated"
           icon={<TrendingUp className="size-5" />}
           iconClassName="bg-keeperhub-green/10 text-keeperhub-green-dark"
           label="Earnings"
@@ -110,6 +141,7 @@ export function EarningsKpiCards(): ReactNode {
           icon={<Activity className="size-5" />}
           iconClassName="bg-blue-500/10 text-blue-600 dark:text-blue-400"
           label="Total Invocations"
+          subtext={invocationChainSplit}
           value={totalInvocations.toLocaleString()}
         />
       </div>

--- a/lib/earnings/queries.ts
+++ b/lib/earnings/queries.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { workflowPayments } from "@/lib/db/schema-payments";
 import type {
+  ChainEarnings,
   EarningsSummary,
   SettlementStatus,
   WorkflowEarningsRow,
@@ -138,6 +139,10 @@ export async function getEarningsSummary(
       totalInvocations: 0,
       platformFeePercent,
       creatorSharePercent,
+      perChain: {
+        base: { grossRevenue: formatUsdc(0), invocationCount: 0 },
+        tempo: { grossRevenue: formatUsdc(0), invocationCount: 0 },
+      },
       workflows: [],
       total: 0,
       page,
@@ -180,6 +185,20 @@ export async function getEarningsSummary(
 
   const totalGross = Number(orgTotals?.grossRevenue ?? "0");
   const totalInvocations = orgTotals?.invocationCount ?? 0;
+
+  // Per-chain breakdown so creators see Base (x402/USDC) vs Tempo (MPP/USDC.e)
+  // split instead of just an aggregate. See docs/workflows/paid-workflows.md.
+  const perChainRows = await db
+    .select({
+      chain: workflowPayments.chain,
+      grossRevenue: sum(workflowPayments.amountUsdc),
+      invocationCount: count(workflowPayments.id),
+    })
+    .from(workflowPayments)
+    .where(inArray(workflowPayments.workflowId, orgWorkflowIds))
+    .groupBy(workflowPayments.chain);
+
+  const perChain = buildPerChainEarnings(perChainRows);
 
   // Per-workflow revenue for the current page only
   const revenueRows = await db
@@ -259,10 +278,51 @@ export async function getEarningsSummary(
     totalInvocations,
     platformFeePercent,
     creatorSharePercent,
+    perChain,
     workflows: paginatedRows,
     total,
     page,
     pageSize,
     hasListedWorkflows: true,
   };
+}
+
+type PerChainRow = {
+  chain: string;
+  grossRevenue: string | null;
+  invocationCount: number;
+};
+
+/**
+ * Reshapes the chain-grouped SQL result into the fixed { base, tempo } shape
+ * expected by the UI. Missing chains default to zero so the UI never has to
+ * null-check.
+ */
+export function buildPerChainEarnings(rows: PerChainRow[]): {
+  base: ChainEarnings;
+  tempo: ChainEarnings;
+} {
+  const base: ChainEarnings = {
+    grossRevenue: formatUsdc(0),
+    invocationCount: 0,
+  };
+  const tempo: ChainEarnings = {
+    grossRevenue: formatUsdc(0),
+    invocationCount: 0,
+  };
+  for (const row of rows) {
+    const gross = Number(row.grossRevenue ?? "0");
+    const entry: ChainEarnings = {
+      grossRevenue: formatUsdc(gross),
+      invocationCount: row.invocationCount,
+    };
+    if (row.chain === "base") {
+      base.grossRevenue = entry.grossRevenue;
+      base.invocationCount = entry.invocationCount;
+    } else if (row.chain === "tempo") {
+      tempo.grossRevenue = entry.grossRevenue;
+      tempo.invocationCount = entry.invocationCount;
+    }
+  }
+  return { base, tempo };
 }

--- a/lib/earnings/types.ts
+++ b/lib/earnings/types.ts
@@ -12,6 +12,16 @@ export type WorkflowEarningsRow = {
   settlementStatus: SettlementStatus;
 };
 
+/**
+ * Revenue split for a single settlement chain. `grossRevenue` is USDC on Base
+ * (x402) or USDC.e on Tempo (MPP) -- both pegged to USD, so summed totals are
+ * meaningful even across chains for display purposes.
+ */
+export type ChainEarnings = {
+  grossRevenue: string;
+  invocationCount: number;
+};
+
 export type EarningsSummary = {
   totalGrossRevenue: string;
   totalCreatorEarnings: string;
@@ -19,6 +29,10 @@ export type EarningsSummary = {
   totalInvocations: number;
   platformFeePercent: number;
   creatorSharePercent: number;
+  perChain: {
+    base: ChainEarnings;
+    tempo: ChainEarnings;
+  };
   workflows: WorkflowEarningsRow[];
   total: number;
   page: number;

--- a/tests/unit/earnings-queries.test.ts
+++ b/tests/unit/earnings-queries.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
+  buildPerChainEarnings,
   computeRevenueSplit,
   deriveSettlementStatus,
   formatUsdc,
@@ -138,5 +139,55 @@ describe("groupTopCallers", () => {
   it("returns empty map for empty input", () => {
     const result = groupTopCallers([]);
     expect(result.size).toBe(0);
+  });
+});
+
+describe("buildPerChainEarnings", () => {
+  it("returns zeros for both chains when no rows are present", () => {
+    const result = buildPerChainEarnings([]);
+    expect(result.base).toEqual({
+      grossRevenue: "$0.00 USDC",
+      invocationCount: 0,
+    });
+    expect(result.tempo).toEqual({
+      grossRevenue: "$0.00 USDC",
+      invocationCount: 0,
+    });
+  });
+
+  it("maps base and tempo chain rows into the fixed shape", () => {
+    const result = buildPerChainEarnings([
+      { chain: "base", grossRevenue: "1.50", invocationCount: 15 },
+      { chain: "tempo", grossRevenue: "0.75", invocationCount: 9 },
+    ]);
+    expect(result.base.grossRevenue).toBe("$1.50 USDC");
+    expect(result.base.invocationCount).toBe(15);
+    expect(result.tempo.grossRevenue).toBe("$0.75 USDC");
+    expect(result.tempo.invocationCount).toBe(9);
+  });
+
+  it("leaves the missing chain at zero when only one chain has activity", () => {
+    const result = buildPerChainEarnings([
+      { chain: "base", grossRevenue: "2.00", invocationCount: 20 },
+    ]);
+    expect(result.base.grossRevenue).toBe("$2.00 USDC");
+    expect(result.tempo.grossRevenue).toBe("$0.00 USDC");
+    expect(result.tempo.invocationCount).toBe(0);
+  });
+
+  it("ignores unknown chain values without throwing", () => {
+    const result = buildPerChainEarnings([
+      { chain: "solana", grossRevenue: "99.00", invocationCount: 1 },
+    ]);
+    expect(result.base.grossRevenue).toBe("$0.00 USDC");
+    expect(result.tempo.grossRevenue).toBe("$0.00 USDC");
+  });
+
+  it("treats null grossRevenue as zero", () => {
+    const result = buildPerChainEarnings([
+      { chain: "base", grossRevenue: null, invocationCount: 0 },
+    ]);
+    expect(result.base.grossRevenue).toBe("$0.00 USDC");
+    expect(result.base.invocationCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Part 2 of [KEEP-259](https://linear.app/keeperhubapp/issue/KEEP-259). Part 1 (#909) added the `paid-workflows` and `agentcash-install` docs pages. This PR surfaces the dual-chain split directly on the Earnings KPI cards so a creator seeing \$3.50 on Base and \$5.20 on Tempo understands the split is a function of which agents paid them, not a bug to investigate.

## What changed

### Data layer

- `lib/earnings/types.ts` -- new `ChainEarnings` type and `perChain: { base, tempo }` on `EarningsSummary`.
- `lib/earnings/queries.ts` -- new chain-grouped aggregation over `workflow_payments.chain` (the column already exists, populated by `lib/payments/router.ts` per the KEEP-176 work). Extracted `buildPerChainEarnings()` as a pure function for unit testing and to guarantee the UI always receives a fixed `{ base, tempo }` shape -- missing chains default to zero, unknown chains are ignored so future protocol additions (e.g. Solana) don't break the UI contract until explicitly wired.

### UI

- `components/earnings/earnings-kpi-cards.tsx`:
  - Total Revenue card: subtext now shows `\"Base \$X -- Tempo \$Y\"` plus a small `HelpCircle` info link opening `docs.keeperhub.com/workflows/paid-workflows` in a new tab.
  - Earnings card: same info link with title \"How creator earnings are calculated\".
  - Total Invocations card: subtext shows per-chain invocation counts.
- No new components, no new pages, no layout changes -- the KPI grid is unchanged in shape.

### Tests

- `tests/unit/earnings-queries.test.ts` -- 5 new cases covering `buildPerChainEarnings` happy path, single-chain activity, missing rows, unknown chains, and null gross revenue.

## Verification

- [x] `pnpm type-check` clean
- [x] `pnpm vitest run tests/unit/earnings-queries.test.ts --dir tests` -- 25/25 passing (5 new)
- [ ] After deploy, confirm the earnings page on an org with mixed x402 + MPP traffic shows both chains populated. For an org with only x402 or only MPP traffic, the missing chain should show `\$0.00 USDC` and `0` invocations.

## Deliberately not in scope

**First-visit dismissible explainer on the wallet overlay.** The ticket listed three UI pieces: per-chain earnings breakdown, info tooltip, and a one-time dismissible explainer. The docs link + inline chain subtext cover the disambiguation need. Adding a separate modal or banner that fires \"on first visit after listing a paid workflow\" requires persistence state (localStorage or a new user preference column), fires at a moment the user may not be looking for guidance, and has no clear measurement of whether it is read. Parked pending evidence that the current affordance is insufficient.

## Related

- KEEP-259 part 1 (#909) -- docs
- KEEP-176 -- shipped the underlying dual-protocol settlement
- KEEP-294 (#907) -- added CDP Bazaar discoverability fields