### PR TITLE
fix: KEEP-336 flashbots network switch stuck on private variant

### DIFF
--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -111,6 +111,7 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
   const [activeTab, setActiveTab] = useAtom(propertiesPanelActiveTabAtom);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const refreshRunsRef = useRef<(() => Promise<void>) | null>(null);
+  const pendingConfigRef = useRef<Record<string, unknown> | null>(null);
 
   const selectedNode = nodes.find((node) => node.id === selectedNodeId);
   const selectedEdge = edges.find((edge) => edge.id === selectedEdgeId);
@@ -164,15 +165,28 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
   }, [selectedNode, globalIntegrations, isOwner, updateNodeData]);
 
   const handleUpdateConfig = useCallback(
-    (key: string, value: string | Record<string, unknown> | undefined) => {
+    (
+      key: string,
+      value: string | boolean | Record<string, unknown> | undefined
+    ): void => {
       if (!selectedNode) {
         return;
       }
+      // KEEP-137: some fields (e.g., ChainSelectField with showPrivateVariants)
+      // fire two synchronous handleUpdateConfig calls. Without pendingConfigRef,
+      // both spread the same stale selectedNode.data.config snapshot and the
+      // second call wipes out the first. The ref batches back-to-back updates
+      // within a microtask so the second call sees the first's merged config.
+      const baseConfig =
+        pendingConfigRef.current ?? selectedNode.data.config ?? {};
+      const newConfig = { ...baseConfig, [key]: value };
+      pendingConfigRef.current = newConfig;
+      queueMicrotask(() => {
+        pendingConfigRef.current = null;
+      });
       updateNodeData({
         id: selectedNode.id,
-        data: {
-          config: { ...selectedNode.data.config, [key]: value },
-        },
+        data: { config: newConfig },
       });
     },
     [selectedNode, updateNodeData]

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -64,7 +64,7 @@ import {
 import { ActionConfigRenderer } from "./action-config-renderer";
 import { SchemaBuilder, type SchemaField } from "./schema-builder";
 
-type ConfigValue = string | Record<string, unknown> | undefined;
+type ConfigValue = string | boolean | Record<string, unknown> | undefined;
 
 type ActionConfigProps = {
   config: Record<string, unknown>;
@@ -776,8 +776,22 @@ export function ActionConfig({
     onUpdateConfig("actionType", value);
   };
 
-  // Adapter for plugin config components that expect (key, value: unknown)
-  const handlePluginUpdateConfig = (key: string, value: unknown) => {
+  // Adapter for plugin config components that expect (key, value: unknown).
+  // KEEP-137: do NOT coerce to string -- booleans (e.g. usePrivateMempool)
+  // must remain booleans so downstream truthy checks work and the ChainSelect
+  // private-mempool variant resolves correctly. String() turns `false` into
+  // the truthy string "false", which both breaks the UI (Select stuck on the
+  // Flashbots variant) and the runtime (private-mempool routing stays on).
+  const handlePluginUpdateConfig = (key: string, value: unknown): void => {
+    if (
+      typeof value === "string" ||
+      typeof value === "boolean" ||
+      value === undefined ||
+      (typeof value === "object" && value !== null && !Array.isArray(value))
+    ) {
+      onUpdateConfig(key, value as ConfigValue);
+      return;
+    }
     onUpdateConfig(key, String(value));
   };
 

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -555,7 +555,11 @@ export const PanelInner = () => {
   );
 
   // Widened value type to support structured config objects (e.g. conditionConfig)
-  const handleUpdateConfig = (key: string, value: string | Record<string, unknown> | undefined) => {
+  // and booleans (e.g. usePrivateMempool for Flashbots routing).
+  const handleUpdateConfig = (
+    key: string,
+    value: string | boolean | Record<string, unknown> | undefined
+  ): void => {
     if (selectedNode) {
       const baseConfig = pendingConfigRef.current ?? selectedNode.data.config;
       let newConfig = { ...baseConfig, [key]: value };


### PR DESCRIPTION
## Summary

- `handlePluginUpdateConfig` ran every plugin value through `String(...)`, which turned booleans into truthy strings -- `usePrivateMempool` stored as `"false"` kept the Flashbots variant active in `ChainSelectField` (no matching item for `chainId:private`, so the Select could not switch away) and would keep private-mempool routing on at runtime in `plugins/web3/steps/*` and `lib/rpc/provider-factory.ts`.
- Widen `ConfigValue` in `action-config.tsx` and the `handleUpdateConfig` signatures in `node-config-panel.tsx` and `configuration-overlay.tsx` to include `boolean`; pass matching values through without coercion.
- Mirror the `pendingConfigRef` microtask-batching pattern from `node-config-panel.tsx` into `configuration-overlay.tsx` so the two synchronous writes `ChainSelectField.onSelectChain` fires (`network` + `usePrivateMempool`) merge correctly instead of the second overwriting the first from a stale render snapshot.

Linear: https://linear.app/keeperhubapp/issue/KEEP-336/network-selector-stuck-on-flashbots-variant-after-selecting-it