### PR TITLE
fix: KEEP-343 withdraw bookmark crash and EIP-1193 Sentry noise

### DIFF
--- a/components/overlays/withdraw-modal.tsx
+++ b/components/overlays/withdraw-modal.tsx
@@ -2,7 +2,7 @@
 
 import { ethers } from "ethers";
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { ChangeEvent, ChangeEventHandler, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Overlay } from "@/components/overlays/overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
@@ -430,7 +430,14 @@ export function WithdrawModal({
           <Label>Recipient Address</Label>
           <SaveAddressBookmark address={recipient}>
             <Input
-              onChange={(e) => setRecipient(e.target.value)}
+              onChange={
+                // SaveAddressBookmark calls child onChange with a string when a
+                // bookmark is picked; keep the DOM event path for direct typing.
+                ((e: ChangeEvent<HTMLInputElement> | string) => {
+                  const value = typeof e === "string" ? e : e.target.value;
+                  setRecipient(value);
+                }) as ChangeEventHandler<HTMLInputElement>
+              }
               placeholder="0x..."
               value={toChecksumAddress(recipient)}
             />

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,10 +2,33 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { captureRouterTransitionStart, init } from "@sentry/nextjs";
+import {
+  captureRouterTransitionStart,
+  type ErrorEvent,
+  init,
+} from "@sentry/nextjs";
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN;
 const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
+
+// Wallet providers (EIP-1193) reject with plain `{ code, message }` objects
+// rather than Error instances, producing unhandled rejections with no stack.
+// These are not actionable, so drop them at ingest.
+function isEip1193ProviderRejection(event: ErrorEvent): boolean {
+  const mechanismType = event.exception?.values?.[0]?.mechanism?.type;
+  if (!mechanismType?.includes("onunhandledrejection")) {
+    return false;
+  }
+  const serialized = (event.extra as { __serialized__?: unknown } | undefined)
+    ?.__serialized__;
+  if (!serialized || typeof serialized !== "object") {
+    return false;
+  }
+  const asRecord = serialized as Record<string, unknown>;
+  return (
+    typeof asRecord.code === "number" && typeof asRecord.message === "string"
+  );
+}
 
 if (SENTRY_DSN) {
   init({
@@ -22,6 +45,13 @@ if (SENTRY_DSN) {
     // Enable sending user PII (Personally Identifiable Information)
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
     sendDefaultPii: true,
+
+    beforeSend(event) {
+      if (isEip1193ProviderRejection(event)) {
+        return null;
+      }
+      return event;
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Two fixes surfaced from the 2026-04-24 Sentry triage of keeperhub-production (KEEP-343).

### 1. Withdraw modal: bookmark-picker crash
`SaveAddressBookmark` invokes the child input's `onChange` with a plain string when a saved address is selected, not a React event. The withdraw modal's recipient `<Input>` read `e.target.value` unconditionally and crashed with `TypeError: Cannot read properties of undefined (reading 'value')` whenever a user picked a saved address. Handler now accepts either shape.

Sentry: [KEEPERHUB-PRODUCTION-M](https://techops-services.sentry.io/issues/KEEPERHUB-PRODUCTION-M)

### 2. Sentry noise filter: EIP-1193 provider rejections
Wallet providers reject with plain `{ code, message }` objects (JSON-RPC `-32603` internal errors) rather than `Error` instances, producing unhandled rejections with no stack and no actionable context. Added a `beforeSend` filter in `instrumentation-client.ts` that matches events from `onunhandledrejection` whose serialized payload is an EIP-1193 shape and drops them. Real errors still flow through.

Sentry: [KEEPERHUB-PRODUCTION-Q](https://techops-services.sentry.io/issues/KEEPERHUB-PRODUCTION-Q)

## Linear
[KEEP-343](https://linear.app/keeperhubapp/issue/KEEP-343/fix-withdraw-modal-bookmark-address-crash-filter-eip-1193-noise)