### PR TITLE
fix(mcp): advertise OAuth resource metadata on /mcp 401s

### DIFF
--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,34 @@
+import {
+  SCOPE_MCP_ADMIN,
+  SCOPE_MCP_READ,
+  SCOPE_MCP_WRITE,
+} from "@/lib/mcp/oauth-scopes";
+
+export const dynamic = "force-dynamic";
+
+const TRAILING_SLASH = /\/$/;
+
+function deriveBaseUrl(request: Request): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
+  if (envUrl) {
+    return envUrl.replace(TRAILING_SLASH, "");
+  }
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+// RFC 9728 Protected Resource Metadata. Claude Desktop and other strict
+// MCP clients discover the authorization server via this document after
+// receiving a 401 from /mcp with a WWW-Authenticate: Bearer resource_metadata=...
+// header. Claude Code tolerates its absence; Claude Desktop does not.
+export function GET(request: Request): Response {
+  const baseUrl = deriveBaseUrl(request);
+  const metadata = {
+    resource: `${baseUrl}/mcp`,
+    authorization_servers: [baseUrl],
+    scopes_supported: [SCOPE_MCP_READ, SCOPE_MCP_WRITE, SCOPE_MCP_ADMIN],
+    bearer_methods_supported: ["header"],
+    resource_documentation: `${baseUrl}/mcp`,
+  };
+  return Response.json(metadata);
+}

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -28,7 +28,7 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
   "Access-Control-Allow-Headers":
     "Authorization, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version",
-  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id, WWW-Authenticate",
 } as const;
 
 // Start the local-cache cleanup interval once per process lifetime.
@@ -77,6 +77,23 @@ function getBaseUrl(request: Request): string {
   }
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
+}
+
+// RFC 9728 / MCP 2025-06-18 require a WWW-Authenticate header on 401 responses
+// so clients can discover the Protected Resource Metadata document. Without it,
+// strict MCP clients (e.g. Claude Desktop) report "Couldn't reach the MCP server"
+// because they cannot locate the authorization server.
+function unauthorizedResponse(request: Request, error: string): Response {
+  const baseUrl = getBaseUrl(request);
+  const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+  return new Response(JSON.stringify({ error }), {
+    status: 401,
+    headers: {
+      "Content-Type": "application/json",
+      "WWW-Authenticate": `Bearer realm="keeperhub-mcp", resource_metadata="${resourceMetadataUrl}"`,
+      ...CORS_HEADERS,
+    },
+  });
 }
 
 async function authenticate(request: Request): Promise<ApiKeyAuthResult> {
@@ -317,14 +334,15 @@ function withRenewedSessionHeader(
 export async function POST(request: Request): Promise<Response> {
   const auth = await authenticate(request);
   if (!auth.authenticated) {
-    logMcpEvent("mcp.auth.failed", { reason: auth.error ?? "Unauthorized" });
-    return new Response(
-      JSON.stringify({ error: auth.error ?? "Unauthorized" }),
-      {
-        status: auth.statusCode ?? 401,
-        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-      }
-    );
+    const reason = auth.error ?? "Unauthorized";
+    logMcpEvent("mcp.auth.failed", { reason });
+    if ((auth.statusCode ?? 401) === 401) {
+      return unauthorizedResponse(request, reason);
+    }
+    return new Response(JSON.stringify({ error: reason }), {
+      status: auth.statusCode,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
   }
 
   const organizationId = auth.organizationId ?? "";
@@ -419,14 +437,15 @@ export async function POST(request: Request): Promise<Response> {
 export async function GET(request: Request): Promise<Response> {
   const auth = await authenticate(request);
   if (!auth.authenticated) {
-    logMcpEvent("mcp.auth.failed", { reason: auth.error ?? "Unauthorized" });
-    return new Response(
-      JSON.stringify({ error: auth.error ?? "Unauthorized" }),
-      {
-        status: auth.statusCode ?? 401,
-        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-      }
-    );
+    const reason = auth.error ?? "Unauthorized";
+    logMcpEvent("mcp.auth.failed", { reason });
+    if ((auth.statusCode ?? 401) === 401) {
+      return unauthorizedResponse(request, reason);
+    }
+    return new Response(JSON.stringify({ error: reason }), {
+      status: auth.statusCode,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
   }
 
   const sessionId = request.headers.get("mcp-session-id");
@@ -458,14 +477,15 @@ export async function GET(request: Request): Promise<Response> {
 export async function DELETE(request: Request): Promise<Response> {
   const auth = await authenticate(request);
   if (!auth.authenticated) {
-    logMcpEvent("mcp.auth.failed", { reason: auth.error ?? "Unauthorized" });
-    return new Response(
-      JSON.stringify({ error: auth.error ?? "Unauthorized" }),
-      {
-        status: auth.statusCode ?? 401,
-        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-      }
-    );
+    const reason = auth.error ?? "Unauthorized";
+    logMcpEvent("mcp.auth.failed", { reason });
+    if ((auth.statusCode ?? 401) === 401) {
+      return unauthorizedResponse(request, reason);
+    }
+    return new Response(JSON.stringify({ error: reason }), {
+      status: auth.statusCode,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
   }
 
   const sessionId = request.headers.get("mcp-session-id");


### PR DESCRIPTION
## Summary

- Unblock Claude Desktop (and any strict MCP 2025-06-18 client) from connecting to `https://app.keeperhub.com/mcp`. Today it fails with `Couldn't reach the MCP server` because the server does not emit the RFC 9728 authorization discovery chain. Claude Code works only because it falls back to probing `/.well-known/oauth-authorization-server` at the host root; Claude Desktop does not fall back and gives up.
- Add `app/.well-known/oauth-protected-resource` returning the Protected Resource Metadata document (resource, authorization_servers, scopes_supported, bearer_methods_supported), derived from the same `NEXT_PUBLIC_APP_URL` / `BETTER_AUTH_URL` base used by the existing authorization-server metadata route.
- Stamp `WWW-Authenticate: Bearer realm="keeperhub-mcp", resource_metadata="<base>/.well-known/oauth-protected-resource"` on every 401 from POST/GET/DELETE `/mcp`. Gate the new helper on `statusCode === 401` so non-401 auth errors (e.g. 403 "missing organization context") keep their original shape.
- Backwards-compatible for Claude Code: authed traffic is unchanged, the 401 body is byte-identical, the only delta is an extra response header plus `WWW-Authenticate` added to `Access-Control-Expose-Headers`. Legacy `/.well-known/oauth-authorization-server` discovery still works.

## Test plan

- [ ] `curl -i -X POST https://<pr-env>/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'` returns 401 with `WWW-Authenticate: Bearer ... resource_metadata="https://<pr-env>/.well-known/oauth-protected-resource"`.
- [ ] `curl https://<pr-env>/.well-known/oauth-protected-resource` returns 200 JSON with `resource`, `authorization_servers`, `scopes_supported`, `bearer_methods_supported`.
- [ ] Connect Claude Desktop via Connectors UI to the PR env `/mcp` URL. OAuth browser consent succeeds and tools appear in the client.
- [ ] Claude Code connects to the same URL via the `keeperhub` plugin without regressions; existing session reconstruction across pods still works.
- [ ] `pnpm vitest run tests/unit/mcp-*.test.ts` stays green (79 tests).