### PR TITLE
fix(agentic-wallet): wrap MPP signature into spec-compliant Credential envelope

### DIFF
--- a/app/api/agentic-wallet/sign/route.ts
+++ b/app/api/agentic-wallet/sign/route.ts
@@ -361,9 +361,20 @@ export async function POST(request: Request): Promise<Response> {
         nonce: String(challenge.nonce ?? ""),
       });
     } else {
+      const serialized =
+        typeof challenge.serialized === "string" ? challenge.serialized : "";
+      if (!serialized) {
+        return Response.json(
+          {
+            error: "paymentChallenge.serialized is required for tempo",
+            code: "MPP_CHALLENGE_MISSING",
+          },
+          { status: 400 }
+        );
+      }
       signature = await signMppProof(auth.subOrgId, walletAddress, {
         chainId: resolvedTempoChainId,
-        challengeId: String(challenge.challengeId ?? ""),
+        serialized,
       });
     }
     return Response.json({ signature }, { status: 200 });

--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -28,8 +28,11 @@
  * id only.
  */
 import { serializeSignature } from "@turnkey/ethers";
+import { Challenge, Credential } from "mppx";
 import { getTurnkeyClientForOrg } from "@/lib/turnkey/agentic-wallet";
 import { BASE_CHAIN_ID, USDC_BASE_ADDRESS } from "./constants";
