### PR TITLE
feat: KEEP-270 rework wallet modal

### DIFF
--- a/components/overlays/overlay-container.tsx
+++ b/components/overlays/overlay-container.tsx
@@ -177,6 +177,26 @@ function DesktopOverlayContainer() {
     }
   }, [stack, isOpen]);
 
+  // Track content size so the modal can shrink when the active view gets
+  // shorter (e.g. switching tabs). Without this the minHeight latched on the
+  // first measurement and content-light views showed a large empty area.
+  useLayoutEffect(() => {
+    if (!(isOpen && contentRef.current)) {
+      return;
+    }
+    const node = contentRef.current;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const h = entry.contentRect.height;
+        if (h > 0) {
+          setMinHeight(h);
+        }
+      }
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [isOpen]);
+
   // Use live stack for options checks (only when open)
   const currentItem = stack.at(-1);
   const springTransition = shouldReduceMotion ? { duration: 0.01 } : iosSpring;
@@ -337,6 +357,25 @@ function MobileOverlayContainer() {
       }
     }
   }, [stack, isOpen]);
+
+  // Track content size so the drawer can shrink when the active view gets
+  // shorter (e.g. switching tabs).
+  useLayoutEffect(() => {
+    if (!(isOpen && contentRef.current)) {
+      return;
+    }
+    const node = contentRef.current;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const h = entry.contentRect.height;
+        if (h > 0) {
+          setMinHeight(h);
+        }
+      }
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [isOpen]);
 
   // Use live stack for options checks (only when open)
   const currentItem = stack.at(-1);

