### PR TITLE
feat: KEEP-301 add wallet_total gauge labeled by provider

### DIFF
--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -40,7 +40,7 @@ Understanding the user/org/wallet model helps interpret metrics correctly:
 | **Anonymous User** | Trial user without org | Can run workflows, but no chain operations |
 
 **Key metric relationships:**
-- `org.total` ≈ `para_wallet.total` (1:1 org-to-wallet)
+- `org.total` ≈ `sum(wallet.total)` (1:1 org-to-wallet; wallets split across `para` / `turnkey` providers)
 - `user.total` ≥ `org.total` (users can share orgs via invites)
 - `user.anonymous` = users without orgs (trial mode)
 - Web3 steps (`transfer-funds`, `write-contract`) require org + wallet
@@ -157,7 +157,8 @@ Gauge metrics tracking user and organization statistics.
 | `apikey.total` | Total API keys | - | DB |
 | `chain.total` | Total blockchain networks configured | - | DB |
 | `chain.enabled` | Enabled blockchain networks | - | DB |
-| `para_wallet.total` | Total Para wallets | - | DB |
+| `wallet.total` | Total active org wallets by provider | `provider` (`para`, `turnkey`) | DB |
+| `para_wallet.total` | [Deprecated] Total active org wallets (all providers). Use `wallet.total` instead. | - | DB |
 | `session.active` | Active (non-expired) sessions | - | DB |
 
 ---
@@ -241,7 +242,7 @@ The following tables are queried:
 - `workflow_schedules` - schedule counts, enabled status, last run status
 - `api_keys` - API key count
 - `chains` - blockchain network count
-- `para_wallets` - Para wallet count
+- `para_wallets` - Active org wallet count (split by provider: `para`, `turnkey`)
 
 ### Multi-Pod Aggregation (Important)
 
@@ -277,7 +278,7 @@ sum by (status) (keeperhub_workflow_executions_total{...})
 | Workflow | `workflow_total`, `workflow_by_visibility`, `workflow_anonymous_total`, `workflow_executions_total`, `workflow_execution_errors_total`, `workflow_queue_depth`, `workflow_concurrent_count` |
 | Schedule | `schedule_total`, `schedule_enabled_total`, `schedule_by_last_status` |
 | Integration | `integration_total`, `integration_managed_total`, `integration_by_type` |
-| Infrastructure | `apikey_total`, `para_wallet_total`, `chain_total`, `chain_enabled_total`, `session_active_total` |
+| Infrastructure | `apikey_total`, `wallet_total`, `para_wallet_total`, `chain_total`, `chain_enabled_total`, `session_active_total` |
 
 **Why this happens:** Each pod queries the same PostgreSQL database and reports the same gauge value. With 2 pods reporting 21 users each, `sum()` returns 42 while `max()` correctly returns 21.
 
@@ -438,7 +439,8 @@ Prometheus metrics are prefixed with `keeperhub_` and use snake_case:
 | `apikey.total` | `keeperhub_apikey_total` | gauge |
 | `chain.total` | `keeperhub_chain_total` | gauge |
 | `chain.enabled` | `keeperhub_chain_enabled_total` | gauge |
-| `para_wallet.total` | `keeperhub_para_wallet_total` | gauge |
+| `wallet.total` | `keeperhub_wallet_total` | gauge |
+| `para_wallet.total` | `keeperhub_para_wallet_total` | gauge (deprecated) |
 | `session.active` | `keeperhub_session_active_total` | gauge |
 | `api.webhook.latency_ms` | `keeperhub_api_webhook_latency_ms` | histogram |
 | `api.status.latency_ms` | `keeperhub_api_status_latency_ms` | histogram |

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -368,11 +368,22 @@ const chainEnabled = getOrCreateGauge(
   []
 );
 
+/**
+ * @deprecated Counts all active org wallets (Para + Turnkey) and is retained
+ * for backward compatibility. Use `keeperhub_wallet_total{provider}` instead.
+ */
 const paraWalletTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_para_wallet_total",
-  "Total Para wallets",
+  "[Deprecated] Total active org wallets (all providers). Use keeperhub_wallet_total{provider} instead.",
   []
