### PR TITLE
fix: KEEP-314 extend safe-fetch coverage to HTTP Request step

### DIFF
--- a/lib/steps/http-request.ts
+++ b/lib/steps/http-request.ts
@@ -3,6 +3,7 @@
  */
 import "server-only";
 
+import { safeFetch } from "../safe-fetch";
 import { getErrorMessage } from "../utils";
 import { type StepInput, withStepLogging } from "./step-handler";
 
@@ -65,10 +66,11 @@ async function httpRequest(
   }
 
   try {
-    const response = await fetch(input.endpoint, {
+    const response = await safeFetch(input.endpoint, {
       method: input.httpMethod,
       headers: parseHeaders(input.httpHeaders),
       body: parseBody(input.httpMethod, input.httpBody),
+      plugin: "http-request",
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- The original KEEP-314 PR (#937) scoped safe-fetch to the \`code\` and \`webhook\` plugins. The HTTP Request system action (\`lib/steps/http-request.ts\`) was left on raw \`fetch()\`.
- That gap made the subsequent enforce flip (PR #950) security theatre: an attacker who wanted \`169.254.169.254\` could pivot from a Code node to an HTTP Request node and the enforcement wall disappears.
- This PR swaps the HTTP Request step to \`safeFetch\` with \`plugin: \"http-request\"\` so Grafana block metrics attribute correctly. Headers, body, and method handling unchanged.
- No behaviour change in shadow mode; blocks private/loopback/link-local/multicast/reserved addresses under enforce mode.

## Scope notes

- \`lib/codegen-templates/http-request.ts\` intentionally NOT changed. That template produces code for user-downloaded workflows that run outside our infrastructure, where \`@/lib/safe-fetch\` is not importable and SSRF is not our concern.
- The Safe plugin (\`plugins/safe/steps/get-pending-transactions.ts\`) is also out of scope. Its URL hostname is hardcoded (\`api.safe.global\`) and path segments are constrained (enumerated chain slug + \`ethers.getAddress\`-validated address). No user-controlled URL, no SSRF vector.

## Gating

PR #950 (enforce flip on staging) stays in draft until this PR is merged and shadow-mode behaviour is verified on the combined deploy.

## Test plan

- [x] \`./node_modules/.bin/biome check lib/steps/http-request.ts\` clean
- [x] \`pnpm type-check\` clean
- [x] \`pnpm test tests/unit/safe-fetch.test.ts\` -- 48/48 pass (no regression in core safe-fetch behaviour)
- [ ] After merge + deploy: HTTP Request node pointed at \`http://169.254.169.254/latest/meta-data/\` in shadow mode emits the \`[safe-fetch] Blocked outbound request (shadow mode)\` warning with \`plugin_name=\"http-request\"\` and the request proceeds to a network-level failure.
- [ ] Same test after enforce flip: returns \`SsrfBlockedError\` to the workflow step.
- [ ] HTTP Request node pointed at a public URL (e.g. CoinGecko) continues to succeed in both modes.