### PR TITLE
fix: KEEP-316 probe with 1 wei in native estimate-gas

### DIFF
--- a/app/api/user/wallet/estimate-gas/route.ts
+++ b/app/api/user/wallet/estimate-gas/route.ts
@@ -123,11 +123,16 @@ export async function POST(request: Request) {
             from: walletAddress,
           });
         }
-        const amountWei = ethers.parseEther(amount);
+        // Native EOA-to-EOA gasUsed is value-independent (always 21000), so we
+        // probe with 1 wei. Using parseEther(amount) causes the node to reject
+        // the estimate with INSUFFICIENT_FUNDS whenever amount >= balance:
+        // displayed balances round half-up to 6 decimals, so on chains with
+        // cheap native gas (Arbitrum One) a user typing their shown balance
+        // trips `balance < value + gas*price` and the whole endpoint 500s.
         return await provider.estimateGas({
           from: walletAddress,
           to: recipient,
-          value: amountWei,
+          value: BigInt(1),
         });
       }
     );


### PR DESCRIPTION
## Summary
- `POST /api/user/wallet/estimate-gas` 500s on Arbitrum One whenever the requested native amount is at or near the wallet balance. The node rejects `estimateGas` with `INSUFFICIENT_FUNDS` because it enforces `balance >= value + gas*price`. Displayed balances round half-up to 6 decimals and can exceed the actual wei balance, so a user typing their shown balance trips the check.
- Native EOA transfers always use 21000 gas regardless of value, so the preview now probes with 1 wei and returns the same estimate without interacting with the balance check. ERC20 path is unchanged. This matches the pattern `withdraw/route.ts` already uses for `fromMax`.

Closes KEEP-316