+);
+
+const walletTotalByProvider = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_wallet_total",
+  "Total active org wallets by provider",
+  ["provider"]
 );
 
 const sessionActive = getOrCreateGauge(
@@ -1127,6 +1138,14 @@ export async function updateDbMetrics(): Promise<void> {
     chainTotal.set(infraStats.chainsTotal);
     chainEnabled.set(infraStats.chainsEnabled);
     paraWalletTotal.set(infraStats.paraWalletsTotal);
+    walletTotalByProvider.set(
+      { provider: "para" },
+      infraStats.walletsByProvider.para
+    );
+    walletTotalByProvider.set(
+      { provider: "turnkey" },
+      infraStats.walletsByProvider.turnkey
+    );
     sessionActive.set(infraStats.sessionsActive);
 
     updateHubVoteMetrics(voteStats);

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -639,7 +639,16 @@ export type InfraStats = {
   apiKeysTotal: number;
   chainsTotal: number;
   chainsEnabled: number;
+  /**
+   * @deprecated Counts all active org wallets regardless of provider.
+   * Kept for backward compatibility with the `keeperhub_para_wallet_total`
+   * gauge. Use `walletsByProvider` instead.
+   */
   paraWalletsTotal: number;
+  walletsByProvider: {
+    para: number;
+    turnkey: number;
+  };
   sessionsActive: number;
 };
 
@@ -657,6 +666,7 @@ export async function getInfraStatsFromDb(): Promise<InfraStats> {
       chainsResult,
       chainsEnabledResult,
       walletsResult,
+      walletsByProviderResult,
       sessionsResult,
     ] = await Promise.all([
       db.select({ count: count() }).from(apiKeys),
@@ -670,16 +680,29 @@ export async function getInfraStatsFromDb(): Promise<InfraStats> {
         .from(paraWallets)
         .where(eq(paraWallets.isActive, true)),
       db
+        .select({ provider: paraWallets.provider, count: count() })
+        .from(paraWallets)
+        .where(eq(paraWallets.isActive, true))
+        .groupBy(paraWallets.provider),
+      db
         .select({ count: count() })
         .from(sessions)
         .where(gte(sessions.expiresAt, now)),
     ]);
+
+    const walletsByProvider = { para: 0, turnkey: 0 };
+    for (const row of walletsByProviderResult) {
+      if (row.provider === "para" || row.provider === "turnkey") {
+        walletsByProvider[row.provider] = Number(row.count) || 0;
+      }
+    }
 
     return {
       apiKeysTotal: Number(apiKeysResult[0]?.count) || 0,
       chainsTotal: Number(chainsResult[0]?.count) || 0,
       chainsEnabled: Number(chainsEnabledResult[0]?.count) || 0,
       paraWalletsTotal: Number(walletsResult[0]?.count) || 0,
+      walletsByProvider,
       sessionsActive: Number(sessionsResult[0]?.count) || 0,
     };
   } catch (error) {
@@ -689,6 +712,7 @@ export async function getInfraStatsFromDb(): Promise<InfraStats> {
       chainsTotal: 0,
       chainsEnabled: 0,
       paraWalletsTotal: 0,
+      walletsByProvider: { para: 0, turnkey: 0 },
       sessionsActive: 0,
     };
   }


### PR DESCRIPTION
## Summary

- Splits the wallet count metric by provider via a `GROUP BY paraWallets.provider` query in `getInfraStatsFromDb`, and exposes a new labeled Prometheus gauge `keeperhub_wallet_total{provider="para"|"turnkey"}`.
- Preserves `keeperhub_para_wallet_total` (which currently counts all active org wallets regardless of provider) unchanged. Marks it `@deprecated` in code and `METRICS_REFERENCE.md` so Grafana Cloud queries can migrate off it before it is removed in a follow-up.

## Migration

Existing queries:

```promql
max(keeperhub_para_wallet_total)
```

should move to:

```promql
sum(max by (provider) (keeperhub_wallet_total))
# or, per-provider:
max(keeperhub_wallet_total{provider="para"})
max(keeperhub_wallet_total{provider="turnkey"})
```