### PR TITLE
fix(wallet): Turnkey SDK contract mismatches caught by local UAT

### DIFF
--- a/lib/agentic-wallet/policy.ts
+++ b/lib/agentic-wallet/policy.ts
@@ -122,7 +122,13 @@ export async function applyBaselinePolicies(
         policyName: p.policyName,
         effect: p.effect,
         condition: p.condition,
-        consensus: "",
+        // Turnkey v5.3.0 requires a valid expression for consensus even on
+        // EFFECT_DENY policies; the empty-string shortcut noted in the original
+        // 33-RESEARCH.md Pitfall 7 was incorrect. "true" means "consensus is
+        // always satisfied" — combined with EFFECT_DENY this unconditionally
+        // denies the operation whenever the condition matches, which is the
+        // intended GUARD-06 behaviour.
+        consensus: "true",
         notes: p.notes,
       })
     )

--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -120,22 +120,19 @@ async function signTypedData(
   typedData: unknown
 ): Promise<string> {
   const client = getTurnkeyClientForOrg(subOrgId).apiClient();
-  // The Turnkey SDK types are strict unions; cast via unknown to let the
-  // shared signing primitive accept both x402 and MPP typed-data bodies.
+  // Turnkey SDK v5.3.0's `signRawPayload` expects parameters FLAT (not nested
+  // under a `parameters` object as the raw v1 activity API required). The
+  // original v1 envelope `{type, organizationId, timestampMs, parameters}`
+  // was rejected with "field required: signWith / payload / encoding".
   const response = (await (
     client as unknown as {
       signRawPayload: (args: unknown) => Promise<TurnkeyActivityResponse>;
     }
   ).signRawPayload({
-    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
-    organizationId: subOrgId,
-    timestampMs: String(Date.now()),
-    parameters: {
-      signWith: walletAddress,
-      payload: JSON.stringify(typedData),
-      encoding: "PAYLOAD_ENCODING_EIP712",
-      hashFunction: "HASH_FUNCTION_NO_OP",
-    },
+    signWith: walletAddress,
+    payload: JSON.stringify(typedData),
+    encoding: "PAYLOAD_ENCODING_EIP712",
+    hashFunction: "HASH_FUNCTION_NO_OP",
   })) as TurnkeyActivityResponse;
 
   const activity = response?.activity;

--- a/tests/unit/agentic-wallet-policy.test.ts
+++ b/tests/unit/agentic-wallet-policy.test.ts
@@ -62,11 +62,10 @@ describe("BASELINE_POLICIES", () => {
     expect(p?.effect).toBe("EFFECT_DENY");
   });
 
-  it("every policy has empty-or-absent consensus (no CONSENSUS_NEEDED surprise)", () => {
+  it("BaselinePolicy type does not carry a consensus field (set at createPolicy call site)", () => {
     for (const p of BASELINE_POLICIES) {
-      const consensus =
-        (p as unknown as { consensus?: string }).consensus ?? "";
-      expect(consensus).toBe("");
+      const hasConsensus = "consensus" in (p as Record<string, unknown>);
+      expect(hasConsensus).toBe(false);
     }
   });
 

--- a/tests/unit/agentic-wallet-provision.test.ts
+++ b/tests/unit/agentic-wallet-provision.test.ts
@@ -183,7 +183,7 @@ describe("provisionAgenticWallet", () => {
       const arg = call[0];
       expect(arg.organizationId).toBe(MOCK_SUB_ORG_ID);
       expect(arg.effect).toBe("EFFECT_DENY");
-      expect(arg.consensus ?? "").toBe("");
+      expect(arg.consensus).toBe("true");
     }
   });
 

--- a/tests/unit/agentic-wallet-sign.test.ts
+++ b/tests/unit/agentic-wallet-sign.test.ts
@@ -76,7 +76,7 @@ describe("signX402Challenge", () => {
     vi.clearAllMocks();
   });
 
-  it("calls signRawPayload with ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2 and EIP-712 encoding", async () => {
+  it("calls signRawPayload with flat EIP-712 args (Turnkey SDK v5.3.0 contract)", async () => {
     await signX402Challenge(SUB_ORG, WALLET, {
       payTo: "0x1111111111111111111111111111111111111111",
       amount: "1000000",
@@ -86,10 +86,9 @@ describe("signX402Challenge", () => {
     });
     expect(mockSignRawPayload).toHaveBeenCalledTimes(1);
     const args = mockSignRawPayload.mock.calls[0]?.[0];
-    expect(args.type).toBe("ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2");
-    expect(args.parameters.signWith).toBe(WALLET);
-    expect(args.parameters.encoding).toBe("PAYLOAD_ENCODING_EIP712");
-    expect(args.parameters.hashFunction).toBe("HASH_FUNCTION_NO_OP");
+    expect(args.signWith).toBe(WALLET);
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_EIP712");
+    expect(args.hashFunction).toBe("HASH_FUNCTION_NO_OP");
   });
 
   it("serialises typed data with chainId 8453, Base USDC verifying contract, and primaryType TransferWithAuthorization", async () => {
@@ -101,7 +100,7 @@ describe("signX402Challenge", () => {
       nonce: `0x${"11".repeat(32)}`,
     });
     const args = mockSignRawPayload.mock.calls[0]?.[0];
-    const typedData = JSON.parse(args.parameters.payload) as {
+    const typedData = JSON.parse(args.payload) as {
       domain: { chainId: number; verifyingContract: string };
       types: Record<string, unknown>;
       primaryType: string;
@@ -190,8 +189,8 @@ describe("signMppProof", () => {
       challengeId: "challenge-abc-123",
     });
     const args = mockSignRawPayload.mock.calls[0]?.[0];
-    expect(args.parameters.encoding).toBe("PAYLOAD_ENCODING_EIP712");
-    const typedData = JSON.parse(args.parameters.payload) as {
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_EIP712");
+    const typedData = JSON.parse(args.payload) as {
       domain: { chainId: number };
       primaryType: string;
     };


### PR DESCRIPTION
## Summary

Local UAT against a real Turnkey API (SDK v5.3.0) caught two contract bugs that would have broken **every** \`/provision\` and \`/sign\` call in production. The existing Phase 33 unit tests mocked Turnkey, so the real API shape was never exercised end-to-end.

Targets \`simon/v1.8-agentic-wallet\` (the PR #917 branch) — these fixes should land before #917 merges to staging.

## Bugs

### B1 — \`policy.ts\`: empty consensus rejected by Turnkey
\`\`\`
Turnkey error 3: invalid policy consensus:
Expression cannot be evaluated: parse error: Unrecognized EOF found at 0
\`\`\`

All three baseline GUARD-06 policies failed to apply. The original 33-RESEARCH.md Pitfall 7 noted that empty consensus avoids CONSENSUS_NEEDED; that claim was wrong for v5.3.0.

**Fix:** \`consensus: "true"\` (always satisfied; combined with EFFECT_DENY this unconditionally denies matching ops — the intended behaviour).

### B2 — \`sign.ts\`: wrong envelope for signRawPayload
\`\`\`
Turnkey error 3: invalid request (fieldViolations: signWith, payload, encoding)
\`\`\`

The code passed the v1 activity envelope \`{type, organizationId, timestampMs, parameters: {...}}\`. SDK v5.3.0's \`signRawPayload()\` takes parameters FLAT.

**Fix:** flattened the args.

## UAT evidence

After both fixes, running against localhost:3000 with real Turnkey creds:

\`\`\`
$ curl -X POST localhost:3000/api/agentic-wallet/provision ...
HTTP 200 { subOrgId, walletAddress, hmacSecret }

$ curl -X POST localhost:3000/api/agentic-wallet/sign ... (HMAC-signed)
HTTP 200 { signature: "0x40445...1b" }  (132-hex EIP-3009)

$ recoverTypedDataAddress(signature, domain, types, message)
=> 0xa52Adf3cBe463111A39C755DEebd8d6093D416cC  (matches wallet)
\`\`\`

## Tests

Two test assertions updated:
- \`agentic-wallet-policy.test.ts\`: was asserting \`consensus === ""\` against the \`BaselinePolicy\` object (which doesn't even have a consensus field — always matched "" via \`?? ""\`). Now asserts the field is absent, which is correct.
- \`agentic-wallet-provision.test.ts\`: was asserting mock arg \`consensus === ""\`. Now asserts \`"true"\`.

21/21 unit tests green in the changed files.

## Retrospective

Phase 33 plans mocked Turnkey at the SDK boundary. That's fine for unit tests, but at least one integration test per Turnkey-calling route should exercise the real SDK against a test org — otherwise contract drift between the codebase and the SDK goes uncaught. This kind of bug (wrong field shape, wrong envelope) is invisible to mocks that only check "was it called" rather than "what shape was sent."

## Test plan

- [ ] Review & merge this PR into simon/v1.8-agentic-wallet
- [ ] Re-run the UAT locally (steps documented in the staging smoke plan)
- [ ] Merge PR #917 to staging