### PR TITLE
fix: KEEP-333 keep run as error when step logs are incomplete

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, lt, notInArray, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, lt, notInArray, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
@@ -69,6 +69,25 @@ export async function GET(request: Request): Promise<NextResponse> {
       .returning({ id: workflowExecutions.id });
 
     const reapedIds = reaped.map((row) => row.id);
+
+    // KEEP-333: Close orphaned 'running' step logs for reaped executions so
+    // the UI doesn't show stuck spinners after the workflow has been marked
+    // as timed out.
+    if (reapedIds.length > 0) {
+      await db
+        .update(workflowExecutionLogs)
+        .set({
+          status: "error",
+          error: "Step did not record completion",
+          completedAt: new Date(),
+        })
+        .where(
+          and(
+            inArray(workflowExecutionLogs.executionId, reapedIds),
+            eq(workflowExecutionLogs.status, "running")
+          )
+        );
+    }
 
     return NextResponse.json({
       reapedCount: reapedIds.length,

--- a/lib/workflow-logging.ts
+++ b/lib/workflow-logging.ts
@@ -4,7 +4,7 @@
  */
 import "server-only";
 
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -112,6 +112,34 @@ export type LogWorkflowCompleteParams = {
   startTime: number;
 };
 
+const STEP_INCOMPLETE_ERROR = "Step did not record completion";
+
+/**
+ * Close any step log rows still in 'running' for the given execution.
+ * Used when the workflow reaches a terminal state to prevent orphaned
+ * 'running' rows from showing as stuck spinners in the UI.
+ */
+async function closeOrphanedRunningLogs(
+  executionId: string,
+  finalStatus: "success" | "error"
+): Promise<void> {
+  const now = new Date();
+  await db
+    .update(workflowExecutionLogs)
+    .set({
+      status: finalStatus,
+      completedAt: now,
+      // Only attach an error message when closing as error
+      error: finalStatus === "error" ? STEP_INCOMPLETE_ERROR : undefined,
+    })
+    .where(
+      and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        eq(workflowExecutionLogs.status, "running")
+      )
+    );
+}
+
 /**
  * Log the completion of a workflow execution
  */
@@ -124,6 +152,12 @@ export async function logWorkflowCompleteDb(
   // The Workflow DevKit can throw "exceeded max retries" AFTER all steps
   // succeed. If we're about to write status='error', check whether any
   // node log actually failed. If none did, the error is spurious.
+  //
+  // KEEP-333: 'running' logs mean a step was started but never recorded
+  // completion (e.g. the worker was killed mid-step). That is not a
+  // spurious SDK error - the workflow really is incomplete. Keep 'error'
+  // and close the orphaned rows below so the UI doesn't show stuck
+  // spinners.
   let resolvedStatus: "success" | "error" = params.status;
   let resolvedError: string | undefined = params.error;
 
@@ -137,16 +171,18 @@ export async function logWorkflowCompleteDb(
     );
 
     try {
-      const errorLogs = await db.query.workflowExecutionLogs.findMany({
+      const unresolvedLogs = await db.query.workflowExecutionLogs.findMany({
         where: and(
           eq(workflowExecutionLogs.executionId, params.executionId),
-          eq(workflowExecutionLogs.status, "error")
+          inArray(workflowExecutionLogs.status, ["error", "running"])
         ),
-        columns: { id: true },
-        limit: 1,
+        columns: { id: true, status: true },
       });
 
-      if (errorLogs.length === 0) {
+      const hasErrorLog = unresolvedLogs.some((l) => l.status === "error");
+      const hasRunningLog = unresolvedLogs.some((l) => l.status === "running");
+
+      if (!(hasErrorLog || hasRunningLog)) {
         logSystemError(
           ErrorCategory.WORKFLOW_ENGINE,
           "[Workflow Logging] No node-level errors found, overriding spurious SDK error to success",
@@ -165,6 +201,19 @@ export async function logWorkflowCompleteDb(
         { execution_id: params.executionId }
       );
     }
+  }
+
+  // Close orphaned 'running' logs before updating the execution so that
+  // any concurrent reader sees a consistent snapshot.
+  try {
+    await closeOrphanedRunningLogs(params.executionId, resolvedStatus);
+  } catch (closeError) {
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[Workflow Logging] Failed to close orphaned running logs",
+      closeError,
+      { execution_id: params.executionId }
+    );
   }
 
   await db

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -10,11 +10,34 @@ vi.mock("@/lib/internal-service-auth", () => ({
   authenticateInternalService: vi.fn(() => mockAuthResult),
 }));
 
+type UpdateCall = {
+  target: unknown;
+  set: Record<string, unknown>;
+};
+
 let mockActiveExecutionIds: { executionId: string }[] = [];
 let mockReapedRows: { id: string }[] = [];
-const mockUpdateReturning = vi.fn(() => mockReapedRows);
-const mockUpdateWhere = vi.fn(() => ({ returning: mockUpdateReturning }));
-const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+let updateCalls: UpdateCall[] = [];
+
+// The reaper chains db.update(target).set(values).where(cond) and for the
+// workflowExecutions update adds .returning(). We record every (target,
+// values) pair so tests can assert on either UPDATE independently.
+type WhereChain = { returning: () => { id: string }[] };
+type SetChain = { where: () => WhereChain };
+type UpdateChain = { set: (values: Record<string, unknown>) => SetChain };
+
+function buildUpdate(target: unknown): UpdateChain {
+  return {
+    set: (values: Record<string, unknown>): SetChain => {
+      updateCalls.push({ target, set: values });
+      return {
+        where: (): WhereChain => ({
+          returning: (): { id: string }[] => mockReapedRows,
+        }),
+      };
+    },
+  };
+}
 
 vi.mock("@/lib/db", () => ({
   db: {
@@ -25,12 +48,14 @@ vi.mock("@/lib/db", () => ({
         })),
       })),
     })),
-    update: vi.fn(() => ({ set: mockUpdateSet })),
+    update: vi.fn((target: unknown) => buildUpdate(target)),
   },
 }));
 
