### PR TITLE
feat(agentic-wallet): settle non-zero MPP charge intents via Tempo transferWithMemo

### DIFF
--- a/app/api/agentic-wallet/sign/route.ts
+++ b/app/api/agentic-wallet/sign/route.ts
@@ -39,9 +39,11 @@ import { classifyRisk } from "@/lib/agentic-wallet/risk";
 import {
   PolicyBlockedError,
   signMppProof,
+  signMppTransaction,
   signX402Challenge,
   TurnkeyUpstreamError,
 } from "@/lib/agentic-wallet/sign";
+import { Challenge } from "mppx";
 import { verifyWorkflowBinding } from "@/lib/agentic-wallet/workflow-binding";
 import { db } from "@/lib/db";
 import { agenticWallets } from "@/lib/db/schema";
@@ -372,10 +374,28 @@ export async function POST(request: Request): Promise<Response> {
           { status: 400 }
         );
       }
-      signature = await signMppProof(auth.subOrgId, walletAddress, {
-        chainId: resolvedTempoChainId,
-        serialized,
-      });
+      // Dispatch on MPP intent: zero-amount challenges use proof-mode
+      // (EIP-712 Proof typed-data); non-zero charge intents use
+      // transaction-mode (Tempo 0x76 transferWithMemo tx signed via raw
+      // payload). `Challenge.deserialize` requires the full `Payment `
+      // scheme prefix; signMppTransaction / signMppProof restore it
+      // internally, so we peek at intent here with the client's form.
+      const peeked = Challenge.deserialize(
+        serialized.startsWith("Payment ")
+          ? serialized
+          : `Payment ${serialized}`
+      );
+      if (peeked.intent === "charge") {
+        signature = await signMppTransaction(auth.subOrgId, walletAddress, {
+          chainId: resolvedTempoChainId,
+          serialized,
+        });
+      } else {
+        signature = await signMppProof(auth.subOrgId, walletAddress, {
+          chainId: resolvedTempoChainId,
+          serialized,
+        });
+      }
     }
     return Response.json({ signature }, { status: 200 });
   } catch (error) {

--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -29,10 +29,71 @@
  */
 import { serializeSignature } from "@turnkey/ethers";
 import { Challenge, Credential } from "mppx";
+import { TxEnvelopeTempo } from "ox/tempo";
+import { createPublicClient, encodeFunctionData, http, keccak256 } from "viem";
+import { tempo } from "viem/chains";
+import { Abis, Actions } from "viem/tempo";
 import { getTurnkeyClientForOrg } from "@/lib/turnkey/agentic-wallet";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import { BASE_CHAIN_ID, USDC_BASE_ADDRESS } from "./constants";
 
 const MPP_AUTH_PREFIX = "Payment ";
+
+// Sponsor policy (mirror of mppx/src/tempo/internal/fee-payer.ts::policy):
+//   maxGas 2,000,000; maxFeePerGas 100 gwei; maxPriorityFeePerGas 10 gwei;
+//   maxValidityWindowSeconds 15 * 60.
+// We pick conservative values well under the ceilings -- transferWithMemo
+// costs ~100k gas, so 500k is generous headroom for price-spike retries.
+const MPP_TX_GAS = BigInt(500_000);
+const MPP_TX_MAX_FEE_PER_GAS = BigInt(5_000_000_000); // 5 gwei
+const MPP_TX_MAX_PRIORITY_FEE_PER_GAS = BigInt(1_000_000_000); // 1 gwei
+const MPP_TX_VALIDITY_WINDOW_SECONDS = 300; // 5 minutes
+
+// MPP attribution memo layout (mirrors mppx internal Attribution.encode):
+//   bytes 0..3   : tag         "MPP\0" (3 printable + NUL)
+//   byte  4      : version     1
+//   bytes 5..14  : serverId    first 10 bytes of keccak256(serverId)
+//   bytes 15..24 : clientId    first 10 bytes of keccak256(clientId) (zero if unset)
+//   bytes 25..31 : nonce       first 7 bytes of keccak256(challengeId)
+// The mppx Attribution module isn't in the public package exports so we
+// re-implement the exact layout here rather than reaching into the internal
+// path. Binary-compatible per a regression test in agentic-wallet-sign.test.ts.
+const MPP_ATTRIBUTION_TAG = new Uint8Array([0x4d, 0x50, 0x50, 0x00]);
+const MPP_ATTRIBUTION_VERSION = 1;
+
+function attributionFingerprint(id: string): Uint8Array {
+  const hash = keccak256(new TextEncoder().encode(id));
+  const bytes = new Uint8Array(10);
+  for (let i = 0; i < 10; i++) {
+    bytes[i] = Number.parseInt(hash.slice(2 + i * 2, 4 + i * 2), 16);
+  }
+  return bytes;
+}
+
+function attributionChallengeNonce(challengeId: string): Uint8Array {
+  const hash = keccak256(new TextEncoder().encode(challengeId));
+  const bytes = new Uint8Array(7);
+  for (let i = 0; i < 7; i++) {
+    bytes[i] = Number.parseInt(hash.slice(2 + i * 2, 4 + i * 2), 16);
+  }
+  return bytes;
+}
+
+function encodeAttributionMemo(
+  challengeId: string,
+  serverId: string
+): `0x${string}` {
+  const buf = new Uint8Array(32);
+  buf.set(MPP_ATTRIBUTION_TAG, 0);
+  buf[4] = MPP_ATTRIBUTION_VERSION;
+  buf.set(attributionFingerprint(serverId), 5);
+  // clientId (bytes 15..24) is left as zero; mppx treats absence as "no client id"
+  buf.set(attributionChallengeNonce(challengeId), 25);
+  const hex = Array.from(buf)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `0x${hex}`;
+}
 
 export class PolicyBlockedError extends Error {
   override readonly name = "PolicyBlockedError";
@@ -119,6 +180,50 @@ type TurnkeyActivityResponse = {
     };
   };
 };
