### PR TITLE
fix(block-dispatcher): handle unhandled rejections from ethers teardown

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -161,6 +161,20 @@ class BlockMonitorService {
   }
 }
 
+// Ethers v6 WebSocketProvider teardown produces a detached eth_unsubscribe rejection when the socket dies mid-subscription; catch it here so Node does not exit the process.
+process.on("unhandledRejection", (reason: unknown) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack : "";
+  console.error(`[BlockDispatcher] Unhandled rejection: ${message}`, stack);
+});
+
+process.on("uncaughtException", (error: Error) => {
+  console.error(
+    `[BlockDispatcher] Uncaught exception: ${error.message}`,
+    error.stack ?? ""
+  );
+});
+
 // Main entry point
 async function main(): Promise<void> {
   console.log("[BlockDispatcher] Starting block dispatcher...");
@@ -211,4 +225,8 @@ async function main(): Promise<void> {
   await service.start();
 }
 
-main();
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[BlockDispatcher] Fatal startup error: ${message}`);
+  process.exit(1);
+});

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -161,18 +161,23 @@ class BlockMonitorService {
   }
 }
 
-// Ethers v6 WebSocketProvider teardown produces a detached eth_unsubscribe rejection when the socket dies mid-subscription; catch it here so Node does not exit the process.
+// Ethers v6 WebSocketProvider teardown produces a detached eth_unsubscribe
+// rejection when the socket dies mid-subscription; log and swallow so Node
+// does not exit the process on transient RPC failures.
 process.on("unhandledRejection", (reason: unknown) => {
   const message = reason instanceof Error ? reason.message : String(reason);
   const stack = reason instanceof Error ? reason.stack : "";
   console.error(`[BlockDispatcher] Unhandled rejection: ${message}`, stack);
 });
 
+// Uncaught sync exceptions indicate corrupted state; log and exit so the
+// orchestrator restarts us cleanly rather than continuing in an unknown state.
 process.on("uncaughtException", (error: Error) => {
   console.error(
     `[BlockDispatcher] Uncaught exception: ${error.message}`,
     error.stack ?? ""
   );
+  process.exit(1);
 });
 
 // Main entry point

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -162,6 +162,24 @@ async function dispatch(): Promise<{
   };
 }
 
+// Log and swallow detached promise rejections so transient failures do not
+// crash the dispatcher (Node v15+ exits on unhandled rejection by default).
+process.on("unhandledRejection", (reason: unknown) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack : "";
+  console.error(`[Dispatcher] Unhandled rejection: ${message}`, stack);
+});
+
+// Uncaught sync exceptions indicate corrupted state; log and exit so the
+// orchestrator restarts us cleanly rather than continuing in an unknown state.
+process.on("uncaughtException", (error: Error) => {
+  console.error(
+    `[Dispatcher] Uncaught exception: ${error.message}`,
+    error.stack ?? ""
+  );
+  process.exit(1);
+});
+
 // Main entry point
 async function main() {
   console.log("[Dispatcher] Starting schedule dispatcher...");
@@ -217,4 +235,8 @@ async function main() {
   }, 60_000); // 60 seconds
 }
 
-main();
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[Dispatcher] Fatal startup error: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Prod block-dispatcher pod was crash-looping (16 restarts in 4h, ~11s uptime each, exit code 1) whenever a primary WSS dropped mid-subscription. Root cause:

- Ethers v6 `SocketSubscriber.stop()` fires `eth_unsubscribe` via `provider.send(...)` without awaiting or catching the resulting promise.
- When `provider.destroy()` then iterates pending requests and rejects them with `UNSUPPORTED_OPERATION`, the detached unsubscribe promise rejects on a chain no one is awaiting.
- The `try/catch` around `destroy()` in `destroyProvider` cannot catch a rejection on a different promise chain.
- Node v24 with default `--unhandled-rejections=throw` exits the process on the stray rejection. Kubernetes restarts the pod. Loop.

Logs on the crashing pod show the exact sequence: WSS closed on Ethereum Mainnet -> first reconnect attempt -> `Error: provider destroyed; cancelled request (operation="eth_unsubscribe")` -> Node exits.

## Changes

- Add `process.on("unhandledRejection")` and `process.on("uncaughtException")` handlers in `block-dispatcher/index.ts`. Log the error and continue running rather than letting Node exit the process. Every long-running Node service should have these; the scheduler had none.
- Add `.catch()` on the top-level `main()` invocation so genuine startup failures exit deliberately with a clean log line instead of surfacing as an unhandled rejection.

## Scope notes

- This is a process-level safety net, not a root-cause fix for ethers' fire-and-forget unsubscribe. An upstream fix would require patching ethers or restructuring teardown to avoid the SocketSubscriber.stop path.
- Swallowing unhandled rejections risks masking real bugs. They are logged with full stack traces so regressions remain observable; worth wiring these log lines to an alert if not already covered.
- Out of scope: chains without fallback WSS (polygon, arbitrum, bsc), HTTP-polling fallback pattern used elsewhere in the repo, and `chain.techops.services` WSS stability. All tracked separately.

## Test plan

- [ ] Deploy image to staging and verify the dispatcher stays up across a primary-WSS drop (can force by blocking egress to `chain.techops.services` briefly).
- [ ] Confirm `[BlockDispatcher] Unhandled rejection: provider destroyed; cancelled request` appears in logs on WSS drop, and the pod does not restart.
- [ ] Confirm reconnect loop proceeds normally after the logged rejection.
- [ ] Smoke test block-triggered workflow enqueue after forced reconnect.