### PR TITLE
fix(analytics): account for app-banner height in page padding

### DIFF
--- a/components/analytics/analytics-page.tsx
+++ b/components/analytics/analytics-page.tsx
@@ -118,7 +118,7 @@ export function AnalyticsPage(): ReactNode {
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
       <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-        <div className="flex flex-col gap-6 p-6 pt-20">
+        <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <AnalyticsHeader onRefetch={refetch} />
 
           <KpiCards />


### PR DESCRIPTION
## Summary

Fixes the failing `analytics-gas.test.ts` e2e test (`Gas Spent KPI card shows non-zero value`) on staging. The `/analytics` page didn't leave room for the new `AppBanner` in its top padding, so the persistent `WorkflowToolbar` was stacking on top of `AnalyticsHeader` and the "7d" time-range button became unclickable whenever the banner was visible (i.e. any fresh session without the localStorage dismissal).

## Root cause

PR #902 introduced `AppBanner` (`fixed top-0 z-[55] h-9`), which sets `document.documentElement --app-banner-height = 36px` while mounted. Pages with fixed/persistent top chrome are expected to pad with `pt-[calc(5rem+var(--app-banner-height,0px))]`. That pattern was applied to `billing-page`, `earnings-page`, and the `hasNoData` branch of `analytics-page`, but the main branch of `analytics-page` still used a flat `pt-20`, leaving `AnalyticsHeader` underneath the stacked banner + toolbar.

## Change

One line in `components/analytics/analytics-page.tsx`:

```diff
-        <div className="flex flex-col gap-6 p-6 pt-20">
+        <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
```

No visual change when the banner is dismissed; shifts analytics content down by 36px while the banner is visible so its header stays below the toolbar.

## Test plan

- [ ] `e2e-playwright-ephemeral` turns green on this PR
- [ ] Smoke-test `/analytics` locally with banner visible and dismissed
