### PR TITLE
hotfix(docs-site): replace content symlink inside the image to unbreak Turbopack build

### DIFF
--- a/docs-site/Dockerfile
+++ b/docs-site/Dockerfile
@@ -14,10 +14,12 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 
-# Copy docs-site source
+# Copy docs-site source. The in-repo `docs-site/content` symlink to `../docs`
+# is a local dev convenience. Inside the image it would resolve outside /app,
+# which Turbopack (Next.js 16) rejects. Remove it and replace with the real
+# docs tree copied in directly.
 COPY docs-site/ ./
-
-# Copy docs content and create symlink structure
+RUN rm -f ./content
 COPY docs/ ./content/
 
 # Build the application


### PR DESCRIPTION
## Summary

- Unblock the `deploy-keeperhub-docs` workflow, which has been failing on every push to `prod` since the latest release. The docs pod never gets the new image, so docs.keeperhub.com is frozen on pre-release content. Not a user-facing outage, but the deploy pipeline is red and blocks anything that needs a docs roll forward.
- Root cause: the release bumped `docs-site/package.json` from `next@~15.5.15` to `next@~16.2.4`. Next 16 uses Turbopack by default, and Turbopack rejects symlinks whose targets resolve outside the project root. `docs-site/content` is a relative symlink to `../docs`, so inside `/app/` it resolves to `/docs/` — outside the container's project root — and every MDX import under `content/` fails to build. Same configuration worked on Next 15 with Webpack.
- Fix: keep the in-repo symlink (developers rely on it for local iteration), but remove it inside the Docker image before the real content copy. Two new lines in `docs-site/Dockerfile`:
  ```
  COPY docs-site/ ./
  RUN rm -f ./content
  COPY docs/ ./content/
  ```
- Verified locally: reproduced the original failure with the current Dockerfile, applied the patch, rebuilt the image cleanly, ran the container and confirmed `/`, `/workflows/introduction`, `/workflows/paid-workflows`, and `/ai-tools/agentic-wallet` all return 200.

## Test plan

- [ ] CI `deploy-keeperhub-docs` workflow build step succeeds when this merges (compared to the trail of symlink failures on recent runs).
- [ ] After merge + release, docs pod updates to the new image and docs.keeperhub.com serves the newly released content (including `/workflows/paid-workflows`).
- [ ] Local `docker build -f docs-site/Dockerfile .` still succeeds against a clean checkout.
- [ ] Developer local flow (`docs-site/content -> ../docs`) remains unchanged; only the container build is modified.