### PR TITLE
hotfix(agentic-wallet): use TIP-1009 expiring nonce for MPP charge txs

### DIFF
--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -30,11 +30,9 @@
 import { serializeSignature } from "@turnkey/ethers";
 import { Challenge, Credential } from "mppx";
 import { TxEnvelopeTempo } from "ox/tempo";
-import { createPublicClient, encodeFunctionData, http, keccak256 } from "viem";
-import { tempo } from "viem/chains";
-import { Abis, Actions } from "viem/tempo";
+import { encodeFunctionData, keccak256 } from "viem";
+import { Abis } from "viem/tempo";
 import { getTurnkeyClientForOrg } from "@/lib/turnkey/agentic-wallet";
-import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import { BASE_CHAIN_ID, USDC_BASE_ADDRESS } from "./constants";
 
 const MPP_AUTH_PREFIX = "Payment ";
@@ -48,6 +46,12 @@ const MPP_TX_GAS = BigInt(500_000);
 const MPP_TX_MAX_FEE_PER_GAS = BigInt(5_000_000_000); // 5 gwei
 const MPP_TX_MAX_PRIORITY_FEE_PER_GAS = BigInt(1_000_000_000); // 1 gwei
 const MPP_TX_VALIDITY_WINDOW_SECONDS = 300; // 5 minutes
+
+// TIP-1009 expiring-nonce marker. viem/tempo/chainConfig.js rewrites
+// `{nonceKey: 'expiring'}` to `{nonceKey: 2**256-1, nonce: 0}`; we hardcode
+// the same values because we build the envelope by hand (no viem
+// prepareTransactionRequest on the Turnkey path).
+const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
 
 // MPP attribution memo layout (mirrors mppx internal Attribution.encode):
 //   bytes 0..3   : tag         "MPP\0" (3 printable + NUL)
@@ -413,24 +417,16 @@ export async function signMppTransaction(
     args: [request.recipient, BigInt(request.amount), memo],
   });
 
-  // nonceKey is a per-wallet-per-call uint >= 1. Derive deterministically
-  // from the challenge id so repeat /sign calls for the same challenge
-  // produce the same nonceKey (idempotent), but different challenges never
-  // collide. Take 8 bytes of keccak256(id) for headroom below uint256.
-  const nonceKeyHex = keccak256(
-    new TextEncoder().encode(parsed.id)
-  ).slice(0, 18);
-  const nonceKey = BigInt(nonceKeyHex);
-
-  const rpcUrl = getRpcUrlByChainId(params.chainId);
-  const client = createPublicClient({
-    chain: tempo,
-    transport: http(rpcUrl),
-  });
-  const nonce = await Actions.nonce.getNonce(client, {
-    account: walletAddressTempo as `0x${string}`,
-    nonceKey,
-  });
+  // TIP-1009 expiring nonce: nonceKey MUST be uint256.max and nonce MUST be
+  // 0. Tempo's fee-payer sponsored path only co-signs transactions that use
+  // this marker; any other nonceKey is treated as a 2D-nonce (non-expiring)
+  // and the facilitator's FeePayer.prepareSponsoredTransaction / signTransaction
+  // chain throws, which mppx's server catch-all wraps as a reason-less
+  // "Payment verification failed" 402. Mirrors mppx/client/Charge.js which
+  // passes `nonceKey: 'expiring'` to prepareTransactionRequest (rewritten by
+  // viem/tempo chainConfig into this same MAX_UINT256 + nonce 0 pair).
+  const nonceKey = MAX_UINT256;
+  const nonce = BigInt(0);
 
   const nowSec = Math.floor(Date.now() / 1000);
   const validBefore = nowSec + MPP_TX_VALIDITY_WINDOW_SECONDS;
@@ -448,7 +444,6 @@ export async function signMppTransaction(
     gas: MPP_TX_GAS,
     maxFeePerGas: MPP_TX_MAX_FEE_PER_GAS,
     maxPriorityFeePerGas: MPP_TX_MAX_PRIORITY_FEE_PER_GAS,
-    validAfter: 0,
     validBefore,
   });
 

--- a/tests/unit/agentic-wallet-sign.test.ts
+++ b/tests/unit/agentic-wallet-sign.test.ts
@@ -34,9 +34,12 @@ vi.mock("@turnkey/sdk-server", () => ({
   }),
 }));
 
-const { PolicyBlockedError, signMppProof, signMppTransaction, signX402Challenge } = await import(
-  "@/lib/agentic-wallet/sign"
-);
+const {
+  PolicyBlockedError,
+  signMppProof,
+  signMppTransaction,
+  signX402Challenge,
+} = await import("@/lib/agentic-wallet/sign");
 
 const { Challenge } = await import("mppx");
 
@@ -70,9 +73,7 @@ function buildTempoChallengeSerialized(): string {
   return full.startsWith("Payment ") ? full.slice("Payment ".length) : full;
 }
 
