### PR TITLE
feat: KEEP-295 introduce ChainProviderManager primitive

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -238,18 +238,28 @@ export class ChainProviderManager {
     if (!(logAddr && logTopic0)) {
       return;
     }
+    // Fire all matching handlers concurrently. Sequential `await` here would
+    // let a slow handler (e.g. one applying the EventListener jitter sleep)
+    // stall dispatch to every other subscriber on the same log, compounding
+    // latency linearly with listener count. Each handler's errors are
+    // isolated so one rejection does not abort the others.
+    const matching: Subscriber[] = [];
     for (const sub of entry.subscribers) {
-      if (sub.address !== logAddr || sub.topic0 !== logTopic0) {
-        continue;
-      }
-      try {
-        await sub.handler(log);
-      } catch (err) {
-        logger.warn(
-          `[ChainProviderManager] chain=${entry.chainId} subscriber handler threw: ${String(err)}`,
-        );
+      if (sub.address === logAddr && sub.topic0 === logTopic0) {
+        matching.push(sub);
       }
     }
+    await Promise.all(
+      matching.map(async (sub) => {
+        try {
+          await sub.handler(log);
+        } catch (err) {
+          logger.warn(
+            `[ChainProviderManager] chain=${entry.chainId} subscriber handler threw: ${String(err)}`,
+          );
+        }
+      }),
+    );
   }
 }
 

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -1,0 +1,256 @@
+import { ethers } from "ethers";
+import { logger } from "../../lib/utils/logger";
+
+/**
+ * ChainProviderManager centralises WebSocket provider ownership and
+ * block-based log delivery per chain. One provider and one
+ * `eth_subscribe(newHeads)` subscription per chainId, regardless of how
+ * many listeners are registered for that chain.
+ *
+ * Log delivery uses block subscription + batched `eth_getLogs` rather than
+ * one `eth_subscribe(logs, ...)` per listener. This decouples RPC-side
+ * subscription count from workflow count (provider subscription caps are
+ * typically ~1000 per WSS).
+ *
+ * Phase 1 scope: provider singleton + block-sub demux. Heartbeat and
+ * reconnect continue to live in `ws-connection.ts` until Phase 3 routes
+ * listeners through this manager at runtime.
+ */
+
+// Address list cap on `eth_getLogs` varies by provider (Alchemy ~500,
+// Infura ~1000). Chunk defensively; multiple calls per block are cheap.
+const GETLOGS_ADDRESS_BATCH = 500;
+
+export type LogHandler = (log: ethers.Log) => void | Promise<void>;
+export type Unsubscribe = () => void;
+
+export type ProviderFactory = (wssUrl: string) => ethers.WebSocketProvider;
+
+export interface SubscribeOptions {
+  chainId: number;
+  wssUrl: string;
+  address: string;
+  topic0: string;
+  handler: LogHandler;
+}
+
+interface Subscriber {
+  address: string; // normalized to lowercase
+  topic0: string; // 0x-prefixed, lowercase
+  handler: LogHandler;
+}
+
+interface ChainEntry {
+  chainId: number;
+  wssUrl: string;
+  provider: ethers.WebSocketProvider | null;
+  readyPromise: Promise<ethers.WebSocketProvider> | null;
+  subscribers: Set<Subscriber>;
+  blockListener: ((blockNumber: number) => Promise<void>) | null;
+}
+
+const defaultFactory: ProviderFactory = (wssUrl) =>
+  new ethers.WebSocketProvider(wssUrl);
+
+export class ChainProviderManager {
+  private readonly chains = new Map<number, ChainEntry>();
+  private readonly factory: ProviderFactory;
+
+  constructor(factory: ProviderFactory = defaultFactory) {
+    this.factory = factory;
+  }
+
+  async getOrCreateProvider(
+    chainId: number,
+    wssUrl: string,
+  ): Promise<ethers.WebSocketProvider> {
+    const entry = this.ensureEntry(chainId, wssUrl);
+
+    if (entry.provider) {
+      return entry.provider;
+    }
+
+    // Two concurrent callers must receive the same provider instance, not
+    // race to create separate ones.
+    if (!entry.readyPromise) {
+      entry.readyPromise = this.createProvider(entry);
+    }
+    return entry.readyPromise;
+  }
+
+  async subscribeToLogs(opts: SubscribeOptions): Promise<Unsubscribe> {
+    const entry = this.ensureEntry(opts.chainId, opts.wssUrl);
+    await this.getOrCreateProvider(opts.chainId, opts.wssUrl);
+
+    const subscriber: Subscriber = {
+      address: opts.address.toLowerCase(),
+      topic0: opts.topic0.toLowerCase(),
+      handler: opts.handler,
+    };
+    entry.subscribers.add(subscriber);
+
+    if (!entry.blockListener) {
+      this.attachBlockListener(entry);
+    }
+
+    return () => {
+      entry.subscribers.delete(subscriber);
+      if (entry.subscribers.size === 0) {
+        this.detachBlockListener(entry);
+      }
+    };
+  }
+
+  async destroy(): Promise<void> {
+    const errors: unknown[] = [];
+    for (const entry of this.chains.values()) {
+      this.detachBlockListener(entry);
+      if (entry.provider) {
+        try {
+          await entry.provider.destroy();
+        } catch (err) {
+          errors.push(err);
+        }
+      }
+      entry.subscribers.clear();
+      entry.provider = null;
+      entry.readyPromise = null;
+    }
+    this.chains.clear();
+    if (errors.length > 0) {
+      logger.warn(
+        `[ChainProviderManager] ${errors.length} provider destroy errors: ${errors
+          .map(String)
+          .join("; ")}`,
+      );
+    }
+  }
+
+  private ensureEntry(chainId: number, wssUrl: string): ChainEntry {
+    const existing = this.chains.get(chainId);
+    if (existing) {
+      if (existing.wssUrl !== wssUrl) {
+        throw new Error(
+          `chainId ${chainId} already registered with wssUrl ${existing.wssUrl}; refusing to reuse for ${wssUrl}`,
+        );
+      }
+      return existing;
+    }
+    const entry: ChainEntry = {
+      chainId,
+      wssUrl,
+      provider: null,
+      readyPromise: null,
+      subscribers: new Set(),
+      blockListener: null,
+    };
+    this.chains.set(chainId, entry);
+    return entry;
+  }
+
+  private async createProvider(
+    entry: ChainEntry,
+  ): Promise<ethers.WebSocketProvider> {
+    const provider = this.factory(entry.wssUrl);
+    await provider.ready;
+    entry.provider = provider;
+    return provider;
+  }
+
+  private attachBlockListener(entry: ChainEntry): void {
+    if (!entry.provider) {
+      throw new Error(
+        `attachBlockListener: provider not initialized for chain ${entry.chainId}`,
+      );
+    }
+    const listener = async (blockNumber: number): Promise<void> => {
+      await this.processBlock(entry, blockNumber);
+    };
+    entry.blockListener = listener;
+    entry.provider.on("block", listener);
+  }
+
+  private detachBlockListener(entry: ChainEntry): void {
+    if (!(entry.provider && entry.blockListener)) {
+      entry.blockListener = null;
+      return;
+    }
+    entry.provider.off("block", entry.blockListener);
+    entry.blockListener = null;
+  }
+
+  private async processBlock(
+    entry: ChainEntry,
+    blockNumber: number,
+  ): Promise<void> {
+    const subscribers = [...entry.subscribers];
+    if (subscribers.length === 0 || !entry.provider) {
+      return;
+    }
+
+    const { addresses, topic0s } = this.collectFilter(subscribers);
+    const blockHex = `0x${blockNumber.toString(16)}`;
+
+    try {
+      const logs: ethers.Log[] = [];
+      for (let i = 0; i < addresses.length; i += GETLOGS_ADDRESS_BATCH) {
+        const chunk = addresses.slice(i, i + GETLOGS_ADDRESS_BATCH);
+        const batch = (await entry.provider.send("eth_getLogs", [
+          {
+            fromBlock: blockHex,
+            toBlock: blockHex,
+            address: chunk,
+            topics: [topic0s],
+          },
+        ])) as ethers.Log[];
+        logs.push(...batch);
+      }
+
+      for (const log of logs) {
+        await this.dispatchLog(entry, log);
+      }
+    } catch (err) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} block=${blockNumber} getLogs failed: ${String(err)}`,
+      );
+    }
+  }
+
+  private collectFilter(subscribers: Subscriber[]): {
+    addresses: string[];
+    topic0s: string[];
+  } {
+    const addressSet = new Set<string>();
+    const topicSet = new Set<string>();
+    for (const sub of subscribers) {
+      addressSet.add(sub.address);
+      topicSet.add(sub.topic0);
+    }
+    return {
+      addresses: [...addressSet],
+      topic0s: [...topicSet],
+    };
+  }
+
+  private async dispatchLog(entry: ChainEntry, log: ethers.Log): Promise<void> {
+    const logAddr = log.address?.toLowerCase();
+    const logTopic0 = log.topics?.[0]?.toLowerCase();
+    if (!(logAddr && logTopic0)) {
+      return;
+    }
+    for (const sub of entry.subscribers) {
+      if (sub.address !== logAddr || sub.topic0 !== logTopic0) {
+        continue;
+      }
+      try {
+        await sub.handler(log);
+      } catch (err) {
+        logger.warn(
+          `[ChainProviderManager] chain=${entry.chainId} subscriber handler threw: ${String(err)}`,
+        );
+      }
+    }
+  }
+}
+
+export const chainProviderManager = new ChainProviderManager();

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -287,6 +287,83 @@ describe("ChainProviderManager", () => {
       expect(h2).toHaveBeenCalledTimes(1);
     });
 
+    it("dispatches matching subscribers in parallel, not serially", async () => {
+      // Two handlers on the same (address, topic0). h1 sleeps; h2 should
+      // start before h1 resolves. With sequential await the h2 start time
+      // would be >= 50ms; in parallel it should be ~0ms.
+      let h1Started = 0;
+      let h2Started = 0;
+      let start = 0;
+      const h1 = vi.fn(async () => {
+        h1Started = Date.now() - start;
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      const h2 = vi.fn(async () => {
+        h2Started = Date.now() - start;
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h1,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h2,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      start = Date.now();
+      await provider.emitBlock(500);
+
+      expect(h1).toHaveBeenCalledTimes(1);
+      expect(h2).toHaveBeenCalledTimes(1);
+      // h2 starts well before h1's 50ms sleep completes.
+      expect(h2Started).toBeLessThan(40);
+      expect(h1Started).toBeLessThan(10);
+    });
+
+    it("one handler throwing does not block or abort the others", async () => {
+      const thrower = vi.fn(async () => {
+        throw new Error("boom");
+      });
+      const later = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: thrower,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: later,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(501);
+
+      expect(thrower).toHaveBeenCalledTimes(1);
+      expect(later).toHaveBeenCalledTimes(1);
+    });
+
     it("does not call a handler after its subscription is cancelled", async () => {
       const handler = vi.fn();
       const unsubscribe = await manager.subscribeToLogs({

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1,0 +1,379 @@
+import type { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ChainProviderManager,
+  type ProviderFactory,
+} from "../../src/chains/provider-manager";
+
+type BlockHandler = (blockNumber: number) => void | Promise<void>;
+
+interface SendCall {
+  method: string;
+  params: unknown[];
+}
+
+class MockProvider {
+  // Vitest's vi.fn provides better assertions (toHaveBeenCalledWith) than a plain
+  // Promise.resolve would, and the field is still awaitable.
+  ready: Promise<void> = Promise.resolve();
+  public sendCalls: SendCall[] = [];
+  public sendResponses: unknown[] = [];
+  public destroyed = false;
+  private blockHandler: BlockHandler | null = null;
+
+  on(event: string, handler: BlockHandler): void {
+    if (event === "block") {
+      this.blockHandler = handler;
+    }
+  }
+
+  off(event: string, handler: BlockHandler): void {
+    if (event === "block" && this.blockHandler === handler) {
+      this.blockHandler = null;
+    }
+  }
+
+  async send(method: string, params: unknown[]): Promise<unknown> {
+    this.sendCalls.push({ method, params });
+    if (this.sendResponses.length === 0) {
+      return [];
+    }
+    return this.sendResponses.shift();
+  }
+
+  async destroy(): Promise<void> {
+    this.destroyed = true;
+  }
+
+  hasBlockHandler(): boolean {
+    return this.blockHandler !== null;
+  }
+
+  async emitBlock(blockNumber: number): Promise<void> {
+    if (this.blockHandler) {
+      await this.blockHandler(blockNumber);
+    }
+  }
+}
+
+// MockProvider implements the ethers.WebSocketProvider surface that
+// ChainProviderManager actually uses. The factory casts through unknown to
+// satisfy the type without pulling in the rest of ethers' provider surface.
+function makeFactory(): {
+  factory: ProviderFactory;
+  created: MockProvider[];
+} {
+  const created: MockProvider[] = [];
+  const factory: ProviderFactory = (_wssUrl: string) => {
+    const mock = new MockProvider();
+    created.push(mock);
+    return mock as unknown as ethers.WebSocketProvider;
+  };
+  return { factory, created };
+}
+
+const CHAIN_A = 31337;
+const CHAIN_B = 1;
+const ADDR_A = "0x1111111111111111111111111111111111111111";
+const ADDR_B = "0x2222222222222222222222222222222222222222";
+const TOPIC_EMITTED =
+  "0x6d7747ff9aaba238de658957a12a32c8a94f6ec3aa0508441fe400ca79ed457c";
+const TOPIC_OTHER =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+describe("ChainProviderManager", () => {
+  let factoryBundle: ReturnType<typeof makeFactory>;
+  let manager: ChainProviderManager;
+
+  beforeEach(() => {
+    factoryBundle = makeFactory();
+    manager = new ChainProviderManager(factoryBundle.factory);
+  });
+
+  describe("getOrCreateProvider", () => {
+    it("returns the same provider instance for the same chainId", async () => {
+      const a = await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const b = await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      expect(a).toBe(b);
+      expect(factoryBundle.created).toHaveLength(1);
+    });
+
+    it("does not double-create under concurrent callers", async () => {
+      const [a, b, c] = await Promise.all([
+        manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+      ]);
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+      expect(factoryBundle.created).toHaveLength(1);
+    });
+
+    it("creates separate providers for different chainIds", async () => {
+      const a = await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const b = await manager.getOrCreateProvider(CHAIN_B, "ws://b");
+      expect(a).not.toBe(b);
+      expect(factoryBundle.created).toHaveLength(2);
+    });
+
+    it("rejects a mismatched wssUrl for a known chainId", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      await expect(
+        manager.getOrCreateProvider(CHAIN_A, "ws://different"),
+      ).rejects.toThrow(/already registered/);
+    });
+  });
+
+  describe("subscribeToLogs block listener lifecycle", () => {
+    it("attaches a block listener on first subscriber", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(true);
+    });
+
+    it("does not re-attach a block listener for a second subscriber", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const spyOn = vi.spyOn(factoryBundle.created[0], "on");
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(spyOn).not.toHaveBeenCalledWith("block", expect.anything());
+    });
+
+    it("detaches the block listener when the last subscriber unsubscribes", async () => {
+      const unsubA = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const unsubB = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      unsubA();
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(true);
+      unsubB();
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(false);
+    });
+  });
+
+  describe("log demux", () => {
+    it("requests eth_getLogs with the union of addresses and topic0s", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_OTHER,
+        handler: vi.fn(),
+      });
+
+      const provider = factoryBundle.created[0];
+      provider.sendResponses = [[]];
+      await provider.emitBlock(100);
+
+      expect(provider.sendCalls).toHaveLength(1);
+      expect(provider.sendCalls[0].method).toBe("eth_getLogs");
+      const filter = provider.sendCalls[0].params[0] as {
+        address: string[];
+        topics: string[][];
+        fromBlock: string;
+        toBlock: string;
+      };
+      expect(filter.address.sort()).toEqual(
+        [ADDR_A.toLowerCase(), ADDR_B.toLowerCase()].sort(),
+      );
+      expect(filter.topics[0].sort()).toEqual(
+        [TOPIC_EMITTED, TOPIC_OTHER].sort(),
+      );
+      expect(filter.fromBlock).toBe("0x64");
+      expect(filter.toBlock).toBe("0x64");
+    });
+
+    it("dispatches a log only to subscribers whose (address, topic0) matches", async () => {
+      const handlerA = vi.fn();
+      const handlerB = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: handlerA,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_OTHER,
+        handler: handlerB,
+      });
+
+      const provider = factoryBundle.created[0];
+      // One log matching A; one log matching B; one log matching neither.
+      const logA = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      const logB = {
+        address: ADDR_B.toLowerCase(),
+        topics: [TOPIC_OTHER],
+      };
+      const logNeither = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_OTHER],
+      };
+      provider.sendResponses = [[logA, logB, logNeither]];
+      await provider.emitBlock(101);
+
+      expect(handlerA).toHaveBeenCalledTimes(1);
+      expect(handlerA).toHaveBeenCalledWith(logA);
+      expect(handlerB).toHaveBeenCalledTimes(1);
+      expect(handlerB).toHaveBeenCalledWith(logB);
+    });
+
+    it("dispatches one log to multiple subscribers when they share (address, topic0)", async () => {
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h1,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h2,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(102);
+
+      expect(h1).toHaveBeenCalledTimes(1);
+      expect(h2).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call a handler after its subscription is cancelled", async () => {
+      const handler = vi.fn();
+      const unsubscribe = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler,
+      });
+      // Need a second subscriber so the block listener stays attached.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_OTHER,
+        handler: vi.fn(),
+      });
+
+      unsubscribe();
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(103);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("isolates handler errors: one throwing handler does not skip later handlers", async () => {
+      const throwing = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const later = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: throwing,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: later,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(104);
+
+      expect(throwing).toHaveBeenCalledTimes(1);
+      expect(later).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("destroy", () => {
+    it("tears down every chain's provider and clears subscriber state", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_B,
+        wssUrl: "ws://b",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      await manager.destroy();
+
+      expect(factoryBundle.created).toHaveLength(2);
+      expect(factoryBundle.created[0].destroyed).toBe(true);
+      expect(factoryBundle.created[1].destroyed).toBe(true);
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the event-tracker refactor tracked in KEEP-295. Adds `ChainProviderManager`, the first piece of the new architecture that future phases will use to collapse per-workflow WebSocket and subscription overhead to per-chain.

**Stacked on #911 (Phase 0)** — base branch is `feat/KEEP-295-phase-0`, not `staging`. When Phase 0 merges to staging, this PR's base should be retargeted.

## What this does

- New file: `keeperhub-events/event-tracker/src/chains/provider-manager.ts`
  - `getOrCreateProvider(chainId, wssUrl)` — lazy `ethers.WebSocketProvider` singleton per chainId. Concurrent callers share the same instance via a `readyPromise` gate.
  - `subscribeToLogs({chainId, wssUrl, address, topic0, handler}) -> Unsubscribe` — registers a log subscriber keyed by `(address, topic0)`. First subscriber on a chain attaches an `eth_subscribe(newHeads)` block listener; on each block the manager issues one batched `eth_getLogs` with a composite filter (union of addresses + topic0s) and demuxes returned logs to matching subscribers. Address lists >500 are chunked defensively. Last unsubscribe detaches the block listener.
  - `destroy()` — tears down every chain's provider and subscribers.
- New file: `keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts` — 13 tests, 353ms.

## What this does NOT do (by design — Option A)

No runtime code is modified. `ws-connection.ts`, `evm-chain.ts`, `child-handler.ts`, `main.ts` are untouched. The manager is a new primitive with no runtime caller. Phase 0 E2E passes unchanged, which is the regression gate.

The original plan called for lifting reconnect + heartbeat from `ws-connection.ts` into the manager. **I deliberately deferred that** to avoid a state machine in a code path with no production callers. Phase 3 lifts them when it routes listeners through the manager at runtime. Documented in `docs/keeperhub/KEEP-214/refactor/plan.md`.

## Design notes

- **Why block-sub + `eth_getLogs` instead of `contract.on(filter, ...)`**: decouples RPC subscription count from listener count. Provider-side caps (~1000 `eth_subscribe` per WSS on Alchemy/Infura) stop being a scaling concern once Phase 3 routes through this. Added latency: ~100-200ms after block notification for the getLogs call, imperceptible against 2-15s block times.
- **Dependency injection for provider factory**: the constructor accepts an optional `ProviderFactory`. Unit tests inject a `MockProvider`; production uses `new ethers.WebSocketProvider(url)`. Avoids `vi.mock("ethers", ...)` which would complicate later test files that use ethers for contract deployment (Phase 0 E2E already does).
- **Address batching at 500**: Alchemy caps `eth_getLogs` address lists around 500, Infura around 1000. Chunk defensively; extra calls per block are cheap.
- **wssUrl mismatch rejection**: if `getOrCreateProvider(chainId, urlA)` is called then later `(chainId, urlB)`, throws. Prevents silent endpoint swapping.

## Test coverage

Unit tests (13) in `tests/unit/provider-manager.test.ts`:

- `getOrCreateProvider`: instance reuse, concurrent-caller safety, different-chain isolation, wssUrl mismatch rejection.
- Block listener lifecycle: attach on first subscriber, no-op on second, detach on last unsubscribe.
- Log demux: composite filter assembly (union of addresses + topic0s, block range as hex), match-only dispatch, shared-subscriber fanout (one log -> two matching handlers), cancellation after unsubscribe, handler error isolation.
- `destroy()` teardown.

Phase 0 E2E still green in CI, confirming no runtime regression.

## Test plan

- [ ] `cd keeperhub-events/event-tracker && pnpm install`
- [ ] `SKIP_INFRA_TESTS=true pnpm test tests/unit/` -- expect 13 passed in <1s
- [ ] `docker compose --profile test up -d test-anvil test-localstack test-localstack-init test-redis`
- [ ] `pnpm test` -- expect 14 passed (13 unit + 1 E2E)
- [ ] `pnpm typecheck` -- clean
- [ ] `pnpm lint` -- clean