### PR TITLE
hotfix(agentic-wallet): bump MPP charge maxFeePerGas above Tempo base fee

### DIFF
--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -42,9 +42,15 @@ const MPP_AUTH_PREFIX = "Payment ";
 //   maxValidityWindowSeconds 15 * 60.
 // We pick conservative values well under the ceilings -- transferWithMemo
 // costs ~100k gas, so 500k is generous headroom for price-spike retries.
+// maxFeePerGas is the user's CEILING, not the actual fee paid -- the fee-payer
+// settles only the network base fee, not the cap, so high values are safe.
+// Tempo's observed base fee runs ~20 gwei; 50 gwei gives ~2.5x headroom while
+// staying well under the sponsor's 100 gwei policy. Setting maxFeePerGas
+// below the live base fee gets the broadcast rejected by the Tempo node, and
+// the resulting plain Error falls through mppx's catch-all as a reason-less
+// VerificationFailedError.
 const MPP_TX_GAS = BigInt(500_000);
-const MPP_TX_MAX_FEE_PER_GAS = BigInt(5_000_000_000); // 5 gwei
-const MPP_TX_MAX_PRIORITY_FEE_PER_GAS = BigInt(1_000_000_000); // 1 gwei
+const MPP_TX_MAX_FEE_PER_GAS = BigInt(50_000_000_000); // 50 gwei
 const MPP_TX_VALIDITY_WINDOW_SECONDS = 300; // 5 minutes
 
 // TIP-1009 expiring-nonce marker. viem/tempo/chainConfig.js rewrites
@@ -443,7 +449,6 @@ export async function signMppTransaction(
     nonceKey,
     gas: MPP_TX_GAS,
     maxFeePerGas: MPP_TX_MAX_FEE_PER_GAS,
-    maxPriorityFeePerGas: MPP_TX_MAX_PRIORITY_FEE_PER_GAS,
     validBefore,
   });
 


### PR DESCRIPTION
## Summary

Third (and hopefully last) round of `/sign` MPP charge fixes. After #976 (credential `type` discriminator) and #979 (TIP-1009 expiring nonce), prod smoke STILL returned `402 "Payment verification failed"` (reason-less, same generic error type as before).

## Root cause

`signMppTransaction` set `maxFeePerGas` to `5 gwei`. Tempo's live base fee currently runs ~20 gwei (`eth_gasPrice = 0x4a817c800` = 20_000_000_000), so the fee-payer-cosigned `0x78` broadcast gets rejected by the Tempo node with `"max fee per gas less than block base fee"`. That error is a plain `Error` (not mppx's `PaymentError` subclass), so the facilitator's outer catch in `mppx/server/Mppx.js:247` wraps it as a reason-less `VerificationFailedError` -- same generic 402 the previous two hotfixes already taught us to read as "something downstream threw and the reason was eaten".

## Envelope diff vs working direct-EOA path

| Field | direct-EOA (works) | pre-fix agentic (402) | this fix |
|---|---|---|---|
| `maxFeePerGas` | 24 gwei (estimated) | **5 gwei (below base fee)** | **50 gwei (cap)** |
| `maxPriorityFeePerGas` | undefined | 1 gwei | undefined |

## Fix

- `MPP_TX_MAX_FEE_PER_GAS`: 5 gwei -> 50 gwei. `maxFeePerGas` is the user's CEILING, not the actual fee paid; the fee-payer settles only the live base fee, so a high cap is safe and stays well under the sponsor's 100 gwei policy. 50 gwei gives ~2.5x headroom over the observed 20 gwei base fee.
- Drop `maxPriorityFeePerGas` entirely. The canonical mppx client (`mppx/client/Charge.js` -> `prepareTransactionRequest`) leaves it undefined; matching that shape minimises envelope drift between the two paths.
- Drop the now-unused `MPP_TX_MAX_PRIORITY_FEE_PER_GAS` constant.

## Test plan

- [x] `pnpm vitest run --dir=tests tests/unit/agentic-wallet-sign.test.ts tests/integration/agentic-wallet-sign-route.test.ts` -- 31 tests pass.
- [x] `pnpm type-check` clean.
- [ ] After merge + deploy: rerun prod MPP smoke against `mcp-test`; expect 200 + executionId + 0.01 USDC.e debit on Tempo.

## Future hardening (not in this PR)

If Tempo's base fee ever spikes above 50 gwei, this static cap will start failing the same way 5 gwei does today. The robust long-term fix is to estimate `maxFeePerGas` per request via `viem.estimateFeesPerGas()` (what `prepareTransactionRequest` does on the canonical client). Filed as a follow-up so we ship the working static value first.

## Related

Builds on #976 + #979. With this third fix the full agentic-wallet MPP charge path should settle end-to-end on prod.