--- a/components/overlays/projects-and-tags-overlay.tsx
+++ b/components/overlays/projects-and-tags-overlay.tsx
@@ -142,10 +142,10 @@ export function ProjectsAndTagsOverlay({
               <div className="space-y-1">
                 {projects.map((project) => (
                   <div
-                    className="flex items-center justify-between rounded-md border px-4 py-3"
+                    className="flex items-center justify-between gap-3 rounded-md border px-4 py-3"
                     key={project.id}
                   >
-                    <div className="flex items-center gap-3">
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
                       <span
                         className="inline-block size-3 shrink-0 rounded-full"
                         style={{
@@ -153,17 +153,19 @@ export function ProjectsAndTagsOverlay({
                             project.color ?? "var(--color-text-muted)",
                         }}
                       />
-                      <div>
-                        <p className="font-medium text-sm">{project.name}</p>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium text-sm">
+                          {project.name}
+                        </p>
                         {project.description && (
-                          <p className="text-muted-foreground text-xs">
+                          <p className="break-words text-muted-foreground text-xs">
                             {project.description}
                           </p>
                         )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-3">
-                      <span className="text-muted-foreground text-xs">
+                    <div className="flex shrink-0 items-center gap-3">
+                      <span className="whitespace-nowrap text-muted-foreground text-xs">
                         {project.workflowCount}{" "}
                         {project.workflowCount === 1
                           ? "workflow"
@@ -212,18 +214,18 @@ export function ProjectsAndTagsOverlay({
               <div className="space-y-1">
                 {tags.map((tag) => (
                   <div
-                    className="flex items-center justify-between rounded-md border px-4 py-3"
+                    className="flex items-center justify-between gap-3 rounded-md border px-4 py-3"
                     key={tag.id}
                   >
-                    <div className="flex items-center gap-3">
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
                       <span
                         className="inline-block size-3 shrink-0 rounded-full"
                         style={{ backgroundColor: tag.color }}
                       />
-                      <p className="font-medium text-sm">{tag.name}</p>
+                      <p className="truncate font-medium text-sm">{tag.name}</p>
                     </div>
-                    <div className="flex items-center gap-3">
-                      <span className="text-muted-foreground text-xs">
+                    <div className="flex shrink-0 items-center gap-3">
+                      <span className="whitespace-nowrap text-muted-foreground text-xs">
                         {tag.workflowCount}{" "}
                         {tag.workflowCount === 1 ? "workflow" : "workflows"}
                       </span>

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -1,1178 +1,39 @@
 "use client";
 
-import {
-  Copy,
-  Eye,
-  EyeOff,
-  ExternalLink,
-  KeyRound,
-  Plus,
-  RefreshCw,
-  SendHorizontal,
-  ShieldCheck,
-  Trash2,
-} from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import Image from "next/image";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Overlay } from "@/components/overlays/overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSession } from "@/lib/auth-client";
 import { useActiveMember } from "@/lib/hooks/use-organization";
 import { fetchAllSupportedTokenBalances } from "@/lib/wallet/fetch-balances";
 import type {
-  ChainBalance,
   ChainData,
   SupportedToken,
   SupportedTokenBalance,
-  TokenBalance,
   TokenData,
   WalletData,
-  WalletInfo,
 } from "@/lib/wallet/types";
 import { useWalletBalances } from "@/lib/wallet/use-wallet-balances";
+import { BalancesTab } from "./wallet/balances-tab";
+import { isTempoChain } from "./wallet/chain-utils";
+import { ManageTab } from "./wallet/manage-tab";
+import { NoWalletSection } from "./wallet/no-wallet-section";
 import { type WithdrawableAsset, WithdrawModal } from "./withdraw-modal";
+
+type WalletTab = "balances" | "manage";
 
 type WalletOverlayProps = {
   overlayId: string;
+  initialTab?: WalletTab;
 };
 
-// TEMPO uses stablecoins for gas, so we display stablecoins only (no native token)
-const TEMPO_CHAIN_IDS = new Set([42_429, 4217]);
-const isTempoChain = (chainId: number): boolean => TEMPO_CHAIN_IDS.has(chainId);
-
-// Chains whose token lineup doesn't mirror Ethereum mainnet's stablecoin set
-// (e.g. Plasma ships USDT0, no Circle USDC, no Sky USDS). For these chains we
-// render the chain's own supported_tokens rows directly instead of overlaying
-// them on the mainnet master list, which would otherwise produce misleading
-// "Not available" entries for assets that simply don't exist on the chain.
-const INDEPENDENT_TOKEN_LIST_CHAIN_IDS = new Set([42_429, 4217, 9745]);
-const hasIndependentTokenList = (chainId: number): boolean =>
-  INDEPENDENT_TOKEN_LIST_CHAIN_IDS.has(chainId);
-
-const MAINNET_CHAIN_ID = 1;
-
-// ============================================================================
-// Balance Display Components
-// ============================================================================
-
-function ChainBalanceDisplay({ balance }: { balance: ChainBalance }) {
-  if (balance.loading) {
-    return <div className="mt-1 text-muted-foreground text-xs">Loading...</div>;
-  }
-  if (balance.error) {
-    return <div className="mt-1 text-destructive text-xs">{balance.error}</div>;
-  }
-  return (
-    <div className="mt-1 text-muted-foreground text-xs">
-      {balance.balance} {balance.symbol}
-    </div>
-  );
-}
-
-// Token item with withdraw and optional delete button
-function TokenItemWithActions({
-  token,
-  isAdmin,
-  isCustom,
-  customExplorerUrl,
-  onDelete,
-  onWithdraw,
-}: {
-  token: SupportedTokenBalance | TokenBalance;
-  isAdmin: boolean;
-  isCustom?: boolean;
-  customExplorerUrl?: string | null;
-  onDelete?: (tokenId: string, symbol: string) => void;
-  onWithdraw: (chainId: number, tokenAddress: string) => void;
-}) {
-  // Type guard to check if it's a SupportedTokenBalance (has logoUrl)
-  const isSupportedToken = (
-    t: SupportedTokenBalance | TokenBalance
-  ): t is SupportedTokenBalance => "logoUrl" in t;
-
-  const supportedToken = isSupportedToken(token) ? token : null;
-  const customToken = isSupportedToken(token) ? null : token;
-
-  const isUnavailable = supportedToken?.available === false;
-  const numBalance = Number.parseFloat(token.balance);
-  const hasBalance = Number.isFinite(numBalance) && numBalance > 0;
-
-  // Both types now have tokenAddress
-  const tokenAddress =
-    supportedToken?.tokenAddress || customToken?.tokenAddress;
-
-  // Explorer URL: use supported token's URL or custom explorer URL for custom tokens
-  const explorerUrl = supportedToken?.explorerUrl || customExplorerUrl;
-
-  const copyTokenAddress = () => {
-    if (tokenAddress) {
-      navigator.clipboard.writeText(tokenAddress);
-      toast.success("Token address copied");
-    }
-  };
-
-  const renderBalance = () => {
-    if (isUnavailable) {
-      return <span className="italic">Not available</span>;
-    }
-    if (token.loading) {
-      return <Spinner className="h-3 w-3" />;
-    }
-    if (token.error) {
-      return <span className="text-destructive">{token.error}</span>;
-    }
-    return `${token.balance} ${token.symbol}`;
-  };
-
-  return (
-    <div
-      className={`flex items-center gap-2 py-1.5 ${isUnavailable ? "opacity-50" : ""}`}
-    >
-      {/* Logo: supported tokens show logo, custom tokens show $ */}
-      {supportedToken?.logoUrl && (
-        <Image
-          alt={token.symbol}
-          className={`h-4 w-4 rounded-full ${isUnavailable ? "grayscale" : ""}`}
-          height={16}
-          src={supportedToken.logoUrl}
-          width={16}
-        />
-      )}
-      {!supportedToken?.logoUrl && (
-        <div className="flex h-4 w-4 items-center justify-center rounded-full bg-muted font-medium text-[10px]">
-          $
-        </div>
-      )}
-      <span className="font-medium text-xs">{token.symbol}</span>
-      {/* Copy + explorer link for all tokens with addresses */}
-      {!isUnavailable && tokenAddress && (
-        <div className="flex items-center gap-1">
-          <button
-            aria-label="Copy token address"
-            className="text-muted-foreground hover:text-foreground"
-            onClick={copyTokenAddress}
-            type="button"
-          >
-            <Copy className="h-3 w-3" />
-          </button>
-          {explorerUrl && (
-            <a
-              className="text-muted-foreground hover:text-foreground"
-              href={explorerUrl}
-              rel="noopener noreferrer"
-              target="_blank"
-              title="View on explorer"
-            >
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          )}
-        </div>
-      )}
-      {/* Delete button for custom tokens - before balance */}
-      {isAdmin && isCustom && customToken && onDelete && (
-        <Button
-          className="ml-auto h-6 w-6"
-          onClick={() => onDelete(customToken.tokenId, customToken.symbol)}
-          size="icon"
-          title="Remove token"
-          variant="ghost"
-        >
-          <Trash2 className="h-3 w-3 text-muted-foreground" />
-        </Button>
-      )}
-      {/* Balance */}
-      <span
-        className={`text-muted-foreground text-xs ${isAdmin && isCustom ? "" : "ml-auto"}`}
-      >
-        {renderBalance()}
-      </span>
-      {/* Withdraw button for tokens with balance */}
-      {isAdmin &&
-        hasBalance &&
-        !token.loading &&
-        !isUnavailable &&
-        tokenAddress && (
-          <Button
-            className="h-6 px-2 text-xs"
-            onClick={() => onWithdraw(token.chainId, tokenAddress)}
-            size="sm"
-            variant="ghost"
-          >
-            <SendHorizontal className="h-3 w-3" />
-          </Button>
-        )}
-    </div>
-  );
-}
-
-// Helper to build explorer URL for a token address
-function buildTokenExplorerUrl(
-  chain: ChainData | undefined,
-  tokenAddress: string
-): string | null {
-  if (!chain?.explorerUrl) {
-    return null;
-  }
-  const path = chain.explorerAddressPath || "/address/{address}";
-  return `${chain.explorerUrl}${path.replace("{address}", tokenAddress)}`;
-}
-
-function ChainBalanceItem({
-  balance,
-  chain,
-  isAdmin,
-  onRemoveToken,
-  onWithdraw,
-  supportedTokenBalances,
-  tokenBalances,
-}: {
-  balance: ChainBalance;
-  chain: ChainData | undefined;
-  isAdmin: boolean;
-  onRemoveToken: (tokenId: string, symbol: string) => void;
-  onWithdraw: (chainId: number, tokenAddress?: string) => void;
-  supportedTokenBalances: SupportedTokenBalance[];
-  tokenBalances: TokenBalance[];
-}) {
-  const chainCustomTokens = tokenBalances.filter(
-    (t) => t.chainId === balance.chainId
-  );
-
-  const isTempo = isTempoChain(balance.chainId);
-  const isMainnet = balance.chainId === MAINNET_CHAIN_ID;
-  const isIndependentTokenList = hasIndependentTokenList(balance.chainId);
-
-  // For chains with their own stablecoin lineup (TEMPO, Plasma, etc.), render
-  // their tokens directly. For other chains, use mainnet tokens as the master
-  // list and overlay availability per-chain.
-  const chainSupportedTokens = (() => {
-    if (isIndependentTokenList) {
-      return supportedTokenBalances.filter(
-        (t) => t.chainId === balance.chainId
-      );
-    }
-
-    // Get mainnet tokens as master list
-    const mainnetTokens = supportedTokenBalances.filter(
-      (t) => t.chainId === MAINNET_CHAIN_ID
-    );
-
-    // If viewing mainnet, just return mainnet tokens
-    if (isMainnet) {
-      return mainnetTokens;
-    }
-
-    // For other chains, map mainnet tokens with availability
-    const chainTokensMap = new Map(
-      supportedTokenBalances
-        .filter((t) => t.chainId === balance.chainId)
-        .map((t) => [t.symbol, t])
-    );
-
-    return mainnetTokens.map((mainnetToken) => {
-      const chainToken = chainTokensMap.get(mainnetToken.symbol);
-      if (chainToken) {
-        // Token available on this chain
-        return { ...chainToken, available: true };
-      }
-      // Token not available - show mainnet data with unavailable flag
-      return { ...mainnetToken, available: false, balance: "N/A" };
-    });
-  })();
-
-  // For non-TEMPO chains, check if native balance is withdrawable
-  const nativeBalance = Number.parseFloat(balance.balance);
-  const hasNativeBalance = Number.isFinite(nativeBalance) && nativeBalance > 0;
-
-  // Determine section label based on whether there are custom tokens
-  const tokenSectionLabel =
-    chainCustomTokens.length > 0 ? "Tokens" : "Stablecoins";
-
-  // For TEMPO, show tokens only (no native balance display)
-  if (isTempo) {
-    return (
-      <div className="rounded-lg border bg-muted/50 p-3">
-        <div className="mb-2 flex items-center gap-1">
-          <span className="font-medium text-sm">TEMPO</span>
-          {balance.explorerUrl && (
-            <a
-              className="text-muted-foreground hover:text-foreground"
-              href={balance.explorerUrl}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          )}
-        </div>
-        <div className="mb-1 font-medium text-muted-foreground text-xs">
-          {tokenSectionLabel}
-        </div>
-        {chainSupportedTokens.length > 0 || chainCustomTokens.length > 0 ? (
-          <div className="divide-y rounded border bg-background/50 px-2">
-            {/* Supported tokens (stablecoins) */}
-            {chainSupportedTokens.map((token) => (
-              <TokenItemWithActions
-                isAdmin={isAdmin}
-                key={`supported-${token.chainId}-${token.tokenAddress}`}
-                onWithdraw={onWithdraw}
-                token={token}
-              />
-            ))}
-            {/* Custom tokens integrated in the same list */}
-            {chainCustomTokens.map((token) => (
-              <TokenItemWithActions
-                customExplorerUrl={buildTokenExplorerUrl(
-                  chain,
-                  token.tokenAddress
-                )}
-                isAdmin={isAdmin}
-                isCustom
-                key={`custom-${token.tokenId}`}
-                onDelete={onRemoveToken}
-                onWithdraw={onWithdraw}
-                token={token}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="text-muted-foreground text-xs">Loading tokens...</div>
-        )}
-      </div>
-    );
-  }
-
-  // Non-TEMPO chains: show native balance and tokens in same card
-  return (
-    <div className="rounded-lg border bg-muted/50 p-3">
-      {/* Chain header with native balance */}
-      <div className="flex items-center justify-between">
-        <div className="flex-1">
-          <div className="flex items-center gap-1">
-            <span className="font-medium text-sm">{balance.name}</span>
-            {balance.explorerUrl && (
-              <a
-                className="text-muted-foreground hover:text-foreground"
-                href={balance.explorerUrl}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            )}
-          </div>
-          <ChainBalanceDisplay balance={balance} />
-        </div>
-        {isAdmin && hasNativeBalance && (
-          <Button
-            className="h-7 px-2 text-xs"
-            onClick={() => onWithdraw(balance.chainId)}
-            size="sm"
-            variant="ghost"
-          >
-            <SendHorizontal className="h-3 w-3" />
-            Withdraw
-          </Button>
-        )}
-      </div>
-      {/* Tokens section (stablecoins + custom tokens combined) */}
-      {(chainSupportedTokens.length > 0 || chainCustomTokens.length > 0) && (
-        <div className="mt-3">
-          <div className="mb-1 font-medium text-muted-foreground text-xs">
-            {tokenSectionLabel}
-          </div>
-          <div className="divide-y rounded border bg-background/50 px-2">
-            {/* Supported tokens (stablecoins) */}
-            {chainSupportedTokens.map((token) => (
-              <TokenItemWithActions
-                isAdmin={isAdmin}
-                key={`supported-${token.chainId}-${token.tokenAddress}`}
-                onWithdraw={onWithdraw}
-                token={token}
-              />
-            ))}
-            {/* Custom tokens integrated in the same list */}
-            {chainCustomTokens.map((token) => (
-              <TokenItemWithActions
-                customExplorerUrl={buildTokenExplorerUrl(
-                  chain,
-                  token.tokenAddress
-                )}
-                isAdmin={isAdmin}
-                isCustom
-                key={`custom-${token.tokenId}`}
-                onDelete={onRemoveToken}
-                onWithdraw={onWithdraw}
-                token={token}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ============================================================================
-// Form Components
-// ============================================================================
-
-function AddTokenForm({
-  chains,
-  onAdd,
-  onCancel,
-}: {
-  chains: ChainData[];
-  onAdd: (chainId: number, tokenAddress: string) => Promise<void>;
-  onCancel: () => void;
-}) {
-  const [chainId, setChainId] = useState<number | null>(null);
-  const [tokenAddress, setTokenAddress] = useState("");
-  const [adding, setAdding] = useState(false);
-
-  const handleAdd = async () => {
-    if (!(chainId && tokenAddress)) {
-      toast.error("Please select a chain and enter a token address");
-      return;
-    }
-    setAdding(true);
-    try {
-      await onAdd(chainId, tokenAddress);
-      setChainId(null);
-      setTokenAddress("");
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to add token"
-      );
-    } finally {
-      setAdding(false);
-    }
-  };
-
-  return (
-    <div className="space-y-3">
-      <div className="space-y-2">
-        <Label>Chain</Label>
-        <Select
-          onValueChange={(value) => setChainId(Number.parseInt(value, 10))}
-          value={chainId?.toString() ?? ""}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Select chain" />
-          </SelectTrigger>
-          <SelectContent>
-            {chains.map((chain) => (
-              <SelectItem key={chain.chainId} value={chain.chainId.toString()}>
-                {chain.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="space-y-2">
-        <Label>Token Address</Label>
-        <Input
-          disabled={adding}
-          onChange={(e) => setTokenAddress(e.target.value)}
-          placeholder="0x..."
-          value={tokenAddress}
-        />
-      </div>
-      <div className="flex gap-2">
-        <Button
-          className="flex-1"
-          disabled={adding}
-          onClick={onCancel}
-          variant="outline"
-        >
-          Cancel
-        </Button>
-        <Button
-          className="flex-1"
-          disabled={adding || !chainId || !tokenAddress}
-          onClick={handleAdd}
-        >
-          {adding ? (
-            <>
-              <Spinner className="mr-2 h-4 w-4" />
-              Adding...
-            </>
-          ) : (
-            "Add Token"
-          )}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function CreateWalletForm({
-  initialEmail,
-  onSubmit,
-}: {
-  initialEmail: string;
-  onSubmit: (email: string) => Promise<void>;
-}) {
-  const [email, setEmail] = useState(initialEmail);
-  const [creating, setCreating] = useState(false);
-
-  const handleCreate = async (): Promise<void> => {
-    if (!email) {
-      toast.error("Email is required");
-      return;
-    }
-    setCreating(true);
-    try {
-      await onSubmit(email);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to create wallet"
-      );
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  return (
-    <div className="space-y-4">
-      <p className="text-muted-foreground text-xs">
-        This wallet will be shared by all members of your organization.
-        Only admins and owners can manage it.
-      </p>
-
-      <div className="space-y-2">
-        <Label htmlFor="wallet-email">Email Address</Label>
-        <Input
-          disabled={creating}
-          id="wallet-email"
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="you@example.com"
-          type="email"
-          value={email}
-        />
-        <p className="text-muted-foreground text-xs">
-          This email will be associated with the wallet for identification
-          purposes.
-        </p>
-      </div>
-
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1.5 text-muted-foreground text-xs">
-          <ShieldCheck className="h-3.5 w-3.5" />
-          <span>Secured by Turnkey</span>
-        </div>
-        <Button disabled={creating || !email} onClick={handleCreate}>
-          {creating ? (
-            <>
-              <Spinner className="mr-2 h-4 w-4" />
-              Creating...
-            </>
-          ) : (
-            "Create Wallet"
-          )}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-// ============================================================================
-// Section Components
-// ============================================================================
-
-function BalanceListSection({
-  balances,
-  chains,
-  isAdmin,
-  onAddToken,
-  onRefresh,
-  onRemoveToken,
-  onWithdraw,
-  refreshing,
-  showAddToken,
-  setShowAddToken,
-  supportedTokenBalances,
-  tokenBalances,
-}: {
-  balances: ChainBalance[];
-  chains: ChainData[];
-  isAdmin: boolean;
-  onAddToken: (chainId: number, tokenAddress: string) => Promise<void>;
-  onRefresh: () => void;
-  onRemoveToken: (tokenId: string, symbol: string) => void;
-  onWithdraw: (chainId: number, tokenAddress?: string) => void;
-  refreshing: boolean;
-  showAddToken: boolean;
-  setShowAddToken: (show: boolean) => void;
-  supportedTokenBalances: SupportedTokenBalance[];
-  tokenBalances: TokenBalance[];
-}) {
-  const [showTestnets, setShowTestnets] = useState(false);
-  const filteredBalances = balances.filter((b) =>
-    showTestnets ? b.isTestnet : !b.isTestnet
-  );
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium text-sm">Balances</h3>
-        <div className="flex items-center gap-2">
-          <div className="flex rounded-md border">
-            <Button
-              className="h-7 rounded-r-none border-0 px-3 text-xs"
-              onClick={() => setShowTestnets(false)}
-              size="sm"
-              variant={showTestnets ? "ghost" : "default"}
-            >
-              Mainnets
-            </Button>
-            <Button
-              className="h-7 rounded-l-none border-0 px-3 text-xs"
-              onClick={() => setShowTestnets(true)}
-              size="sm"
-              variant={showTestnets ? "default" : "ghost"}
-            >
-              Testnets
-            </Button>
-          </div>
-          <Button
-            aria-label="Refresh balances"
-            data-testid="wallet-refresh-button"
-            disabled={refreshing}
-            onClick={onRefresh}
-            size="sm"
-            variant="ghost"
-          >
-            <RefreshCw
-              className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`}
-            />
-          </Button>
-        </div>
-      </div>
-
-      {balances.length === 0 ? (
-        <div className="text-muted-foreground text-sm">Loading chains...</div>
-      ) : (
-        <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
-          {filteredBalances.map((balance) => (
-            <ChainBalanceItem
-              balance={balance}
-              chain={chains.find((c) => c.chainId === balance.chainId)}
-              isAdmin={isAdmin}
-              key={balance.chainId}
-              onRemoveToken={onRemoveToken}
-              onWithdraw={onWithdraw}
-              supportedTokenBalances={supportedTokenBalances}
-              tokenBalances={tokenBalances}
-            />
-          ))}
-          {filteredBalances.length === 0 && (
-            <div className="py-4 text-center text-muted-foreground text-sm">
-              No {showTestnets ? "testnet" : "mainnet"} chains available
-            </div>
-          )}
-        </div>
-      )}
-
-      {isAdmin && (
-        <div className="mt-4 border-t pt-4">
-          {showAddToken ? (
-            <AddTokenForm
-              chains={chains}
-              onAdd={onAddToken}
-              onCancel={() => setShowAddToken(false)}
-            />
-          ) : (
-            <Button
-              className="w-full"
-              onClick={() => setShowAddToken(true)}
-              variant="outline"
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Add Token
-            </Button>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function NoWalletSection({
-  isAdmin,
-  initialEmail,
-  onCreateWallet,
-}: {
-  isAdmin: boolean;
-  initialEmail: string;
-  onCreateWallet: (email: string) => Promise<void>;
-}) {
-  if (!isAdmin) {
-    return (
-      <div className="rounded-lg border bg-muted/50 p-4">
-        <p className="text-muted-foreground text-sm">
-          No wallet found for this organization. Only organization admins and
-          owners can create wallets.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <CreateWalletForm
-      initialEmail={initialEmail}
-      onSubmit={onCreateWallet}
-    />
-  );
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
-
-type ExportStep = "idle" | "requesting" | "otp" | "verifying" | "done";
-
-function ExportPrivateKeyButton(): React.ReactElement {
-  const [open, setOpen] = useState(false);
-  const [step, setStep] = useState<ExportStep>("idle");
-  const [otpCode, setOtpCode] = useState("");
-  const [privateKey, setPrivateKey] = useState<string | null>(null);
-  const [revealed, setRevealed] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleOpen = async (): Promise<void> => {
-    setOpen(true);
-    setStep("requesting");
-    setError(null);
-    setOtpCode("");
-    setPrivateKey(null);
-    setRevealed(false);
-    try {
-      const res = await fetch("/api/user/wallet/export-key/request", {
-        method: "POST",
-      });
-      const data: { error?: string } = await res.json();
-
-      if (!res.ok) {
-        throw new Error(data.error ?? "Failed to send verification code");
-      }
-
-      setStep("otp");
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to send code"
-      );
-      setOpen(false);
-      setStep("idle");
-    }
-  };
-
-  const handleVerify = async (): Promise<void> => {
-    if (otpCode.length !== 6) {
-      setError("Enter the 6-digit code from your email");
-      return;
-    }
-
-    setStep("verifying");
-    setError(null);
-    try {
-      const res = await fetch("/api/user/wallet/export-key/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code: otpCode }),
-      });
-      const data: { privateKey?: string; error?: string } = await res.json();
-
-      if (!res.ok) {
-        throw new Error(data.error ?? "Verification failed");
-      }
-
-      if (!data.privateKey) {
-        throw new Error("No private key returned");
-      }
-
-      setPrivateKey(data.privateKey);
-      setRevealed(false);
-      setStep("done");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Verification failed");
-      setStep("otp");
-    }
-  };
-
-  const handleCopy = (): void => {
-    if (!privateKey) {
-      return;
-    }
-    navigator.clipboard.writeText(privateKey);
-    toast.success("Private key copied to clipboard");
-  };
-
-  const handleClose = (): void => {
-    setOpen(false);
-    setStep("idle");
-    setOtpCode("");
-    setPrivateKey(null);
-    setRevealed(false);
-    setError(null);
-  };
-
-  return (
-    <>
-      <Button
-        className="w-full"
-        onClick={handleOpen}
-        size="sm"
-        variant="outline"
-      >
-        <KeyRound className="mr-2 h-3 w-3" />
-        Export Private Key
-      </Button>
-
-      <Dialog onOpenChange={(v) => { if (!v) { handleClose(); } }} open={open}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Export Private Key</DialogTitle>
-            <DialogDescription>
-              {step === "done"
-                ? "Your private key is shown below. Copy it and store it securely."
-                : "A verification code has been sent to your email."}
-            </DialogDescription>
-          </DialogHeader>
-
-          {step === "requesting" && (
-            <div className="flex items-center justify-center py-8">
-              <Spinner className="h-6 w-6" />
-            </div>
-          )}
-
-          {(step === "otp" || step === "verifying") && (
-            <div className="space-y-4 py-2">
-              <div className="space-y-2">
-                <Label htmlFor="export-otp">Verification Code</Label>
-                <Input
-                  className="font-mono text-center text-lg tracking-[0.3em]"
-                  id="export-otp"
-                  maxLength={6}
-                  onChange={(e) =>
-                    setOtpCode(e.target.value.replace(/\D/g, ""))
-                  }
-                  placeholder="000000"
-                  value={otpCode}
-                />
-                {error && (
-                  <p className="text-destructive text-sm">{error}</p>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  className="flex-1"
-                  disabled={step === "verifying"}
-                  onClick={handleClose}
-                  variant="outline"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  className="flex-1"
-                  disabled={step === "verifying" || otpCode.length !== 6}
-                  onClick={handleVerify}
-                >
-                  {step === "verifying" ? (
-                    <>
-                      <Spinner className="mr-2 h-4 w-4" />
-                      Verifying...
-                    </>
-                  ) : (
-                    "Verify & Export"
-                  )}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {step === "done" && privateKey && (
-            <div className="space-y-4 py-2">
-              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
-                <div className="mb-2 flex items-center justify-between">
-                  <span className="font-medium text-destructive text-sm">
-                    Private Key
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <button
-                      aria-label={
-                        revealed ? "Hide private key" : "Reveal private key"
-                      }
-                      className="text-muted-foreground hover:text-foreground"
-                      onClick={() => setRevealed(!revealed)}
-                      type="button"
-                    >
-                      {revealed ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                    <button
-                      aria-label="Copy private key"
-                      className="text-muted-foreground hover:text-foreground"
-                      onClick={handleCopy}
-                      type="button"
-                    >
-                      <Copy className="h-4 w-4" />
-                    </button>
-                  </div>
-                </div>
-                <code className="block break-all font-mono text-sm">
-                  {revealed
-                    ? privateKey
-                    : privateKey.replace(/./g, "\u2022")}
-                </code>
-              </div>
-              <Button className="w-full" onClick={handleClose}>
-                Done
-              </Button>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
-function AccountDetailsSection({
-  email,
-  walletAddress,
-  isAdmin,
-  canExportKey,
-  onEmailUpdated,
-}: {
-  email: string;
-  walletAddress: string;
-  isAdmin: boolean;
-  canExportKey: boolean;
-  onEmailUpdated: () => void;
-}) {
-  const [isEditingEmail, setIsEditingEmail] = useState(false);
-  const [newEmail, setNewEmail] = useState("");
-  const [updating, setUpdating] = useState(false);
-
-  const handleUpdateEmail = async () => {
-    if (!newEmail) {
-      toast.error("Email is required");
-      return;
-    }
-
-    setUpdating(true);
-    try {
-      const response = await fetch("/api/user/wallet", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: newEmail }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to update email");
-      }
-
-      toast.success("Wallet email updated successfully!");
-      setIsEditingEmail(false);
-      setNewEmail("");
-      onEmailUpdated();
-    } catch (error) {
-      console.error("Failed to update wallet email:", error);
-      toast.error(
-        error instanceof Error ? error.message : "Failed to update email"
-      );
-    } finally {
-      setUpdating(false);
-    }
-  };
-
-  const startEditing = () => {
-    setNewEmail(email);
-    setIsEditingEmail(true);
-  };
-
-  const cancelEditing = () => {
-    setIsEditingEmail(false);
-    setNewEmail("");
-  };
-
-  const copyAddress = () => {
-    navigator.clipboard.writeText(toChecksumAddress(walletAddress));
-    toast.success("Address copied to clipboard");
-  };
-
-  return (
-    <div className="rounded-lg border bg-muted/50 p-4">
-      <div className="mb-2 text-muted-foreground text-sm">Account details</div>
-
-      {isEditingEmail ? (
-        <div className="space-y-2">
-          <Input
-            className="text-sm"
-            disabled={updating}
-            onChange={(e) => setNewEmail(e.target.value)}
-            placeholder="newemail@example.com"
-            type="email"
-            value={newEmail}
-          />
-          <div className="flex gap-2">
-            <Button
-              disabled={updating}
-              onClick={cancelEditing}
-              size="sm"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              disabled={updating || !newEmail || newEmail === email}
-              onClick={handleUpdateEmail}
-              size="sm"
-            >
-              {updating ? (
-                <>
-                  <Spinner className="mr-2 h-3 w-3" />
-                  Saving...
-                </>
-              ) : (
-                "Save"
-              )}
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <span className="text-sm">{email}</span>
-            {isAdmin && (
-              <Button
-                className="h-5 px-1.5 text-xs"
-                onClick={startEditing}
-                size="sm"
-                variant="ghost"
-              >
-                Edit
-              </Button>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            <code className="font-mono text-muted-foreground text-xs">
-              {truncateAddress(walletAddress)}
-            </code>
-            <button
-              aria-label="Copy wallet address"
-              className="text-muted-foreground hover:text-foreground"
-              data-testid="wallet-copy-address"
-              onClick={copyAddress}
-              type="button"
-            >
-              <Copy className="h-3 w-3" />
-            </button>
-          </div>
-        </div>
-      )}
-
-      {isAdmin && canExportKey && (
-        <div className="mt-3">
-          <ExportPrivateKeyButton />
-        </div>
-      )}
-    </div>
-  );
-}
-
-const PROVIDER_DISPLAY_ORDER: Record<"para" | "turnkey", number> = {
-  para: 0,
-  turnkey: 1,
-} as const;
-
-function WalletSwitcher({
-  wallets,
-  isAdmin,
-  switching,
-  onSelect,
-}: {
-  wallets: WalletInfo[];
-  isAdmin: boolean;
-  switching: boolean;
-  onSelect: (walletId: string) => void;
-}): React.ReactElement {
-  const ordered = [...wallets].sort(
-    (a, b) =>
-      PROVIDER_DISPLAY_ORDER[a.provider] - PROVIDER_DISPLAY_ORDER[b.provider]
-  );
-  const hasPara = ordered.some((w) => w.provider === "para");
-  return (
-    <div className="rounded-lg border bg-muted/50 p-3">
-      <div className="mb-2 text-muted-foreground text-xs">
-        Active wallet for signing
-      </div>
-      {hasPara && (
-        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-amber-700 text-xs dark:text-amber-400">
-          Para will be deprecated soon. Switch the active wallet to Turnkey and
-          move your assets from the Para wallet before the cutover.
-        </div>
-      )}
-      <div className="flex gap-2">
-        {ordered.map((wallet) => {
-          const label = wallet.provider === "para" ? "Para" : "Turnkey";
-          return (
-            <button
-              className={`flex-1 rounded-md border px-3 py-2 text-left text-sm transition ${
-                wallet.isActive
-                  ? "border-primary bg-primary/10"
-                  : "border-border hover:bg-background"
-              } ${!isAdmin || switching ? "cursor-not-allowed opacity-60" : ""}`}
-              disabled={!isAdmin || switching || wallet.isActive}
-              key={wallet.id}
-              onClick={() => onSelect(wallet.id)}
-              type="button"
-            >
-              <div className="flex items-center justify-between">
-                <span className="font-medium">{label}</span>
-                {wallet.isActive && (
-                  <span className="rounded bg-primary/20 px-1.5 py-0.5 text-[10px] text-primary">
-                    Active
-                  </span>
-                )}
-              </div>
-              <code className="font-mono text-muted-foreground text-xs">
-                {truncateAddress(wallet.walletAddress)}
-              </code>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-export function WalletOverlay({ overlayId }: WalletOverlayProps) {
+export function WalletOverlay({
+  overlayId,
+  initialTab = "balances",
+}: WalletOverlayProps) {
   const { closeAll, push } = useOverlay();
   const { data: session } = useSession();
   const { isAdmin } = useActiveMember();
@@ -1185,11 +46,21 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
   const [supportedTokenBalances, setSupportedTokenBalances] = useState<
     SupportedTokenBalance[]
   >([]);
+  const [supportedBalancesLoading, setSupportedBalancesLoading] =
+    useState(false);
   const [refreshing, setRefreshing] = useState(false);
-  const [showAddToken, setShowAddToken] = useState(false);
   const [switchingWallet, setSwitchingWallet] = useState(false);
+  // Controlled tab state so reload cycles (e.g. switching Para/Turnkey) don't
+  // reset the user's active tab back to "balances".
+  const [activeTab, setActiveTab] = useState<WalletTab>(initialTab);
 
-  const { balances, tokenBalances, fetchBalances } = useWalletBalances();
+  const {
+    balances,
+    tokenBalances,
+    loading: nativeBalancesLoading,
+    fetchBalances,
+  } = useWalletBalances();
+  const isLoadingBalances = nativeBalancesLoading || supportedBalancesLoading;
 
   const fetchChains = useCallback(async (): Promise<ChainData[]> => {
     try {
@@ -1236,13 +107,13 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
       walletAddress: string,
       chainList: ChainData[],
       tokenList: SupportedToken[]
-    ) => {
+    ): Promise<void> => {
       if (tokenList.length === 0) {
         setSupportedTokenBalances([]);
         return;
       }
 
-      // Set loading state
+      setSupportedBalancesLoading(true);
       setSupportedTokenBalances(
         tokenList.map((token) => ({
           chainId: token.chainId,
@@ -1255,13 +126,16 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
         }))
       );
 
-      // Fetch balances
-      const results = await fetchAllSupportedTokenBalances(
-        walletAddress,
-        tokenList,
-        chainList
-      );
-      setSupportedTokenBalances(results);
+      try {
+        const results = await fetchAllSupportedTokenBalances(
+          walletAddress,
+          tokenList,
+          chainList
+        );
+        setSupportedTokenBalances(results);
+      } finally {
+        setSupportedBalancesLoading(false);
+      }
     },
     []
   );
@@ -1327,7 +201,10 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     fetchSupportedBalances,
   ]);
 
-  const handleAddToken = async (chainId: number, tokenAddress: string) => {
+  const handleAddToken = async (
+    chainId: number,
+    tokenAddress: string
+  ): Promise<void> => {
     const response = await fetch("/api/user/wallet/tokens", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1340,11 +217,13 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
     }
 
     toast.success(`Added ${data.token.symbol} to tracked tokens`);
-    setShowAddToken(false);
     await loadWallet();
   };
 
-  const handleRemoveToken = async (tokenId: string, symbol: string) => {
+  const handleRemoveToken = async (
+    tokenId: string,
+    symbol: string
+  ): Promise<void> => {
     try {
       const response = await fetch("/api/user/wallet/tokens", {
         method: "DELETE",
@@ -1358,9 +237,8 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
       }
 
       toast.success(`Removed ${symbol} from tracked tokens`);
-      await loadWallet(); // Refresh to show updated token list
+      await loadWallet();
     } catch (error) {
-      console.error("Failed to remove token:", error);
       toast.error(
         error instanceof Error ? error.message : "Failed to remove token"
       );
@@ -1413,14 +291,11 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
   const buildWithdrawableAssets = useCallback((): WithdrawableAsset[] => {
     const assets: WithdrawableAsset[] = [];
 
-    // Add native balances (skip TEMPO - it uses stablecoins, not native tokens)
     for (const balance of balances) {
-      // Skip TEMPO native balance - it uses stablecoins only
       if (isTempoChain(balance.chainId)) {
         continue;
       }
       const chain = chains.find((c) => c.chainId === balance.chainId);
-      // Skip if not a valid positive number
       const numBalance = Number.parseFloat(balance.balance);
       if (!(chain && Number.isFinite(numBalance)) || numBalance <= 0) {
         continue;
@@ -1437,9 +312,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
       });
     }
 
-    // Add supported token balances (stablecoins)
     for (const token of supportedTokenBalances) {
-      // Skip if not a valid positive number
       const numBalance = Number.parseFloat(token.balance);
       if (!Number.isFinite(numBalance) || numBalance <= 0) {
         continue;
@@ -1466,7 +339,11 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
   }, [balances, chains, supportedTokenBalances]);
 
   const findAssetIndex = useCallback(
-    (assets: WithdrawableAsset[], chainId: number, tokenAddress?: string) => {
+    (
+      assets: WithdrawableAsset[],
+      chainId: number,
+      tokenAddress?: string
+    ): number => {
       if (tokenAddress) {
         const idx = assets.findIndex(
           (a) => a.chainId === chainId && a.tokenAddress === tokenAddress
@@ -1482,7 +359,7 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
   );
 
   const handleWithdraw = useCallback(
-    (chainId: number, tokenAddress?: string) => {
+    (chainId: number, tokenAddress?: string): void => {
       if (!walletData?.walletAddress) {
         return;
       }
@@ -1530,40 +407,45 @@ export function WalletOverlay({ overlayId }: WalletOverlayProps) {
       )}
 
       {!walletLoading && walletData?.hasWallet && (
-        <div className="space-y-4">
-          {walletData.wallets && walletData.wallets.length > 1 && (
-            <WalletSwitcher
+        <Tabs
+          className="w-full"
+          onValueChange={(value) => setActiveTab(value as WalletTab)}
+          value={activeTab}
+        >
+          <TabsList className="w-full">
+            <TabsTrigger value="balances">Balances</TabsTrigger>
+            <TabsTrigger value="manage">Manage</TabsTrigger>
+          </TabsList>
+          <TabsContent className="mt-4" value="balances">
+            <BalancesTab
+              balances={balances}
+              chains={chains}
               isAdmin={isAdmin}
-              onSelect={handleSelectActiveWallet}
-              switching={switchingWallet}
-              wallets={walletData.wallets}
+              isLoadingBalances={isLoadingBalances}
+              onAddToken={handleAddToken}
+              onRefresh={handleRefresh}
+              onRemoveToken={handleRemoveToken}
+              onWithdraw={handleWithdraw}
+              refreshing={refreshing}
+              supportedTokenBalances={supportedTokenBalances}
+              tokenBalances={tokenBalances}
             />
-          )}
-          {walletData.email && walletData.walletAddress && (
-            <AccountDetailsSection
-              canExportKey={!!walletData.canExportKey}
-              email={walletData.email}
-              isAdmin={isAdmin}
-              onEmailUpdated={loadWallet}
-              walletAddress={walletData.walletAddress}
-            />
-          )}
-
-          <BalanceListSection
-            balances={balances}
-            chains={chains}
-            isAdmin={isAdmin}
-            onAddToken={handleAddToken}
-            onRefresh={handleRefresh}
-            onRemoveToken={handleRemoveToken}
-            onWithdraw={handleWithdraw}
-            refreshing={refreshing}
-            setShowAddToken={setShowAddToken}
-            showAddToken={showAddToken}
-            supportedTokenBalances={supportedTokenBalances}
-            tokenBalances={tokenBalances}
-          />
-        </div>
+          </TabsContent>
+          <TabsContent className="mt-4 space-y-4" value="manage">
+            {walletData.email && walletData.walletAddress && (
+              <ManageTab
+                canExportKey={!!walletData.canExportKey}
+                email={walletData.email}
+                isAdmin={isAdmin}
+                onEmailUpdated={loadWallet}
+                onSelectActiveWallet={handleSelectActiveWallet}
+                switchingWallet={switchingWallet}
+                walletAddress={walletData.walletAddress}
+                wallets={walletData.wallets}
+              />
+            )}
+          </TabsContent>
+        </Tabs>
       )}
 
       {!(walletLoading || walletData?.hasWallet) && (

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -18,6 +18,7 @@ import type {
   WalletData,
 } from "@/lib/wallet/types";
 import { useWalletBalances } from "@/lib/wallet/use-wallet-balances";
+import { useInvalidateWalletInfo } from "@/lib/wallet/use-wallet-info";
 import { BalancesTab } from "./wallet/balances-tab";
 import { ManageTab } from "./wallet/manage-tab";
 import { NoWalletSection } from "./wallet/no-wallet-section";
@@ -37,6 +38,7 @@ export function WalletOverlay({
   const { closeAll, push } = useOverlay();
   const { data: session } = useSession();
   const { isAdmin } = useActiveMember();
+  const invalidateWalletInfo = useInvalidateWalletInfo();
 
   const [walletLoading, setWalletLoading] = useState(true);
   const [walletData, setWalletData] = useState<WalletData | null>(null);
@@ -259,6 +261,7 @@ export function WalletOverlay({
 
     toast.success("Wallet created successfully!");
     await loadWallet();
+    invalidateWalletInfo();
   };
 
   const handleSelectActiveWallet = useCallback(
@@ -276,6 +279,7 @@ export function WalletOverlay({
         }
         toast.success("Active wallet updated");
         await loadWallet();
+        invalidateWalletInfo();
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Failed to switch wallet"
@@ -284,7 +288,7 @@ export function WalletOverlay({
         setSwitchingWallet(false);
       }
     },
-    [loadWallet]
+    [loadWallet, invalidateWalletInfo]
   );
 
   const buildAssets = useCallback(

--- a/components/overlays/wallet/balances-tab.tsx
+++ b/components/overlays/wallet/balances-tab.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type {
+  ChainBalance,
+  ChainData,
+  SupportedTokenBalance,
+  TokenBalance,
+} from "@/lib/wallet/types";
+import { ChainBalanceItem } from "./chain-balance-item";
+import { getChainOrderIndex, hasPositiveBalance } from "./chain-utils";
+
+export function BalancesTab({
+  balances,
+  chains,
+  isAdmin,
+  isLoadingBalances,
+  onAddToken,
+  onRefresh,
+  onRemoveToken,
+  onWithdraw,
+  refreshing,
+  supportedTokenBalances,
+  tokenBalances,
+}: {
+  balances: ChainBalance[];
+  chains: ChainData[];
+  isAdmin: boolean;
+  isLoadingBalances: boolean;
+  onAddToken: (chainId: number, tokenAddress: string) => Promise<void>;
+  onRefresh: () => void;
+  onRemoveToken: (tokenId: string, symbol: string) => void;
+  onWithdraw: (chainId: number, tokenAddress?: string) => void;
+  refreshing: boolean;
+  supportedTokenBalances: SupportedTokenBalance[];
+  tokenBalances: TokenBalance[];
+}): React.ReactElement {
+  const [showTestnets, setShowTestnets] = useState(false);
+
+  const filteredBalances = balances
+    .filter((b) => (showTestnets ? b.isTestnet : !b.isTestnet))
+    .sort(
+      (a, b) => getChainOrderIndex(a.chainId) - getChainOrderIndex(b.chainId)
+    );
+
+  const chainHasBalance = (chainId: number): boolean => {
+    const native = balances.find((b) => b.chainId === chainId);
+    if (native && hasPositiveBalance(native.balance)) {
+      return true;
+    }
+    const hasSupported = supportedTokenBalances.some(
+      (t) => t.chainId === chainId && hasPositiveBalance(t.balance)
+    );
+    if (hasSupported) {
+      return true;
+    }
+    return tokenBalances.some(
+      (t) => t.chainId === chainId && hasPositiveBalance(t.balance)
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium text-sm">Balances</h3>
+        <div className="flex items-center gap-2">
+          <div className="flex rounded-md border">
+            <Button
+              className="h-7 rounded-r-none border-0 px-3 text-xs"
+              onClick={() => setShowTestnets(false)}
+              size="sm"
+              variant={showTestnets ? "ghost" : "default"}
+            >
+              Mainnets
+            </Button>
+            <Button
+              className="h-7 rounded-l-none border-0 px-3 text-xs"
+              onClick={() => setShowTestnets(true)}
+              size="sm"
+              variant={showTestnets ? "default" : "ghost"}
+            >
+              Testnets
+            </Button>
+          </div>
+          <Button
+            aria-label="Refresh balances"
+            data-testid="wallet-refresh-button"
+            disabled={refreshing}
+            onClick={onRefresh}
+            size="sm"
+            variant="ghost"
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`}
+            />
+          </Button>
+        </div>
+      </div>
+
+      {balances.length === 0 ? (
+        <div className="text-muted-foreground text-sm">Loading chains...</div>
+      ) : (
+        <div className="space-y-2">
+          {filteredBalances.map((balance) => (
+            <ChainBalanceItem
+              balance={balance}
+              chain={chains.find((c) => c.chainId === balance.chainId)}
+              hasAnyBalance={chainHasBalance(balance.chainId)}
+              isAdmin={isAdmin}
+              isLoadingBalances={isLoadingBalances}
+              key={balance.chainId}
+              onAddToken={onAddToken}
+              onRemoveToken={onRemoveToken}
+              onWithdraw={onWithdraw}
+              supportedTokenBalances={supportedTokenBalances}
+              tokenBalances={tokenBalances}
+            />
+          ))}
+          {filteredBalances.length === 0 && (
+            <div className="py-4 text-center text-muted-foreground text-sm">
+              No {showTestnets ? "testnet" : "mainnet"} chains available
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/overlays/wallet/chain-balance-item.tsx
+++ b/components/overlays/wallet/chain-balance-item.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import {
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  Plus,
+  SendHorizontal,
+  Trash2,
+} from "lucide-react";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { toChecksumAddress } from "@/lib/address-utils";
+import type {
+  ChainBalance,
+  ChainData,
+  SupportedTokenBalance,
+  TokenBalance,
+} from "@/lib/wallet/types";
+import {
+  hasIndependentTokenList,
+  isTempoChain,
+  MAINNET_CHAIN_ID,
+} from "./chain-utils";
+
+function ChainBalanceDisplay({
+  balance,
+}: {
+  balance: ChainBalance;
+}): React.ReactElement {
+  if (balance.loading) {
+    return <div className="mt-1 text-muted-foreground text-xs">Loading...</div>;
+  }
+  if (balance.error) {
+    return <div className="mt-1 text-destructive text-xs">{balance.error}</div>;
+  }
+  return (
+    <div className="mt-1 text-muted-foreground text-xs">
+      {balance.balance} {balance.symbol}
+    </div>
+  );
+}
+
+function buildTokenExplorerUrl(
+  chain: ChainData | undefined,
+  tokenAddress: string
+): string | null {
+  if (!chain?.explorerUrl) {
+    return null;
+  }
+  const path = chain.explorerAddressPath || "/address/{address}";
+  return `${chain.explorerUrl}${path.replace("{address}", tokenAddress)}`;
+}
+
+type TokenItemProps = {
+  token: SupportedTokenBalance | TokenBalance;
+  isAdmin: boolean;
+  isCustom?: boolean;
+  customExplorerUrl?: string | null;
+  onDelete?: (tokenId: string, symbol: string) => void;
+  onWithdraw: (chainId: number, tokenAddress: string) => void;
+};
+
+function TokenItemWithActions({
+  token,
+  isAdmin,
+  isCustom,
+  customExplorerUrl,
+  onDelete,
+  onWithdraw,
+}: TokenItemProps): React.ReactElement {
+  const isSupportedToken = (
+    t: SupportedTokenBalance | TokenBalance
+  ): t is SupportedTokenBalance => "logoUrl" in t;
+
+  const supportedToken = isSupportedToken(token) ? token : null;
+  const customToken = isSupportedToken(token) ? null : token;
+
+  const isUnavailable = supportedToken?.available === false;
+  const numBalance = Number.parseFloat(token.balance);
+  const hasBalance = Number.isFinite(numBalance) && numBalance > 0;
+
+  const tokenAddress =
+    supportedToken?.tokenAddress || customToken?.tokenAddress;
+  const explorerUrl = supportedToken?.explorerUrl || customExplorerUrl;
+
+  const copyTokenAddress = (): void => {
+    if (tokenAddress) {
+      navigator.clipboard.writeText(toChecksumAddress(tokenAddress));
+      toast.success("Token address copied");
+    }
+  };
+
+  const renderBalance = (): React.ReactNode => {
+    if (isUnavailable) {
+      return <span className="italic">Not available</span>;
+    }
+    if (token.loading) {
+      return <Spinner className="h-3 w-3" />;
+    }
+    if (token.error) {
+      return <span className="text-destructive">{token.error}</span>;
+    }
+    return `${token.balance} ${token.symbol}`;
+  };
+
+  return (
+    <div
+      className={`flex items-center gap-2 py-1.5 ${isUnavailable ? "opacity-50" : ""}`}
+    >
+      {supportedToken?.logoUrl && (
+        <Image
+          alt={token.symbol}
+          className={`h-4 w-4 rounded-full ${isUnavailable ? "grayscale" : ""}`}
+          height={16}
+          src={supportedToken.logoUrl}
+          width={16}
+        />
+      )}
+      {!supportedToken?.logoUrl && (
+        <div className="flex h-4 w-4 items-center justify-center rounded-full bg-muted font-medium text-[10px]">
+          $
+        </div>
+      )}
+      <span className="font-medium text-xs">{token.symbol}</span>
+      {!isUnavailable && tokenAddress && (
+        <div className="flex items-center gap-1">
+          <button
+            aria-label="Copy token address"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={copyTokenAddress}
+            type="button"
+          >
+            <Copy className="h-3 w-3" />
+          </button>
+          {explorerUrl && (
+            <a
+              className="text-muted-foreground hover:text-foreground"
+              href={explorerUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+              title="View on explorer"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      )}
+      {isAdmin && isCustom && customToken && onDelete && (
+        <Button
+          className="ml-auto h-6 w-6"
+          onClick={() => onDelete(customToken.tokenId, customToken.symbol)}
+          size="icon"
+          title="Remove token"
+          variant="ghost"
+        >
+          <Trash2 className="h-3 w-3 text-muted-foreground" />
+        </Button>
+      )}
+      <span
+        className={`text-muted-foreground text-xs ${
+          isAdmin && isCustom ? "" : "ml-auto"
+        }`}
+      >
+        {renderBalance()}
+      </span>
+      {isAdmin &&
+        hasBalance &&
+        !token.loading &&
+        !isUnavailable &&
+        tokenAddress && (
+          <Button
+            className="h-6 px-2 text-xs"
+            onClick={() => onWithdraw(token.chainId, tokenAddress)}
+            size="sm"
+            variant="ghost"
+          >
+            <SendHorizontal className="h-3 w-3" />
+          </Button>
+        )}
+    </div>
+  );
+}
+
+function AddTokenRow({
+  chainId,
+  onAdd,
+}: {
+  chainId: number;
+  onAdd: (chainId: number, tokenAddress: string) => Promise<void>;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = (): void => {
+    setOpen(false);
+    setValue("");
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    // EIP-55 normalise before sending so the server receives a canonical
+    // checksummed address. Falls back to the raw input if it isn't a valid
+    // hex address so the server can return a clearer validation error.
+    const address = toChecksumAddress(trimmed);
+    setSubmitting(true);
+    try {
+      await onAdd(chainId, address);
+      reset();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to add token"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <div className="mt-2 flex justify-end">
+        <Button
+          className="h-7 px-2 text-muted-foreground text-xs hover:text-foreground"
+          onClick={() => setOpen(true)}
+          size="sm"
+          variant="ghost"
+        >
+          <Plus className="h-3 w-3" />
+          Add token
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <Input
+        autoFocus
+        className="h-7 flex-1 truncate font-mono !text-xs placeholder:text-xs focus-visible:ring-0 focus-visible:ring-offset-0 md:!text-xs"
+        disabled={submitting}
+        onChange={(e) => {
+          const next = e.target.value;
+          // Auto-checksum once the value is a complete 0x + 40 hex chars.
+          // Keeps partial/typed input untouched so the caret doesn't jitter.
+          if (/^0x[a-fA-F0-9]{40}$/.test(next)) {
+            setValue(toChecksumAddress(next));
+          } else {
+            setValue(next);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            handleSubmit();
+          } else if (e.key === "Escape") {
+            reset();
+          }
+        }}
+        placeholder="0x token contract"
+        value={value}
+      />
+      <Button
+        className="h-7 px-2 text-xs"
+        disabled={submitting}
+        onClick={reset}
+        size="sm"
+        variant="ghost"
+      >
+        Cancel
+      </Button>
+      <Button
+        className="h-7 px-2 text-xs"
+        disabled={submitting || !value.trim()}
+        onClick={handleSubmit}
+        size="sm"
+      >
+        {submitting ? <Spinner className="h-3 w-3" /> : "Add"}
+      </Button>
+    </div>
+  );
+}
+
+export type ChainBalanceItemProps = {
+  balance: ChainBalance;
+  chain: ChainData | undefined;
+  /** True once balances are loaded and this chain has a positive balance. */
+  hasAnyBalance: boolean;
+  /** True while balances are still being fetched; keep items folded. */
+  isLoadingBalances: boolean;
+  isAdmin: boolean;
+  onAddToken: (chainId: number, tokenAddress: string) => Promise<void>;
+  onRemoveToken: (tokenId: string, symbol: string) => void;
+  onWithdraw: (chainId: number, tokenAddress?: string) => void;
+  supportedTokenBalances: SupportedTokenBalance[];
+  tokenBalances: TokenBalance[];
+};
+
+export function ChainBalanceItem({
+  balance,
+  chain,
+  hasAnyBalance,
+  isLoadingBalances,
+  isAdmin,
+  onAddToken,
+  onRemoveToken,
+  onWithdraw,
+  supportedTokenBalances,
+  tokenBalances,
+}: ChainBalanceItemProps): React.ReactElement {
+  // Auto-expand once loading completes and the chain has a balance. Folded by
+  // default and during fetch. Null means "follow auto"; once the user toggles
+  // manually we stick with their choice.
+  const [userToggled, setUserToggled] = useState<boolean | null>(null);
+  const autoOpen = !isLoadingBalances && hasAnyBalance;
+  const isOpen = userToggled ?? autoOpen;
+
+  // Skip the Radix open/close animation on first paint: when an item mounts
+  // already open (e.g. switching Mainnets → Testnets for a chain that has a
+  // balance) the 200ms slide makes it feel slow. Enable animations after the
+  // initial render so later toggles still transition smoothly.
+  const [animate, setAnimate] = useState(false);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setAnimate(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const chainCustomTokens = tokenBalances.filter(
+    (t) => t.chainId === balance.chainId
+  );
+
+  const isTempo = isTempoChain(balance.chainId);
+  const isMainnet = balance.chainId === MAINNET_CHAIN_ID;
+  const isIndependentTokenList = hasIndependentTokenList(balance.chainId);
+
+  const chainSupportedTokens = (() => {
+    if (isIndependentTokenList) {
+      return supportedTokenBalances.filter(
+        (t) => t.chainId === balance.chainId
+      );
+    }
+
+    const mainnetTokens = supportedTokenBalances.filter(
+      (t) => t.chainId === MAINNET_CHAIN_ID
+    );
+
+    if (isMainnet) {
+      return mainnetTokens;
+    }
+
+    const chainTokensMap = new Map(
+      supportedTokenBalances
+        .filter((t) => t.chainId === balance.chainId)
+        .map((t) => [t.symbol, t])
+    );
+
+    return mainnetTokens.map((mainnetToken) => {
+      const chainToken = chainTokensMap.get(mainnetToken.symbol);
+      if (chainToken) {
+        return { ...chainToken, available: true };
+      }
+      return { ...mainnetToken, available: false, balance: "N/A" };
+    });
+  })();
+
+  const nativeBalance = Number.parseFloat(balance.balance);
+  const hasNativeBalance = Number.isFinite(nativeBalance) && nativeBalance > 0;
+
+  const tokenSectionLabel =
+    chainCustomTokens.length > 0 ? "Tokens" : "Stablecoins";
+
+  const chevron = (
+    <ChevronDown
+      className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200 ${
+        isOpen ? "" : "-rotate-90"
+      }`}
+    />
+  );
+
+  const chainLabel = isTempo ? "TEMPO" : balance.name;
+
+  const tokenList =
+    chainSupportedTokens.length > 0 || chainCustomTokens.length > 0 ? (
+      <div className="divide-y rounded border bg-background/50 px-2">
+        {chainSupportedTokens.map((token) => (
+          <TokenItemWithActions
+            isAdmin={isAdmin}
+            key={`supported-${token.chainId}-${token.tokenAddress}`}
+            onWithdraw={onWithdraw}
+            token={token}
+          />
+        ))}
+        {chainCustomTokens.map((token) => (
+          <TokenItemWithActions
+            customExplorerUrl={buildTokenExplorerUrl(chain, token.tokenAddress)}
+            isAdmin={isAdmin}
+            isCustom
+            key={`custom-${token.tokenId}`}
+            onDelete={onRemoveToken}
+            onWithdraw={onWithdraw}
+            token={token}
+          />
+        ))}
+      </div>
+    ) : (
+      <div className="text-muted-foreground text-xs">Loading tokens...</div>
+    );
+
+  return (
+    <Collapsible
+      className="rounded-lg border bg-muted/50 p-3"
+      onOpenChange={(open) => setUserToggled(open)}
+      open={isOpen}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <CollapsibleTrigger
+          asChild
+          className="flex flex-1 items-start gap-2 text-left"
+        >
+          <button type="button">
+            <span className="mt-0.5">{chevron}</span>
+            <span className="flex-1">
+              <span className="flex items-center gap-1">
+                <span className="font-medium text-sm">{chainLabel}</span>
+              </span>
+              {!isTempo && <ChainBalanceDisplay balance={balance} />}
+            </span>
+          </button>
+        </CollapsibleTrigger>
+        <div className="flex items-center gap-1">
+          {balance.explorerUrl && (
+            <a
+              className="text-muted-foreground hover:text-foreground"
+              href={balance.explorerUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+          {!isTempo && isAdmin && hasNativeBalance && (
+            <Button
+              className="h-7 px-2 text-xs"
+              onClick={() => onWithdraw(balance.chainId)}
+              size="sm"
+              variant="ghost"
+            >
+              <SendHorizontal className="h-3 w-3" />
+              Withdraw
+            </Button>
+          )}
+        </div>
+      </div>
+      <CollapsibleContent
+        className={`overflow-hidden ${
+          animate
+            ? "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down"
+            : ""
+        }`}
+      >
+        <div className="mt-3">
+          <div className="mb-1 font-medium text-muted-foreground text-xs">
+            {tokenSectionLabel}
+          </div>
+          {tokenList}
+          {isAdmin && (
+            <AddTokenRow chainId={balance.chainId} onAdd={onAddToken} />
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/components/overlays/wallet/chain-utils.ts
+++ b/components/overlays/wallet/chain-utils.ts
@@ -1,0 +1,45 @@
+// TEMPO uses stablecoins for gas, so we display stablecoins only (no native token)
+const TEMPO_CHAIN_IDS: ReadonlySet<number> = new Set([42_429, 4217]);
+
+// Chains whose token lineup doesn't mirror Ethereum mainnet's stablecoin set
+// (e.g. Plasma ships USDT0, no Circle USDC, no Sky USDS). For these chains we
+// render the chain's own supported_tokens rows directly instead of overlaying
+// them on the mainnet master list, which would otherwise produce misleading
+// "Not available" entries for assets that simply don't exist on the chain.
+const INDEPENDENT_TOKEN_LIST_CHAIN_IDS: ReadonlySet<number> = new Set([
+  42_429, 4217, 9745,
+]);
+
+export const MAINNET_CHAIN_ID = 1;
+
+export function isTempoChain(chainId: number): boolean {
+  return TEMPO_CHAIN_IDS.has(chainId);
+}
+
+export function hasIndependentTokenList(chainId: number): boolean {
+  return INDEPENDENT_TOKEN_LIST_CHAIN_IDS.has(chainId);
+}
+
+// Display order for balances view: Ethereum, Base, Tempo, then other chains.
+// Mainnets and testnets are filtered into separate views; the order here
+// applies within each group so mainnet Ethereum is first in mainnets and
+// Sepolia Ethereum is first in testnets.
+const CHAIN_DISPLAY_ORDER: Record<number, number> = {
+  // Mainnets
+  1: 0, // Ethereum
+  8453: 1, // Base
+  4217: 2, // TEMPO mainnet
+  // Testnets
+  11_155_111: 10, // Ethereum Sepolia
+  84_532: 11, // Base Sepolia
+  42_429: 12, // TEMPO testnet
+} as const;
+
+export function getChainOrderIndex(chainId: number): number {
+  return CHAIN_DISPLAY_ORDER[chainId] ?? 999;
+}
+
+export function hasPositiveBalance(value: string): boolean {
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) && n > 0;
+}

--- a/components/overlays/wallet/export-private-key-button.tsx
+++ b/components/overlays/wallet/export-private-key-button.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { Copy, Eye, EyeOff, KeyRound } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+
+type ExportStep = "idle" | "requesting" | "otp" | "verifying" | "done";
+
+export function ExportPrivateKeyButton(): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<ExportStep>("idle");
+  const [otpCode, setOtpCode] = useState("");
+  const [privateKey, setPrivateKey] = useState<string | null>(null);
+  const [revealed, setRevealed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleOpen = async (): Promise<void> => {
+    setOpen(true);
+    setStep("requesting");
+    setError(null);
+    setOtpCode("");
+    setPrivateKey(null);
+    setRevealed(false);
+    try {
+      const res = await fetch("/api/user/wallet/export-key/request", {
+        method: "POST",
+      });
+      const data: { error?: string } = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? "Failed to send verification code");
+      }
+
+      setStep("otp");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send code");
+      setOpen(false);
+      setStep("idle");
+    }
+  };
+
+  const handleVerify = async (): Promise<void> => {
+    if (otpCode.length !== 6) {
+      setError("Enter the 6-digit code from your email");
+      return;
+    }
+
+    setStep("verifying");
+    setError(null);
+    try {
+      const res = await fetch("/api/user/wallet/export-key/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: otpCode }),
+      });
+      const data: { privateKey?: string; error?: string } = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? "Verification failed");
+      }
+
+      if (!data.privateKey) {
+        throw new Error("No private key returned");
+      }
+
+      setPrivateKey(data.privateKey);
+      setRevealed(false);
+      setStep("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Verification failed");
+      setStep("otp");
+    }
+  };
+
+  const handleCopy = (): void => {
+    if (!privateKey) {
+      return;
+    }
+    navigator.clipboard.writeText(privateKey);
+    toast.success("Private key copied to clipboard");
+  };
+
+  const handleClose = (): void => {
+    setOpen(false);
+    setStep("idle");
+    setOtpCode("");
+    setPrivateKey(null);
+    setRevealed(false);
+    setError(null);
+  };
+
+  return (
+    <>
+      <Button
+        className="w-full"
+        onClick={handleOpen}
+        size="sm"
+        variant="outline"
+      >
+        <KeyRound className="mr-2 h-3 w-3" />
+        Export Private Key
+      </Button>
+
+      <Dialog
+        onOpenChange={(v) => {
+          if (!v) {
+            handleClose();
+          }
+        }}
+        open={open}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Export Private Key</DialogTitle>
+            <DialogDescription>
+              {step === "done"
+                ? "Your private key is shown below. Copy it and store it securely."
+                : "A verification code has been sent to your email."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {step === "requesting" && (
+            <div className="flex items-center justify-center py-8">
+              <Spinner className="h-6 w-6" />
+            </div>
+          )}
+
+          {(step === "otp" || step === "verifying") && (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="export-otp">Verification Code</Label>
+                <Input
+                  className="font-mono text-center text-lg tracking-[0.3em]"
+                  id="export-otp"
+                  maxLength={6}
+                  onChange={(e) =>
+                    setOtpCode(e.target.value.replace(/\D/g, ""))
+                  }
+                  placeholder="000000"
+                  value={otpCode}
+                />
+                {error && <p className="text-destructive text-sm">{error}</p>}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  className="flex-1"
+                  disabled={step === "verifying"}
+                  onClick={handleClose}
+                  variant="outline"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  className="flex-1"
+                  disabled={step === "verifying" || otpCode.length !== 6}
+                  onClick={handleVerify}
+                >
+                  {step === "verifying" ? (
+                    <>
+                      <Spinner className="mr-2 h-4 w-4" />
+                      Verifying...
+                    </>
+                  ) : (
+                    "Verify & Export"
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {step === "done" && privateKey && (
+            <div className="space-y-4 py-2">
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="font-medium text-destructive text-sm">
+                    Private Key
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      aria-label={
+                        revealed ? "Hide private key" : "Reveal private key"
+                      }
+                      className="text-muted-foreground hover:text-foreground"
+                      onClick={() => setRevealed(!revealed)}
+                      type="button"
+                    >
+                      {revealed ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                    <button
+                      aria-label="Copy private key"
+                      className="text-muted-foreground hover:text-foreground"
+                      onClick={handleCopy}
+                      type="button"
+                    >
+                      <Copy className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+                <code className="block break-all font-mono text-sm">
+                  {revealed ? privateKey : privateKey.replace(/./g, "\u2022")}
+                </code>
+              </div>
+              <Button className="w-full" onClick={handleClose}>
+                Done
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/overlays/wallet/manage-tab.tsx
+++ b/components/overlays/wallet/manage-tab.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { WalletInfo } from "@/lib/wallet/types";
+import { RecoveryEmailCard } from "./recovery-email-card";
+import { SecurityCard } from "./security-card";
+import { WalletAddressCard } from "./wallet-address-card";
+import { WalletSwitcher } from "./wallet-switcher";
+
+export function ManageTab({
+  canExportKey,
+  email,
+  isAdmin,
+  onEmailUpdated,
+  onSelectActiveWallet,
+  switchingWallet,
+  walletAddress,
+  wallets,
+}: {
+  canExportKey: boolean;
+  email: string;
+  isAdmin: boolean;
+  onEmailUpdated: () => void;
+  onSelectActiveWallet: (walletId: string) => void;
+  switchingWallet: boolean;
+  walletAddress: string;
+  wallets: WalletInfo[] | undefined;
+}): React.ReactElement {
+  return (
+    <>
+      {wallets && wallets.length > 1 && (
+        <WalletSwitcher
+          isAdmin={isAdmin}
+          onSelect={onSelectActiveWallet}
+          switching={switchingWallet}
+          wallets={wallets}
+        />
+      )}
+      <WalletAddressCard walletAddress={walletAddress} />
+      <RecoveryEmailCard
+        email={email}
+        isAdmin={isAdmin}
+        onUpdated={onEmailUpdated}
+      />
+      {isAdmin && canExportKey && <SecurityCard />}
+    </>
+  );
+}

--- a/components/overlays/wallet/no-wallet-section.tsx
+++ b/components/overlays/wallet/no-wallet-section.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { ShieldCheck } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+
+function CreateWalletForm({
+  initialEmail,
+  onSubmit,
+}: {
+  initialEmail: string;
+  onSubmit: (email: string) => Promise<void>;
+}): React.ReactElement {
+  const [email, setEmail] = useState(initialEmail);
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = async (): Promise<void> => {
+    if (!email) {
+      toast.error("Email is required");
+      return;
+    }
+    setCreating(true);
+    try {
+      await onSubmit(email);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to create wallet"
+      );
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-xs">
+        This wallet will be shared by all members of your organization. Only
+        admins and owners can manage it.
+      </p>
+
+      <div className="space-y-2">
+        <Label htmlFor="wallet-email">Email Address</Label>
+        <Input
+          disabled={creating}
+          id="wallet-email"
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          type="email"
+          value={email}
+        />
+        <p className="text-muted-foreground text-xs">
+          This email will be associated with the wallet for identification
+          purposes.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-muted-foreground text-xs">
+          <ShieldCheck className="h-3.5 w-3.5" />
+          <span>Secured by Turnkey</span>
+        </div>
+        <Button disabled={creating || !email} onClick={handleCreate}>
+          {creating ? (
+            <>
+              <Spinner className="mr-2 h-4 w-4" />
+              Creating...
+            </>
+          ) : (
+            "Create Wallet"
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function NoWalletSection({
+  initialEmail,
+  isAdmin,
+  onCreateWallet,
+}: {
+  initialEmail: string;
+  isAdmin: boolean;
+  onCreateWallet: (email: string) => Promise<void>;
+}): React.ReactElement {
+  if (!isAdmin) {
+    return (
+      <div className="rounded-lg border bg-muted/50 p-4">
+        <p className="text-muted-foreground text-sm">
+          No wallet found for this organization. Only organization admins and
+          owners can create wallets.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <CreateWalletForm initialEmail={initialEmail} onSubmit={onCreateWallet} />
+  );
+}

--- a/components/overlays/wallet/recovery-email-card.tsx
+++ b/components/overlays/wallet/recovery-email-card.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+
+export function RecoveryEmailCard({
+  email,
+  isAdmin,
+  onUpdated,
+}: {
+  email: string;
+  isAdmin: boolean;
+  onUpdated: () => void;
+}): React.ReactElement {
+  const [isEditing, setIsEditing] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [updating, setUpdating] = useState(false);
+
+  const startEditing = (): void => {
+    setNewEmail(email);
+    setIsEditing(true);
+  };
+
+  const cancelEditing = (): void => {
+    setIsEditing(false);
+    setNewEmail("");
+  };
+
+  const handleSave = async (): Promise<void> => {
+    if (!newEmail) {
+      toast.error("Email is required");
+      return;
+    }
+    setUpdating(true);
+    try {
+      const response = await fetch("/api/user/wallet", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: newEmail }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to update email");
+      }
+      toast.success("Wallet email updated successfully!");
+      setIsEditing(false);
+      setNewEmail("");
+      onUpdated();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update email"
+      );
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <section>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium text-sm">Recovery email</span>
+        {!isEditing && isAdmin && (
+          <Button
+            className="h-6 px-2 text-xs"
+            onClick={startEditing}
+            size="sm"
+            variant="ghost"
+          >
+            Edit
+          </Button>
+        )}
+      </div>
+      {isEditing ? (
+        <div className="space-y-2">
+          <Input
+            className="text-sm"
+            disabled={updating}
+            onChange={(e) => setNewEmail(e.target.value)}
+            placeholder="newemail@example.com"
+            type="email"
+            value={newEmail}
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              disabled={updating}
+              onClick={cancelEditing}
+              size="sm"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={updating || !newEmail || newEmail === email}
+              onClick={handleSave}
+              size="sm"
+            >
+              {updating ? (
+                <>
+                  <Spinner className="mr-2 h-3 w-3" />
+                  Saving...
+                </>
+              ) : (
+                "Save"
+              )}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-1">
+          <p className="text-sm">{email}</p>
+          <p className="text-muted-foreground text-xs">
+            Used for verification when exporting the private key.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/overlays/wallet/security-card.tsx
+++ b/components/overlays/wallet/security-card.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ExportPrivateKeyButton } from "./export-private-key-button";
+
+export function SecurityCard(): React.ReactElement {
+  return (
+    <section>
+      <div className="mb-1 font-medium text-sm">Security</div>
+      <p className="mb-3 text-muted-foreground text-xs">
+        Export the private key to move funds to another wallet or access your
+        wallet outside KeeperHub. Keep it secret. Anyone with the key controls
+        the wallet.
+      </p>
+      <ExportPrivateKeyButton />
+    </section>
+  );
+}

--- a/components/overlays/wallet/wallet-address-card.tsx
+++ b/components/overlays/wallet/wallet-address-card.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { toChecksumAddress } from "@/lib/address-utils";
+
+const COPIED_FEEDBACK_MS = 3000;
+
+export function WalletAddressCard({
+  walletAddress,
+}: {
+  walletAddress: string;
+}): React.ReactElement {
+  const checksummed = toChecksumAddress(walletAddress);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = (): void => {
+    navigator.clipboard.writeText(checksummed);
+    toast.success("Address copied to clipboard");
+    setCopied(true);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+  };
+
+  return (
+    <section>
+      <div className="mb-2 font-medium text-sm">Wallet address</div>
+      <button
+        aria-label="Copy wallet address"
+        className={`group flex w-full items-center justify-between gap-2 rounded-md border bg-background px-3 py-2 text-left transition-colors duration-300 hover:bg-background ${
+          copied
+            ? "border-keeperhub-green/80 ring-1 ring-keeperhub-green/30"
+            : "border-border"
+        }`}
+        data-testid="wallet-copy-address"
+        onClick={handleCopy}
+        type="button"
+      >
+        <code className="break-all font-mono text-foreground text-xs">
+          {checksummed}
+        </code>
+        {copied ? (
+          <Check className="h-3.5 w-3.5 shrink-0 text-keeperhub-green/80" />
+        ) : (
+          <Copy className="h-3.5 w-3.5 shrink-0 text-muted-foreground group-hover:text-foreground" />
+        )}
+      </button>
+      <p className="mt-2 text-muted-foreground text-xs">
+        {copied ? "Copied to clipboard" : "Click to copy"}
+      </p>
+    </section>
+  );
+}

--- a/components/overlays/wallet/wallet-switcher.tsx
+++ b/components/overlays/wallet/wallet-switcher.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { truncateAddress } from "@/lib/address-utils";
+import type { WalletInfo } from "@/lib/wallet/types";
+
+const PROVIDER_DISPLAY_ORDER: Record<"para" | "turnkey", number> = {
+  para: 0,
+  turnkey: 1,
+} as const;
+
+export function WalletSwitcher({
+  wallets,
+  isAdmin,
+  switching,
+  onSelect,
+}: {
+  wallets: WalletInfo[];
+  isAdmin: boolean;
+  switching: boolean;
+  onSelect: (walletId: string) => void;
+}): React.ReactElement {
+  const ordered = [...wallets].sort(
+    (a, b) =>
+      PROVIDER_DISPLAY_ORDER[a.provider] - PROVIDER_DISPLAY_ORDER[b.provider]
+  );
+  const hasPara = ordered.some((w) => w.provider === "para");
+  return (
+    <section>
+      <div className="mb-2 font-medium text-sm">Active wallet for signing</div>
+      {hasPara && (
+        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-amber-700 text-xs dark:text-amber-400">
+          Para will be deprecated soon. Switch the active wallet to Turnkey and
+          move your assets from the Para wallet before the cutover.
+        </div>
+      )}
+      <div className="flex gap-2">
+        {ordered.map((wallet) => {
+          const label = wallet.provider === "para" ? "Para" : "Turnkey";
+          const disabled = !isAdmin || switching || wallet.isActive;
+          return (
+            <button
+              className={`flex-1 rounded-md border px-3 py-2 text-left text-sm transition ${
+                wallet.isActive
+                  ? "border-primary bg-primary/10"
+                  : "border-border hover:bg-background"
+              } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+              disabled={disabled}
+              key={wallet.id}
+              onClick={() => onSelect(wallet.id)}
+              type="button"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{label}</span>
+                {wallet.isActive && (
+                  <span className="rounded bg-primary/20 px-1.5 py-0.5 text-[10px] text-primary">
+                    Active
+                  </span>
+                )}
+              </div>
+              <code className="font-mono text-muted-foreground text-xs">
+                {truncateAddress(wallet.walletAddress)}
+              </code>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/workflow/wallet-toolbar-button.tsx
+++ b/components/workflow/wallet-toolbar-button.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Copy, Plus, Wallet } from "lucide-react";
+import { toast } from "sonner";
+import { useOverlay } from "@/components/overlays/overlay-provider";
+import { WalletOverlay } from "@/components/overlays/wallet-overlay";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
+import { useSession } from "@/lib/auth-client";
+import { isAnonymousUser } from "@/lib/is-anonymous";
+import { useWalletInfo } from "@/lib/wallet/use-wallet-info";
+
+/**
+ * Compact toolbar affordance for the organization wallet.
+ *
+ * - Shows the truncated wallet address when a wallet exists (click opens
+ *   the wallet overlay; clipboard copies the full checksummed address).
+ * - Shows a "Create wallet" button when the user is signed in but has no
+ *   wallet yet (click opens the overlay on the balances tab so admins can
+ *   create one).
+ * - Renders nothing for anonymous / unverified users to keep the toolbar
+ *   clean on first load.
+ */
+export function WalletToolbarButton(): React.ReactElement | null {
+  const { data: session, isPending } = useSession();
+  const { open: openOverlay } = useOverlay();
+  const { hasWallet, walletAddress, isLoading } = useWalletInfo();
+
+  if (isPending) {
+    return null;
+  }
+
+  if (!session?.user || isAnonymousUser(session.user)) {
+    return null;
+  }
+
+  if (session.user.emailVerified !== true) {
+    return null;
+  }
+
+  if (isLoading && !walletAddress) {
+    return null;
+  }
+
+  if (!hasWallet || !walletAddress) {
+    return (
+      <Button
+        className="h-9"
+        onClick={() => openOverlay(WalletOverlay)}
+        size="sm"
+        variant="outline"
+      >
+        <Plus className="size-4" />
+        <span className="hidden sm:inline">Create wallet</span>
+        <span className="sm:hidden">Wallet</span>
+      </Button>
+    );
+  }
+
+  const handleOpenWallet = (): void => {
+    openOverlay(WalletOverlay);
+  };
+
+  const handleCopy = (e: React.MouseEvent<HTMLButtonElement>): void => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(toChecksumAddress(walletAddress));
+    toast.success("Address copied to clipboard");
+  };
+
+  return (
+    <div className="flex h-9 items-center rounded-md border bg-secondary text-secondary-foreground">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="flex h-full items-center gap-2 rounded-l-md px-3 font-medium text-sm transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+            data-testid="wallet-toolbar-address"
+            onClick={handleOpenWallet}
+            type="button"
+          >
+            <Wallet className="size-4 shrink-0" />
+            <span className="font-mono text-xs">
+              {truncateAddress(walletAddress)}
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Open wallet</TooltipContent>
+      </Tooltip>
+      <div className="h-5 w-px bg-border" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            aria-label="Copy wallet address"
+            className="flex h-full items-center rounded-r-md px-2 text-muted-foreground transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/5"
+            onClick={handleCopy}
+            type="button"
+          >
+            <Copy className="size-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Copy address</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -36,6 +36,7 @@ import { OrgSwitcher } from "@/components/organization/org-switcher";
 import { GoLiveOverlay } from "@/components/overlays/go-live-overlay";
 import { ListingOverlay } from "@/components/overlays/listing-overlay";
 import { Switch } from "@/components/ui/switch";
+import { WalletToolbarButton } from "@/components/workflow/wallet-toolbar-button";
 import { BUILTIN_NODE_ID } from "@/lib/builtin-variables";
 import { isAnonymousUser } from "@/lib/is-anonymous";
 import { api, ApiError, type Project, type Tag } from "@/lib/api-client";
@@ -1855,6 +1856,7 @@ export const WorkflowToolbar = ({
               />
             )}
             <div className="flex items-center gap-2">
+              <WalletToolbarButton />
               {isWorkflowRoute && effectiveWorkflowId && !state.isOwner && (
                 <DuplicateButton
                   isDuplicating={state.isDuplicating}

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -8,7 +8,6 @@ import {
   Plug,
   Settings,
   Users,
-  Wallet,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -22,7 +21,6 @@ import { IntegrationsOverlay } from "@/components/overlays/integrations-overlay"
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { ProjectsAndTagsOverlay } from "@/components/overlays/projects-and-tags-overlay";
 import { SettingsOverlay } from "@/components/overlays/settings-overlay";
-import { WalletOverlay } from "@/components/overlays/wallet-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -144,10 +142,6 @@ export const UserMenu = (): React.ReactElement => {
             </DropdownMenuItem>
             <DropdownMenuSeparator />
           </div>
-          <DropdownMenuItem onClick={() => openOverlay(WalletOverlay)}>
-            <Wallet className="size-4" />
-            <span>Wallet</span>
-          </DropdownMenuItem>
           <DropdownMenuItem onClick={() => openOverlay(SettingsOverlay)}>
             <Settings className="size-4" />
             <span>Settings</span>

--- a/lib/wallet/use-wallet-info.ts
+++ b/lib/wallet/use-wallet-info.ts
@@ -1,7 +1,8 @@
 "use client";
 
+import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useState } from "react";
-import { useSession } from "@/lib/auth-client";
+import { authClient, useSession } from "@/lib/auth-client";
 
 export type WalletInfoState = {
   hasWallet: boolean;
@@ -16,12 +17,32 @@ type WalletResponse = {
 };
 
 /**
+ * Counter atom to let parts of the app (e.g. the wallet overlay after
+ * switching the active wallet) invalidate any mounted useWalletInfo hooks.
+ */
+const walletInfoRefreshAtom = atom(0);
+
+/**
+ * Call from components that mutate wallet state (create, switch active, etc.)
+ * to force every subscribed useWalletInfo consumer to refetch.
+ */
+export function useInvalidateWalletInfo(): () => void {
+  const setCounter = useSetAtom(walletInfoRefreshAtom);
+  return useCallback(() => {
+    setCounter((n) => n + 1);
+  }, [setCounter]);
+}
+
+/**
  * Lightweight hook that tracks whether the active organization has a wallet
  * and exposes the primary address. Safe to mount in shared chrome (toolbar)
- * because it short-circuits for anonymous sessions.
+ * because it short-circuits for anonymous sessions. Refetches automatically
+ * when the active org changes or useInvalidateWalletInfo is fired.
  */
 export function useWalletInfo(): WalletInfoState {
   const { data: session } = useSession();
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const refreshCounter = useAtomValue(walletInfoRefreshAtom);
   const [hasWallet, setHasWallet] = useState(false);
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -33,6 +54,8 @@ export function useWalletInfo(): WalletInfoState {
     !!email &&
     !email.startsWith("temp-") &&
     session?.user?.emailVerified === true;
+
+  const activeOrgId = activeOrg?.id ?? null;
 
   const refresh = useCallback(async (): Promise<void> => {
     if (!isAuthed) {
@@ -64,9 +87,11 @@ export function useWalletInfo(): WalletInfoState {
     }
   }, [isAuthed]);
 
+  // Refetch when auth state changes, when the active org switches, or when
+  // useInvalidateWalletInfo bumps the counter (wallet create / switch active).
   useEffect(() => {
     refresh();
-  }, [refresh]);
+  }, [refresh, activeOrgId, refreshCounter]);
 
   return { hasWallet, walletAddress, isLoading, refresh };
 }

--- a/lib/wallet/use-wallet-info.ts
+++ b/lib/wallet/use-wallet-info.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "@/lib/auth-client";
+
+export type WalletInfoState = {
+  hasWallet: boolean;
+  walletAddress: string | null;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+};
+
+type WalletResponse = {
+  hasWallet?: boolean;
+  walletAddress?: string;
+};
+
+/**
+ * Lightweight hook that tracks whether the active organization has a wallet
+ * and exposes the primary address. Safe to mount in shared chrome (toolbar)
+ * because it short-circuits for anonymous sessions.
+ */
+export function useWalletInfo(): WalletInfoState {
+  const { data: session } = useSession();
+  const [hasWallet, setHasWallet] = useState(false);
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const sessionUserId = session?.user?.id;
+  const email = session?.user?.email;
+  const isAuthed =
+    !!sessionUserId &&
+    !!email &&
+    !email.startsWith("temp-") &&
+    session?.user?.emailVerified === true;
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!isAuthed) {
+      setHasWallet(false);
+      setWalletAddress(null);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/user/wallet");
+      if (!response.ok) {
+        setHasWallet(false);
+        setWalletAddress(null);
+        return;
+      }
+      const data = (await response.json()) as WalletResponse;
+      if (data.hasWallet && data.walletAddress) {
+        setHasWallet(true);
+        setWalletAddress(data.walletAddress);
+      } else {
+        setHasWallet(false);
+        setWalletAddress(null);
+      }
+    } catch {
+      setHasWallet(false);
+      setWalletAddress(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isAuthed]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { hasWallet, walletAddress, isLoading, refresh };
+}


### PR DESCRIPTION
## Summary

- **Balances tab**: chains folded by default, auto-expand when native/stablecoin/custom-token balance > 0, smooth collapse animation (skipped on first paint so filter switches feel instant). Ethereum, Base, Tempo come first in both Mainnets and Testnets. Per-chain inline "Add token" input replaces the global form; addresses are EIP-55 checksummed on input and on submit.
- **Manage tab** (replaces "Settings"): Wallet address card with click-to-copy (3s confirmation state), recovery email with inline edit, Security section gating Export Private Key behind admin + Turnkey. Tabs are controlled so Para → Turnkey wallet switches no longer bounce the user back to Balances.
- **Toolbar wallet pill**: between Run and the user avatar. Shows truncated checksummed address with a separate copy button; falls back to a "Create wallet" button for signed-in users without one. Wallet entry removed from the user dropdown.
- **Refactor**: split the 1700-line wallet-overlay.tsx into focused modules under `components/overlays/wallet/` (balances-tab, chain-balance-item, manage-tab, wallet-address-card, recovery-email-card, security-card, wallet-switcher, export-private-key-button, no-wallet-section, chain-utils). Main overlay is now pure orchestration.

Linear: https://linear.app/keeperhubapp/issue/KEEP-270/rework-wallet-modal