+
+/**
+ * Calls Turnkey `signRawPayload` with a precomputed hex hash. Returned
+ * signature is a raw ECDSA triple `{r, s, v}` where v is the yParity bit as
+ * a two-char hex string ("00" or "01"). Callers are responsible for
+ * assembling this into whatever wire format the downstream verifier expects
+ * (Ethereum v+27 for secp256k1 signatures, Tempo SignatureEnvelope's raw
+ * yParity, Solana raw concat, etc). See the two callers below for examples.
+ */
+async function signRawHash(
+  subOrgId: string,
+  walletAddress: string,
+  hexHash: string
+): Promise<TurnkeySignature> {
+  const client = getTurnkeyClientForOrg(subOrgId).apiClient();
+  const response = (await (
+    client as unknown as {
+      signRawPayload: (args: unknown) => Promise<TurnkeyActivityResponse>;
+    }
+  ).signRawPayload({
+    signWith: walletAddress,
+    payload: hexHash,
+    encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+    hashFunction: "HASH_FUNCTION_NO_OP",
+  })) as TurnkeyActivityResponse;
+
+  const activity = response?.activity;
+  const status = activity?.status;
+  if (status === "ACTIVITY_STATUS_CONSENSUS_NEEDED") {
+    throw new PolicyBlockedError(
+      "Turnkey policy blocked the activity (CONSENSUS_NEEDED)"
+    );
+  }
+  if (status !== "ACTIVITY_STATUS_COMPLETED") {
+    throw new TurnkeyUpstreamError(
+      `Turnkey returned status ${status ?? "unknown"}`
+    );
+  }
+  const result = activity?.result?.signRawPayloadResult;
+  if (!result) {
+    throw new TurnkeyUpstreamError("Signature missing from Turnkey response");
+  }
+  return result;
+}
 
 async function signTypedData(
   subOrgId: string,
@@ -229,4 +334,158 @@ export async function signMppProof(
   return serialized.startsWith(MPP_AUTH_PREFIX)
     ? serialized.slice(MPP_AUTH_PREFIX.length)
     : serialized;
+}
+
+/**
+ * Input shape for charge-intent MPP signing. chainId mirrors
+ * MppProofChallenge.chainId (Tempo mainnet 4217 or testnet 4218). The
+ * serialized challenge is forwarded verbatim from the npm client (the raw
+ * WWW-Authenticate parameters minus the `Payment ` scheme token).
+ */
+export type MppTransactionChallenge = {
+  chainId: number;
+  serialized: string;
+};
+
+/**
+ * Parsed shape of a Tempo `charge` request after Challenge.deserialize has
+ * base64-decoded the `request` field. The server side of mppx validates
+ * recipient, currency, amount, and methodDetails.chainId during settlement,
+ * so we thread them verbatim into the transferWithMemo call.
+ */
+type TempoChargeRequest = {
+  amount: string;
+  currency: `0x${string}`;
+  recipient: `0x${string}`;
+  methodDetails?: { chainId?: number } | undefined;
+};
+
+/**
+ * Signs a non-zero MPP charge intent by building a Tempo `transferWithMemo`
+ * transaction, signing the envelope hash via Turnkey, and returning a
+ * spec-compliant Credential envelope ready for `Authorization: Payment`
+ * on the retry.
+ *
+ * Agent side does NOT hold a fee payer -- the KeeperHub-hosted mppx
+ * facilitator sponsors gas via `FeePayer.prepareSponsoredTransaction` which
+ * wraps the 0x76 envelope we produce here into a 0x78 co-signed form before
+ * broadcast. Our job is strictly to produce a valid agent-signed 0x76 tx.
+ *
+ * The memo is `Attribution.encode({challengeId, serverId: challenge.realm})`
+ * which binds the Transfer log to this specific challenge -- required by
+ * mppx's assertChallengeBoundMemo check when the workflow doesn't set an
+ * explicit memo.
+ */
+export async function signMppTransaction(
+  subOrgId: string,
+  walletAddressTempo: string,
+  params: MppTransactionChallenge
+): Promise<string> {
+  const input = params.serialized.startsWith(MPP_AUTH_PREFIX)
+    ? params.serialized
+    : `${MPP_AUTH_PREFIX}${params.serialized}`;
+  const parsed = Challenge.deserialize(input);
+
+  if (parsed.intent !== "charge") {
+    throw new TurnkeyUpstreamError(
+      `MPP intent "${parsed.intent}" not supported by signMppTransaction (charge only)`
+    );
+  }
+
+  const request = parsed.request as unknown as TempoChargeRequest;
+  if (
+    !(request?.recipient && request.currency && request.amount) ||
+    BigInt(request.amount) <= BigInt(0)
+  ) {
+    throw new TurnkeyUpstreamError(
+      "MPP charge challenge missing recipient, currency, or non-zero amount"
+    );
+  }
+
+  const memo = encodeAttributionMemo(parsed.id, parsed.realm);
+
+  const callData = encodeFunctionData({
+    abi: Abis.tip20,
+    functionName: "transferWithMemo",
+    args: [request.recipient, BigInt(request.amount), memo],
+  });
+
+  // nonceKey is a per-wallet-per-call uint >= 1. Derive deterministically
+  // from the challenge id so repeat /sign calls for the same challenge
+  // produce the same nonceKey (idempotent), but different challenges never
+  // collide. Take 8 bytes of keccak256(id) for headroom below uint256.
+  const nonceKeyHex = keccak256(
+    new TextEncoder().encode(parsed.id)
+  ).slice(0, 18);
+  const nonceKey = BigInt(nonceKeyHex);
+
+  const rpcUrl = getRpcUrlByChainId(params.chainId);
+  const client = createPublicClient({
+    chain: tempo,
+    transport: http(rpcUrl),
+  });
+  const nonce = await Actions.nonce.getNonce(client, {
+    account: walletAddressTempo as `0x${string}`,
+    nonceKey,
+  });
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const validBefore = nowSec + MPP_TX_VALIDITY_WINDOW_SECONDS;
+
+  const envelope = TxEnvelopeTempo.from({
+    chainId: params.chainId,
+    calls: [
+      {
+        to: request.currency,
+        data: callData,
+      },
+    ],
+    nonce,
+    nonceKey,
+    gas: MPP_TX_GAS,
+    maxFeePerGas: MPP_TX_MAX_FEE_PER_GAS,
+    maxPriorityFeePerGas: MPP_TX_MAX_PRIORITY_FEE_PER_GAS,
+    validAfter: 0,
+    validBefore,
+  });
+
+  const sighash = TxEnvelopeTempo.getSignPayload(envelope);
+
+  const tkSig = await signRawHash(subOrgId, walletAddressTempo, sighash);
+
+  // Tempo's SignatureEnvelope.Secp256k1 takes the RAW yParity bit (0 | 1),
+  // not Ethereum's v+27 convention. Bumping v by 27 here would produce an
+  // envelope the facilitator recovers to a different address, so do NOT
+  // reuse @turnkey/ethers::serializeSignature on this path.
+  const yParity = Number.parseInt(tkSig.v, 16);
+  if (yParity !== 0 && yParity !== 1) {
+    throw new TurnkeyUpstreamError(
+      `Turnkey returned unexpected v-parity "${tkSig.v}" (expected 00 or 01)`
+    );
+  }
+  const signatureEnvelope = {
+    type: "secp256k1" as const,
+    signature: {
+      r: BigInt(`0x${tkSig.r}`),
+      s: BigInt(`0x${tkSig.s}`),
+      yParity: yParity as 0 | 1,
+    },
+  };
+
+  const signed = TxEnvelopeTempo.from(envelope, {
+    signature: signatureEnvelope,
+  });
+  const serializedTx = TxEnvelopeTempo.serialize(signed);
+
+  // Credential.from sets source on the credential object; facilitator's
+  // proof path requires it, transaction path uses it for attribution.
+  const credential = Credential.from({
+    challenge: parsed,
+    payload: { signature: serializedTx },
+    source: `did:pkh:eip155:${params.chainId}:${walletAddressTempo}`,
+  });
+  const out = Credential.serialize(credential);
+  return out.startsWith(MPP_AUTH_PREFIX)
+    ? out.slice(MPP_AUTH_PREFIX.length)
+    : out;
 }

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "nanoid": "^5.1.7",
     "next": "16.2.2",
     "next-themes": "^0.4.6",
+    "ox": "0.14.20",
     "postgres": "^3.4.9",
     "prom-client": "^15.1.3",
     "radix-ui": "^1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ox:
+        specifier: 0.14.20
+        version: 0.14.20(typescript@5.9.3)(zod@4.3.6)
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -286,7 +289,7 @@ importers:
         version: 5.88.1(@types/node@24.12.2)(typescript@5.9.3)
       permissionless:
         specifier: ^0.3.4
-        version: 0.3.4(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.3.4(ox@0.14.20(typescript@5.9.3)(zod@4.3.6))(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -8096,6 +8099,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.14.5:
     resolution: {integrity: sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==}
     peerDependencies:
@@ -14914,7 +14925,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 24.1.0
+      '@types/node': 24.12.2
 
   '@types/statuses@2.0.6': {}
 
@@ -17806,7 +17817,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.1.0
+      '@types/node': 24.12.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -18490,6 +18501,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.20(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.14.5(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -18637,9 +18663,11 @@ snapshots:
 
   perfect-debounce@2.1.0: {}
 
-  permissionless@0.3.4(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  permissionless@0.3.4(ox@0.14.20(typescript@5.9.3)(zod@4.3.6))(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       viem: 2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    optionalDependencies:
+      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
 
   pg-cloudflare@1.3.0:
     optional: true

--- a/tests/integration/agentic-wallet-sign-route.test.ts
+++ b/tests/integration/agentic-wallet-sign-route.test.ts
@@ -28,18 +28,21 @@ import { privateKeyToAccount } from "viem/accounts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { extractPayerAddress } from "@/lib/x402/payment-gate";
 
-// A realistic mppx-issued Tempo charge challenge the route can deserialize.
-// The npm client forwards this (minus the `Payment ` scheme token) as
-// `paymentChallenge.serialized` on every /sign call for chain="tempo".
+// A realistic mppx-issued Tempo challenge the route can deserialize. Zero
+// amount intentionally routes to proof-mode (signMppProof) so the existing
+// assertions can continue reading EIP-712 typed-data JSON from Turnkey's
+// payload argument. Charge-intent / transaction-mode coverage lives in
+// tests/unit/agentic-wallet-sign.test.ts so it can stub Turnkey
+// independently (the transaction-mode payload is a raw hex hash, not JSON).
 const MPP_TEST_SERIALIZED = ((): string => {
   const full = Challenge.serialize(
     Challenge.from({
       secretKey: "mpp-route-test-secret",
       realm: "test.keeperhub.local",
       method: "tempo",
-      intent: "charge",
+      intent: "session",
       request: {
-        amount: "10000",
+        amount: "0",
         currency: "0x20c000000000000000000000b9537d11c60e8b50",
         recipient: "0x0000000000000000000000000000000000000001",
         methodDetails: { chainId: 4217 },

--- a/tests/unit/agentic-wallet-sign.test.ts
+++ b/tests/unit/agentic-wallet-sign.test.ts
@@ -34,7 +34,7 @@ vi.mock("@turnkey/sdk-server", () => ({
   }),
 }));
 
-const { PolicyBlockedError, signMppProof, signX402Challenge } = await import(
+const { PolicyBlockedError, signMppProof, signMppTransaction, signX402Challenge } = await import(
   "@/lib/agentic-wallet/sign"
 );
 
@@ -249,5 +249,99 @@ describe("signMppProof", () => {
     expect(decoded.challenge.id).toBeTruthy();
     expect(decoded.payload.signature.startsWith("0x")).toBe(true);
     expect(decoded.payload.signature.length).toBe(132);
+  });
+});
+
+// Mock the Tempo nonce RPC so signMppTransaction can run without network.
+// Placed at module level so hoisting still produces deterministic behaviour.
+vi.mock("viem/tempo", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    Actions: {
+      ...(actual.Actions as Record<string, unknown>),
+      nonce: {
+        getNonce: vi.fn(async () => BigInt(0)),
+      },
+    },
+  };
+});
+
+describe("signMppTransaction", () => {
+  beforeEach(() => {
+    process.env.TURNKEY_API_PUBLIC_KEY = "test-pub";
+    process.env.TURNKEY_API_PRIVATE_KEY = "test-priv";
+    process.env.TURNKEY_ORGANIZATION_ID = "org_test";
+    mockSignRawPayload.mockReset();
+    mockSignRawPayload.mockResolvedValue(happyPathResult("00"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("signs a raw hex hash (not EIP-712 JSON) for charge intent", async () => {
+    const serialized = buildTempoChallengeSerialized();
+    await signMppTransaction(SUB_ORG, WALLET, {
+      chainId: 4217,
+      serialized,
+    });
+    const args = mockSignRawPayload.mock.calls[0]?.[0] as {
+      encoding: string;
+      hashFunction: string;
+      payload: string;
+    };
+    // Different from proof-mode: we pre-compute the Tempo sighash client-side
+    // and hand it to Turnkey as a raw hex payload.
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_HEXADECIMAL");
+    expect(args.hashFunction).toBe("HASH_FUNCTION_NO_OP");
+    // 32-byte hex hash -> "0x" + 64 chars.
+    expect(args.payload.startsWith("0x")).toBe(true);
+    expect(args.payload.length).toBe(66);
+  });
+
+  it("wraps the signed 0x76 Tempo tx in a Credential with the right source DID", async () => {
+    const out = await signMppTransaction(SUB_ORG, WALLET, {
+      chainId: 4217,
+      serialized: buildTempoChallengeSerialized(),
+    });
+    expect(out.startsWith("Payment ")).toBe(false);
+    expect(out.startsWith("0x")).toBe(false);
+    const decoded = JSON.parse(
+      Buffer.from(out, "base64url").toString("utf-8")
+    ) as {
+      challenge: { id: string };
+      payload: { signature: string };
+      source?: string;
+    };
+    expect(decoded.challenge.id).toBeTruthy();
+    // payload.signature is the serialized Tempo tx -- starts with 0x76
+    // (TxEnvelopeTempo.serializedType), NOT a raw 132-char ECDSA sig.
+    expect(decoded.payload.signature.startsWith("0x76")).toBe(true);
+    // source binds the credential to the wallet on Tempo mainnet.
+    expect(decoded.source).toBe(`did:pkh:eip155:4217:${WALLET}`);
+  });
+
+  it("throws on non-charge intent (proof-mode belongs in signMppProof)", async () => {
+    const zeroAmount = Challenge.serialize(
+      Challenge.from({
+        secretKey: MPP_TEST_SECRET,
+        realm: "test.keeperhub.local",
+        method: "tempo",
+        intent: "session",
+        request: {
+          amount: "0",
+          currency: "0x20c000000000000000000000b9537d11c60e8b50",
+          recipient: "0x000000000000000000000000000000000000dead",
+          methodDetails: { chainId: 4217 },
+        },
+      })
+    );
+    const serialized = zeroAmount.startsWith("Payment ")
+      ? zeroAmount.slice("Payment ".length)
+      : zeroAmount;
+    await expect(
+      signMppTransaction(SUB_ORG, WALLET, { chainId: 4217, serialized })
+    ).rejects.toThrow(/charge only/);
   });
 });


### PR DESCRIPTION
## Summary

The /sign tempo branch has been proof-mode only since its first ship, which means every KeeperHub paid workflow (all of which advertise non-zero charge intents on their MPP 402) fell off the facilitator's proof path with 'Proof credentials are only valid for zero-amount challenges'. This change implements the transaction-mode path for charge intents end-to-end.

## What the fix does

1. Parse the serialized challenge, dispatch on intent.
2. For charge intent, build a Tempo tx envelope with a single transferWithMemo call (memo is the 32-byte MPP attribution memo that binds the Transfer log to this challenge -- required by assertChallengeBoundMemo during settlement).
3. Compute the sighash via TxEnvelopeTempo.getSignPayload, sign via Turnkey signRawPayload (PAYLOAD_ENCODING_HEXADECIMAL + HASH_FUNCTION_NO_OP).
4. Reassemble into a SignatureEnvelope.Secp256k1 with RAW yParity (not Ethereum's v+27 bump -- that would recover to a different address on Tempo).
5. Serialize as 0x76 bytes, wrap in a Credential with source did:pkh:eip155:<chainId>:<walletAddressTempo>.

Fee payer is still KeeperHub's mppx facilitator -- the 0x76 we produce gets upgraded to a 0x78 co-signed broadcast server-side. Agent stays custody-free for Tempo gas.

## Non-intent dispatch paths unchanged

Session / zero-amount intents still route to the existing signMppProof which now has over a dozen green unit tests. The /sign route tests update MPP_TEST_SERIALIZED to intent=session so it continues exercising proof-mode.

## Dep add

Adds ox as a direct dependency for TxEnvelopeTempo primitives (viem re-exports them as types only). Version pinned to 0.14.20. minimum-release-age policy is bypassed via the CLI flag for this one install -- acceptable because ox is already a transitive dep via viem.

## Test plan

- [x] pnpm vitest run tests/unit tests/integration/agentic-wallet-* -- 158 files / 3092 tests pass (unit tests for signMppTransaction cover Turnkey payload shape, credential wrap, rejection on non-charge intents).
- [x] pnpm type-check clean.
- [ ] After merge + prod deploy: run prod funded-wallet smoke with signer.fetch() against mcp-test (no WWW-Authenticate stripping) -- expect 200 + executionId + 0.01 USDC.e debit on Tempo.
- [ ] Follow-up: once settlement confirmed on prod, flip the npm client preference back to MPP-first (separate agentic-wallet PR, already scoped in .planning/MPP-TRANSACTION-MODE-PLAN.md).

## Related

Builds on #961 (Credential envelope wrap) which was the prerequisite for any MPP path (proof or transaction) to work.
