### PR TITLE
test: KEEP-295 add event-tracker E2E test harness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -455,6 +455,40 @@ services:
     profiles:
       - test
 
+  test-anvil:
+    image: ghcr.io/foundry-rs/foundry:latest
+    container_name: keeperhub-test-anvil
+    ports:
+      - "8546:8545"
+    entrypoint: anvil
+    command:
+      - --host
+      - 0.0.0.0
+      - --block-time
+      - "1"
+      - --chain-id
+      - "31337"
+    healthcheck:
+      test: ["CMD-SHELL", "cast block-number --rpc-url http://localhost:8545 > /dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    profiles:
+      - test
+
+  test-redis:
+    image: valkey/valkey:latest
+    container_name: keeperhub-test-redis
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    profiles:
+      - test
+
   test-app:
     image: node:22-alpine
     container_name: keeperhub-test-app

--- a/keeperhub-events/event-tracker/lib/config/environment.ts
+++ b/keeperhub-events/event-tracker/lib/config/environment.ts
@@ -10,4 +10,5 @@ export const NODE_ENV: string = process.env.NODE_ENV || "development";
 
 export const SQS_QUEUE_URL: string = process.env.SQS_QUEUE_URL || "";
 export const AWS_REGION: string = process.env.AWS_REGION || "us-east-1";
-export const AWS_ENDPOINT_URL: string | undefined = process.env.AWS_ENDPOINT_URL;
+export const AWS_ENDPOINT_URL: string | undefined =
+  process.env.AWS_ENDPOINT_URL;

--- a/keeperhub-events/event-tracker/lib/sync/redis.ts
+++ b/keeperhub-events/event-tracker/lib/sync/redis.ts
@@ -89,11 +89,7 @@ class SyncContainerManager extends SyncManager {
   async removeContainer(): Promise<void> {
     await this.removeAllContainerProcesses(this.containerId);
 
-    await this.rtStorage.lrem(
-      `containers:${NODE_ENV}`,
-      0,
-      this.containerId,
-    );
+    await this.rtStorage.lrem(`containers:${NODE_ENV}`, 0, this.containerId);
 
     this.logger.log(
       `Container ${this.containerId} removed - timestamp ${Date.now()}`,
@@ -140,11 +136,7 @@ class SyncContainerManager extends SyncManager {
   async removeContainerById(id: string): Promise<void> {
     await this.removeAllContainerProcesses(id);
 
-    await this.rtStorage.lrem(
-      `containers:${NODE_ENV}`,
-      0,
-      id,
-    );
+    await this.rtStorage.lrem(`containers:${NODE_ENV}`, 0, id);
 
     this.logger.log(`Container ${id} removed - timestamp ${Date.now()}`);
   }

--- a/keeperhub-events/event-tracker/package.json
+++ b/keeperhub-events/event-tracker/package.json
@@ -8,7 +8,10 @@
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "vitest run"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1005.0",
@@ -20,6 +23,10 @@
   },
   "devDependencies": {
     "@types/deep-diff": "^1.0.5",
-    "@types/uuid": "^10.0.0"
+    "@types/node": "^24.12.2",
+    "@types/uuid": "^10.0.0",
+    "solc": "^0.8.29",
+    "vite": "^7.3.0",
+    "vitest": "4.1.2"
   }
 }

--- a/keeperhub-events/event-tracker/src/chains/abstract-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/abstract-chain.ts
@@ -5,8 +5,8 @@ import {
   KEEPERHUB_API_URL,
   SQS_QUEUE_URL,
 } from "../../lib/config/environment";
-import { sqs } from "../../lib/sqs-client";
 import type { WorkflowEvent } from "../../lib/models/workflow-event";
+import { sqs } from "../../lib/sqs-client";
 import type { NetworkConfig, NetworksWrapper } from "../../lib/types";
 import { type Logger, logger } from "../../lib/utils/logger";
 
@@ -72,9 +72,7 @@ export class AbstractChain {
         }),
       );
 
-      logger.log(
-        `[SQS] Enqueued workflow ${workflowId} for event execution`,
-      );
+      logger.log(`[SQS] Enqueued workflow ${workflowId} for event execution`);
       return true;
     } catch (error: any) {
       logger.error(`Error enqueuing workflow to SQS: ${error.message}`);

--- a/keeperhub-events/event-tracker/src/chains/evm-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/evm-chain.ts
@@ -64,7 +64,12 @@ export class EvmChain extends AbstractChain {
     this.isInitialized = false;
     this.connection = null;
 
-    this.dedup = new TransactionDedup(this.options.id!, REDIS_HOST, REDIS_PORT, REDIS_PASSWORD);
+    this.dedup = new TransactionDedup(
+      this.options.id!,
+      REDIS_HOST,
+      REDIS_PORT,
+      REDIS_PASSWORD,
+    );
   }
 
   async initializeProvider(): Promise<void> {

--- a/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
@@ -1,0 +1,199 @@
+/**
+ * E2E baseline for the current fork-based event-tracker architecture.
+ *
+ * Requires the `test` docker-compose profile (test-anvil, test-localstack,
+ * test-redis). Run with:
+ *
+ *   docker compose --profile test up -d test-anvil test-localstack test-localstack-init test-redis
+ *   pnpm test
+ *
+ * Skipped when SKIP_INFRA_TESTS=true.
+ */
+
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import type { ethers } from "ethers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getAnvilChainId,
+  getAnvilRpcUrl,
+  getAnvilWallet,
+  getAnvilWssUrl,
+  waitForAnvil,
+} from "./helpers/anvil-helpers";
+import {
+  type DeployedFixture,
+  deployEventEmitter,
+} from "./helpers/fixture-contract";
+import { type MockApiServer, startMockApi } from "./helpers/mock-api";
+import {
+  createQueue,
+  deleteQueue,
+  makeSqsClient,
+  pollForMessage,
+  purgeQueue,
+} from "./helpers/sqs-helpers";
+
+const SKIP_INFRA_TESTS = process.env.SKIP_INFRA_TESTS === "true";
+const AWS_ENDPOINT = process.env.AWS_ENDPOINT_URL ?? "http://localhost:4567";
+const REDIS_HOST = process.env.REDIS_HOST ?? "localhost";
+const REDIS_PORT = Number(process.env.REDIS_PORT ?? 6380);
+const TEST_QUEUE_NAME = "keeperhub-event-tracker-test-queue";
+const WORKFLOW_ID = "test-workflow-keep-295";
+
+function buildWorkflow(address: string, abi: unknown[]): unknown {
+  return {
+    id: WORKFLOW_ID,
+    name: "Phase 0 Baseline",
+    userId: "test-user",
+    organizationId: "test-org",
+    enabled: true,
+    nodes: [
+      {
+        id: "node-1",
+        type: "trigger",
+        selected: false,
+        data: {
+          type: "event-trigger",
+          label: "Emitted",
+          status: "active",
+          description: "Baseline listener for fork architecture",
+          config: {
+            network: String(getAnvilChainId()),
+            eventName: "Emitted",
+            contractABI: JSON.stringify(abi),
+            triggerType: "event",
+            contractAddress: address,
+          },
+        },
+      },
+    ],
+  };
+}
+
+function buildNetworks(): Record<number, unknown> {
+  const now = new Date().toISOString();
+  return {
+    [getAnvilChainId()]: {
+      id: `local-${getAnvilChainId()}`,
+      chainId: getAnvilChainId(),
+      name: "Anvil",
+      symbol: "ETH",
+      chainType: "evm",
+      defaultPrimaryRpc: getAnvilRpcUrl(),
+      defaultFallbackRpc: getAnvilRpcUrl(),
+      defaultPrimaryWss: getAnvilWssUrl(),
+      defaultFallbackWss: getAnvilWssUrl(),
+      isTestnet: true,
+      isEnabled: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+describe.skipIf(SKIP_INFRA_TESTS)(
+  "event-tracker: on-chain event -> SQS (fork architecture baseline)",
+  () => {
+    let fixture: DeployedFixture;
+    let wallet: ethers.Wallet;
+    let mockApi: MockApiServer;
+    let sqsClient: SQSClient;
+    let queueUrl: string;
+    // Modules imported dynamically after env is set up, so redis.ts picks up
+    // the correct REDIS_HOST/PORT before it constructs its client.
+    let syncModule: {
+      registerContainer: () => Promise<void>;
+      removeAllContainers: () => Promise<void>;
+      rtStorage?: { quit?: () => Promise<unknown> };
+    };
+    let synchronizeData: () => Promise<void>;
+
+    beforeAll(async () => {
+      await waitForAnvil();
+      wallet = getAnvilWallet();
+      fixture = await deployEventEmitter(wallet);
+
+      sqsClient = makeSqsClient(AWS_ENDPOINT);
+      queueUrl = await createQueue(sqsClient, TEST_QUEUE_NAME, AWS_ENDPOINT);
+      await purgeQueue(sqsClient, queueUrl);
+
+      mockApi = await startMockApi();
+      mockApi.setResponse("/api/workflows/events", {
+        workflows: [buildWorkflow(fixture.address, fixture.abi)],
+        networks: buildNetworks(),
+      });
+
+      process.env.KEEPERHUB_API_URL = mockApi.url;
+      process.env.KEEPERHUB_API_KEY = "test-key";
+      process.env.SQS_QUEUE_URL = queueUrl;
+      process.env.AWS_ENDPOINT_URL = AWS_ENDPOINT;
+      process.env.AWS_REGION = "us-east-1";
+      process.env.AWS_ACCESS_KEY_ID = "test";
+      process.env.AWS_SECRET_ACCESS_KEY = "test";
+      process.env.REDIS_HOST = REDIS_HOST;
+      process.env.REDIS_PORT = String(REDIS_PORT);
+      process.env.NODE_ENV = "test";
+
+      const redisMod = await import("../../lib/sync/redis");
+      syncModule = redisMod.syncModule;
+      const mainMod = await import("../../src/main");
+      synchronizeData = mainMod.synchronizeData;
+
+      await syncModule.removeAllContainers();
+      await syncModule.registerContainer();
+    }, 120_000);
+
+    afterAll(async () => {
+      // Ask the fork architecture to tear down its child processes by sending
+      // an empty workflow list, then disconnect Redis so vitest exits cleanly.
+      try {
+        mockApi?.setResponse("/api/workflows/events", {
+          workflows: [],
+          networks: {},
+        });
+        if (synchronizeData) {
+          await synchronizeData();
+        }
+      } catch {
+        // best-effort cleanup
+      }
+      try {
+        await syncModule?.removeAllContainers?.();
+      } catch {
+        // ignore
+      }
+      try {
+        // SyncModule holds its Redis client as a protected `rtStorage` field.
+        // Closing it lets vitest exit without hanging on open handles.
+        await syncModule?.rtStorage?.quit?.();
+      } catch {
+        // ignore
+      }
+      await mockApi?.close();
+      await deleteQueue(sqsClient, queueUrl);
+    }, 30_000);
+
+    it("forwards an emitted contract event to SQS", async () => {
+      await synchronizeData();
+
+      // Give the forked child time to boot, connect WSS, and register the
+      // filter before we emit. 5s is generous for local anvil.
+      await new Promise((r) => setTimeout(r, 5_000));
+
+      const emitEvent = fixture.contract.getFunction("emitEvent");
+      const tx = await emitEvent(42n);
+      await tx.wait();
+
+      const message = await pollForMessage(sqsClient, queueUrl, 20_000);
+      expect(message, "no SQS message received within timeout").not.toBeNull();
+      const body = JSON.parse(message?.Body ?? "{}") as {
+        workflowId: string;
+        triggerType: string;
+        triggerData: unknown;
+      };
+      expect(body.workflowId).toBe(WORKFLOW_ID);
+      expect(body.triggerType).toBe("event");
+      expect(body.triggerData).toBeDefined();
+    }, 90_000);
+  },
+);

--- a/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
@@ -39,6 +39,26 @@ const REDIS_HOST = process.env.REDIS_HOST ?? "localhost";
 const REDIS_PORT = Number(process.env.REDIS_PORT ?? 6380);
 const TEST_QUEUE_NAME = "keeperhub-event-tracker-test-queue";
 const WORKFLOW_ID = "test-workflow-keep-295";
+const EMITTED_VALUE = 42n;
+
+// Shape of the payload emitted by AbstractChain.executeWorkflow. Kept loose
+// because event-serializer output is the production contract; tighten in
+// later phases if we want to assert more aggressively.
+interface TypedValue {
+  value: string;
+  type: string;
+}
+interface TriggerData {
+  eventName: string;
+  args: Record<string, TypedValue>;
+  address: string;
+  transactionHash: string;
+}
+interface SqsBody {
+  workflowId: string;
+  triggerType: string;
+  triggerData: TriggerData;
+}
 
 function buildWorkflow(address: string, abi: unknown[]): unknown {
   return {
@@ -123,6 +143,14 @@ describe.skipIf(SKIP_INFRA_TESTS)(
         networks: buildNetworks(),
       });
 
+      // Env vars below are mutated and intentionally not restored in afterAll.
+      // This is safe because the event-tracker modules capture them at import
+      // time (e.g. lib/config/environment.ts, lib/sync/redis.ts constructs
+      // its Redis client eagerly). A restore after import would have no effect
+      // on the captured values, so it is not worth the noise. If another test
+      // file is added that imports event-tracker modules with different env,
+      // run test files in separate vitest processes (isolate: true) or move
+      // this setup to a global setup file.
       process.env.KEEPERHUB_API_URL = mockApi.url;
       process.env.KEEPERHUB_API_KEY = "test-key";
       process.env.SQS_QUEUE_URL = queueUrl;
@@ -163,8 +191,12 @@ describe.skipIf(SKIP_INFRA_TESTS)(
         // ignore
       }
       try {
-        // SyncModule holds its Redis client as a protected `rtStorage` field.
-        // Closing it lets vitest exit without hanging on open handles.
+        // Reaches into SyncModule's `rtStorage` field, which is declared
+        // `protected` on SyncManager. This is brittle but acceptable:
+        // event-tracker has no public disconnect API today, vitest hangs on
+        // the open ioredis connection if we don't close it, and Phase 6 of
+        // the KEEP-295 plan deletes SyncModule/Redis entirely. When this
+        // bracket goes, so does the need for this access.
         await syncModule?.rtStorage?.quit?.();
       } catch {
         // ignore
@@ -176,24 +208,50 @@ describe.skipIf(SKIP_INFRA_TESTS)(
     it("forwards an emitted contract event to SQS", async () => {
       await synchronizeData();
 
-      // Give the forked child time to boot, connect WSS, and register the
-      // filter before we emit. 5s is generous for local anvil.
-      await new Promise((r) => setTimeout(r, 5_000));
-
+      // The child process forks, connects its WSS provider, validates the
+      // contract, and attaches its filter asynchronously. Anvil WSS
+      // subscriptions only deliver events from blocks AFTER the subscribe
+      // call, so an event emitted before the child is ready is lost forever.
+      //
+      // There is no production hook to await "child is listening" from the
+      // test process (IPC is consumed inside WorkflowHandler). Instead: emit
+      // in a retry loop, polling SQS after each emit. Each emit is a new
+      // transaction with a new tx_hash, so Redis dedup never interferes.
+      // Once the listener is up, the next emit lands in SQS. First-attempt
+      // success is the typical case; retries only kick in if the child is
+      // slow to boot on a busy machine.
+      const MAX_ATTEMPTS = 10;
+      const PER_ATTEMPT_MS = 3_000;
       const emitEvent = fixture.contract.getFunction("emitEvent");
-      const tx = await emitEvent(42n);
-      await tx.wait();
 
-      const message = await pollForMessage(sqsClient, queueUrl, 20_000);
-      expect(message, "no SQS message received within timeout").not.toBeNull();
-      const body = JSON.parse(message?.Body ?? "{}") as {
-        workflowId: string;
-        triggerType: string;
-        triggerData: unknown;
-      };
+      let received: Awaited<ReturnType<typeof pollForMessage>> = null;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        const tx = await emitEvent(EMITTED_VALUE);
+        await tx.wait();
+        received = await pollForMessage(sqsClient, queueUrl, PER_ATTEMPT_MS);
+        if (received) {
+          break;
+        }
+      }
+
+      expect(
+        received,
+        `no SQS message received after ${MAX_ATTEMPTS} emits; listener likely never attached`,
+      ).not.toBeNull();
+
+      const body = JSON.parse(received?.Body ?? "{}") as SqsBody;
       expect(body.workflowId).toBe(WORKFLOW_ID);
       expect(body.triggerType).toBe("event");
-      expect(body.triggerData).toBeDefined();
+      expect(body.triggerData.eventName).toBe("Emitted");
+      expect(body.triggerData.address.toLowerCase()).toBe(
+        fixture.address.toLowerCase(),
+      );
+      expect(body.triggerData.args.value.type).toBe("uint256");
+      expect(body.triggerData.args.value.value).toBe(String(EMITTED_VALUE));
+      expect(body.triggerData.args.sender.type).toBe("address");
+      expect(body.triggerData.args.sender.value.toLowerCase()).toBe(
+        wallet.address.toLowerCase(),
+      );
     }, 90_000);
   },
 );

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/anvil-helpers.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/anvil-helpers.ts
@@ -1,0 +1,44 @@
+import { ethers } from "ethers";
+
+const ANVIL_RPC = process.env.ANVIL_RPC_URL ?? "http://localhost:8546";
+const ANVIL_WSS = process.env.ANVIL_WSS_URL ?? "ws://localhost:8546";
+const ANVIL_CHAIN_ID = 31337;
+
+// Anvil's first well-known test account. Never used on any mainnet.
+const ANVIL_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+export function getAnvilRpcUrl(): string {
+  return ANVIL_RPC;
+}
+
+export function getAnvilWssUrl(): string {
+  return ANVIL_WSS;
+}
+
+export function getAnvilChainId(): number {
+  return ANVIL_CHAIN_ID;
+}
+
+export function getAnvilWallet(): ethers.Wallet {
+  const provider = new ethers.JsonRpcProvider(ANVIL_RPC);
+  return new ethers.Wallet(ANVIL_PRIVATE_KEY, provider);
+}
+
+export async function waitForAnvil(maxMs = 30_000): Promise<void> {
+  const provider = new ethers.JsonRpcProvider(ANVIL_RPC);
+  const deadline = Date.now() + maxMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await provider.getBlockNumber();
+      return;
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw new Error(
+    `Anvil not reachable at ${ANVIL_RPC} within ${maxMs}ms: ${String(lastErr)}`,
+  );
+}

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/fixture-contract.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/fixture-contract.ts
@@ -1,0 +1,83 @@
+import { ethers } from "ethers";
+import solc from "solc";
+
+const SOURCE = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract EventEmitter {
+    event Emitted(address indexed sender, uint256 value);
+
+    function emitEvent(uint256 value) external {
+        emit Emitted(msg.sender, value);
+    }
+}
+`;
+
+export interface CompiledContract {
+  abi: unknown[];
+  bytecode: string;
+}
+
+export interface DeployedFixture {
+  address: string;
+  abi: unknown[];
+  contract: ethers.Contract;
+}
+
+let cached: CompiledContract | null = null;
+
+export function compileEventEmitter(): CompiledContract {
+  if (cached) {
+    return cached;
+  }
+  const input = {
+    language: "Solidity",
+    sources: { "EventEmitter.sol": { content: SOURCE } },
+    settings: {
+      outputSelection: {
+        "*": { "*": ["abi", "evm.bytecode.object"] },
+      },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input))) as {
+    contracts?: Record<
+      string,
+      Record<string, { abi: unknown[]; evm: { bytecode: { object: string } } }>
+    >;
+    errors?: { severity: string; formattedMessage: string }[];
+  };
+
+  const fatal = (output.errors ?? []).filter((e) => e.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(
+      `solc compile failed:\n${fatal.map((e) => e.formattedMessage).join("\n")}`,
+    );
+  }
+
+  const artifact = output.contracts?.["EventEmitter.sol"]?.EventEmitter;
+  if (!artifact) {
+    throw new Error("EventEmitter artifact missing from solc output");
+  }
+
+  cached = {
+    abi: artifact.abi,
+    bytecode: `0x${artifact.evm.bytecode.object}`,
+  };
+  return cached;
+}
+
+export async function deployEventEmitter(
+  wallet: ethers.Wallet,
+): Promise<DeployedFixture> {
+  const { abi, bytecode } = compileEventEmitter();
+  const factory = new ethers.ContractFactory(
+    abi as ethers.InterfaceAbi,
+    bytecode,
+    wallet,
+  );
+  const deployed = await factory.deploy();
+  await deployed.waitForDeployment();
+  const address = await deployed.getAddress();
+  return { address, abi, contract: deployed as ethers.Contract };
+}

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/mock-api.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/mock-api.ts
@@ -1,0 +1,43 @@
+import { type AddressInfo, type Server, createServer } from "node:http";
+
+export interface MockApiServer {
+  url: string;
+  setResponse(path: string, body: unknown): void;
+  close(): Promise<void>;
+}
+
+export async function startMockApi(): Promise<MockApiServer> {
+  const responses = new Map<string, unknown>();
+
+  const server: Server = createServer((req, res) => {
+    const fullUrl = req.url ?? "/";
+    const pathOnly = fullUrl.split("?")[0];
+    const body = responses.get(pathOnly);
+    if (body === undefined) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "not found", path: pathOnly }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const addr = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    url,
+    setResponse(path, body) {
+      responses.set(path, body);
+    },
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/sqs-helpers.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/sqs-helpers.ts
@@ -1,0 +1,87 @@
+import {
+  CreateQueueCommand,
+  DeleteQueueCommand,
+  type Message,
+  PurgeQueueCommand,
+  ReceiveMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+
+export function makeSqsClient(endpoint: string): SQSClient {
+  return new SQSClient({
+    region: "us-east-1",
+    endpoint,
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  });
+}
+
+export async function createQueue(
+  client: SQSClient,
+  name: string,
+  endpoint: string,
+): Promise<string> {
+  try {
+    const result = await client.send(
+      new CreateQueueCommand({ QueueName: name }),
+    );
+    if (!result.QueueUrl) {
+      throw new Error("CreateQueueCommand returned no QueueUrl");
+    }
+    // LocalStack may return a URL with an internal hostname. Rewrite to the
+    // endpoint the test process can actually reach.
+    return result.QueueUrl.replace("host.minikube.internal", "localhost")
+      .replace("test-localstack", "localhost")
+      .replace("localstack", "localhost");
+  } catch {
+    // Queue may already exist from a prior test run.
+    return `${endpoint}/000000000000/${name}`;
+  }
+}
+
+export async function deleteQueue(
+  client: SQSClient,
+  url: string,
+): Promise<void> {
+  try {
+    await client.send(new DeleteQueueCommand({ QueueUrl: url }));
+  } catch {
+    // Ignore cleanup errors.
+  }
+}
+
+export async function purgeQueue(
+  client: SQSClient,
+  url: string,
+): Promise<void> {
+  try {
+    await client.send(new PurgeQueueCommand({ QueueUrl: url }));
+  } catch {
+    // Purge fails if the queue was purged recently; harmless.
+  }
+}
+
+export async function pollForMessage(
+  client: SQSClient,
+  url: string,
+  timeoutMs: number,
+): Promise<Message | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const waitSeconds = Math.max(
+      1,
+      Math.min(20, Math.ceil((deadline - Date.now()) / 1000)),
+    );
+    const result = await client.send(
+      new ReceiveMessageCommand({
+        QueueUrl: url,
+        MaxNumberOfMessages: 1,
+        WaitTimeSeconds: waitSeconds,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+    if (result.Messages && result.Messages.length > 0) {
+      return result.Messages[0];
+    }
+  }
+  return null;
+}

--- a/keeperhub-events/event-tracker/vitest.config.mts
+++ b/keeperhub-events/event-tracker/vitest.config.mts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    exclude: ["node_modules"],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
+});

--- a/keeperhub-events/pnpm-lock.yaml
+++ b/keeperhub-events/pnpm-lock.yaml
@@ -45,9 +45,21 @@ importers:
       '@types/deep-diff':
         specifier: ^1.0.5
         version: 1.0.5
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      solc:
+        specifier: ^0.8.29
+        version: 0.8.34
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)
+      vitest:
+        specifier: 4.1.2
+        version: 4.1.2(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0))
 
 packages:
 
@@ -383,12 +395,140 @@ packages:
   '@ioredis/commands@1.5.0':
     resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
 
   '@smithy/abort-controller@4.2.11':
     resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
@@ -566,8 +706,20 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/deep-diff@1.0.5':
     resolution: {integrity: sha512-PQyNSy1YMZU1hgZA5tTYfHPpUAo9Dorn1PZho2/budQLfqLu3JIP37JAavnwYpR1S2yFZTXa3hxaE4ifGW5jaA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
@@ -575,18 +727,68 @@ packages:
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -605,14 +807,28 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   ethers@6.16.0:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-xml-builder@1.0.0:
     resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
@@ -620,6 +836,24 @@ packages:
   fast-xml-parser@5.4.1:
     resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
     hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -633,14 +867,120 @@ packages:
     resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
 
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -653,11 +993,57 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  solc@0.8.34:
+    resolution: {integrity: sha512-qf8HajA1sHhXRV0hMSDXLjVbc4v3Q+SQbL9zok+1WmgVj7Z4oMjMHxaysCzfGtFVqjZdfDDJWyZI+tcx5bO7Dw==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -678,8 +1064,91 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   ws@8.17.1:
@@ -1149,11 +1618,88 @@ snapshots:
 
   '@ioredis/commands@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
 
   '@noble/hashes@1.3.2': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
 
   '@smithy/abort-controller@4.2.11':
     dependencies:
@@ -1435,7 +1981,18 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/deep-diff@1.0.5': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/node@22.19.13':
     dependencies:
@@ -1445,13 +2002,68 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/uuid@10.0.0': {}
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   aes-js@4.0.0-beta.5: {}
 
+  assertion-error@2.0.1: {}
+
   bowser@2.14.1: {}
 
+  chai@6.2.2: {}
+
   cluster-key-slot@1.1.2: {}
+
+  command-exists@1.2.9: {}
+
+  commander@8.3.0: {}
+
+  convert-source-map@2.0.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -1460,6 +2072,11 @@ snapshots:
   deep-diff@1.0.2: {}
 
   denque@2.1.0: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1490,6 +2107,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   ethers@6.16.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
@@ -1503,12 +2124,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  expect-type@1.3.0: {}
+
   fast-xml-builder@1.0.0: {}
 
   fast-xml-parser@5.4.1:
     dependencies:
       fast-xml-builder: 1.0.0
       strnum: 2.2.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  follow-redirects@1.16.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1531,11 +2160,87 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  js-sha3@0.8.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+    optional: true
+
   lodash.defaults@4.2.0: {}
 
   lodash.isarguments@3.1.0: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  memorystream@0.3.1: {}
+
   ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  os-tmpdir@1.0.2: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   redis-errors@1.2.0: {}
 
@@ -1545,9 +2250,77 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  semver@5.7.2: {}
+
+  siginfo@2.0.0: {}
+
+  solc@0.8.34:
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.16.0
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 5.7.2
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
+  std-env@4.1.0: {}
+
   strnum@2.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
 
   tslib@2.7.0: {}
 
@@ -1564,6 +2337,54 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   uuid@11.1.0: {}
+
+  vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+
+  vitest@4.1.2(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.17.1: {}


### PR DESCRIPTION
## Summary

Phase 0 of the event-tracker refactor tracked in KEEP-295. Establishes a test safety net **before** any code changes in subsequent phases.

- Adds `vitest`, `solc`, and a minimal Solidity fixture (`EventEmitter`) under `keeperhub-events/event-tracker/tests/e2e/`
- Adds `test-anvil` (foundry) and `test-redis` services to `docker-compose.yml` under the existing `test` profile
- Writes one end-to-end scenario: deploy fixture contract -> register mock workflow -> emit event on-chain -> assert SQS message
- The test is architecture-agnostic: Phases 1+ (single-process async refactor) can use the same scenario as a regression gate

## Design notes

- **No production code changed in this PR.** The second commit fixes pre-existing biome formatter errors in files I read while scoping, since the pre-commit hook blocks any commit while lint is dirty.
- **Mock API server, not `vi.mock()`**: children don't hit the API today (audited), but the HTTP server is robust against future refactors and closer to production behavior.
- **Fork path intentionally exercised**: calling `synchronizeData()` forks real child processes. Children inherit env and connect to anvil + LocalStack + redis on the host.
- **Cleanup**: afterAll serves an empty workflow list and re-runs `synchronizeData()` so `removeExcessProcesses` kills the forked child, then closes the Redis connection so vitest exits without hanging handles.

## Vite 8 / rolldown caveat

`vitest@4.1.x` without a peer `vite` constraint resolves to `vite@8` which depends on `rolldown` and needs a platform-specific native binding that pnpm doesn't always fetch in every environment. Pinned `vite: ^7.3.0` as a devDep to force resolution to the same variant the main app uses. Revisit when vite 8 / rolldown stabilizes.

## Test plan

- [ ] `docker compose --profile test up -d test-anvil test-localstack test-localstack-init test-redis`
- [ ] `cd keeperhub-events/event-tracker && pnpm install`
- [ ] `pnpm test` -- expect 1 passed (1) in ~17s
- [ ] `pnpm typecheck` -- clean
- [ ] `pnpm lint` -- clean
- [ ] `SKIP_INFRA_TESTS=true pnpm test` -- all tests skipped