### PR TITLE
hotfix: KEEP-314 stop routing safe-fetch block log through Prometheus labelset

### DIFF
--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -3,8 +3,8 @@ import "server-only";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { lookup as dnsLookup } from "node:dns";
 import { BlockList, isIP } from "node:net";
+import { captureException } from "@sentry/nextjs";
 import { Agent, buildConnector, fetch as undiciFetch } from "undici";
-import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 
 export type SsrfBlockReason =
@@ -211,25 +211,33 @@ function recordBlock(ctx: BlockContext, shadow: boolean): void {
     shadow: shadow ? "true" : "false",
   });
 
-  const payload: Record<string, string> = {
-    hostname: ctx.hostname,
-    reason: ctx.reason,
-    shadow_mode: String(shadow),
-  };
-  if (ctx.resolvedIp !== undefined) {
-    payload.resolved_ip = ctx.resolvedIp;
-  }
-  if (ctx.plugin !== undefined) {
-    payload.plugin_name = ctx.plugin;
-  }
-
-  const suffix = shadow ? " (shadow mode)" : "";
-  logUserError(
-    ErrorCategory.VALIDATION,
-    `[safe-fetch] Blocked outbound request${suffix}`,
-    new Error(`safe-fetch block: ${ctx.reason}`),
-    payload
+  // Do NOT route through logUserError: it forwards caller labels to a
+  // Prometheus error metric with a fixed initial labelset, which rejects
+  // hostname/resolved_ip with "Added label not included in initial labelset"
+  // and turns shadow mode into a synchronous throw.
+  const modeSuffix = shadow ? " (shadow mode)" : "";
+  const resolvedSuffix =
+    ctx.resolvedIp !== undefined && ctx.resolvedIp !== ctx.hostname
+      ? ` -> ${ctx.resolvedIp}`
+      : "";
+  const pluginSuffix =
+    ctx.plugin === undefined ? "" : ` [plugin=${ctx.plugin}]`;
+  console.warn(
+    `[safe-fetch] Blocked outbound request${modeSuffix}: ${ctx.hostname}${resolvedSuffix} (reason=${ctx.reason})${pluginSuffix}`
   );
+
+  captureException(new Error(`safe-fetch block: ${ctx.reason}`), {
+    level: "warning",
+    tags: {
+      safe_fetch_reason: ctx.reason,
+      safe_fetch_shadow: shadow ? "true" : "false",
+      plugin_name: ctx.plugin ?? "unknown",
+    },
+    extra: {
+      hostname: ctx.hostname,
+      resolved_ip: ctx.resolvedIp,
+    },
+  });
 }
 
 function blockedMessage(ctx: BlockContext): string {

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -2,13 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/logging", () => ({
-  ErrorCategory: {
-    VALIDATION: "validation",
-    INFRASTRUCTURE: "infrastructure",
-  },
-  logUserError: vi.fn(),
-  logSystemError: vi.fn(),
+// vi.hoisted ensures the spy exists before the mock factory runs — the
+// factory is invoked when safe-fetch.ts imports @sentry/nextjs during ES
+// module graph resolution, which is before top-level test file statements
+// execute. A bare `const` would hit TDZ.
+const { captureException } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+}));
+vi.mock("@sentry/nextjs", () => ({
+  captureException,
 }));
 
 const incrementCounter = vi.fn();
@@ -27,6 +29,8 @@ import {
   type SsrfBlockReason,
   safeFetch,
 } from "@/lib/safe-fetch";
