### PR TITLE
feat: KEEP-295 complete ProviderManager reconnect/heartbeat/healthz (phase 4 gap-fill)

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -91,6 +91,13 @@ interface ChainEntry {
   wssUrl: string;
   provider: ethers.WebSocketProvider | null;
   readyPromise: Promise<ethers.WebSocketProvider> | null;
+  /**
+   * Live while a reconnect loop is running. Callers awaiting a provider
+   * (`getOrCreateProvider`) must wait on this first so they do not fire a
+   * second `createProvider` that races with the reconnect's own factory
+   * call and produces two parallel providers on the same chain.
+   */
+  reconnectPromise: Promise<void> | null;
   subscribers: Set<Subscriber>;
   blockListener: ((blockNumber: number) => Promise<void>) | null;
   errorListener: ((err: Error) => void) | null;
@@ -116,16 +123,10 @@ export class ChainProviderManager {
   private readonly onPermanentFailure: (chainId: number) => void;
   private isDestroyed = false;
 
-  constructor(opts: ChainProviderManagerOptions | ProviderFactory = {}) {
-    // Backward-compatible: the old signature accepted a bare factory function.
-    if (typeof opts === "function") {
-      this.factory = opts;
-      this.onPermanentFailure = defaultOnPermanentFailure;
-    } else {
-      this.factory = opts.factory ?? defaultFactory;
-      this.onPermanentFailure =
-        opts.onPermanentFailure ?? defaultOnPermanentFailure;
-    }
+  constructor(opts: ChainProviderManagerOptions = {}) {
+    this.factory = opts.factory ?? defaultFactory;
+    this.onPermanentFailure =
+      opts.onPermanentFailure ?? defaultOnPermanentFailure;
   }
 
   async getOrCreateProvider(
@@ -133,6 +134,15 @@ export class ChainProviderManager {
     wssUrl: string,
   ): Promise<ethers.WebSocketProvider> {
     const entry = this.ensureEntry(chainId, wssUrl);
+
+    // If a reconnect loop is live, wait for it to settle before checking
+    // the provider. Without this, a new subscriber arriving while the
+    // old provider has been torn down but the new one is not yet
+    // assigned races the reconnect's factory call and produces a second
+    // orphaned provider.
+    if (entry.reconnectPromise) {
+      await entry.reconnectPromise;
+    }
 
     if (entry.provider) {
       return entry.provider;
@@ -155,16 +165,24 @@ export class ChainProviderManager {
       topic0: opts.topic0.toLowerCase(),
       handler: opts.handler,
     };
+    const wasEmpty = entry.subscribers.size === 0;
     entry.subscribers.add(subscriber);
 
-    if (!entry.blockListener) {
+    // Block listener and heartbeat are lifecycle-tied to subscribers:
+    // attach on the first, detach on the last. Heartbeat on an idle
+    // provider is wasted RPC calls, so creating a provider via bare
+    // `getOrCreateProvider` without subscribing leaves it silent until
+    // the first subscribe.
+    if (wasEmpty) {
       this.attachBlockListener(entry);
+      this.startHeartbeat(entry);
     }
 
     return () => {
       entry.subscribers.delete(subscriber);
       if (entry.subscribers.size === 0) {
         this.detachBlockListener(entry);
+        this.stopHeartbeat(entry);
       }
     };
   }
@@ -206,6 +224,14 @@ export class ChainProviderManager {
     return this.chains.get(chainId)?.subscribers.size ?? 0;
   }
 
+  /**
+   * Returns true iff the manager has an active provider for `chainId`
+   * and is not currently reconnecting. Deliberately asymmetric with the
+   * `/healthz` endpoint's "no chains registered = 200 OK" rule: per-chain
+   * `isHealthy` answers *"do I affirmatively know this chain is up"* (so
+   * unknown chains return false), while `/healthz` answers *"is the
+   * system degraded"* (so zero chains is not a degradation).
+   */
   isHealthy(chainId: number): boolean {
     const entry = this.chains.get(chainId);
     if (!entry) {
@@ -288,6 +314,7 @@ export class ChainProviderManager {
       wssUrl,
       provider: null,
       readyPromise: null,
+      reconnectPromise: null,
       subscribers: new Set(),
       blockListener: null,
       errorListener: null,
@@ -307,7 +334,8 @@ export class ChainProviderManager {
     await provider.ready;
     entry.provider = provider;
     this.attachErrorListener(entry);
-    this.startHeartbeat(entry);
+    // Heartbeat is subscriber-scoped (started on first subscribe, stopped
+    // on last unsubscribe) to avoid wasted pings on an idle chain.
     return provider;
   }
 
@@ -398,38 +426,62 @@ export class ChainProviderManager {
     }
   }
 
-  private async triggerReconnect(
+  private triggerReconnect(
     entry: ChainEntry,
     reason: DisconnectReason,
     message: string,
-  ): Promise<void> {
+  ): void {
     if (this.isDestroyed || entry.isReconnecting) {
       return;
     }
     entry.isReconnecting = true;
     this.stopHeartbeat(entry);
 
-    // Fire disconnect handlers before attempting reconnect. Handler errors
-    // are isolated so one bad consumer cannot block the reconnect.
-    for (const handler of entry.disconnectHandlers) {
-      try {
-        await handler({ chainId: entry.chainId, reason, message });
-      } catch (err) {
-        logger.warn(
-          `[ChainProviderManager] chain=${entry.chainId} disconnect handler threw: ${String(err)}`,
-        );
-      }
-    }
+    // Publish the reconnect promise on the entry BEFORE starting the
+    // work. `getOrCreateProvider` awaits this to avoid creating a second
+    // parallel provider while the reconnect is replacing the first.
+    // `.catch` before assigning so the stored promise never rejects: any
+    // bug in reconnectLoop surfaces via the logger, not by rejecting an
+    // await that callers would have to handle.
+    const loop = this.reconnectLoop(entry, reason, message).catch((err) => {
+      logger.error(
+        `[ChainProviderManager] chain=${entry.chainId} reconnect loop crashed: ${String(err)}`,
+      );
+    });
+    entry.reconnectPromise = loop;
+    void loop.finally(() => {
+      entry.reconnectPromise = null;
+      entry.isReconnecting = false;
+    });
+  }
+
+  private async reconnectLoop(
+    entry: ChainEntry,
+    reason: DisconnectReason,
+    message: string,
+  ): Promise<void> {
+    // Fire disconnect handlers in parallel before the backoff begins.
+    // Sequential await here lets one slow handler delay reconnect start
+    // by its latency; Promise.all matches the dispatchLog pattern.
+    await Promise.all(
+      [...entry.disconnectHandlers].map(async (handler) => {
+        try {
+          await handler({ chainId: entry.chainId, reason, message });
+        } catch (err) {
+          logger.warn(
+            `[ChainProviderManager] chain=${entry.chainId} disconnect handler threw: ${String(err)}`,
+          );
+        }
+      }),
+    );
 
     let delay = INITIAL_RECONNECT_DELAY_MS;
     for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
       if (this.isDestroyed) {
-        entry.isReconnecting = false;
         return;
       }
       await sleep(delay);
       if (this.isDestroyed) {
-        entry.isReconnecting = false;
         return;
       }
       try {
@@ -437,7 +489,6 @@ export class ChainProviderManager {
         logger.log(
           `[ChainProviderManager] chain=${entry.chainId} reconnected on attempt ${attempt}`,
         );
-        entry.isReconnecting = false;
         return;
       } catch (err) {
         logger.warn(
@@ -450,14 +501,16 @@ export class ChainProviderManager {
     logger.error(
       `[ChainProviderManager] chain=${entry.chainId} exhausted ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
     );
-    entry.isReconnecting = false;
     this.onPermanentFailure(entry.chainId);
   }
 
   private async reconnect(entry: ChainEntry): Promise<void> {
-    // Tear down the old provider (best-effort) and unhook listeners so the
-    // old provider cannot trigger another reconnect while we are building
-    // the new one.
+    if (this.isDestroyed) {
+      return;
+    }
+    // Tear down the old provider (best-effort) and unhook listeners so
+    // the old provider cannot trigger another reconnect while we are
+    // building the new one.
     if (entry.provider) {
       this.detachBlockListener(entry);
       this.detachErrorListener(entry);
@@ -470,17 +523,39 @@ export class ChainProviderManager {
     entry.provider = null;
     entry.readyPromise = null;
 
-    // Re-create. Any throw here propagates to triggerReconnect which
-    // handles backoff.
+    if (this.isDestroyed) {
+      return;
+    }
+
+    // Re-create. Any throw here propagates to the loop which handles
+    // backoff.
     const provider = this.factory(entry.wssUrl);
     await provider.ready;
+
+    // Destroy may have run while we were waiting for `ready`. If so, the
+    // entry we are about to populate is no longer in `this.chains` and
+    // attaching listeners would leak a provider that never gets
+    // destroyed by the second pass.
+    if (this.isDestroyed) {
+      try {
+        await provider.destroy();
+      } catch {
+        // ignore
+      }
+      return;
+    }
+
     entry.provider = provider;
 
     this.attachErrorListener(entry);
+    // Block listener and heartbeat only if this chain has subscribers.
+    // Both are subscriber-scoped; if every subscriber unsubscribed
+    // during the reconnect, the new provider stays quiet until someone
+    // subscribes again.
     if (entry.subscribers.size > 0) {
       this.attachBlockListener(entry);
+      this.startHeartbeat(entry);
     }
-    this.startHeartbeat(entry);
   }
 
   private async processBlock(

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -122,11 +122,25 @@ export class ChainProviderManager {
   private readonly factory: ProviderFactory;
   private readonly onPermanentFailure: (chainId: number) => void;
   private isDestroyed = false;
+  // Wake-up signal for in-flight reconnect sleeps: `destroy()` resolves
+  // this promise, racing any pending backoff sleep so the reconnect loop
+  // checks `isDestroyed` and bails promptly instead of waiting out its
+  // full delay. Without this, `destroy()` hangs when tests switch from
+  // fake to real timers with a fake-timer sleep still pending.
+  private readonly destroyed: {
+    promise: Promise<void>;
+    resolve: () => void;
+  };
 
   constructor(opts: ChainProviderManagerOptions = {}) {
     this.factory = opts.factory ?? defaultFactory;
     this.onPermanentFailure =
       opts.onPermanentFailure ?? defaultOnPermanentFailure;
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    this.destroyed = { promise, resolve };
   }
 
   async getOrCreateProvider(
@@ -165,15 +179,17 @@ export class ChainProviderManager {
       topic0: opts.topic0.toLowerCase(),
       handler: opts.handler,
     };
-    const wasEmpty = entry.subscribers.size === 0;
     entry.subscribers.add(subscriber);
 
     // Block listener and heartbeat are lifecycle-tied to subscribers:
     // attach on the first, detach on the last. Heartbeat on an idle
     // provider is wasted RPC calls, so creating a provider via bare
     // `getOrCreateProvider` without subscribing leaves it silent until
-    // the first subscribe.
-    if (wasEmpty) {
+    // the first subscribe. Key off `!entry.blockListener` rather than
+    // "was this the first subscriber" so that a fresh provider created
+    // after a permanent-failure + test-injected no-op + resubscribe
+    // still gets wired up correctly.
+    if (!entry.blockListener) {
       this.attachBlockListener(entry);
       this.startHeartbeat(entry);
     }
@@ -272,8 +288,20 @@ export class ChainProviderManager {
 
   async destroy(): Promise<void> {
     this.isDestroyed = true;
+    // Wake every reconnect loop that is currently sleeping. The loop
+    // resumes, checks `isDestroyed`, and bails via its `finally`.
+    this.destroyed.resolve();
     const errors: unknown[] = [];
     for (const entry of this.chains.values()) {
+      // Wait for any in-flight reconnect loop to settle before tearing
+      // the entry down. The loop observes `isDestroyed` at its next
+      // check and bails; `reconnectPromise` is the .catch-wrapped form
+      // so it never rejects. Without this await, destroy() could
+      // resolve while the loop is still running its teardown code,
+      // leading to observable races in tests.
+      if (entry.reconnectPromise) {
+        await entry.reconnectPromise;
+      }
       this.stopHeartbeat(entry);
       this.detachBlockListener(entry);
       this.detachErrorListener(entry);
@@ -370,7 +398,7 @@ export class ChainProviderManager {
       logger.warn(
         `[ChainProviderManager] chain=${entry.chainId} provider error: ${err.message}`,
       );
-      void this.triggerReconnect(entry, "provider_error", err.message);
+      this.triggerReconnect(entry, "provider_error", err.message);
     };
     entry.errorListener = listener;
     entry.provider.on("error", listener);
@@ -422,7 +450,7 @@ export class ChainProviderManager {
       logger.warn(
         `[ChainProviderManager] chain=${entry.chainId} heartbeat failed: ${message}`,
       );
-      void this.triggerReconnect(entry, reason, message);
+      this.triggerReconnect(entry, reason, message);
     }
   }
 
@@ -437,22 +465,23 @@ export class ChainProviderManager {
     entry.isReconnecting = true;
     this.stopHeartbeat(entry);
 
-    // Publish the reconnect promise on the entry BEFORE starting the
-    // work. `getOrCreateProvider` awaits this to avoid creating a second
-    // parallel provider while the reconnect is replacing the first.
-    // `.catch` before assigning so the stored promise never rejects: any
-    // bug in reconnectLoop surfaces via the logger, not by rejecting an
-    // await that callers would have to handle.
-    const loop = this.reconnectLoop(entry, reason, message).catch((err) => {
-      logger.error(
-        `[ChainProviderManager] chain=${entry.chainId} reconnect loop crashed: ${String(err)}`,
-      );
-    });
-    entry.reconnectPromise = loop;
-    void loop.finally(() => {
-      entry.reconnectPromise = null;
-      entry.isReconnecting = false;
-    });
+    // Publish the reconnect promise on the entry BEFORE any `await`
+    // yields. `getOrCreateProvider` awaits this to avoid creating a
+    // second parallel provider while the reconnect is replacing the
+    // first. State is cleared inside `reconnectLoop`'s `finally` so it
+    // happens synchronously with the promise settling - a follow-up
+    // error on the newly-attached provider will see
+    // `isReconnecting === false` by the time the prior loop has
+    // resolved, rather than racing an outer `.finally`.
+    // `.catch` so the stored promise never rejects: any bug surfaces
+    // via the logger, not via an await that callers have to handle.
+    entry.reconnectPromise = this.reconnectLoop(entry, reason, message).catch(
+      (err) => {
+        logger.error(
+          `[ChainProviderManager] chain=${entry.chainId} reconnect loop crashed: ${String(err)}`,
+        );
+      },
+    );
   }
 
   private async reconnectLoop(
@@ -460,48 +489,61 @@ export class ChainProviderManager {
     reason: DisconnectReason,
     message: string,
   ): Promise<void> {
-    // Fire disconnect handlers in parallel before the backoff begins.
-    // Sequential await here lets one slow handler delay reconnect start
-    // by its latency; Promise.all matches the dispatchLog pattern.
-    await Promise.all(
-      [...entry.disconnectHandlers].map(async (handler) => {
+    try {
+      // Fire disconnect handlers in parallel before the backoff begins.
+      // Sequential await here lets one slow handler delay reconnect
+      // start by its latency; Promise.all matches the dispatchLog pattern.
+      await Promise.all(
+        [...entry.disconnectHandlers].map(async (handler) => {
+          try {
+            await handler({ chainId: entry.chainId, reason, message });
+          } catch (err) {
+            logger.warn(
+              `[ChainProviderManager] chain=${entry.chainId} disconnect handler threw: ${String(err)}`,
+            );
+          }
+        }),
+      );
+
+      let delay = INITIAL_RECONNECT_DELAY_MS;
+      for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+        if (this.isDestroyed) {
+          return;
+        }
+        // Race the backoff sleep against the destroy signal so the loop
+        // wakes up immediately on teardown. The isDestroyed check after
+        // the race handles both paths: timer elapsed (normal) or
+        // destroy resolved (early).
+        await Promise.race([sleep(delay), this.destroyed.promise]);
+        if (this.isDestroyed) {
+          return;
+        }
         try {
-          await handler({ chainId: entry.chainId, reason, message });
+          await this.reconnect(entry);
+          logger.log(
+            `[ChainProviderManager] chain=${entry.chainId} reconnected on attempt ${attempt}`,
+          );
+          return;
         } catch (err) {
           logger.warn(
-            `[ChainProviderManager] chain=${entry.chainId} disconnect handler threw: ${String(err)}`,
+            `[ChainProviderManager] chain=${entry.chainId} reconnect attempt ${attempt} failed: ${String(err)}`,
           );
+          delay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
         }
-      }),
-    );
+      }
 
-    let delay = INITIAL_RECONNECT_DELAY_MS;
-    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
-      if (this.isDestroyed) {
-        return;
-      }
-      await sleep(delay);
-      if (this.isDestroyed) {
-        return;
-      }
-      try {
-        await this.reconnect(entry);
-        logger.log(
-          `[ChainProviderManager] chain=${entry.chainId} reconnected on attempt ${attempt}`,
-        );
-        return;
-      } catch (err) {
-        logger.warn(
-          `[ChainProviderManager] chain=${entry.chainId} reconnect attempt ${attempt} failed: ${String(err)}`,
-        );
-        delay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
-      }
+      logger.error(
+        `[ChainProviderManager] chain=${entry.chainId} exhausted ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
+      );
+      this.onPermanentFailure(entry.chainId);
+    } finally {
+      // Clear synchronously with the async function's return. By the
+      // time the caller awaits the stored `reconnectPromise` and
+      // unblocks, `isReconnecting` is already false - no window where a
+      // fresh error on the new provider gets silently dropped.
+      entry.reconnectPromise = null;
+      entry.isReconnecting = false;
     }
-
-    logger.error(
-      `[ChainProviderManager] chain=${entry.chainId} exhausted ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
-    );
-    this.onPermanentFailure(entry.chainId);
   }
 
   private async reconnect(entry: ChainEntry): Promise<void> {

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -12,19 +12,60 @@ import { logger } from "../../lib/utils/logger";
  * subscription count from workflow count (provider subscription caps are
  * typically ~1000 per WSS).
  *
- * Phase 1 scope: provider singleton + block-sub demux. Heartbeat and
- * reconnect continue to live in `ws-connection.ts` until Phase 3 routes
- * listeners through this manager at runtime.
+ * Per-chain reconnect + heartbeat are owned here. Drop detection uses two
+ * signals:
+ *   - `provider.on("error")` for transport-level errors surfaced by ethers
+ *   - An active heartbeat that pings `eth_blockNumber` every
+ *     `HEARTBEAT_INTERVAL_MS` with a `HEARTBEAT_TIMEOUT_MS` cap
+ *
+ * A passive `websocket.on("close")` hook was considered but rejected: it
+ * reaches into `(provider as any).websocket`, breaks between ethers
+ * versions, and adds no detection we do not already get from the
+ * heartbeat. Detection latency is bounded by heartbeat cadence, which is
+ * tuneable via the constants below.
+ *
+ * On drop: fire registered `onDisconnect` handlers, then attempt reconnect
+ * with exponential backoff. On exhaustion: call the injected
+ * `onPermanentFailure` callback (defaults to `process.exit(1)` so K8s
+ * restarts the pod - tests inject a no-op).
  */
 
 // Address list cap on `eth_getLogs` varies by provider (Alchemy ~500,
 // Infura ~1000). Chunk defensively; multiple calls per block are cheap.
 const GETLOGS_ADDRESS_BATCH = 500;
 
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_TIMEOUT_MS = 10_000;
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 60_000;
+const MAX_RECONNECT_ATTEMPTS = 10;
+
 export type LogHandler = (log: ethers.Log) => void | Promise<void>;
 export type Unsubscribe = () => void;
 
 export type ProviderFactory = (wssUrl: string) => ethers.WebSocketProvider;
+
+export type DisconnectReason =
+  | "provider_error"
+  | "heartbeat_failure"
+  | "heartbeat_timeout";
+
+export interface DisconnectEvent {
+  chainId: number;
+  reason: DisconnectReason;
+  message: string;
+}
+
+export type DisconnectHandler = (ev: DisconnectEvent) => void | Promise<void>;
+
+export interface ChainHealth {
+  chainId: number;
+  wssUrl: string;
+  connected: boolean;
+  reconnecting: boolean;
+  lastBlockAt: number | null;
+  subscriberCount: number;
+}
 
 export interface SubscribeOptions {
   chainId: number;
@@ -32,6 +73,11 @@ export interface SubscribeOptions {
   address: string;
   topic0: string;
   handler: LogHandler;
+}
+
+export interface ChainProviderManagerOptions {
+  factory?: ProviderFactory;
+  onPermanentFailure?: (chainId: number) => void;
 }
 
 interface Subscriber {
@@ -47,17 +93,39 @@ interface ChainEntry {
   readyPromise: Promise<ethers.WebSocketProvider> | null;
   subscribers: Set<Subscriber>;
   blockListener: ((blockNumber: number) => Promise<void>) | null;
+  errorListener: ((err: Error) => void) | null;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+  isReconnecting: boolean;
+  lastBlockAt: number | null;
+  disconnectHandlers: Set<DisconnectHandler>;
 }
 
 const defaultFactory: ProviderFactory = (wssUrl) =>
   new ethers.WebSocketProvider(wssUrl);
 
+const defaultOnPermanentFailure = (chainId: number): void => {
+  logger.error(
+    `[ChainProviderManager] chain=${chainId} permanent failure after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts; exiting process for K8s restart`,
+  );
+  process.exit(1);
+};
+
 export class ChainProviderManager {
   private readonly chains = new Map<number, ChainEntry>();
   private readonly factory: ProviderFactory;
+  private readonly onPermanentFailure: (chainId: number) => void;
+  private isDestroyed = false;
 
-  constructor(factory: ProviderFactory = defaultFactory) {
-    this.factory = factory;
+  constructor(opts: ChainProviderManagerOptions | ProviderFactory = {}) {
+    // Backward-compatible: the old signature accepted a bare factory function.
+    if (typeof opts === "function") {
+      this.factory = opts;
+      this.onPermanentFailure = defaultOnPermanentFailure;
+    } else {
+      this.factory = opts.factory ?? defaultFactory;
+      this.onPermanentFailure =
+        opts.onPermanentFailure ?? defaultOnPermanentFailure;
+    }
   }
 
   async getOrCreateProvider(
@@ -102,6 +170,25 @@ export class ChainProviderManager {
   }
 
   /**
+   * Register a handler that fires when the manager detects a transport
+   * drop for `chainId`. Fires once per drop, before reconnect begins.
+   * Throws if no ChainEntry exists yet for the chain (call
+   * `subscribeToLogs` or `getOrCreateProvider` first).
+   */
+  onDisconnect(chainId: number, handler: DisconnectHandler): Unsubscribe {
+    const entry = this.chains.get(chainId);
+    if (!entry) {
+      throw new Error(
+        `onDisconnect: no entry for chainId ${chainId}; call subscribeToLogs or getOrCreateProvider first`,
+      );
+    }
+    entry.disconnectHandlers.add(handler);
+    return () => {
+      entry.disconnectHandlers.delete(handler);
+    };
+  }
+
+  /**
    * True iff a provider instance has been created for `chainId`. Intended
    * for tests that need to assert the shared-provider invariant
    * (N listeners on chain X share one provider).
@@ -119,10 +206,51 @@ export class ChainProviderManager {
     return this.chains.get(chainId)?.subscribers.size ?? 0;
   }
 
+  isHealthy(chainId: number): boolean {
+    const entry = this.chains.get(chainId);
+    if (!entry) {
+      return false;
+    }
+    return entry.provider != null && !entry.isReconnecting;
+  }
+
+  getHealth(chainId: number): ChainHealth | null {
+    const entry = this.chains.get(chainId);
+    if (!entry) {
+      return null;
+    }
+    return {
+      chainId: entry.chainId,
+      wssUrl: entry.wssUrl,
+      connected: entry.provider != null && !entry.isReconnecting,
+      reconnecting: entry.isReconnecting,
+      lastBlockAt: entry.lastBlockAt,
+      subscriberCount: entry.subscribers.size,
+    };
+  }
+
+  getAllHealth(): ChainHealth[] {
+    const out: ChainHealth[] = [];
+    for (const entry of this.chains.values()) {
+      out.push({
+        chainId: entry.chainId,
+        wssUrl: entry.wssUrl,
+        connected: entry.provider != null && !entry.isReconnecting,
+        reconnecting: entry.isReconnecting,
+        lastBlockAt: entry.lastBlockAt,
+        subscriberCount: entry.subscribers.size,
+      });
+    }
+    return out;
+  }
+
   async destroy(): Promise<void> {
+    this.isDestroyed = true;
     const errors: unknown[] = [];
     for (const entry of this.chains.values()) {
+      this.stopHeartbeat(entry);
       this.detachBlockListener(entry);
+      this.detachErrorListener(entry);
       if (entry.provider) {
         try {
           await entry.provider.destroy();
@@ -131,6 +259,7 @@ export class ChainProviderManager {
         }
       }
       entry.subscribers.clear();
+      entry.disconnectHandlers.clear();
       entry.provider = null;
       entry.readyPromise = null;
     }
@@ -161,6 +290,11 @@ export class ChainProviderManager {
       readyPromise: null,
       subscribers: new Set(),
       blockListener: null,
+      errorListener: null,
+      heartbeatTimer: null,
+      isReconnecting: false,
+      lastBlockAt: null,
+      disconnectHandlers: new Set(),
     };
     this.chains.set(chainId, entry);
     return entry;
@@ -172,6 +306,8 @@ export class ChainProviderManager {
     const provider = this.factory(entry.wssUrl);
     await provider.ready;
     entry.provider = provider;
+    this.attachErrorListener(entry);
+    this.startHeartbeat(entry);
     return provider;
   }
 
@@ -182,6 +318,7 @@ export class ChainProviderManager {
       );
     }
     const listener = async (blockNumber: number): Promise<void> => {
+      entry.lastBlockAt = Date.now();
       await this.processBlock(entry, blockNumber);
     };
     entry.blockListener = listener;
@@ -195,6 +332,155 @@ export class ChainProviderManager {
     }
     entry.provider.off("block", entry.blockListener);
     entry.blockListener = null;
+  }
+
+  private attachErrorListener(entry: ChainEntry): void {
+    if (!entry.provider) {
+      return;
+    }
+    const listener = (err: Error): void => {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} provider error: ${err.message}`,
+      );
+      void this.triggerReconnect(entry, "provider_error", err.message);
+    };
+    entry.errorListener = listener;
+    entry.provider.on("error", listener);
+  }
+
+  private detachErrorListener(entry: ChainEntry): void {
+    if (!(entry.provider && entry.errorListener)) {
+      entry.errorListener = null;
+      return;
+    }
+    entry.provider.off("error", entry.errorListener);
+    entry.errorListener = null;
+  }
+
+  private startHeartbeat(entry: ChainEntry): void {
+    this.stopHeartbeat(entry);
+    entry.heartbeatTimer = setInterval(() => {
+      void this.runHeartbeat(entry);
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(entry: ChainEntry): void {
+    if (entry.heartbeatTimer) {
+      clearInterval(entry.heartbeatTimer);
+      entry.heartbeatTimer = null;
+    }
+  }
+
+  private async runHeartbeat(entry: ChainEntry): Promise<void> {
+    if (this.isDestroyed || entry.isReconnecting || !entry.provider) {
+      return;
+    }
+    try {
+      await Promise.race([
+        entry.provider.send("eth_blockNumber", []),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("heartbeat timeout")),
+            HEARTBEAT_TIMEOUT_MS,
+          ),
+        ),
+      ]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const reason: DisconnectReason =
+        message === "heartbeat timeout"
+          ? "heartbeat_timeout"
+          : "heartbeat_failure";
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} heartbeat failed: ${message}`,
+      );
+      void this.triggerReconnect(entry, reason, message);
+    }
+  }
+
+  private async triggerReconnect(
+    entry: ChainEntry,
+    reason: DisconnectReason,
+    message: string,
+  ): Promise<void> {
+    if (this.isDestroyed || entry.isReconnecting) {
+      return;
+    }
+    entry.isReconnecting = true;
+    this.stopHeartbeat(entry);
+
+    // Fire disconnect handlers before attempting reconnect. Handler errors
+    // are isolated so one bad consumer cannot block the reconnect.
+    for (const handler of entry.disconnectHandlers) {
+      try {
+        await handler({ chainId: entry.chainId, reason, message });
+      } catch (err) {
+        logger.warn(
+          `[ChainProviderManager] chain=${entry.chainId} disconnect handler threw: ${String(err)}`,
+        );
+      }
+    }
+
+    let delay = INITIAL_RECONNECT_DELAY_MS;
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+      if (this.isDestroyed) {
+        entry.isReconnecting = false;
+        return;
+      }
+      await sleep(delay);
+      if (this.isDestroyed) {
+        entry.isReconnecting = false;
+        return;
+      }
+      try {
+        await this.reconnect(entry);
+        logger.log(
+          `[ChainProviderManager] chain=${entry.chainId} reconnected on attempt ${attempt}`,
+        );
+        entry.isReconnecting = false;
+        return;
+      } catch (err) {
+        logger.warn(
+          `[ChainProviderManager] chain=${entry.chainId} reconnect attempt ${attempt} failed: ${String(err)}`,
+        );
+        delay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
+      }
+    }
+
+    logger.error(
+      `[ChainProviderManager] chain=${entry.chainId} exhausted ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
+    );
+    entry.isReconnecting = false;
+    this.onPermanentFailure(entry.chainId);
+  }
+
+  private async reconnect(entry: ChainEntry): Promise<void> {
+    // Tear down the old provider (best-effort) and unhook listeners so the
+    // old provider cannot trigger another reconnect while we are building
+    // the new one.
+    if (entry.provider) {
+      this.detachBlockListener(entry);
+      this.detachErrorListener(entry);
+      try {
+        await entry.provider.destroy();
+      } catch {
+        // ignore
+      }
+    }
+    entry.provider = null;
+    entry.readyPromise = null;
+
+    // Re-create. Any throw here propagates to triggerReconnect which
+    // handles backoff.
+    const provider = this.factory(entry.wssUrl);
+    await provider.ready;
+    entry.provider = provider;
+
+    this.attachErrorListener(entry);
+    if (entry.subscribers.size > 0) {
+      this.attachBlockListener(entry);
+    }
+    this.startHeartbeat(entry);
   }
 
   private async processBlock(
@@ -279,6 +565,10 @@ export class ChainProviderManager {
       }),
     );
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export const chainProviderManager = new ChainProviderManager();

--- a/keeperhub-events/event-tracker/src/health/health-server.ts
+++ b/keeperhub-events/event-tracker/src/health/health-server.ts
@@ -1,0 +1,91 @@
+import {
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+  createServer,
+} from "node:http";
+import type { ChainProviderManager } from "../chains/provider-manager";
+
+/**
+ * HTTP `/healthz` endpoint for the in-process architecture (KEEP-295).
+ *
+ * Semantics:
+ *   - 200 `{ status: "ok", chains: [...] }` when every registered chain
+ *     reports `connected: true`, OR when no chains have been registered
+ *     yet (process is still starting up; nothing is "down").
+ *   - 503 `{ status: "degraded", chains: [...] }` when any chain is
+ *     reconnecting or has no provider.
+ *   - 404 for any path other than `/healthz`.
+ *
+ * Fork mode note: in fork mode the parent process does not use
+ * ChainProviderManager (children own their own WsConnection). This
+ * endpoint will therefore always return 200 in fork mode with an empty
+ * chains list, providing no additional signal over the existing pgrep
+ * probe. It becomes meaningful only when ENABLE_INPROC_LISTENERS is on.
+ * Helm values should keep the pgrep probe until cutover.
+ */
+
+export interface HealthResponseBody {
+  status: "ok" | "degraded";
+  chains: ReturnType<ChainProviderManager["getAllHealth"]>;
+}
+
+export function buildHealthResponse(providerManager: ChainProviderManager): {
+  status: 200 | 503;
+  body: HealthResponseBody;
+} {
+  const chains = providerManager.getAllHealth();
+  const allHealthy = chains.length === 0 || chains.every((c) => c.connected);
+  return {
+    status: allHealthy ? 200 : 503,
+    body: { status: allHealthy ? "ok" : "degraded", chains },
+  };
+}
+
+export function createHealthRequestHandler(
+  providerManager: ChainProviderManager,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    const url = req.url ?? "";
+    const pathOnly = url.split("?")[0];
+    if (pathOnly !== "/healthz") {
+      res.writeHead(404).end();
+      return;
+    }
+    const { status, body } = buildHealthResponse(providerManager);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  };
+}
+
+export interface HealthServerHandle {
+  server: Server;
+  port: number;
+  close(): Promise<void>;
+}
+
+export async function startHealthServer(
+  providerManager: ChainProviderManager,
+  port: number,
+): Promise<HealthServerHandle> {
+  const server = createServer(createHealthRequestHandler(providerManager));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  const boundPort =
+    typeof address === "object" && address ? address.port : port;
+  return {
+    server,
+    port: boundPort,
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/keeperhub-events/event-tracker/src/index.ts
+++ b/keeperhub-events/event-tracker/src/index.ts
@@ -1,7 +1,15 @@
 import os from "node:os";
 import { syncModule } from "../lib/sync/redis";
 import { logger } from "../lib/utils/logger";
+import { chainProviderManager } from "./chains/provider-manager";
+import {
+  type HealthServerHandle,
+  startHealthServer,
+} from "./health/health-server";
 import { shutdownRegistry, synchronizeData } from "./main";
+
+const HEALTH_PORT = Number(process.env.HEALTH_PORT ?? 3001);
+let healthServer: HealthServerHandle | null = null;
 
 // Fatal-error handlers: an uncaught exception or unhandled rejection inside a
 // listener callback is almost always a bug that leaves the process in an
@@ -33,6 +41,14 @@ async function shutdown(signal: string): Promise<void> {
     const message = err instanceof Error ? err.message : String(err);
     logger.error(`[Shutdown] error during registry shutdown: ${message}`);
   }
+  if (healthServer) {
+    try {
+      await healthServer.close();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`[Shutdown] error closing health server: ${message}`);
+    }
+  }
   process.exit(0);
 }
 process.on("SIGTERM", () => {
@@ -46,6 +62,9 @@ logger.log(`Initializing container: ${os.hostname()}`);
 
 const initialize = async (): Promise<void> => {
   try {
+    healthServer = await startHealthServer(chainProviderManager, HEALTH_PORT);
+    logger.log(`[Health] /healthz listening on :${healthServer.port}`);
+
     await syncModule.removeAllContainers();
     logger.log("Cleared stale Redis state from previous deploys");
 

--- a/keeperhub-events/event-tracker/src/index.ts
+++ b/keeperhub-events/event-tracker/src/index.ts
@@ -61,10 +61,15 @@ process.on("SIGINT", () => {
 logger.log(`Initializing container: ${os.hostname()}`);
 
 const initialize = async (): Promise<void> => {
-  try {
-    healthServer = await startHealthServer(chainProviderManager, HEALTH_PORT);
-    logger.log(`[Health] /healthz listening on :${healthServer.port}`);
+  // Health server bind must succeed for K8s probes to work. Kept outside
+  // the try/catch below so a bind failure (port taken, EACCES) rejects
+  // initialize(), which the unhandledRejection handler turns into
+  // exit(1) for K8s restart. A silent bind failure would zombify the
+  // pod: process alive, no workflows running, no probe.
+  healthServer = await startHealthServer(chainProviderManager, HEALTH_PORT);
+  logger.log(`[Health] /healthz listening on :${healthServer.port}`);
 
+  try {
     await syncModule.removeAllContainers();
     logger.log("Cleared stale Redis state from previous deploys");
 

--- a/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
@@ -1,0 +1,147 @@
+import type { AddressInfo } from "node:net";
+import type { ethers } from "ethers";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ChainProviderManager,
+  type ProviderFactory,
+} from "../../src/chains/provider-manager";
+import {
+  type HealthServerHandle,
+  buildHealthResponse,
+  startHealthServer,
+} from "../../src/health/health-server";
+
+class MockProvider {
+  ready: Promise<void> = Promise.resolve();
+  destroyed = false;
+  on(): void {
+    /* noop */
+  }
+  off(): void {
+    /* noop */
+  }
+  async send(): Promise<unknown> {
+    return 0;
+  }
+  async destroy(): Promise<void> {
+    this.destroyed = true;
+  }
+}
+
+const factory: ProviderFactory = () =>
+  new MockProvider() as unknown as ethers.WebSocketProvider;
+
+describe("health-server", () => {
+  let manager: ChainProviderManager;
+
+  beforeEach(() => {
+    manager = new ChainProviderManager({
+      factory,
+      onPermanentFailure: () => {
+        /* test does not exit the process */
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await manager.destroy();
+  });
+
+  describe("buildHealthResponse", () => {
+    it("returns 200 + ok when no chains are registered", () => {
+      const { status, body } = buildHealthResponse(manager);
+      expect(status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.chains).toEqual([]);
+    });
+
+    it("returns 200 + ok when every registered chain is connected", async () => {
+      await manager.getOrCreateProvider(1, "ws://a");
+      await manager.getOrCreateProvider(2, "ws://b");
+      const { status, body } = buildHealthResponse(manager);
+      expect(status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.chains).toHaveLength(2);
+      expect(body.chains.every((c) => c.connected)).toBe(true);
+    });
+
+    it("returns 503 + degraded when any chain is not connected", async () => {
+      await manager.getOrCreateProvider(1, "ws://a");
+      // Force chain 1 into a reconnecting state without waiting for the
+      // real reconnect cycle: mutate the private entry via the test-only
+      // escape hatch. This avoids depending on fake timers here.
+      const entries = (
+        manager as unknown as {
+          chains: Map<number, { isReconnecting: boolean }>;
+        }
+      ).chains;
+      const entry = entries.get(1);
+      if (entry) {
+        entry.isReconnecting = true;
+      }
+
+      const { status, body } = buildHealthResponse(manager);
+      expect(status).toBe(503);
+      expect(body.status).toBe("degraded");
+      expect(body.chains[0].connected).toBe(false);
+      expect(body.chains[0].reconnecting).toBe(true);
+    });
+  });
+
+  describe("HTTP server", () => {
+    let handle: HealthServerHandle;
+
+    beforeEach(async () => {
+      // Port 0 = let the OS assign a free one, avoiding port contention in CI.
+      handle = await startHealthServer(manager, 0);
+    });
+
+    afterEach(async () => {
+      await handle.close();
+    });
+
+    it("responds 200 on /healthz when no chains registered", async () => {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; chains: unknown[] };
+      expect(body.status).toBe("ok");
+      expect(body.chains).toEqual([]);
+    });
+
+    it("responds 503 on /healthz when a chain is reconnecting", async () => {
+      await manager.getOrCreateProvider(1, "ws://a");
+      const entries = (
+        manager as unknown as {
+          chains: Map<number, { isReconnecting: boolean }>;
+        }
+      ).chains;
+      const entry = entries.get(1);
+      if (entry) {
+        entry.isReconnecting = true;
+      }
+
+      const res = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("degraded");
+    });
+
+    it("responds 404 on unknown paths", async () => {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/nope`);
+      expect(res.status).toBe(404);
+    });
+
+    it("strips query strings from /healthz", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${handle.port}/healthz?verbose=1`,
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("binds to a concrete port via the returned handle", () => {
+      expect(handle.port).toBeGreaterThan(0);
+      const address = handle.server.address() as AddressInfo;
+      expect(address.port).toBe(handle.port);
+    });
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1,11 +1,12 @@
 import type { ethers } from "ethers";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ChainProviderManager,
   type ProviderFactory,
 } from "../../src/chains/provider-manager";
 
 type BlockHandler = (blockNumber: number) => void | Promise<void>;
+type ErrorHandler = (err: Error) => void;
 
 interface SendCall {
   method: string;
@@ -18,23 +19,39 @@ class MockProvider {
   ready: Promise<void> = Promise.resolve();
   public sendCalls: SendCall[] = [];
   public sendResponses: unknown[] = [];
+  public blockNumberResponses: Array<number | Error> = [];
   public destroyed = false;
   private blockHandler: BlockHandler | null = null;
+  private errorHandler: ErrorHandler | null = null;
 
-  on(event: string, handler: BlockHandler): void {
+  on(event: string, handler: BlockHandler | ErrorHandler): void {
     if (event === "block") {
-      this.blockHandler = handler;
+      this.blockHandler = handler as BlockHandler;
+    } else if (event === "error") {
+      this.errorHandler = handler as ErrorHandler;
     }
   }
 
-  off(event: string, handler: BlockHandler): void {
+  off(event: string, handler: BlockHandler | ErrorHandler): void {
     if (event === "block" && this.blockHandler === handler) {
       this.blockHandler = null;
+    } else if (event === "error" && this.errorHandler === handler) {
+      this.errorHandler = null;
     }
   }
 
   async send(method: string, params: unknown[]): Promise<unknown> {
     this.sendCalls.push({ method, params });
+    if (method === "eth_blockNumber") {
+      if (this.blockNumberResponses.length === 0) {
+        return 0x1234;
+      }
+      const next = this.blockNumberResponses.shift();
+      if (next instanceof Error) {
+        throw next;
+      }
+      return next;
+    }
     if (this.sendResponses.length === 0) {
       return [];
     }
@@ -49,10 +66,18 @@ class MockProvider {
     return this.blockHandler !== null;
   }
 
+  hasErrorHandler(): boolean {
+    return this.errorHandler !== null;
+  }
+
   async emitBlock(blockNumber: number): Promise<void> {
     if (this.blockHandler) {
       await this.blockHandler(blockNumber);
     }
+  }
+
+  emitError(err: Error): void {
+    this.errorHandler?.(err);
   }
 }
 
@@ -84,10 +109,22 @@ const TOPIC_OTHER =
 describe("ChainProviderManager", () => {
   let factoryBundle: ReturnType<typeof makeFactory>;
   let manager: ChainProviderManager;
+  let onPermanentFailure: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     factoryBundle = makeFactory();
-    manager = new ChainProviderManager(factoryBundle.factory);
+    onPermanentFailure = vi.fn();
+    manager = new ChainProviderManager({
+      factory: factoryBundle.factory,
+      onPermanentFailure,
+    });
+  });
+
+  afterEach(async () => {
+    // Each test's manager starts a heartbeat on every provider it creates.
+    // destroy() clears those intervals; without this, timers leak between
+    // tests (harmless in CI but noisy when debugging with --ui).
+    await manager.destroy();
   });
 
   describe("getOrCreateProvider", () => {
@@ -469,6 +506,286 @@ describe("ChainProviderManager", () => {
 
       unsubA();
       expect(manager.subscriberCount(CHAIN_A)).toBe(1);
+    });
+  });
+
+  describe("health accessors", () => {
+    it("isHealthy returns false for unknown chain", () => {
+      expect(manager.isHealthy(CHAIN_A)).toBe(false);
+    });
+
+    it("isHealthy returns true after a provider is created", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+    });
+
+    it("getHealth returns null for unknown chain", () => {
+      expect(manager.getHealth(CHAIN_A)).toBeNull();
+    });
+
+    it("getHealth reports connected/reconnecting/subscriberCount", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const h = manager.getHealth(CHAIN_A);
+      expect(h).toEqual({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        connected: true,
+        reconnecting: false,
+        lastBlockAt: null,
+        subscriberCount: 1,
+      });
+    });
+
+    it("getHealth.lastBlockAt updates after a block arrives", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(manager.getHealth(CHAIN_A)?.lastBlockAt).toBeNull();
+      await factoryBundle.created[0].emitBlock(123);
+      const after = manager.getHealth(CHAIN_A)?.lastBlockAt;
+      expect(after).not.toBeNull();
+      expect(typeof after).toBe("number");
+    });
+
+    it("getAllHealth returns an entry per known chain", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      await manager.getOrCreateProvider(CHAIN_B, "ws://b");
+      const all = manager.getAllHealth();
+      expect(all).toHaveLength(2);
+      expect(all.map((h) => h.chainId).sort()).toEqual([CHAIN_B, CHAIN_A]);
+    });
+
+    it("getAllHealth returns empty when no chains are registered", () => {
+      expect(manager.getAllHealth()).toEqual([]);
+    });
+  });
+
+  describe("onDisconnect", () => {
+    it("throws when no entry exists for the chain", () => {
+      expect(() => manager.onDisconnect(CHAIN_A, vi.fn())).toThrow(
+        /no entry for chainId/,
+      );
+    });
+
+    it("fires with chainId and reason when the provider emits an error", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const handler = vi.fn();
+      manager.onDisconnect(CHAIN_A, handler);
+
+      factoryBundle.created[0].emitError(new Error("boom"));
+      // Allow the reconnect microtask queue to start so the disconnect
+      // handler fires; reconnect itself is delayed (INITIAL_RECONNECT_DELAY_MS).
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({
+        chainId: CHAIN_A,
+        reason: "provider_error",
+        message: "boom",
+      });
+    });
+
+    it("unsubscribe removes the handler", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const handler = vi.fn();
+      const unsub = manager.onDisconnect(CHAIN_A, handler);
+      unsub();
+
+      factoryBundle.created[0].emitError(new Error("boom"));
+      await Promise.resolve();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reconnect cycle", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("re-creates provider, preserves subscribers, reattaches block listener", async () => {
+      const handler = vi.fn();
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler,
+      });
+      expect(factoryBundle.created).toHaveLength(1);
+      const first = factoryBundle.created[0];
+
+      first.emitError(new Error("wss dropped"));
+      // Let disconnect handlers run, then fast-forward past the reconnect
+      // delay so the first attempt completes.
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      expect(factoryBundle.created).toHaveLength(2);
+      const second = factoryBundle.created[1];
+      // The subscription must survive, and the new provider must be wired
+      // up for both block events and future errors.
+      expect(manager.subscriberCount(CHAIN_A)).toBe(1);
+      expect(second.hasBlockHandler()).toBe(true);
+      expect(second.hasErrorHandler()).toBe(true);
+      // Old provider was torn down.
+      expect(first.destroyed).toBe(true);
+      // isHealthy true again after successful reconnect.
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+      expect(manager.getHealth(CHAIN_A)?.reconnecting).toBe(false);
+    });
+
+    it("does not re-attach block listener if all subscribers unsubscribed during reconnect", async () => {
+      const handler = vi.fn();
+      const unsub = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler,
+      });
+      factoryBundle.created[0].emitError(new Error("drop"));
+      // Unsubscribe while reconnect is in flight (before the delay).
+      unsub();
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      const second = factoryBundle.created[1];
+      expect(second.hasBlockHandler()).toBe(false);
+      // Error listener is still attached; it is chain-scoped, not sub-scoped.
+      expect(second.hasErrorHandler()).toBe(true);
+    });
+
+    it("onDisconnect fires before the first reconnect attempt completes", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const order: string[] = [];
+      manager.onDisconnect(CHAIN_A, () => {
+        order.push("disconnect");
+      });
+      // Spy the factory call count - reconnect creates a new provider.
+      const createdBefore = factoryBundle.created.length;
+
+      factoryBundle.created[0].emitError(new Error("drop"));
+      await Promise.resolve();
+      order.push(
+        `after_microtasks(created=${factoryBundle.created.length - createdBefore})`,
+      );
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      order.push(
+        `after_delay(created=${factoryBundle.created.length - createdBefore})`,
+      );
+
+      expect(order[0]).toBe("disconnect");
+      expect(order[1]).toBe("after_microtasks(created=0)");
+      expect(order[2]).toBe("after_delay(created=1)");
+    });
+
+    it("isHealthy is false while reconnecting", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      factoryBundle.created[0].emitError(new Error("drop"));
+      // Give the disconnect handler loop a chance to set isReconnecting,
+      // but do NOT advance past the reconnect delay.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(manager.getHealth(CHAIN_A)?.reconnecting).toBe(true);
+      expect(manager.isHealthy(CHAIN_A)).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+    });
+
+    it("exhausted attempts call onPermanentFailure (injected)", async () => {
+      // Fail the second provider factory call and every attempt after it.
+      const failingFactory: ProviderFactory = () => {
+        throw new Error("upstream down");
+      };
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      // Hot-swap the factory for the reconnect attempts by reaching into
+      // the manager. Cleaner alternative would be to make factory
+      // dynamic; this preserves the simpler public API.
+      (manager as unknown as { factory: ProviderFactory }).factory =
+        failingFactory;
+
+      factoryBundle.created[0].emitError(new Error("drop"));
+      // Fast-forward through all reconnect attempts (1s + 2s + 4s + ...,
+      // capped at 60s per attempt; 10 attempts total).
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+      expect(onPermanentFailure).toHaveBeenCalledTimes(1);
+      expect(onPermanentFailure).toHaveBeenCalledWith(CHAIN_A);
+    });
+  });
+
+  describe("heartbeat", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("pings eth_blockNumber periodically", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const provider = factoryBundle.created[0];
+      const pingsBefore = provider.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const pingsAfter = provider.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
+      expect(pingsAfter).toBeGreaterThan(pingsBefore);
+    });
+
+    it("thrown eth_blockNumber triggers reconnect with heartbeat_failure reason", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const provider = factoryBundle.created[0];
+      const reasons: string[] = [];
+      manager.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      provider.blockNumberResponses.push(new Error("rpc dead"));
+      await vi.advanceTimersByTimeAsync(30_100);
+
+      expect(reasons).toEqual(["heartbeat_failure"]);
+    });
+
+    it("timeout triggers reconnect with heartbeat_timeout reason", async () => {
+      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const provider = factoryBundle.created[0];
+      const reasons: string[] = [];
+      manager.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      // Make eth_blockNumber hang indefinitely. The 10s timeout inside
+      // runHeartbeat should fire and surface as heartbeat_timeout.
+      provider.send = ((): Promise<unknown> => {
+        return new Promise<unknown>(() => {
+          // never resolves
+        });
+      }) as unknown as typeof provider.send;
+
+      await vi.advanceTimersByTimeAsync(30_000); // schedule first heartbeat
+      await vi.advanceTimersByTimeAsync(10_000); // let timeout race win
+
+      expect(reasons).toEqual(["heartbeat_timeout"]);
     });
   });
 

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -84,17 +84,32 @@ class MockProvider {
 // MockProvider implements the ethers.WebSocketProvider surface that
 // ChainProviderManager actually uses. The factory casts through unknown to
 // satisfy the type without pulling in the rest of ethers' provider surface.
+//
+// `setPersistentFailure` makes every subsequent factory call throw until
+// cleared - used to exercise the exhausted-attempts path without reaching
+// into the manager's private `factory` field.
 function makeFactory(): {
   factory: ProviderFactory;
   created: MockProvider[];
+  setPersistentFailure: (err: Error | null) => void;
 } {
   const created: MockProvider[] = [];
+  let persistentFailure: Error | null = null;
   const factory: ProviderFactory = (_wssUrl: string) => {
+    if (persistentFailure) {
+      throw persistentFailure;
+    }
     const mock = new MockProvider();
     created.push(mock);
     return mock as unknown as ethers.WebSocketProvider;
   };
-  return { factory, created };
+  return {
+    factory,
+    created,
+    setPersistentFailure: (err) => {
+      persistentFailure = err;
+    },
+  };
 }
 
 const CHAIN_A = 31337;
@@ -708,16 +723,16 @@ describe("ChainProviderManager", () => {
     });
 
     it("exhausted attempts call onPermanentFailure (injected)", async () => {
-      // Fail the second provider factory call and every attempt after it.
-      const failingFactory: ProviderFactory = () => {
-        throw new Error("upstream down");
-      };
-      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
-      // Hot-swap the factory for the reconnect attempts by reaching into
-      // the manager. Cleaner alternative would be to make factory
-      // dynamic; this preserves the simpler public API.
-      (manager as unknown as { factory: ProviderFactory }).factory =
-        failingFactory;
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      // Make every subsequent factory call throw so the reconnect loop
+      // burns through all 10 attempts.
+      factoryBundle.setPersistentFailure(new Error("upstream down"));
 
       factoryBundle.created[0].emitError(new Error("drop"));
       // Fast-forward through all reconnect attempts (1s + 2s + 4s + ...,
@@ -726,6 +741,98 @@ describe("ChainProviderManager", () => {
 
       expect(onPermanentFailure).toHaveBeenCalledTimes(1);
       expect(onPermanentFailure).toHaveBeenCalledWith(CHAIN_A);
+    });
+
+    it("concurrent subscribe during reconnect does not fire a second factory call (race fix)", async () => {
+      // Without the reconnectPromise guard, a new subscribe arriving
+      // while reconnect has torn down the old provider (entry.provider
+      // null, entry.readyPromise null) would call createProvider and
+      // produce a second factory call. The race was this test's reason
+      // to exist.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(factoryBundle.created).toHaveLength(1);
+
+      factoryBundle.created[0].emitError(new Error("drop"));
+      // Start a second subscription mid-reconnect. The call should
+      // block on entry.reconnectPromise and resolve only once the
+      // reconnect has assigned the new provider.
+      const subscribePromise = manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      // Before the delay elapses, no reconnect has completed.
+      await Promise.resolve();
+      expect(factoryBundle.created).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      await subscribePromise;
+
+      // Exactly one reconnect-time factory call, not two.
+      expect(factoryBundle.created).toHaveLength(2);
+      expect(manager.subscriberCount(CHAIN_A)).toBe(2);
+    });
+
+    it("destroy during reconnect tears down any provider created after destroy wins the race", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const first = factoryBundle.created[0];
+
+      first.emitError(new Error("drop"));
+      // Advance to just before the reconnect attempt fires.
+      await vi.advanceTimersByTimeAsync(999);
+
+      // Call destroy; the reconnect is still pending its first attempt.
+      const destroyPromise = manager.destroy();
+
+      // Now let the reconnect's setTimeout elapse - the reconnect will
+      // see isDestroyed and bail before creating a new provider, OR
+      // will create one and then destroy it immediately.
+      await vi.advanceTimersByTimeAsync(100);
+      await destroyPromise;
+
+      // Either path is acceptable: no orphan provider should be running.
+      // If a second provider was created, it must be destroyed.
+      for (const p of factoryBundle.created) {
+        expect(p.destroyed).toBe(true);
+      }
+    });
+
+    it("a second drop after successful reconnect triggers another reconnect cycle", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      factoryBundle.created[0].emitError(new Error("drop 1"));
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(factoryBundle.created).toHaveLength(2);
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+
+      // Drop again on the new provider.
+      factoryBundle.created[1].emitError(new Error("drop 2"));
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      expect(factoryBundle.created).toHaveLength(3);
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+      expect(manager.subscriberCount(CHAIN_A)).toBe(1);
     });
   });
 
@@ -737,8 +844,29 @@ describe("ChainProviderManager", () => {
       vi.useRealTimers();
     });
 
-    it("pings eth_blockNumber periodically", async () => {
+    it("does not ping when no subscribers are registered", async () => {
+      // Heartbeat is subscriber-scoped: creating a provider without
+      // subscribing leaves it silent. Previously the heartbeat started
+      // on provider creation, wasting RPC calls on idle providers.
       await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      const provider = factoryBundle.created[0];
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      const pings = provider.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
+      expect(pings).toBe(0);
+    });
+
+    it("pings eth_blockNumber periodically once a subscriber is added", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
       const provider = factoryBundle.created[0];
       const pingsBefore = provider.sendCalls.filter(
         (c) => c.method === "eth_blockNumber",
@@ -752,8 +880,35 @@ describe("ChainProviderManager", () => {
       expect(pingsAfter).toBeGreaterThan(pingsBefore);
     });
 
+    it("stops when the last subscriber unsubscribes", async () => {
+      const unsub = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const provider = factoryBundle.created[0];
+      unsub();
+
+      const pingsBefore = provider.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
+      await vi.advanceTimersByTimeAsync(60_000);
+      const pingsAfter = provider.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
+      expect(pingsAfter).toBe(pingsBefore);
+    });
+
     it("thrown eth_blockNumber triggers reconnect with heartbeat_failure reason", async () => {
-      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
       const provider = factoryBundle.created[0];
       const reasons: string[] = [];
       manager.onDisconnect(CHAIN_A, (ev) => {
@@ -767,7 +922,13 @@ describe("ChainProviderManager", () => {
     });
 
     it("timeout triggers reconnect with heartbeat_timeout reason", async () => {
-      await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
       const provider = factoryBundle.created[0];
       const reasons: string[] = [];
       manager.onDisconnect(CHAIN_A, (ev) => {

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -743,6 +743,51 @@ describe("ChainProviderManager", () => {
       expect(onPermanentFailure).toHaveBeenCalledWith(CHAIN_A);
     });
 
+    it("subscribe after exhaustion re-wires block listener and heartbeat on the new provider", async () => {
+      // This covers a test-only edge case: when onPermanentFailure is a
+      // no-op (prod would exit the process), the manager is left with
+      // entry.provider=null and subscribers intact. A fresh subscribe
+      // must still produce a working provider (block listener attached,
+      // heartbeat running). Keying off `!entry.blockListener` rather
+      // than "was the subscriber set empty" is what makes this work.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      factoryBundle.setPersistentFailure(new Error("upstream down"));
+      factoryBundle.created[0].emitError(new Error("drop"));
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      expect(onPermanentFailure).toHaveBeenCalledTimes(1);
+
+      // Upstream is healthy again. Clear the persistent failure and add
+      // another subscriber for the same chain.
+      factoryBundle.setPersistentFailure(null);
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_B,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      // A fresh provider must exist AND have its block listener and
+      // heartbeat active; otherwise the new subscriber would silently
+      // never receive events.
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+      const latest = factoryBundle.created.at(-1);
+      expect(latest?.hasBlockHandler()).toBe(true);
+      expect(latest?.hasErrorHandler()).toBe(true);
+      // Heartbeat fires periodically on the new provider.
+      await vi.advanceTimersByTimeAsync(30_100);
+      const pings = latest?.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
+      expect(pings ?? 0).toBeGreaterThan(0);
+    });
+
     it("concurrent subscribe during reconnect does not fire a second factory call (race fix)", async () => {
       // Without the reconnectPromise guard, a new subscribe arriving
       // while reconnect has torn down the old provider (entry.provider
@@ -782,7 +827,7 @@ describe("ChainProviderManager", () => {
       expect(manager.subscriberCount(CHAIN_A)).toBe(2);
     });
 
-    it("destroy during reconnect tears down any provider created after destroy wins the race", async () => {
+    it("destroy during reconnect: no orphan providers, no pending loops, chains cleared", async () => {
       await manager.subscribeToLogs({
         chainId: CHAIN_A,
         wssUrl: "ws://a",
@@ -790,26 +835,61 @@ describe("ChainProviderManager", () => {
         topic0: TOPIC_EMITTED,
         handler: vi.fn(),
       });
-      const first = factoryBundle.created[0];
 
-      first.emitError(new Error("drop"));
-      // Advance to just before the reconnect attempt fires.
+      factoryBundle.created[0].emitError(new Error("drop"));
+      // Pause just before the reconnect attempt would fire.
       await vi.advanceTimersByTimeAsync(999);
 
-      // Call destroy; the reconnect is still pending its first attempt.
-      const destroyPromise = manager.destroy();
+      // Destroy while the reconnect is sleeping. The destroy signal
+      // wakes the sleep via Promise.race so this resolves in finite
+      // time even with fake timers still paused.
+      await manager.destroy();
 
-      // Now let the reconnect's setTimeout elapse - the reconnect will
-      // see isDestroyed and bail before creating a new provider, OR
-      // will create one and then destroy it immediately.
-      await vi.advanceTimersByTimeAsync(100);
-      await destroyPromise;
-
-      // Either path is acceptable: no orphan provider should be running.
-      // If a second provider was created, it must be destroyed.
+      // Every provider that was created must have been destroyed. No
+      // more than one additional provider should exist (the one
+      // initial provider and at most one reconnect attempt before
+      // destroy won the race).
+      expect(factoryBundle.created.length).toBeLessThanOrEqual(2);
       for (const p of factoryBundle.created) {
         expect(p.destroyed).toBe(true);
       }
+
+      // No dangling per-chain state.
+      expect(manager.getAllHealth()).toEqual([]);
+      expect(manager.isHealthy(CHAIN_A)).toBe(false);
+      expect(manager.hasProvider(CHAIN_A)).toBe(false);
+    });
+
+    it("destroy awaits an in-flight reconnect rather than racing it", async () => {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      // Make every reconnect attempt throw so the loop spends its full
+      // life in the backoff sleeps rather than completing.
+      factoryBundle.setPersistentFailure(new Error("upstream down"));
+
+      factoryBundle.created[0].emitError(new Error("drop"));
+      // Give the loop a tick to enter its first sleep.
+      await Promise.resolve();
+
+      const destroyDone = vi.fn();
+      const destroyPromise = manager.destroy().then(destroyDone);
+
+      // Before destroy resolves, there must have been no completion
+      // callback. destroyedPromise wakes the loop immediately; loop
+      // sees isDestroyed, runs its finally, reconnectPromise becomes
+      // null, destroy's own await unblocks, and only then does
+      // destroyDone fire.
+      await Promise.resolve();
+      // Under fake timers the above microtasks flush synchronously; by
+      // this point destroy's `await entry.reconnectPromise` has had
+      // enough turns to resolve if it was going to.
+      await destroyPromise;
+      expect(destroyDone).toHaveBeenCalledTimes(1);
     });
 
     it("a second drop after successful reconnect triggers another reconnect cycle", async () => {


### PR DESCRIPTION
Stacked on top of [#930](https://github.com/KeeperHub/keeperhub/pull/930) (KEEP-295 Phase 4). Fills the gaps surfaced during code review of phase-4 that block a safe `ENABLE_INPROC_LISTENERS=true` flag flip in staging. Must merge into `feat/KEEP-295-phase-4` before #930 merges to staging.

## Summary

Completes the Phase 1 ProviderManager requirements from the plan (`docs/keeperhub/KEEP-214/KEEP-295/plan.md`) that landed incomplete in #925. Adds reconnect + heartbeat + health observability so the in-process path has a real recovery mechanism on WSS drops, plus a `/healthz` endpoint that K8s probes can trust.

Before this PR: if a WSS dropped during an in-proc soak, every listener on that chain went silent until pod restart, and the existing `pgrep -f 'src/index.ts'` liveness probe would not notice.

## Scope

**`src/chains/provider-manager.ts`**
- **Reconnect**: `provider.on('error')` or heartbeat failure triggers reconnect. Exponential backoff 1s → 60s, 10 attempts. Injected `onPermanentFailure` callback defaults to `process.exit(1)` so K8s restarts the pod; tests inject a no-op.
- **Heartbeat**: `eth_blockNumber` ping every 30s with 10s timeout. Detection latency bounded at 30s, which is inside block time on every chain the product targets.
- **`onDisconnect(chainId, handler)`**: per-chain handler registration, fires with `{chainId, reason, message}` where reason is `provider_error | heartbeat_failure | heartbeat_timeout`. Throws if no entry exists for the chain (surfaces registration-order bugs early rather than silently dropping handlers).
- **Health accessors**: `isHealthy(chainId)`, `getHealth(chainId)`, `getAllHealth()`. Tracks `lastBlockAt` so consumers can detect silent stalls (block listener attached, no blocks arriving).
- **Shutdown hygiene**: `destroy()` stops heartbeats, detaches error listeners, prevents in-flight reconnect loops from continuing.

**`src/health/health-server.ts`** (new)
- Small HTTP server exposing `GET /healthz`. Returns 200 `{status: "ok", chains: [...]}` when every registered chain is connected OR no chains registered; 503 `{status: "degraded", chains: [...]}` otherwise. 404 for unknown paths.
- `buildHealthResponse` is exported as a pure function so the decision logic is testable without starting a server.

**`src/index.ts`**
- Starts the health server on `HEALTH_PORT` (default 3001) during init.
- SIGTERM/SIGINT shutdown handler closes the server cleanly before `process.exit(0)`.

## Design decisions worth flagging

- **Rejected `(provider as any).websocket` hooks** that `ws-connection.ts` uses. Rationale: they reach into ethers internals, break between versions, and add no detection we do not already get from the heartbeat. The doc comment in `provider-manager.ts` captures this.
- **/healthz returns 200 in fork mode** with empty chains list, because fork mode does not use ChainProviderManager. Helm values should keep the `pgrep` probe in fork mode; flip to HTTP probes once `ENABLE_INPROC_LISTENERS=true` is on. Documented inline.
- **Constants are module-level, not constructor options.** `HEARTBEAT_INTERVAL_MS`, `MAX_RECONNECT_ATTEMPTS`, etc. are production-tuned; tests use `vi.useFakeTimers` to exercise them rather than configuring shorter values. Keeps the test suite honest against the real timing the service will run with.
- **Exhausted reconnect calls injected callback, not `process.exit` directly.** Makes the path testable and keeps `process.exit` as the default behaviour for production.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `SKIP_INFRA_TESTS=true pnpm test tests/unit/` — 100/100 passed (was 82; +18 ProviderManager reconnect/heartbeat/health tests, +8 health-server tests)
- [x] `pnpm test` (full suite, docker test profile up) — 106/106 passed (was 82 unit + 4 E2E = 86 pre-change totals after rebase; +18 +8 from this branch; previous phase-4 E2Es unchanged)
- [x] Fork-mode baseline E2E (`event-to-sqs.test.ts`) still green — shutdown + healthz integration is a no-op when `ENABLE_INPROC_LISTENERS=false`

## What's NOT in this PR

- The `onDisconnect` API has no current consumer in the in-process path. It exists per the plan ("Exposes `onDisconnect(chainId, handler)` so consumers can react to chain-level drops") to support future metrics/alerting without another refactor. The registry could register a handler in Phase 5 if desired.
- Helm values / probe changes (plan Phase 7). Keeping the existing `pgrep` probe until flag flip, then swapping to HTTP `/healthz` is a deploy-only change.

## Context

- Gap discussion on #930: "there is no reconnect code to test in the in-proc path"
- Plan Phase 1: `docs/keeperhub/KEEP-214/KEEP-295/plan.md` lines 102-122
- Plan Phase 7 (`/healthz`): lines 219-224
