### PR TITLE
fix(mcp): make call_workflow wait for read completion (KEEP-265)

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/payments/router";
 import { executeWorkflow } from "@/lib/workflow-executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow-store";
+import { buildCallCompletionResponse } from "@/lib/x402/execution-wait";
 import {
   hashPaymentSignature,
   recordPayment,
@@ -146,8 +147,9 @@ function startExecutionInBackground(
 }
 
 /**
- * Free-path helper: prepares the execution and starts it. Used by the
- * non-paid call path where there is no payment to record between the two.
+ * Free-path helper: prepares the execution, starts it, and awaits completion
+ * up to the read-wait timeout. Returns the mapped output inline on success or
+ * falls back to `{executionId, status: "running"}` on timeout.
  */
 async function createAndStartExecution(
   workflow: CallRouteWorkflow,
@@ -158,10 +160,11 @@ async function createAndStartExecution(
     return prepared.error;
   }
   startExecutionInBackground(workflow, body, prepared.executionId);
-  return NextResponse.json(
-    { executionId: prepared.executionId, status: "running" },
-    { headers: corsHeaders }
+  const responseBody = await buildCallCompletionResponse(
+    prepared.executionId,
+    workflow.outputMapping
   );
+  return NextResponse.json(responseBody, { headers: corsHeaders });
 }
 
 async function lookupWorkflow(slug: string): Promise<CallRouteWorkflow | null> {
@@ -333,10 +336,11 @@ async function handlePaidWorkflow(
 
         startExecutionInBackground(workflow, body, executionId);
 
-        return NextResponse.json(
-          { executionId, status: "running" },
-          { headers: corsHeaders }
+        const responseBody = await buildCallCompletionResponse(
+          executionId,
+          workflow.outputMapping
         );
+        return NextResponse.json(responseBody, { headers: corsHeaders });
       };
     }
   );

--- a/lib/x402/execution-wait.ts
+++ b/lib/x402/execution-wait.ts
@@ -1,0 +1,145 @@
+import "server-only";
+
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+
+/**
+ * Default timeout for waiting on read-workflow completion before falling back
+ * to the async `{executionId, status: "running"}` response. Kept under typical
+ * HTTP/MCP client timeouts (~30s) so clients don't time out on us.
+ */
+export const DEFAULT_CALL_WAIT_TIMEOUT_MS = 25_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+type TerminalStatus = "success" | "error" | "cancelled";
+
+type ExecutionResult = {
+  status: TerminalStatus;
+  output: unknown;
+  error: string | null;
+};
+
+/**
+ * Poll workflowExecutions.status until it reaches a terminal state (success,
+ * error, cancelled) or the timeout elapses. Returns null on timeout.
+ */
+export async function waitForExecutionCompletion(
+  executionId: string,
+  timeoutMs: number = DEFAULT_CALL_WAIT_TIMEOUT_MS,
+  pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS
+): Promise<ExecutionResult | null> {
+  if (timeoutMs <= 0) {
+    return null;
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const row = await db.query.workflowExecutions.findFirst({
+      where: eq(workflowExecutions.id, executionId),
+      columns: { status: true, output: true, error: true },
+    });
+    if (!row) {
+      return null;
+    }
+    if (
+      row.status === "success" ||
+      row.status === "error" ||
+      row.status === "cancelled"
+    ) {
+      return {
+        status: row.status,
+        output: row.output,
+        error: row.error ?? null,
+      };
+    }
+    if (Date.now() + pollIntervalMs >= deadline) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
+/**
+ * Resolve the payload returned inline to the caller for a completed read
+ * workflow. outputMapping shape is `{ nodeId?: string, fields?: string[] }`:
+ *   - If nodeId is set, fetch that node's successful log output.
+ *   - If fields is set, pick only those keys from the node output.
+ *   - Otherwise, return the workflow-level output as-is.
+ */
+export async function applyOutputMapping(
+  executionId: string,
+  workflowOutput: unknown,
+  outputMapping: Record<string, unknown> | null | undefined
+): Promise<unknown> {
+  if (!outputMapping || typeof outputMapping !== "object") {
+    return workflowOutput;
+  }
+  const mapping = outputMapping as { nodeId?: unknown; fields?: unknown };
+  const nodeId = typeof mapping.nodeId === "string" ? mapping.nodeId : null;
+  if (!nodeId) {
+    return workflowOutput;
+  }
+
+  const log = await db.query.workflowExecutionLogs.findFirst({
+    where: and(
+      eq(workflowExecutionLogs.executionId, executionId),
+      eq(workflowExecutionLogs.nodeId, nodeId),
+      eq(workflowExecutionLogs.status, "success")
+    ),
+    orderBy: [desc(workflowExecutionLogs.completedAt)],
+  });
+  const nodeOutput = log?.output ?? workflowOutput;
+
+  if (
+    Array.isArray(mapping.fields) &&
+    mapping.fields.length > 0 &&
+    nodeOutput &&
+    typeof nodeOutput === "object"
+  ) {
+    const picked: Record<string, unknown> = {};
+    for (const field of mapping.fields) {
+      if (typeof field === "string") {
+        picked[field] = (nodeOutput as Record<string, unknown>)[field];
+      }
+    }
+    return picked;
+  }
+  return nodeOutput;
+}
+
+export type CallCompletionResponse =
+  | { executionId: string; status: "success"; output: unknown }
+  | { executionId: string; status: "error"; error: string }
+  | { executionId: string; status: "running" };
+
+/**
+ * Wait for the read-workflow execution to complete, then build the response
+ * payload. On timeout, returns `{status: "running"}` so clients can fall back
+ * to polling the existing status/logs endpoints.
+ */
+export async function buildCallCompletionResponse(
+  executionId: string,
+  outputMapping: Record<string, unknown> | null | undefined,
+  timeoutMs: number = DEFAULT_CALL_WAIT_TIMEOUT_MS
+): Promise<CallCompletionResponse> {
+  const result = await waitForExecutionCompletion(executionId, timeoutMs);
+  if (!result) {
+    return { executionId, status: "running" };
+  }
+  if (result.status === "success") {
+    const output = await applyOutputMapping(
+      executionId,
+      result.output,
+      outputMapping
+    );
+    return { executionId, status: "success", output };
+  }
+  if (result.status === "cancelled") {
+    return { executionId, status: "error", error: "Execution cancelled" };
+  }
+  return {
+    executionId,
+    status: "error",
+    error: result.error ?? "Execution failed",
+  };
+}

--- a/tests/unit/execution-wait.test.ts
+++ b/tests/unit/execution-wait.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockFindFirstExecution, mockFindFirstLog } = vi.hoisted(() => ({
+  mockFindFirstExecution: vi.fn(),
+  mockFindFirstLog: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      workflowExecutions: { findFirst: mockFindFirstExecution },
+      workflowExecutionLogs: { findFirst: mockFindFirstLog },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id" },
+  workflowExecutionLogs: {
+    executionId: "execution_id",
+    nodeId: "node_id",
+    status: "status",
+    completedAt: "completed_at",
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("waitForExecutionCompletion (KEEP-265)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null immediately when timeout <= 0", async () => {
+    const { waitForExecutionCompletion } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const result = await waitForExecutionCompletion("exec-1", 0);
+    expect(result).toBeNull();
+    expect(mockFindFirstExecution).not.toHaveBeenCalled();
+  });
+
+  it("returns success result when execution is already terminal", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "success",
+      output: { foo: "bar" },
+      error: null,
+    });
+    const { waitForExecutionCompletion } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const result = await waitForExecutionCompletion("exec-1", 1000, 10);
+    expect(result).toEqual({
+      status: "success",
+      output: { foo: "bar" },
+      error: null,
+    });
+  });
+
+  it("returns error result with error message when execution failed", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "error",
+      output: null,
+      error: "RPC down",
+    });
+    const { waitForExecutionCompletion } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const result = await waitForExecutionCompletion("exec-1", 1000, 10);
+    expect(result?.status).toBe("error");
+    expect(result?.error).toBe("RPC down");
+  });
+
+  it("returns null if execution row is missing", async () => {
+    mockFindFirstExecution.mockResolvedValue(undefined);
+    const { waitForExecutionCompletion } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const result = await waitForExecutionCompletion("exec-missing", 100, 10);
+    expect(result).toBeNull();
+  });
+
+  it("polls until terminal status appears", async () => {
+    mockFindFirstExecution
+      .mockResolvedValueOnce({ status: "running", output: null, error: null })
+      .mockResolvedValueOnce({ status: "running", output: null, error: null })
+      .mockResolvedValueOnce({
+        status: "success",
+        output: { balance: "1.3286 ETH" },
+        error: null,
+      });
+    const { waitForExecutionCompletion } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const result = await waitForExecutionCompletion("exec-2", 1000, 5);
+    expect(result?.status).toBe("success");
+    expect(mockFindFirstExecution).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns null on timeout when never reaching terminal state", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "running",
+      output: null,
+      error: null,
+    });
+    const { waitForExecutionCompletion } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const start = Date.now();
+    const result = await waitForExecutionCompletion("exec-3", 40, 10);
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    expect(elapsed).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe("applyOutputMapping (KEEP-265)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns raw workflow output when outputMapping is null", async () => {
+    const { applyOutputMapping } = await import("@/lib/x402/execution-wait");
+    const result = await applyOutputMapping("exec-1", { balance: "1.5" }, null);
+    expect(result).toEqual({ balance: "1.5" });
+    expect(mockFindFirstLog).not.toHaveBeenCalled();
+  });
+
+  it("returns raw workflow output when outputMapping has no nodeId", async () => {
+    const { applyOutputMapping } = await import("@/lib/x402/execution-wait");
+    const result = await applyOutputMapping(
+      "exec-1",
+      { balance: "1.5" },
+      { fields: ["balance"] }
+    );
+    expect(result).toEqual({ balance: "1.5" });
+  });
+
+  it("picks specific fields from the mapped node output", async () => {
+    mockFindFirstLog.mockResolvedValue({
+      output: {
+        riskScore: 3,
+        vulnerabilities: ["reentrancy"],
+        internalDebug: "ignore-me",
+      },
+    });
+    const { applyOutputMapping } = await import("@/lib/x402/execution-wait");
+    const result = await applyOutputMapping("exec-1", null, {
+      nodeId: "audit-1",
+      fields: ["riskScore", "vulnerabilities"],
+    });
+    expect(result).toEqual({
+      riskScore: 3,
+      vulnerabilities: ["reentrancy"],
+    });
+  });
+
+  it("returns full node output when nodeId is set but fields is not", async () => {
+    mockFindFirstLog.mockResolvedValue({
+      output: { a: 1, b: 2 },
+    });
+    const { applyOutputMapping } = await import("@/lib/x402/execution-wait");
+    const result = await applyOutputMapping("exec-1", null, {
+      nodeId: "audit-1",
+    });
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it("falls back to workflow output when the mapped node log is missing", async () => {
+    mockFindFirstLog.mockResolvedValue(undefined);
+    const { applyOutputMapping } = await import("@/lib/x402/execution-wait");
+    const result = await applyOutputMapping(
+      "exec-1",
+      { fallback: true },
+      { nodeId: "missing-node" }
+    );
+    expect(result).toEqual({ fallback: true });
+  });
+});
+
+describe("buildCallCompletionResponse (KEEP-265)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns { status: 'running' } on timeout", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "running",
+      output: null,
+      error: null,
+    });
+    const { buildCallCompletionResponse } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const res = await buildCallCompletionResponse("exec-timeout", null, 30);
+    expect(res).toEqual({ executionId: "exec-timeout", status: "running" });
+  });
+
+  it("returns mapped output on successful completion", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "success",
+      output: { balance: "1.3286 ETH", _debug: "noise" },
+      error: null,
+    });
+    mockFindFirstLog.mockResolvedValue({
+      output: { balance: "1.3286 ETH", _debug: "noise" },
+    });
+    const { buildCallCompletionResponse } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const res = await buildCallCompletionResponse(
+      "exec-success",
+      { nodeId: "last", fields: ["balance"] },
+      1000
+    );
+    expect(res).toEqual({
+      executionId: "exec-success",
+      status: "success",
+      output: { balance: "1.3286 ETH" },
+    });
+  });
+
+  it("returns error payload when execution fails within timeout", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "error",
+      output: null,
+      error: "RPC failed",
+    });
+    const { buildCallCompletionResponse } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const res = await buildCallCompletionResponse("exec-err", null, 1000);
+    expect(res).toEqual({
+      executionId: "exec-err",
+      status: "error",
+      error: "RPC failed",
+    });
+  });
+
+  it("maps cancelled status to an error response", async () => {
+    mockFindFirstExecution.mockResolvedValue({
+      status: "cancelled",
+      output: null,
+      error: null,
+    });
+    const { buildCallCompletionResponse } = await import(
+      "@/lib/x402/execution-wait"
+    );
+    const res = await buildCallCompletionResponse("exec-cancel", null, 1000);
+    expect(res).toEqual({
+      executionId: "exec-cancel",
+      status: "error",
+      error: "Execution cancelled",
+    });
+  });
+});

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -382,6 +382,7 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
     mockGenerateCalldata,
     mockAuthenticateApiKey,
     mockAuthenticateOAuthToken,
