### PR TITLE
fix: warn when listed input fields are not referenced by any node

### DIFF
--- a/components/overlays/listing-overlay.tsx
+++ b/components/overlays/listing-overlay.tsx
@@ -129,6 +129,73 @@ function parseOutputMapping(
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Input-schema reference check
+// ---------------------------------------------------------------------------
+
+function collectConfigStrings(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectConfigStrings(item, out);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const v of Object.values(value)) {
+      collectConfigStrings(v, out);
+    }
+  }
+}
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Matches the template patterns resolved by the executor (see
+// lib/workflow-executor.workflow.ts processTemplates): both stored
+// {{@nodeId:Label.field}} and display {{Label.field}} forms.
+function fieldIsReferencedInConfigs(
+  fieldName: string,
+  nodes: WorkflowNode[]
+): boolean {
+  const pattern = new RegExp(
+    `\\{\\{[^}]*\\b${escapeForRegex(fieldName)}\\b[^}]*\\}\\}`
+  );
+  const strings: string[] = [];
+  for (const node of nodes) {
+    if (node.data.config) {
+      collectConfigStrings(node.data.config, strings);
+    }
+  }
+  return strings.some((s) => pattern.test(s));
+}
+
+function findUnreferencedRequiredInputs(
+  fields: SchemaField[],
+  nodes: WorkflowNode[]
+): string[] {
+  return fields
+    .filter((f) => f.required && f.name)
+    .map((f) => f.name)
+    .filter((name) => !fieldIsReferencedInConfigs(name, nodes));
+}
+
+function getTriggerLabel(nodes: WorkflowNode[]): string {
+  const trigger = nodes.find((n) => n.data.type === "trigger");
+  if (!trigger) {
+    return "Manual";
+  }
+  if (trigger.data.label) {
+    return trigger.data.label;
+  }
+  const configured = trigger.data.config?.triggerType;
+  return typeof configured === "string" ? configured : "Manual";
+}
+
 function hasChanges(
   local: {
     isListed: boolean;
@@ -290,8 +357,28 @@ export function ListingOverlay({
   const performSave = async (overrides?: {
     isListed?: boolean;
   }): Promise<void> => {
-    setIsSaving(true);
     const effectiveIsListed = overrides?.isListed ?? localIsListed;
+
+    if (effectiveIsListed && localInputSchema.length > 0) {
+      const unreferenced = findUnreferencedRequiredInputs(
+        localInputSchema,
+        nodes
+      );
+      if (unreferenced.length > 0) {
+        const triggerLabel = getTriggerLabel(nodes);
+        const [firstField] = unreferenced;
+        const suffix =
+          unreferenced.length > 1
+            ? ` (and ${unreferenced.length - 1} more)`
+            : "";
+        toast.error(
+          `Input "${firstField}"${suffix} is declared but not referenced by any node. In a node field, type @ and select ${triggerLabel}.data.${firstField}.`
+        );
+        return;
+      }
+    }
+
+    setIsSaving(true);
     try {
       const schema =
         localInputSchema.length > 0
@@ -497,6 +584,16 @@ export function ListingOverlay({
             onChange={setLocalInputSchema}
             schema={localInputSchema}
           />
+          {localInputSchema.length > 0 && (
+            <p className="px-1 text-muted-foreground text-xs">
+              Reference each input in a node field: type{" "}
+              <code className="rounded bg-muted px-1">@</code> and select{" "}
+              <code className="rounded bg-muted px-1">
+                {getTriggerLabel(nodes)}.data.{"<fieldName>"}
+              </code>
+              .
+            </p>
+          )}
         </TabsContent>
 
         {/* Output Mapping Tab */}


### PR DESCRIPTION
## Summary

- Block publish when a listed workflow declares required input fields that aren't referenced in any node's config via `{{...}}` template.
- Show a small hint under the Input Schema editor pointing at the wiring contract (type `@` and select `Manual.data.<fieldName>`) so the pattern is visible before an author opens a node.

## Why

Today you can list a workflow with a required input like `address` and save successfully even if no node references it. The call path then accepts the payment (x402/MPP settles) and the workflow runs with a missing value, surfacing a confusing error like `Invalid Ethereum address:` at runtime. Three paid test calls can cost real USDC before anyone notices the node's field was left blank.

The MCP call route already merges the agent input into the trigger node's output (`lib/workflow-executor.workflow.ts:1786`), and the template autocomplete already surfaces listing schema fields under `{TriggerLabel}.data.*`. The only gap is that nothing warns the author if they forget to wire the input into a downstream node.

## Test plan

- [ ] List a workflow with required input `address`; node's Address field empty: save is blocked with a toast pointing at `@Manual.data.address`.
- [ ] List a workflow with required input referenced as `{{Manual.data.address}}` somewhere: save succeeds.
- [ ] Unlist flow (`isListed = false`) skips the check entirely.
- [ ] Hint under Input Schema editor renders the current trigger label (falls back to `Manual`).
- [ ] Existing slug/price validation still blocks appropriately.