+
+const LABELSET_ERROR_RE = /initial labelset/i;
 
 describe("isBlockedIp", () => {
   const blockedV4: [string, SsrfBlockReason][] = [
@@ -118,6 +122,7 @@ describe("safeFetch (enforce mode)", () => {
   beforeEach(() => {
     process.env.SAFE_FETCH_ENFORCE = "true";
     incrementCounter.mockClear();
+    captureException.mockClear();
   });
 
   afterEach(() => {
@@ -209,6 +214,7 @@ describe("safeFetch (shadow mode)", () => {
     // biome-ignore lint/performance/noDelete: default shadow requires unset
     delete process.env.SAFE_FETCH_ENFORCE;
     incrementCounter.mockClear();
+    captureException.mockClear();
   });
 
   afterEach(() => {
@@ -234,6 +240,16 @@ describe("safeFetch (shadow mode)", () => {
       "safe_fetch.blocks.total",
       expect.objectContaining({ reason: "loopback", shadow: "true" })
     );
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({
+          safe_fetch_reason: "loopback",
+          safe_fetch_shadow: "true",
+        }),
+      })
+    );
   });
 
   it("records scheme block with shadow=true on non-http URL", async () => {
@@ -242,6 +258,51 @@ describe("safeFetch (shadow mode)", () => {
     expect(incrementCounter).toHaveBeenCalledWith(
       "safe_fetch.blocks.total",
       expect.objectContaining({ reason: "scheme", shadow: "true" })
+    );
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({
+          safe_fetch_reason: "scheme",
+          safe_fetch_shadow: "true",
+        }),
+      })
+    );
+  });
+
+  it("does not throw a Prometheus labelset error from recordBlock (regression)", async () => {
+    // Regression for KEEP-314: recordBlock originally routed the block log
+    // through logUserError, which forwarded caller-supplied labels
+    // (hostname, resolved_ip, shadow_mode) to a Prometheus error metric
+    // with a fixed initial labelset. prom-client then threw "Added label
+    // not included in initial labelset" from inside the fetch pipeline,
+    // making shadow mode fatal for any workflow that hit a blocked IP.
+    //
+    // Uses loopback rather than link-local to avoid network-layer flake
+    // (connect timeouts on 169.254.x.x vary by runner). recordBlock runs
+    // synchronously before any network call, so the bug reproduces
+    // regardless of which reason the block carries.
+    let thrown: unknown;
+    try {
+      await safeFetch("http://127.0.0.1:9999/", { plugin: "code" });
+    } catch (err) {
+      thrown = err;
+    }
+    if (thrown !== undefined) {
+      const message = thrown instanceof Error ? thrown.message : String(thrown);
+      expect(message).not.toMatch(LABELSET_ERROR_RE);
+    }
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({
+          safe_fetch_reason: "loopback",
+          safe_fetch_shadow: "true",
+          plugin_name: "code",
+        }),
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary

- `recordBlock()` in `lib/safe-fetch.ts` routed block logs through `logUserError`, which forwards caller labels (`hostname`, `resolved_ip`, `shadow_mode`) to a Prometheus error metric with a fixed initial labelset. prom-client threw `Added label "hostname" is not included in initial labelset` synchronously from inside the fetch pipeline, making shadow mode fatal for any workflow that hit a blocked IP (observed live in staging) and would have masked the intended `SsrfBlockedError` behind a labelset TypeError once enforce was flipped.
- Fix: emit block logs directly via `console.warn` and `captureException` instead of going through `logUserError`. The `safe_fetch.blocks.total` counter was already emitted inline in `recordBlock` and is unchanged.
- Tests: strengthened the existing shadow-mode assertions to verify `captureException` is called with `level=warning` and the expected tags, and added a regression test that asserts any error thrown from `safeFetch` in shadow mode does not match `/initial labelset/`. The original tests mocked `@/lib/logging` with a `vi.fn()` no-op, which is why CI didn't catch this. The new mock targets `@sentry/nextjs` via `vi.hoisted`, and `@/lib/logging` is no longer imported by safe-fetch.

## Test plan

- [x] `pnpm test tests/unit/safe-fetch.test.ts` -- 48/48 pass
- [x] `pnpm type-check` clean
- [x] `pnpm check` clean
- [ ] After merge to staging: re-run a code-node fetch to `http://169.254.169.254/latest/meta-data/` -- expect the fetch to proceed past safe-fetch (network-level failure or body, not a labelset error), a `[safe-fetch] Blocked outbound request (shadow mode)` warning in the executor pod logs, and `safe_fetch.blocks.total{shadow="true", reason="link-local"}` incrementing.
- [ ] Flip `SAFE_FETCH_ENFORCE=true` in `deploy/keeperhub/staging/values.yaml` in a follow-up PR, then re-test: expect `SsrfBlockedError` for the same URL, public URLs (CoinGecko, Etherscan) unaffected, and webhook plugin behaviour matching the KEEP-314 test plan.