+    mockBuildCallCompletionResponse,
   } = vi.hoisted(() => ({
     mockDbSelect: vi.fn(),
     mockDbInsert: vi.fn(),
@@ -401,6 +402,7 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
     mockGenerateCalldata: vi.fn(),
     mockAuthenticateApiKey: vi.fn(),
     mockAuthenticateOAuthToken: vi.fn(),
+    mockBuildCallCompletionResponse: vi.fn(),
   }));
 
   vi.mock("@/lib/db", () => ({
@@ -461,6 +463,10 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
 
   vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
     checkConcurrencyLimit: mockCheckConcurrencyLimit,
+  }));
+
+  vi.mock("@/lib/x402/execution-wait", () => ({
+    buildCallCompletionResponse: mockBuildCallCompletionResponse,
   }));
 
   vi.mock("@/lib/logging", () => ({
@@ -546,6 +552,11 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
         where: vi.fn().mockResolvedValue(undefined),
       }),
     });
+    // Default: completion wait times out so we fall back to running response.
+    mockBuildCallCompletionResponse.mockImplementation(
+      (executionId: string) =>
+        Promise.resolve({ executionId, status: "running" })
+    );
     // Default: caller is authenticated. The write workflow path requires
     // an API key or MCP OAuth token, same as the free read path.
     mockAuthenticateOAuthToken.mockReturnValue({

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -21,6 +21,7 @@ const {
   mockLogSystemError,
   mockAuthenticateApiKey,
   mockAuthenticateOAuthToken,
+  mockBuildCallCompletionResponse,
 } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
   mockDbInsert: vi.fn(),
@@ -38,6 +39,7 @@ const {
   mockLogSystemError: vi.fn(),
   mockAuthenticateApiKey: vi.fn(),
   mockAuthenticateOAuthToken: vi.fn(),
+  mockBuildCallCompletionResponse: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -100,6 +102,10 @@ vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
   logSystemError: mockLogSystemError,
+}));
+
+vi.mock("@/lib/x402/execution-wait", () => ({
+  buildCallCompletionResponse: mockBuildCallCompletionResponse,
 }));
 
 // ---------------------------------------------------------------------------
