### PR TITLE
fix: KEEP-319 restrict wallet private-key export to wallet creator

### DIFF
--- a/app/api/user/wallet/export-key/_lib/rate-limit.ts
+++ b/app/api/user/wallet/export-key/_lib/rate-limit.ts
@@ -39,10 +39,46 @@ function check(
   return { allowed: true };
 }
 
+// Evict entries whose most recent hit is older than the bucket window, so the
+// Map does not grow unbounded across unique user ids over time.
+function evictStale(store: Map<string, number[]>, windowMs: number): void {
+  const cutoff = Date.now() - windowMs;
+  for (const [key, timestamps] of store) {
+    const mostRecent = timestamps.at(-1);
+    if (mostRecent === undefined || mostRecent <= cutoff) {
+      store.delete(key);
+    }
+  }
+}
+
+// Sweep once every N calls rather than on a timer so tests stay deterministic
+// without fake clocks. N is large enough that the per-call amortised cost is
+// negligible, small enough that a quiet period after a spike cleans up soon.
+const SWEEP_EVERY_N_CALLS = 256;
+let requestCallsSinceSweep = 0;
+let verifyCallsSinceSweep = 0;
+
 export function checkRequestRateLimit(userId: string): RateLimitResult {
+  if (++requestCallsSinceSweep >= SWEEP_EVERY_N_CALLS) {
+    requestCallsSinceSweep = 0;
+    evictStale(requestLog, REQUEST_BUCKET.windowMs);
+  }
   return check(requestLog, REQUEST_BUCKET, userId);
 }
 
 export function checkVerifyRateLimit(userId: string): RateLimitResult {
+  if (++verifyCallsSinceSweep >= SWEEP_EVERY_N_CALLS) {
+    verifyCallsSinceSweep = 0;
+    evictStale(verifyLog, VERIFY_BUCKET.windowMs);
+  }
   return check(verifyLog, VERIFY_BUCKET, userId);
+}
+
+// Test-only helper to reset all internal state between tests. Not exported
+// from a barrel file; callers must reach in via the full module path.
+export function __resetRateLimitForTesting(): void {
+  requestLog.clear();
+  verifyLog.clear();
+  requestCallsSinceSweep = 0;
+  verifyCallsSinceSweep = 0;
 }

--- a/app/api/user/wallet/export-key/_lib/rate-limit.ts
+++ b/app/api/user/wallet/export-key/_lib/rate-limit.ts
@@ -1,0 +1,48 @@
+// Per-user in-memory rate limiter for wallet export endpoints. Per pod, so
+// the effective limit is LIMIT * num_replicas; acceptable at current replica
+// count. Redis-backed is a project-wide decision (see the same caveat on
+// app/api/execute/_lib/rate-limit.ts).
+
+type Bucket = { limit: number; windowMs: number };
+
+const REQUEST_BUCKET: Bucket = { limit: 3, windowMs: 5 * 60_000 };
+const VERIFY_BUCKET: Bucket = { limit: 10, windowMs: 5 * 60_000 };
+
+const requestLog = new Map<string, number[]>();
+const verifyLog = new Map<string, number[]>();
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfter: number };
+
+function check(
+  store: Map<string, number[]>,
+  bucket: Bucket,
+  key: string
+): RateLimitResult {
+  const now = Date.now();
+  const windowStart = now - bucket.windowMs;
+
+  const timestamps = store.get(key);
+  const recent = timestamps ? timestamps.filter((t) => t > windowStart) : [];
+
+  if (recent.length >= bucket.limit) {
+    const oldestInWindow = recent[0];
+    const retryAfter = Math.ceil(
+      (oldestInWindow + bucket.windowMs - now) / 1000
+    );
+    return { allowed: false, retryAfter: Math.max(retryAfter, 1) };
+  }
+
+  recent.push(now);
+  store.set(key, recent);
+  return { allowed: true };
+}
+
+export function checkRequestRateLimit(userId: string): RateLimitResult {
+  return check(requestLog, REQUEST_BUCKET, userId);
+}
+
+export function checkVerifyRateLimit(userId: string): RateLimitResult {
+  return check(verifyLog, VERIFY_BUCKET, userId);
+}

--- a/app/api/user/wallet/export-key/request/route.ts
+++ b/app/api/user/wallet/export-key/request/route.ts
@@ -48,13 +48,6 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    if (activeMember.role !== "admin" && activeMember.role !== "owner") {
-      return NextResponse.json(
-        { error: "Only admins and owners can export wallet keys" },
-        { status: 403 }
-      );
-    }
-
     // Verify a Turnkey wallet exists (only Turnkey wallets are exportable;
     // Para wallets during migration are inactive and not exportable here)
     const turnkeyWallets = await db

--- a/app/api/user/wallet/export-key/request/route.ts
+++ b/app/api/user/wallet/export-key/request/route.ts
@@ -8,6 +8,7 @@ import { db } from "@/lib/db";
 import { keyExportCodes, organizationWallets } from "@/lib/db/schema";
 import { sendEmail } from "@/lib/email";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
+import { checkRequestRateLimit } from "../_lib/rate-limit";
 
 const CODE_EXPIRY_MINUTES = 5;
 
@@ -45,6 +46,20 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json(
         { error: "You are not a member of the active organization" },
         { status: 403 }
+      );
+    }
+
+    const rateLimit = checkRequestRateLimit(session.user.id);
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        {
+          error: "Too many export requests. Please wait before trying again.",
+          retryAfter: rateLimit.retryAfter,
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimit.retryAfter) },
+        }
       );
     }
 

