### PR TITLE
hotfix(agentic-wallet): add type discriminator to MPP credential payload

### DIFF
--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -326,9 +326,12 @@ export async function signMppProof(
   // prepends its own `Payment ` scheme token when building the Authorization
   // header, so we strip the prefix on the way out and ship only the encoded
   // payload. Opaque pass-through from the client's point of view.
+  // `type` is the discriminator in mppx Methods.charge.schema.credential.payload
+  // (tempo/Methods.ts). Without it the schema parse rejects the credential
+  // with "Credential payload is invalid" before any crypto check runs.
   const credential = Credential.from({
     challenge: parsed,
-    payload: { signature: rawSignature },
+    payload: { type: "proof", signature: rawSignature },
   });
   const serialized = Credential.serialize(credential);
   return serialized.startsWith(MPP_AUTH_PREFIX)
@@ -479,9 +482,13 @@ export async function signMppTransaction(
 
   // Credential.from sets source on the credential object; facilitator's
   // proof path requires it, transaction path uses it for attribution.
+  // `type: "transaction"` is the schema discriminator in
+  // mppx/tempo/Methods.ts::charge (payload is a z.discriminatedUnion on
+  // 'type'). Without it the credential fails schema parse before any crypto
+  // validation runs -> "Credential payload is invalid".
   const credential = Credential.from({
     challenge: parsed,
-    payload: { signature: serializedTx },
+    payload: { type: "transaction", signature: serializedTx },
     source: `did:pkh:eip155:${params.chainId}:${walletAddressTempo}`,
   });
   const out = Credential.serialize(credential);

--- a/tests/unit/agentic-wallet-sign.test.ts
+++ b/tests/unit/agentic-wallet-sign.test.ts
@@ -242,11 +242,17 @@ describe("signMppProof", () => {
     // token is stripped so callers can prepend it themselves).
     expect(out.startsWith("0x")).toBe(false);
     expect(out.startsWith("Payment ")).toBe(false);
-    // Decoding back yields a Credential with `{challenge, payload:{signature}}`.
+    // Decoding back yields a Credential with `{challenge, payload:{type, signature}}`.
     const decoded = JSON.parse(
       Buffer.from(out, "base64url").toString("utf-8")
-    ) as { challenge: { id: string }; payload: { signature: string } };
+    ) as {
+      challenge: { id: string };
+      payload: { type: string; signature: string };
+    };
     expect(decoded.challenge.id).toBeTruthy();
+    // `type` is the discriminator mppx Methods.charge.schema.credential.payload
+    // expects. Proof-mode sigs are `type: "proof"`.
+    expect(decoded.payload.type).toBe("proof");
     expect(decoded.payload.signature.startsWith("0x")).toBe(true);
     expect(decoded.payload.signature.length).toBe(132);
   });
@@ -311,10 +317,13 @@ describe("signMppTransaction", () => {
       Buffer.from(out, "base64url").toString("utf-8")
     ) as {
       challenge: { id: string };
-      payload: { signature: string };
+      payload: { type: string; signature: string };
       source?: string;
     };
     expect(decoded.challenge.id).toBeTruthy();
+    // `type` is the discriminator mppx Methods.charge.schema.credential.payload
+    // expects. Tx-mode is `type: "transaction"`.
+    expect(decoded.payload.type).toBe("transaction");
     // payload.signature is the serialized Tempo tx -- starts with 0x76
     // (TxEnvelopeTempo.serializedType), NOT a raw 132-char ECDSA sig.
     expect(decoded.payload.signature.startsWith("0x76")).toBe(true);


### PR DESCRIPTION
## Summary

The MPP PR that just merged shipped a credential `payload` without the `type` field that mppx's schema requires. mppx's `Methods.charge.schema.credential.payload` is a zod `discriminatedUnion` on `type` (`proof` | `transaction` | `hash`), so without the discriminator the parse step fails before any crypto check runs and the facilitator returns 402 "Credential payload is invalid" on every MPP attempt.

Prod smoke caught it immediately after deploy. The envelope + tx bytes themselves are correct -- signature recovers to the wallet address, envelope fields all valid, fee-payer flow ready. Only the schema-level `type` field was missing.

## Fix

- `signMppProof` returns `payload: { type: "proof", signature: <0x...132> }`
- `signMppTransaction` returns `payload: { type: "transaction", signature: <0x76...> }`

Unit tests updated to assert the discriminator is present.

## Test plan

- [x] `pnpm vitest run tests/unit/agentic-wallet-sign.test.ts tests/integration/agentic-wallet-sign-route.test.ts` -- 30 tests pass (11 unit including new discriminator asserts, 19 integration).
- [x] `pnpm type-check` clean.
- [ ] After merge + deploy: re-run prod MPP smoke; expect 200 + executionId + 0.01 USDC.e debit on Tempo.
