### PR TITLE
fix(ci): restore docs/ and docs-site/ in docs image build context

### DIFF
--- a/docs-site/Dockerfile.dockerignore
+++ b/docs-site/Dockerfile.dockerignore
@@ -1,0 +1,133 @@
+# Dockerfile-specific ignore file for the docs-site image.
+#
+# The docs-site build uses the repo root as its Docker context and
+# copies docs-site/ and docs/ into the image. The root .dockerignore
+# excludes both to keep the main app's build context small, which
+# works for the main Dockerfile but breaks this one. BuildKit uses
+# this file in place of the root .dockerignore when the build is
+# invoked with file: ./docs-site/Dockerfile, restoring the needed
+# paths while keeping every other exclusion the main file enforces.
+
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Next.js build output
+.next
+out
+dist
+
+# Development files
+.git
+.gitignore
+.worktrees
+README.md
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker-compose.*.yml
+
+# Directories not needed by the docs image
+tests/
+specs/
+analysis/
+.claude/
+.cursor/
+.probes/
+
+# Dev-only config files
+playwright.config.ts
+vitest.config.mts
+biome.jsonc
+
+# IDE files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# nuxt.js build output
+.nuxt
+
+# vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# TernJS port file
+.tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# Svelte build output
+.svelte-kit
+
+# Database
+*.db
+*.sqlite
+
+# Temporary files
+tmp/
+temp/
+
+# Build artifacts
+build/


### PR DESCRIPTION
## Summary

- Prod `deploy-keeperhub-docs` workflow has been failing on every push since PR #890 (2026-04-17) with `"/docs-site/package.json": not found` at the first `COPY` in the docs Dockerfile.
- Root cause: commit `47eb705b` ("KEEP-283 split COPY into granular COPYs") added `docs-site/` and `docs/` to the root `.dockerignore` to shrink the main app build context, but the docs image uses the repo root as its context and copies both directories in. BuildKit was stripping them before `COPY` saw them.
- Fix: adds a Dockerfile-specific ignore at `docs-site/Dockerfile.dockerignore`. BuildKit prefers this over the root `.dockerignore` when invoked with `file: ./docs-site/Dockerfile`, so the docs build gets the directories back while the main app's optimised context is untouched.

## Test plan

- [x] Local `docker buildx build --target deps -f ./docs-site/Dockerfile .` now reaches `COPY docs-site/package.json ./ DONE` and proceeds into `pnpm install` (previously failed at this exact step).
- [x] Build context for the deps stage transferred only 739 B — the Dockerfile-specific ignore still excludes `.git`, `.next`, `.claude`, `node_modules`, etc.
- [ ] After merge to `staging`, dispatch `deploy-docs.yaml` on staging (or wait for the staging merge path) to confirm before cutting the prod release PR.

## Failing run for reference

https://github.com/KeeperHub/keeperhub/actions/runs/24712857066