### PR TITLE
fix: KEEP-299 clamp long node labels and descriptions

### DIFF
--- a/components/workflow/nodes/action-node.tsx
+++ b/components/workflow/nodes/action-node.tsx
@@ -18,11 +18,10 @@ import Image from "next/image";
 import { memo, useState } from "react";
 import {
   Node,
-  NodeDescription,
-  NodeTitle,
   type SourceHandleConfig,
 } from "@/components/ai-elements/node";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { NodeLabel } from "@/components/workflow/nodes/node-label";
 import {
   integrationIdsAtom,
   integrationsLoadedAtom,
@@ -308,16 +307,12 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
             <EyeOff className="size-3.5 text-white" />
           </div>
         )}
-        <div className="flex flex-col items-center justify-center gap-3 p-6">
+        <div className="flex w-full min-w-0 flex-col items-center justify-center gap-3 p-6">
           <Zap className="size-12 text-muted-foreground" strokeWidth={1.5} />
-          <div className="flex flex-col items-center gap-1 text-center">
-            <NodeTitle className="text-base">
-              {data.label || "Action"}
-            </NodeTitle>
-            <NodeDescription className="text-xs">
-              Select an action
-            </NodeDescription>
-          </div>
+          <NodeLabel
+            description="Select an action"
+            title={data.label || "Action"}
+          />
         </div>
       </Node>
     );
@@ -399,7 +394,7 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
       {/* Status indicator badge in top right */}
       <StatusBadge status={status} />
 
-      <div className="flex flex-col items-center justify-center gap-3 p-6">
+      <div className="flex w-full min-w-0 flex-col items-center justify-center gap-3 p-6">
         {hasGeneratedImage ? (
           <GeneratedImageThumbnail
             base64={(nodeLog.output as { base64: string }).base64}
@@ -407,16 +402,11 @@ export const ActionNode = memo(({ data, selected, id }: ActionNodeProps) => {
         ) : (
           getProviderLogo(actionType)
         )}
-        <div className="flex flex-col items-center gap-1 text-center">
-          <NodeTitle className="text-base">{displayTitle}</NodeTitle>
-          {displayDescription && (
-            <NodeDescription className="line-clamp-2 text-xs">
-              {displayDescription}
-            </NodeDescription>
-          )}
-          {/* Model badge for AI nodes */}
-          {aiModel && <ModelBadge model={aiModel} />}
-        </div>
+        <NodeLabel
+          description={displayDescription || undefined}
+          title={displayTitle}
+        />
+        {aiModel && <ModelBadge model={aiModel} />}
       </div>
     </Node>
   );

--- a/components/workflow/nodes/node-label.tsx
+++ b/components/workflow/nodes/node-label.tsx
@@ -1,0 +1,22 @@
+import {
+  NodeDescription,
+  NodeTitle,
+} from "@/components/ai-elements/node";
+
+type NodeLabelProps = {
+  title: string;
+  description?: string;
+};
+
+export const NodeLabel = ({ title, description }: NodeLabelProps) => (
+  <div className="flex w-full min-w-0 flex-col items-center gap-1 text-center">
+    <NodeTitle className="line-clamp-2 w-full break-words text-base">
+      {title}
+    </NodeTitle>
+    {description && (
+      <NodeDescription className="line-clamp-2 w-full break-words text-xs">
+        {description}
+      </NodeDescription>
+    )}
+  </div>
+);

--- a/components/workflow/nodes/trigger-node.tsx
+++ b/components/workflow/nodes/trigger-node.tsx
@@ -4,11 +4,8 @@ import type { NodeProps } from "@xyflow/react";
 import { Box, Boxes, Check, Clock, Play, Webhook, XCircle } from "lucide-react";
 import Image from "next/image";
 import { type ElementType, memo } from "react";
-import {
-  Node,
-  NodeDescription,
-  NodeTitle,
-} from "@/components/ai-elements/node";
+import { Node } from "@/components/ai-elements/node";
+import { NodeLabel } from "@/components/workflow/nodes/node-label";
 import { cn } from "@/lib/utils";
 import type {
   WorkflowNodeData,
@@ -75,7 +72,7 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
         </div>
       )}
 
-      <div className="flex flex-col items-center justify-center gap-3 p-6">
+      <div className="flex w-full min-w-0 flex-col items-center justify-center gap-3 p-6">
         {hasProtocolIcon ? (
           <Image
             alt="Protocol"
@@ -87,14 +84,7 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
         ) : (
           <TriggerIcon className="size-12 text-blue-500" strokeWidth={1.5} />
         )}
-        <div className="flex flex-col items-center gap-1 text-center">
-          <NodeTitle className="text-base">{displayTitle}</NodeTitle>
-          {displayDescription && (
-            <NodeDescription className="line-clamp-2 text-xs">
-              {displayDescription}
-            </NodeDescription>
-          )}
-        </div>
+        <NodeLabel description={displayDescription} title={displayTitle} />
       </div>
     </Node>
   );


### PR DESCRIPTION
## Summary

Long titles and descriptions on workflow nodes (webhook URLs, verbose labels, long sentences) could overflow the fixed 192px node card and break the canvas layout.

Introduces a shared `NodeLabel` wrapper used by both `TriggerNode` and `ActionNode`:

- Clamps both the title and the description to two lines via `line-clamp-2`
- Adds `break-words` so unbreakable tokens (URLs, PascalCase, snake_case) wrap instead of extending past the card
- Constrains the inner flex column with `w-full min-w-0` so flex children cannot grow beyond the card