### PR TITLE
feat: KEEP-295 cache ethers.Interface instances across workflows

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/evm-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/evm-chain.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import type { ethers } from "ethers";
 import {
   REDIS_HOST,
   REDIS_PASSWORD,
@@ -14,6 +14,7 @@ import {
   buildEventPayload,
   extractEventArgs,
 } from "./event-serializer";
+import { getInterface } from "./interface-cache";
 import { TransactionDedup } from "./transaction-dedup";
 import type { AbiEvent } from "./validation";
 import {
@@ -303,7 +304,7 @@ export class EvmChain extends AbstractChain {
       ({ type }: { type: string }) => type === "event",
     );
     const eventsAbi = rawEventsAbi.map(buildEventAbi);
-    const abiInterface = new ethers.Interface(eventsAbi);
+    const abiInterface = getInterface(eventsAbi);
 
     this.eventListener = this.connection!.on(
       filter,

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -32,7 +32,19 @@ function hashAbi(abi: ethers.InterfaceAbi): string {
   // rawEventsAbi.map(buildEventAbi). If two callers pass semantically
   // equivalent ABIs with different key orderings, they will miss the cache
   // and allocate a second Interface. That is an overhead, not a bug.
-  return createHash("sha256").update(JSON.stringify(abi)).digest("hex");
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(abi);
+  } catch (err) {
+    // JSON.stringify throws on circular refs or BigInt. The native error
+    // doesn't mention the ABI, so callers hit a confusing stack from
+    // inside this module. Re-throw with context.
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `interface-cache: ABI is not JSON-serializable (${cause}); cannot compute cache key`,
+    );
+  }
+  return createHash("sha256").update(serialized).digest("hex");
 }
 
 export function getInterface(abi: ethers.InterfaceAbi): ethers.Interface {

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+import { ethers } from "ethers";
+
+/**
+ * Cache of `ethers.Interface` instances keyed by a stable hash of the ABI.
+ * Multiple workflows watching the same contract schema share one parsed
+ * Interface; reconnects on a single workflow skip the parse entirely on
+ * the second call.
+ *
+ * `ethers.Interface` is effectively immutable (it exposes decode/encode
+ * against a parsed ABI and holds no network state), so sharing across
+ * unrelated callers is safe.
+ */
+
+const cache = new Map<string, ethers.Interface>();
+
+function hashAbi(abi: readonly unknown[]): string {
+  // JSON.stringify is deterministic for the object shapes produced by
+  // rawEventsAbi.map(buildEventAbi). If two callers pass semantically
+  // equivalent ABIs with different key orderings, they will miss the cache
+  // and allocate a second Interface. That is an overhead, not a bug.
+  return createHash("sha256").update(JSON.stringify(abi)).digest("hex");
+}
+
+export function getInterface(abi: readonly unknown[]): ethers.Interface {
+  const key = hashAbi(abi);
+  const existing = cache.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = new ethers.Interface(abi as ethers.InterfaceAbi);
+  cache.set(key, created);
+  return created;
+}
+
+export function clearInterfaceCache(): void {
+  cache.clear();
+}
+
+export function getInterfaceCacheSize(): number {
+  return cache.size;
+}

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -27,7 +27,7 @@ const MAX_CACHE_SIZE = 1000;
 
 const cache = new Map<string, ethers.Interface>();
 
-function hashAbi(abi: readonly unknown[]): string {
+function hashAbi(abi: ethers.InterfaceAbi): string {
   // JSON.stringify is deterministic for the object shapes produced by
   // rawEventsAbi.map(buildEventAbi). If two callers pass semantically
   // equivalent ABIs with different key orderings, they will miss the cache
@@ -35,7 +35,7 @@ function hashAbi(abi: readonly unknown[]): string {
   return createHash("sha256").update(JSON.stringify(abi)).digest("hex");
 }
 
-export function getInterface(abi: readonly unknown[]): ethers.Interface {
+export function getInterface(abi: ethers.InterfaceAbi): ethers.Interface {
   const key = hashAbi(abi);
   const existing = cache.get(key);
   if (existing) {
@@ -45,7 +45,7 @@ export function getInterface(abi: readonly unknown[]): ethers.Interface {
     cache.set(key, existing);
     return existing;
   }
-  const created = new ethers.Interface(abi as ethers.InterfaceAbi);
+  const created = new ethers.Interface(abi);
   if (cache.size >= MAX_CACHE_SIZE) {
     // Map iteration order is insertion order, so the first key is the LRU
     // entry. next() on the keys iterator is O(1) and does not materialise

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -10,7 +10,20 @@ import { ethers } from "ethers";
  * `ethers.Interface` is effectively immutable (it exposes decode/encode
  * against a parsed ABI and holds no network state), so sharing across
  * unrelated callers is safe.
+ *
+ * Bounded via a fixed-size LRU: under the in-process listener model
+ * (KEEP-295 Phase 3+), one pod sees every distinct ABI ever registered
+ * over its lifetime. Without eviction the cache would grow monotonically.
+ * An insertion-ordered Map gives us LRU for free: delete-and-reinsert on
+ * hit moves the entry to the end, and when we exceed MAX_CACHE_SIZE we
+ * drop the iterator's first entry (the least recently used).
  */
+
+// Sized so an untuned deployment can comfortably hold every unique ABI
+// a KeeperHub org has today (low hundreds) with headroom. At ~100-200 KB
+// per parsed Interface, 1000 entries caps worst-case RSS at ~200 MB -
+// acceptable for event-tracker, and we'll revisit if real pods climb.
+const MAX_CACHE_SIZE = 1000;
 
 const cache = new Map<string, ethers.Interface>();
 
@@ -26,9 +39,22 @@ export function getInterface(abi: readonly unknown[]): ethers.Interface {
   const key = hashAbi(abi);
   const existing = cache.get(key);
   if (existing) {
+    // LRU touch: move this entry to the end so it is the newest. Without
+    // this the cache degrades to FIFO and evicts frequently-used entries.
+    cache.delete(key);
+    cache.set(key, existing);
     return existing;
   }
   const created = new ethers.Interface(abi as ethers.InterfaceAbi);
+  if (cache.size >= MAX_CACHE_SIZE) {
+    // Map iteration order is insertion order, so the first key is the LRU
+    // entry. next() on the keys iterator is O(1) and does not materialise
+    // the full list.
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
   cache.set(key, created);
   return created;
 }
@@ -39,4 +65,8 @@ export function clearInterfaceCache(): void {
 
 export function getInterfaceCacheSize(): number {
   return cache.size;
+}
+
+export function getInterfaceCacheMaxSize(): number {
+  return MAX_CACHE_SIZE;
 }

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -38,6 +38,16 @@ const OTHER_EVENTS = [
   },
 ];
 
+// Production call site (evm-chain.ts) passes `rawEventsAbi.map(buildEventAbi)`
+// which returns `string[]` of signature strings, not the AbiEvent object
+// array above. Both shapes are valid ethers.InterfaceAbi, but we cache on
+// hashed content so the cache key spaces are disjoint. Tests here must
+// exercise the string-array shape that real listeners pass.
+const ERC20_EVENT_STRINGS = [
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+  "event Approval(address indexed owner, address indexed spender, uint256 value)",
+];
+
 describe("interface-cache", () => {
   beforeEach(() => {
     clearInterfaceCache();
@@ -102,5 +112,39 @@ describe("interface-cache", () => {
     expect(getInterfaceCacheSize()).toBe(2);
     clearInterfaceCache();
     expect(getInterfaceCacheSize()).toBe(0);
+  });
+
+  describe("production call shape (string[])", () => {
+    it("caches by content for the signature-string array shape", () => {
+      const a = getInterface(ERC20_EVENT_STRINGS);
+      const b = getInterface(ERC20_EVENT_STRINGS);
+      expect(a).toBe(b);
+      expect(getInterfaceCacheSize()).toBe(1);
+    });
+
+    it("produces an Interface that decodes logs correctly", () => {
+      const iface = getInterface(ERC20_EVENT_STRINGS);
+      const from = "0x0000000000000000000000000000000000000001";
+      const to = "0x0000000000000000000000000000000000000002";
+      const value = 42n;
+
+      const encoded = iface.encodeEventLog("Transfer", [from, to, value]);
+      const parsed = iface.parseLog({
+        topics: encoded.topics,
+        data: encoded.data,
+      });
+      expect(parsed?.name).toBe("Transfer");
+      expect(parsed?.args.value).toBe(value);
+    });
+
+    it("string shape and object shape hash to different cache keys", () => {
+      // Same logical ABI in two different representations. Both valid,
+      // but they serialise differently so they miss each other's cache.
+      // Documented-as-overhead behaviour; the assertion here locks it in.
+      const fromStrings = getInterface(ERC20_EVENT_STRINGS);
+      const fromObjects = getInterface(ERC20_EVENTS);
+      expect(fromStrings).not.toBe(fromObjects);
+      expect(getInterfaceCacheSize()).toBe(2);
+    });
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -115,6 +115,25 @@ describe("interface-cache", () => {
     expect(getInterfaceCacheSize()).toBe(0);
   });
 
+  describe("non-serializable ABI", () => {
+    it("throws a contextual error when the ABI has a circular reference", () => {
+      const circular: unknown[] = [];
+      circular.push(circular);
+      expect(() =>
+        // Cast via unknown to bypass the InterfaceAbi type guard; this test
+        // exists precisely to verify behaviour on malformed input.
+        getInterface(circular as unknown as ethers.InterfaceAbi),
+      ).toThrow(/interface-cache: ABI is not JSON-serializable/);
+    });
+
+    it("throws a contextual error when the ABI contains a BigInt", () => {
+      const withBigInt = [{ type: "event", name: "X", inputs: [], max: 1n }];
+      expect(() =>
+        getInterface(withBigInt as unknown as ethers.InterfaceAbi),
+      ).toThrow(/interface-cache: ABI is not JSON-serializable/);
+    });
+  });
+
   describe("LRU eviction", () => {
     // Helper: build a cheap unique signature-string ABI for the Nth entry.
     function uniqueAbi(n: number): string[] {

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearInterfaceCache,
   getInterface,
+  getInterfaceCacheMaxSize,
   getInterfaceCacheSize,
 } from "../../src/chains/interface-cache";
 
@@ -112,6 +113,61 @@ describe("interface-cache", () => {
     expect(getInterfaceCacheSize()).toBe(2);
     clearInterfaceCache();
     expect(getInterfaceCacheSize()).toBe(0);
+  });
+
+  describe("LRU eviction", () => {
+    // Helper: build a cheap unique signature-string ABI for the Nth entry.
+    function uniqueAbi(n: number): string[] {
+      return [`event Unique${n}(uint256 value)`];
+    }
+
+    it("evicts the least-recently-used entry once full", () => {
+      const cap = getInterfaceCacheMaxSize();
+      // Fill the cache to capacity.
+      for (let i = 0; i < cap; i++) {
+        getInterface(uniqueAbi(i));
+      }
+      expect(getInterfaceCacheSize()).toBe(cap);
+
+      const oldest = getInterface(uniqueAbi(0));
+
+      // One more insertion forces an eviction. The LRU is abi(1) because
+      // abi(0) was just touched above.
+      getInterface(uniqueAbi(cap));
+      expect(getInterfaceCacheSize()).toBe(cap);
+
+      // abi(0) should still be there (and be the same instance).
+      expect(getInterface(uniqueAbi(0))).toBe(oldest);
+
+      // abi(1) should have been evicted, so requesting it produces a new
+      // Interface instance.
+      const refreshed = getInterface(uniqueAbi(1));
+      expect(refreshed).not.toBe(oldest);
+    });
+
+    it("cache-hit touch moves entry to most-recently-used position", () => {
+      // Simpler scenario, easier to reason about than the cap-sized one.
+      // Fill 3 entries, touch the first, force one eviction; the second
+      // (oldest untouched) is what should go.
+      const first = getInterface(uniqueAbi(1));
+      getInterface(uniqueAbi(2));
+      getInterface(uniqueAbi(3));
+
+      // Touch #1.
+      expect(getInterface(uniqueAbi(1))).toBe(first);
+
+      // Force enough inserts to evict exactly one entry: we need cap-2
+      // more new inserts beyond the 3 we already placed.
+      const cap = getInterfaceCacheMaxSize();
+      for (let i = 4; i <= cap + 1; i++) {
+        getInterface(uniqueAbi(i));
+      }
+      expect(getInterfaceCacheSize()).toBe(cap);
+
+      // #1 survives (touched); #2 should have been evicted (oldest
+      // untouched at the point of first overflow).
+      expect(getInterface(uniqueAbi(1))).toBe(first);
+    });
   });
 
   describe("production call shape (string[])", () => {

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -1,0 +1,106 @@
+import { ethers } from "ethers";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearInterfaceCache,
+  getInterface,
+  getInterfaceCacheSize,
+} from "../../src/chains/interface-cache";
+
+const ERC20_EVENTS = [
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "Approval",
+    inputs: [
+      { name: "owner", type: "address", indexed: true },
+      { name: "spender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+];
+
+const OTHER_EVENTS = [
+  {
+    type: "event",
+    name: "Emitted",
+    inputs: [
+      { name: "sender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+];
+
+describe("interface-cache", () => {
+  beforeEach(() => {
+    clearInterfaceCache();
+  });
+
+  it("returns the same Interface instance for the same ABI", () => {
+    const a = getInterface(ERC20_EVENTS);
+    const b = getInterface(ERC20_EVENTS);
+    expect(a).toBe(b);
+    expect(getInterfaceCacheSize()).toBe(1);
+  });
+
+  it("returns the same Interface for a deep-cloned equivalent ABI", () => {
+    const clone = JSON.parse(JSON.stringify(ERC20_EVENTS));
+    const a = getInterface(ERC20_EVENTS);
+    const b = getInterface(clone);
+    expect(a).toBe(b);
+    expect(getInterfaceCacheSize()).toBe(1);
+  });
+
+  it("creates separate Interface instances for different ABIs", () => {
+    const a = getInterface(ERC20_EVENTS);
+    const b = getInterface(OTHER_EVENTS);
+    expect(a).not.toBe(b);
+    expect(getInterfaceCacheSize()).toBe(2);
+  });
+
+  it("produces an Interface that decodes logs correctly", () => {
+    const iface = getInterface(ERC20_EVENTS);
+    const from = "0x0000000000000000000000000000000000000001";
+    const to = "0x0000000000000000000000000000000000000002";
+    const value = 123n;
+
+    const encoded = iface.encodeEventLog("Transfer", [from, to, value]);
+    const parsed = iface.parseLog({
+      topics: encoded.topics,
+      data: encoded.data,
+    });
+    expect(parsed?.name).toBe("Transfer");
+    expect(parsed?.args.from.toLowerCase()).toBe(from);
+    expect(parsed?.args.to.toLowerCase()).toBe(to);
+    expect(parsed?.args.value).toBe(value);
+  });
+
+  it("decoding still works after a cache hit", () => {
+    getInterface(ERC20_EVENTS); // populate
+    const iface = getInterface(ERC20_EVENTS); // hit
+    const topics = [
+      ethers.id("Transfer(address,address,uint256)"),
+      ethers.zeroPadValue("0x0000000000000000000000000000000000000001", 32),
+      ethers.zeroPadValue("0x0000000000000000000000000000000000000002", 32),
+    ];
+    const data = ethers.AbiCoder.defaultAbiCoder().encode(["uint256"], [7n]);
+    const parsed = iface.parseLog({ topics, data });
+    expect(parsed?.name).toBe("Transfer");
+    expect(parsed?.args.value).toBe(7n);
+  });
+
+  it("clearInterfaceCache empties the cache", () => {
+    getInterface(ERC20_EVENTS);
+    getInterface(OTHER_EVENTS);
+    expect(getInterfaceCacheSize()).toBe(2);
+    clearInterfaceCache();
+    expect(getInterfaceCacheSize()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the event-tracker refactor tracked in KEEP-295. Introduces a module-level `ethers.Interface` cache so multiple workflows watching the same contract schema share one parsed `Interface`, and reconnects on a single workflow skip the parse entirely on the second call.

**Stacked on #925 (Phase 1)** which is stacked on #911 (Phase 0). Base should be retargeted to `staging` once upstream PRs land.

## What this does

- **New**: `keeperhub-events/event-tracker/src/chains/interface-cache.ts`
  - `getInterface(abi): ethers.Interface` — returns a cached `Interface` keyed by `sha256(JSON.stringify(abi))`. Equivalent ABIs (deep clones, object-reference differences) hit the same cache entry.
  - `clearInterfaceCache()` and `getInterfaceCacheSize()` for test support.
- **Modified**: `keeperhub-events/event-tracker/src/chains/evm-chain.ts`
  - `new ethers.Interface(eventsAbi)` -> `getInterface(eventsAbi)`. Drop-in swap, no behavior change.
  - `import { ethers }` becomes `import type { ethers }` since the last runtime reference went away.
- **New**: `keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts`, 6 tests, <100ms.

## Why this is safe

`ethers.Interface` is effectively immutable: it holds parsed ABI and exposes decode/encode helpers, no network state, no mutable per-instance configuration. Sharing across unrelated callers has no correctness risk.

## Impact

ABI parse is ~tens of ms per call on a typical ERC-20-scale ABI, more on larger contracts. Today `listenEvent()` rebuilds the `Interface` on every call -- once per workflow, plus once per reconnect. Under the fork model this is bounded by workflow count. **The real win compounds in Phase 3** when listeners consolidate into one process and N workflows on the same contract schema share the parse too.

Phase 0 E2E test runtime incidentally dropped from ~17s to ~12s (the retry-emit loop hits the listener on the first attempt now). Not a claim of performance benefit -- just an observation.

## Design notes

- **SHA-256 of `JSON.stringify(abi)` as cache key**: deterministic for the objects produced by `rawEventsAbi.map(buildEventAbi)`. Two callers with semantically-equal ABIs but different key orderings would miss the cache -- that's a memory overhead, not a correctness bug. Acceptable because all in-tree callers pass the same transformation result.
- **Why not `WeakMap` keyed by the ABI array**: ABI arrays are frequently fresh objects (parsed from JSON on each workflow load), so `WeakMap` identity would miss constantly. Content-hash keying is the right primitive here.
- **Dead-code concern**: unlike Phase 1 (ChainProviderManager, no runtime caller yet), this PR has one runtime caller (`evm-chain.ts:listenEvent`). Phase 0 E2E exercises the change.

## Test plan

- [ ] `cd keeperhub-events/event-tracker && pnpm install`
- [ ] `SKIP_INFRA_TESTS=true pnpm test tests/unit/` -- expect 19 passed (13 provider-manager + 6 interface-cache) in <1s
- [ ] `docker compose --profile test up -d test-anvil test-localstack test-localstack-init test-redis`
- [ ] `pnpm test` -- expect 20 passed (13 + 6 + 1 E2E)
- [ ] `pnpm typecheck` -- clean
- [ ] `pnpm lint` -- clean