### PR TITLE
fix: sandbox hostname and drop redundant healthz smoke

### DIFF
--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -168,18 +168,3 @@ jobs:
             exit 1
           fi
           echo "WORK-03 smoke: token file ENOENT"
-
-      - name: Healthz smoke
-        if: steps.skip.outputs.skip_deploy != 'true'
-        run: |
-          kubectl -n "${{ env.NAMESPACE }}" port-forward \
-            svc/"${{ env.RELEASE_NAME }}" 18787:8787 >/dev/null 2>&1 &
-          PF_PID=$!
-          sleep 3
-          if ! curl -sf http://localhost:18787/healthz | grep -q '^ok$'; then
-            echo "::error::/healthz did not return ok"
-            kill $PF_PID 2>/dev/null
-            exit 1
-          fi
-          echo "Healthz smoke: ok"
-          kill $PF_PID 2>/dev/null

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -35,7 +35,7 @@ shared_env: &shared_env
     value: "remote"
   SANDBOX_URL:
     type: kv
-    value: "http://keeperhub-sandbox.keeperhub.svc.cluster.local:8787"
+    value: "http://keeperhub-sandbox-common.keeperhub.svc.cluster.local:8787"
 
 replicaCount: 2
 

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -35,7 +35,7 @@ shared_env: &shared_env
     value: "remote"
   SANDBOX_URL:
     type: kv
-    value: "http://keeperhub-sandbox.keeperhub.svc.cluster.local:8787"
+    value: "http://keeperhub-sandbox-common.keeperhub.svc.cluster.local:8787"
 
 replicaCount: 1
 


### PR DESCRIPTION
## Summary

Follow-ups on top of #960 after the first live deploy of `keeperhub-sandbox` to techops-staging surfaced two issues.

### 1. SANDBOX_URL pointed at a non-existent Service

`techops-services/common` chart v0.2.1 templates the Service resource name as `{{ include "common.fullname" . }}`, which expands to `{release}-common` when the release name does not contain the chart name (`common`). The sandbox release is `keeperhub-sandbox`, so the actual in-cluster Service is `keeperhub-sandbox-common`. There is no `keeperhub-sandbox` Service, and the main app's DNS lookup fails:

```
sandbox client error: getaddrinfo ENOTFOUND keeperhub-sandbox.keeperhub.svc.cluster.local
```

Point `SANDBOX_URL` in both staging and prod main-app values at the actual Service name (`keeperhub-sandbox-common.keeperhub.svc.cluster.local:8787`). `service.name` in the sandbox values is ignored by this chart so it cannot be used to control the generated name.

### 2. Redundant Healthz smoke step removed (already merged as 99449b6)

The `Healthz smoke` step in `deploy-sandbox.yaml` was a bash `kubectl port-forward svc/${RELEASE_NAME} & sleep 3 && curl /healthz`. Two problems:

- It port-forwarded at `svc/${RELEASE_NAME}` which does not exist (same chart-naming issue as above), so it would always fail.
- It is redundant with `readinessProbe`/`livenessProbe` on `/healthz` (already configured in the sandbox values.yaml) combined with `atomic: true` on `helm upgrade` -- if the pod does not become Ready, helm rolls back and the workflow step fails. Every other deploy workflow in this repo (`deploy-events`, `deploy-executor`, `deploy-scheduler`, `deploy-docs`) relies solely on that and does not port-forward post-deploy.

## Verification done pre-PR

- Manually patched `deployment/keeperhub-common` in techops-staging cluster (`kubectl set env`) to the `-common` hostname; main app reloaded and Code action executes against the sandbox without DNS error.
- `kubectl -n keeperhub get svc keeperhub-sandbox-common` confirms the Service exists on that exact name.

## Test plan

- [ ] Merge to `staging`; `deploy-keeperhub.yaml` rolls the main app and `SANDBOX_URL` takes effect across all pods.
- [ ] Run a Code action in the staging app -- no DNS error, sandbox responds as expected.
- [ ] Confirm `deploy-sandbox.yaml` still returns green (without the healthz smoke step, atomic helm + probes do the work).