### PR TITLE
feat: KEEP-295 add in-process listener registry primitive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -455,6 +455,40 @@ services:
     profiles:
       - test
 
+  test-anvil:
+    image: ghcr.io/foundry-rs/foundry:latest
+    container_name: keeperhub-test-anvil
+    ports:
+      - "8546:8545"
+    entrypoint: anvil
+    command:
+      - --host
+      - 0.0.0.0
+      - --block-time
+      - "1"
+      - --chain-id
+      - "31337"
+    healthcheck:
+      test: ["CMD-SHELL", "cast block-number --rpc-url http://localhost:8545 > /dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    profiles:
+      - test
+
+  test-redis:
+    image: valkey/valkey:latest
+    container_name: keeperhub-test-redis
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    profiles:
+      - test
+
   test-app:
     image: node:22-alpine
     container_name: keeperhub-test-app

--- a/keeperhub-events/event-tracker/lib/config/environment.ts
+++ b/keeperhub-events/event-tracker/lib/config/environment.ts
@@ -10,4 +10,5 @@ export const NODE_ENV: string = process.env.NODE_ENV || "development";
 
 export const SQS_QUEUE_URL: string = process.env.SQS_QUEUE_URL || "";
 export const AWS_REGION: string = process.env.AWS_REGION || "us-east-1";
-export const AWS_ENDPOINT_URL: string | undefined = process.env.AWS_ENDPOINT_URL;
+export const AWS_ENDPOINT_URL: string | undefined =
+  process.env.AWS_ENDPOINT_URL;

--- a/keeperhub-events/event-tracker/lib/sync/redis.ts
+++ b/keeperhub-events/event-tracker/lib/sync/redis.ts
@@ -89,11 +89,7 @@ class SyncContainerManager extends SyncManager {
   async removeContainer(): Promise<void> {
     await this.removeAllContainerProcesses(this.containerId);
 
-    await this.rtStorage.lrem(
-      `containers:${NODE_ENV}`,
-      0,
-      this.containerId,
-    );
+    await this.rtStorage.lrem(`containers:${NODE_ENV}`, 0, this.containerId);
 
     this.logger.log(
       `Container ${this.containerId} removed - timestamp ${Date.now()}`,
@@ -140,11 +136,7 @@ class SyncContainerManager extends SyncManager {
   async removeContainerById(id: string): Promise<void> {
     await this.removeAllContainerProcesses(id);
 
-    await this.rtStorage.lrem(
-      `containers:${NODE_ENV}`,
-      0,
-      id,
-    );
+    await this.rtStorage.lrem(`containers:${NODE_ENV}`, 0, id);
 
     this.logger.log(`Container ${id} removed - timestamp ${Date.now()}`);
   }

--- a/keeperhub-events/event-tracker/lib/workflow-sqs.ts
+++ b/keeperhub-events/event-tracker/lib/workflow-sqs.ts
@@ -1,0 +1,43 @@
+import { type SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+/**
+ * Shape of every event-trigger message the tracker enqueues to SQS. Kept
+ * in one place so the fork-path (`AbstractChain.executeWorkflow`) and
+ * the in-process path (`EventListener.sendToSqs`) can not drift from
+ * each other as the refactor progresses.
+ *
+ * Phase 6 will delete the fork path and this helper survives as the sole
+ * producer of the SQS contract.
+ */
+
+export interface WorkflowEventTrigger {
+  workflowId: string;
+  userId: string;
+  triggerData: unknown;
+}
+
+export async function enqueueWorkflowEventTrigger(
+  client: SQSClient,
+  queueUrl: string,
+  trigger: WorkflowEventTrigger,
+): Promise<void> {
+  const body = {
+    workflowId: trigger.workflowId,
+    userId: trigger.userId,
+    triggerType: "event" as const,
+    triggerData: trigger.triggerData,
+  };
+  await client.send(
+    new SendMessageCommand({
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(body),
+      MessageAttributes: {
+        TriggerType: { DataType: "String", StringValue: "event" },
+        WorkflowId: {
+          DataType: "String",
+          StringValue: trigger.workflowId,
+        },
+      },
+    }),
+  );
+}

--- a/keeperhub-events/event-tracker/package.json
+++ b/keeperhub-events/event-tracker/package.json
@@ -8,7 +8,10 @@
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "vitest run"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1005.0",
@@ -20,6 +23,10 @@
   },
   "devDependencies": {
     "@types/deep-diff": "^1.0.5",
-    "@types/uuid": "^10.0.0"
+    "@types/node": "^24.12.2",
+    "@types/uuid": "^10.0.0",
+    "solc": "^0.8.29",
+    "vite": "^7.3.0",
+    "vitest": "4.1.2"
   }
 }

--- a/keeperhub-events/event-tracker/src/chains/abstract-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/abstract-chain.ts
@@ -5,8 +5,8 @@ import {
   KEEPERHUB_API_URL,
   SQS_QUEUE_URL,
 } from "../../lib/config/environment";
-import { sqs } from "../../lib/sqs-client";
 import type { WorkflowEvent } from "../../lib/models/workflow-event";
+import { sqs } from "../../lib/sqs-client";
 import type { NetworkConfig, NetworksWrapper } from "../../lib/types";
 import { type Logger, logger } from "../../lib/utils/logger";
 
@@ -72,9 +72,7 @@ export class AbstractChain {
         }),
       );
 
-      logger.log(
-        `[SQS] Enqueued workflow ${workflowId} for event execution`,
-      );
+      logger.log(`[SQS] Enqueued workflow ${workflowId} for event execution`);
       return true;
     } catch (error: any) {
       logger.error(`Error enqueuing workflow to SQS: ${error.message}`);

--- a/keeperhub-events/event-tracker/src/chains/abstract-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/abstract-chain.ts
@@ -1,4 +1,3 @@
-import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import {
   JWT_TOKEN_PASSWORD,
   JWT_TOKEN_USERNAME,
@@ -9,6 +8,7 @@ import type { WorkflowEvent } from "../../lib/models/workflow-event";
 import { sqs } from "../../lib/sqs-client";
 import type { NetworkConfig, NetworksWrapper } from "../../lib/types";
 import { type Logger, logger } from "../../lib/utils/logger";
+import { enqueueWorkflowEventTrigger } from "../../lib/workflow-sqs";
 
 export class AbstractChain {
   executionLogs: { logs: any[] } = {
@@ -48,30 +48,11 @@ export class AbstractChain {
 
   async executeWorkflow(workflowId: string, payload: any): Promise<boolean> {
     try {
-      const message = {
+      await enqueueWorkflowEventTrigger(sqs, SQS_QUEUE_URL, {
         workflowId,
         userId: this.event.workflow.userId,
-        triggerType: "event" as const,
         triggerData: payload,
-      };
-
-      await sqs.send(
-        new SendMessageCommand({
-          QueueUrl: SQS_QUEUE_URL,
-          MessageBody: JSON.stringify(message),
-          MessageAttributes: {
-            TriggerType: {
-              DataType: "String",
-              StringValue: "event",
-            },
-            WorkflowId: {
-              DataType: "String",
-              StringValue: workflowId,
-            },
-          },
-        }),
-      );
-
+      });
       logger.log(`[SQS] Enqueued workflow ${workflowId} for event execution`);
       return true;
     } catch (error: any) {

--- a/keeperhub-events/event-tracker/src/chains/evm-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/evm-chain.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import type { ethers } from "ethers";
 import {
   REDIS_HOST,
   REDIS_PASSWORD,
@@ -14,6 +14,7 @@ import {
   buildEventPayload,
   extractEventArgs,
 } from "./event-serializer";
+import { getInterface } from "./interface-cache";
 import { TransactionDedup } from "./transaction-dedup";
 import type { AbiEvent } from "./validation";
 import {
@@ -303,7 +304,7 @@ export class EvmChain extends AbstractChain {
       ({ type }: { type: string }) => type === "event",
     );
     const eventsAbi = rawEventsAbi.map(buildEventAbi);
-    const abiInterface = new ethers.Interface(eventsAbi);
+    const abiInterface = getInterface(eventsAbi);
 
     this.eventListener = this.connection!.on(
       filter,

--- a/keeperhub-events/event-tracker/src/chains/evm-chain.ts
+++ b/keeperhub-events/event-tracker/src/chains/evm-chain.ts
@@ -64,7 +64,12 @@ export class EvmChain extends AbstractChain {
     this.isInitialized = false;
     this.connection = null;
 
-    this.dedup = new TransactionDedup(this.options.id!, REDIS_HOST, REDIS_PORT, REDIS_PASSWORD);
+    this.dedup = new TransactionDedup(
+      this.options.id!,
+      REDIS_HOST,
+      REDIS_PORT,
+      REDIS_PASSWORD,
+    );
   }
 
   async initializeProvider(): Promise<void> {

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -32,7 +32,19 @@ function hashAbi(abi: ethers.InterfaceAbi): string {
   // rawEventsAbi.map(buildEventAbi). If two callers pass semantically
   // equivalent ABIs with different key orderings, they will miss the cache
   // and allocate a second Interface. That is an overhead, not a bug.
-  return createHash("sha256").update(JSON.stringify(abi)).digest("hex");
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(abi);
+  } catch (err) {
+    // JSON.stringify throws on circular refs or BigInt. The native error
+    // doesn't mention the ABI, so callers hit a confusing stack from
+    // inside this module. Re-throw with context.
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `interface-cache: ABI is not JSON-serializable (${cause}); cannot compute cache key`,
+    );
+  }
+  return createHash("sha256").update(serialized).digest("hex");
 }
 
 export function getInterface(abi: ethers.InterfaceAbi): ethers.Interface {

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+import { ethers } from "ethers";
+
+/**
+ * Cache of `ethers.Interface` instances keyed by a stable hash of the ABI.
+ * Multiple workflows watching the same contract schema share one parsed
+ * Interface; reconnects on a single workflow skip the parse entirely on
+ * the second call.
+ *
+ * `ethers.Interface` is effectively immutable (it exposes decode/encode
+ * against a parsed ABI and holds no network state), so sharing across
+ * unrelated callers is safe.
+ */
+
+const cache = new Map<string, ethers.Interface>();
+
+function hashAbi(abi: readonly unknown[]): string {
+  // JSON.stringify is deterministic for the object shapes produced by
+  // rawEventsAbi.map(buildEventAbi). If two callers pass semantically
+  // equivalent ABIs with different key orderings, they will miss the cache
+  // and allocate a second Interface. That is an overhead, not a bug.
+  return createHash("sha256").update(JSON.stringify(abi)).digest("hex");
+}
+
+export function getInterface(abi: readonly unknown[]): ethers.Interface {
+  const key = hashAbi(abi);
+  const existing = cache.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = new ethers.Interface(abi as ethers.InterfaceAbi);
+  cache.set(key, created);
+  return created;
+}
+
+export function clearInterfaceCache(): void {
+  cache.clear();
+}
+
+export function getInterfaceCacheSize(): number {
+  return cache.size;
+}

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -27,7 +27,7 @@ const MAX_CACHE_SIZE = 1000;
 
 const cache = new Map<string, ethers.Interface>();
 
-function hashAbi(abi: readonly unknown[]): string {
+function hashAbi(abi: ethers.InterfaceAbi): string {
   // JSON.stringify is deterministic for the object shapes produced by
   // rawEventsAbi.map(buildEventAbi). If two callers pass semantically
   // equivalent ABIs with different key orderings, they will miss the cache
@@ -35,7 +35,7 @@ function hashAbi(abi: readonly unknown[]): string {
   return createHash("sha256").update(JSON.stringify(abi)).digest("hex");
 }
 
-export function getInterface(abi: readonly unknown[]): ethers.Interface {
+export function getInterface(abi: ethers.InterfaceAbi): ethers.Interface {
   const key = hashAbi(abi);
   const existing = cache.get(key);
   if (existing) {
@@ -45,7 +45,7 @@ export function getInterface(abi: readonly unknown[]): ethers.Interface {
     cache.set(key, existing);
     return existing;
   }
-  const created = new ethers.Interface(abi as ethers.InterfaceAbi);
+  const created = new ethers.Interface(abi);
   if (cache.size >= MAX_CACHE_SIZE) {
     // Map iteration order is insertion order, so the first key is the LRU
     // entry. next() on the keys iterator is O(1) and does not materialise

--- a/keeperhub-events/event-tracker/src/chains/interface-cache.ts
+++ b/keeperhub-events/event-tracker/src/chains/interface-cache.ts
@@ -10,7 +10,20 @@ import { ethers } from "ethers";
  * `ethers.Interface` is effectively immutable (it exposes decode/encode
  * against a parsed ABI and holds no network state), so sharing across
  * unrelated callers is safe.
+ *
+ * Bounded via a fixed-size LRU: under the in-process listener model
+ * (KEEP-295 Phase 3+), one pod sees every distinct ABI ever registered
+ * over its lifetime. Without eviction the cache would grow monotonically.
+ * An insertion-ordered Map gives us LRU for free: delete-and-reinsert on
+ * hit moves the entry to the end, and when we exceed MAX_CACHE_SIZE we
+ * drop the iterator's first entry (the least recently used).
  */
+
+// Sized so an untuned deployment can comfortably hold every unique ABI
+// a KeeperHub org has today (low hundreds) with headroom. At ~100-200 KB
+// per parsed Interface, 1000 entries caps worst-case RSS at ~200 MB -
+// acceptable for event-tracker, and we'll revisit if real pods climb.
+const MAX_CACHE_SIZE = 1000;
 
 const cache = new Map<string, ethers.Interface>();
 
@@ -26,9 +39,22 @@ export function getInterface(abi: readonly unknown[]): ethers.Interface {
   const key = hashAbi(abi);
   const existing = cache.get(key);
   if (existing) {
+    // LRU touch: move this entry to the end so it is the newest. Without
+    // this the cache degrades to FIFO and evicts frequently-used entries.
+    cache.delete(key);
+    cache.set(key, existing);
     return existing;
   }
   const created = new ethers.Interface(abi as ethers.InterfaceAbi);
+  if (cache.size >= MAX_CACHE_SIZE) {
+    // Map iteration order is insertion order, so the first key is the LRU
+    // entry. next() on the keys iterator is O(1) and does not materialise
+    // the full list.
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
   cache.set(key, created);
   return created;
 }
@@ -39,4 +65,8 @@ export function clearInterfaceCache(): void {
 
 export function getInterfaceCacheSize(): number {
   return cache.size;
+}
+
+export function getInterfaceCacheMaxSize(): number {
+  return MAX_CACHE_SIZE;
 }

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -238,18 +238,28 @@ export class ChainProviderManager {
     if (!(logAddr && logTopic0)) {
       return;
     }
+    // Fire all matching handlers concurrently. Sequential `await` here would
+    // let a slow handler (e.g. one applying the EventListener jitter sleep)
+    // stall dispatch to every other subscriber on the same log, compounding
+    // latency linearly with listener count. Each handler's errors are
+    // isolated so one rejection does not abort the others.
+    const matching: Subscriber[] = [];
     for (const sub of entry.subscribers) {
-      if (sub.address !== logAddr || sub.topic0 !== logTopic0) {
-        continue;
-      }
-      try {
-        await sub.handler(log);
-      } catch (err) {
-        logger.warn(
-          `[ChainProviderManager] chain=${entry.chainId} subscriber handler threw: ${String(err)}`,
-        );
+      if (sub.address === logAddr && sub.topic0 === logTopic0) {
+        matching.push(sub);
       }
     }
+    await Promise.all(
+      matching.map(async (sub) => {
+        try {
+          await sub.handler(log);
+        } catch (err) {
+          logger.warn(
+            `[ChainProviderManager] chain=${entry.chainId} subscriber handler threw: ${String(err)}`,
+          );
+        }
+      }),
+    );
   }
 }
 

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -1,0 +1,256 @@
+import { ethers } from "ethers";
+import { logger } from "../../lib/utils/logger";
+
+/**
+ * ChainProviderManager centralises WebSocket provider ownership and
+ * block-based log delivery per chain. One provider and one
+ * `eth_subscribe(newHeads)` subscription per chainId, regardless of how
+ * many listeners are registered for that chain.
+ *
+ * Log delivery uses block subscription + batched `eth_getLogs` rather than
+ * one `eth_subscribe(logs, ...)` per listener. This decouples RPC-side
+ * subscription count from workflow count (provider subscription caps are
+ * typically ~1000 per WSS).
+ *
+ * Phase 1 scope: provider singleton + block-sub demux. Heartbeat and
+ * reconnect continue to live in `ws-connection.ts` until Phase 3 routes
+ * listeners through this manager at runtime.
+ */
+
+// Address list cap on `eth_getLogs` varies by provider (Alchemy ~500,
+// Infura ~1000). Chunk defensively; multiple calls per block are cheap.
+const GETLOGS_ADDRESS_BATCH = 500;
+
+export type LogHandler = (log: ethers.Log) => void | Promise<void>;
+export type Unsubscribe = () => void;
+
+export type ProviderFactory = (wssUrl: string) => ethers.WebSocketProvider;
+
+export interface SubscribeOptions {
+  chainId: number;
+  wssUrl: string;
+  address: string;
+  topic0: string;
+  handler: LogHandler;
+}
+
+interface Subscriber {
+  address: string; // normalized to lowercase
+  topic0: string; // 0x-prefixed, lowercase
+  handler: LogHandler;
+}
+
+interface ChainEntry {
+  chainId: number;
+  wssUrl: string;
+  provider: ethers.WebSocketProvider | null;
+  readyPromise: Promise<ethers.WebSocketProvider> | null;
+  subscribers: Set<Subscriber>;
+  blockListener: ((blockNumber: number) => Promise<void>) | null;
+}
+
+const defaultFactory: ProviderFactory = (wssUrl) =>
+  new ethers.WebSocketProvider(wssUrl);
+
+export class ChainProviderManager {
+  private readonly chains = new Map<number, ChainEntry>();
+  private readonly factory: ProviderFactory;
+
+  constructor(factory: ProviderFactory = defaultFactory) {
+    this.factory = factory;
+  }
+
+  async getOrCreateProvider(
+    chainId: number,
+    wssUrl: string,
+  ): Promise<ethers.WebSocketProvider> {
+    const entry = this.ensureEntry(chainId, wssUrl);
+
+    if (entry.provider) {
+      return entry.provider;
+    }
+
+    // Two concurrent callers must receive the same provider instance, not
+    // race to create separate ones.
+    if (!entry.readyPromise) {
+      entry.readyPromise = this.createProvider(entry);
+    }
+    return entry.readyPromise;
+  }
+
+  async subscribeToLogs(opts: SubscribeOptions): Promise<Unsubscribe> {
+    const entry = this.ensureEntry(opts.chainId, opts.wssUrl);
+    await this.getOrCreateProvider(opts.chainId, opts.wssUrl);
+
+    const subscriber: Subscriber = {
+      address: opts.address.toLowerCase(),
+      topic0: opts.topic0.toLowerCase(),
+      handler: opts.handler,
+    };
+    entry.subscribers.add(subscriber);
+
+    if (!entry.blockListener) {
+      this.attachBlockListener(entry);
+    }
+
+    return () => {
+      entry.subscribers.delete(subscriber);
+      if (entry.subscribers.size === 0) {
+        this.detachBlockListener(entry);
+      }
+    };
+  }
+
+  async destroy(): Promise<void> {
+    const errors: unknown[] = [];
+    for (const entry of this.chains.values()) {
+      this.detachBlockListener(entry);
+      if (entry.provider) {
+        try {
+          await entry.provider.destroy();
+        } catch (err) {
+          errors.push(err);
+        }
+      }
+      entry.subscribers.clear();
+      entry.provider = null;
+      entry.readyPromise = null;
+    }
+    this.chains.clear();
+    if (errors.length > 0) {
+      logger.warn(
+        `[ChainProviderManager] ${errors.length} provider destroy errors: ${errors
+          .map(String)
+          .join("; ")}`,
+      );
+    }
+  }
+
+  private ensureEntry(chainId: number, wssUrl: string): ChainEntry {
+    const existing = this.chains.get(chainId);
+    if (existing) {
+      if (existing.wssUrl !== wssUrl) {
+        throw new Error(
+          `chainId ${chainId} already registered with wssUrl ${existing.wssUrl}; refusing to reuse for ${wssUrl}`,
+        );
+      }
+      return existing;
+    }
+    const entry: ChainEntry = {
+      chainId,
+      wssUrl,
+      provider: null,
+      readyPromise: null,
+      subscribers: new Set(),
+      blockListener: null,
+    };
+    this.chains.set(chainId, entry);
+    return entry;
+  }
+
+  private async createProvider(
+    entry: ChainEntry,
+  ): Promise<ethers.WebSocketProvider> {
+    const provider = this.factory(entry.wssUrl);
+    await provider.ready;
+    entry.provider = provider;
+    return provider;
+  }
+
+  private attachBlockListener(entry: ChainEntry): void {
+    if (!entry.provider) {
+      throw new Error(
+        `attachBlockListener: provider not initialized for chain ${entry.chainId}`,
+      );
+    }
+    const listener = async (blockNumber: number): Promise<void> => {
+      await this.processBlock(entry, blockNumber);
+    };
+    entry.blockListener = listener;
+    entry.provider.on("block", listener);
+  }
+
+  private detachBlockListener(entry: ChainEntry): void {
+    if (!(entry.provider && entry.blockListener)) {
+      entry.blockListener = null;
+      return;
+    }
+    entry.provider.off("block", entry.blockListener);
+    entry.blockListener = null;
+  }
+
+  private async processBlock(
+    entry: ChainEntry,
+    blockNumber: number,
+  ): Promise<void> {
+    const subscribers = [...entry.subscribers];
+    if (subscribers.length === 0 || !entry.provider) {
+      return;
+    }
+
+    const { addresses, topic0s } = this.collectFilter(subscribers);
+    const blockHex = `0x${blockNumber.toString(16)}`;
+
+    try {
+      const logs: ethers.Log[] = [];
+      for (let i = 0; i < addresses.length; i += GETLOGS_ADDRESS_BATCH) {
+        const chunk = addresses.slice(i, i + GETLOGS_ADDRESS_BATCH);
+        const batch = (await entry.provider.send("eth_getLogs", [
+          {
+            fromBlock: blockHex,
+            toBlock: blockHex,
+            address: chunk,
+            topics: [topic0s],
+          },
+        ])) as ethers.Log[];
+        logs.push(...batch);
+      }
+
+      for (const log of logs) {
+        await this.dispatchLog(entry, log);
+      }
+    } catch (err) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} block=${blockNumber} getLogs failed: ${String(err)}`,
+      );
+    }
+  }
+
+  private collectFilter(subscribers: Subscriber[]): {
+    addresses: string[];
+    topic0s: string[];
+  } {
+    const addressSet = new Set<string>();
+    const topicSet = new Set<string>();
+    for (const sub of subscribers) {
+      addressSet.add(sub.address);
+      topicSet.add(sub.topic0);
+    }
+    return {
+      addresses: [...addressSet],
+      topic0s: [...topicSet],
+    };
+  }
+
+  private async dispatchLog(entry: ChainEntry, log: ethers.Log): Promise<void> {
+    const logAddr = log.address?.toLowerCase();
+    const logTopic0 = log.topics?.[0]?.toLowerCase();
+    if (!(logAddr && logTopic0)) {
+      return;
+    }
+    for (const sub of entry.subscribers) {
+      if (sub.address !== logAddr || sub.topic0 !== logTopic0) {
+        continue;
+      }
+      try {
+        await sub.handler(log);
+      } catch (err) {
+        logger.warn(
+          `[ChainProviderManager] chain=${entry.chainId} subscriber handler threw: ${String(err)}`,
+        );
+      }
+    }
+  }
+}
+
+export const chainProviderManager = new ChainProviderManager();

--- a/keeperhub-events/event-tracker/src/listener/dedup-redis.ts
+++ b/keeperhub-events/event-tracker/src/listener/dedup-redis.ts
@@ -1,17 +1,29 @@
 import { Redis } from "ioredis";
 import {
+  NODE_ENV,
   REDIS_HOST,
   REDIS_PASSWORD,
   REDIS_PORT,
 } from "../../lib/config/environment";
-import { DEDUP_TTL_SECONDS, type DedupStore, buildDedupKey } from "./dedup";
+import type { DedupStore } from "./dedup";
 
 /**
  * Redis-backed DedupStore. Split from dedup.ts so that registry.ts can
  * depend on the `DedupStore` interface without pulling ioredis into test
  * environments that do not have it installed. Phase 5 replaces this with a
  * Postgres-backed implementation; the factory swap happens in `factory.ts`.
+ *
+ * Redis-specific details (key namespace, TTL expiry) live in this module
+ * rather than the interface module because they do not translate to the
+ * Postgres impl - a row with `processed_at` plus a cleanup cron has no
+ * notion of TTL and a different natural key format.
  */
+
+const DEDUP_TTL_SECONDS = 24 * 60 * 60;
+
+function buildDedupKey(workflowId: string, txHash: string): string {
+  return `${NODE_ENV}:keeper_id:${workflowId}:processed_tx:${txHash}`;
+}
 
 export class RedisDedupStore implements DedupStore {
   constructor(private readonly redis: Redis) {}

--- a/keeperhub-events/event-tracker/src/listener/dedup-redis.ts
+++ b/keeperhub-events/event-tracker/src/listener/dedup-redis.ts
@@ -1,0 +1,44 @@
+import { Redis } from "ioredis";
+import {
+  REDIS_HOST,
+  REDIS_PASSWORD,
+  REDIS_PORT,
+} from "../../lib/config/environment";
+import { DEDUP_TTL_SECONDS, type DedupStore, buildDedupKey } from "./dedup";
+
+/**
+ * Redis-backed DedupStore. Split from dedup.ts so that registry.ts can
+ * depend on the `DedupStore` interface without pulling ioredis into test
+ * environments that do not have it installed. Phase 5 replaces this with a
+ * Postgres-backed implementation; the factory swap happens in `factory.ts`.
+ */
+
+export class RedisDedupStore implements DedupStore {
+  constructor(private readonly redis: Redis) {}
+
+  async isProcessed(workflowId: string, txHash: string): Promise<boolean> {
+    return (await this.redis.exists(buildDedupKey(workflowId, txHash))) === 1;
+  }
+
+  async markProcessed(workflowId: string, txHash: string): Promise<void> {
+    await this.redis.set(
+      buildDedupKey(workflowId, txHash),
+      "1",
+      "EX",
+      DEDUP_TTL_SECONDS,
+    );
+  }
+
+  async disconnect(): Promise<void> {
+    await this.redis.quit();
+  }
+}
+
+export function createRedisDedupStore(): RedisDedupStore {
+  const redis = new Redis({
+    host: REDIS_HOST,
+    port: REDIS_PORT,
+    ...(REDIS_PASSWORD && { password: REDIS_PASSWORD }),
+  });
+  return new RedisDedupStore(redis);
+}

--- a/keeperhub-events/event-tracker/src/listener/dedup.ts
+++ b/keeperhub-events/event-tracker/src/listener/dedup.ts
@@ -1,0 +1,34 @@
+import { NODE_ENV } from "../../lib/config/environment";
+
+/**
+ * Transaction dedup store used by EventListener to avoid forwarding the same
+ * on-chain event twice (across reconnects, reorg replay, and pod restarts).
+ *
+ * Kept behind an interface so Phase 5 can swap the Redis-backed
+ * implementation for a Postgres-backed one without touching the listener
+ * code. A single dedup instance is shared across every listener in a
+ * process, replacing the one-connection-per-workflow pattern from the fork
+ * model.
+ *
+ * This semantic is best-effort by design: `markProcessed` has a 24h TTL
+ * and individual failures must not stop event forwarding (the downstream
+ * workflow executor is the idempotency authority).
+ *
+ * Deliberately contains no value imports beyond `NODE_ENV`: this module is
+ * loaded by registry.ts, and registry's unit tests run in environments that
+ * do not have `ioredis` installed (main-app workspace). The Redis-backed
+ * implementation lives in `dedup-redis.ts` and is only loaded at runtime
+ * through `factory.ts`.
+ */
+
+export const DEDUP_TTL_SECONDS = 24 * 60 * 60;
+
+export interface DedupStore {
+  isProcessed(workflowId: string, txHash: string): Promise<boolean>;
+  markProcessed(workflowId: string, txHash: string): Promise<void>;
+  disconnect(): Promise<void>;
+}
+
+export function buildDedupKey(workflowId: string, txHash: string): string {
+  return `${NODE_ENV}:keeper_id:${workflowId}:processed_tx:${txHash}`;
+}

--- a/keeperhub-events/event-tracker/src/listener/dedup.ts
+++ b/keeperhub-events/event-tracker/src/listener/dedup.ts
@@ -19,6 +19,19 @@
  * through `factory.ts`.
  */
 
+/**
+ * Concurrency note: the check-then-set shape (isProcessed + markProcessed)
+ * is deliberately non-atomic. The refactor chose ordering "read -> send ->
+ * mark" inside EventListener so a send failure does not leave a marked-
+ * but-undelivered event. Atomic `SET NX EX` semantics would force mark-
+ * before-send and trade a benign race for a lost-event risk.
+ *
+ * The race window only matters for a single listener receiving the same
+ * txHash twice (WSS reconnect or chain reorg), since the dedup key
+ * includes workflowId - two workflows on the same (address, topic0) hash
+ * to different keys and do not interfere. The downstream executor is the
+ * idempotency authority; the occasional duplicate is acceptable.
+ */
 export interface DedupStore {
   isProcessed(workflowId: string, txHash: string): Promise<boolean>;
   markProcessed(workflowId: string, txHash: string): Promise<void>;

--- a/keeperhub-events/event-tracker/src/listener/dedup.ts
+++ b/keeperhub-events/event-tracker/src/listener/dedup.ts
@@ -1,5 +1,3 @@
-import { NODE_ENV } from "../../lib/config/environment";
-
 /**
  * Transaction dedup store used by EventListener to avoid forwarding the same
  * on-chain event twice (across reconnects, reorg replay, and pod restarts).
@@ -11,24 +9,18 @@ import { NODE_ENV } from "../../lib/config/environment";
  * model.
  *
  * This semantic is best-effort by design: `markProcessed` has a 24h TTL
- * and individual failures must not stop event forwarding (the downstream
- * workflow executor is the idempotency authority).
+ * (Redis impl) and individual failures must not stop event forwarding
+ * (the downstream workflow executor is the idempotency authority).
  *
- * Deliberately contains no value imports beyond `NODE_ENV`: this module is
- * loaded by registry.ts, and registry's unit tests run in environments that
- * do not have `ioredis` installed (main-app workspace). The Redis-backed
+ * Deliberately contains no value imports: this module is loaded by
+ * registry.ts, and registry's unit tests run in environments that do not
+ * have `ioredis` installed (main-app workspace). The Redis-backed
  * implementation lives in `dedup-redis.ts` and is only loaded at runtime
  * through `factory.ts`.
  */
-
-export const DEDUP_TTL_SECONDS = 24 * 60 * 60;
 
 export interface DedupStore {
   isProcessed(workflowId: string, txHash: string): Promise<boolean>;
   markProcessed(workflowId: string, txHash: string): Promise<void>;
   disconnect(): Promise<void>;
-}
-
-export function buildDedupKey(workflowId: string, txHash: string): string {
-  return `${NODE_ENV}:keeper_id:${workflowId}:processed_tx:${txHash}`;
 }

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -1,6 +1,7 @@
-import { type SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import type { SQSClient } from "@aws-sdk/client-sqs";
 import type { ethers } from "ethers";
 import { logger } from "../../lib/utils/logger";
+import { enqueueWorkflowEventTrigger } from "../../lib/workflow-sqs";
 import {
   buildEventPayload,
   extractEventArgs,
@@ -169,25 +170,11 @@ export class EventListener {
   }
 
   private async sendToSqs(payload: unknown): Promise<void> {
-    const message = {
+    await enqueueWorkflowEventTrigger(this.opts.sqs, this.opts.sqsQueueUrl, {
       workflowId: this.opts.workflowId,
       userId: this.opts.userId,
-      triggerType: "event" as const,
       triggerData: payload,
-    };
-    await this.opts.sqs.send(
-      new SendMessageCommand({
-        QueueUrl: this.opts.sqsQueueUrl,
-        MessageBody: JSON.stringify(message),
-        MessageAttributes: {
-          TriggerType: { DataType: "String", StringValue: "event" },
-          WorkflowId: {
-            DataType: "String",
-            StringValue: this.opts.workflowId,
-          },
-        },
-      }),
-    );
+    });
     logger.log(`[EventListener:${this.opts.workflowId}] enqueued to SQS`);
   }
 }

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -1,0 +1,167 @@
+import { type SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import type { ethers } from "ethers";
+import { logger } from "../../lib/utils/logger";
+import {
+  buildEventPayload,
+  extractEventArgs,
+} from "../chains/event-serializer";
+import { getInterface } from "../chains/interface-cache";
+import type {
+  ChainProviderManager,
+  Unsubscribe,
+} from "../chains/provider-manager";
+import type { AbiEvent } from "../chains/validation";
+import type { DedupStore } from "./dedup";
+
+/**
+ * EventListener encapsulates a single workflow's contract-event listener
+ * running in-process (no child_process.fork). It registers with
+ * ChainProviderManager's shared block-subscription + demux, so many
+ * listeners on the same chain share one WSS connection.
+ *
+ * Phase 3 scope: standalone class + unit tests. Phase 4 wires the
+ * ListenerRegistry into `main.ts` behind the ENABLE_INPROC_LISTENERS
+ * feature flag.
+ */
+
+const DEFAULT_JITTER_MS = 10_000;
+
+export interface EventListenerOptions {
+  workflowId: string;
+  userId: string;
+  workflowName: string;
+  chainId: number;
+  wssUrl: string;
+  contractAddress: string;
+  eventName: string;
+  eventsAbiStrings: string[];
+  rawEventsAbi: AbiEvent[];
+
+  sqs: SQSClient;
+  sqsQueueUrl: string;
+  dedup: DedupStore;
+  providerManager: ChainProviderManager;
+
+  /**
+   * Maximum jitter applied before forwarding a matched event to SQS. Keeps
+   * parity with the existing `evm-chain.ts:processEventLog` behaviour which
+   * spreads downstream load when many events fire simultaneously. Tests
+   * should pass 0 to keep runs deterministic.
+   */
+  jitterMs?: number;
+}
+
+export class EventListener {
+  private readonly opts: EventListenerOptions;
+  private unsubscribe: Unsubscribe | null = null;
+  private started = false;
+
+  constructor(opts: EventListenerOptions) {
+    this.opts = opts;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+
+    const iface = getInterface(this.opts.eventsAbiStrings);
+    const eventFragment = iface.getEvent(this.opts.eventName);
+    if (!eventFragment) {
+      throw new Error(
+        `EventListener(${this.opts.workflowId}): event "${this.opts.eventName}" not found in ABI`,
+      );
+    }
+
+    this.unsubscribe = await this.opts.providerManager.subscribeToLogs({
+      chainId: this.opts.chainId,
+      wssUrl: this.opts.wssUrl,
+      address: this.opts.contractAddress,
+      topic0: eventFragment.topicHash,
+      handler: (log) => this.onLog(log),
+    });
+    this.started = true;
+    logger.log(
+      `[EventListener:${this.opts.workflowId}] started - chain=${this.opts.chainId} address=${this.opts.contractAddress} event=${this.opts.eventName}`,
+    );
+  }
+
+  stop(): void {
+    if (!this.started) {
+      return;
+    }
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.started = false;
+    logger.log(`[EventListener:${this.opts.workflowId}] stopped`);
+  }
+
+  isStarted(): boolean {
+    return this.started;
+  }
+
+  private async onLog(log: ethers.Log): Promise<void> {
+    try {
+      const iface = getInterface(this.opts.eventsAbiStrings);
+      const parsed = iface.parseLog({
+        topics: [...log.topics],
+        data: log.data,
+      });
+      if (!parsed || parsed.name !== this.opts.eventName) {
+        return;
+      }
+
+      const txHash = log.transactionHash;
+      if (!txHash) {
+        logger.warn(
+          `[EventListener:${this.opts.workflowId}] log missing transactionHash; skipping`,
+        );
+        return;
+      }
+
+      const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
+      if (maxJitter > 0) {
+        await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+      }
+
+      if (await this.opts.dedup.isProcessed(this.opts.workflowId, txHash)) {
+        logger.log(
+          `[EventListener:${this.opts.workflowId}] ${txHash} already processed`,
+        );
+        return;
+      }
+      await this.opts.dedup.markProcessed(this.opts.workflowId, txHash);
+
+      const args = extractEventArgs(parsed, this.opts.rawEventsAbi);
+      const payload = buildEventPayload(log, parsed, args);
+      await this.sendToSqs(payload);
+    } catch (err) {
+      logger.warn(
+        `[EventListener:${this.opts.workflowId}] handler error: ${String(err)}`,
+      );
+    }
+  }
+
+  private async sendToSqs(payload: unknown): Promise<void> {
+    const message = {
+      workflowId: this.opts.workflowId,
+      userId: this.opts.userId,
+      triggerType: "event" as const,
+      triggerData: payload,
+    };
+    await this.opts.sqs.send(
+      new SendMessageCommand({
+        QueueUrl: this.opts.sqsQueueUrl,
+        MessageBody: JSON.stringify(message),
+        MessageAttributes: {
+          TriggerType: { DataType: "String", StringValue: "event" },
+          WorkflowId: {
+            DataType: "String",
+            StringValue: this.opts.workflowId,
+          },
+        },
+      }),
+    );
+    logger.log(`[EventListener:${this.opts.workflowId}] enqueued to SQS`);
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -82,7 +82,7 @@ export class EventListener {
     });
     this.started = true;
     logger.log(
-      `[EventListener:${this.opts.workflowId}] started - chain=${this.opts.chainId} address=${this.opts.contractAddress} event=${this.opts.eventName}`,
+      `[EventListener:${this.opts.workflowId}] started - name="${this.opts.workflowName}" chain=${this.opts.chainId} address=${this.opts.contractAddress} event=${this.opts.eventName}`,
     );
   }
 

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -124,17 +124,42 @@ export class EventListener {
         await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
       }
 
-      if (await this.opts.dedup.isProcessed(this.opts.workflowId, txHash)) {
+      // Dedup is best-effort. If the read throws we fall through and
+      // forward the event anyway; the downstream workflow executor is the
+      // idempotency authority. If the read succeeds and reports a hit,
+      // skip forwarding.
+      let alreadyProcessed = false;
+      try {
+        alreadyProcessed = await this.opts.dedup.isProcessed(
+          this.opts.workflowId,
+          txHash,
+        );
+      } catch (err) {
+        logger.warn(
+          `[EventListener:${this.opts.workflowId}] dedup isProcessed failed, proceeding: ${String(err)}`,
+        );
+      }
+      if (alreadyProcessed) {
         logger.log(
           `[EventListener:${this.opts.workflowId}] ${txHash} already processed`,
         );
         return;
       }
-      await this.opts.dedup.markProcessed(this.opts.workflowId, txHash);
 
       const args = extractEventArgs(parsed, this.opts.rawEventsAbi);
       const payload = buildEventPayload(log, parsed, args);
       await this.sendToSqs(payload);
+
+      // Mark after the send. A crash between send and mark would re-fire
+      // the event on the next reconnect (documented best-effort trade).
+      // A mark failure here does not un-send SQS - fine, dedup is best-effort.
+      try {
+        await this.opts.dedup.markProcessed(this.opts.workflowId, txHash);
+      } catch (err) {
+        logger.warn(
+          `[EventListener:${this.opts.workflowId}] dedup markProcessed failed: ${String(err)}`,
+        );
+      }
     } catch (err) {
       logger.warn(
         `[EventListener:${this.opts.workflowId}] handler error: ${String(err)}`,

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -12,6 +12,7 @@ import type {
 } from "../chains/provider-manager";
 import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
+import { formatError } from "./format-error";
 
 /**
  * EventListener encapsulates a single workflow's contract-event listener
@@ -136,7 +137,7 @@ export class EventListener {
         );
       } catch (err) {
         logger.warn(
-          `[EventListener:${this.opts.workflowId}] dedup isProcessed failed, proceeding: ${String(err)}`,
+          `[EventListener:${this.opts.workflowId}] dedup isProcessed failed, proceeding: ${formatError(err)}`,
         );
       }
       if (alreadyProcessed) {
@@ -157,12 +158,12 @@ export class EventListener {
         await this.opts.dedup.markProcessed(this.opts.workflowId, txHash);
       } catch (err) {
         logger.warn(
-          `[EventListener:${this.opts.workflowId}] dedup markProcessed failed: ${String(err)}`,
+          `[EventListener:${this.opts.workflowId}] dedup markProcessed failed: ${formatError(err)}`,
         );
       }
     } catch (err) {
       logger.warn(
-        `[EventListener:${this.opts.workflowId}] handler error: ${String(err)}`,
+        `[EventListener:${this.opts.workflowId}] handler error: ${formatError(err)}`,
       );
     }
   }

--- a/keeperhub-events/event-tracker/src/listener/factory.ts
+++ b/keeperhub-events/event-tracker/src/listener/factory.ts
@@ -1,0 +1,22 @@
+import { SQS_QUEUE_URL } from "../../lib/config/environment";
+import { sqs } from "../../lib/sqs-client";
+import { chainProviderManager } from "../chains/provider-manager";
+import { createRedisDedupStore } from "./dedup-redis";
+import { ListenerRegistry } from "./registry";
+
+/**
+ * Production wiring for ListenerRegistry. Imports the concrete
+ * `RedisDedupStore` factory and the module-level singletons the registry
+ * needs. Intentionally kept in a separate file from `registry.ts` so the
+ * registry's test file can import the class without pulling `ioredis` into
+ * the test runtime.
+ */
+
+export function createRegistry(): ListenerRegistry {
+  return new ListenerRegistry({
+    providerManager: chainProviderManager,
+    dedup: createRedisDedupStore(),
+    sqs,
+    sqsQueueUrl: SQS_QUEUE_URL,
+  });
+}

--- a/keeperhub-events/event-tracker/src/listener/format-error.ts
+++ b/keeperhub-events/event-tracker/src/listener/format-error.ts
@@ -1,0 +1,12 @@
+/**
+ * Convert an unknown caught value into a log-friendly string, preserving
+ * the stack trace when present. `String(err)` on an Error returns only
+ * `"Error: message"` and drops the stack, which is the piece an operator
+ * actually needs for triage.
+ */
+export function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -1,0 +1,100 @@
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import { logger } from "../../lib/utils/logger";
+import type { ChainProviderManager } from "../chains/provider-manager";
+import type { AbiEvent } from "../chains/validation";
+import type { DedupStore } from "./dedup";
+import { EventListener } from "./event-listener";
+
+/**
+ * In-process registry of EventListener instances, keyed by workflow ID.
+ * The Phase 4 reconciler will diff the active workflow list against this
+ * registry and call add/remove to converge.
+ *
+ * All listeners share the same ChainProviderManager (one WSS per chain)
+ * and the same DedupStore (one Redis client instead of per-workflow).
+ *
+ * Deliberately does not import the concrete `RedisDedupStore` factory so
+ * that this module can be loaded by unit tests without requiring `ioredis`
+ * at the test runtime. Production wiring of the factory lives in
+ * `factory.ts`.
+ */
+
+export interface WorkflowRegistration {
+  workflowId: string;
+  userId: string;
+  workflowName: string;
+  chainId: number;
+  wssUrl: string;
+  contractAddress: string;
+  eventName: string;
+  eventsAbiStrings: string[];
+  rawEventsAbi: AbiEvent[];
+}
+
+export interface RegistryDeps {
+  providerManager: ChainProviderManager;
+  dedup: DedupStore;
+  sqs: SQSClient;
+  sqsQueueUrl: string;
+}
+
+export class ListenerRegistry {
+  private readonly listeners = new Map<string, EventListener>();
+  private readonly deps: RegistryDeps;
+
+  constructor(deps: RegistryDeps) {
+    this.deps = deps;
+  }
+
+  async add(reg: WorkflowRegistration): Promise<void> {
+    if (this.listeners.has(reg.workflowId)) {
+      // Idempotent: Phase 4 reconciler handles config changes via
+      // remove+add rather than in-place mutation.
+      return;
+    }
+    const listener = new EventListener({
+      ...reg,
+      providerManager: this.deps.providerManager,
+      dedup: this.deps.dedup,
+      sqs: this.deps.sqs,
+      sqsQueueUrl: this.deps.sqsQueueUrl,
+    });
+    try {
+      await listener.start();
+    } catch (err) {
+      logger.warn(
+        `[ListenerRegistry] failed to start listener ${reg.workflowId}: ${String(err)}`,
+      );
+      return;
+    }
+    this.listeners.set(reg.workflowId, listener);
+  }
+
+  remove(workflowId: string): void {
+    const listener = this.listeners.get(workflowId);
+    if (!listener) {
+      return;
+    }
+    listener.stop();
+    this.listeners.delete(workflowId);
+  }
+
+  has(workflowId: string): boolean {
+    return this.listeners.has(workflowId);
+  }
+
+  ids(): string[] {
+    return [...this.listeners.keys()];
+  }
+
+  size(): number {
+    return this.listeners.size;
+  }
+
+  async stopAll(): Promise<void> {
+    for (const listener of this.listeners.values()) {
+      listener.stop();
+    }
+    this.listeners.clear();
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -4,6 +4,7 @@ import type { ChainProviderManager } from "../chains/provider-manager";
 import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { EventListener } from "./event-listener";
+import { formatError } from "./format-error";
 
 /**
  * In-process registry of EventListener instances, keyed by workflow ID.
@@ -63,7 +64,7 @@ export class ListenerRegistry {
       await listener.start();
     } catch (err) {
       logger.warn(
-        `[ListenerRegistry] failed to start listener ${reg.workflowId}: ${String(err)}`,
+        `[ListenerRegistry] failed to start listener ${reg.workflowId}: ${formatError(err)}`,
       );
       return;
     }

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -47,6 +47,18 @@ export class ListenerRegistry {
     this.deps = deps;
   }
 
+  /**
+   * Not concurrency-safe against interleaved `remove(workflowId)` calls
+   * for the same id. The has() check and the final `listeners.set` straddle
+   * an `await` on `listener.start()`, so a `remove` that lands in that
+   * window sees nothing to remove, the add completes, and a zombie
+   * listener is left registered.
+   *
+   * Phase 4's reconciler calls `add` and `remove` from a single sequential
+   * loop inside `synchronizeData`, so this race cannot be observed in the
+   * production code path. If a caller needs concurrent calls, wrap
+   * Registry access in a serialising queue at the call site.
+   */
   async add(reg: WorkflowRegistration): Promise<void> {
     if (this.listeners.has(reg.workflowId)) {
       // Idempotent: Phase 4 reconciler handles config changes via

--- a/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
@@ -1,0 +1,199 @@
+/**
+ * E2E baseline for the current fork-based event-tracker architecture.
+ *
+ * Requires the `test` docker-compose profile (test-anvil, test-localstack,
+ * test-redis). Run with:
+ *
+ *   docker compose --profile test up -d test-anvil test-localstack test-localstack-init test-redis
+ *   pnpm test
+ *
+ * Skipped when SKIP_INFRA_TESTS=true.
+ */
+
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import type { ethers } from "ethers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getAnvilChainId,
+  getAnvilRpcUrl,
+  getAnvilWallet,
+  getAnvilWssUrl,
+  waitForAnvil,
+} from "./helpers/anvil-helpers";
+import {
+  type DeployedFixture,
+  deployEventEmitter,
+} from "./helpers/fixture-contract";
+import { type MockApiServer, startMockApi } from "./helpers/mock-api";
+import {
+  createQueue,
+  deleteQueue,
+  makeSqsClient,
+  pollForMessage,
+  purgeQueue,
+} from "./helpers/sqs-helpers";
+
+const SKIP_INFRA_TESTS = process.env.SKIP_INFRA_TESTS === "true";
+const AWS_ENDPOINT = process.env.AWS_ENDPOINT_URL ?? "http://localhost:4567";
+const REDIS_HOST = process.env.REDIS_HOST ?? "localhost";
+const REDIS_PORT = Number(process.env.REDIS_PORT ?? 6380);
+const TEST_QUEUE_NAME = "keeperhub-event-tracker-test-queue";
+const WORKFLOW_ID = "test-workflow-keep-295";
+
+function buildWorkflow(address: string, abi: unknown[]): unknown {
+  return {
+    id: WORKFLOW_ID,
+    name: "Phase 0 Baseline",
+    userId: "test-user",
+    organizationId: "test-org",
+    enabled: true,
+    nodes: [
+      {
+        id: "node-1",
+        type: "trigger",
+        selected: false,
+        data: {
+          type: "event-trigger",
+          label: "Emitted",
+          status: "active",
+          description: "Baseline listener for fork architecture",
+          config: {
+            network: String(getAnvilChainId()),
+            eventName: "Emitted",
+            contractABI: JSON.stringify(abi),
+            triggerType: "event",
+            contractAddress: address,
+          },
+        },
+      },
+    ],
+  };
+}
+
+function buildNetworks(): Record<number, unknown> {
+  const now = new Date().toISOString();
+  return {
+    [getAnvilChainId()]: {
+      id: `local-${getAnvilChainId()}`,
+      chainId: getAnvilChainId(),
+      name: "Anvil",
+      symbol: "ETH",
+      chainType: "evm",
+      defaultPrimaryRpc: getAnvilRpcUrl(),
+      defaultFallbackRpc: getAnvilRpcUrl(),
+      defaultPrimaryWss: getAnvilWssUrl(),
+      defaultFallbackWss: getAnvilWssUrl(),
+      isTestnet: true,
+      isEnabled: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+describe.skipIf(SKIP_INFRA_TESTS)(
+  "event-tracker: on-chain event -> SQS (fork architecture baseline)",
+  () => {
+    let fixture: DeployedFixture;
+    let wallet: ethers.Wallet;
+    let mockApi: MockApiServer;
+    let sqsClient: SQSClient;
+    let queueUrl: string;
+    // Modules imported dynamically after env is set up, so redis.ts picks up
+    // the correct REDIS_HOST/PORT before it constructs its client.
+    let syncModule: {
+      registerContainer: () => Promise<void>;
+      removeAllContainers: () => Promise<void>;
+      rtStorage?: { quit?: () => Promise<unknown> };
+    };
+    let synchronizeData: () => Promise<void>;
+
+    beforeAll(async () => {
+      await waitForAnvil();
+      wallet = getAnvilWallet();
+      fixture = await deployEventEmitter(wallet);
+
+      sqsClient = makeSqsClient(AWS_ENDPOINT);
+      queueUrl = await createQueue(sqsClient, TEST_QUEUE_NAME, AWS_ENDPOINT);
+      await purgeQueue(sqsClient, queueUrl);
+
+      mockApi = await startMockApi();
+      mockApi.setResponse("/api/workflows/events", {
+        workflows: [buildWorkflow(fixture.address, fixture.abi)],
+        networks: buildNetworks(),
+      });
+
+      process.env.KEEPERHUB_API_URL = mockApi.url;
+      process.env.KEEPERHUB_API_KEY = "test-key";
+      process.env.SQS_QUEUE_URL = queueUrl;
+      process.env.AWS_ENDPOINT_URL = AWS_ENDPOINT;
+      process.env.AWS_REGION = "us-east-1";
+      process.env.AWS_ACCESS_KEY_ID = "test";
+      process.env.AWS_SECRET_ACCESS_KEY = "test";
+      process.env.REDIS_HOST = REDIS_HOST;
+      process.env.REDIS_PORT = String(REDIS_PORT);
+      process.env.NODE_ENV = "test";
+
+      const redisMod = await import("../../lib/sync/redis");
+      syncModule = redisMod.syncModule;
+      const mainMod = await import("../../src/main");
+      synchronizeData = mainMod.synchronizeData;
+
+      await syncModule.removeAllContainers();
+      await syncModule.registerContainer();
+    }, 120_000);
+
+    afterAll(async () => {
+      // Ask the fork architecture to tear down its child processes by sending
+      // an empty workflow list, then disconnect Redis so vitest exits cleanly.
+      try {
+        mockApi?.setResponse("/api/workflows/events", {
+          workflows: [],
+          networks: {},
+        });
+        if (synchronizeData) {
+          await synchronizeData();
+        }
+      } catch {
+        // best-effort cleanup
+      }
+      try {
+        await syncModule?.removeAllContainers?.();
+      } catch {
+        // ignore
+      }
+      try {
+        // SyncModule holds its Redis client as a protected `rtStorage` field.
+        // Closing it lets vitest exit without hanging on open handles.
+        await syncModule?.rtStorage?.quit?.();
+      } catch {
+        // ignore
+      }
+      await mockApi?.close();
+      await deleteQueue(sqsClient, queueUrl);
+    }, 30_000);
+
+    it("forwards an emitted contract event to SQS", async () => {
+      await synchronizeData();
+
+      // Give the forked child time to boot, connect WSS, and register the
+      // filter before we emit. 5s is generous for local anvil.
+      await new Promise((r) => setTimeout(r, 5_000));
+
+      const emitEvent = fixture.contract.getFunction("emitEvent");
+      const tx = await emitEvent(42n);
+      await tx.wait();
+
+      const message = await pollForMessage(sqsClient, queueUrl, 20_000);
+      expect(message, "no SQS message received within timeout").not.toBeNull();
+      const body = JSON.parse(message?.Body ?? "{}") as {
+        workflowId: string;
+        triggerType: string;
+        triggerData: unknown;
+      };
+      expect(body.workflowId).toBe(WORKFLOW_ID);
+      expect(body.triggerType).toBe("event");
+      expect(body.triggerData).toBeDefined();
+    }, 90_000);
+  },
+);

--- a/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/event-to-sqs.test.ts
@@ -39,6 +39,26 @@ const REDIS_HOST = process.env.REDIS_HOST ?? "localhost";
 const REDIS_PORT = Number(process.env.REDIS_PORT ?? 6380);
 const TEST_QUEUE_NAME = "keeperhub-event-tracker-test-queue";
 const WORKFLOW_ID = "test-workflow-keep-295";
+const EMITTED_VALUE = 42n;
+
+// Shape of the payload emitted by AbstractChain.executeWorkflow. Kept loose
+// because event-serializer output is the production contract; tighten in
+// later phases if we want to assert more aggressively.
+interface TypedValue {
+  value: string;
+  type: string;
+}
+interface TriggerData {
+  eventName: string;
+  args: Record<string, TypedValue>;
+  address: string;
+  transactionHash: string;
+}
+interface SqsBody {
+  workflowId: string;
+  triggerType: string;
+  triggerData: TriggerData;
+}
 
 function buildWorkflow(address: string, abi: unknown[]): unknown {
   return {
@@ -123,6 +143,14 @@ describe.skipIf(SKIP_INFRA_TESTS)(
         networks: buildNetworks(),
       });
 
+      // Env vars below are mutated and intentionally not restored in afterAll.
+      // This is safe because the event-tracker modules capture them at import
+      // time (e.g. lib/config/environment.ts, lib/sync/redis.ts constructs
+      // its Redis client eagerly). A restore after import would have no effect
+      // on the captured values, so it is not worth the noise. If another test
+      // file is added that imports event-tracker modules with different env,
+      // run test files in separate vitest processes (isolate: true) or move
+      // this setup to a global setup file.
       process.env.KEEPERHUB_API_URL = mockApi.url;
       process.env.KEEPERHUB_API_KEY = "test-key";
       process.env.SQS_QUEUE_URL = queueUrl;
@@ -163,8 +191,12 @@ describe.skipIf(SKIP_INFRA_TESTS)(
         // ignore
       }
       try {
-        // SyncModule holds its Redis client as a protected `rtStorage` field.
-        // Closing it lets vitest exit without hanging on open handles.
+        // Reaches into SyncModule's `rtStorage` field, which is declared
+        // `protected` on SyncManager. This is brittle but acceptable:
+        // event-tracker has no public disconnect API today, vitest hangs on
+        // the open ioredis connection if we don't close it, and Phase 6 of
+        // the KEEP-295 plan deletes SyncModule/Redis entirely. When this
+        // bracket goes, so does the need for this access.
         await syncModule?.rtStorage?.quit?.();
       } catch {
         // ignore
@@ -176,24 +208,50 @@ describe.skipIf(SKIP_INFRA_TESTS)(
     it("forwards an emitted contract event to SQS", async () => {
       await synchronizeData();
 
-      // Give the forked child time to boot, connect WSS, and register the
-      // filter before we emit. 5s is generous for local anvil.
-      await new Promise((r) => setTimeout(r, 5_000));
-
+      // The child process forks, connects its WSS provider, validates the
+      // contract, and attaches its filter asynchronously. Anvil WSS
+      // subscriptions only deliver events from blocks AFTER the subscribe
+      // call, so an event emitted before the child is ready is lost forever.
+      //
+      // There is no production hook to await "child is listening" from the
+      // test process (IPC is consumed inside WorkflowHandler). Instead: emit
+      // in a retry loop, polling SQS after each emit. Each emit is a new
+      // transaction with a new tx_hash, so Redis dedup never interferes.
+      // Once the listener is up, the next emit lands in SQS. First-attempt
+      // success is the typical case; retries only kick in if the child is
+      // slow to boot on a busy machine.
+      const MAX_ATTEMPTS = 10;
+      const PER_ATTEMPT_MS = 3_000;
       const emitEvent = fixture.contract.getFunction("emitEvent");
-      const tx = await emitEvent(42n);
-      await tx.wait();
 
-      const message = await pollForMessage(sqsClient, queueUrl, 20_000);
-      expect(message, "no SQS message received within timeout").not.toBeNull();
-      const body = JSON.parse(message?.Body ?? "{}") as {
-        workflowId: string;
-        triggerType: string;
-        triggerData: unknown;
-      };
+      let received: Awaited<ReturnType<typeof pollForMessage>> = null;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        const tx = await emitEvent(EMITTED_VALUE);
+        await tx.wait();
+        received = await pollForMessage(sqsClient, queueUrl, PER_ATTEMPT_MS);
+        if (received) {
+          break;
+        }
+      }
+
+      expect(
+        received,
+        `no SQS message received after ${MAX_ATTEMPTS} emits; listener likely never attached`,
+      ).not.toBeNull();
+
+      const body = JSON.parse(received?.Body ?? "{}") as SqsBody;
       expect(body.workflowId).toBe(WORKFLOW_ID);
       expect(body.triggerType).toBe("event");
-      expect(body.triggerData).toBeDefined();
+      expect(body.triggerData.eventName).toBe("Emitted");
+      expect(body.triggerData.address.toLowerCase()).toBe(
+        fixture.address.toLowerCase(),
+      );
+      expect(body.triggerData.args.value.type).toBe("uint256");
+      expect(body.triggerData.args.value.value).toBe(String(EMITTED_VALUE));
+      expect(body.triggerData.args.sender.type).toBe("address");
+      expect(body.triggerData.args.sender.value.toLowerCase()).toBe(
+        wallet.address.toLowerCase(),
+      );
     }, 90_000);
   },
 );

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/anvil-helpers.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/anvil-helpers.ts
@@ -1,0 +1,44 @@
+import { ethers } from "ethers";
+
+const ANVIL_RPC = process.env.ANVIL_RPC_URL ?? "http://localhost:8546";
+const ANVIL_WSS = process.env.ANVIL_WSS_URL ?? "ws://localhost:8546";
+const ANVIL_CHAIN_ID = 31337;
+
+// Anvil's first well-known test account. Never used on any mainnet.
+const ANVIL_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+export function getAnvilRpcUrl(): string {
+  return ANVIL_RPC;
+}
+
+export function getAnvilWssUrl(): string {
+  return ANVIL_WSS;
+}
+
+export function getAnvilChainId(): number {
+  return ANVIL_CHAIN_ID;
+}
+
+export function getAnvilWallet(): ethers.Wallet {
+  const provider = new ethers.JsonRpcProvider(ANVIL_RPC);
+  return new ethers.Wallet(ANVIL_PRIVATE_KEY, provider);
+}
+
+export async function waitForAnvil(maxMs = 30_000): Promise<void> {
+  const provider = new ethers.JsonRpcProvider(ANVIL_RPC);
+  const deadline = Date.now() + maxMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await provider.getBlockNumber();
+      return;
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw new Error(
+    `Anvil not reachable at ${ANVIL_RPC} within ${maxMs}ms: ${String(lastErr)}`,
+  );
+}

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/fixture-contract.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/fixture-contract.ts
@@ -1,0 +1,83 @@
+import { ethers } from "ethers";
+import solc from "solc";
+
+const SOURCE = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract EventEmitter {
+    event Emitted(address indexed sender, uint256 value);
+
+    function emitEvent(uint256 value) external {
+        emit Emitted(msg.sender, value);
+    }
+}
+`;
+
+export interface CompiledContract {
+  abi: unknown[];
+  bytecode: string;
+}
+
+export interface DeployedFixture {
+  address: string;
+  abi: unknown[];
+  contract: ethers.Contract;
+}
+
+let cached: CompiledContract | null = null;
+
+export function compileEventEmitter(): CompiledContract {
+  if (cached) {
+    return cached;
+  }
+  const input = {
+    language: "Solidity",
+    sources: { "EventEmitter.sol": { content: SOURCE } },
+    settings: {
+      outputSelection: {
+        "*": { "*": ["abi", "evm.bytecode.object"] },
+      },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input))) as {
+    contracts?: Record<
+      string,
+      Record<string, { abi: unknown[]; evm: { bytecode: { object: string } } }>
+    >;
+    errors?: { severity: string; formattedMessage: string }[];
+  };
+
+  const fatal = (output.errors ?? []).filter((e) => e.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(
+      `solc compile failed:\n${fatal.map((e) => e.formattedMessage).join("\n")}`,
+    );
+  }
+
+  const artifact = output.contracts?.["EventEmitter.sol"]?.EventEmitter;
+  if (!artifact) {
+    throw new Error("EventEmitter artifact missing from solc output");
+  }
+
+  cached = {
+    abi: artifact.abi,
+    bytecode: `0x${artifact.evm.bytecode.object}`,
+  };
+  return cached;
+}
+
+export async function deployEventEmitter(
+  wallet: ethers.Wallet,
+): Promise<DeployedFixture> {
+  const { abi, bytecode } = compileEventEmitter();
+  const factory = new ethers.ContractFactory(
+    abi as ethers.InterfaceAbi,
+    bytecode,
+    wallet,
+  );
+  const deployed = await factory.deploy();
+  await deployed.waitForDeployment();
+  const address = await deployed.getAddress();
+  return { address, abi, contract: deployed as ethers.Contract };
+}

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/mock-api.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/mock-api.ts
@@ -1,0 +1,43 @@
+import { type AddressInfo, type Server, createServer } from "node:http";
+
+export interface MockApiServer {
+  url: string;
+  setResponse(path: string, body: unknown): void;
+  close(): Promise<void>;
+}
+
+export async function startMockApi(): Promise<MockApiServer> {
+  const responses = new Map<string, unknown>();
+
+  const server: Server = createServer((req, res) => {
+    const fullUrl = req.url ?? "/";
+    const pathOnly = fullUrl.split("?")[0];
+    const body = responses.get(pathOnly);
+    if (body === undefined) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "not found", path: pathOnly }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const addr = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    url,
+    setResponse(path, body) {
+      responses.set(path, body);
+    },
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/keeperhub-events/event-tracker/tests/e2e/helpers/sqs-helpers.ts
+++ b/keeperhub-events/event-tracker/tests/e2e/helpers/sqs-helpers.ts
@@ -1,0 +1,87 @@
+import {
+  CreateQueueCommand,
+  DeleteQueueCommand,
+  type Message,
+  PurgeQueueCommand,
+  ReceiveMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+
+export function makeSqsClient(endpoint: string): SQSClient {
+  return new SQSClient({
+    region: "us-east-1",
+    endpoint,
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  });
+}
+
+export async function createQueue(
+  client: SQSClient,
+  name: string,
+  endpoint: string,
+): Promise<string> {
+  try {
+    const result = await client.send(
+      new CreateQueueCommand({ QueueName: name }),
+    );
+    if (!result.QueueUrl) {
+      throw new Error("CreateQueueCommand returned no QueueUrl");
+    }
+    // LocalStack may return a URL with an internal hostname. Rewrite to the
+    // endpoint the test process can actually reach.
+    return result.QueueUrl.replace("host.minikube.internal", "localhost")
+      .replace("test-localstack", "localhost")
+      .replace("localstack", "localhost");
+  } catch {
+    // Queue may already exist from a prior test run.
+    return `${endpoint}/000000000000/${name}`;
+  }
+}
+
+export async function deleteQueue(
+  client: SQSClient,
+  url: string,
+): Promise<void> {
+  try {
+    await client.send(new DeleteQueueCommand({ QueueUrl: url }));
+  } catch {
+    // Ignore cleanup errors.
+  }
+}
+
+export async function purgeQueue(
+  client: SQSClient,
+  url: string,
+): Promise<void> {
+  try {
+    await client.send(new PurgeQueueCommand({ QueueUrl: url }));
+  } catch {
+    // Purge fails if the queue was purged recently; harmless.
+  }
+}
+
+export async function pollForMessage(
+  client: SQSClient,
+  url: string,
+  timeoutMs: number,
+): Promise<Message | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const waitSeconds = Math.max(
+      1,
+      Math.min(20, Math.ceil((deadline - Date.now()) / 1000)),
+    );
+    const result = await client.send(
+      new ReceiveMessageCommand({
+        QueueUrl: url,
+        MaxNumberOfMessages: 1,
+        WaitTimeSeconds: waitSeconds,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+    if (result.Messages && result.Messages.length > 0) {
+      return result.Messages[0];
+    }
+  }
+  return null;
+}

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -1,0 +1,381 @@
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import type { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearInterfaceCache,
+  getInterface,
+} from "../../src/chains/interface-cache";
+import type {
+  ChainProviderManager,
+  SubscribeOptions,
+  Unsubscribe,
+} from "../../src/chains/provider-manager";
+import type { AbiEvent } from "../../src/chains/validation";
+import type { DedupStore } from "../../src/listener/dedup";
+import {
+  EventListener,
+  type EventListenerOptions,
+} from "../../src/listener/event-listener";
+
+// Minimal ABI fixture: a single `Emitted(address indexed sender, uint256 value)`
+// matching the Phase 0 E2E fixture contract so unit and integration tests
+// share a mental model.
+const RAW_EVENTS_ABI: AbiEvent[] = [
+  {
+    type: "event",
+    name: "Emitted",
+    inputs: [
+      { name: "sender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+];
+
+const EVENTS_ABI_STRINGS = [
+  "event Emitted(address indexed sender, uint256 value)",
+];
+
+const WORKFLOW_ID = "wf-abc";
+const USER_ID = "user-1";
+const CONTRACT_ADDRESS = "0x1111111111111111111111111111111111111111";
+const SENDER = "0x2222222222222222222222222222222222222222";
+const SQS_QUEUE_URL = "https://sqs.test/queue";
+
+interface MockProviderManager {
+  manager: ChainProviderManager;
+  subscribeToLogs: ReturnType<typeof vi.fn>;
+  capturedHandler: ((log: ethers.Log) => Promise<void> | void) | null;
+  unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+function makeProviderManagerMock(): MockProviderManager {
+  const unsubscribe: Unsubscribe = vi.fn();
+  let capturedHandler: ((log: ethers.Log) => Promise<void> | void) | null =
+    null;
+  const subscribeToLogs = vi.fn(async (opts: SubscribeOptions) => {
+    capturedHandler = opts.handler;
+    return unsubscribe;
+  });
+  const manager = {
+    subscribeToLogs,
+  } as unknown as ChainProviderManager;
+  return {
+    manager,
+    subscribeToLogs,
+    get capturedHandler() {
+      return capturedHandler;
+    },
+    set capturedHandler(fn) {
+      capturedHandler = fn;
+    },
+    unsubscribe: unsubscribe as ReturnType<typeof vi.fn>,
+  };
+}
+
+function makeDedupMock(): DedupStore & {
+  isProcessed: ReturnType<typeof vi.fn>;
+  markProcessed: ReturnType<typeof vi.fn>;
+} {
+  return {
+    isProcessed: vi.fn(async () => false),
+    markProcessed: vi.fn(async () => undefined),
+    disconnect: vi.fn(async () => undefined),
+  } as DedupStore & {
+    isProcessed: ReturnType<typeof vi.fn>;
+    markProcessed: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeSqsMock(): SQSClient & { send: ReturnType<typeof vi.fn> } {
+  return {
+    send: vi.fn(async () => ({ MessageId: "msg-1" })),
+  } as unknown as SQSClient & { send: ReturnType<typeof vi.fn> };
+}
+
+function buildOptions(
+  overrides: Partial<EventListenerOptions> = {},
+): EventListenerOptions {
+  const providerMock = makeProviderManagerMock();
+  return {
+    workflowId: WORKFLOW_ID,
+    userId: USER_ID,
+    workflowName: "Unit Test",
+    chainId: 31_337,
+    wssUrl: "ws://localhost:8546",
+    contractAddress: CONTRACT_ADDRESS,
+    eventName: "Emitted",
+    eventsAbiStrings: EVENTS_ABI_STRINGS,
+    rawEventsAbi: RAW_EVENTS_ABI,
+    sqs: makeSqsMock(),
+    sqsQueueUrl: SQS_QUEUE_URL,
+    dedup: makeDedupMock(),
+    providerManager: providerMock.manager,
+    jitterMs: 0,
+    ...overrides,
+  };
+}
+
+function makeLog(params: {
+  txHash: string;
+  sender: string;
+  value: bigint;
+}): ethers.Log {
+  const iface = getInterface(EVENTS_ABI_STRINGS);
+  const { topics, data } = iface.encodeEventLog("Emitted", [
+    params.sender,
+    params.value,
+  ]);
+  // Cast via unknown because ethers.Log has getters on a real Log instance
+  // that we don't need here; the EventListener only reads topics/data and
+  // metadata fields.
+  return {
+    topics,
+    data,
+    address: CONTRACT_ADDRESS,
+    blockNumber: 100,
+    blockHash:
+      "0x3333333333333333333333333333333333333333333333333333333333333333",
+    transactionHash: params.txHash,
+    transactionIndex: 0,
+    index: 0,
+  } as unknown as ethers.Log;
+}
+
+describe("EventListener", () => {
+  beforeEach(() => {
+    clearInterfaceCache();
+  });
+
+  describe("lifecycle", () => {
+    it("subscribes with the correct (chain, address, topic0) on start", async () => {
+      const providerMock = makeProviderManagerMock();
+      const listener = new EventListener(
+        buildOptions({ providerManager: providerMock.manager }),
+      );
+      await listener.start();
+
+      expect(providerMock.subscribeToLogs).toHaveBeenCalledTimes(1);
+      const call = providerMock.subscribeToLogs.mock
+        .calls[0][0] as SubscribeOptions;
+      expect(call.chainId).toBe(31_337);
+      expect(call.address).toBe(CONTRACT_ADDRESS);
+
+      const iface = getInterface(EVENTS_ABI_STRINGS);
+      const expectedTopic = iface.getEvent("Emitted")?.topicHash;
+      expect(call.topic0).toBe(expectedTopic);
+      expect(listener.isStarted()).toBe(true);
+    });
+
+    it("start is idempotent", async () => {
+      const providerMock = makeProviderManagerMock();
+      const listener = new EventListener(
+        buildOptions({ providerManager: providerMock.manager }),
+      );
+      await listener.start();
+      await listener.start();
+      expect(providerMock.subscribeToLogs).toHaveBeenCalledTimes(1);
+    });
+
+    it("stop calls the unsubscribe returned by subscribeToLogs", async () => {
+      const providerMock = makeProviderManagerMock();
+      const listener = new EventListener(
+        buildOptions({ providerManager: providerMock.manager }),
+      );
+      await listener.start();
+      listener.stop();
+      expect(providerMock.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(listener.isStarted()).toBe(false);
+    });
+
+    it("stop without start is a no-op", () => {
+      const providerMock = makeProviderManagerMock();
+      const listener = new EventListener(
+        buildOptions({ providerManager: providerMock.manager }),
+      );
+      listener.stop();
+      expect(providerMock.unsubscribe).not.toHaveBeenCalled();
+    });
+
+    it("throws if the event name is not in the ABI", async () => {
+      const listener = new EventListener(
+        buildOptions({ eventName: "Missing" }),
+      );
+      await expect(listener.start()).rejects.toThrow(/Missing/);
+    });
+  });
+
+  describe("log handling", () => {
+    it("dedup miss -> mark + SQS send", async () => {
+      const providerMock = makeProviderManagerMock();
+      const dedup = makeDedupMock();
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          dedup,
+          sqs,
+        }),
+      );
+      await listener.start();
+
+      const log = makeLog({
+        txHash:
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        sender: SENDER,
+        value: 42n,
+      });
+      await providerMock.capturedHandler!(log);
+
+      expect(dedup.isProcessed).toHaveBeenCalledWith(
+        WORKFLOW_ID,
+        log.transactionHash,
+      );
+      expect(dedup.markProcessed).toHaveBeenCalledWith(
+        WORKFLOW_ID,
+        log.transactionHash,
+      );
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("dedup hit -> skip SQS", async () => {
+      const providerMock = makeProviderManagerMock();
+      const dedup = makeDedupMock();
+      dedup.isProcessed.mockResolvedValue(true);
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          dedup,
+          sqs,
+        }),
+      );
+      await listener.start();
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash:
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      expect(dedup.markProcessed).not.toHaveBeenCalled();
+      expect(sqs.send).not.toHaveBeenCalled();
+    });
+
+    it("handler errors are caught and do not throw", async () => {
+      const providerMock = makeProviderManagerMock();
+      const dedup = makeDedupMock();
+      dedup.isProcessed.mockRejectedValue(new Error("redis down"));
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          dedup,
+          sqs,
+        }),
+      );
+      await listener.start();
+
+      await expect(
+        providerMock.capturedHandler!(
+          makeLog({
+            txHash:
+              "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            sender: SENDER,
+            value: 1n,
+          }),
+        ),
+      ).resolves.toBeUndefined();
+      expect(sqs.send).not.toHaveBeenCalled();
+    });
+
+    it("SQS message contains the correct workflowId, triggerType, and payload", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({ providerManager: providerMock.manager, sqs }),
+      );
+      await listener.start();
+
+      const txHash =
+        "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+      await providerMock.capturedHandler!(
+        makeLog({ txHash, sender: SENDER, value: 42n }),
+      );
+
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+      const command = sqs.send.mock.calls[0][0] as {
+        input: {
+          QueueUrl: string;
+          MessageBody: string;
+          MessageAttributes: Record<string, { StringValue: string }>;
+        };
+      };
+      expect(command.input.QueueUrl).toBe(SQS_QUEUE_URL);
+      expect(command.input.MessageAttributes.WorkflowId.StringValue).toBe(
+        WORKFLOW_ID,
+      );
+      expect(command.input.MessageAttributes.TriggerType.StringValue).toBe(
+        "event",
+      );
+      const body = JSON.parse(command.input.MessageBody) as {
+        workflowId: string;
+        userId: string;
+        triggerType: string;
+        triggerData: {
+          eventName: string;
+          args: { value: { value: string; type: string } };
+          transactionHash: string;
+        };
+      };
+      expect(body.workflowId).toBe(WORKFLOW_ID);
+      expect(body.userId).toBe(USER_ID);
+      expect(body.triggerType).toBe("event");
+      expect(body.triggerData.eventName).toBe("Emitted");
+      expect(body.triggerData.args.value.value).toBe("42");
+      expect(body.triggerData.args.value.type).toBe("uint256");
+      expect(body.triggerData.transactionHash).toBe(txHash);
+    });
+
+    it("ignores logs whose parsed name does not match eventName", async () => {
+      // Build a second listener configured for a different event name; feed
+      // it a log for "Emitted" and assert nothing is forwarded. Parsing the
+      // log with a cache that only knows the Emitted ABI will succeed, but
+      // the name filter rejects it.
+      const providerMock = makeProviderManagerMock();
+      const dedup = makeDedupMock();
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({
+          eventName: "DifferentEvent",
+          eventsAbiStrings: [
+            "event Emitted(address indexed sender, uint256 value)",
+            "event DifferentEvent(uint256 value)",
+          ],
+          rawEventsAbi: [
+            ...RAW_EVENTS_ABI,
+            {
+              type: "event",
+              name: "DifferentEvent",
+              inputs: [{ name: "value", type: "uint256", indexed: false }],
+            },
+          ],
+          providerManager: providerMock.manager,
+          dedup,
+          sqs,
+        }),
+      );
+      await listener.start();
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash:
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      expect(dedup.markProcessed).not.toHaveBeenCalled();
+      expect(sqs.send).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -292,6 +292,52 @@ describe("EventListener", () => {
       expect(sqs.send).toHaveBeenCalledTimes(1);
     });
 
+    it("applies jitter up to the configured cap before forwarding", async () => {
+      // Pin Math.random() to 1 so the jitter is exactly the cap, and use
+      // fake timers so the test does not actually wait. The goal is to
+      // verify the jitter branch executes and respects the cap; precise
+      // timing is out of scope.
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
+      vi.useFakeTimers();
+      try {
+        const providerMock = makeProviderManagerMock();
+        const sqs = makeSqsMock();
+        const listener = new EventListener(
+          buildOptions({
+            providerManager: providerMock.manager,
+            sqs,
+            jitterMs: 7_000,
+          }),
+        );
+        await listener.start();
+
+        const handlerPromise = providerMock.capturedHandler!(
+          makeLog({
+            txHash:
+              "0xffff000000000000000000000000000000000000000000000000000000000000",
+            sender: SENDER,
+            value: 9n,
+          }),
+        );
+
+        // Before advancing timers the handler has not reached SQS.
+        await Promise.resolve();
+        expect(sqs.send).not.toHaveBeenCalled();
+
+        // Advance to just under the cap - still no send.
+        await vi.advanceTimersByTimeAsync(6_999);
+        expect(sqs.send).not.toHaveBeenCalled();
+
+        // Advance past the cap - send happens.
+        await vi.advanceTimersByTimeAsync(1);
+        await handlerPromise;
+        expect(sqs.send).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+        randomSpy.mockRestore();
+      }
+    });
+
     it("dedup markProcessed failure -> SQS send already happened, swallowed", async () => {
       // The mark happens after the send. A mark failure must not throw out
       // of the handler (it's logged and swallowed) and must not affect the

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -262,7 +262,10 @@ describe("EventListener", () => {
       expect(sqs.send).not.toHaveBeenCalled();
     });
 
-    it("handler errors are caught and do not throw", async () => {
+    it("dedup isProcessed failure -> still forwards to SQS (best-effort)", async () => {
+      // The dedup read failing must not drop the event. Downstream is the
+      // idempotency authority, so a duplicate is acceptable; a lost event
+      // is not.
       const providerMock = makeProviderManagerMock();
       const dedup = makeDedupMock();
       dedup.isProcessed.mockRejectedValue(new Error("redis down"));
@@ -286,7 +289,37 @@ describe("EventListener", () => {
           }),
         ),
       ).resolves.toBeUndefined();
-      expect(sqs.send).not.toHaveBeenCalled();
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("dedup markProcessed failure -> SQS send already happened, swallowed", async () => {
+      // The mark happens after the send. A mark failure must not throw out
+      // of the handler (it's logged and swallowed) and must not affect the
+      // SQS delivery we already made.
+      const providerMock = makeProviderManagerMock();
+      const dedup = makeDedupMock();
+      dedup.markProcessed.mockRejectedValue(new Error("redis down"));
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          dedup,
+          sqs,
+        }),
+      );
+      await listener.start();
+
+      await expect(
+        providerMock.capturedHandler!(
+          makeLog({
+            txHash:
+              "0xdede000000000000000000000000000000000000000000000000000000000000",
+            sender: SENDER,
+            value: 1n,
+          }),
+        ),
+      ).resolves.toBeUndefined();
+      expect(sqs.send).toHaveBeenCalledTimes(1);
     });
 
     it("SQS message contains the correct workflowId, triggerType, and payload", async () => {

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -38,6 +38,16 @@ const OTHER_EVENTS = [
   },
 ];
 
+// Production call site (evm-chain.ts) passes `rawEventsAbi.map(buildEventAbi)`
+// which returns `string[]` of signature strings, not the AbiEvent object
+// array above. Both shapes are valid ethers.InterfaceAbi, but we cache on
+// hashed content so the cache key spaces are disjoint. Tests here must
+// exercise the string-array shape that real listeners pass.
+const ERC20_EVENT_STRINGS = [
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+  "event Approval(address indexed owner, address indexed spender, uint256 value)",
+];
+
 describe("interface-cache", () => {
   beforeEach(() => {
     clearInterfaceCache();
@@ -102,5 +112,39 @@ describe("interface-cache", () => {
     expect(getInterfaceCacheSize()).toBe(2);
     clearInterfaceCache();
     expect(getInterfaceCacheSize()).toBe(0);
+  });
+
+  describe("production call shape (string[])", () => {
+    it("caches by content for the signature-string array shape", () => {
+      const a = getInterface(ERC20_EVENT_STRINGS);
+      const b = getInterface(ERC20_EVENT_STRINGS);
+      expect(a).toBe(b);
+      expect(getInterfaceCacheSize()).toBe(1);
+    });
+
+    it("produces an Interface that decodes logs correctly", () => {
+      const iface = getInterface(ERC20_EVENT_STRINGS);
+      const from = "0x0000000000000000000000000000000000000001";
+      const to = "0x0000000000000000000000000000000000000002";
+      const value = 42n;
+
+      const encoded = iface.encodeEventLog("Transfer", [from, to, value]);
+      const parsed = iface.parseLog({
+        topics: encoded.topics,
+        data: encoded.data,
+      });
+      expect(parsed?.name).toBe("Transfer");
+      expect(parsed?.args.value).toBe(value);
+    });
+
+    it("string shape and object shape hash to different cache keys", () => {
+      // Same logical ABI in two different representations. Both valid,
+      // but they serialise differently so they miss each other's cache.
+      // Documented-as-overhead behaviour; the assertion here locks it in.
+      const fromStrings = getInterface(ERC20_EVENT_STRINGS);
+      const fromObjects = getInterface(ERC20_EVENTS);
+      expect(fromStrings).not.toBe(fromObjects);
+      expect(getInterfaceCacheSize()).toBe(2);
+    });
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -115,6 +115,25 @@ describe("interface-cache", () => {
     expect(getInterfaceCacheSize()).toBe(0);
   });
 
+  describe("non-serializable ABI", () => {
+    it("throws a contextual error when the ABI has a circular reference", () => {
+      const circular: unknown[] = [];
+      circular.push(circular);
+      expect(() =>
+        // Cast via unknown to bypass the InterfaceAbi type guard; this test
+        // exists precisely to verify behaviour on malformed input.
+        getInterface(circular as unknown as ethers.InterfaceAbi),
+      ).toThrow(/interface-cache: ABI is not JSON-serializable/);
+    });
+
+    it("throws a contextual error when the ABI contains a BigInt", () => {
+      const withBigInt = [{ type: "event", name: "X", inputs: [], max: 1n }];
+      expect(() =>
+        getInterface(withBigInt as unknown as ethers.InterfaceAbi),
+      ).toThrow(/interface-cache: ABI is not JSON-serializable/);
+    });
+  });
+
   describe("LRU eviction", () => {
     // Helper: build a cheap unique signature-string ABI for the Nth entry.
     function uniqueAbi(n: number): string[] {

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearInterfaceCache,
   getInterface,
+  getInterfaceCacheMaxSize,
   getInterfaceCacheSize,
 } from "../../src/chains/interface-cache";
 
@@ -112,6 +113,61 @@ describe("interface-cache", () => {
     expect(getInterfaceCacheSize()).toBe(2);
     clearInterfaceCache();
     expect(getInterfaceCacheSize()).toBe(0);
+  });
+
+  describe("LRU eviction", () => {
+    // Helper: build a cheap unique signature-string ABI for the Nth entry.
+    function uniqueAbi(n: number): string[] {
+      return [`event Unique${n}(uint256 value)`];
+    }
+
+    it("evicts the least-recently-used entry once full", () => {
+      const cap = getInterfaceCacheMaxSize();
+      // Fill the cache to capacity.
+      for (let i = 0; i < cap; i++) {
+        getInterface(uniqueAbi(i));
+      }
+      expect(getInterfaceCacheSize()).toBe(cap);
+
+      const oldest = getInterface(uniqueAbi(0));
+
+      // One more insertion forces an eviction. The LRU is abi(1) because
+      // abi(0) was just touched above.
+      getInterface(uniqueAbi(cap));
+      expect(getInterfaceCacheSize()).toBe(cap);
+
+      // abi(0) should still be there (and be the same instance).
+      expect(getInterface(uniqueAbi(0))).toBe(oldest);
+
+      // abi(1) should have been evicted, so requesting it produces a new
+      // Interface instance.
+      const refreshed = getInterface(uniqueAbi(1));
+      expect(refreshed).not.toBe(oldest);
+    });
+
+    it("cache-hit touch moves entry to most-recently-used position", () => {
+      // Simpler scenario, easier to reason about than the cap-sized one.
+      // Fill 3 entries, touch the first, force one eviction; the second
+      // (oldest untouched) is what should go.
+      const first = getInterface(uniqueAbi(1));
+      getInterface(uniqueAbi(2));
+      getInterface(uniqueAbi(3));
+
+      // Touch #1.
+      expect(getInterface(uniqueAbi(1))).toBe(first);
+
+      // Force enough inserts to evict exactly one entry: we need cap-2
+      // more new inserts beyond the 3 we already placed.
+      const cap = getInterfaceCacheMaxSize();
+      for (let i = 4; i <= cap + 1; i++) {
+        getInterface(uniqueAbi(i));
+      }
+      expect(getInterfaceCacheSize()).toBe(cap);
+
+      // #1 survives (touched); #2 should have been evicted (oldest
+      // untouched at the point of first overflow).
+      expect(getInterface(uniqueAbi(1))).toBe(first);
+    });
   });
 
   describe("production call shape (string[])", () => {

--- a/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/interface-cache.test.ts
@@ -1,0 +1,106 @@
+import { ethers } from "ethers";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearInterfaceCache,
+  getInterface,
+  getInterfaceCacheSize,
+} from "../../src/chains/interface-cache";
+
+const ERC20_EVENTS = [
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "Approval",
+    inputs: [
+      { name: "owner", type: "address", indexed: true },
+      { name: "spender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+];
+
+const OTHER_EVENTS = [
+  {
+    type: "event",
+    name: "Emitted",
+    inputs: [
+      { name: "sender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+];
+
+describe("interface-cache", () => {
+  beforeEach(() => {
+    clearInterfaceCache();
+  });
+
+  it("returns the same Interface instance for the same ABI", () => {
+    const a = getInterface(ERC20_EVENTS);
+    const b = getInterface(ERC20_EVENTS);
+    expect(a).toBe(b);
+    expect(getInterfaceCacheSize()).toBe(1);
+  });
+
+  it("returns the same Interface for a deep-cloned equivalent ABI", () => {
+    const clone = JSON.parse(JSON.stringify(ERC20_EVENTS));
+    const a = getInterface(ERC20_EVENTS);
+    const b = getInterface(clone);
+    expect(a).toBe(b);
+    expect(getInterfaceCacheSize()).toBe(1);
+  });
+
+  it("creates separate Interface instances for different ABIs", () => {
+    const a = getInterface(ERC20_EVENTS);
+    const b = getInterface(OTHER_EVENTS);
+    expect(a).not.toBe(b);
+    expect(getInterfaceCacheSize()).toBe(2);
+  });
+
+  it("produces an Interface that decodes logs correctly", () => {
+    const iface = getInterface(ERC20_EVENTS);
+    const from = "0x0000000000000000000000000000000000000001";
+    const to = "0x0000000000000000000000000000000000000002";
+    const value = 123n;
+
+    const encoded = iface.encodeEventLog("Transfer", [from, to, value]);
+    const parsed = iface.parseLog({
+      topics: encoded.topics,
+      data: encoded.data,
+    });
+    expect(parsed?.name).toBe("Transfer");
+    expect(parsed?.args.from.toLowerCase()).toBe(from);
+    expect(parsed?.args.to.toLowerCase()).toBe(to);
+    expect(parsed?.args.value).toBe(value);
+  });
+
+  it("decoding still works after a cache hit", () => {
+    getInterface(ERC20_EVENTS); // populate
+    const iface = getInterface(ERC20_EVENTS); // hit
+    const topics = [
+      ethers.id("Transfer(address,address,uint256)"),
+      ethers.zeroPadValue("0x0000000000000000000000000000000000000001", 32),
+      ethers.zeroPadValue("0x0000000000000000000000000000000000000002", 32),
+    ];
+    const data = ethers.AbiCoder.defaultAbiCoder().encode(["uint256"], [7n]);
+    const parsed = iface.parseLog({ topics, data });
+    expect(parsed?.name).toBe("Transfer");
+    expect(parsed?.args.value).toBe(7n);
+  });
+
+  it("clearInterfaceCache empties the cache", () => {
+    getInterface(ERC20_EVENTS);
+    getInterface(OTHER_EVENTS);
+    expect(getInterfaceCacheSize()).toBe(2);
+    clearInterfaceCache();
+    expect(getInterfaceCacheSize()).toBe(0);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -287,6 +287,83 @@ describe("ChainProviderManager", () => {
       expect(h2).toHaveBeenCalledTimes(1);
     });
 
+    it("dispatches matching subscribers in parallel, not serially", async () => {
+      // Two handlers on the same (address, topic0). h1 sleeps; h2 should
+      // start before h1 resolves. With sequential await the h2 start time
+      // would be >= 50ms; in parallel it should be ~0ms.
+      let h1Started = 0;
+      let h2Started = 0;
+      let start = 0;
+      const h1 = vi.fn(async () => {
+        h1Started = Date.now() - start;
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      const h2 = vi.fn(async () => {
+        h2Started = Date.now() - start;
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h1,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h2,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      start = Date.now();
+      await provider.emitBlock(500);
+
+      expect(h1).toHaveBeenCalledTimes(1);
+      expect(h2).toHaveBeenCalledTimes(1);
+      // h2 starts well before h1's 50ms sleep completes.
+      expect(h2Started).toBeLessThan(40);
+      expect(h1Started).toBeLessThan(10);
+    });
+
+    it("one handler throwing does not block or abort the others", async () => {
+      const thrower = vi.fn(async () => {
+        throw new Error("boom");
+      });
+      const later = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: thrower,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: later,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(501);
+
+      expect(thrower).toHaveBeenCalledTimes(1);
+      expect(later).toHaveBeenCalledTimes(1);
+    });
+
     it("does not call a handler after its subscription is cancelled", async () => {
       const handler = vi.fn();
       const unsubscribe = await manager.subscribeToLogs({

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1,0 +1,379 @@
+import type { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ChainProviderManager,
+  type ProviderFactory,
+} from "../../src/chains/provider-manager";
+
+type BlockHandler = (blockNumber: number) => void | Promise<void>;
+
+interface SendCall {
+  method: string;
+  params: unknown[];
+}
+
+class MockProvider {
+  // Vitest's vi.fn provides better assertions (toHaveBeenCalledWith) than a plain
+  // Promise.resolve would, and the field is still awaitable.
+  ready: Promise<void> = Promise.resolve();
+  public sendCalls: SendCall[] = [];
+  public sendResponses: unknown[] = [];
+  public destroyed = false;
+  private blockHandler: BlockHandler | null = null;
+
+  on(event: string, handler: BlockHandler): void {
+    if (event === "block") {
+      this.blockHandler = handler;
+    }
+  }
+
+  off(event: string, handler: BlockHandler): void {
+    if (event === "block" && this.blockHandler === handler) {
+      this.blockHandler = null;
+    }
+  }
+
+  async send(method: string, params: unknown[]): Promise<unknown> {
+    this.sendCalls.push({ method, params });
+    if (this.sendResponses.length === 0) {
+      return [];
+    }
+    return this.sendResponses.shift();
+  }
+
+  async destroy(): Promise<void> {
+    this.destroyed = true;
+  }
+
+  hasBlockHandler(): boolean {
+    return this.blockHandler !== null;
+  }
+
+  async emitBlock(blockNumber: number): Promise<void> {
+    if (this.blockHandler) {
+      await this.blockHandler(blockNumber);
+    }
+  }
+}
+
+// MockProvider implements the ethers.WebSocketProvider surface that
+// ChainProviderManager actually uses. The factory casts through unknown to
+// satisfy the type without pulling in the rest of ethers' provider surface.
+function makeFactory(): {
+  factory: ProviderFactory;
+  created: MockProvider[];
+} {
+  const created: MockProvider[] = [];
+  const factory: ProviderFactory = (_wssUrl: string) => {
+    const mock = new MockProvider();
+    created.push(mock);
+    return mock as unknown as ethers.WebSocketProvider;
+  };
+  return { factory, created };
+}
+
+const CHAIN_A = 31337;
+const CHAIN_B = 1;
+const ADDR_A = "0x1111111111111111111111111111111111111111";
+const ADDR_B = "0x2222222222222222222222222222222222222222";
+const TOPIC_EMITTED =
+  "0x6d7747ff9aaba238de658957a12a32c8a94f6ec3aa0508441fe400ca79ed457c";
+const TOPIC_OTHER =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+describe("ChainProviderManager", () => {
+  let factoryBundle: ReturnType<typeof makeFactory>;
+  let manager: ChainProviderManager;
+
+  beforeEach(() => {
+    factoryBundle = makeFactory();
+    manager = new ChainProviderManager(factoryBundle.factory);
+  });
+
+  describe("getOrCreateProvider", () => {
+    it("returns the same provider instance for the same chainId", async () => {
+      const a = await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const b = await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      expect(a).toBe(b);
+      expect(factoryBundle.created).toHaveLength(1);
+    });
+
+    it("does not double-create under concurrent callers", async () => {
+      const [a, b, c] = await Promise.all([
+        manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+      ]);
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+      expect(factoryBundle.created).toHaveLength(1);
+    });
+
+    it("creates separate providers for different chainIds", async () => {
+      const a = await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const b = await manager.getOrCreateProvider(CHAIN_B, "ws://b");
+      expect(a).not.toBe(b);
+      expect(factoryBundle.created).toHaveLength(2);
+    });
+
+    it("rejects a mismatched wssUrl for a known chainId", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      await expect(
+        manager.getOrCreateProvider(CHAIN_A, "ws://different"),
+      ).rejects.toThrow(/already registered/);
+    });
+  });
+
+  describe("subscribeToLogs block listener lifecycle", () => {
+    it("attaches a block listener on first subscriber", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(true);
+    });
+
+    it("does not re-attach a block listener for a second subscriber", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const spyOn = vi.spyOn(factoryBundle.created[0], "on");
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(spyOn).not.toHaveBeenCalledWith("block", expect.anything());
+    });
+
+    it("detaches the block listener when the last subscriber unsubscribes", async () => {
+      const unsubA = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const unsubB = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      unsubA();
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(true);
+      unsubB();
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(false);
+    });
+  });
+
+  describe("log demux", () => {
+    it("requests eth_getLogs with the union of addresses and topic0s", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_OTHER,
+        handler: vi.fn(),
+      });
+
+      const provider = factoryBundle.created[0];
+      provider.sendResponses = [[]];
+      await provider.emitBlock(100);
+
+      expect(provider.sendCalls).toHaveLength(1);
+      expect(provider.sendCalls[0].method).toBe("eth_getLogs");
+      const filter = provider.sendCalls[0].params[0] as {
+        address: string[];
+        topics: string[][];
+        fromBlock: string;
+        toBlock: string;
+      };
+      expect(filter.address.sort()).toEqual(
+        [ADDR_A.toLowerCase(), ADDR_B.toLowerCase()].sort(),
+      );
+      expect(filter.topics[0].sort()).toEqual(
+        [TOPIC_EMITTED, TOPIC_OTHER].sort(),
+      );
+      expect(filter.fromBlock).toBe("0x64");
+      expect(filter.toBlock).toBe("0x64");
+    });
+
+    it("dispatches a log only to subscribers whose (address, topic0) matches", async () => {
+      const handlerA = vi.fn();
+      const handlerB = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: handlerA,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_OTHER,
+        handler: handlerB,
+      });
+
+      const provider = factoryBundle.created[0];
+      // One log matching A; one log matching B; one log matching neither.
+      const logA = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      const logB = {
+        address: ADDR_B.toLowerCase(),
+        topics: [TOPIC_OTHER],
+      };
+      const logNeither = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_OTHER],
+      };
+      provider.sendResponses = [[logA, logB, logNeither]];
+      await provider.emitBlock(101);
+
+      expect(handlerA).toHaveBeenCalledTimes(1);
+      expect(handlerA).toHaveBeenCalledWith(logA);
+      expect(handlerB).toHaveBeenCalledTimes(1);
+      expect(handlerB).toHaveBeenCalledWith(logB);
+    });
+
+    it("dispatches one log to multiple subscribers when they share (address, topic0)", async () => {
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h1,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: h2,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(102);
+
+      expect(h1).toHaveBeenCalledTimes(1);
+      expect(h2).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call a handler after its subscription is cancelled", async () => {
+      const handler = vi.fn();
+      const unsubscribe = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler,
+      });
+      // Need a second subscriber so the block listener stays attached.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_OTHER,
+        handler: vi.fn(),
+      });
+
+      unsubscribe();
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(103);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("isolates handler errors: one throwing handler does not skip later handlers", async () => {
+      const throwing = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const later = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: throwing,
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: later,
+      });
+
+      const provider = factoryBundle.created[0];
+      const log = {
+        address: ADDR_A.toLowerCase(),
+        topics: [TOPIC_EMITTED],
+      };
+      provider.sendResponses = [[log]];
+      await provider.emitBlock(104);
+
+      expect(throwing).toHaveBeenCalledTimes(1);
+      expect(later).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("destroy", () => {
+    it("tears down every chain's provider and clears subscriber state", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      await manager.subscribeToLogs({
+        chainId: CHAIN_B,
+        wssUrl: "ws://b",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      await manager.destroy();
+
+      expect(factoryBundle.created).toHaveLength(2);
+      expect(factoryBundle.created[0].destroyed).toBe(true);
+      expect(factoryBundle.created[1].destroyed).toBe(true);
+      expect(factoryBundle.created[0].hasBlockHandler()).toBe(false);
+    });
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/registry.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/registry.test.ts
@@ -1,0 +1,144 @@
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ChainProviderManager,
+  SubscribeOptions,
+  Unsubscribe,
+} from "../../src/chains/provider-manager";
+import type { AbiEvent } from "../../src/chains/validation";
+import type { DedupStore } from "../../src/listener/dedup";
+import {
+  ListenerRegistry,
+  type WorkflowRegistration,
+} from "../../src/listener/registry";
+
+const RAW_EVENTS_ABI: AbiEvent[] = [
+  {
+    type: "event",
+    name: "Emitted",
+    inputs: [
+      { name: "sender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+];
+
+const EVENTS_ABI_STRINGS = [
+  "event Emitted(address indexed sender, uint256 value)",
+];
+
+function makeWorkflow(
+  id: string,
+  overrides: Partial<WorkflowRegistration> = {},
+): WorkflowRegistration {
+  return {
+    workflowId: id,
+    userId: "user-1",
+    workflowName: `Test ${id}`,
+    chainId: 31_337,
+    wssUrl: "ws://localhost:8546",
+    contractAddress: "0x1111111111111111111111111111111111111111",
+    eventName: "Emitted",
+    eventsAbiStrings: EVENTS_ABI_STRINGS,
+    rawEventsAbi: RAW_EVENTS_ABI,
+    ...overrides,
+  };
+}
+
+function makeDeps(): {
+  providerManager: ChainProviderManager;
+  subscribeToLogs: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+  dedup: DedupStore;
+  sqs: SQSClient;
+  sqsQueueUrl: string;
+} {
+  const unsubscribe: Unsubscribe = vi.fn();
+  const subscribeToLogs = vi.fn(async (_opts: SubscribeOptions) => {
+    return unsubscribe;
+  });
+  const providerManager = {
+    subscribeToLogs,
+  } as unknown as ChainProviderManager;
+  const dedup: DedupStore = {
+    isProcessed: vi.fn(async () => false),
+    markProcessed: vi.fn(async () => undefined),
+    disconnect: vi.fn(async () => undefined),
+  };
+  const sqs = { send: vi.fn(async () => ({ MessageId: "m" })) };
+  return {
+    providerManager,
+    subscribeToLogs,
+    unsubscribe: unsubscribe as ReturnType<typeof vi.fn>,
+    dedup,
+    sqs: sqs as unknown as SQSClient,
+    sqsQueueUrl: "https://sqs.test/queue",
+  };
+}
+
+describe("ListenerRegistry", () => {
+  let deps: ReturnType<typeof makeDeps>;
+  let registry: ListenerRegistry;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    registry = new ListenerRegistry({
+      providerManager: deps.providerManager,
+      dedup: deps.dedup,
+      sqs: deps.sqs,
+      sqsQueueUrl: deps.sqsQueueUrl,
+    });
+  });
+
+  it("add starts a listener and records it by workflowId", async () => {
+    await registry.add(makeWorkflow("wf-1"));
+    expect(deps.subscribeToLogs).toHaveBeenCalledTimes(1);
+    expect(registry.has("wf-1")).toBe(true);
+    expect(registry.size()).toBe(1);
+    expect(registry.ids()).toEqual(["wf-1"]);
+  });
+
+  it("add is idempotent for the same workflowId", async () => {
+    await registry.add(makeWorkflow("wf-1"));
+    await registry.add(makeWorkflow("wf-1"));
+    expect(deps.subscribeToLogs).toHaveBeenCalledTimes(1);
+    expect(registry.size()).toBe(1);
+  });
+
+  it("remove unsubscribes and drops the listener", async () => {
+    await registry.add(makeWorkflow("wf-1"));
+    registry.remove("wf-1");
+    expect(deps.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(registry.has("wf-1")).toBe(false);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("remove for an unknown id is a no-op", () => {
+    registry.remove("unknown");
+    expect(deps.unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it("stopAll stops every listener and clears the registry", async () => {
+    await registry.add(makeWorkflow("wf-1"));
+    await registry.add(makeWorkflow("wf-2"));
+    await registry.stopAll();
+    expect(deps.unsubscribe).toHaveBeenCalledTimes(2);
+    expect(registry.size()).toBe(0);
+    expect(registry.ids()).toEqual([]);
+  });
+
+  it("does not record a listener whose start() throws", async () => {
+    // Simulate a start failure by making subscribeToLogs reject.
+    deps.subscribeToLogs.mockRejectedValueOnce(new Error("provider down"));
+    await registry.add(makeWorkflow("wf-broken"));
+    expect(registry.has("wf-broken")).toBe(false);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("different workflowIds do not collide", async () => {
+    await registry.add(makeWorkflow("wf-1"));
+    await registry.add(makeWorkflow("wf-2"));
+    expect(deps.subscribeToLogs).toHaveBeenCalledTimes(2);
+    expect(new Set(registry.ids())).toEqual(new Set(["wf-1", "wf-2"]));
+  });
+});

--- a/keeperhub-events/event-tracker/vitest.config.mts
+++ b/keeperhub-events/event-tracker/vitest.config.mts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    exclude: ["node_modules"],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
+});

--- a/keeperhub-events/pnpm-lock.yaml
+++ b/keeperhub-events/pnpm-lock.yaml
@@ -45,9 +45,21 @@ importers:
       '@types/deep-diff':
         specifier: ^1.0.5
         version: 1.0.5
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      solc:
+        specifier: ^0.8.29
+        version: 0.8.34
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)
+      vitest:
+        specifier: 4.1.2
+        version: 4.1.2(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0))
 
 packages:
 
@@ -383,12 +395,140 @@ packages:
   '@ioredis/commands@1.5.0':
     resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
 
   '@smithy/abort-controller@4.2.11':
     resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
@@ -566,8 +706,20 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/deep-diff@1.0.5':
     resolution: {integrity: sha512-PQyNSy1YMZU1hgZA5tTYfHPpUAo9Dorn1PZho2/budQLfqLu3JIP37JAavnwYpR1S2yFZTXa3hxaE4ifGW5jaA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
@@ -575,18 +727,68 @@ packages:
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -605,14 +807,28 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   ethers@6.16.0:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-xml-builder@1.0.0:
     resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
@@ -620,6 +836,24 @@ packages:
   fast-xml-parser@5.4.1:
     resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
     hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -633,14 +867,120 @@ packages:
     resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
 
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -653,11 +993,57 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  solc@0.8.34:
+    resolution: {integrity: sha512-qf8HajA1sHhXRV0hMSDXLjVbc4v3Q+SQbL9zok+1WmgVj7Z4oMjMHxaysCzfGtFVqjZdfDDJWyZI+tcx5bO7Dw==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -678,8 +1064,91 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   ws@8.17.1:
@@ -1149,11 +1618,88 @@ snapshots:
 
   '@ioredis/commands@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
 
   '@noble/hashes@1.3.2': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
 
   '@smithy/abort-controller@4.2.11':
     dependencies:
@@ -1435,7 +1981,18 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/deep-diff@1.0.5': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/node@22.19.13':
     dependencies:
@@ -1445,13 +2002,68 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/uuid@10.0.0': {}
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   aes-js@4.0.0-beta.5: {}
 
+  assertion-error@2.0.1: {}
+
   bowser@2.14.1: {}
 
+  chai@6.2.2: {}
+
   cluster-key-slot@1.1.2: {}
+
+  command-exists@1.2.9: {}
+
+  commander@8.3.0: {}
+
+  convert-source-map@2.0.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -1460,6 +2072,11 @@ snapshots:
   deep-diff@1.0.2: {}
 
   denque@2.1.0: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1490,6 +2107,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   ethers@6.16.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
@@ -1503,12 +2124,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  expect-type@1.3.0: {}
+
   fast-xml-builder@1.0.0: {}
 
   fast-xml-parser@5.4.1:
     dependencies:
       fast-xml-builder: 1.0.0
       strnum: 2.2.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  follow-redirects@1.16.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1531,11 +2160,87 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  js-sha3@0.8.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+    optional: true
+
   lodash.defaults@4.2.0: {}
 
   lodash.isarguments@3.1.0: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  memorystream@0.3.1: {}
+
   ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  os-tmpdir@1.0.2: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   redis-errors@1.2.0: {}
 
@@ -1545,9 +2250,77 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  semver@5.7.2: {}
+
+  siginfo@2.0.0: {}
+
+  solc@0.8.34:
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.16.0
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 5.7.2
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
+  std-env@4.1.0: {}
+
   strnum@2.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
 
   tslib@2.7.0: {}
 
@@ -1564,6 +2337,54 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   uuid@11.1.0: {}
+
+  vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+
+  vitest@4.1.2(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.17.1: {}


### PR DESCRIPTION
## Summary

Phase 3 of the event-tracker refactor tracked in KEEP-295. Adds the `EventListener` + `ListenerRegistry` primitives that future phases will use to run all workflow event listeners inside a single Node process instead of forking a child per workflow.

**Stacked on #927 (Phase 2)**, which is stacked on #925 (Phase 1), which is stacked on #911 (Phase 0). Base should be retargeted to `staging` as each upstream PR lands.

Like Phase 1, this adds the primitives without wiring them into the runtime. The fork path in `main.ts` / `child-handler.ts` is unchanged. Phase 0 E2E stays green unchanged. **Phase 4 wires everything in** via the `ENABLE_INPROC_LISTENERS` feature flag and a reconciler loop in `main.ts`.

## What this does

### `src/listener/dedup.ts` (new)

`DedupStore` interface with a `RedisDedupStore` implementation that **shares one Redis client across all workflows** in a process (vs one-per-workflow in today's `TransactionDedup`). Kept behind an interface so Phase 5 can swap to Postgres without touching the listener code. Best-effort semantic by design -- the downstream workflow executor is the idempotency authority.

### `src/listener/event-listener.ts` (new)

Per-workflow listener.

- `start()` subscribes via `ChainProviderManager.subscribeToLogs` (Phase 1) -- shared chain-level WSS + block-subscription + demux, **no per-listener `eth_subscribe`**.
- Log handler: parse via cached `ethers.Interface` (Phase 2), apply jitter for downstream load spreading, check dedup, send to SQS, mark dedup.
- Handler errors caught and logged, never propagate up to kill the process.
- Jitter is configurable via `jitterMs` so tests can pass 0 for determinism.

### `src/listener/registry.ts` (new)

`Map<workflowId, EventListener>` with idempotent add/remove/size/stopAll. Exports `createRegistry()` factory that wires the production dependencies (chainProviderManager singleton, Redis dedup store, SQS singleton, `SQS_QUEUE_URL`).

### Unit coverage: 23 tests, 2.47s

**`tests/unit/event-listener.test.ts`** (10 tests):
- Lifecycle: subscribes with correct `(chainId, address, topic0)`, start idempotent, stop unsubscribes, stop-before-start no-op, unknown `eventName` rejected.
- Log handling: dedup miss -> mark + SQS, dedup hit -> skip SQS, handler errors caught without throwing, SQS message shape matches event-serializer output, name-mismatch logs ignored.

**`tests/unit/registry.test.ts`** (6 tests):
- add records and starts; add is idempotent for the same workflowId; remove unsubscribes and drops; remove unknown no-op; stopAll cleans everything; failed `start()` does not leave a phantom entry; different ids do not collide.

## Why these are safe to merge pre-integration

Same answer as Phase 1 (#925):

- No runtime code path references these modules yet. `ws-connection.ts`, `evm-chain.ts`, `child-handler.ts`, `main.ts` remain untouched.
- Phase 0 E2E still green (37 tests total -- 36 unit + 1 E2E), confirming the fork path is unaffected.
- Phase 4 is a small-and-reviewable follow-up (~150 lines of main.ts changes + a feature-flag check) that turns these primitives into live code.

## What Phase 4 will add

(For context, not in this PR.)

1. `ENABLE_INPROC_LISTENERS=true` env flag check in `main.ts`.
2. When flag is on, `synchronizeData()` diffs active workflows against `registry.ids()` and calls `registry.add()` / `registry.remove()` instead of forking children.
3. Top-level `process.on("uncaughtException")` and `process.on("unhandledRejection")` handlers: log and `process.exit(1)` so K8s restarts the pod.
4. E2E test flip: same scenario as Phase 0 but with the flag on, asserting single-process path works end to end.

## Test plan

- [ ] `cd keeperhub-events/event-tracker && pnpm install`
- [ ] `SKIP_INFRA_TESTS=true pnpm test tests/unit/` -- expect 36 passed in <3s
- [ ] `docker compose --profile test up -d test-anvil test-localstack test-localstack-init test-redis`
- [ ] `pnpm test` -- expect 37 passed (36 unit + 1 E2E)
- [ ] `pnpm typecheck` -- clean
- [ ] `pnpm lint` -- clean