### PR TITLE
fix: KEEP-331 disable Code node pending sandbox replacement

### DIFF
--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -29,6 +29,14 @@ const MAX_LOG_ENTRIES = 200;
 const VM_LINE_REGEX = /user-code\.js:(\d+)/;
 const UNRESOLVED_TEMPLATE_REGEX = /\{\{@?[^}]+\}\}/g;
 
+// Security kill switch for KEEP-331. node:vm is not a security boundary:
+// user code can escape via Error.constructor("return process")() and read
+// the executor pod's environment. Disabled until a proper sandbox lands.
+// Widened to boolean so downstream code is not flagged as unreachable.
+const CODE_STEP_DISABLED: boolean = true;
+const CODE_STEP_DISABLED_ERROR =
+  "Code step is disabled pending security review. Contact your administrator.";
+
 /**
  * Strip JS string literals (single, double, backtick) so that {{...}}
  * patterns inside strings are not mistaken for unresolved templates.
@@ -98,6 +106,10 @@ function createCapturedConsole(logs: LogEntry[]): {
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: single cohesive handler with sandbox setup, timeout, and error handling
 async function stepHandler(input: RunCodeCoreInput): Promise<RunCodeResult> {
+  if (CODE_STEP_DISABLED) {
+    return { success: false, error: CODE_STEP_DISABLED_ERROR, logs: [] };
+  }
+
   const { code } = input;
 
   if (!code || code.trim() === "") {

--- a/tests/unit/code-run-code.test.ts
+++ b/tests/unit/code-run-code.test.ts
@@ -73,7 +73,7 @@ async function expectFailure(
 
 // --- Basic Execution ---------------------------------------------------------
 
-describe("code/run-code - basic execution", () => {
+describe.skip("code/run-code - basic execution", () => {
   it("returns the result of a simple expression", async () => {
     const result = await expectSuccess({ code: "return 1 + 2" });
     expect(result.result).toBe(3);
@@ -118,7 +118,7 @@ describe("code/run-code - basic execution", () => {
 
 // --- BigInt Support -----------------------------------------------------------
 
-describe("code/run-code - BigInt support", () => {
+describe.skip("code/run-code - BigInt support", () => {
   it("creates and returns BigInt values", async () => {
     const result = await expectSuccess({
       code: "return BigInt('9007199254740993')",
@@ -178,7 +178,7 @@ describe("code/run-code - BigInt support", () => {
 
 // --- Console Capture ---------------------------------------------------------
 
-describe("code/run-code - console capture", () => {
+describe.skip("code/run-code - console capture", () => {
   it("captures console.log", async () => {
     const result = await expectSuccess({
       code: 'console.log("hello"); return true;',
@@ -209,7 +209,7 @@ describe("code/run-code - console capture", () => {
 
 // --- Sandbox Globals ---------------------------------------------------------
 
-describe("code/run-code - sandbox globals", () => {
+describe.skip("code/run-code - sandbox globals", () => {
   it("has access to JSON", async () => {
     const result = await expectSuccess({
       code: "return JSON.parse('{\"a\":1}');",
@@ -401,7 +401,7 @@ describe("code/run-code - sandbox globals", () => {
 
 // --- Error Handling ----------------------------------------------------------
 
-describe("code/run-code - error handling", () => {
+describe.skip("code/run-code - error handling", () => {
   it("fails with empty code", async () => {
     const result = await expectFailure({ code: "" });
     expect(result.error).toBe("No code provided");
@@ -499,7 +499,7 @@ describe("code/run-code - error handling", () => {
 // These mirror the example workflows from docs/plugins/code.md to ensure the
 // sandbox supports the data transformations users will actually write.
 
-describe("code/run-code - data transformation patterns", () => {
+describe.skip("code/run-code - data transformation patterns", () => {
   it("filters and aggregates event data with BigInt", async () => {
     const code = [
       "const events = [",
@@ -685,7 +685,7 @@ describe("code/run-code - data transformation patterns", () => {
   });
 });
 
-describe("code/run-code - async patterns", () => {
+describe.skip("code/run-code - async patterns", () => {
   it("uses Promise.all for parallel operations", async () => {
     const code = [
       "const results = await Promise.all([",
@@ -733,7 +733,7 @@ describe("code/run-code - async patterns", () => {
 
 // --- Timeout -----------------------------------------------------------------
 
-describe("code/run-code - timeout", () => {
+describe.skip("code/run-code - timeout", () => {
   it("uses custom timeout", async () => {
     const result = await expectSuccess({
       code: "return true;",
@@ -764,5 +764,24 @@ describe("code/run-code - timeout", () => {
       timeout: 0,
     });
     expect(result.result).toBe(true);
+  });
+});
+
+// --- Disabled Gate (KEEP-331) ------------------------------------------------
+// The describe blocks above are .skip'd while the kill switch is active.
+// See plugins/code/steps/run-code.ts (CODE_STEP_DISABLED). Re-enable both
+// the switch and the tests above together when a real sandbox lands.
+
+describe("code/run-code - gate (disabled)", () => {
+  it("returns the disabled error for valid code input", async () => {
+    const result = await expectFailure({ code: "return 1 + 2" });
+    expect(result.error).toContain("Code step is disabled");
+    expect(result.logs).toEqual([]);
+  });
+
+  it("returns the disabled error before the empty-code check", async () => {
+    const result = await expectFailure({ code: "" });
+    expect(result.error).toContain("Code step is disabled");
+    expect(result.error).not.toBe("No code provided");
   });
 });


### PR DESCRIPTION
## Summary

- Adds a runtime kill switch (`CODE_STEP_DISABLED`) at the top of the Code step handler that returns a clear disabled error before any user code runs.
- Existing workflows with a Code node will surface this error on next execution. Intentional - the vulnerable path must not keep running.
- Skips the execution-exercising unit tests via `describe.skip`; adds a new describe block that verifies the gate returns the expected error for both valid and empty code inputs.

## Why

`node:vm` is not a security boundary.

This returns the host process and every secret mounted into the workflow executor pod (DB credentials, service-to-service tokens, cloud credentials, wallet/signing creds, RPC keys). Blast radius is cross-tenant: the same credentials back every tenant's workflows.

The risk is already documented in `plugins/code/steps/run-code.ts:93-98` with the rationale *"acceptable for a self-hosted platform where users are authenticated team members."* That rationale does not hold for a multi-tenant deployment.

Linear: [KEEP-331](https://linear.app/keeperhubapp/issue/KEEP-331) (Urgent)

## What this PR is NOT

- Not a fix for the underlying sandbox escape - that requires a real isolation boundary (`isolated-vm`, subprocess + seccomp, or a WASM runtime). Tracked as follow-up in KEEP-331.
- Not a removal of the plugin - registration is unchanged. Revert this commit to re-enable once a proper sandbox lands.

## User impact

Any workflow containing a Code node will surface `"Code step is disabled pending security review. Contact your administrator."` on next execution. Communication plan for affected users is TBD and tracked on the ticket.

## Test plan

- [x] `pnpm test:unit tests/unit/code-run-code.test.ts` - all execution tests `.skip`'d, two new gate tests pass
- [x] Full `pnpm test:unit` - 141 files pass, 2808 tests pass, 70 skipped, 0 failed
- [x] `pnpm type-check` - clean (required `NODE_OPTIONS=--max-old-space-size=8192`)
- [ ] Verify on staging: create a workflow with a Code node and run it; expect the disabled error, no code execution
- [ ] Verify no regression in other workflow steps on staging

## Follow-up tickets needed

1. Permanent sandbox replacement (scope `isolated-vm` vs. subprocess + seccomp vs. WASM runtime)
2. Audit executor pod RBAC and env injection to minimise blast radius
3. Credential rotation for anything ever present in the executor pod env (assume prior compromise)
4. Decision on whether to keep Code as a capability at all, or gate behind admin/feature flag permanently