### PR TITLE
fix: KEEP-314 add safe-fetch SSRF block for code and webhook plugins

### DIFF
--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -1,9 +1,10 @@
 import "server-only";
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { lookup as dnsLookup } from "node:dns";
-import { BlockList, isIP, type LookupFunction } from "node:net";
-import { Agent, fetch as undiciFetch } from "undici";
-import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import { BlockList, isIP } from "node:net";
+import { Agent, buildConnector, fetch as undiciFetch } from "undici";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 
 export type SsrfBlockReason =
@@ -189,6 +190,19 @@ type BlockContext = {
   plugin?: string;
 };
 
+/**
+ * Carries the calling plugin label across the async boundary into the
+ * module-level Agent's lookup callback, where the original `safeFetch`
+ * closure is out of scope. Without this, DNS-path blocks record
+ * plugin_name="unknown" — precisely the case the shadow-mode soak needs
+ * to attribute.
+ */
+const pluginContext = new AsyncLocalStorage<{ plugin?: string }>();
+
+function currentPlugin(): string | undefined {
+  return pluginContext.getStore()?.plugin;
+}
+
 function recordBlock(ctx: BlockContext, shadow: boolean): void {
   const metrics = getMetricsCollector();
   metrics.incrementCounter("safe_fetch.blocks.total", {
@@ -209,21 +223,13 @@ function recordBlock(ctx: BlockContext, shadow: boolean): void {
     payload.plugin_name = ctx.plugin;
   }
 
-  if (shadow) {
-    logSystemError(
-      ErrorCategory.INFRASTRUCTURE,
-      "[safe-fetch] Would block (shadow mode)",
-      new Error(`safe-fetch shadow: ${ctx.reason}`),
-      payload
-    );
-  } else {
-    logUserError(
-      ErrorCategory.VALIDATION,
-      "[safe-fetch] Blocked outbound request",
-      new Error(`safe-fetch block: ${ctx.reason}`),
-      payload
-    );
-  }
+  const suffix = shadow ? " (shadow mode)" : "";
+  logUserError(
+    ErrorCategory.VALIDATION,
+    `[safe-fetch] Blocked outbound request${suffix}`,
+    new Error(`safe-fetch block: ${ctx.reason}`),
+    payload
+  );
 }
 
 function blockedMessage(ctx: BlockContext): string {
@@ -249,54 +255,73 @@ function extractUrlString(input: RequestInfo | URL): string {
 }
 
 /**
- * Validating DNS lookup. Undici's Agent invokes this per connection, including
- * redirect hops. The socket connects using the exact IP returned here, closing
- * the TOCTOU window between DNS resolution and the TCP handshake.
+ * Custom undici connector that resolves DNS, validates the resolved IP, and
+ * only then hands off to the default TCP/TLS connector. Invoked per TCP
+ * connection including redirect hops, so validation fires every time.
+ *
+ * The base connector is given the already-resolved IP as `hostname`, so it
+ * does not perform a second DNS lookup — this closes the TOCTOU window
+ * between our check and the socket handshake.
  */
-const validatingLookup: LookupFunction = (hostname, options, callback) => {
-  dnsLookup(hostname, options, (err, address, family) => {
+type ConnectOptions = Parameters<ReturnType<typeof buildConnector>>[0];
+type ConnectCallback = Parameters<ReturnType<typeof buildConnector>>[1];
+
+const baseConnector = buildConnector({});
+
+function validatingConnect(
+  options: ConnectOptions,
+  callback: ConnectCallback
+): void {
+  const { hostname } = options;
+
+  // IP literals are caught at the URL-entry check in `safeFetch` already,
+  // so `hostname` here is expected to be a domain name. Still, resolve it
+  // and re-check defensively — covers any code path that might feed an IP
+  // through the connector directly.
+  dnsLookup(hostname, { family: 0 }, (err, address) => {
     if (err) {
-      callback(err, "", 0);
+      callback(err as Error, null);
       return;
     }
     const resolved = String(address);
-    const resolvedFamily = family ?? isIP(resolved);
     const check = isBlockedIp(resolved);
-    if (!check.blocked) {
-      callback(null, resolved, resolvedFamily);
-      return;
-    }
     const shadow = isShadowMode();
-    recordBlock(
-      { hostname, resolvedIp: resolved, reason: check.reason },
-      shadow
-    );
-    if (shadow) {
-      callback(null, resolved, resolvedFamily);
-      return;
+    const plugin = currentPlugin();
+
+    if (check.blocked) {
+      recordBlock(
+        { hostname, resolvedIp: resolved, reason: check.reason, plugin },
+        shadow
+      );
+      if (!shadow) {
+        callback(
+          new SsrfBlockedError({
+            hostname,
+            resolvedIp: resolved,
+            reason: check.reason,
+            message: blockedMessage({
+              hostname,
+              resolvedIp: resolved,
+              reason: check.reason,
+              plugin,
+            }),
+          }),
+          null
+        );
+        return;
+      }
     }
-    callback(
-      new SsrfBlockedError({
-        hostname,
-        resolvedIp: resolved,
-        reason: check.reason,
-        message: blockedMessage({
-          hostname,
-          resolvedIp: resolved,
-          reason: check.reason,
-        }),
-      }),
-      "",
-      0
-    );
+
+    // Hand off to the default connector with the already-resolved address.
+    baseConnector({ ...options, hostname: resolved }, callback);
   });
-};
+}
 
 /**
  * Module-level Agent. Pooling outbound sockets across requests is fine because
- * the lookup fires per connection, not per Agent.
+ * the connector fires per connection, not per Agent.
  */
-const safeAgent = new Agent({ connect: { lookup: validatingLookup } });
+const safeAgent = new Agent({ connect: validatingConnect });
 
 export type SafeFetchOptions = RequestInit & {
   /** Plugin identifier for observability (e.g. "code", "webhook"). */
@@ -379,5 +404,10 @@ export async function safeFetch(
     dispatcher: safeAgent,
   } as unknown as UndiciFetchInit;
 
-  return (await undiciFetch(rawUrl, initWithDispatcher)) as unknown as Response;
+  // Run the fetch inside the plugin-context store so the shared Agent's
+  // DNS lookup can attribute blocks to the calling plugin.
+  const response = await pluginContext.run({ plugin }, () =>
+    undiciFetch(rawUrl, initWithDispatcher)
+  );
+  return response as unknown as Response;
 }

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -1,0 +1,380 @@
+import "server-only";
+
+import { lookup as dnsLookup } from "node:dns";
+import { BlockList, isIP } from "node:net";
+import { Agent, fetch as undiciFetch } from "undici";
+import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import { getMetricsCollector } from "@/lib/metrics";
+
+export type SsrfBlockReason =
+  | "scheme"
+  | "private-ip"
+  | "loopback"
+  | "link-local"
+  | "multicast"
+  | "reserved"
+  | "ipv4-mapped-private";
+
+export class SsrfBlockedError extends Error {
+  readonly code = "SSRF_BLOCKED";
+  readonly hostname: string;
+  readonly resolvedIp?: string;
+  readonly reason: SsrfBlockReason;
+
+  constructor(params: {
+    hostname: string;
+    resolvedIp?: string;
+    reason: SsrfBlockReason;
+    message: string;
+  }) {
+    super(params.message);
+    this.name = "SsrfBlockedError";
+    this.hostname = params.hostname;
+    this.resolvedIp = params.resolvedIp;
+    this.reason = params.reason;
+  }
+}
+
+const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+
+const IPV4_MAPPED_PREFIX = "::ffff:";
+
+const IPV4_MULTICAST_REGEX = /^(22[4-9]|23\d)\./;
+
+const IPV4_MAPPED_HEX_REGEX = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
+
+/**
+ * Denylist of IP ranges that must never be reached from user-controlled fetch.
+ * IPv4 covers unspecified, private, loopback, link-local (incl. IMDS
+ * 169.254.169.254), CGNAT, documentation ranges, benchmarking, multicast,
+ * reserved, broadcast. IPv6 covers unspecified, loopback, IPv4-mapped, NAT64,
+ * discard, ULA, link-local, multicast.
+ */
+function buildBlockList(): BlockList {
+  const list = new BlockList();
+
+  list.addSubnet("0.0.0.0", 8, "ipv4");
+  list.addSubnet("10.0.0.0", 8, "ipv4");
+  list.addSubnet("100.64.0.0", 10, "ipv4");
+  list.addSubnet("127.0.0.0", 8, "ipv4");
+  list.addSubnet("169.254.0.0", 16, "ipv4");
+  list.addSubnet("172.16.0.0", 12, "ipv4");
+  list.addSubnet("192.0.0.0", 24, "ipv4");
+  list.addSubnet("192.0.2.0", 24, "ipv4");
+  list.addSubnet("192.88.99.0", 24, "ipv4");
+  list.addSubnet("192.168.0.0", 16, "ipv4");
+  list.addSubnet("198.18.0.0", 15, "ipv4");
+  list.addSubnet("198.51.100.0", 24, "ipv4");
+  list.addSubnet("203.0.113.0", 24, "ipv4");
+  list.addSubnet("224.0.0.0", 4, "ipv4");
+  list.addSubnet("240.0.0.0", 4, "ipv4");
+  list.addAddress("255.255.255.255", "ipv4");
+
+  list.addAddress("::", "ipv6");
+  list.addAddress("::1", "ipv6");
+  // Note: ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not added here.
+  // Node's BlockList treats that subnet as "all IPv4", which makes every
+  // IPv4 check return true. IPv4-mapped IPv6 addresses pointing at private
+  // IPv4 space are caught via extractMappedIpv4 below.
+  list.addSubnet("64:ff9b::", 96, "ipv6");
+  list.addSubnet("100::", 64, "ipv6");
+  list.addSubnet("fc00::", 7, "ipv6");
+  list.addSubnet("fe80::", 10, "ipv6");
+  list.addSubnet("ff00::", 8, "ipv6");
+
+  return list;
+}
+
+const BLOCK_LIST = buildBlockList();
+
+function reasonForIpv4(ip: string): SsrfBlockReason {
+  if (ip.startsWith("127.")) {
+    return "loopback";
+  }
+  if (ip.startsWith("169.254.")) {
+    return "link-local";
+  }
+  if (IPV4_MULTICAST_REGEX.test(ip)) {
+    return "multicast";
+  }
+  if (ip.startsWith("240.") || ip === "255.255.255.255") {
+    return "reserved";
+  }
+  return "private-ip";
+}
+
+function reasonForIpv6(ip: string): SsrfBlockReason {
+  const normalised = ip.toLowerCase();
+  if (normalised === "::1") {
+    return "loopback";
+  }
+  if (normalised.startsWith(IPV4_MAPPED_PREFIX)) {
+    return "ipv4-mapped-private";
+  }
+  if (normalised.startsWith("fe80:")) {
+    return "link-local";
+  }
+  if (normalised.startsWith("ff")) {
+    return "multicast";
+  }
+  return "private-ip";
+}
+
+/**
+ * Extract the embedded IPv4 from an IPv4-mapped IPv6 address. Handles both
+ * dotted-quad (`::ffff:169.254.169.254`) and hex (`::ffff:a9fe:a9fe`) forms.
+ */
+function extractMappedIpv4(ipv6: string): string | undefined {
+  const lower = ipv6.toLowerCase();
+  if (!lower.startsWith(IPV4_MAPPED_PREFIX)) {
+    return;
+  }
+  const suffix = lower.slice(IPV4_MAPPED_PREFIX.length);
+  if (isIP(suffix) === 4) {
+    return suffix;
+  }
+  const hexMatch = suffix.match(IPV4_MAPPED_HEX_REGEX);
+  if (!hexMatch) {
+    return;
+  }
+  const high = Number.parseInt(hexMatch[1] ?? "", 16);
+  const low = Number.parseInt(hexMatch[2] ?? "", 16);
+  if (!(Number.isFinite(high) && Number.isFinite(low))) {
+    return;
+  }
+  return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(
+    "."
+  );
+}
+
+/**
+ * Check an IP literal against the denylist. For IPv4-mapped IPv6 addresses,
+ * the embedded IPv4 is also matched against the IPv4 denylist so an IPv6
+ * literal cannot be used to bypass an IPv4-range check.
+ */
+export function isBlockedIp(
+  ip: string
+): { blocked: true; reason: SsrfBlockReason } | { blocked: false } {
+  const family = isIP(ip);
+  if (family === 0) {
+    return { blocked: false };
+  }
+
+  const familyKey = family === 4 ? "ipv4" : "ipv6";
+  if (BLOCK_LIST.check(ip, familyKey)) {
+    return {
+      blocked: true,
+      reason: family === 4 ? reasonForIpv4(ip) : reasonForIpv6(ip),
+    };
+  }
+
+  if (family === 6) {
+    const mapped = extractMappedIpv4(ip);
+    if (mapped && BLOCK_LIST.check(mapped, "ipv4")) {
+      return { blocked: true, reason: "ipv4-mapped-private" };
+    }
+  }
+
+  return { blocked: false };
+}
+
+export function isShadowMode(): boolean {
+  return process.env.SAFE_FETCH_ENFORCE !== "true";
+}
+
+type BlockContext = {
+  hostname: string;
+  resolvedIp?: string;
+  reason: SsrfBlockReason;
+  plugin?: string;
+};
+
+function recordBlock(ctx: BlockContext, shadow: boolean): void {
+  const metrics = getMetricsCollector();
+  metrics.incrementCounter("safe_fetch.blocks.total", {
+    reason: ctx.reason,
+    plugin_name: ctx.plugin ?? "unknown",
+    shadow: shadow ? "true" : "false",
+  });
+
+  const payload = {
+    hostname: ctx.hostname,
+    resolved_ip: ctx.resolvedIp,
+    reason: ctx.reason,
+    plugin_name: ctx.plugin,
+    shadow_mode: shadow,
+  };
+
+  if (shadow) {
+    logSystemError(
+      ErrorCategory.INFRASTRUCTURE,
+      "[safe-fetch] Would block (shadow mode)",
+      new Error(`safe-fetch shadow: ${ctx.reason}`),
+      payload
+    );
+  } else {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[safe-fetch] Blocked outbound request",
+      new Error(`safe-fetch block: ${ctx.reason}`),
+      payload
+    );
+  }
+}
+
+function blockedMessage(ctx: BlockContext): string {
+  const ipPart = ctx.resolvedIp ? ` (resolved to ${ctx.resolvedIp})` : "";
+  return `Outbound request to ${ctx.hostname}${ipPart} blocked by SSRF policy (${ctx.reason}).`;
+}
+
+function stripIpv6Brackets(hostname: string): string {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+function extractUrlString(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
+/**
+ * Validating DNS lookup. Undici's Agent invokes this per connection, including
+ * redirect hops. The socket connects using the exact IP returned here, closing
+ * the TOCTOU window between DNS resolution and the TCP handshake.
+ */
+function validatingLookup(
+  hostname: string,
+  options: Parameters<typeof dnsLookup>[1],
+  callback: Parameters<typeof dnsLookup>[2]
+): void {
+  dnsLookup(hostname, options, (err, address, family) => {
+    if (err) {
+      callback(err, "", 0);
+      return;
+    }
+    const resolved = String(address);
+    const check = isBlockedIp(resolved);
+    if (!check.blocked) {
+      callback(null, resolved, family ?? (isIP(resolved) || 0));
+      return;
+    }
+    const shadow = isShadowMode();
+    recordBlock(
+      { hostname, resolvedIp: resolved, reason: check.reason },
+      shadow
+    );
+    if (shadow) {
+      callback(null, resolved, family ?? (isIP(resolved) || 0));
+      return;
+    }
+    callback(
+      new SsrfBlockedError({
+        hostname,
+        resolvedIp: resolved,
+        reason: check.reason,
+        message: blockedMessage({
+          hostname,
+          resolvedIp: resolved,
+          reason: check.reason,
+        }),
+      }),
+      "",
+      0
+    );
+  });
+}
+
+/**
+ * Module-level Agent. Pooling outbound sockets across requests is fine because
+ * the lookup fires per connection, not per Agent.
+ */
+const safeAgent = new Agent({ connect: { lookup: validatingLookup } });
+
+export type SafeFetchOptions = RequestInit & {
+  /** Plugin identifier for observability (e.g. "code", "webhook"). */
+  plugin?: string;
+};
+
+/**
+ * Drop-in replacement for `fetch` that refuses to connect to private,
+ * loopback, link-local, or reserved addresses. Non-http(s) schemes are
+ * rejected at the entry. IP-literal URLs are validated before any network
+ * call; DNS-resolved IPs are validated via a custom undici Agent lookup on
+ * every redirect hop.
+ *
+ * Shadow mode is the default: blocks are logged and counted but the request
+ * proceeds. Set `SAFE_FETCH_ENFORCE=true` to enforce.
+ */
+export async function safeFetch(
+  input: RequestInfo | URL,
+  init?: SafeFetchOptions
+): Promise<Response> {
+  const plugin = init?.plugin;
+  const shadow = isShadowMode();
+
+  const rawUrl = extractUrlString(input);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (_err) {
+    throw new TypeError(`safe-fetch: invalid URL "${rawUrl}"`);
+  }
+
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    recordBlock(
+      { hostname: parsed.hostname, reason: "scheme", plugin },
+      shadow
+    );
+    if (!shadow) {
+      throw new SsrfBlockedError({
+        hostname: parsed.hostname,
+        reason: "scheme",
+        message: `safe-fetch: scheme "${parsed.protocol}" not allowed`,
+      });
+    }
+  }
+
+  const hostname = stripIpv6Brackets(parsed.hostname);
+  if (isIP(hostname) !== 0) {
+    const check = isBlockedIp(hostname);
+    if (check.blocked) {
+      recordBlock(
+        { hostname, resolvedIp: hostname, reason: check.reason, plugin },
+        shadow
+      );
+      if (!shadow) {
+        throw new SsrfBlockedError({
+          hostname,
+          resolvedIp: hostname,
+          reason: check.reason,
+          message: blockedMessage({
+            hostname,
+            resolvedIp: hostname,
+            reason: check.reason,
+            plugin,
+          }),
+        });
+      }
+    }
+  }
+
+  const { plugin: _omit, ...fetchInit } = init ?? {};
+
+  // undici's fetch accepts a `dispatcher` option at runtime that is not part
+  // of the DOM `RequestInit` type. Cast through `unknown` to avoid `any`
+  // while still passing the dispatcher to undici.
+  const initWithDispatcher = {
+    ...fetchInit,
+    dispatcher: safeAgent,
+  } as unknown as RequestInit;
+
+  return (await undiciFetch(rawUrl, initWithDispatcher)) as unknown as Response;
+}

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { lookup as dnsLookup } from "node:dns";
-import { BlockList, isIP } from "node:net";
+import { BlockList, isIP, type LookupFunction } from "node:net";
 import { Agent, fetch as undiciFetch } from "undici";
 import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
@@ -197,13 +197,17 @@ function recordBlock(ctx: BlockContext, shadow: boolean): void {
     shadow: shadow ? "true" : "false",
   });
 
-  const payload = {
+  const payload: Record<string, string> = {
     hostname: ctx.hostname,
-    resolved_ip: ctx.resolvedIp,
     reason: ctx.reason,
-    plugin_name: ctx.plugin,
-    shadow_mode: shadow,
+    shadow_mode: String(shadow),
   };
+  if (ctx.resolvedIp !== undefined) {
+    payload.resolved_ip = ctx.resolvedIp;
+  }
+  if (ctx.plugin !== undefined) {
+    payload.plugin_name = ctx.plugin;
+  }
 
   if (shadow) {
     logSystemError(
@@ -249,20 +253,17 @@ function extractUrlString(input: RequestInfo | URL): string {
  * redirect hops. The socket connects using the exact IP returned here, closing
  * the TOCTOU window between DNS resolution and the TCP handshake.
  */
-function validatingLookup(
-  hostname: string,
-  options: Parameters<typeof dnsLookup>[1],
-  callback: Parameters<typeof dnsLookup>[2]
-): void {
+const validatingLookup: LookupFunction = (hostname, options, callback) => {
   dnsLookup(hostname, options, (err, address, family) => {
     if (err) {
       callback(err, "", 0);
       return;
     }
     const resolved = String(address);
+    const resolvedFamily = family ?? isIP(resolved);
     const check = isBlockedIp(resolved);
     if (!check.blocked) {
-      callback(null, resolved, family ?? (isIP(resolved) || 0));
+      callback(null, resolved, resolvedFamily);
       return;
     }
     const shadow = isShadowMode();
@@ -271,7 +272,7 @@ function validatingLookup(
       shadow
     );
     if (shadow) {
-      callback(null, resolved, family ?? (isIP(resolved) || 0));
+      callback(null, resolved, resolvedFamily);
       return;
     }
     callback(
@@ -289,7 +290,7 @@ function validatingLookup(
       0
     );
   });
-}
+};
 
 /**
  * Module-level Agent. Pooling outbound sockets across requests is fine because
@@ -369,12 +370,14 @@ export async function safeFetch(
   const { plugin: _omit, ...fetchInit } = init ?? {};
 
   // undici's fetch accepts a `dispatcher` option at runtime that is not part
-  // of the DOM `RequestInit` type. Cast through `unknown` to avoid `any`
-  // while still passing the dispatcher to undici.
+  // of the DOM `RequestInit` type, and undici's own `RequestInit` differs
+  // from the DOM's on `body` nullability. Build the call args via the
+  // parameter type of the function we're calling to avoid `any`.
+  type UndiciFetchInit = Parameters<typeof undiciFetch>[1];
   const initWithDispatcher = {
     ...fetchInit,
     dispatcher: safeAgent,
-  } as unknown as RequestInit;
+  } as unknown as UndiciFetchInit;
 
   return (await undiciFetch(rawUrl, initWithDispatcher)) as unknown as Response;
 }

--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { createContext, runInContext } from "node:vm";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { safeFetch } from "@/lib/safe-fetch";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -143,9 +144,11 @@ async function stepHandler(input: RunCodeCoreInput): Promise<RunCodeResult> {
       });
     }
 
-    return fetch(resource, { ...init, signal: controller.signal }).finally(() =>
-      clearTimeout(timer)
-    );
+    return safeFetch(resource, {
+      ...init,
+      signal: controller.signal,
+      plugin: "code",
+    }).finally(() => clearTimeout(timer));
   }
 
   const sandbox = createContext({

--- a/plugins/webhook/steps/send-webhook.ts
+++ b/plugins/webhook/steps/send-webhook.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { safeFetch } from "@/lib/safe-fetch";
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -130,7 +131,10 @@ async function stepHandler(
       fetchOptions.body = JSON.stringify(payload);
     }
 
-    const response = await fetch(url, fetchOptions);
+    const response = await safeFetch(url, {
+      ...fetchOptions,
+      plugin: "webhook",
+    });
 
     let responseData: unknown;
     const contentType = response.headers.get("content-type");

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    INFRASTRUCTURE: "infrastructure",
+  },
+  logUserError: vi.fn(),
+  logSystemError: vi.fn(),
+}));
+
+const incrementCounter = vi.fn();
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter,
+    recordLatency: vi.fn(),
+    recordError: vi.fn(),
+    setGauge: vi.fn(),
+  }),
+}));
+
+import {
+  isBlockedIp,
+  SsrfBlockedError,
+  type SsrfBlockReason,
+  safeFetch,
+} from "@/lib/safe-fetch";
+
+describe("isBlockedIp", () => {
+  const blockedV4: [string, SsrfBlockReason][] = [
+    ["0.0.0.0", "private-ip"],
+    ["10.1.2.3", "private-ip"],
+    ["100.64.0.1", "private-ip"],
+    ["127.0.0.1", "loopback"],
+    ["127.255.255.254", "loopback"],
+    ["169.254.169.254", "link-local"],
+    ["172.16.0.1", "private-ip"],
+    ["172.31.255.254", "private-ip"],
+    ["192.168.0.1", "private-ip"],
+    ["192.168.255.254", "private-ip"],
+    ["198.18.0.1", "private-ip"],
+    ["224.0.0.1", "multicast"],
+    ["239.255.255.255", "multicast"],
+    ["240.0.0.1", "reserved"],
+    ["255.255.255.255", "reserved"],
+  ];
+
+  for (const [ip, reason] of blockedV4) {
+    it(`blocks IPv4 ${ip} (${reason})`, () => {
+      const result = isBlockedIp(ip);
+      expect(result.blocked).toBe(true);
+      if (result.blocked) {
+        expect(result.reason).toBe(reason);
+      }
+    });
+  }
+
+  const blockedV6: [string, SsrfBlockReason][] = [
+    ["::", "private-ip"],
+    ["::1", "loopback"],
+    ["fe80::1", "link-local"],
+    ["fc00::1", "private-ip"],
+    ["fd00::1", "private-ip"],
+    ["ff02::1", "multicast"],
+  ];
+
+  for (const [ip, reason] of blockedV6) {
+    it(`blocks IPv6 ${ip} (${reason})`, () => {
+      const result = isBlockedIp(ip);
+      expect(result.blocked).toBe(true);
+      if (result.blocked) {
+        expect(result.reason).toBe(reason);
+      }
+    });
+  }
+
+  it("blocks IPv4-mapped-IPv6 dotted form (::ffff:169.254.169.254)", () => {
+    const result = isBlockedIp("::ffff:169.254.169.254");
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.reason).toBe("ipv4-mapped-private");
+    }
+  });
+
+  it("blocks IPv4-mapped-IPv6 hex form (::ffff:a9fe:a9fe)", () => {
+    const result = isBlockedIp("::ffff:a9fe:a9fe");
+    expect(result.blocked).toBe(true);
+  });
+
+  const allowedV4 = ["8.8.8.8", "1.1.1.1", "93.184.216.34", "185.60.216.35"];
+  for (const ip of allowedV4) {
+    it(`allows public IPv4 ${ip}`, () => {
+      const result = isBlockedIp(ip);
+      expect(result.blocked).toBe(false);
+    });
+  }
+
+  const allowedV6 = ["2001:4860:4860::8888", "2606:4700:4700::1111"];
+  for (const ip of allowedV6) {
+    it(`allows public IPv6 ${ip}`, () => {
+      const result = isBlockedIp(ip);
+      expect(result.blocked).toBe(false);
+    });
+  }
+
+  it("returns not-blocked for non-IP strings", () => {
+    expect(isBlockedIp("example.com").blocked).toBe(false);
+    expect(isBlockedIp("").blocked).toBe(false);
+    expect(isBlockedIp("not-an-ip").blocked).toBe(false);
+  });
+});
+
+describe("safeFetch (enforce mode)", () => {
+  const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
+
+  beforeEach(() => {
+    process.env.SAFE_FETCH_ENFORCE = "true";
+    incrementCounter.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalEnforce === undefined) {
+      process.env.SAFE_FETCH_ENFORCE = undefined;
+      // biome-ignore lint/performance/noDelete: ensure env var is fully removed
+      delete process.env.SAFE_FETCH_ENFORCE;
+    } else {
+      process.env.SAFE_FETCH_ENFORCE = originalEnforce;
+    }
+  });
+
+  const blockedSchemes = [
+    "file:///etc/passwd",
+    "data:text/plain,hello",
+    "gopher://example.com/",
+    "ftp://example.com/",
+  ];
+
+  for (const url of blockedSchemes) {
+    it(`rejects scheme in ${url}`, async () => {
+      await expect(safeFetch(url)).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(incrementCounter).toHaveBeenCalledWith(
+        "safe_fetch.blocks.total",
+        expect.objectContaining({ reason: "scheme", shadow: "false" })
+      );
+    });
+  }
+
+  const blockedLiteralUrls = [
+    ["http://127.0.0.1/", "loopback"],
+    ["http://169.254.169.254/latest/meta-data/", "link-local"],
+    ["http://10.0.0.1/", "private-ip"],
+    ["http://192.168.1.1/", "private-ip"],
+    ["http://[::1]/", "loopback"],
+    ["http://[fe80::1]/", "link-local"],
+    ["http://[fc00::1]/", "private-ip"],
+    ["http://[::ffff:169.254.169.254]/", "ipv4-mapped-private"],
+  ];
+
+  for (const [url, reason] of blockedLiteralUrls) {
+    it(`rejects IP literal ${url} (${reason})`, async () => {
+      await expect(safeFetch(url as string)).rejects.toBeInstanceOf(
+        SsrfBlockedError
+      );
+      expect(incrementCounter).toHaveBeenCalledWith(
+        "safe_fetch.blocks.total",
+        expect.objectContaining({ reason, shadow: "false" })
+      );
+    });
+  }
+
+  it("labels plugin when provided", async () => {
+    await expect(
+      safeFetch("http://127.0.0.1/", { plugin: "code" })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+    expect(incrementCounter).toHaveBeenCalledWith(
+      "safe_fetch.blocks.total",
+      expect.objectContaining({ plugin_name: "code" })
+    );
+  });
+
+  it("throws TypeError for malformed URLs", async () => {
+    await expect(safeFetch("not a url")).rejects.toBeInstanceOf(TypeError);
+  });
+});
+
+describe("safeFetch (shadow mode)", () => {
+  const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
+
+  beforeEach(() => {
+    // biome-ignore lint/performance/noDelete: default shadow requires unset
+    delete process.env.SAFE_FETCH_ENFORCE;
+    incrementCounter.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalEnforce === undefined) {
+      // biome-ignore lint/performance/noDelete: restore unset state
+      delete process.env.SAFE_FETCH_ENFORCE;
+    } else {
+      process.env.SAFE_FETCH_ENFORCE = originalEnforce;
+    }
+  });
+
+  it("records a block with shadow=true but does not throw SsrfBlockedError on IP literal", async () => {
+    // Note: the fetch itself will still fail to connect to 127.0.0.1 in the
+    // test env (no listener). The important behaviour is that safe-fetch
+    // does not short-circuit with SsrfBlockedError.
+    try {
+      await safeFetch("http://127.0.0.1:1/");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(SsrfBlockedError);
+    }
+    expect(incrementCounter).toHaveBeenCalledWith(
+      "safe_fetch.blocks.total",
+      expect.objectContaining({ reason: "loopback", shadow: "true" })
+    );
+  });
+
+  it("records scheme block with shadow=true on non-http URL", async () => {
+    // undici will reject the scheme anyway; we just want to see the metric.
+    await safeFetch("file:///etc/passwd").catch(() => undefined);
+    expect(incrementCounter).toHaveBeenCalledWith(
+      "safe_fetch.blocks.total",
+      expect.objectContaining({ reason: "scheme", shadow: "true" })
+    );
+  });
+});

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -180,6 +180,23 @@ describe("safeFetch (enforce mode)", () => {
     );
   });
 
+  it("attributes plugin on DNS-resolved private IP (localhost)", async () => {
+    // `localhost` is not an IP literal, so it reaches the DNS path and is
+    // resolved inside the Agent's connector to 127.0.0.1 or ::1. The plugin
+    // label must propagate there via AsyncLocalStorage. Port 9999 avoids
+    // the WHATWG fetch "bad port" list (which includes port 1).
+    await expect(
+      safeFetch("http://localhost:9999/", { plugin: "webhook" })
+    ).rejects.toThrow();
+    expect(incrementCounter).toHaveBeenCalledWith(
+      "safe_fetch.blocks.total",
+      expect.objectContaining({
+        plugin_name: "webhook",
+        reason: "loopback",
+      })
+    );
+  });
+
   it("throws TypeError for malformed URLs", async () => {
     await expect(safeFetch("not a url")).rejects.toBeInstanceOf(TypeError);
   });
@@ -204,11 +221,12 @@ describe("safeFetch (shadow mode)", () => {
   });
 
   it("records a block with shadow=true but does not throw SsrfBlockedError on IP literal", async () => {
-    // Note: the fetch itself will still fail to connect to 127.0.0.1 in the
-    // test env (no listener). The important behaviour is that safe-fetch
-    // does not short-circuit with SsrfBlockedError.
+    // The fetch itself will still fail to connect to 127.0.0.1 in the test
+    // env (no listener). The important behaviour is that safe-fetch does
+    // not short-circuit with SsrfBlockedError. Port 9999 avoids the
+    // WHATWG fetch "bad port" list.
     try {
-      await safeFetch("http://127.0.0.1:1/");
+      await safeFetch("http://127.0.0.1:9999/");
     } catch (err) {
       expect(err).not.toBeInstanceOf(SsrfBlockedError);
     }


### PR DESCRIPTION
## Summary

- Add `lib/safe-fetch.ts` — drop-in `fetch` replacement that blocks scheme abuse and connections to private / loopback / link-local / reserved IPs. Denylist enforced at two layers: URL-entry for literals, and a custom undici Agent lookup for DNS-resolved IPs on every connection (including redirect hops).
- Swap the two user-reachable fetch call sites: `plugins/code/steps/run-code.ts` and `plugins/webhook/steps/send-webhook.ts`.
- 46 new unit tests covering IPv4 + IPv6 denylist matrix, IPv4-mapped IPv6 (both dotted and hex forms), scheme rejection, IP-literal rejection, shadow-mode behaviour.

Closes KEEP-314. Child of KEEP-234 (sandbox security boundary umbrella).

## Problem

`plugins/code` and `plugins/webhook` both expose `fetch` to user-controlled URLs with only URL-syntax validation:

- `plugins/code/steps/run-code.ts:146` — `sandboxedFetch` wraps host `fetch` with a timeout; the `node:vm` sandbox calls it with any URL.
- `plugins/webhook/steps/send-webhook.ts:133` — `fetch(url, fetchOptions)` after `new URL(url)`.

Both permit reaching `http://169.254.169.254/latest/meta-data/iam/security-credentials/` (EC2 IMDS), in-cluster services, and any private IP the pod can route to. If the runner Job's default ServiceAccount has IRSA, this yields AWS STS credentials without any sandbox escape.

See KEEP-234 comments for the full blast-radius analysis.

## Approach

**Two enforcement layers**:

1. URL-entry — scheme allowlist (`http:`, `https:` only), IP-literal check against the denylist (handles `[::1]`, `[fe80::1]`, `[::ffff:169.254.169.254]`).
2. Connection-time — custom `lookup` on an undici `Agent`, fires per TCP connection including redirect hops. The socket connects using the exact IP the lookup returned, closing the resolve-to-connect TOCTOU window that naive pre-resolve checks have.

**Denylist** built with Node's `net.BlockList`:

- IPv4: `0/8`, `10/8`, `100.64/10` (CGNAT), `127/8`, `169.254/16` (link-local + IMDS), `172.16/12`, `192.0.0/24`, `192.0.2/24`, `192.88.99/24`, `192.168/16`, `198.18/15`, `198.51.100/24`, `203.0.113/24`, `224/4` (multicast), `240/4` (reserved), `255.255.255.255`.
- IPv6: `::`, `::1`, `64:ff9b::/96` (NAT64), `100::/64` (discard), `fc00::/7` (ULA), `fe80::/10` (link-local), `ff00::/8` (multicast).

IPv4-mapped IPv6 is handled by a separate extraction path (both `::ffff:169.254.169.254` and hex form `::ffff:a9fe:a9fe`) rather than via the BlockList — Node's `addSubnet("::ffff:0:0", 96, "ipv6")` makes every IPv4 check return true because that subnet semantically *is* the entire IPv4 space. Comment in the file flags this for future maintainers.

## Rollout

Default is shadow mode. Blocks are logged (`logSystemError` / `logUserError`) and counted (`safe_fetch.blocks.total{reason, plugin_name, shadow}`) but the request proceeds. Set `SAFE_FETCH_ENFORCE=true` on the pod env to enforce.

Proposed deploy sequence, per the KEEP-314 description:

1. Merge this PR — shadow mode active everywhere.
2. Run 7 days in staging; review `safe_fetch.blocks.total{shadow="true"}` in Grafana for false positives.
3. Add `SAFE_FETCH_ENFORCE: kv value: "true"` to `deploy/executor/staging/values.yaml` — enforce in staging.
4. Soak 7 days in staging.
5. Add the same to `deploy/executor/prod/values.yaml` — enforce in prod.

## Out of scope

Tracked in KEEP-234 or separate tickets:

- Sandbox escape hardening — KEEP-315 (Option A, isolated-vm stopgap) depends on the `safe-fetch` module added here.
- Separate sandbox container (Option B).
- `lib/workflow-executor.workflow.ts:313` `new Function()` condition evaluator — separate surface.
- NetworkPolicy in the `keeperhub` namespace as a network-layer backstop to this application-layer check.

## Test plan

- [x] CI passes (lint, type-check, unit, integration).
- [ ] In staging with `SAFE_FETCH_ENFORCE` unset: a workflow with a code step attempting `fetch("http://169.254.169.254/latest/meta-data/")` succeeds (shadow mode) but emits a `safe_fetch.blocks.total{reason="link-local", shadow="true"}` metric and a `[safe-fetch] Would block (shadow mode)` log line.
- [ ] In staging with `SAFE_FETCH_ENFORCE=true`: the same workflow returns an `SsrfBlockedError`.
- [ ] Public URLs (CoinGecko, Etherscan) continue to work in both modes.
- [ ] Webhook plugin sending to a public receiver continues to work.
- [ ] Webhook plugin pointed at `http://10.0.0.1/` logs a block (shadow) or errors (enforce).
- [ ] Review Grafana `safe_fetch.blocks.total{shadow="true"}` after 7 days for unexpected hits from legitimate user workflows.
