### PR TITLE
docs: fix local dev setup so all three modes actually boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,22 @@
+# =============================================================================
+# Core (required for the dev server to boot)
+# =============================================================================
+
+# Postgres connection. For Local Development mode use the host Postgres.
+# For Docker / Hybrid modes use the compose Postgres exposed on host port 5433:
+#   DATABASE_URL=postgresql://postgres:postgres@localhost:5433/keeperhub
+DATABASE_URL=
+
+# better-auth signing key. Generate with: openssl rand -hex 32
+BETTER_AUTH_SECRET=
+
+# better-auth callback URL (matches the dev server)
+BETTER_AUTH_URL=http://localhost:3000
+
+# =============================================================================
+# Feature-specific (only needed when you exercise that feature)
+# =============================================================================
+
 # OpenAI API key for workflow orchestration
 export OPENAI_API_KEY=""
 
@@ -21,8 +40,10 @@ SENTRY_AUTH_TOKEN=
 # Internal config
 KEEPERHUB_API_KEY=
 
-# LocalStack (required for local dev with SQS)
-# Get token from: 1Password not called "localstack.cloud"
+# LocalStack auth token. REQUIRED for Docker and Hybrid modes -- the compose
+# file uses the Pro image which exits 55 ("License activation failed") if this
+# is empty. Free dev tokens at https://app.localstack.cloud, or grab the team
+# one from 1Password ("localstack.cloud").
 LOCALSTACK_AUTH_TOKEN=
 
 PIMLICO_API_KEY=

--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ Restart Claude Code after setup. [Plugin source code](https://github.com/KeeperH
 
 ### Prerequisites
 
-- Node.js 18+
-- PostgreSQL database
+- Node.js 22 (Next.js 16 requires `>=20.9.0`; Node 18 will not work)
 - pnpm package manager
+- PostgreSQL 16 (only for "Local Development" mode below; Docker and Hybrid modes start their own Postgres in a container)
+- Docker Engine with the Compose plugin (only for Docker and Hybrid modes)
+- A LocalStack auth token (only for Docker and Hybrid modes; the compose file uses the Pro image and refuses to boot without it). Free dev tokens are available at https://app.localstack.cloud.
 
 ### Environment Variables
 
-Create a `.env.local` file:
+Copy `.env.example` to `.env` and fill in the keys you need. Use `.env`, not `.env.local`: `drizzle-kit` (used by `pnpm db:push`) reads `.env` only.
+
+The minimum keys needed to boot the dev server are:
 
 ```env
 # Database
@@ -79,18 +83,11 @@ DATABASE_URL=postgresql://user:password@localhost:5432/keeperhub
 BETTER_AUTH_SECRET=your-secret-key
 BETTER_AUTH_URL=http://localhost:3000
 
-# AI (choose one)
-OPENAI_API_KEY=your-openai-api-key
-AI_MODEL=gpt-4o
-
-# Para Wallet
-PARA_API_KEY=your-para-api-key
-PARA_ENVIRONMENT=beta
-
-# Encryption
-WALLET_ENCRYPTION_KEY=your-wallet-encryption-key
-INTEGRATION_ENCRYPTION_KEY=your-integration-encryption-key
+# Required for Docker and Hybrid modes (LocalStack Pro license)
+LOCALSTACK_AUTH_TOKEN=your-localstack-token
 ```
+
+Feature-specific keys (AI, Para wallets, encryption, OAuth providers, etc.) are listed in `.env.example` and only need values when you exercise that feature.
 
 ### Installation
 
@@ -100,13 +97,13 @@ pnpm db:push
 pnpm dev
 ```
 
-Visit [http://localhost:3000](http://localhost:3000) to get started.
+Visit [http://localhost:3000](http://localhost:3000) to get started. The first request triggers a Next.js dev compile that can take 30-60 seconds; subsequent requests are fast.
 
 ## Running Modes
 
 ### Local Development (Simplest)
 
-For UI/API development without Docker:
+For UI/API development without Docker. Requires PostgreSQL running on the host.
 
 ```bash
 pnpm install
@@ -116,7 +113,18 @@ pnpm dev
 
 ### Dev Mode with Docker
 
-Full development stack with scheduled workflow execution:
+Full development stack with scheduled workflow execution.
+
+The compose file declares four resources as `external: true`. Create them once before the first `make dev-setup`:
+
+```bash
+docker network create keeperhub-network
+docker volume create keeperhub_db_data
+docker volume create keeperhub_node_modules
+docker volume create keeperhub_localstack_data
+```
+
+Then:
 
 ```bash
 make dev-setup    # First time (starts services + migrations)
@@ -125,11 +133,22 @@ make dev-logs     # View logs
 make dev-down     # Stop services
 ```
 
-Services: PostgreSQL (5433), LocalStack SQS (4566), Redis (6379), KeeperHub App (3000), Scheduler, Block Dispatcher, Event Tracker, Executor
+Services: PostgreSQL (5433), LocalStack SQS (4566), Redis (6379), KeeperHub App (3000), Scheduler, Block Dispatcher, Event Tracker, Executor.
 
 ### Hybrid Mode with K8s Jobs
 
-For testing workflow execution in isolated K8s Job containers:
+For testing workflow execution in isolated K8s Job containers. Requires Docker, `kubectl` and `minikube` on the host. Run as a regular user, **not** root - Minikube refuses the docker driver under root.
+
+Create the same four external Docker resources as for Dev mode (see above) before the first run:
+
+```bash
+docker network create keeperhub-network
+docker volume create keeperhub_db_data
+docker volume create keeperhub_node_modules
+docker volume create keeperhub_localstack_data
+```
+
+Then:
 
 ```bash
 make hybrid-setup     # Full setup


### PR DESCRIPTION
## Summary

Validated the three documented local dev setup paths (`pnpm dev`, `make dev-setup`, `make hybrid-setup`) on fresh Multipass Ubuntu 24.04 VMs and patched `README.md` + `.env.example` to match what actually works. With these doc fixes, all three modes boot cleanly and serve `http://localhost:3000` (200 OK).

Tracking ticket: [KEEP-334](https://linear.app/keeperhubapp/issue/KEEP-334/test-local-dev-env)

## What changed

* Bump Node requirement from 18+ to **22**. Next.js 16 needs `>=20.9.0`, so the README's "Node 18+" claim was wrong and `pnpm dev` fails outright on Node 18.
* Tell contributors to use `.env`, not `.env.local`. drizzle-kit (called by `pnpm db:push`) reads `.env` only and was silently missing `DATABASE_URL` when contributors put it in `.env.local` per the old docs.
* Add `DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` placeholders to `.env.example` so contributors do not have to author them by hand.
* Document the four external Docker resources the compose file declares (`keeperhub-network`, `keeperhub_db_data`, `keeperhub_node_modules`, `keeperhub_localstack_data`). Without creating them up front, both `make dev-setup` and `make hybrid-setup` fail with "external network/volume not found".
* Make `LOCALSTACK_AUTH_TOKEN` mandatory in the Prerequisites: the compose uses the LocalStack Pro image which exits 55 ("License activation failed") when the token is empty. Both Docker and Hybrid modes are dead in the water without it.
* Note that Hybrid mode must run as a regular user, not root - Minikube refuses `--driver=docker` under root.
* Mention the Next.js dev cold compile (~30-60s on first request) so contributors do not assume the server is hung.