@@ -212,6 +218,12 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     mockRecordPayment.mockResolvedValue(undefined);
     mockHashPaymentSignature.mockReturnValue("hash-abc");
     mockResolveCreatorWallet.mockResolvedValue(CREATOR_WALLET);
+    // Default: simulate timeout so we fall back to running response. Tests
+    // exercising the synchronous completion path override this explicitly.
+    mockBuildCallCompletionResponse.mockImplementation(
+      (executionId: string) =>
+        Promise.resolve({ executionId, status: "running" })
+    );
     // Default no-op update chain: db.update(table).set(values).where(filter)
     mockDbUpdate.mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -532,6 +544,88 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     );
     // The workflow itself was never started.
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("Test 15b: free read workflow returns mapped output inline when execution completes within timeout (KEEP-265)", async () => {
+    setupDbSelectWorkflow(FREE_WORKFLOW);
+    setupDbInsertExecution("exec-sync-1");
+    mockBuildCallCompletionResponse.mockResolvedValue({
+      executionId: "exec-sync-1",
+      status: "success",
+      output: { balance: "1.3286 ETH" },
+    });
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow");
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.executionId).toBe("exec-sync-1");
+    expect(body.status).toBe("success");
+    expect(body.output).toEqual({ balance: "1.3286 ETH" });
+    // Workflow still kicked off in the background prior to the wait.
+    expect(mockStart).toHaveBeenCalled();
+  });
+
+  it("Test 15c: free read workflow falls back to running on timeout (KEEP-265)", async () => {
+    setupDbSelectWorkflow(FREE_WORKFLOW);
+    setupDbInsertExecution("exec-timeout-1");
+    mockBuildCallCompletionResponse.mockResolvedValue({
+      executionId: "exec-timeout-1",
+      status: "running",
+    });
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow");
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.executionId).toBe("exec-timeout-1");
+    expect(body.status).toBe("running");
+    expect(body.output).toBeUndefined();
+  });
+
+  it("Test 15d: free read workflow returns error status when execution fails within timeout (KEEP-265)", async () => {
+    setupDbSelectWorkflow(FREE_WORKFLOW);
+    setupDbInsertExecution("exec-err-1");
+    mockBuildCallCompletionResponse.mockResolvedValue({
+      executionId: "exec-err-1",
+      status: "error",
+      error: "RPC provider returned 500",
+    });
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow");
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.executionId).toBe("exec-err-1");
+    expect(body.status).toBe("error");
+    expect(body.error).toContain("RPC provider");
+  });
+
+  it("Test 15e: paid read workflow returns mapped output inline on synchronous completion (KEEP-265)", async () => {
+    setupDbSelectWorkflow(LISTED_WORKFLOW);
+    setupDbInsertExecution("exec-paid-sync-1");
+    makePassThroughGatePayment();
+    mockBuildCallCompletionResponse.mockResolvedValue({
+      executionId: "exec-paid-sync-1",
+      status: "success",
+      output: { riskScore: 2 },
+    });
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow", {
+      paymentSignature: "sig-sync",
+    });
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.executionId).toBe("exec-paid-sync-1");
+    expect(body.status).toBe("success");
+    expect(body.output).toEqual({ riskScore: 2 });
+    // Payment must still be recorded before completion wait returned a result.
+    expect(mockRecordPayment).toHaveBeenCalled();
   });
 
   it("Test 16: paid workflow probe with empty body returns 402 before body validation", async () => {


### PR DESCRIPTION
## Summary

- `call_workflow` (MCP + REST) now blocks up to ~25s for **read** workflow completion and returns the mapped output inline — no second round-trip needed.
- Falls back to the existing `{executionId, status: "running"}` response on timeout so long-running reads still work via polling.
- **Write** workflows and the 402 / calldata paths are unchanged.

Implements [KEEP-265](https://linear.app/keeperhubapp/issue/KEEP-265/call-workflow-should-wait-for-read-workflow-completion-before).

## Changes

- `lib/x402/execution-wait.ts` (new) — polls `workflowExecutions.status` until terminal, applies `outputMapping.{nodeId, fields}` against node logs, and builds the sync response.
- `app/api/mcp/workflows/[slug]/call/route.ts` — free and paid read paths now await `buildCallCompletionResponse` after kicking off the workflow.

## Test plan

- [x] `pnpm vitest run tests/unit/execution-wait.test.ts tests/unit/x402-call-route.test.ts tests/unit/mcp-meta-tools.test.ts` — 62 tests pass (15 new for the helpers, 4 new for sync/timeout/error response shapes on the route).
- [x] `pnpm vitest run tests/unit` (excluding stale worktree copies) — all 2,653 tests pass.
- [x] `pnpm type-check` — clean.
- [x] Local smoke test against `pnpm dev`: seeded a free read workflow, POSTed to `/api/mcp/workflows/<slug>/call`, got HTTP 200 with `{executionId, status: "success", output: ...}` in a single round-trip. DB confirmed the execution completed before the response returned.
- [ ] PR environment smoke test against the original repro (`mcp-test` slug with address `0xd8dA...96045`) once deploy previews.