### PR TITLE
chore: KEEP-314 enable safe-fetch SSRF enforcement in staging

### DIFF
--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -409,6 +409,9 @@ env:
   ALLOW_TEST_ENDPOINTS:
     type: kv
     value: "true"
+  SAFE_FETCH_ENFORCE:
+    type: kv
+    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-staging


### PR DESCRIPTION
## Summary

- Flips \`SAFE_FETCH_ENFORCE=true\` on \`keeperhub-common\` in staging via \`deploy/keeperhub/staging/values.yaml\`. With this set, \`lib/safe-fetch.ts\` returns \`isAuditOnly() === false\`, and requests to private, loopback, link-local, multicast, reserved, or IPv4-mapped-private addresses throw \`SsrfBlockedError\` instead of proceeding with a shadow log.
- Single-line staging-only change. \`deploy/keeperhub/prod/\` is intentionally untouched; production promotion is a separate PR after staging observation.

## Blocked on

1. PR #949 (hotfix for the Prometheus labelset bug in \`recordBlock\`) must be merged and deployed first. Without it, shadow mode is fatal and enforce mode would surface the labelset TypeError instead of the intended \`SsrfBlockedError\`.
2. Shadow-mode behaviour must be verified end-to-end on staging after the hotfix rollout:
    - A workflow code step fetching \`http://169.254.169.254/latest/meta-data/\` proceeds past safe-fetch (network-level failure is fine, labelset error is not).
    - Pod logs show \`[safe-fetch] Blocked outbound request (shadow mode)\`.
    - Grafana \`safe_fetch.blocks.total{reason=\"link-local\", shadow=\"true\"}\` increments.

This PR is kept as a draft until both are satisfied.

## Test plan (post-merge)

- [ ] \`keeperhub-common\` pod env shows \`SAFE_FETCH_ENFORCE=true\` after rollout.
- [ ] Code step fetching \`http://169.254.169.254/latest/meta-data/\` returns \`SsrfBlockedError\` to the workflow step (no longer proceeds).
- [ ] Code step fetching \`http://10.0.0.1/\` returns \`SsrfBlockedError\`.
- [ ] Code step fetching a public URL (e.g. CoinGecko or Etherscan) continues to succeed.
- [ ] Webhook plugin pointed at a public receiver continues to deliver.
- [ ] Webhook plugin pointed at \`http://10.0.0.1/\` errors with \`SsrfBlockedError\`.
- [ ] Grafana \`safe_fetch.blocks.total{shadow=\"false\"}\` starts incrementing for the synthetic test calls; \`{shadow=\"true\"}\` stops.