### PR TITLE
fix: KEEP-235 replace custom JWT with jose and fix timing attack

### DIFF
--- a/app/api/execute/_lib/auth.ts
+++ b/app/api/execute/_lib/auth.ts
@@ -16,7 +16,7 @@ export type ApiKeyContext = {
 export async function validateApiKey(
   request: Request
 ): Promise<ApiKeyContext | null> {
-  const oauthResult = authenticateOAuthToken(request);
+  const oauthResult = await authenticateOAuthToken(request);
   if (oauthResult.authenticated && oauthResult.organizationId) {
     return {
       organizationId: oauthResult.organizationId,

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -66,7 +66,7 @@ async function handleAuthorizationCode(
   // Consume the code immediately (single use)
   await deleteAuthCode(code);
 
-  const accessToken = createAccessToken({
+  const accessToken = await createAccessToken({
     sub: authCode.userId,
     org: authCode.organizationId,
     scope: authCode.scope,
@@ -129,7 +129,7 @@ async function handleRefreshToken(params: URLSearchParams): Promise<Response> {
     expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
   });
 
-  const accessToken = createAccessToken({
+  const accessToken = await createAccessToken({
     sub: entry.userId,
     org: entry.organizationId,
     scope: entry.scope,

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -87,7 +87,7 @@ async function authenticate(request: Request): Promise<ApiKeyAuthResult> {
     return await authenticateApiKey(request);
   }
 
-  const oauthResult = authenticateOAuthToken(request);
+  const oauthResult = await authenticateOAuthToken(request);
   if (oauthResult.authenticated) {
     return {
       authenticated: true,
@@ -220,7 +220,7 @@ async function resolveSession(
   // Slow path: verify JWT and reconstruct transport+server (different pod or restart).
   // Accept expired-but-valid-signature JWTs so sessions survive pod restarts
   // and idle periods within the 24h sliding window.
-  const result = verifySessionTokenDetailed(sessionId);
+  const result = await verifySessionTokenDetailed(sessionId);
 
   if (!result.payload) {
     const isExpiredBeyondRenewal =
@@ -276,7 +276,7 @@ async function resolveSession(
   // The client adopts the new session ID from the Mcp-Session-Id response header.
   let renewedSessionId: string | undefined;
   if (result.expired) {
-    renewedSessionId = createSessionToken({
+    renewedSessionId = await createSessionToken({
       org: result.payload.org,
       key: result.payload.key,
       scope: result.payload.scope,
@@ -392,7 +392,7 @@ export async function POST(request: Request): Promise<Response> {
 
   // Mint the JWT that becomes the Mcp-Session-Id returned to the client.
   // Any pod can verify and reconstruct state from this token on future requests.
-  const newSessionId = createSessionToken({
+  const newSessionId = await createSessionToken({
     org: organizationId,
     key: apiKeyId,
     scope,
@@ -483,7 +483,7 @@ export async function DELETE(request: Request): Promise<Response> {
 
   // Verify ownership via JWT before touching anything in the local cache.
   // Accept expired JWTs so clients can clean up old sessions.
-  const payload = verifySessionToken(sessionId, { allowExpired: true });
+  const payload = await verifySessionToken(sessionId, { allowExpired: true });
   if (!payload || payload.org !== organizationId) {
     return new Response(sessionErrorBody("session_not_found"), {
       status: 404,

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -17,12 +17,19 @@ export type OAuthAuthResult = {
   statusCode?: number;
 };
 
+let cachedJwtSecret: { raw: string; encoded: Uint8Array } | null = null;
+
 function getJwtSecret(): Uint8Array {
   const secret = process.env.OAUTH_JWT_SECRET;
   if (!secret) {
     throw new Error("OAUTH_JWT_SECRET environment variable is not set");
   }
-  return new TextEncoder().encode(secret);
+  if (cachedJwtSecret?.raw === secret) {
+    return cachedJwtSecret.encoded;
+  }
+  const encoded = new TextEncoder().encode(secret);
+  cachedJwtSecret = { raw: secret, encoded };
+  return encoded;
 }
 
 export async function createAccessToken(payload: {

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -50,6 +50,20 @@ export async function createAccessToken(payload: {
     .sign(secret);
 }
 
+function isOAuthTokenPayload(value: unknown): value is OAuthTokenPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const p = value as Record<string, unknown>;
+  return (
+    typeof p.sub === "string" &&
+    typeof p.org === "string" &&
+    typeof p.scope === "string" &&
+    typeof p.iat === "number" &&
+    typeof p.exp === "number"
+  );
+}
+
 export async function verifyAccessToken(
   token: string
 ): Promise<OAuthTokenPayload | null> {
@@ -58,7 +72,10 @@ export async function verifyAccessToken(
     const { payload } = await jwtVerify(token, secret, {
       algorithms: ["HS256"],
     });
-    return payload as unknown as OAuthTokenPayload;
+    if (!isOAuthTokenPayload(payload)) {
+      return null;
+    }
+    return payload;
   } catch {
     return null;
   }

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { jwtVerify, SignJWT } from "jose";
 
 export type OAuthTokenPayload = {
   sub: string;
@@ -17,88 +17,49 @@ export type OAuthAuthResult = {
   statusCode?: number;
 };
 
-function getJwtSecret(): string {
+function getJwtSecret(): Uint8Array {
   const secret = process.env.OAUTH_JWT_SECRET;
   if (!secret) {
     throw new Error("OAUTH_JWT_SECRET environment variable is not set");
   }
-  return secret;
+  return new TextEncoder().encode(secret);
 }
 
-function base64UrlEncode(data: string): string {
-  return Buffer.from(data)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
-}
-
-function base64UrlDecode(data: string): string {
-  const padded = data.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = 4 - (padded.length % 4);
-  const withPadding = padding < 4 ? `${padded}${"=".repeat(padding)}` : padded;
-  return Buffer.from(withPadding, "base64").toString("utf8");
-}
-
-export function createAccessToken(payload: {
+export async function createAccessToken(payload: {
   sub: string;
   org: string;
   scope: string;
-}): string {
+}): Promise<string> {
   const secret = getJwtSecret();
-  const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const now = Math.floor(Date.now() / 1000);
-  const claims: OAuthTokenPayload = {
+  return await new SignJWT({
     sub: payload.sub,
     org: payload.org,
     scope: payload.scope,
-    iat: now,
-    exp: now + 3600, // 1 hour
-  };
-  const body = base64UrlEncode(JSON.stringify(claims));
-  const signingInput = `${header}.${body}`;
-  const signature = createHmac("sha256", secret)
-    .update(signingInput)
-    .digest("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
-  return `${signingInput}.${signature}`;
+  })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600) // 1 hour
+    .sign(secret);
 }
 
-export function verifyAccessToken(token: string): OAuthTokenPayload | null {
+export async function verifyAccessToken(
+  token: string
+): Promise<OAuthTokenPayload | null> {
   try {
     const secret = getJwtSecret();
-    const parts = token.split(".");
-    if (parts.length !== 3) {
-      return null;
-    }
-    const [header, body, signature] = parts;
-    const signingInput = `${header}.${body}`;
-    const expectedSignature = createHmac("sha256", secret)
-      .update(signingInput)
-      .digest("base64")
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=/g, "");
-
-    if (signature !== expectedSignature) {
-      return null;
-    }
-
-    const payload = JSON.parse(base64UrlDecode(body)) as OAuthTokenPayload;
-    const now = Math.floor(Date.now() / 1000);
-    if (payload.exp < now) {
-      return null;
-    }
-
-    return payload;
+    const { payload } = await jwtVerify(token, secret, {
+      algorithms: ["HS256"],
+    });
+    return payload as unknown as OAuthTokenPayload;
   } catch {
     return null;
   }
 }
 
-export function authenticateOAuthToken(request: Request): OAuthAuthResult {
+export async function authenticateOAuthToken(
+  request: Request
+): Promise<OAuthAuthResult> {
   const authHeader = request.headers.get("Authorization");
   if (!authHeader) {
     return {
@@ -127,7 +88,7 @@ export function authenticateOAuthToken(request: Request): OAuthAuthResult {
     };
   }
 
-  const payload = verifyAccessToken(token);
+  const payload = await verifyAccessToken(token);
   if (!payload) {
     return {
       authenticated: false,

--- a/lib/mcp/session-token.ts
+++ b/lib/mcp/session-token.ts
@@ -78,8 +78,8 @@ export async function verifySessionToken(
 export async function verifySessionTokenDetailed(
   token: string
 ): Promise<VerifyResult> {
-  const secret = getSessionSecret();
   try {
+    const secret = getSessionSecret();
     const { payload } = await jwtVerify(token, secret, {
       algorithms: ["HS256"],
       clockTolerance: MAX_RENEWAL_GRACE_SECONDS,

--- a/lib/mcp/session-token.ts
+++ b/lib/mcp/session-token.ts
@@ -82,6 +82,21 @@ export async function verifySessionToken(
   return result.payload;
 }
 
+function isSessionPayload(value: unknown): value is SessionPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const p = value as Record<string, unknown>;
+  return (
+    typeof p.org === "string" &&
+    typeof p.key === "string" &&
+    typeof p.iat === "number" &&
+    typeof p.exp === "number" &&
+    (p.scope === undefined || typeof p.scope === "string") &&
+    (p.original_iat === undefined || typeof p.original_iat === "number")
+  );
+}
+
 export async function verifySessionTokenDetailed(
   token: string
 ): Promise<VerifyResult> {
@@ -96,7 +111,10 @@ export async function verifySessionTokenDetailed(
       clockTolerance: MAX_RENEWAL_GRACE_SECONDS,
     });
 
-    const claims = payload as unknown as SessionPayload;
+    if (!isSessionPayload(payload)) {
+      return { payload: null, expired: false, reason: "malformed" };
+    }
+    const claims = payload;
     const now = Math.floor(Date.now() / 1000);
     const sessionOrigin = claims.original_iat ?? claims.iat;
     if (now - sessionOrigin > MAX_SESSION_LIFETIME_SECONDS) {

--- a/lib/mcp/session-token.ts
+++ b/lib/mcp/session-token.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { errors, jwtVerify, SignJWT } from "jose";
 
 export type SessionPayload = {
   org: string;
@@ -13,7 +13,7 @@ export const SESSION_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 export const MAX_RENEWAL_GRACE_SECONDS = 48 * 60 * 60; // 48 hours
 export const MAX_SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
-function getSessionSecret(): string {
+function getSessionSecret(): Uint8Array {
   const secret =
     process.env.MCP_SESSION_SECRET ??
     process.env.OAUTH_JWT_SECRET ??
@@ -23,52 +23,25 @@ function getSessionSecret(): string {
       "No session secret configured. Set MCP_SESSION_SECRET, OAUTH_JWT_SECRET, or BETTER_AUTH_SECRET."
     );
   }
-  return secret;
+  return new TextEncoder().encode(secret);
 }
 
-function base64UrlEncode(data: string): string {
-  return Buffer.from(data)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
-}
-
-function base64UrlDecode(data: string): string {
-  const padded = data.replace(/-/g, "+").replace(/_/g, "/");
-  const remainder = padded.length % 4;
-  const withPadding =
-    remainder > 0 ? `${padded}${"=".repeat(4 - remainder)}` : padded;
-  return Buffer.from(withPadding, "base64").toString("utf8");
-}
-
-function hmacSign(secret: string, signingInput: string): string {
-  return createHmac("sha256", secret)
-    .update(signingInput)
-    .digest("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
-}
-
-export function createSessionToken(
+export async function createSessionToken(
   payload: Omit<SessionPayload, "iat" | "exp">
-): string {
+): Promise<string> {
   const secret = getSessionSecret();
-  const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const now = Math.floor(Date.now() / 1000);
-  const claims: SessionPayload = {
+  const originalIat = payload.original_iat ?? now;
+  return await new SignJWT({
     org: payload.org,
     key: payload.key,
     scope: payload.scope,
-    iat: now,
-    exp: now + SESSION_TTL_SECONDS,
-    original_iat: payload.original_iat ?? now,
-  };
-  const body = base64UrlEncode(JSON.stringify(claims));
-  const signingInput = `${header}.${body}`;
-  const signature = hmacSign(secret, signingInput);
-  return `${signingInput}.${signature}`;
+    original_iat: originalIat,
+  })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt(now)
+    .setExpirationTime(now + SESSION_TTL_SECONDS)
+    .sign(secret);
 }
 
 export type VerifyOptions = {
@@ -88,11 +61,11 @@ export type VerifyResult =
         | "max_lifetime_exceeded";
     };
 
-export function verifySessionToken(
+export async function verifySessionToken(
   token: string,
   options?: VerifyOptions
-): SessionPayload | null {
-  const result = verifySessionTokenDetailed(token);
+): Promise<SessionPayload | null> {
+  const result = await verifySessionTokenDetailed(token);
   if (!result.payload) {
     return null;
   }
@@ -102,38 +75,34 @@ export function verifySessionToken(
   return result.payload;
 }
 
-export function verifySessionTokenDetailed(token: string): VerifyResult {
+export async function verifySessionTokenDetailed(
+  token: string
+): Promise<VerifyResult> {
+  const secret = getSessionSecret();
   try {
-    const secret = getSessionSecret();
-    const parts = token.split(".");
-    if (parts.length !== 3) {
-      return { payload: null, expired: false, reason: "malformed" };
-    }
-    const [header, body, signature] = parts;
-    const signingInput = `${header}.${body}`;
-    const expectedSignature = hmacSign(secret, signingInput);
+    const { payload } = await jwtVerify(token, secret, {
+      algorithms: ["HS256"],
+      clockTolerance: MAX_RENEWAL_GRACE_SECONDS,
+    });
 
-    if (signature !== expectedSignature) {
-      return { payload: null, expired: false, reason: "invalid_signature" };
-    }
-
-    const payload = JSON.parse(base64UrlDecode(body)) as SessionPayload;
+    const claims = payload as unknown as SessionPayload;
     const now = Math.floor(Date.now() / 1000);
-
-    const sessionOrigin = payload.original_iat ?? payload.iat;
+    const sessionOrigin = claims.original_iat ?? claims.iat;
     if (now - sessionOrigin > MAX_SESSION_LIFETIME_SECONDS) {
       return { payload: null, expired: false, reason: "max_lifetime_exceeded" };
     }
 
-    if (payload.exp < now) {
-      if (now - payload.exp > MAX_RENEWAL_GRACE_SECONDS) {
-        return { payload: null, expired: false, reason: "too_old" };
-      }
-      return { payload, expired: true };
+    if (claims.exp < now) {
+      return { payload: claims, expired: true };
     }
-
-    return { payload, expired: false };
-  } catch {
+    return { payload: claims, expired: false };
+  } catch (err) {
+    if (err instanceof errors.JWTExpired) {
+      return { payload: null, expired: false, reason: "too_old" };
+    }
+    if (err instanceof errors.JWSSignatureVerificationFailed) {
+      return { payload: null, expired: false, reason: "invalid_signature" };
+    }
     return { payload: null, expired: false, reason: "malformed" };
   }
 }

--- a/lib/mcp/session-token.ts
+++ b/lib/mcp/session-token.ts
@@ -13,6 +13,8 @@ export const SESSION_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 export const MAX_RENEWAL_GRACE_SECONDS = 48 * 60 * 60; // 48 hours
 export const MAX_SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
+let cachedSessionSecret: { raw: string; encoded: Uint8Array } | null = null;
+
 function getSessionSecret(): Uint8Array {
   const secret =
     process.env.MCP_SESSION_SECRET ??
@@ -23,7 +25,12 @@ function getSessionSecret(): Uint8Array {
       "No session secret configured. Set MCP_SESSION_SECRET, OAUTH_JWT_SECRET, or BETTER_AUTH_SECRET."
     );
   }
-  return new TextEncoder().encode(secret);
+  if (cachedSessionSecret?.raw === secret) {
+    return cachedSessionSecret.encoded;
+  }
+  const encoded = new TextEncoder().encode(secret);
+  cachedSessionSecret = { raw: secret, encoded };
+  return encoded;
 }
 
 export async function createSessionToken(

--- a/lib/mcp/session-token.ts
+++ b/lib/mcp/session-token.ts
@@ -80,6 +80,10 @@ export async function verifySessionTokenDetailed(
 ): Promise<VerifyResult> {
   try {
     const secret = getSessionSecret();
+    // clockTolerance here is intentionally the 48h renewal grace, not the
+    // usual few seconds of clock skew. Tokens past `exp` but within the
+    // grace window must still verify so the slow path in app/mcp/route.ts
+    // can reconstruct the session and mint a renewed token.
     const { payload } = await jwtVerify(token, secret, {
       algorithms: ["HS256"],
       clockTolerance: MAX_RENEWAL_GRACE_SECONDS,
@@ -97,6 +101,11 @@ export async function verifySessionTokenDetailed(
     }
     return { payload: claims, expired: false };
   } catch (err) {
+    // Note on reason priority: a token that is both past the 48h grace AND
+    // past the 30d absolute lifetime will surface here as too_old (jose's
+    // JWTExpired fires before our manual max_lifetime_exceeded check can
+    // run). app/mcp/route.ts treats both reasons identically via
+    // isExpiredBeyondRenewal, so there's no HTTP-level drift.
     if (err instanceof errors.JWTExpired) {
       return { payload: null, expired: false, reason: "too_old" };
     }

--- a/lib/middleware/auth-helpers.ts
+++ b/lib/middleware/auth-helpers.ts
@@ -16,10 +16,10 @@ export type DualAuthContext =
  * These tokens are issued by the MCP OAuth flow and forwarded
  * by the MCP server when calling downstream API endpoints.
  */
-function resolveOAuthToken(
+async function resolveOAuthToken(
   request: Request
-): { userId: string | null; organizationId: string | null } | null {
-  const result = authenticateOAuthToken(request);
+): Promise<{ userId: string | null; organizationId: string | null } | null> {
+  const result = await authenticateOAuthToken(request);
   if (!result.authenticated) {
     return null;
   }
@@ -43,7 +43,7 @@ export async function getDualAuthContext(
 ): Promise<DualAuthContext> {
   const required = options?.required ?? true;
 
-  const oauthAuth = resolveOAuthToken(request);
+  const oauthAuth = await resolveOAuthToken(request);
   if (oauthAuth) {
     return {
       ...oauthAuth,
@@ -90,7 +90,7 @@ function resolveApiKeyContext(apiKeyAuth: {
 export async function resolveOrganizationId(
   request: Request
 ): Promise<{ organizationId: string } | { error: string; status: number }> {
-  const oauthAuth = resolveOAuthToken(request);
+  const oauthAuth = await resolveOAuthToken(request);
   if (oauthAuth?.organizationId) {
     return { organizationId: oauthAuth.organizationId };
   }
@@ -127,7 +127,7 @@ export async function resolveCreatorContext(
 ): Promise<
   { organizationId: string; userId: string } | { error: string; status: number }
 > {
-  const oauthAuth = resolveOAuthToken(request);
+  const oauthAuth = await resolveOAuthToken(request);
   if (oauthAuth) {
     return validateCreatorFields(oauthAuth.organizationId, oauthAuth.userId);
   }

--- a/tests/unit/dual-auth-context.test.ts
+++ b/tests/unit/dual-auth-context.test.ts
@@ -43,12 +43,12 @@ function makeRequest(headers: Record<string, string> = {}): Request {
 describe("getDualAuthContext", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAuthenticateOAuthToken.mockReturnValue({ authenticated: false });
+    mockAuthenticateOAuthToken.mockResolvedValue({ authenticated: false });
   });
 
   describe("OAuth authentication", () => {
     it("returns userId and organizationId from OAuth token", async () => {
-      mockAuthenticateOAuthToken.mockReturnValue({
+      mockAuthenticateOAuthToken.mockResolvedValue({
         authenticated: true,
         userId: "user_oauth",
         organizationId: "org_oauth",
@@ -188,7 +188,7 @@ describe("getDualAuthContext", () => {
 
   describe("auth priority", () => {
     it("prefers OAuth over API key and session", async () => {
-      mockAuthenticateOAuthToken.mockReturnValue({
+      mockAuthenticateOAuthToken.mockResolvedValue({
         authenticated: true,
         userId: "user_oauth",
         organizationId: "org_oauth",

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -564,13 +564,12 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
       }),
     });
     // Default: completion wait times out so we fall back to running response.
-    mockBuildCallCompletionResponse.mockImplementation(
-      (executionId: string) =>
-        Promise.resolve({ executionId, status: "running" })
+    mockBuildCallCompletionResponse.mockImplementation((executionId: string) =>
+      Promise.resolve({ executionId, status: "running" })
     );
     // Default: caller is authenticated. The write workflow path requires
     // an API key or MCP OAuth token, same as the free read path.
-    mockAuthenticateOAuthToken.mockReturnValue({
+    mockAuthenticateOAuthToken.mockResolvedValue({
       authenticated: true,
       organizationId: "caller-org-1",
       userId: "caller-user-1",

--- a/tests/unit/mcp-session-longevity.test.ts
+++ b/tests/unit/mcp-session-longevity.test.ts
@@ -277,6 +277,26 @@ describe("verifySessionTokenDetailed rejects alg:none attack", () => {
   });
 });
 
+describe("verifySessionTokenDetailed rejects malformed payloads", () => {
+  it("returns malformed when org claim is the wrong type", async () => {
+    const token = await createTokenWithOverrides({ org: 42 });
+    const result = await verifySessionTokenDetailed(token);
+    expect(result.payload).toBeNull();
+    if (!result.payload) {
+      expect(result.reason).toBe("malformed");
+    }
+  });
+
+  it("returns malformed when a required claim is missing", async () => {
+    const token = await createTokenWithOverrides({ key: null });
+    const result = await verifySessionTokenDetailed(token);
+    expect(result.payload).toBeNull();
+    if (!result.payload) {
+      expect(result.reason).toBe("malformed");
+    }
+  });
+});
+
 describe("verifySessionTokenDetailed handles config errors", () => {
   it("returns malformed when no session secret is configured", async () => {
     delete process.env.MCP_SESSION_SECRET;

--- a/tests/unit/mcp-session-longevity.test.ts
+++ b/tests/unit/mcp-session-longevity.test.ts
@@ -191,6 +191,20 @@ describe("verifySessionToken rejects invalid signature", () => {
   });
 });
 
+describe("verifySessionTokenDetailed handles config errors", () => {
+  it("returns malformed when no session secret is configured", async () => {
+    delete process.env.MCP_SESSION_SECRET;
+    delete process.env.OAUTH_JWT_SECRET;
+    delete process.env.BETTER_AUTH_SECRET;
+
+    const result = await verifySessionTokenDetailed("any.token.here");
+    expect(result.payload).toBeNull();
+    if (!result.payload) {
+      expect(result.reason).toBe("malformed");
+    }
+  });
+});
+
 describe("absolute max session lifetime", () => {
   it("MAX_SESSION_LIFETIME_SECONDS is 2592000 (30 days)", () => {
     expect(MAX_SESSION_LIFETIME_SECONDS).toBe(2_592_000);

--- a/tests/unit/mcp-session-longevity.test.ts
+++ b/tests/unit/mcp-session-longevity.test.ts
@@ -203,7 +203,7 @@ describe("verifySessionTokenDetailed wire compatibility", () => {
     payload: Record<string, unknown>,
     secret: string
   ): string {
-      const b64url = (s: string): string =>
+    const b64url = (s: string): string =>
       Buffer.from(s)
         .toString("base64")
         .replace(/\+/g, "-")

--- a/tests/unit/mcp-session-longevity.test.ts
+++ b/tests/unit/mcp-session-longevity.test.ts
@@ -16,7 +16,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // biome-ignore lint/performance/noDelete: delete is required to remove env vars (undefined assignment coerces to string)
   delete process.env.MCP_SESSION_SECRET;
 });
 
@@ -31,14 +30,14 @@ describe("TTL constants", () => {
 });
 
 describe("createSessionToken produces 24-hour expiry", () => {
-  it("sets exp = iat + 86400", () => {
-    const token = createSessionToken({
+  it("sets exp = iat + 86400", async () => {
+    const token = await createSessionToken({
       org: "org-1",
       key: "key-1",
       scope: "read",
     });
 
-    const result = verifySessionTokenDetailed(token);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.payload).not.toBeNull();
     if (!result.payload) {
       return;
@@ -53,8 +52,10 @@ describe("createSessionToken produces 24-hour expiry", () => {
  * Creates a token then re-signs it with modified claims.
  * `overrides` is merged into the decoded JWT body before re-signing.
  */
-function createTokenWithOverrides(overrides: Record<string, unknown>): string {
-  const token = createSessionToken({
+async function createTokenWithOverrides(
+  overrides: Record<string, unknown>
+): Promise<string> {
+  const token = await createSessionToken({
     org: "org-1",
     key: "key-1",
     scope: "read",
@@ -95,30 +96,30 @@ function createTokenWithOverrides(overrides: Record<string, unknown>): string {
   return `${signingInput}.${signature}`;
 }
 
-function createTokenExpiredAgo(hoursAgo: number): string {
-  return createTokenWithOverrides({
+async function createTokenExpiredAgo(hoursAgo: number): Promise<string> {
+  return await createTokenWithOverrides({
     exp: Math.floor(Date.now() / 1000) - hoursAgo * 60 * 60,
   });
 }
 
 describe("verifySessionToken with expired but valid signature", () => {
-  it("returns null by default for expired tokens", () => {
-    const token = createTokenExpiredAgo(25);
-    const result = verifySessionToken(token);
+  it("returns null by default for expired tokens", async () => {
+    const token = await createTokenExpiredAgo(25);
+    const result = await verifySessionToken(token);
     expect(result).toBeNull();
   });
 
-  it("returns payload with allowExpired for expired but valid signature", () => {
-    const token = createTokenExpiredAgo(25);
-    const result = verifySessionToken(token, { allowExpired: true });
+  it("returns payload with allowExpired for expired but valid signature", async () => {
+    const token = await createTokenExpiredAgo(25);
+    const result = await verifySessionToken(token, { allowExpired: true });
     expect(result).not.toBeNull();
     expect(result?.org).toBe("org-1");
     expect(result?.key).toBe("key-1");
   });
 
-  it("verifySessionTokenDetailed marks token as expired", () => {
-    const token = createTokenExpiredAgo(25);
-    const result = verifySessionTokenDetailed(token);
+  it("verifySessionTokenDetailed marks token as expired", async () => {
+    const token = await createTokenExpiredAgo(25);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.expired).toBe(true);
     expect(result.payload).not.toBeNull();
     expect(result.payload?.org).toBe("org-1");
@@ -130,50 +131,50 @@ describe("renewal grace window", () => {
     expect(MAX_RENEWAL_GRACE_SECONDS).toBe(172_800);
   });
 
-  it("accepts expired token within grace window", () => {
-    const token = createTokenExpiredAgo(47);
-    const result = verifySessionTokenDetailed(token);
+  it("accepts expired token within grace window", async () => {
+    const token = await createTokenExpiredAgo(47);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.expired).toBe(true);
     expect(result.payload).not.toBeNull();
   });
 
-  it("rejects expired token beyond grace window as too_old", () => {
-    const token = createTokenExpiredAgo(49);
-    const result = verifySessionTokenDetailed(token);
+  it("rejects expired token beyond grace window as too_old", async () => {
+    const token = await createTokenExpiredAgo(49);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.payload).toBeNull();
     if (!result.payload) {
       expect(result.reason).toBe("too_old");
     }
   });
 
-  it("verifySessionToken returns null for too_old tokens even with allowExpired", () => {
-    const token = createTokenExpiredAgo(49);
-    const result = verifySessionToken(token, { allowExpired: true });
+  it("verifySessionToken returns null for too_old tokens even with allowExpired", async () => {
+    const token = await createTokenExpiredAgo(49);
+    const result = await verifySessionToken(token, { allowExpired: true });
     expect(result).toBeNull();
   });
 });
 
 describe("verifySessionToken rejects invalid signature", () => {
-  it("returns null for tampered tokens", () => {
-    const token = createSessionToken({
+  it("returns null for tampered tokens", async () => {
+    const token = await createSessionToken({
       org: "org-1",
       key: "key-1",
     });
 
     // Tamper with the signature
     const tampered = `${token.slice(0, -4)}XXXX`;
-    const result = verifySessionToken(tampered, { allowExpired: true });
+    const result = await verifySessionToken(tampered, { allowExpired: true });
     expect(result).toBeNull();
   });
 
-  it("verifySessionTokenDetailed returns invalid_signature reason", () => {
-    const token = createSessionToken({
+  it("verifySessionTokenDetailed returns invalid_signature reason", async () => {
+    const token = await createSessionToken({
       org: "org-1",
       key: "key-1",
     });
 
     const tampered = `${token.slice(0, -4)}XXXX`;
-    const result = verifySessionTokenDetailed(tampered);
+    const result = await verifySessionTokenDetailed(tampered);
     expect(result.payload).toBeNull();
     expect(result.expired).toBe(false);
     if (!result.payload) {
@@ -181,8 +182,8 @@ describe("verifySessionToken rejects invalid signature", () => {
     }
   });
 
-  it("returns malformed for garbage input", () => {
-    const result = verifySessionTokenDetailed("not-a-jwt");
+  it("returns malformed for garbage input", async () => {
+    const result = await verifySessionTokenDetailed("not-a-jwt");
     expect(result.payload).toBeNull();
     if (!result.payload) {
       expect(result.reason).toBe("malformed");
@@ -195,50 +196,50 @@ describe("absolute max session lifetime", () => {
     expect(MAX_SESSION_LIFETIME_SECONDS).toBe(2_592_000);
   });
 
-  it("accepts token with original_iat within 30 days", () => {
+  it("accepts token with original_iat within 30 days", async () => {
     const twentyNineDaysAgo = Math.floor(Date.now() / 1000) - 29 * 24 * 60 * 60;
-    const token = createTokenWithOverrides({
+    const token = await createTokenWithOverrides({
       original_iat: twentyNineDaysAgo,
     });
-    const result = verifySessionTokenDetailed(token);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.payload).not.toBeNull();
     expect(result.expired).toBe(false);
   });
 
-  it("rejects token with original_iat beyond 30 days", () => {
+  it("rejects token with original_iat beyond 30 days", async () => {
     const thirtyOneDaysAgo = Math.floor(Date.now() / 1000) - 31 * 24 * 60 * 60;
-    const token = createTokenWithOverrides({
+    const token = await createTokenWithOverrides({
       original_iat: thirtyOneDaysAgo,
     });
-    const result = verifySessionTokenDetailed(token);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.payload).toBeNull();
     if (!result.payload) {
       expect(result.reason).toBe("max_lifetime_exceeded");
     }
   });
 
-  it("falls back to iat when original_iat is absent", () => {
+  it("falls back to iat when original_iat is absent", async () => {
     const thirtyOneDaysAgo = Math.floor(Date.now() / 1000) - 31 * 24 * 60 * 60;
-    const token = createTokenWithOverrides({
+    const token = await createTokenWithOverrides({
       iat: thirtyOneDaysAgo,
       exp: Math.floor(Date.now() / 1000) + 3600,
       original_iat: null,
     });
-    const result = verifySessionTokenDetailed(token);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.payload).toBeNull();
     if (!result.payload) {
       expect(result.reason).toBe("max_lifetime_exceeded");
     }
   });
 
-  it("propagates original_iat through createSessionToken", () => {
+  it("propagates original_iat through createSessionToken", async () => {
     const originalIat = Math.floor(Date.now() / 1000) - 86_400;
-    const token = createSessionToken({
+    const token = await createSessionToken({
       org: "org-1",
       key: "key-1",
       original_iat: originalIat,
     });
-    const result = verifySessionTokenDetailed(token);
+    const result = await verifySessionTokenDetailed(token);
     expect(result.payload).not.toBeNull();
     if (result.payload) {
       expect(result.payload.original_iat).toBe(originalIat);

--- a/tests/unit/mcp-session-longevity.test.ts
+++ b/tests/unit/mcp-session-longevity.test.ts
@@ -191,6 +191,92 @@ describe("verifySessionToken rejects invalid signature", () => {
   });
 });
 
+describe("verifySessionTokenDetailed wire compatibility", () => {
+  /**
+   * Builds a token exactly the way the pre-jose implementation did:
+   * hand-rolled base64url + HMAC-SHA256, header literal `{"alg":"HS256","typ":"JWT"}`
+   * with that key order. If this ever fails, it means in-flight tokens
+   * minted by a previous deploy would stop verifying after this one, and
+   * a rollback would stop verifying tokens minted under the current one.
+   */
+  function oldStyleToken(
+    payload: Record<string, unknown>,
+    secret: string
+  ): string {
+    const { createHmac } = require("node:crypto") as typeof import("node:crypto");
+    const b64url = (s: string): string =>
+      Buffer.from(s)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+    const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const body = b64url(JSON.stringify(payload));
+    const signingInput = `${header}.${body}`;
+    const signature = createHmac("sha256", secret)
+      .update(signingInput)
+      .digest("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+    return `${signingInput}.${signature}`;
+  }
+
+  it("verifies tokens produced by the pre-jose hand-rolled signer", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = oldStyleToken(
+      {
+        org: "org-legacy",
+        key: "key-legacy",
+        scope: "read",
+        iat: now,
+        exp: now + 3600,
+        original_iat: now,
+      },
+      TEST_SECRET
+    );
+
+    const result = await verifySessionTokenDetailed(token);
+    expect(result.payload).not.toBeNull();
+    if (result.payload) {
+      expect(result.payload.org).toBe("org-legacy");
+      expect(result.payload.key).toBe("key-legacy");
+      expect(result.expired).toBe(false);
+    }
+  });
+});
+
+describe("verifySessionTokenDetailed rejects alg:none attack", () => {
+  it('treats a token with alg:"none" as malformed or invalid_signature', async () => {
+    const b64url = (s: string): string =>
+      Buffer.from(s)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+    const now = Math.floor(Date.now() / 1000);
+    const header = b64url(JSON.stringify({ alg: "none", typ: "JWT" }));
+    const body = b64url(
+      JSON.stringify({
+        org: "org-attack",
+        key: "key-attack",
+        iat: now,
+        exp: now + 3600,
+      })
+    );
+    const unsignedToken = `${header}.${body}.`;
+
+    const result = await verifySessionTokenDetailed(unsignedToken);
+    expect(result.payload).toBeNull();
+    if (!result.payload) {
+      // jose rejects wrong-alg tokens with JOSEAlgNotAllowed, which maps to
+      // malformed in our catch. invalid_signature is acceptable too if the
+      // mapping ever changes -- what matters is the token is rejected.
+      expect(["malformed", "invalid_signature"]).toContain(result.reason);
+    }
+  });
+});
+
 describe("verifySessionTokenDetailed handles config errors", () => {
   it("returns malformed when no session secret is configured", async () => {
     delete process.env.MCP_SESSION_SECRET;

--- a/tests/unit/mcp-session-longevity.test.ts
+++ b/tests/unit/mcp-session-longevity.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createSessionToken,
@@ -84,7 +85,6 @@ async function createTokenWithOverrides(
     .replace(/\//g, "_")
     .replace(/=/g, "");
 
-  const { createHmac } = require("node:crypto") as typeof import("node:crypto");
   const signingInput = `${header}.${newBody}`;
   const signature = createHmac("sha256", TEST_SECRET)
     .update(signingInput)
@@ -203,8 +203,7 @@ describe("verifySessionTokenDetailed wire compatibility", () => {
     payload: Record<string, unknown>,
     secret: string
   ): string {
-    const { createHmac } = require("node:crypto") as typeof import("node:crypto");
-    const b64url = (s: string): string =>
+      const b64url = (s: string): string =>
       Buffer.from(s)
         .toString("base64")
         .replace(/\+/g, "-")

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -231,9 +231,8 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     mockResolveCreatorWallet.mockResolvedValue(CREATOR_WALLET);
     // Default: simulate timeout so we fall back to running response. Tests
     // exercising the synchronous completion path override this explicitly.
-    mockBuildCallCompletionResponse.mockImplementation(
-      (executionId: string) =>
-        Promise.resolve({ executionId, status: "running" })
+    mockBuildCallCompletionResponse.mockImplementation((executionId: string) =>
+      Promise.resolve({ executionId, status: "running" })
     );
     // Default no-op update chain: db.update(table).set(values).where(filter)
     mockDbUpdate.mockReturnValue({
@@ -243,7 +242,7 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     });
     // Default: caller is authenticated. Tests that exercise the unauthenticated
     // path must explicitly override these to return { authenticated: false }.
-    mockAuthenticateOAuthToken.mockReturnValue({
+    mockAuthenticateOAuthToken.mockResolvedValue({
       authenticated: true,
       organizationId: "caller-org-1",
       userId: "caller-user-1",
@@ -272,7 +271,7 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
   });
 
   function setUnauthenticated(): void {
-    mockAuthenticateOAuthToken.mockReturnValue({ authenticated: false });
+    mockAuthenticateOAuthToken.mockResolvedValue({ authenticated: false });
     mockAuthenticateApiKey.mockResolvedValue({ authenticated: false });
   }
 


### PR DESCRIPTION
## Summary

Replace hand-rolled JWT implementations in `lib/mcp/oauth-auth.ts` and `lib/mcp/session-token.ts` with the `jose` library, eliminating a timing side-channel on signature comparison.

Both files compared HMAC signatures with string `!==` (oauth-auth.ts:85, session-token.ts:116), which is a textbook timing attack vector. jose uses constant-time comparison internally and pins the algorithm to HS256.

## What changed

- **Crypto**: swapped `~300` lines of hand-rolled `createHmac` + base64url code for `jose.SignJWT` / `jose.jwtVerify`.
- **Session token envelope preserved**: 24h TTL, 48h renewal grace, 30d absolute lifetime cap. Grace window is now expressed via jose's `clockTolerance` option; the `max_lifetime_exceeded` check (custom `original_iat` claim) stays manual since jose has no concept of it. `VerifyResult.reason` strings are unchanged.
- **Wire compatibility**: protected header remains `{"alg":"HS256","typ":"JWT"}` so tokens in flight at deploy verify correctly, and a rollback is signature-safe.
- **API surface**: `createAccessToken`, `verifyAccessToken`, `authenticateOAuthToken`, `createSessionToken`, `verifySessionToken`, `verifySessionTokenDetailed` are now async (jose uses Web Crypto). Callers in `app/mcp/route.ts`, `lib/middleware/auth-helpers.ts`, `app/api/oauth/token/route.ts`, and `app/api/execute/_lib/auth.ts` updated with `await`. Mock-based tests switch `mockReturnValue` to `mockResolvedValue` for the OAuth authenticator.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm check` reports zero diagnostics in touched files
- [x] `pnpm vitest run tests/unit` — 134 files, 2707 tests pass
- [x] Targeted tests: `mcp-session-longevity`, `dual-auth-context`, `mcp-meta-tools`, `x402-call-route` — 75 tests pass
- [ ] Manual smoke test on staging: MCP session reconnect across pod restart still renews within the 24h/48h window
- [ ] Confirm existing OAuth tokens minted by current staging verify after deploy (wire-compat check)