### PR TITLE
fix(mcp): align /mcp discovery with RFC 6750 + RFC 9728 expectations

### DIFF
--- a/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -1,0 +1,12 @@
+import { GET as rootMetadata } from "../route";
+
+export const dynamic = "force-dynamic";
+
+// Path-scoped Protected Resource Metadata per RFC 9728 §3.1. Some strict MCP
+// clients construct the metadata URL by appending the resource path to the
+// .well-known prefix (e.g. Notion's MCP) instead of following the
+// WWW-Authenticate hint. Serve the same document at both mounts so either
+// discovery strategy resolves.
+export function GET(request: Request): Response {
+  return rootMetadata(request);
+}

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -21,13 +21,18 @@ function deriveBaseUrl(request: Request): string {
 // MCP clients discover the authorization server via this document after
 // receiving a 401 from /mcp with a WWW-Authenticate: Bearer resource_metadata=...
 // header. Claude Code tolerates its absence; Claude Desktop does not.
+//
+// `resource` is intentionally the host root (not the /mcp path) so the
+// well-known mount stays at the RFC 9728 §3.1 path-less location. This matches
+// the pattern Linear and other working MCP servers ship.
 export function GET(request: Request): Response {
   const baseUrl = deriveBaseUrl(request);
   const metadata = {
-    resource: `${baseUrl}/mcp`,
+    resource: baseUrl,
     authorization_servers: [baseUrl],
     scopes_supported: [SCOPE_MCP_READ, SCOPE_MCP_WRITE, SCOPE_MCP_ADMIN],
     bearer_methods_supported: ["header"],
+    resource_name: "KeeperHub",
     resource_documentation: `${baseUrl}/mcp`,
   };
   return Response.json(metadata);

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -83,14 +83,26 @@ function getBaseUrl(request: Request): string {
 // so clients can discover the Protected Resource Metadata document. Without it,
 // strict MCP clients (e.g. Claude Desktop) report "Couldn't reach the MCP server"
 // because they cannot locate the authorization server.
+//
+// Per RFC 6750 §3, Bearer challenges include error + error_description when a
+// token is missing/invalid. The MCP host on claude.ai appears to require these
+// parameters during its discovery validation; omitting them causes the connect
+// flow to halt at `start_error` before DCR ever runs. We match Linear, Sentry,
+// and Notion's challenge shape.
 function unauthorizedResponse(request: Request, error: string): Response {
   const baseUrl = getBaseUrl(request);
   const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+  const challenge = [
+    'Bearer realm="OAuth"',
+    `resource_metadata="${resourceMetadataUrl}"`,
+    'error="invalid_token"',
+    'error_description="Missing or invalid access token"',
+  ].join(", ");
   return new Response(JSON.stringify({ error }), {
     status: 401,
     headers: {
       "Content-Type": "application/json",
-      "WWW-Authenticate": `Bearer realm="keeperhub-mcp", resource_metadata="${resourceMetadataUrl}"`,
+      "WWW-Authenticate": challenge,
       ...CORS_HEADERS,
     },
   });


### PR DESCRIPTION
## Summary

- The first discovery fix (#954) unblocked the bare 401/PRM chain but Claude Desktop still halts at `start_error` before DCR runs — the connect flow URL carries `step=start_error` and no OAuth browser tab opens. Discovery is the Anthropic backend's job (`claude.ai/api/.../mcp/start-auth/...`), and its validator is stricter than the bare minimum. Compared our challenge + PRM against Linear, Sentry, and Notion's MCP servers and found three consistent differences, each a plausible reject path for a strict validator.
- Add RFC 6750 Bearer parameters `error="invalid_token"` and `error_description="Missing or invalid access token"` to the `WWW-Authenticate` header. All three working servers send them; we did not.
- Drop the `/mcp` suffix from PRM `resource` so the root `/.well-known/oauth-protected-resource` mount lines up with RFC 9728 §3.1's path construction (Linear's pattern). Also mount the same document at `/.well-known/oauth-protected-resource/mcp` so clients that follow the path-scoped convention instead (Notion's pattern) resolve too — belt and braces.
- Add `resource_name: "KeeperHub"` so the entry renders in connector catalogs, and switch `realm` to `"OAuth"` to match convention.
- Backwards-compatible for Claude Code and any already-issued OAuth tokens: none of the authenticated request paths are touched, only the 401 response shape and the public discovery documents.

## Test plan

- [ ] After deploy: `curl -i -X POST https://<pr-env>/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"probe\",\"version\":\"1\"}}}'` returns 401 with `WWW-Authenticate: Bearer realm=\"OAuth\", resource_metadata=\"...\", error=\"invalid_token\", error_description=\"...\"`.
- [ ] `curl https://<pr-env>/.well-known/oauth-protected-resource` and `curl https://<pr-env>/.well-known/oauth-protected-resource/mcp` both return 200 with `resource`, `authorization_servers`, `resource_name: \"KeeperHub\"`.
- [ ] Remove the keeperhub connector in Claude Desktop, re-add, click Connect. OAuth browser tab opens, user consents, and MCP tools appear in the client.
- [ ] Claude Code still connects via the `keeperhub` plugin without regressions; tool calls succeed.
- [ ] `pnpm vitest run tests/unit/mcp-*.test.ts` stays green (79 tests).