--- a/app/api/user/wallet/export-key/request/route.ts
+++ b/app/api/user/wallet/export-key/request/route.ts
@@ -58,7 +58,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     // Verify a Turnkey wallet exists (only Turnkey wallets are exportable;
     // Para wallets during migration are inactive and not exportable here)
     const turnkeyWallets = await db
-      .select({ id: organizationWallets.id })
+      .select({
+        id: organizationWallets.id,
+        userId: organizationWallets.userId,
+        email: organizationWallets.email,
+      })
       .from(organizationWallets)
       .where(
         and(
@@ -75,6 +79,18 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
+    const wallet = turnkeyWallets[0];
+
+    // Export must be initiated by the wallet creator, not just any org admin.
+    if (wallet.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: "Only the wallet creator can export its private key" },
+        { status: 403 }
+      );
+    }
+
+    const walletEmail = wallet.email;
+
     // Delete any existing codes for this org
     await db
       .delete(keyExportCodes)
@@ -90,22 +106,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       expiresAt,
     });
 
-    // Send to admin's email
-    const userEmail = session.user.email;
-    if (!userEmail) {
-      return NextResponse.json(
-        { error: "No email address on your account" },
-        { status: 400 }
-      );
-    }
-
+    // Send to the wallet's recovery email, not the requester's — any org
+    // admin may request export, but only the wallet owner should approve it.
     await sendEmail({
-      to: userEmail,
+      to: walletEmail,
       subject: "Private Key Export Verification - KeeperHub",
-      text: `Your verification code to export the wallet private key is: ${code}\n\nThis code expires in ${CODE_EXPIRY_MINUTES} minutes.\n\nIf you did not request this, please ignore this email.`,
+      text: `A request to export the wallet's private key was made from your KeeperHub organization.\n\nYour verification code is: ${code}\n\nThis code expires in ${CODE_EXPIRY_MINUTES} minutes.\n\nIf you did not request this, please ignore this email.`,
       html: `
 <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 20px;">
   <h2 style="color: #1a1a2e;">Private Key Export Verification</h2>
+  <p>A request to export the wallet's private key was made from your KeeperHub organization.</p>
   <p>Your verification code is:</p>
   <div style="text-align: center; margin: 24px 0;">
     <div style="display: inline-block; background: #f5f5f5; padding: 16px 32px; border-radius: 8px; font-size: 28px; font-weight: bold; letter-spacing: 6px; font-family: monospace; color: #1a1a2e;">${code}</div>
@@ -114,7 +124,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 </div>`.trim(),
     });
 
-    return NextResponse.json({ sent: true });
+    return NextResponse.json({ sent: true, email: walletEmail });
   } catch (error) {
     return apiError(error, "Failed to send export verification code");
   }

--- a/app/api/user/wallet/export-key/request/route.ts
+++ b/app/api/user/wallet/export-key/request/route.ts
@@ -99,8 +99,9 @@ export async function POST(request: Request): Promise<NextResponse> {
       expiresAt,
     });
 
-    // Send to the wallet's recovery email, not the requester's — any org
-    // admin may request export, but only the wallet owner should approve it.
+    // The requester is always the wallet creator at this point (gated above);
+    // the OTP is a second factor tied to the wallet's recovery inbox, which
+    // may differ from the creator's account email.
     await sendEmail({
       to: walletEmail,
       subject: "Private Key Export Verification - KeeperHub",

--- a/app/api/user/wallet/export-key/verify/route.ts
+++ b/app/api/user/wallet/export-key/verify/route.ts
@@ -136,6 +136,14 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     const wallet = wallets[0];
 
+    // Export must be completed by the wallet creator, not just any org admin.
+    if (wallet.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: "Only the wallet creator can export its private key" },
+        { status: 403 }
+      );
+    }
+
     if (!wallet.turnkeySubOrgId) {
       return NextResponse.json(
         { error: "Turnkey wallet configuration is incomplete" },

--- a/app/api/user/wallet/export-key/verify/route.ts
+++ b/app/api/user/wallet/export-key/verify/route.ts
@@ -10,6 +10,7 @@ import { keyExportCodes, organizationWallets } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { exportTurnkeyPrivateKey } from "@/lib/turnkey/turnkey-client";
+import { checkVerifyRateLimit } from "../_lib/rate-limit";
 
 function hashCode(code: string): string {
   return crypto.createHash("sha256").update(code).digest("hex");
@@ -41,6 +42,20 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json(
         { error: "You are not a member of the active organization" },
         { status: 403 }
+      );
+    }
+
+    const rateLimit = checkVerifyRateLimit(session.user.id);
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        {
+          error: "Too many verification attempts. Please wait before retrying.",
+          retryAfter: rateLimit.retryAfter,
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimit.retryAfter) },
+        }
       );
     }
 
@@ -80,13 +95,17 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     const MAX_ATTEMPTS = 5;
 
-    // Increment attempt counter before comparing to prevent TOCTOU races
-    await db
+    // Atomic increment-and-return: Postgres serialises per-row UPDATEs, so N
+    // concurrent attempts each get a unique post-UPDATE value. Gating on the
+    // returned counter (rather than the pre-read one) prevents concurrent
+    // callers from all passing the lockout check with stale values.
+    const [updated] = await db
       .update(keyExportCodes)
       .set({ attempts: sql`${keyExportCodes.attempts} + 1` })
-      .where(eq(keyExportCodes.id, storedCode.id));
+      .where(eq(keyExportCodes.id, storedCode.id))
+      .returning({ attempts: keyExportCodes.attempts });
 
