### PR TITLE
fix(mcp): match Linear/Notion response shapes on 401 + DCR

### DIFF
--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -5,6 +5,17 @@ import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 
 export const dynamic = "force-dynamic";
 
+const TRAILING_SLASH = /\/$/;
+
+function deriveBaseUrl(request: Request): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
+  if (envUrl) {
+    return envUrl.replace(TRAILING_SLASH, "");
+  }
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
 type RegistrationRequestBody = {
   client_name?: unknown;
   redirect_uris?: unknown;
@@ -136,6 +147,7 @@ export async function POST(request: Request): Promise<Response> {
   // causes strict MCP hosts (e.g. Claude Desktop's connector validator) to
   // reject the registration. Store a secret hash either way so the schema
   // stays stable, but only expose it for confidential-client registrations.
+  const baseUrl = deriveBaseUrl(request);
   const responseBase = {
     client_id: clientId,
     client_id_issued_at: Math.floor(client.createdAt / 1000),
@@ -145,6 +157,9 @@ export async function POST(request: Request): Promise<Response> {
     response_types: ["code"],
     token_endpoint_auth_method: authMethod,
     scope: resolvedScope,
+    // RFC 7591 §3.2.1 management endpoint. Linear/Notion return this; some
+    // strict validators treat its absence as an incomplete registration.
+    registration_client_uri: `${baseUrl}/api/oauth/register/${clientId}`,
   };
   const responseBody =
     authMethod === "none"

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -89,7 +89,7 @@ function getBaseUrl(request: Request): string {
 // parameters during its discovery validation; omitting them causes the connect
 // flow to halt at `start_error` before DCR ever runs. We match Linear, Sentry,
 // and Notion's challenge shape.
-function unauthorizedResponse(request: Request, error: string): Response {
+function unauthorizedResponse(request: Request): Response {
   const baseUrl = getBaseUrl(request);
   const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
   const challenge = [
@@ -98,7 +98,14 @@ function unauthorizedResponse(request: Request, error: string): Response {
     'error="invalid_token"',
     'error_description="Missing or invalid access token"',
   ].join(", ");
-  return new Response(JSON.stringify({ error }), {
+  // RFC 6749 §5.2 error response. Match Linear/Notion/Sentry's body shape so
+  // any OAuth 2.1 parser (including Anthropic's connector validator) can read
+  // the error consistently with the WWW-Authenticate challenge.
+  const body = {
+    error: "invalid_token",
+    error_description: "Missing or invalid access token",
+  };
+  return new Response(JSON.stringify(body), {
     status: 401,
     headers: {
       "Content-Type": "application/json",
@@ -349,7 +356,7 @@ export async function POST(request: Request): Promise<Response> {
     const reason = auth.error ?? "Unauthorized";
     logMcpEvent("mcp.auth.failed", { reason });
     if ((auth.statusCode ?? 401) === 401) {
-      return unauthorizedResponse(request, reason);
+      return unauthorizedResponse(request);
     }
     return new Response(JSON.stringify({ error: reason }), {
       status: auth.statusCode,
@@ -452,7 +459,7 @@ export async function GET(request: Request): Promise<Response> {
     const reason = auth.error ?? "Unauthorized";
     logMcpEvent("mcp.auth.failed", { reason });
     if ((auth.statusCode ?? 401) === 401) {
-      return unauthorizedResponse(request, reason);
+      return unauthorizedResponse(request);
     }
     return new Response(JSON.stringify({ error: reason }), {
       status: auth.statusCode,
@@ -492,7 +499,7 @@ export async function DELETE(request: Request): Promise<Response> {
     const reason = auth.error ?? "Unauthorized";
     logMcpEvent("mcp.auth.failed", { reason });
     if ((auth.statusCode ?? 401) === 401) {
-      return unauthorizedResponse(request, reason);
+      return unauthorizedResponse(request);
     }
     return new Response(JSON.stringify({ error: reason }), {
       status: auth.statusCode,


### PR DESCRIPTION
## Summary

- Ran Anthropic's public MCP TypeScript SDK (`@modelcontextprotocol/sdk` 1.29.0) against `app.keeperhub.com/mcp` end-to-end: discovery, DCR, authorization URL build all succeed; `auth()` returns `REDIRECT` with a valid URL. So our server is spec-compliant for the public client path. Claude Desktop still halts at `step=start_error` inside `claude.ai/api/.../mcp/start-auth/...` -- that failure is in Anthropic's backend validator, not the SDK. To close the remaining shape deltas versus Linear, Notion, and Sentry (all of which connect cleanly), align two body shapes.
- `/mcp` 401 body was a free-text object `{"error": "Missing Authorization header"}`. RFC 6749 §5.2 and OAuth 2.1 error responses use `{"error": "invalid_token", "error_description": "..."}`. All three working servers return that exact pair. Rewrite our body so any OAuth 2.1 parser reads it consistently with the `WWW-Authenticate` challenge we already set.
- DCR response now includes `registration_client_uri`. RFC 7591 §3.2.1 documents it, and Linear and Notion both emit it. The URL is informational (we don't implement the management endpoint yet).
- No logic changes: auth, token exchange, rate limiting, scope, and public-vs-confidential client shape all unchanged.

## Test plan

- [ ] After deploy: `curl -sS -X POST https://<pr-env>/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'` returns 401 with body `{"error":"invalid_token","error_description":"Missing or invalid access token"}` and the same `WWW-Authenticate` header as today.
- [ ] `curl -sS -X POST https://<pr-env>/api/oauth/register -H 'Content-Type: application/json' -d '{"client_name":"probe","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],"token_endpoint_auth_method":"none"}'` returns 201 with `registration_client_uri: "https://<pr-env>/api/oauth/register/<client_id>"`, and still no `client_secret` for public clients.
- [ ] `pnpm vitest run tests/unit/mcp-*.test.ts` stays green (79 tests).
- [ ] Remove + re-add the keeperhub connector in Claude Desktop and click Connect. OAuth browser tab should now open. If it still fails at `start_error`, the remaining suspicion is cached per-org state inside claude.ai -- worth pursuing with Anthropic support using the new `ofid_...` reference.