+
+const MPP_AUTH_PREFIX = "Payment ";
 
 export class PolicyBlockedError extends Error {
   override readonly name = "PolicyBlockedError";
@@ -95,7 +98,15 @@ export type X402Challenge = {
 
 export type MppProofChallenge = {
   chainId: number;
-  challengeId: string;
+  /**
+   * The raw WWW-Authenticate value (without the `Payment ` prefix) as forwarded
+   * by the npm client. signMppProof parses this via `Challenge.deserialize`
+   * (from mppx) to derive the challenge id it signs, and then wraps the raw
+   * EIP-712 signature into a spec-compliant Credential envelope so the caller
+   * can pass the returned string straight into `Authorization: Payment <...>`
+   * without any client-side decoding or mutation.
+   */
+  serialized: string;
 };
 
 type TurnkeySignature = { r: string; s: string; v: string };
@@ -181,13 +192,41 @@ export async function signMppProof(
   walletAddress: string,
   challenge: MppProofChallenge
 ): Promise<string> {
+  // Parse the raw WWW-Authenticate parameters into a structured mppx Challenge
+  // so we (a) have the canonical challenge id to sign, and (b) can wrap the
+  // raw signature into a spec-compliant Credential envelope below. Without
+  // the wrap the facilitator rejects every retry with "Credential is
+  // malformed: Invalid base64url or JSON".
+  //
+  // The npm client strips the `Payment ` scheme token before forwarding, but
+  // Challenge.deserialize expects the full `Payment <params>` form. Re-add the
+  // prefix on input so either form works.
+  const input = challenge.serialized.startsWith(MPP_AUTH_PREFIX)
+    ? challenge.serialized
+    : `${MPP_AUTH_PREFIX}${challenge.serialized}`;
+  const parsed = Challenge.deserialize(input);
+
   // Override PROOF_DOMAIN_TEMPO.chainId if the caller supplies a different
   // chainId (e.g. Tempo testnet). Default path is 4217 from the challenge.
   const typedData = {
     domain: { ...PROOF_DOMAIN_TEMPO, chainId: challenge.chainId },
     types: PROOF_TYPES,
     primaryType: "Proof",
-    message: { challengeId: challenge.challengeId },
+    message: { challengeId: parsed.id },
   };
-  return signTypedData(subOrgId, walletAddress, typedData);
+  const rawSignature = await signTypedData(subOrgId, walletAddress, typedData);
+
+  // Wrap into an MPP Credential and base64url-encode per mppx spec so
+  // `Credential.serialize()` produces `"Payment eyJ..."`. The npm client
+  // prepends its own `Payment ` scheme token when building the Authorization
+  // header, so we strip the prefix on the way out and ship only the encoded
+  // payload. Opaque pass-through from the client's point of view.
+  const credential = Credential.from({
+    challenge: parsed,
+    payload: { signature: rawSignature },
+  });
+  const serialized = Credential.serialize(credential);
+  return serialized.startsWith(MPP_AUTH_PREFIX)
+    ? serialized.slice(MPP_AUTH_PREFIX.length)
+    : serialized;
 }

--- a/tests/integration/agentic-wallet-sign-route.test.ts
+++ b/tests/integration/agentic-wallet-sign-route.test.ts
@@ -22,10 +22,32 @@
  * risk=block -> 403 RISK_BLOCKED.
  */
 import { createHash, createHmac } from "node:crypto";
+import { Challenge } from "mppx";
 import { recoverTypedDataAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { extractPayerAddress } from "@/lib/x402/payment-gate";
+
+// A realistic mppx-issued Tempo charge challenge the route can deserialize.
+// The npm client forwards this (minus the `Payment ` scheme token) as
+// `paymentChallenge.serialized` on every /sign call for chain="tempo".
+const MPP_TEST_SERIALIZED = ((): string => {
+  const full = Challenge.serialize(
+    Challenge.from({
+      secretKey: "mpp-route-test-secret",
+      realm: "test.keeperhub.local",
+      method: "tempo",
+      intent: "charge",
+      request: {
+        amount: "10000",
+        currency: "0x20c000000000000000000000b9537d11c60e8b50",
+        recipient: "0x0000000000000000000000000000000000000001",
+        methodDetails: { chainId: 4217 },
+      },
+    })
+  );
+  return full.startsWith("Payment ") ? full.slice("Payment ".length) : full;
+})();
 
 const TEST_PRIVATE_KEY =
   "0x1111111111111111111111111111111111111111111111111111111111111111";
@@ -793,7 +815,7 @@ describe("POST /api/agentic-wallet/sign -- MPP chainId enum (Phase 37 fix #3)", 
       workflowSlug: "test-slug",
       paymentChallenge: {
         chainId: 1,
-        challengeId: "abc",
+        serialized: MPP_TEST_SERIALIZED,
         payTo: "0x0000000000000000000000000000000000000001",
         amount: "0",
       },
@@ -835,7 +857,7 @@ describe("POST /api/agentic-wallet/sign -- MPP chainId enum (Phase 37 fix #3)", 
       workflowSlug: "test-slug",
       paymentChallenge: {
         chainId: 4218,
-        challengeId: "abc",
+        serialized: MPP_TEST_SERIALIZED,
         payTo: "0x0000000000000000000000000000000000000001",
         amount: "0",
       },
@@ -875,7 +897,7 @@ describe("POST /api/agentic-wallet/sign -- MPP chainId enum (Phase 37 fix #3)", 
       chain: "tempo",
       workflowSlug: "test-slug",
       paymentChallenge: {
-        challengeId: "abc",
+        serialized: MPP_TEST_SERIALIZED,
         payTo: "0x0000000000000000000000000000000000000001",
         amount: "0",
       },

--- a/tests/unit/agentic-wallet-sign.test.ts
+++ b/tests/unit/agentic-wallet-sign.test.ts
@@ -38,9 +38,37 @@ const { PolicyBlockedError, signMppProof, signX402Challenge } = await import(
   "@/lib/agentic-wallet/sign"
 );
 
+const { Challenge } = await import("mppx");
+
 const SUB_ORG = "subOrg_sign_test";
 const WALLET = "0xabc000000000000000000000000000000000dead";
 const BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+const MPP_TEST_SECRET = "test-secret-key-for-mpp-challenge-signing";
+
+/**
+ * Build a mppx-serialized Tempo charge challenge and return the
+ * parameters string (without the `Payment ` scheme prefix) that the npm
+ * client would forward to /sign as `paymentChallenge.serialized`. Using the
+ * real Challenge.from + Challenge.serialize path keeps the test aligned
+ * with whatever shape mppx ships.
+ */
+function buildTempoChallengeSerialized(): string {
+  const challenge = Challenge.from({
+    secretKey: MPP_TEST_SECRET,
+    realm: "test.keeperhub.local",
+    method: "tempo",
+    intent: "charge",
+    request: {
+      amount: "10000",
+      currency: "0x20c000000000000000000000b9537d11c60e8b50",
+      recipient: "0x000000000000000000000000000000000000dead",
+      methodDetails: { chainId: 4217 },
+    },
+  });
+  const full = Challenge.serialize(challenge);
+  return full.startsWith("Payment ") ? full.slice("Payment ".length) : full;
+}
 
 function happyPathResult(
   v: "00" | "01"
@@ -185,24 +213,41 @@ describe("signMppProof", () => {
   it("serialises typed data with chainId 4217 and primaryType Proof (Tempo proof-mode)", async () => {
     await signMppProof(SUB_ORG, WALLET, {
       chainId: 4217,
-      challengeId: "challenge-abc-123",
+      serialized: buildTempoChallengeSerialized(),
     });
     const args = mockSignRawPayload.mock.calls[0]?.[0];
     expect(args.encoding).toBe("PAYLOAD_ENCODING_EIP712");
     const typedData = JSON.parse(args.payload) as {
       domain: { chainId: number };
       primaryType: string;
+      message: { challengeId: string };
     };
     expect(typedData.domain.chainId).toBe(4217);
     expect(typedData.primaryType).toBe("Proof");
+    // challengeId comes from the parsed Challenge.id (HMAC-bound), not a
+    // caller-supplied field. Any non-empty string means the parse+sign path
+    // ran against real mppx-issued challenge data.
+    expect(typedData.message.challengeId).toBeTruthy();
+    expect(typeof typedData.message.challengeId).toBe("string");
   });
 
-  it("returns a 0x-prefixed 132-char signature for a Tempo proof", async () => {
-    const sig = await signMppProof(SUB_ORG, WALLET, {
+  it("returns a serialized Credential envelope, not the raw 0x signature", async () => {
+    const out = await signMppProof(SUB_ORG, WALLET, {
       chainId: 4217,
-      challengeId: "challenge-abc-123",
+      serialized: buildTempoChallengeSerialized(),
     });
-    expect(sig.startsWith("0x")).toBe(true);
-    expect(sig.length).toBe(132);
+    // Not the raw EIP-712 signature -- that would shape-fail the facilitator
+    // with "Credential is malformed". The return value is the encoded portion
+    // of what mppx's `Credential.serialize()` emits (the `Payment ` scheme
+    // token is stripped so callers can prepend it themselves).
+    expect(out.startsWith("0x")).toBe(false);
+    expect(out.startsWith("Payment ")).toBe(false);
+    // Decoding back yields a Credential with `{challenge, payload:{signature}}`.
+    const decoded = JSON.parse(
+      Buffer.from(out, "base64url").toString("utf-8")
+    ) as { challenge: { id: string }; payload: { signature: string } };
+    expect(decoded.challenge.id).toBeTruthy();
+    expect(decoded.payload.signature.startsWith("0x")).toBe(true);
+    expect(decoded.payload.signature.length).toBe(132);
   });
 });


### PR DESCRIPTION
## Summary

Funded-wallet prod smoke found the MPP retry path universally rejected with \`Credential is malformed: Invalid base64url or JSON\`. Root cause was in the agentic-wallet \`/sign\` tempo branch:

- \`signMppProof\` signed \`message.challengeId = \"\"\` because the route read \`challenge.challengeId\` from the client body -- a field the npm client never sends (client forwards \`paymentChallenge.serialized\` instead).
- The route returned the raw EIP-712 signature to the client. The client attached it as \`Authorization: Payment <0x...>\`, but per the MPP spec + \`mppx.Credential.serialize\` the header value must decode to \`{ challenge, payload: { signature } }\`.

Every call to a paid KeeperHub workflow on prod was going through this path, because when both challenges are present the wallet prefers MPP (cheaper/faster Tempo settlement). So the npm package was effectively unusable against any dual-challenge workflow until callers manually stripped the WWW-Authenticate header to force x402 fallback.

## Fix

\`/sign\` tempo branch now requires \`paymentChallenge.serialized\` (the raw WWW-Authenticate parameters minus the \`Payment \` scheme token, which is what the client already ships). \`signMppProof\` parses it via \`Challenge.deserialize\`, signs the Proof typed-data against the real challenge id, and wraps the raw signature via \`Credential.from({challenge, payload:{signature}})\`. The return value is \`Credential.serialize()\` output with the \`Payment \` scheme stripped off so the client can keep prepending its own \`Payment \` scheme token.

Missing \`serialized\` now returns \`400 MPP_CHALLENGE_MISSING\` -- pre-existing clients that only sent \`challengeId\` fail fast instead of silently signing an empty challenge.

## Client compatibility

No npm-client change required. The client's \`paymentChallenge.serialized\` already forwards the raw WWW-Authenticate value; it was just being ignored server-side in favour of a nonexistent \`challengeId\` field. The MPP retry path's design invariant -- \"the client never parses, decodes, or mutates the MPP credential\" -- is preserved.

## Test plan

- [x] \`pnpm vitest run tests/unit tests/integration/agentic-wallet-sign-route.test.ts ...\` -- 158 files / 3089 tests pass (27 touched: 8 in agentic-wallet-sign unit tests with a new assertion that signMppProof returns an encoded credential not a raw 0x signature; 19 in the integration sign-route tests now exercising the serialized-challenge path).
- [x] \`pnpm type-check\` clean.
- [ ] Ship to staging, run the prod smoke mpp-e2e.mjs script against staging + prod after deploy: dual-challenge 402 -> \`signer.fetch()\` -> 200 with executionId via the MPP path (without stripping WWW-Authenticate).

## Notes

The npm client's preference-ordering (\`pay-03\`) still prefers MPP when both challenges are offered; this fix is what makes that preference actually produce a usable credential. x402 fallback stays wired up for workflows that only advertise x402.