-vi.mock("@/lib/db/schema", () => ({
-  workflowExecutions: {
+// vi.mock factories are hoisted; use vi.hoisted for shared identity with
+// assertions so `target === workflowExecutionsMock` works in tests.
+const { workflowExecutionsMock, workflowExecutionLogsMock } = vi.hoisted(() => ({
+  workflowExecutionsMock: {
     id: "id",
     workflowId: "workflow_id",
     startedAt: "started_at",
@@ -39,10 +64,18 @@ vi.mock("@/lib/db/schema", () => ({
     error: "error",
     duration: "duration",
   },
-  workflowExecutionLogs: {
+  workflowExecutionLogsMock: {
+    id: "id",
     executionId: "execution_id",
+    status: "status",
+    error: "error",
     completedAt: "completed_at",
   },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: workflowExecutionsMock,
+  workflowExecutionLogs: workflowExecutionLogsMock,
 }));
 
 import { GET } from "@/app/api/internal/reaper/route";
@@ -54,11 +87,20 @@ function createRequest(): Request {
   });
 }
 
+function getExecUpdate(): UpdateCall | undefined {
+  return updateCalls.find((c) => c.target === workflowExecutionsMock);
+}
+
+function getLogUpdate(): UpdateCall | undefined {
+  return updateCalls.find((c) => c.target === workflowExecutionLogsMock);
+}
+
 describe("/api/internal/reaper", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockActiveExecutionIds = [];
     mockReapedRows = [];
+    updateCalls = [];
     mockAuthResult.authenticated = true;
   });
 
@@ -103,7 +145,7 @@ describe("/api/internal/reaper", () => {
 
     await GET(createRequest());
 
-    expect(mockUpdateSet).toHaveBeenCalledWith(
+    expect(getExecUpdate()?.set).toEqual(
       expect.objectContaining({
         status: "error",
         error: expect.stringContaining("timed out"),
@@ -117,9 +159,7 @@ describe("/api/internal/reaper", () => {
 
     await GET(createRequest());
 
-    const calls = mockUpdateSet.mock.calls as unknown[][];
-    const setArg = calls[0]?.[0] as Record<string, unknown> | undefined;
-    expect(setArg?.duration).toBeDefined();
+    expect(getExecUpdate()?.set.duration).toBeDefined();
   });
 
   it("excludes executions with recent step activity", async () => {
@@ -142,7 +182,9 @@ describe("/api/internal/reaper", () => {
     expect(response.status).toBe(200);
     expect(data.reapedCount).toBe(3);
     expect(data.reapedIds).toEqual(["exec_1", "exec_2", "exec_3"]);
-    expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+    // Exactly one UPDATE against workflow_executions, one against logs.
+    expect(updateCalls.filter((c) => c.target === workflowExecutionsMock))
+      .toHaveLength(1);
   });
 
   it("uses configurable threshold from env var", async () => {
@@ -151,10 +193,8 @@ describe("/api/internal/reaper", () => {
 
     await GET(createRequest());
 
-    expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: expect.stringContaining("60 minutes"),
-      })
+    expect(getExecUpdate()?.set.error).toEqual(
+      expect.stringContaining("60 minutes")
     );
   });
 
@@ -163,5 +203,31 @@ describe("/api/internal/reaper", () => {
     await GET(request);
 
     expect(authenticateInternalService).toHaveBeenCalledWith(request);
+  });
+
+  // KEEP-333: orphaned running step logs must be closed alongside the
+  // workflow execution so the Runs tab doesn't render stuck spinners.
+  it("closes orphaned 'running' step logs for reaped executions", async () => {
+    mockReapedRows = [{ id: "exec_1" }, { id: "exec_2" }];
+
+    await GET(createRequest());
+
+    const logUpdate = getLogUpdate();
+    expect(logUpdate).toBeDefined();
+    expect(logUpdate?.set).toEqual(
+      expect.objectContaining({
+        status: "error",
+        error: expect.stringContaining("did not record completion"),
+        completedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("does not run the log cleanup update when nothing was reaped", async () => {
+    mockReapedRows = [];
+
+    await GET(createRequest());
+
+    expect(getLogUpdate()).toBeUndefined();
   });
 });

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    WORKFLOW_ENGINE: "workflow_engine",
+    DATABASE: "database",
+  },
+  logSystemError: vi.fn(),
+}));
+
+// Hoisted schema stubs so the vi.mock factory can reference them.
+const { workflowExecutionsMock, workflowExecutionLogsMock } = vi.hoisted(
+  () => ({
+    workflowExecutionsMock: {
+      id: "id",
+      status: "status",
+      output: "output",
+      error: "error",
+      completedAt: "completed_at",
+      duration: "duration",
+      currentNodeId: "current_node_id",
+      currentNodeName: "current_node_name",
+    },
+    workflowExecutionLogsMock: {
+      id: "id",
+      executionId: "execution_id",
+      status: "status",
+      error: "error",
+      completedAt: "completed_at",
+    },
+  })
+);
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: workflowExecutionsMock,
+  workflowExecutionLogs: workflowExecutionLogsMock,
+}));
+
+// State the tests mutate between runs.
+type UpdateCall = {
+  target: unknown;
+  set: Record<string, unknown>;
+};
+let unresolvedLogs: { id: string; status: string }[] = [];
+let updateCalls: UpdateCall[] = [];
+let updateShouldThrow = false;
+
+type WhereChain = Promise<void>;
+type SetChain = { where: () => WhereChain };
+type UpdateChain = { set: (values: Record<string, unknown>) => SetChain };
+
+function buildUpdate(target: unknown): UpdateChain {
+  return {
+    set: (values: Record<string, unknown>): SetChain => {
+      updateCalls.push({ target, set: values });
+      if (updateShouldThrow) {
+        return {
+          where: (): WhereChain => Promise.reject(new Error("db down")),
+        };
+      }
+      return {
+        where: (): WhereChain => Promise.resolve(),
+      };
+    },
+  };
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      workflowExecutionLogs: {
+        findMany: vi.fn(() => Promise.resolve(unresolvedLogs)),
+      },
+    },
+    update: vi.fn((target: unknown) => buildUpdate(target)),
+  },
+}));
+
+import { logWorkflowCompleteDb } from "@/lib/workflow-logging";
+
+function getExecUpdate(): UpdateCall | undefined {
+  return updateCalls.find((c) => c.target === workflowExecutionsMock);
+}
+
+function getLogUpdate(): UpdateCall | undefined {
+  return updateCalls.find((c) => c.target === workflowExecutionLogsMock);
+}
+
+describe("logWorkflowCompleteDb", () => {
+  beforeEach(() => {
+    unresolvedLogs = [];
+    updateCalls = [];
+    updateShouldThrow = false;
+    vi.clearAllMocks();
+  });
+
+  it("writes success status unchanged when workflow succeeded", async () => {
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      output: { ok: true },
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "success",
+        output: { ok: true },
+      })
+    );
+  });
+
+  it("keeps error status when a node log recorded an error", async () => {
+    unresolvedLogs = [{ id: "log_1", status: "error" }];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "Step failed",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "error",
+        error: "Step failed",
+      })
+    );
+  });
+
+  it("overrides spurious SDK error to success when no logs are error or running", async () => {
+    unresolvedLogs = [];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "exceeded max retries",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "success",
+        error: undefined,
+      })
+    );
+  });
+
+  // KEEP-333: If a step started but never recorded completion, the workflow
+  // really is incomplete. Don't lie to the user by overriding to success.
+  it("keeps error status when any log is stuck in running", async () => {
+    unresolvedLogs = [{ id: "log_running", status: "running" }];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "worker killed",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "error",
+        error: "worker killed",
+      })
+    );
+  });
+
+  it("closes orphaned running logs on completion (error path)", async () => {
+    unresolvedLogs = [{ id: "log_running", status: "running" }];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "worker killed",
+      startTime: Date.now() - 1000,
+    });
+
+    const logUpdate = getLogUpdate();
+    expect(logUpdate).toBeDefined();
+    expect(logUpdate?.set).toEqual(
+      expect.objectContaining({
+        status: "error",
+        error: expect.stringContaining("did not record completion"),
+        completedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("closes orphaned running logs as success when workflow succeeded", async () => {
+    // Spurious SDK error reconciled to success; any running rows should
+    // match the reconciled status so the UI is consistent.
+    unresolvedLogs = [];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      startTime: Date.now() - 1000,
+    });
+
+    const logUpdate = getLogUpdate();
+    expect(logUpdate).toBeDefined();
+    expect(logUpdate?.set).toEqual(
+      expect.objectContaining({
+        status: "success",
+      })
+    );
+    // On success we don't attach a "did not record completion" error.
+    expect(logUpdate?.set.error).toBeUndefined();
+  });
+
+  it("still updates execution status when log cleanup throws", async () => {
+    // Simulate a transient DB failure during the log cleanup UPDATE;
+    // the execution status update must still run.
+    unresolvedLogs = [];
+    let callIndex = 0;
+    updateShouldThrow = false;
+
+    // Patch buildUpdate behavior per-call: first UPDATE (logs) throws,
+    // second UPDATE (executions) succeeds.
+    const { db } = await import("@/lib/db");
+    (db.update as unknown as {
+      mockImplementation: (fn: (t: unknown) => UpdateChain) => void;
+    }).mockImplementation((target: unknown) => ({
+      set: (values: Record<string, unknown>): SetChain => {
+        updateCalls.push({ target, set: values });
+        const shouldThrow =
+          callIndex === 0 && target === workflowExecutionLogsMock;
+        callIndex += 1;
+        return {
+          where: (): WhereChain =>
+            shouldThrow
+              ? Promise.reject(new Error("transient db failure"))
+              : Promise.resolve(),
+        };
+      },
+    }));
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      startTime: Date.now() - 1000,
+    });
+
+    // Execution update still ran despite the log cleanup throwing.
+    expect(getExecUpdate()).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Step status icons in the Runs tab were getting stuck on the blue "running" spinner after a workflow finished, while the run-level indicator showed green. KEEP-333.

The KEEP-1549 reconciliation in `logWorkflowCompleteDb` used "no log rows with status=error" as proof that an SDK error was spurious and the run really succeeded. That test misses the case where a step was killed mid-execution: the row stays at `status='running'` with `completed_at=NULL`, the reconciliation counts zero error rows and flips the workflow to `success`. The DB then ends up with `workflow_executions.status='success'` alongside `workflow_execution_logs.status='running'`, which the UI renders as green run + blue stuck step.

## Changes

- `lib/workflow-logging.ts`: the reconciliation now also counts `running` rows. If any step log is still `running`, the workflow is treated as genuinely incomplete and the original `error` status is kept. After the reconciliation, any remaining `running` rows for the execution are closed to match the final status - on error they carry a "Step did not record completion" message.
- `app/api/internal/reaper/route.ts`: when the reaper marks stale executions as `error`, their orphaned `running` step logs are closed with the same message so the UI never shows a stuck spinner for a reaped run.
- `tests/integration/workflow-logging.test.ts`: new coverage for the reconciliation branches and the orphan-log cleanup.
- `tests/integration/reaper-route.test.ts`: mock restructured so we can assert the new log-cleanup UPDATE; added cases for the cleanup and the "nothing reaped" short-circuit.