### PR TITLE
fix: gate app-banner on NEXT_PUBLIC_BILLING_ENABLED

### DIFF
--- a/components/app-banner.tsx
+++ b/components/app-banner.tsx
@@ -3,10 +3,18 @@
 import { Info, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { isBillingEnabled } from "@/lib/billing/feature-flag";
 
 const STORAGE_KEY = "kh-billing-announce-v1";
 
 export function AppBanner(): React.ReactElement | null {
+  if (!isBillingEnabled()) {
+    return null;
+  }
+  return <BillingBanner />;
+}
+
+function BillingBanner(): React.ReactElement | null {
   const [mounted, setMounted] = useState(false);
   const [dismissed, setDismissed] = useState(true);
 


### PR DESCRIPTION
## Summary

- Hide the billing announcement banner (added in #902) in environments where billing isn't enabled, so non-billing deployments don't advertise Pro/Business plans that have no backing Stripe integration.
- Wrapped `AppBanner` with an outer component that short-circuits when `NEXT_PUBLIC_BILLING_ENABLED !== "true"`, then delegates to an inner `BillingBanner` that owns all the hooks — keeps rules-of-hooks clean since the flag check happens before any hook runs.

## Test Plan

- [ ] With `NEXT_PUBLIC_BILLING_ENABLED=true`, banner renders as before and remains dismissible
- [ ] With the flag unset/false, banner is not in the DOM and `--app-banner-height` is never set
- [ ] `pnpm check` and `pnpm type-check` pass