-function happyPathResult(
-  v: "00" | "01"
-): Record<string, unknown> {
+function happyPathResult(v: "00" | "01"): Record<string, unknown> {
   return {
     activity: {
       status: "ACTIVITY_STATUS_COMPLETED",
@@ -258,21 +259,6 @@ describe("signMppProof", () => {
   });
 });
 
-// Mock the Tempo nonce RPC so signMppTransaction can run without network.
-// Placed at module level so hoisting still produces deterministic behaviour.
-vi.mock("viem/tempo", async (orig) => {
-  const actual = (await orig()) as Record<string, unknown>;
-  return {
-    ...actual,
-    Actions: {
-      ...(actual.Actions as Record<string, unknown>),
-      nonce: {
-        getNonce: vi.fn(async () => BigInt(0)),
-      },
-    },
-  };
-});
-
 describe("signMppTransaction", () => {
   beforeEach(() => {
     process.env.TURNKEY_API_PUBLIC_KEY = "test-pub";
@@ -329,6 +315,27 @@ describe("signMppTransaction", () => {
     expect(decoded.payload.signature.startsWith("0x76")).toBe(true);
     // source binds the credential to the wallet on Tempo mainnet.
     expect(decoded.source).toBe(`did:pkh:eip155:4217:${WALLET}`);
+  });
+
+  it("uses the TIP-1009 expiring-nonce marker (nonceKey=uint256.max, nonce=0)", async () => {
+    // Regression guard for the second MPP hotfix. Tempo's fee-payer path
+    // only co-signs envelopes with the expiring-nonce marker; any other
+    // nonceKey causes the facilitator to throw a non-PaymentError that mppx
+    // wraps as a reason-less "Payment verification failed" 402. This mirrors
+    // what `prepareTransactionRequest({nonceKey: 'expiring'})` produces in
+    // mppx/client/Charge.js.
+    const { TxEnvelopeTempo } = await import("ox/tempo");
+    const out = await signMppTransaction(SUB_ORG, WALLET, {
+      chainId: 4217,
+      serialized: buildTempoChallengeSerialized(),
+    });
+    const decoded = JSON.parse(
+      Buffer.from(out, "base64url").toString("utf-8")
+    ) as { payload: { signature: `0x76${string}` } };
+    const envelope = TxEnvelopeTempo.deserialize(decoded.payload.signature);
+    const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
+    expect(envelope.nonceKey).toBe(MAX_UINT256);
+    expect(envelope.nonce).toBe(BigInt(0));
   });
 
   it("throws on non-charge intent (proof-mode belongs in signMppProof)", async () => {


### PR DESCRIPTION
## Summary

Prod smoke after #976 still returned `402 "Payment verification failed"` (reason-less). A direct-EOA `mppx` client against the same `mcp-test` workflow PASSed (executionId + 0.01 USDC.e debit settled), isolating the bug to `signMppTransaction`'s envelope construction.

## Root cause

`signMppTransaction` derived a custom `nonceKey` from `keccak256(challengeId).slice(0,18)`. Tempo's fee-payer sponsored path only co-signs transactions that use the TIP-1009 expiring-nonce marker (`nonceKey = uint256.max` + `nonce = 0`). Any other `nonceKey` combined with `feePayer` in `FeePayer.prepareSponsoredTransaction` / `signTransaction` throws a `FeePayerValidationError` -- a plain `Error`, not mppx's `PaymentError` subclass -- and the facilitator's outer catch in `server/Mppx.js:247` wraps it as a reason-less `VerificationFailedError`, which is why the 402 body carries no diagnostic detail.

The canonical mppx client avoids this by passing `nonceKey: 'expiring'` to `prepareTransactionRequest`, which `viem/tempo/chainConfig.js:48-67` rewrites to the exact `MAX_UINT256 + nonce 0` pair we now hardcode. Our Turnkey-backed path builds the envelope by hand and missed that rewrite.

## Envelope diff (working direct-EOA vs broken pre-fix)

| Field | direct-EOA (works) | pre-fix agentic (402) |
|---|---|---|
| `nonceKey` | `2**256 - 1` | `BigInt(keccak256(challengeId)[0..18])` |
| `nonce` | `0` | `0` (from on-chain `getNonce`) |

## Fix

- `nonceKey = MAX_UINT256`, `nonce = 0` (TIP-1009 expiring nonce).
- Drop the `Actions.nonce.getNonce` RPC call (nonce is always 0 for expiring; no on-chain state needed).
- Drop `createPublicClient` / `http` / `viem/chains#tempo` / `Actions` / `getRpcUrlByChainId` imports that only existed for the removed RPC call.

## Test plan

- [x] `pnpm vitest run --dir=tests tests/unit/agentic-wallet-sign.test.ts tests/integration/agentic-wallet-sign-route.test.ts` -- 31 tests pass (12 unit + 19 integration). New regression test decodes the returned credential, reads the `0x76` envelope, and asserts `nonceKey === uint256.max && nonce === 0`.
- [x] `pnpm type-check` clean.
- [ ] After merge + deploy: rerun prod MPP smoke against `mcp-test`; expect 200 + executionId + 0.01 USDC.e debit on Tempo.

## Related

Follow-up to #976 (credential `type` discriminator) and #967 (MPP transaction-mode). With this fix the full agentic-wallet MPP charge path should settle end-to-end.