-    if (storedCode.attempts + 1 >= MAX_ATTEMPTS) {
+    if (!updated || updated.attempts >= MAX_ATTEMPTS) {
       await db
         .delete(keyExportCodes)
         .where(eq(keyExportCodes.id, storedCode.id));
@@ -97,8 +116,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
 
     const providedHash = hashCode(code);
+    const providedBuffer = Buffer.from(providedHash, "hex");
+    const storedBuffer = Buffer.from(storedCode.codeHash, "hex");
 
-    if (providedHash !== storedCode.codeHash) {
+    if (
+      providedBuffer.length !== storedBuffer.length ||
+      !crypto.timingSafeEqual(providedBuffer, storedBuffer)
+    ) {
       return NextResponse.json(
         { error: "Invalid verification code" },
         { status: 400 }

--- a/app/api/user/wallet/export-key/verify/route.ts
+++ b/app/api/user/wallet/export-key/verify/route.ts
@@ -44,13 +44,6 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    if (activeMember.role !== "admin" && activeMember.role !== "owner") {
-      return NextResponse.json(
-        { error: "Only admins and owners can export wallet keys" },
-        { status: 403 }
-      );
-    }
-
     const body: { code?: string } = await request.json();
     const { code } = body;
 

--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -11,7 +11,6 @@ import { db } from "@/lib/db";
 import { createIntegration } from "@/lib/db/integrations";
 import { integrations, organizationWallets } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { resolveCreatorContext } from "@/lib/middleware/auth-helpers";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { createTurnkeyWallet } from "@/lib/turnkey/turnkey-client";
 
@@ -201,14 +200,20 @@ async function storeTurnkeyWalletAndIntegration(options: {
 
 export async function GET(request: Request) {
   try {
-    const authCtx = await resolveCreatorContext(request);
-    if ("error" in authCtx) {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const activeOrgId = getActiveOrgId(session);
+    if (!activeOrgId) {
       return NextResponse.json(
-        { error: authCtx.error },
-        { status: authCtx.status }
+        { error: "No active organization" },
+        { status: 400 }
       );
     }
-    const { organizationId: activeOrgId, userId } = authCtx;
+
+    const userId = session.user.id;
 
     const allWallets = await db
       .select()

--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -1,4 +1,3 @@
-import { Environment, Para as ParaServer } from "@getpara/server-sdk";
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
@@ -12,12 +11,10 @@ import { db } from "@/lib/db";
 import { createIntegration } from "@/lib/db/integrations";
 import { integrations, organizationWallets } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { resolveCreatorContext } from "@/lib/middleware/auth-helpers";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { createTurnkeyWallet } from "@/lib/turnkey/turnkey-client";
 
-const PARA_API_KEY = process.env.PARA_API_KEY ?? "";
-const PARA_ENV = process.env.PARA_ENVIRONMENT ?? "beta";
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Helper: Validate user authentication, organization membership, and admin permissions
@@ -204,14 +201,14 @@ async function storeTurnkeyWalletAndIntegration(options: {
 
 export async function GET(request: Request) {
   try {
-    const authCtx = await resolveOrganizationId(request);
+    const authCtx = await resolveCreatorContext(request);
     if ("error" in authCtx) {
       return NextResponse.json(
         { error: authCtx.error },
         { status: authCtx.status }
       );
     }
-    const { organizationId: activeOrgId } = authCtx;
+    const { organizationId: activeOrgId, userId } = authCtx;
 
     const allWallets = await db
       .select()
@@ -235,6 +232,8 @@ export async function GET(request: Request) {
         id: w.id,
         provider: w.provider,
         canExportKey: w.provider === "turnkey",
+        // Only the wallet creator may export its key, regardless of org role.
+        isOwner: w.userId === userId,
         walletAddress: w.walletAddress,
         walletId: w.paraWalletId ?? w.turnkeyWalletId,
         email: w.email,
@@ -319,111 +318,6 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     return getErrorResponse(error);
-  }
-}
-
-export async function PATCH(request: Request) {
-  try {
-    // 1. Validate user, organization, and admin permissions
-    const validation = await validateUserAndOrganization(request);
-    if ("error" in validation) {
-      return NextResponse.json(
-        { error: validation.error },
-        { status: validation.status }
-      );
-    }
-    const { organizationId } = validation;
-
-    // 2. Get new email from request body
-    const body = await request.json();
-    const newEmail = body.email;
-
-    if (!newEmail || typeof newEmail !== "string") {
-      return NextResponse.json(
-        { error: "Email is required to update wallet" },
-        { status: 400 }
-      );
-    }
-
-    // Basic email validation
-    if (!EMAIL_REGEX.test(newEmail)) {
-      return NextResponse.json(
-        { error: "Invalid email format" },
-        { status: 400 }
-      );
-    }
-
-    // 3. Get the org's active wallet (PATCH only targets the active wallet;
-    // the deactivated Para wallet during migration is not user-editable).
-    const existingWallet = await db
-      .select()
-      .from(organizationWallets)
-      .where(
-        and(
-          eq(organizationWallets.organizationId, organizationId),
-          eq(organizationWallets.isActive, true)
-        )
-      )
-      .limit(1);
-
-    if (existingWallet.length === 0) {
-      return NextResponse.json(
-        { error: "No wallet found for this organization" },
-        { status: 404 }
-      );
-    }
-
-    const wallet = existingWallet[0];
-
-    // 4. Check if email is actually different
-    if (wallet.email === newEmail) {
-      return NextResponse.json(
-        { error: "New email is the same as the current email" },
-        { status: 400 }
-      );
-    }
-
-    // 5. Update wallet identifier in provider (Para only)
-    if (wallet.provider === "para" && wallet.paraWalletId) {
-      const environment =
-        PARA_ENV === "prod" ? Environment.PROD : Environment.BETA;
-      const paraClient = new ParaServer(environment, PARA_API_KEY);
-
-      await paraClient.updatePregenWalletIdentifier({
-        walletId: wallet.paraWalletId,
-        newPregenId: { email: newEmail },
-      });
-    }
-
-    // 6. Update email in local database (only the active wallet row)
-    await db
-      .update(organizationWallets)
-      .set({ email: newEmail })
-      .where(
-        and(
-          eq(organizationWallets.organizationId, organizationId),
-          eq(organizationWallets.isActive, true)
-        )
-      );
-
-    return NextResponse.json({
-      success: true,
-      message: "Wallet email updated successfully",
-      wallet: {
-        address: wallet.walletAddress,
-        walletId: wallet.paraWalletId ?? wallet.turnkeyWalletId,
-        email: newEmail,
-        organizationId,
-      },
-    });
-  } catch (error) {
-    logSystemError(
-      ErrorCategory.EXTERNAL_SERVICE,
-      "[Para] Failed to update wallet email",
-      error,
-      { endpoint: "/api/user/wallet", operation: "patch" }
-    );
-    return apiError(error, "Failed to update wallet email");
   }
 }
 

--- a/components/overlays/wallet-overlay.tsx
+++ b/components/overlays/wallet-overlay.tsx
@@ -410,7 +410,7 @@ export function WalletOverlay({
                 canExportKey={!!walletData.canExportKey}
                 email={walletData.email}
                 isAdmin={isAdmin}
-                onEmailUpdated={loadWallet}
+                isOwner={!!walletData.isOwner}
                 onSelectActiveWallet={handleSelectActiveWallet}
                 switchingWallet={switchingWallet}
                 walletAddress={walletData.walletAddress}

--- a/components/overlays/wallet/export-private-key-button.tsx
+++ b/components/overlays/wallet/export-private-key-button.tsx
@@ -24,6 +24,9 @@ function getDescription(
   if (step === "done") {
     return "Your private key is shown below. Copy it and store it securely.";
   }
+  if (step === "requesting") {
+    return "Sending a verification code to the wallet's recovery email...";
+  }
   if (recipientEmail) {
     return `A verification code has been sent to ${recipientEmail} (the wallet's recovery email).`;
   }

--- a/components/overlays/wallet/export-private-key-button.tsx
+++ b/components/overlays/wallet/export-private-key-button.tsx
@@ -17,6 +17,19 @@ import { Spinner } from "@/components/ui/spinner";
 
 type ExportStep = "idle" | "requesting" | "otp" | "verifying" | "done";
 
+function getDescription(
+  step: ExportStep,
+  recipientEmail: string | null
+): string {
+  if (step === "done") {
+    return "Your private key is shown below. Copy it and store it securely.";
+  }
+  if (recipientEmail) {
+    return `A verification code has been sent to ${recipientEmail} (the wallet's recovery email).`;
+  }
+  return "A verification code has been sent to the wallet's recovery email.";
+}
+
 export function ExportPrivateKeyButton(): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<ExportStep>("idle");
@@ -24,6 +37,7 @@ export function ExportPrivateKeyButton(): React.ReactElement {
   const [privateKey, setPrivateKey] = useState<string | null>(null);
   const [revealed, setRevealed] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [recipientEmail, setRecipientEmail] = useState<string | null>(null);
 
   const handleOpen = async (): Promise<void> => {
     setOpen(true);
@@ -32,16 +46,18 @@ export function ExportPrivateKeyButton(): React.ReactElement {
     setOtpCode("");
     setPrivateKey(null);
     setRevealed(false);
+    setRecipientEmail(null);
     try {
       const res = await fetch("/api/user/wallet/export-key/request", {
         method: "POST",
       });
-      const data: { error?: string } = await res.json();
+      const data: { error?: string; email?: string } = await res.json();
 
       if (!res.ok) {
         throw new Error(data.error ?? "Failed to send verification code");
       }
 
+      setRecipientEmail(data.email ?? null);
       setStep("otp");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to send code");
@@ -98,6 +114,7 @@ export function ExportPrivateKeyButton(): React.ReactElement {
     setPrivateKey(null);
     setRevealed(false);
     setError(null);
+    setRecipientEmail(null);
   };
 
   return (
@@ -123,11 +140,7 @@ export function ExportPrivateKeyButton(): React.ReactElement {
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Export Private Key</DialogTitle>
-            <DialogDescription>
-              {step === "done"
-                ? "Your private key is shown below. Copy it and store it securely."
-                : "A verification code has been sent to your email."}
-            </DialogDescription>
+            <DialogDescription>{getDescription(step, recipientEmail)}</DialogDescription>
           </DialogHeader>
 
           {step === "requesting" && (

--- a/components/overlays/wallet/manage-tab.tsx
+++ b/components/overlays/wallet/manage-tab.tsx
@@ -10,7 +10,7 @@ export function ManageTab({
   canExportKey,
   email,
   isAdmin,
-  onEmailUpdated,
+  isOwner,
   onSelectActiveWallet,
   switchingWallet,
   walletAddress,
@@ -19,7 +19,7 @@ export function ManageTab({
   canExportKey: boolean;
   email: string;
   isAdmin: boolean;
-  onEmailUpdated: () => void;
+  isOwner: boolean;
   onSelectActiveWallet: (walletId: string) => void;
   switchingWallet: boolean;
   walletAddress: string;
@@ -36,12 +36,8 @@ export function ManageTab({
         />
       )}
       <WalletAddressCard walletAddress={walletAddress} />
-      <RecoveryEmailCard
-        email={email}
-        isAdmin={isAdmin}
-        onUpdated={onEmailUpdated}
-      />
-      {isAdmin && canExportKey && <SecurityCard />}
+      <RecoveryEmailCard email={email} />
+      {isOwner && canExportKey && <SecurityCard />}
     </>
   );
 }

--- a/components/overlays/wallet/recovery-email-card.tsx
+++ b/components/overlays/wallet/recovery-email-card.tsx
@@ -1,121 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Spinner } from "@/components/ui/spinner";
-
 export function RecoveryEmailCard({
   email,
-  isAdmin,
-  onUpdated,
 }: {
   email: string;
-  isAdmin: boolean;
-  onUpdated: () => void;
 }): React.ReactElement {
-  const [isEditing, setIsEditing] = useState(false);
-  const [newEmail, setNewEmail] = useState("");
-  const [updating, setUpdating] = useState(false);
-
-  const startEditing = (): void => {
-    setNewEmail(email);
-    setIsEditing(true);
-  };
-
-  const cancelEditing = (): void => {
-    setIsEditing(false);
-    setNewEmail("");
-  };
-
-  const handleSave = async (): Promise<void> => {
-    if (!newEmail) {
-      toast.error("Email is required");
-      return;
-    }
-    setUpdating(true);
-    try {
-      const response = await fetch("/api/user/wallet", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: newEmail }),
-      });
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to update email");
-      }
-      toast.success("Wallet email updated successfully!");
-      setIsEditing(false);
-      setNewEmail("");
-      onUpdated();
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to update email"
-      );
-    } finally {
-      setUpdating(false);
-    }
-  };
-
   return (
     <section>
       <div className="mb-2 flex items-center justify-between">
         <span className="font-medium text-sm">Recovery email</span>
-        {!isEditing && isAdmin && (
-          <Button
-            className="h-6 px-2 text-xs"
-            onClick={startEditing}
-            size="sm"
-            variant="ghost"
-          >
-            Edit
-          </Button>
-        )}
       </div>
-      {isEditing ? (
-        <div className="space-y-2">
-          <Input
-            className="text-sm"
-            disabled={updating}
-            onChange={(e) => setNewEmail(e.target.value)}
-            placeholder="newemail@example.com"
-            type="email"
-            value={newEmail}
-          />
-          <div className="flex justify-end gap-2">
-            <Button
-              disabled={updating}
-              onClick={cancelEditing}
-              size="sm"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              disabled={updating || !newEmail || newEmail === email}
-              onClick={handleSave}
-              size="sm"
-            >
-              {updating ? (
-                <>
-                  <Spinner className="mr-2 h-3 w-3" />
-                  Saving...
-                </>
-              ) : (
-                "Save"
-              )}
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="space-y-1">
-          <p className="text-sm">{email}</p>
-          <p className="text-muted-foreground text-xs">
-            Used for verification when exporting the private key.
-          </p>
-        </div>
-      )}
+      <div className="space-y-1">
+        <p className="text-sm">{email}</p>
+        <p className="text-muted-foreground text-xs">
+          Used for verification when exporting the private key. Contact support
+          to change this address.
+        </p>
+      </div>
     </section>
   );
 }

--- a/lib/wallet/types.ts
+++ b/lib/wallet/types.ts
@@ -131,6 +131,7 @@ export type WalletInfo = {
   email: string;
   createdAt: string;
   canExportKey: boolean;
+  isOwner: boolean;
   organizationId: string;
   isActive: boolean;
 };
@@ -143,6 +144,7 @@ export type WalletData = {
   email?: string;
   createdAt?: string;
   canExportKey?: boolean;
+  isOwner?: boolean;
   wallets?: WalletInfo[];
 };
 

--- a/protocols/uniswap-v3.ts
+++ b/protocols/uniswap-v3.ts
@@ -4,7 +4,7 @@ import positionManagerAbi from "./abis/uniswap-position-manager.json";
 import quoterAbi from "./abis/uniswap-quoter.json";
 import swapRouterAbi from "./abis/uniswap-swap-router.json";
 
-const UNISWAP_DOCS = "https://docs.uniswap.org/contracts/v3/reference";
+const UNISWAP_DOCS = "https://developers.uniswap.org/docs/protocols/v3/overview";
 
 const FEE_TIER_TIP =
   "Pool fee tier in hundredths of a basis point. Common values: 100 (0.01% - stablecoin pairs), 500 (0.05% - correlated pairs), 3000 (0.3% - most pairs), 10000 (1% - exotic pairs).";

--- a/tests/integration/wallet-export-key-route.test.ts
+++ b/tests/integration/wallet-export-key-route.test.ts
@@ -35,7 +35,7 @@ const mockWalletSelectLimit = vi.fn();
 const mockCodeSelectLimit = vi.fn();
 const mockDelete = vi.fn();
 const mockInsertValues = vi.fn().mockResolvedValue(undefined);
-const mockUpdateSetWhere = vi.fn().mockResolvedValue(undefined);
+const mockUpdateReturning = vi.fn().mockResolvedValue([{ attempts: 1 }]);
 
 vi.mock("@/lib/db", () => ({
   db: {
@@ -57,7 +57,9 @@ vi.mock("@/lib/db", () => ({
     })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
-        where: (...args: unknown[]) => mockUpdateSetWhere(...args),
+        where: vi.fn(() => ({
+          returning: (...args: unknown[]) => mockUpdateReturning(...args),
+        })),
       })),
     })),
   },
@@ -218,5 +220,63 @@ describe("POST /api/user/wallet/export-key/verify", () => {
       "Only the wallet creator can export its private key"
     );
     expect(mockExportTurnkeyPrivateKey).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 and deletes the code when post-increment attempts reach MAX_ATTEMPTS", async () => {
+    // Use a fresh user id so the per-user rate limiter window stays clean.
+    mockGetSession.mockResolvedValue({
+      user: { id: "verify-user-toctou", email: "x@x.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    mockGetActiveOrgId.mockReturnValue(ORG_ID);
+    mockGetActiveMember.mockResolvedValue({ role: "owner" });
+
+    const code = "123456";
+    const codeHash = crypto.createHash("sha256").update(code).digest("hex");
+    mockCodeSelectLimit.mockResolvedValueOnce([
+      {
+        id: "code-1",
+        organizationId: ORG_ID,
+        codeHash,
+        attempts: 4,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ]);
+    mockUpdateReturning.mockResolvedValueOnce([{ attempts: 5 }]);
+
+    const res = await verifyPost(createJsonRequest({ code }));
+
+    expect(res.status).toBe(429);
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockExportTurnkeyPrivateKey).not.toHaveBeenCalled();
+  });
+});
+
+describe("Wallet export rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWalletSelectLimit.mockReset();
+  });
+
+  it("returns 429 on the 4th request call within the window", async () => {
+    const userId = "rate-request-user";
+    mockGetSession.mockResolvedValue({
+      user: { id: userId, email: "rr@x.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    mockGetActiveOrgId.mockReturnValue(ORG_ID);
+    mockGetActiveMember.mockResolvedValue({ role: "owner" });
+    mockWalletSelectLimit.mockResolvedValue([
+      { id: "wallet-1", userId, email: WALLET_EMAIL },
+    ]);
+
+    for (const _ of Array.from({ length: 3 })) {
+      const ok = await requestPost(createJsonRequest());
+      expect(ok.status).toBe(200);
+    }
+    const over = await requestPost(createJsonRequest());
+    expect(over.status).toBe(429);
+    const data = await over.json();
+    expect(data.retryAfter).toBeGreaterThan(0);
   });
 });

--- a/tests/integration/wallet-export-key-route.test.ts
+++ b/tests/integration/wallet-export-key-route.test.ts
@@ -90,6 +90,7 @@ vi.mock("@/lib/logging", () => ({
 
 import { POST as requestPost } from "@/app/api/user/wallet/export-key/request/route";
 import { POST as verifyPost } from "@/app/api/user/wallet/export-key/verify/route";
+import { __resetRateLimitForTesting } from "@/app/api/user/wallet/export-key/_lib/rate-limit";
 
 const CREATOR_ID = "user-creator";
 const OTHER_ADMIN_ID = "user-other-admin";
@@ -125,6 +126,7 @@ function createJsonRequest(body?: Record<string, unknown>): Request {
 describe("POST /api/user/wallet/export-key/request", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetRateLimitForTesting();
     mockWalletSelectLimit.mockReset();
     mockSendEmail.mockClear();
   });
@@ -182,6 +184,7 @@ describe("POST /api/user/wallet/export-key/request", () => {
 describe("POST /api/user/wallet/export-key/verify", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetRateLimitForTesting();
     mockWalletSelectLimit.mockReset();
     mockCodeSelectLimit.mockReset();
     mockExportTurnkeyPrivateKey.mockReset();
@@ -255,7 +258,9 @@ describe("POST /api/user/wallet/export-key/verify", () => {
 describe("Wallet export rate limiting", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetRateLimitForTesting();
     mockWalletSelectLimit.mockReset();
+    mockCodeSelectLimit.mockReset();
   });
 
   it("returns 429 on the 4th request call within the window", async () => {
@@ -278,5 +283,60 @@ describe("Wallet export rate limiting", () => {
     expect(over.status).toBe(429);
     const data = await over.json();
     expect(data.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("returns 429 on the 11th verify call within the window", async () => {
+    const userId = "rate-verify-user";
+    mockGetSession.mockResolvedValue({
+      user: { id: userId, email: "rv@x.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    mockGetActiveOrgId.mockReturnValue(ORG_ID);
+    mockGetActiveMember.mockResolvedValue({ role: "owner" });
+    // Each verify call bumps the counter past the identity/hash gate; return
+    // an empty code set so every call short-circuits at 400 after the rate
+    // counter is incremented.
+    mockCodeSelectLimit.mockResolvedValue([]);
+
+    for (const _ of Array.from({ length: 10 })) {
+      const res = await verifyPost(createJsonRequest({ code: "123456" }));
+      expect(res.status).toBe(400);
+    }
+    const over = await verifyPost(createJsonRequest({ code: "123456" }));
+    expect(over.status).toBe(429);
+    const data = await over.json();
+    expect(data.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("rejects a wrong verification code via timing-safe compare", async () => {
+    const userId = "timing-user";
+    mockGetSession.mockResolvedValue({
+      user: { id: userId, email: "ts@x.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    mockGetActiveOrgId.mockReturnValue(ORG_ID);
+    mockGetActiveMember.mockResolvedValue({ role: "owner" });
+
+    // Stored code hash is for "654321"; caller submits "123456". Must 400.
+    const storedCode = "654321";
+    const storedHash = crypto
+      .createHash("sha256")
+      .update(storedCode)
+      .digest("hex");
+    mockCodeSelectLimit.mockResolvedValueOnce([
+      {
+        id: "code-1",
+        organizationId: ORG_ID,
+        codeHash: storedHash,
+        attempts: 0,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    const res = await verifyPost(createJsonRequest({ code: "123456" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid verification code");
+    expect(mockExportTurnkeyPrivateKey).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/wallet-export-key-route.test.ts
+++ b/tests/integration/wallet-export-key-route.test.ts
@@ -1,0 +1,222 @@
+import crypto from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+const mockGetActiveMember = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+      getActiveMember: (...args: unknown[]) => mockGetActiveMember(...args),
+    },
+  },
+}));
+
+const mockGetActiveOrgId = vi.fn();
+
+vi.mock("@/lib/middleware/org-context", () => ({
+  getActiveOrgId: (...args: unknown[]) => mockGetActiveOrgId(...args),
+}));
+
+const mockSendEmail = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+const mockWalletSelectLimit = vi.fn();
+const mockCodeSelectLimit = vi.fn();
+const mockDelete = vi.fn();
+const mockInsertValues = vi.fn().mockResolvedValue(undefined);
+const mockUpdateSetWhere = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => ({
+          limit: (n: number) =>
+            table === "key_export_codes_table"
+              ? mockCodeSelectLimit(n)
+              : mockWalletSelectLimit(n),
+        })),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: (...args: unknown[]) => mockDelete(...args),
+    })),
+    insert: vi.fn(() => ({
+      values: (...args: unknown[]) => mockInsertValues(...args),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: (...args: unknown[]) => mockUpdateSetWhere(...args),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organizationWallets: {
+    id: "id",
+    userId: "user_id",
+    email: "email",
+    organizationId: "organization_id",
+    provider: "provider",
+  },
+  keyExportCodes: "key_export_codes_table",
+}));
+
+const mockExportTurnkeyPrivateKey = vi.fn();
+
+vi.mock("@/lib/turnkey/turnkey-client", () => ({
+  exportTurnkeyPrivateKey: (...args: unknown[]) =>
+    mockExportTurnkeyPrivateKey(...args),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { EXTERNAL_SERVICE: "EXTERNAL_SERVICE" },
+  logSystemError: vi.fn(),
+}));
+
+import { POST as requestPost } from "@/app/api/user/wallet/export-key/request/route";
+import { POST as verifyPost } from "@/app/api/user/wallet/export-key/verify/route";
+
+const CREATOR_ID = "user-creator";
+const OTHER_ADMIN_ID = "user-other-admin";
+const ORG_ID = "org-1";
+const WALLET_EMAIL = "vault@example.com";
+
+function mockCreatorSession(): void {
+  mockGetSession.mockResolvedValue({
+    user: { id: CREATOR_ID, email: "creator@account.com" },
+    session: { activeOrganizationId: ORG_ID },
+  });
+  mockGetActiveOrgId.mockReturnValue(ORG_ID);
+  mockGetActiveMember.mockResolvedValue({ role: "owner" });
+}
+
+function mockOtherAdminSession(): void {
+  mockGetSession.mockResolvedValue({
+    user: { id: OTHER_ADMIN_ID, email: "other@account.com" },
+    session: { activeOrganizationId: ORG_ID },
+  });
+  mockGetActiveOrgId.mockReturnValue(ORG_ID);
+  mockGetActiveMember.mockResolvedValue({ role: "admin" });
+}
+
+function createJsonRequest(body?: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/user/wallet/export-key", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/user/wallet/export-key/request", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWalletSelectLimit.mockReset();
+    mockSendEmail.mockClear();
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await requestPost(createJsonRequest());
+    expect(res.status).toBe(401);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when user is not a member of the active org", async () => {
+    mockCreatorSession();
+    mockGetActiveMember.mockResolvedValueOnce(null);
+
+    const res = await requestPost(createJsonRequest());
+    expect(res.status).toBe(403);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when session user is not the wallet creator", async () => {
+    mockOtherAdminSession();
+    mockWalletSelectLimit.mockResolvedValueOnce([
+      { id: "wallet-1", userId: CREATOR_ID, email: WALLET_EMAIL },
+    ]);
+
+    const res = await requestPost(createJsonRequest());
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toBe(
+      "Only the wallet creator can export its private key"
+    );
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends OTP to wallet recovery email (not session email) for the creator", async () => {
+    mockCreatorSession();
+    mockWalletSelectLimit.mockResolvedValueOnce([
+      { id: "wallet-1", userId: CREATOR_ID, email: WALLET_EMAIL },
+    ]);
+
+    const res = await requestPost(createJsonRequest());
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toEqual({ sent: true, email: WALLET_EMAIL });
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    const emailArgs = mockSendEmail.mock.calls[0][0] as { to: string };
+    expect(emailArgs.to).toBe(WALLET_EMAIL);
+    expect(emailArgs.to).not.toBe("creator@account.com");
+  });
+});
+
+describe("POST /api/user/wallet/export-key/verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWalletSelectLimit.mockReset();
+    mockCodeSelectLimit.mockReset();
+    mockExportTurnkeyPrivateKey.mockReset();
+  });
+
+  it("returns 403 when session user is not the wallet creator", async () => {
+    mockOtherAdminSession();
+
+    const code = "123456";
+    const codeHash = crypto.createHash("sha256").update(code).digest("hex");
+    mockCodeSelectLimit.mockResolvedValueOnce([
+      {
+        id: "code-1",
+        organizationId: ORG_ID,
+        codeHash,
+        attempts: 0,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ]);
+    mockWalletSelectLimit.mockResolvedValueOnce([
+      {
+        id: "wallet-1",
+        userId: CREATOR_ID,
+        email: WALLET_EMAIL,
+        provider: "turnkey",
+        turnkeySubOrgId: "sub-org-1",
+        walletAddress: "0x0000000000000000000000000000000000000001",
+      },
+    ]);
+
+    const res = await verifyPost(createJsonRequest({ code }));
+
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toBe(
+      "Only the wallet creator can export its private key"
+    );
+    expect(mockExportTurnkeyPrivateKey).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/wallet-route.test.ts
+++ b/tests/integration/wallet-route.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+    },
+  },
+}));
+
+const mockGetActiveOrgId = vi.fn();
+
+vi.mock("@/lib/middleware/org-context", () => ({
+  getActiveOrgId: (...args: unknown[]) => mockGetActiveOrgId(...args),
+}));
+
+const mockWalletSelectWhere = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: (...args: unknown[]) => mockWalletSelectWhere(...args),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organizationWallets: {
+    id: "id",
+    userId: "user_id",
+    email: "email",
+    organizationId: "organization_id",
+    provider: "provider",
+    paraWalletId: "para_wallet_id",
+    turnkeyWalletId: "turnkey_wallet_id",
+    walletAddress: "wallet_address",
+    createdAt: "created_at",
+    isActive: "is_active",
+  },
+  integrations: {},
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { EXTERNAL_SERVICE: "EXTERNAL_SERVICE" },
+  logSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/turnkey/turnkey-client", () => ({
+  createTurnkeyWallet: vi.fn(),
+}));
+
+vi.mock("@/lib/db/integrations", () => ({
+  createIntegration: vi.fn(),
+}));
+
+import { GET } from "@/app/api/user/wallet/route";
+
+const CREATOR_ID = "user-creator";
+const OTHER_USER_ID = "user-other";
+const ORG_ID = "org-1";
+
+function buildWalletRow(userId: string): Record<string, unknown> {
+  return {
+    id: "wallet-1",
+    userId,
+    organizationId: ORG_ID,
+    provider: "turnkey",
+    email: "vault@example.com",
+    walletAddress: "0x0000000000000000000000000000000000000001",
+    paraWalletId: null,
+    turnkeyWalletId: "tk-wallet-id",
+    createdAt: new Date("2026-01-01"),
+    isActive: true,
+  };
+}
+
+function createGetRequest(): Request {
+  return new Request("http://localhost/api/user/wallet", { method: "GET" });
+}
+
+describe("GET /api/user/wallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWalletSelectWhere.mockReset();
+  });
+
+  it("returns 401 when there is no session (non-session callers blocked)", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await GET(createGetRequest());
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns isOwner: true for the wallet creator", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: CREATOR_ID, email: "creator@account.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    mockGetActiveOrgId.mockReturnValue(ORG_ID);
+    mockWalletSelectWhere.mockResolvedValueOnce([buildWalletRow(CREATOR_ID)]);
+
+    const res = await GET(createGetRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.isOwner).toBe(true);
+    expect(data.wallets).toHaveLength(1);
+    expect(data.wallets[0].isOwner).toBe(true);
+  });
+
+  it("returns isOwner: false for members who did not create the wallet", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: OTHER_USER_ID, email: "other@account.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    mockGetActiveOrgId.mockReturnValue(ORG_ID);
+    mockWalletSelectWhere.mockResolvedValueOnce([buildWalletRow(CREATOR_ID)]);
+
+    const res = await GET(createGetRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.isOwner).toBe(false);
+    expect(data.wallets[0].isOwner).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes [KEEP-319](https://linear.app/keeperhubapp/issue/KEEP-319/export-turnkey-private-key-email-should-be-sent-to-the-owner-of-the).

Previously any org admin or owner could request a Turnkey private-key export and the OTP was sent to their own session email, letting any admin/owner drain another member's wallet. Ticket asked for the OTP to go to the wallet owner's email; on review this turned out to be insufficient because admins could also PATCH the wallet's recovery email to their own. This PR closes both paths.

## Changes

- `POST /api/user/wallet/export-key/request`: selects `wallet.userId` and rejects with 403 if `wallet.userId !== session.user.id`. OTP is now sent to `wallet.email` (the recovery email) instead of `session.user.email`. Response includes the recipient email.
- `POST /api/user/wallet/export-key/verify`: same `wallet.userId === session.user.id` gate before exporting.
- `PATCH /api/user/wallet`: removed entirely. The recovery email can no longer be changed from the UI; rotation is a support-only flow. The `@getpara/server-sdk` import and Para pregen-identifier update code went with it.
- `GET /api/user/wallet`: now resolves via `resolveCreatorContext` and returns `isOwner: w.userId === userId` on each wallet entry.
- `WalletInfo` / `WalletData`: added `isOwner` field.
- `RecoveryEmailCard`: stripped the Edit button and all editing state; copy now reads "Contact support to change this address."
- `ManageTab`: `SecurityCard` is now gated by `isOwner && canExportKey` (was `isAdmin && canExportKey`).
- `ExportPrivateKeyButton`: dialog description now shows which recovery email the code was sent to.

## What this does not do

- No backfill or migration. `wallet.userId` is already populated on every row (`notNull`).
- No admin API for support-driven recovery email rotation. That should be a follow-up if ops needs it to be self-serve.