### PR TITLE
fix: KEEP-298 withdraw modal gas reserve and custom token listing

### DIFF
--- a/app/api/user/wallet/estimate-gas/route.ts
+++ b/app/api/user/wallet/estimate-gas/route.ts
@@ -1,0 +1,159 @@
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { apiError } from "@/lib/api-error";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { chains } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { getActiveOrgId } from "@/lib/middleware/org-context";
+import { getOrganizationWalletAddress } from "@/lib/para/wallet-helpers";
+import { getGasStrategy } from "@/lib/web3/gas-strategy";
+
+const ERC20_TRANSFER_ABI = [
+  "function transfer(address to, uint256 amount) returns (bool)",
+  "function decimals() view returns (uint8)",
+];
+
+async function validateUserAndOrganization(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+
+  if (!session?.user) {
+    return { error: "Unauthorized", status: 401 } as const;
+  }
+
+  const activeOrgId = getActiveOrgId(session);
+  if (!activeOrgId) {
+    return {
+      error: "No active organization. Please select or create an organization.",
+      status: 400,
+    } as const;
+  }
+
+  const activeMember = await auth.api.getActiveMember({
+    headers: await headers(),
+  });
+  if (!activeMember) {
+    return {
+      error: "You are not a member of the active organization",
+      status: 403,
+    } as const;
+  }
+
+  const role = activeMember.role;
+  if (role !== "admin" && role !== "owner") {
+    return {
+      error: "Only organization admins and owners can estimate withdrawals",
+      status: 403,
+    } as const;
+  }
+
+  return { organizationId: activeOrgId };
+}
+
+export async function POST(request: Request) {
+  try {
+    const validation = await validateUserAndOrganization(request);
+    if ("error" in validation) {
+      return NextResponse.json(
+        { error: validation.error },
+        { status: validation.status }
+      );
+    }
+    const { organizationId } = validation;
+
+    const body = await request.json();
+    const { chainId: rawChainId, tokenAddress, amount, recipient } = body;
+
+    if (!(rawChainId && amount && recipient)) {
+      return NextResponse.json(
+        { error: "Missing required fields: chainId, amount, recipient" },
+        { status: 400 }
+      );
+    }
+
+    const chainId = Number.parseInt(String(rawChainId), 10);
+    if (Number.isNaN(chainId)) {
+      return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
+    }
+
+    if (!ethers.isAddress(recipient)) {
+      return NextResponse.json(
+        { error: "Invalid recipient address" },
+        { status: 400 }
+      );
+    }
+
+    const parsedAmount = Number.parseFloat(amount);
+    if (Number.isNaN(parsedAmount) || parsedAmount <= 0) {
+      return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+    }
+
+    const chainResult = await db
+      .select()
+      .from(chains)
+      .where(eq(chains.chainId, chainId))
+      .limit(1);
+
+    if (chainResult.length === 0) {
+      return NextResponse.json(
+        { error: `Chain ${chainId} not found` },
+        { status: 404 }
+      );
+    }
+
+    const chain = chainResult[0];
+    const walletAddress = await getOrganizationWalletAddress(organizationId);
+    const provider = new ethers.JsonRpcProvider(chain.defaultPrimaryRpc);
+
+    let estimatedGas: bigint;
+    if (tokenAddress) {
+      const contract = new ethers.Contract(
+        tokenAddress,
+        ERC20_TRANSFER_ABI,
+        provider
+      );
+      const decimals: number = await contract.decimals();
+      const amountWei = ethers.parseUnits(amount, decimals);
+      estimatedGas = await contract.transfer.estimateGas(recipient, amountWei, {
+        from: walletAddress,
+      });
+    } else {
+      const amountWei = ethers.parseEther(amount);
+      estimatedGas = await provider.estimateGas({
+        from: walletAddress,
+        to: recipient,
+        value: amountWei,
+      });
+    }
+
+    const gasConfig = await getGasStrategy().getGasConfig(
+      provider,
+      "manual",
+      estimatedGas,
+      chainId
+    );
+
+    const gasCostWei = gasConfig.gasLimit * gasConfig.maxFeePerGas;
+
+    return NextResponse.json({
+      gasCostWei: gasCostWei.toString(),
+      gasCostEth: ethers.formatEther(gasCostWei),
+      nativeSymbol: chain.symbol,
+      gasLimit: gasConfig.gasLimit.toString(),
+      maxFeePerGasGwei: ethers.formatUnits(gasConfig.maxFeePerGas, "gwei"),
+    });
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[EstimateGas] Failed",
+      error,
+      {
+        endpoint: "/api/user/wallet/estimate-gas",
+        operation: "post",
+      }
+    );
+    return apiError(error, "Failed to estimate gas");
+  }
+}

--- a/app/api/user/wallet/estimate-gas/route.ts
+++ b/app/api/user/wallet/estimate-gas/route.ts
@@ -139,12 +139,17 @@ export async function POST(request: Request) {
       chainId
     );
 
-    const gasCostWei = gasConfig.gasLimit * gasConfig.maxFeePerGas;
+    // Upper-bound on what the tx will actually burn: estimatedGas * maxFeePerGas.
+    // gasLimit is a consumption cap, not a prepay, so we do not multiply by it here
+    // or we would quote (and reserve) a fee that the tx cannot reach in practice.
+    // maxFeePerGas already encodes headroom for a baseFee spike.
+    const gasCostWei = estimatedGas * gasConfig.maxFeePerGas;
 
     return NextResponse.json({
       gasCostWei: gasCostWei.toString(),
       gasCostEth: ethers.formatEther(gasCostWei),
       nativeSymbol: chain.symbol,
+      estimatedGas: estimatedGas.toString(),
       gasLimit: gasConfig.gasLimit.toString(),
       maxFeePerGasGwei: ethers.formatUnits(gasConfig.maxFeePerGas, "gwei"),
     });

