### PR TITLE
release: to prod

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -21,7 +21,11 @@ export function GET(request: Request): Response {
     scopes_supported: ["mcp:read", "mcp:write", "mcp:admin"],
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
-    token_endpoint_auth_methods_supported: ["client_secret_post"],
+    token_endpoint_auth_methods_supported: [
+      "client_secret_basic",
+      "client_secret_post",
+      "none",
+    ],
     code_challenge_methods_supported: ["S256"],
   };
   return Response.json(metadata);

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -10,12 +10,34 @@ type RegistrationRequestBody = {
   redirect_uris?: unknown;
   scope?: unknown;
   grant_types?: unknown;
+  token_endpoint_auth_method?: unknown;
 };
+
+type TokenEndpointAuthMethod =
+  | "client_secret_basic"
+  | "client_secret_post"
+  | "none";
+
+const SUPPORTED_AUTH_METHODS: ReadonlyArray<TokenEndpointAuthMethod> = [
+  "client_secret_basic",
+  "client_secret_post",
+  "none",
+];
 
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
   );
+}
+
+function resolveAuthMethod(value: unknown): TokenEndpointAuthMethod {
+  if (typeof value === "string") {
+    const match = SUPPORTED_AUTH_METHODS.find((m) => m === value);
+    if (match) {
+      return match;
+    }
+  }
+  return "client_secret_post";
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -38,7 +60,14 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { client_name, redirect_uris, scope, grant_types } = body;
+  const {
+    client_name,
+    redirect_uris,
+    scope,
+    grant_types,
+    token_endpoint_auth_method,
+  } = body;
+  const authMethod = resolveAuthMethod(token_endpoint_auth_method);
 
   if (typeof client_name !== "string" || client_name.trim().length === 0) {
     return Response.json(
@@ -101,15 +130,26 @@ export async function POST(request: Request): Promise<Response> {
 
   await storeOAuthClient(client);
 
-  return Response.json(
-    {
-      client_id: clientId,
-      client_secret: clientSecretRaw,
-      client_name: client.clientName,
-      redirect_uris: client.redirectUris,
-      grant_types: client.grantTypes,
-      scope: resolvedScope,
-    },
-    { status: 201 }
-  );
+  // Public clients (RFC 8252 native apps) register with
+  // `token_endpoint_auth_method: "none"` and rely on PKCE. Returning a
+  // client_secret in that case contradicts what the client asked for and
+  // causes strict MCP hosts (e.g. Claude Desktop's connector validator) to
+  // reject the registration. Store a secret hash either way so the schema
+  // stays stable, but only expose it for confidential-client registrations.
+  const responseBase = {
+    client_id: clientId,
+    client_id_issued_at: Math.floor(client.createdAt / 1000),
+    client_name: client.clientName,
+    redirect_uris: client.redirectUris,
+    grant_types: client.grantTypes,
+    response_types: ["code"],
+    token_endpoint_auth_method: authMethod,
+    scope: resolvedScope,
+  };
+  const responseBody =
+    authMethod === "none"
+      ? responseBase
+      : { ...responseBase, client_secret: clientSecretRaw };
+
+  return Response.json(responseBody, { status: 201 });
 }


### PR DESCRIPTION
## Summary

Promote the following merged PR from staging to prod:

- #963 fix(mcp): honor token_endpoint_auth_method in DCR for public clients

## Post-deploy verification

- [ ] `deploy-keeperhub` workflow finishes green
- [ ] `curl -fsS https://app.keeperhub.com/api/health` returns 200
- [ ] DCR public-client shape: `curl -sS -X POST https://app.keeperhub.com/api/oauth/register -H 'Content-Type: application/json' -d '{"client_name":"probe","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],"token_endpoint_auth_method":"none"}'` returns 201 with NO `client_secret`, and includes `token_endpoint_auth_method: "none"`, `response_types: ["code"]`, `client_id_issued_at`
- [ ] DCR confidential-client fallback still works: same call with `"token_endpoint_auth_method":"client_secret_post"` returns a `client_secret`
- [ ] AS metadata: `curl https://app.keeperhub.com/.well-known/oauth-authorization-server` lists `["client_secret_basic", "client_secret_post", "none"]` in `token_endpoint_auth_methods_supported`
- [ ] Remove and re-add the keeperhub connector in Claude Desktop; click Connect. OAuth browser tab opens (no more `start_error`) and tools appear after consent
- [ ] Claude Code still connects via the `keeperhub` plugin without regressions
- [ ] Watch Sentry / logs for ~10 minutes after rollout; no elevated 5xx on `/api/oauth/register` or `/mcp`
