### PR TITLE
fix(mcp): honor token_endpoint_auth_method in DCR for public clients

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -21,7 +21,11 @@ export function GET(request: Request): Response {
     scopes_supported: ["mcp:read", "mcp:write", "mcp:admin"],
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
-    token_endpoint_auth_methods_supported: ["client_secret_post"],
+    token_endpoint_auth_methods_supported: [
+      "client_secret_basic",
+      "client_secret_post",
+      "none",
+    ],
     code_challenge_methods_supported: ["S256"],
   };
   return Response.json(metadata);

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -10,12 +10,34 @@ type RegistrationRequestBody = {
   redirect_uris?: unknown;
   scope?: unknown;
   grant_types?: unknown;
+  token_endpoint_auth_method?: unknown;
 };
+
+type TokenEndpointAuthMethod =
+  | "client_secret_basic"
+  | "client_secret_post"
+  | "none";
+
+const SUPPORTED_AUTH_METHODS: ReadonlyArray<TokenEndpointAuthMethod> = [
+  "client_secret_basic",
+  "client_secret_post",
+  "none",
+];
 
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
   );
+}
+
+function resolveAuthMethod(value: unknown): TokenEndpointAuthMethod {
+  if (typeof value === "string") {
+    const match = SUPPORTED_AUTH_METHODS.find((m) => m === value);
+    if (match) {
+      return match;
+    }
+  }
+  return "client_secret_post";
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -38,7 +60,14 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { client_name, redirect_uris, scope, grant_types } = body;
+  const {
+    client_name,
+    redirect_uris,
+    scope,
+    grant_types,
+    token_endpoint_auth_method,
+  } = body;
+  const authMethod = resolveAuthMethod(token_endpoint_auth_method);
 
   if (typeof client_name !== "string" || client_name.trim().length === 0) {
     return Response.json(
@@ -101,15 +130,26 @@ export async function POST(request: Request): Promise<Response> {
 
   await storeOAuthClient(client);
 
-  return Response.json(
-    {
-      client_id: clientId,
-      client_secret: clientSecretRaw,
-      client_name: client.clientName,
-      redirect_uris: client.redirectUris,
-      grant_types: client.grantTypes,
-      scope: resolvedScope,
-    },
-    { status: 201 }
-  );
+  // Public clients (RFC 8252 native apps) register with
+  // `token_endpoint_auth_method: "none"` and rely on PKCE. Returning a
+  // client_secret in that case contradicts what the client asked for and
+  // causes strict MCP hosts (e.g. Claude Desktop's connector validator) to
+  // reject the registration. Store a secret hash either way so the schema
+  // stays stable, but only expose it for confidential-client registrations.
+  const responseBase = {
+    client_id: clientId,
+    client_id_issued_at: Math.floor(client.createdAt / 1000),
+    client_name: client.clientName,
+    redirect_uris: client.redirectUris,
+    grant_types: client.grantTypes,
+    response_types: ["code"],
+    token_endpoint_auth_method: authMethod,
+    scope: resolvedScope,
+  };
+  const responseBody =
+    authMethod === "none"
+      ? responseBase
+      : { ...responseBase, client_secret: clientSecretRaw };
+
+  return Response.json(responseBody, { status: 201 });
 }


### PR DESCRIPTION
## Summary

- Unblock Claude Desktop's connector validator, which still rejects the MCP server at `start_error` after the previous two discovery fixes landed. Traced it to the DCR response shape: Claude Desktop registers as a public client (`token_endpoint_auth_method: \"none\"` + PKCE, per RFC 8252), but our `/api/oauth/register` ignored that field and always returned a `client_secret`. The validator treats the mismatch as a protocol error before the OAuth browser tab ever opens. Linear and Notion's MCP servers both honor `\"none\"` and omit the secret.
- Honor the requested auth method: if `\"none\"`, skip `client_secret` in the response; if `\"client_secret_basic\"` or `\"client_secret_post\"`, return it as before. The stored secret hash stays intact either way so the DB schema needs no migration. Token exchange for the auth-code grant was already PKCE-only (no `client_secret` check), so public-client flows work end-to-end with this change.
- Advertise all three methods in `/.well-known/oauth-authorization-server`'s `token_endpoint_auth_methods_supported` so AS metadata matches what DCR accepts (Linear advertises the same three).
- Echo the RFC 7591 niceties Claude Desktop's SDK expects in the DCR body: `client_id_issued_at`, `response_types: [\"code\"]`, and `token_endpoint_auth_method` reflected back.
- Backwards compatible for Claude Code and any confidential-client integrations: the default remains `\"client_secret_post\"` and the legacy shape (with `client_secret`) is returned unchanged when that's what the caller asks for.

## Test plan

- [ ] After deploy: `curl -sS -X POST https://<pr-env>/api/oauth/register -H 'Content-Type: application/json' -d '{\"client_name\":\"public-probe\",\"redirect_uris\":[\"https://claude.ai/api/mcp/auth_callback\"],\"token_endpoint_auth_method\":\"none\"}'` returns 201 with NO `client_secret`, and includes `token_endpoint_auth_method: \"none\"`, `response_types: [\"code\"]`, `client_id_issued_at`.
- [ ] Same call with `\"token_endpoint_auth_method\":\"client_secret_post\"` still returns a `client_secret` and echoes `token_endpoint_auth_method: \"client_secret_post\"`.
- [ ] `curl https://<pr-env>/.well-known/oauth-authorization-server` lists all three methods in `token_endpoint_auth_methods_supported`.
- [ ] Remove the keeperhub connector in Claude Desktop, re-add, click Connect. OAuth browser tab should now open (no more `start_error`).
- [ ] Claude Code still connects via the `keeperhub` plugin without regressions.
- [ ] `pnpm vitest run tests/unit/mcp-*.test.ts` stays green (79 tests).