--- a/app/api/user/wallet/estimate-gas/route.ts
+++ b/app/api/user/wallet/estimate-gas/route.ts
@@ -9,6 +9,7 @@ import { chains } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { getOrganizationWalletAddress } from "@/lib/para/wallet-helpers";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getGasStrategy } from "@/lib/web3/gas-strategy";
 
 const ERC20_TRANSFER_ABI = [
@@ -105,31 +106,34 @@ export async function POST(request: Request) {
 
     const chain = chainResult[0];
     const walletAddress = await getOrganizationWalletAddress(organizationId);
-    const provider = new ethers.JsonRpcProvider(chain.defaultPrimaryRpc);
+    const rpcManager = await getRpcProvider({ chainId });
 
-    let estimatedGas: bigint;
-    if (tokenAddress) {
-      const contract = new ethers.Contract(
-        tokenAddress,
-        ERC20_TRANSFER_ABI,
-        provider
-      );
-      const decimals: number = await contract.decimals();
-      const amountWei = ethers.parseUnits(amount, decimals);
-      estimatedGas = await contract.transfer.estimateGas(recipient, amountWei, {
-        from: walletAddress,
-      });
-    } else {
-      const amountWei = ethers.parseEther(amount);
-      estimatedGas = await provider.estimateGas({
-        from: walletAddress,
-        to: recipient,
-        value: amountWei,
-      });
-    }
+    const estimatedGas = await rpcManager.executeWithFailover(
+      async (provider): Promise<bigint> => {
+        if (tokenAddress) {
+          const contract = new ethers.Contract(
+            tokenAddress,
+            ERC20_TRANSFER_ABI,
+            provider
+          );
+          const decimalsBig: bigint = await contract.decimals();
+          const decimals = Number(decimalsBig);
+          const amountWei = ethers.parseUnits(amount, decimals);
+          return await contract.transfer.estimateGas(recipient, amountWei, {
+            from: walletAddress,
+          });
+        }
+        const amountWei = ethers.parseEther(amount);
+        return await provider.estimateGas({
+          from: walletAddress,
+          to: recipient,
+          value: amountWei,
+        });
+      }
+    );
 
     const gasConfig = await getGasStrategy().getGasConfig(
-      provider,
+      rpcManager.getProvider(),
       "manual",
       estimatedGas,
       chainId

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -38,6 +38,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
 import { useSession } from "@/lib/auth-client";
 import { useActiveMember } from "@/lib/hooks/use-organization";
+import { buildWithdrawableAssets } from "@/lib/wallet/build-withdrawable-assets";
 import { fetchAllSupportedTokenBalances } from "@/lib/wallet/fetch-balances";
 import type {
   ChainBalance,
@@ -1409,100 +1410,25 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     [loadWallet]
   );
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Logic is straightforward, three loops with validation
-  const buildWithdrawableAssets = useCallback((): WithdrawableAsset[] => {
-    const assets: WithdrawableAsset[] = [];
-
-    // Add native balances (skip TEMPO - it uses stablecoins, not native tokens)
-    for (const balance of balances) {
-      if (isTempoChain(balance.chainId)) {
-        continue;
-      }
-      const chain = chains.find((c) => c.chainId === balance.chainId);
-      const numBalance = Number.parseFloat(balance.balance);
-      if (!(chain && Number.isFinite(numBalance)) || numBalance <= 0) {
-        continue;
-      }
-      assets.push({
-        type: "native",
-        chainId: balance.chainId,
-        chainName: balance.name,
-        symbol: balance.symbol,
-        balance: balance.balance,
-        decimals: 18,
-        rpcUrl: chain.defaultPrimaryRpc,
-        explorerUrl: balance.explorerUrl,
-      });
-    }
-
-    // Add supported token balances (stablecoins)
-    for (const token of supportedTokenBalances) {
-      const numBalance = Number.parseFloat(token.balance);
-      if (!Number.isFinite(numBalance) || numBalance <= 0) {
-        continue;
-      }
-      const chain = chains.find((c) => c.chainId === token.chainId);
-      if (!chain) {
-        continue;
-      }
-      const tokenMeta = supportedTokens.find(
-        (t) =>
-          t.chainId === token.chainId && t.tokenAddress === token.tokenAddress
-      );
-      const balance = balances.find((b) => b.chainId === token.chainId);
-      assets.push({
-        type: "token",
-        chainId: token.chainId,
-        chainName: chain.name,
-        symbol: token.symbol,
-        balance: token.balance,
-        tokenAddress: token.tokenAddress,
-        decimals: tokenMeta?.decimals ?? 6,
-        rpcUrl: chain.defaultPrimaryRpc,
-        explorerUrl: balance?.explorerUrl || null,
-      });
-    }
-
-    // Add custom token balances (user-added ERC20s)
-    for (const token of tokenBalances) {
-      const numBalance = Number.parseFloat(token.balance);
-      if (!Number.isFinite(numBalance) || numBalance <= 0) {
-        continue;
-      }
-      const chain = chains.find((c) => c.chainId === token.chainId);
-      if (!chain) {
-        continue;
-      }
-      const tokenMeta = tokens.find(
-        (t) =>
-          t.chainId === token.chainId && t.tokenAddress === token.tokenAddress
-      );
-      if (!tokenMeta) {
-        continue;
-      }
-      const nativeBalance = balances.find((b) => b.chainId === token.chainId);
-      assets.push({
-        type: "token",
-        chainId: token.chainId,
-        chainName: chain.name,
-        symbol: token.symbol,
-        balance: token.balance,
-        tokenAddress: token.tokenAddress,
-        decimals: tokenMeta.decimals,
-        rpcUrl: chain.defaultPrimaryRpc,
-        explorerUrl: nativeBalance?.explorerUrl || null,
-      });
-    }
-
-    return assets;
-  }, [
-    balances,
-    chains,
-    supportedTokenBalances,
-    supportedTokens,
-    tokenBalances,
-    tokens,
-  ]);
+  const buildAssets = useCallback(
+    (): WithdrawableAsset[] =>
+      buildWithdrawableAssets({
+        balances,
+        chains,
+        supportedTokenBalances,
+        supportedTokens,
+        tokenBalances,
+        tokens,
+      }),
+    [
+      balances,
+      chains,
+      supportedTokenBalances,
+      supportedTokens,
+      tokenBalances,
+      tokens,
+    ]
+  );
 
   const findAssetIndex = useCallback(
     (assets: WithdrawableAsset[], chainId: number, tokenAddress?: string) => {
@@ -1526,7 +1452,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
         return;
       }
 
-      const assets = buildWithdrawableAssets();
+      const assets = buildAssets();
       if (assets.length === 0) {
         toast.error("No assets available for withdrawal");
         return;
@@ -1539,7 +1465,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
         initialAssetIndex: initialIndex,
       });
     },
-    [walletData?.walletAddress, buildWithdrawableAssets, findAssetIndex, push]
+    [walletData?.walletAddress, buildAssets, findAssetIndex, push]
   );
 
   // Re-fetch wallet when session changes (e.g., user signs in)

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -1409,18 +1409,16 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     [loadWallet]
   );
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Logic is straightforward, two loops with validation
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Logic is straightforward, three loops with validation
   const buildWithdrawableAssets = useCallback((): WithdrawableAsset[] => {
     const assets: WithdrawableAsset[] = [];
 
     // Add native balances (skip TEMPO - it uses stablecoins, not native tokens)
     for (const balance of balances) {
-      // Skip TEMPO native balance - it uses stablecoins only
       if (isTempoChain(balance.chainId)) {
         continue;
       }
       const chain = chains.find((c) => c.chainId === balance.chainId);
-      // Skip if not a valid positive number
       const numBalance = Number.parseFloat(balance.balance);
       if (!(chain && Number.isFinite(numBalance)) || numBalance <= 0) {
         continue;
@@ -1439,7 +1437,6 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
 
     // Add supported token balances (stablecoins)
     for (const token of supportedTokenBalances) {
-      // Skip if not a valid positive number
       const numBalance = Number.parseFloat(token.balance);
       if (!Number.isFinite(numBalance) || numBalance <= 0) {
         continue;
@@ -1448,6 +1445,10 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
       if (!chain) {
         continue;
       }
+      const tokenMeta = supportedTokens.find(
+        (t) =>
+          t.chainId === token.chainId && t.tokenAddress === token.tokenAddress
+      );
       const balance = balances.find((b) => b.chainId === token.chainId);
       assets.push({
         type: "token",
@@ -1456,14 +1457,52 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
         symbol: token.symbol,
         balance: token.balance,
         tokenAddress: token.tokenAddress,
-        decimals: 6,
+        decimals: tokenMeta?.decimals ?? 6,
         rpcUrl: chain.defaultPrimaryRpc,
         explorerUrl: balance?.explorerUrl || null,
       });
     }
 
+    // Add custom token balances (user-added ERC20s)
+    for (const token of tokenBalances) {
+      const numBalance = Number.parseFloat(token.balance);
+      if (!Number.isFinite(numBalance) || numBalance <= 0) {
+        continue;
+      }
+      const chain = chains.find((c) => c.chainId === token.chainId);
+      if (!chain) {
+        continue;
+      }
+      const tokenMeta = tokens.find(
+        (t) =>
+          t.chainId === token.chainId && t.tokenAddress === token.tokenAddress
+      );
+      if (!tokenMeta) {
+        continue;
+      }
+      const nativeBalance = balances.find((b) => b.chainId === token.chainId);
+      assets.push({
+        type: "token",
+        chainId: token.chainId,
+        chainName: chain.name,
+        symbol: token.symbol,
+        balance: token.balance,
+        tokenAddress: token.tokenAddress,
+        decimals: tokenMeta.decimals,
+        rpcUrl: chain.defaultPrimaryRpc,
+        explorerUrl: nativeBalance?.explorerUrl || null,
+      });
+    }
+
     return assets;
-  }, [balances, chains, supportedTokenBalances]);
+  }, [
+    balances,
+    chains,
+    supportedTokenBalances,
+    supportedTokens,
+    tokenBalances,
+    tokens,
+  ]);
 
   const findAssetIndex = useCallback(
     (assets: WithdrawableAsset[], chainId: number, tokenAddress?: string) => {

--- a/components/overlays/withdraw-modal.tsx
+++ b/components/overlays/withdraw-modal.tsx
@@ -185,14 +185,13 @@ export function WithdrawModal({
 
       const balanceWei = ethers.parseEther(selectedAsset.balance);
       const gasCostWei = BigInt(data.gasCostWei);
-      const gasCostWithBuffer = (gasCostWei * BigInt(110)) / BigInt(100);
 
-      if (balanceWei <= gasCostWithBuffer) {
+      if (balanceWei <= gasCostWei) {
         toast.error("Balance is too low to cover network fee");
         return;
       }
 
-      const maxWei = balanceWei - gasCostWithBuffer;
+      const maxWei = balanceWei - gasCostWei;
       const newAmount = ethers.formatEther(maxWei);
 
       lastEstimateKeyRef.current = `${selectedAsset.chainId}|native|${newAmount}|${estimationRecipient}`;

--- a/components/overlays/withdraw-modal.tsx
+++ b/components/overlays/withdraw-modal.tsx
@@ -56,6 +56,7 @@ export function WithdrawModal({
   const [gasEstimateLoading, setGasEstimateLoading] = useState(false);
   const [gasEstimateError, setGasEstimateError] = useState<string | null>(null);
   const [maxReserveApplied, setMaxReserveApplied] = useState(false);
+  const [maxLoading, setMaxLoading] = useState(false);
   const lastEstimateKeyRef = useRef<string | null>(null);
 
   const selectedAsset = assets[selectedAssetIndex];
@@ -88,50 +89,52 @@ export function WithdrawModal({
     }
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
+    const runEstimate = async (): Promise<void> => {
       setGasEstimateLoading(true);
       setGasEstimateError(null);
-      fetch("/api/user/wallet/estimate-gas", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          chainId: selectedAsset.chainId,
-          tokenAddress: selectedAsset.tokenAddress,
-          amount,
-          recipient: estimationRecipient,
-        }),
-        signal: controller.signal,
-      })
-        .then(async (response) => {
-          const data = await response.json();
-          if (!response.ok) {
-            throw new Error(data.error ?? "Gas estimation failed");
-          }
-          return data as {
-            gasCostWei: string;
-            gasCostEth: string;
-            nativeSymbol: string;
-          };
-        })
-        .then((data) => {
-          setGasEstimate({
-            costWei: BigInt(data.gasCostWei),
-            costEth: data.gasCostEth,
-            nativeSymbol: data.nativeSymbol,
-          });
-          lastEstimateKeyRef.current = key;
-          setGasEstimateLoading(false);
-        })
-        .catch((err: unknown) => {
-          if (err instanceof Error && err.name === "AbortError") {
-            return;
-          }
-          setGasEstimate(null);
-          setGasEstimateError(
-            err instanceof Error ? err.message : "Gas estimation failed"
-          );
-          setGasEstimateLoading(false);
+      try {
+        const response = await fetch("/api/user/wallet/estimate-gas", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chainId: selectedAsset.chainId,
+            tokenAddress: selectedAsset.tokenAddress,
+            amount,
+            recipient: estimationRecipient,
+          }),
+          signal: controller.signal,
         });
+        const data = (await response.json()) as {
+          gasCostWei?: string;
+          gasCostEth?: string;
+          nativeSymbol?: string;
+          error?: string;
+        };
+        if (
+          !(response.ok && data.gasCostWei && data.gasCostEth && data.nativeSymbol)
+        ) {
+          throw new Error(data.error ?? "Gas estimation failed");
+        }
+        setGasEstimate({
+          costWei: BigInt(data.gasCostWei),
+          costEth: data.gasCostEth,
+          nativeSymbol: data.nativeSymbol,
+        });
+        lastEstimateKeyRef.current = key;
+        setGasEstimateLoading(false);
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === "AbortError") {
+          return;
+        }
+        setGasEstimate(null);
+        setGasEstimateError(
+          err instanceof Error ? err.message : "Gas estimation failed"
+        );
+        setGasEstimateLoading(false);
+      }
+    };
+    const timeoutId = setTimeout(() => {
+      void runEstimate();
     }, 500);
 
     return () => {
@@ -144,8 +147,6 @@ export function WithdrawModal({
     selectedAsset,
     walletAddress,
   ]);
-
-  const [maxLoading, setMaxLoading] = useState(false);
 
   const handleMaxClick = async (): Promise<void> => {
     if (!selectedAsset) {
@@ -169,6 +170,9 @@ export function WithdrawModal({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           chainId: selectedAsset.chainId,
+          // Native gasUsed is amount-independent, so a tiny placeholder is enough
+          // to get the fee estimate. Passing the full balance here would make
+          // provider.estimateGas reject with insufficient-funds for this very call.
           amount: "0.000001",
           recipient: estimationRecipient,
         }),

--- a/components/overlays/withdraw-modal.tsx
+++ b/components/overlays/withdraw-modal.tsx
@@ -2,7 +2,7 @@
 
 import { ethers } from "ethers";
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Overlay } from "@/components/overlays/overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
@@ -40,6 +40,12 @@ type WithdrawModalProps = {
 
 type WithdrawState = "input" | "confirming" | "success" | "error";
 
+type GasEstimate = {
+  costWei: bigint;
+  costEth: string;
+  nativeSymbol: string;
+};
+
 export function WithdrawModal({
   overlayId,
   assets,
@@ -55,13 +61,164 @@ export function WithdrawModal({
   const [state, setState] = useState<WithdrawState>("input");
   const [txHash, setTxHash] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [gasEstimate, _setGasEstimate] = useState<string | null>(null);
+  const [gasEstimate, setGasEstimate] = useState<GasEstimate | null>(null);
+  const [gasEstimateLoading, setGasEstimateLoading] = useState(false);
+  const [gasEstimateError, setGasEstimateError] = useState<string | null>(null);
+  const [maxReserveApplied, setMaxReserveApplied] = useState(false);
+  const lastEstimateKeyRef = useRef<string | null>(null);
 
   const selectedAsset = assets[selectedAssetIndex];
 
-  const handleMaxClick = () => {
-    if (selectedAsset) {
+  useEffect(() => {
+    if (!selectedAsset) {
+      return;
+    }
+    const parsedAmount = Number.parseFloat(amount);
+    if (!(amount && Number.isFinite(parsedAmount)) || parsedAmount <= 0) {
+      setGasEstimate(null);
+      setGasEstimateError(null);
+      setGasEstimateLoading(false);
+      return;
+    }
+    if (parsedAmount > Number.parseFloat(selectedAsset.balance)) {
+      setGasEstimate(null);
+      setGasEstimateError(null);
+      setGasEstimateLoading(false);
+      return;
+    }
+
+    const estimationRecipient = ethers.isAddress(recipient)
+      ? recipient
+      : walletAddress;
+
+    const key = `${selectedAsset.chainId}|${selectedAsset.tokenAddress ?? "native"}|${amount}|${estimationRecipient}`;
+    if (lastEstimateKeyRef.current === key) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      setGasEstimateLoading(true);
+      setGasEstimateError(null);
+      fetch("/api/user/wallet/estimate-gas", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chainId: selectedAsset.chainId,
+          tokenAddress: selectedAsset.tokenAddress,
+          amount,
+          recipient: estimationRecipient,
+        }),
+        signal: controller.signal,
+      })
+        .then(async (response) => {
+          const data = await response.json();
+          if (!response.ok) {
+            throw new Error(data.error ?? "Gas estimation failed");
+          }
+          return data as {
+            gasCostWei: string;
+            gasCostEth: string;
+            nativeSymbol: string;
+          };
+        })
+        .then((data) => {
+          setGasEstimate({
+            costWei: BigInt(data.gasCostWei),
+            costEth: data.gasCostEth,
+            nativeSymbol: data.nativeSymbol,
+          });
+          lastEstimateKeyRef.current = key;
+          setGasEstimateLoading(false);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof Error && err.name === "AbortError") {
+            return;
+          }
+          setGasEstimate(null);
+          setGasEstimateError(
+            err instanceof Error ? err.message : "Gas estimation failed"
+          );
+          setGasEstimateLoading(false);
+        });
+    }, 500);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeoutId);
+    };
+  }, [
+    amount,
+    recipient,
+    selectedAsset,
+    walletAddress,
+  ]);
+
+  const [maxLoading, setMaxLoading] = useState(false);
+
+  const handleMaxClick = async (): Promise<void> => {
+    if (!selectedAsset) {
+      return;
+    }
+
+    if (selectedAsset.type === "token") {
       setAmount(selectedAsset.balance);
+      setMaxReserveApplied(false);
+      return;
+    }
+
+    setMaxLoading(true);
+    try {
+      const estimationRecipient = ethers.isAddress(recipient)
+        ? recipient
+        : walletAddress;
+
+      const response = await fetch("/api/user/wallet/estimate-gas", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chainId: selectedAsset.chainId,
+          amount: "0.000001",
+          recipient: estimationRecipient,
+        }),
+      });
+      const data = (await response.json()) as {
+        gasCostWei?: string;
+        gasCostEth?: string;
+        nativeSymbol?: string;
+        error?: string;
+      };
+      if (!(response.ok && data.gasCostWei && data.gasCostEth && data.nativeSymbol)) {
+        throw new Error(data.error ?? "Gas estimation failed");
+      }
+
+      const balanceWei = ethers.parseEther(selectedAsset.balance);
+      const gasCostWei = BigInt(data.gasCostWei);
+      const gasCostWithBuffer = (gasCostWei * BigInt(110)) / BigInt(100);
+
+      if (balanceWei <= gasCostWithBuffer) {
+        toast.error("Balance is too low to cover network fee");
+        return;
+      }
+
+      const maxWei = balanceWei - gasCostWithBuffer;
+      const newAmount = ethers.formatEther(maxWei);
+
+      lastEstimateKeyRef.current = `${selectedAsset.chainId}|native|${newAmount}|${estimationRecipient}`;
+      setGasEstimate({
+        costWei: gasCostWei,
+        costEth: data.gasCostEth,
+        nativeSymbol: data.nativeSymbol,
+      });
+      setGasEstimateError(null);
+      setMaxReserveApplied(true);
+      setAmount(newAmount);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to calculate max amount"
+      );
+    } finally {
+      setMaxLoading(false);
     }
   };
 
@@ -211,6 +368,7 @@ export function WithdrawModal({
             onValueChange={(value) => {
               setSelectedAssetIndex(Number.parseInt(value, 10));
               setAmount("");
+              setMaxReserveApplied(false);
             }}
             value={selectedAssetIndex.toString()}
           >
@@ -235,18 +393,26 @@ export function WithdrawModal({
           <Label>Amount</Label>
           <div className="flex gap-2">
             <Input
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={(e) => {
+                setAmount(e.target.value);
+                setMaxReserveApplied(false);
+              }}
               placeholder="0.00"
               type="number"
               value={amount}
             />
             <Button
+              disabled={maxLoading}
               onClick={handleMaxClick}
               size="sm"
               type="button"
               variant="outline"
             >
-              Max
+              {maxLoading ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                "Max"
+              )}
             </Button>
           </div>
           {selectedAsset && (
@@ -272,11 +438,31 @@ export function WithdrawModal({
         </div>
 
         {/* Gas Estimate (informational) */}
-        {gasEstimate && (
-          <div className="rounded-md border bg-muted/50 p-3">
-            <p className="text-muted-foreground text-xs">
-              Estimated network fee: {gasEstimate}
-            </p>
+        {(gasEstimateLoading || gasEstimate || gasEstimateError) && (
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">Network fee</span>
+              {gasEstimateLoading && (
+                <span className="flex items-center gap-1.5 text-muted-foreground">
+                  <Loader2 className="size-3 animate-spin" />
+                  Estimating...
+                </span>
+              )}
+              {!gasEstimateLoading && gasEstimate && (
+                <span className="font-medium text-foreground">
+                  {gasEstimate.costEth} {gasEstimate.nativeSymbol}
+                </span>
+              )}
+              {!gasEstimateLoading && gasEstimateError && (
+                <span className="text-destructive">Unable to estimate</span>
+              )}
+            </div>
+            {maxReserveApplied && gasEstimate && (
+              <p className="text-muted-foreground text-xs">
+                Max amount reduced to reserve {gasEstimate.costEth}{" "}
+                {gasEstimate.nativeSymbol} for the network fee.
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/components/overlays/withdraw-modal.tsx
+++ b/components/overlays/withdraw-modal.tsx
@@ -18,18 +18,9 @@ import {
 } from "@/components/ui/select";
 import { SaveAddressBookmark } from "@/components/address-book/save-address-bookmark";
 import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
+import type { WithdrawableAsset } from "@/lib/wallet/build-withdrawable-assets";
 
-export type WithdrawableAsset = {
-  type: "native" | "token";
-  chainId: number;
-  chainName: string;
-  symbol: string;
-  balance: string;
-  tokenAddress?: string;
-  decimals: number;
-  rpcUrl: string;
-  explorerUrl: string | null;
-};
+export type { WithdrawableAsset };
 
 type WithdrawModalProps = {
   overlayId: string;

--- a/lib/wallet/build-withdrawable-assets.ts
+++ b/lib/wallet/build-withdrawable-assets.ts
@@ -1,0 +1,144 @@
+import type {
+  ChainBalance,
+  ChainData,
+  SupportedToken,
+  SupportedTokenBalance,
+  TokenBalance,
+  TokenData,
+} from "./types";
+
+export type WithdrawableAsset = {
+  type: "native" | "token";
+  chainId: number;
+  chainName: string;
+  symbol: string;
+  balance: string;
+  tokenAddress?: string;
+  decimals: number;
+  rpcUrl: string;
+  explorerUrl: string | null;
+};
+
+export type BuildWithdrawableAssetsInput = {
+  balances: ChainBalance[];
+  chains: ChainData[];
+  supportedTokenBalances: SupportedTokenBalance[];
+  supportedTokens: SupportedToken[];
+  tokenBalances: TokenBalance[];
+  tokens: TokenData[];
+};
+
+const TEMPO_CHAIN_IDS: ReadonlySet<number> = new Set([42_429, 4217]);
+const DEFAULT_STABLECOIN_DECIMALS = 6;
+
+function hasPositiveBalance(raw: string): boolean {
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0;
+}
+
+function collectNativeAssets(
+  input: BuildWithdrawableAssetsInput
+): WithdrawableAsset[] {
+  const assets: WithdrawableAsset[] = [];
+  for (const balance of input.balances) {
+    if (TEMPO_CHAIN_IDS.has(balance.chainId)) {
+      continue;
+    }
+    const chain = input.chains.find((c) => c.chainId === balance.chainId);
+    if (!(chain && hasPositiveBalance(balance.balance))) {
+      continue;
+    }
+    assets.push({
+      type: "native",
+      chainId: balance.chainId,
+      chainName: balance.name,
+      symbol: balance.symbol,
+      balance: balance.balance,
+      decimals: 18,
+      rpcUrl: chain.defaultPrimaryRpc,
+      explorerUrl: balance.explorerUrl,
+    });
+  }
+  return assets;
+}
+
+function collectSupportedTokenAssets(
+  input: BuildWithdrawableAssetsInput
+): WithdrawableAsset[] {
+  const assets: WithdrawableAsset[] = [];
+  for (const token of input.supportedTokenBalances) {
+    if (!hasPositiveBalance(token.balance)) {
+      continue;
+    }
+    const chain = input.chains.find((c) => c.chainId === token.chainId);
+    if (!chain) {
+      continue;
+    }
+    const tokenMeta = input.supportedTokens.find(
+      (t) =>
+        t.chainId === token.chainId && t.tokenAddress === token.tokenAddress
+    );
+    const nativeBalance = input.balances.find(
+      (b) => b.chainId === token.chainId
+    );
+    assets.push({
+      type: "token",
+      chainId: token.chainId,
+      chainName: chain.name,
+      symbol: token.symbol,
+      balance: token.balance,
+      tokenAddress: token.tokenAddress,
+      decimals: tokenMeta?.decimals ?? DEFAULT_STABLECOIN_DECIMALS,
+      rpcUrl: chain.defaultPrimaryRpc,
+      explorerUrl: nativeBalance?.explorerUrl ?? null,
+    });
+  }
+  return assets;
+}
+
+function collectCustomTokenAssets(
+  input: BuildWithdrawableAssetsInput
+): WithdrawableAsset[] {
+  const assets: WithdrawableAsset[] = [];
+  for (const token of input.tokenBalances) {
+    if (!hasPositiveBalance(token.balance)) {
+      continue;
+    }
+    const chain = input.chains.find((c) => c.chainId === token.chainId);
+    if (!chain) {
+      continue;
+    }
+    const tokenMeta = input.tokens.find(
+      (t) =>
+        t.chainId === token.chainId && t.tokenAddress === token.tokenAddress
+    );
+    if (!tokenMeta) {
+      continue;
+    }
+    const nativeBalance = input.balances.find(
+      (b) => b.chainId === token.chainId
+    );
+    assets.push({
+      type: "token",
+      chainId: token.chainId,
+      chainName: chain.name,
+      symbol: token.symbol,
+      balance: token.balance,
+      tokenAddress: token.tokenAddress,
+      decimals: tokenMeta.decimals,
+      rpcUrl: chain.defaultPrimaryRpc,
+      explorerUrl: nativeBalance?.explorerUrl ?? null,
+    });
+  }
+  return assets;
+}
+
+export function buildWithdrawableAssets(
+  input: BuildWithdrawableAssetsInput
+): WithdrawableAsset[] {
+  return [
+    ...collectNativeAssets(input),
+    ...collectSupportedTokenAssets(input),
+    ...collectCustomTokenAssets(input),
+  ];
+}

--- a/tests/unit/build-withdrawable-assets.test.ts
+++ b/tests/unit/build-withdrawable-assets.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import {
+  type BuildWithdrawableAssetsInput,
+  buildWithdrawableAssets,
+} from "@/lib/wallet/build-withdrawable-assets";
+import type {
+  ChainBalance,
+  ChainData,
+  SupportedToken,
+  SupportedTokenBalance,
+  TokenBalance,
+  TokenData,
+} from "@/lib/wallet/types";
+
+const MAINNET: ChainData = {
+  id: "eth-mainnet",
+  chainId: 1,
+  name: "Ethereum Mainnet",
+  symbol: "ETH",
+  chainType: "evm",
+  defaultPrimaryRpc: "https://rpc.eth.example",
+  defaultFallbackRpc: null,
+  explorerUrl: null,
+  explorerAddressPath: null,
+  isTestnet: false,
+  isEnabled: true,
+};
+
+const SEPOLIA: ChainData = {
+  ...MAINNET,
+  id: "eth-sepolia",
+  chainId: 11_155_111,
+  name: "Ethereum Sepolia",
+  defaultPrimaryRpc: "https://rpc.sepolia.example",
+  isTestnet: true,
+};
+
+const TEMPO: ChainData = {
+  ...MAINNET,
+  id: "tempo",
+  chainId: 4217,
+  name: "Tempo",
+  defaultPrimaryRpc: "https://rpc.tempo.example",
+};
+
+function nativeBalance(overrides: Partial<ChainBalance> = {}): ChainBalance {
+  return {
+    chainId: 1,
+    name: "Ethereum Mainnet",
+    symbol: "ETH",
+    balance: "1.000000",
+    loading: false,
+    isTestnet: false,
+    explorerUrl: "https://etherscan.io/address/0x0",
+    ...overrides,
+  };
+}
+
+function supportedTokenBalance(
+  overrides: Partial<SupportedTokenBalance> = {}
+): SupportedTokenBalance {
+  return {
+    chainId: 1,
+    tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    symbol: "USDC",
+    name: "USD Coin",
+    logoUrl: null,
+    balance: "10.000000",
+    loading: false,
+    ...overrides,
+  };
+}
+
+function supportedToken(
+  overrides: Partial<SupportedToken> = {}
+): SupportedToken {
+  return {
+    id: "stk_usdc_mainnet",
+    chainId: 1,
+    tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6,
+    logoUrl: null,
+    ...overrides,
+  };
+}
+
+function customTokenBalance(
+  overrides: Partial<TokenBalance> = {}
+): TokenBalance {
+  return {
+    tokenId: "tok_sky",
+    chainId: 1,
+    tokenAddress: "0x56072c95faa701256059aa122697b133aded9279",
+    symbol: "SKY",
+    name: "SKY Governance Token",
+    balance: "0.671051",
+    loading: false,
+    ...overrides,
+  };
+}
+
+function customToken(overrides: Partial<TokenData> = {}): TokenData {
+  return {
+    id: "tok_sky",
+    chainId: 1,
+    tokenAddress: "0x56072c95faa701256059aa122697b133aded9279",
+    symbol: "SKY",
+    name: "SKY Governance Token",
+    decimals: 18,
+    logoUrl: null,
+    ...overrides,
+  };
+}
+
+function emptyInput(
+  overrides: Partial<BuildWithdrawableAssetsInput> = {}
+): BuildWithdrawableAssetsInput {
+  return {
+    balances: [],
+    chains: [MAINNET],
+    supportedTokenBalances: [],
+    supportedTokens: [],
+    tokenBalances: [],
+    tokens: [],
+    ...overrides,
+  };
+}
+
+describe("buildWithdrawableAssets", () => {
+  it("returns empty array when nothing is funded", () => {
+    expect(buildWithdrawableAssets(emptyInput())).toEqual([]);
+  });
+
+  it("includes native balances with positive amount", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({ balances: [nativeBalance({ balance: "0.5" })] })
+    );
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      type: "native",
+      chainId: 1,
+      symbol: "ETH",
+      balance: "0.5",
+      decimals: 18,
+      rpcUrl: MAINNET.defaultPrimaryRpc,
+    });
+  });
+
+  it("skips native balances that are zero or negative", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        balances: [
+          nativeBalance({ balance: "0" }),
+          nativeBalance({ balance: "0.0" }),
+          nativeBalance({ balance: "-1" }),
+        ],
+      })
+    );
+    expect(assets).toEqual([]);
+  });
+
+  it("skips native balances whose chain is missing from the chains list", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        chains: [],
+        balances: [nativeBalance({ balance: "1" })],
+      })
+    );
+    expect(assets).toEqual([]);
+  });
+
+  it("skips TEMPO native balances (TEMPO uses stablecoins only)", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        chains: [TEMPO],
+        balances: [
+          nativeBalance({
+            chainId: TEMPO.chainId,
+            name: TEMPO.name,
+            balance: "5",
+          }),
+        ],
+      })
+    );
+    expect(assets).toEqual([]);
+  });
+
+  it("includes supported tokens with positive balance and metadata decimals", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        supportedTokenBalances: [
+          supportedTokenBalance({ symbol: "USDS", balance: "3.5" }),
+        ],
+        supportedTokens: [supportedToken({ symbol: "USDS", decimals: 18 })],
+      })
+    );
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      type: "token",
+      symbol: "USDS",
+      balance: "3.5",
+      decimals: 18,
+    });
+  });
+
+  it("falls back to 6 decimals when supported token metadata is missing", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        supportedTokenBalances: [supportedTokenBalance({ balance: "7" })],
+        supportedTokens: [],
+      })
+    );
+    expect(assets).toHaveLength(1);
+    expect(assets[0].decimals).toBe(6);
+  });
+
+  it("skips supported tokens with zero balance", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        supportedTokenBalances: [
+          supportedTokenBalance({ balance: "0.000000" }),
+        ],
+        supportedTokens: [supportedToken()],
+      })
+    );
+    expect(assets).toEqual([]);
+  });
+
+  it("includes custom tokens with positive balance and real decimals", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        tokenBalances: [customTokenBalance()],
+        tokens: [customToken()],
+      })
+    );
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      type: "token",
+      symbol: "SKY",
+      balance: "0.671051",
+      decimals: 18,
+      tokenAddress: "0x56072c95faa701256059aa122697b133aded9279",
+    });
+  });
+
+  it("skips custom tokens when metadata is missing", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        tokenBalances: [customTokenBalance()],
+        tokens: [],
+      })
+    );
+    expect(assets).toEqual([]);
+  });
+
+  it("skips custom tokens with zero balance", () => {
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        tokenBalances: [customTokenBalance({ balance: "0" })],
+        tokens: [customToken()],
+      })
+    );
+    expect(assets).toEqual([]);
+  });
+
+  it("orders assets as native, supported tokens, custom tokens", () => {
+    const assets = buildWithdrawableAssets({
+      chains: [MAINNET, SEPOLIA],
+      balances: [
+        nativeBalance({
+          chainId: SEPOLIA.chainId,
+          name: SEPOLIA.name,
+          balance: "0.01",
+        }),
+      ],
+      supportedTokenBalances: [
+        supportedTokenBalance({ balance: "2" }),
+      ],
+      supportedTokens: [supportedToken()],
+      tokenBalances: [customTokenBalance()],
+      tokens: [customToken()],
+    });
+    expect(assets.map((a) => `${a.type}:${a.symbol}`)).toEqual([
+      "native:ETH",
+      "token:USDC",
+      "token:SKY",
+    ]);
+  });
+
+  it("propagates native chain explorerUrl onto token assets", () => {
+    const nativeExplorer = "https://etherscan.io/address/0xabc";
+    const assets = buildWithdrawableAssets(
+      emptyInput({
+        balances: [nativeBalance({ explorerUrl: nativeExplorer })],
+        supportedTokenBalances: [supportedTokenBalance()],
+        supportedTokens: [supportedToken()],
+        tokenBalances: [customTokenBalance()],
+        tokens: [customToken()],
+      })
+    );
+    const tokenAssets = assets.filter((a) => a.type === "token");
+    expect(tokenAssets.every((a) => a.explorerUrl === nativeExplorer)).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/api/user/wallet/estimate-gas` and wires it into `WithdrawModal` so the network fee previews while the user types an amount and recipient. The fee display updates on every valid change with debounce, abort of stale requests, and a dedupe key so the handler below doesn't double-fetch.
- Clicking MAX on a native asset now subtracts the estimated gas cost plus a 10% buffer from the balance, so the transaction no longer fails with insufficient-funds. Seeds the gas estimate state so the useEffect skips its refetch for the same key. A muted note explains the reduction when MAX is applied; it resets when the user edits the amount or switches asset. ERC20 MAX still uses the full balance (gas is paid in native).
- `buildWithdrawableAssets` now iterates `tokenBalances` alongside native and supported balances, so user-added ERC20s like SKY reach the dropdown. Decimals for both supported and custom tokens are read from metadata instead of hardcoded to 6, matching 18-decimal tokens (USDS, DAI, SKY).