### PR TITLE
fix: KEEP-344 redundant recovery for wedged nonce locks

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -2,6 +2,7 @@ import { and, eq, gt, inArray, lt, notInArray, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+import { walletLocks } from "@/lib/db/schema-extensions";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
@@ -87,6 +88,19 @@ export async function GET(request: Request): Promise<NextResponse> {
             eq(workflowExecutionLogs.status, "running")
           )
         );
+
+      // KEEP-344: Release any nonce locks still held by reaped executions.
+      // The wallet_locks TTL would clear them on its own, but releasing them
+      // here unwedges affected wallets immediately when reaper runs, instead
+      // of leaving the user blocked until expires_at.
+      await db
+        .update(walletLocks)
+        .set({
+          lockedBy: null,
+          lockedAt: null,
+          expiresAt: sql`NOW()`,
+        })
+        .where(inArray(walletLocks.lockedBy, reapedIds));
     }
 
     return NextResponse.json({

--- a/app/api/internal/wallet-unlock/route.ts
+++ b/app/api/internal/wallet-unlock/route.ts
@@ -74,7 +74,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json({ released: false, previousHolder: null });
     }
 
-    await db
+    // Conditional update: only clear if we observe the same holder we read.
+    // If the lock was legitimately released and re-acquired between the
+    // SELECT and this UPDATE, the WHERE will fail and we report no release
+    // — the operator can re-issue rather than us killing an unrelated holder.
+    const released = await db
       .update(walletLocks)
       .set({
         lockedBy: null,
@@ -84,9 +88,15 @@ export async function POST(request: Request): Promise<NextResponse> {
       .where(
         and(
           eq(walletLocks.walletAddress, normalizedAddress),
-          eq(walletLocks.chainId, chainId)
+          eq(walletLocks.chainId, chainId),
+          eq(walletLocks.lockedBy, previousHolder)
         )
-      );
+      )
+      .returning({ walletAddress: walletLocks.walletAddress });
+
+    if (released.length === 0) {
+      return NextResponse.json({ released: false, previousHolder: null });
+    }
 
     return NextResponse.json({ released: true, previousHolder });
   } catch (error) {

--- a/app/api/internal/wallet-unlock/route.ts
+++ b/app/api/internal/wallet-unlock/route.ts
@@ -1,0 +1,114 @@
+import { and, eq, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { walletLocks } from "@/lib/db/schema-extensions";
+import { authenticateInternalService } from "@/lib/internal-service-auth";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
+/**
+ * POST /api/internal/wallet-unlock
+ *
+ * KEEP-344: ops escape valve for clearing a held nonce lock without DB
+ * access. The wallet_locks TTL self-clears within lockTtlMs and the reaper
+ * clears locks for stale executions, so this endpoint is for the rare case
+ * where a wallet+chain needs unblocking immediately.
+ *
+ * Body: { walletAddress: string, chainId: number }
+ * Returns: { released: boolean, previousHolder: string | null }
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return NextResponse.json(
+      { error: auth.error ?? "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { walletAddress, chainId } = (body ?? {}) as {
+    walletAddress?: unknown;
+    chainId?: unknown;
+  };
+
+  if (typeof walletAddress !== "string" || walletAddress.length === 0) {
+    return NextResponse.json(
+      { error: "walletAddress is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (typeof chainId !== "number" || !Number.isInteger(chainId)) {
+    return NextResponse.json(
+      { error: "chainId is required and must be an integer" },
+      { status: 400 }
+    );
+  }
+
+  const normalizedAddress = walletAddress.toLowerCase();
+
+  try {
+    const existing = await db
+      .select({
+        lockedBy: walletLocks.lockedBy,
+        expiresAt: walletLocks.expiresAt,
+      })
+      .from(walletLocks)
+      .where(
+        and(
+          eq(walletLocks.walletAddress, normalizedAddress),
+          eq(walletLocks.chainId, chainId)
+        )
+      )
+      .limit(1);
+
+    const previousHolder = existing[0]?.lockedBy ?? null;
+
+    if (previousHolder === null) {
+      return NextResponse.json({ released: false, previousHolder: null });
+    }
+
+    await db
+      .update(walletLocks)
+      .set({
+        lockedBy: null,
+        lockedAt: null,
+        expiresAt: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(walletLocks.walletAddress, normalizedAddress),
+          eq(walletLocks.chainId, chainId)
+        )
+      );
+
+    return NextResponse.json({ released: true, previousHolder });
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "Failed to release nonce lock",
+      error,
+      {
+        endpoint: "/api/internal/wallet-unlock",
+        operation: "post",
+        walletAddress: normalizedAddress,
+        chainId: String(chainId),
+      }
+    );
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to release nonce lock",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/drizzle/0060_keep_344_wallet_lock_ttl.sql
+++ b/drizzle/0060_keep_344_wallet_lock_ttl.sql
@@ -1,0 +1,4 @@
+-- KEEP-344: replace advisory-lock metadata table with row-based TTL lock.
+-- Adds expires_at so the row itself is the lock; a crashed holder no longer
+-- wedges the wallet+chain forever.
+ALTER TABLE "wallet_locks" ADD COLUMN "expires_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1776908908648,
       "tag": "0059_agentic_wallet_daily_spend",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1777112436741,
+      "tag": "0060_keep_344_wallet_lock_ttl",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -220,14 +220,14 @@ export type NewSupportedToken = typeof supportedTokens.$inferInsert;
 /**
  * Wallet Locks table
  *
- * Tracks which execution currently holds the lock for a wallet+chain combination.
- * PostgreSQL advisory locks don't persist lock holder info, so we track it here.
+ * Distributed lock for serializing nonce assignment across concurrent workflow
+ * executions on the same (wallet_address, chain_id). The row IS the lock:
+ * a row with locked_by != NULL AND expires_at > NOW() means the lock is held.
  *
- * Used by NonceManager to:
- * - Prevent concurrent workflows from conflicting on nonce assignment
- * - Detect and recover from stale locks (crash recovery)
- *
- * NOTE: The actual locking is done via pg_advisory_lock(), this table only tracks metadata.
+ * Acquire is an atomic conditional UPSERT (insert-on-conflict, then update-where-
+ * expired). Release clears locked_by/locked_at and sets expires_at to NOW().
+ * The expires_at TTL guarantees that a crashed holder cannot wedge the lock
+ * forever: any caller can take over once expires_at < NOW().
  */
 export const walletLocks = pgTable(
   "wallet_locks",
@@ -236,6 +236,9 @@ export const walletLocks = pgTable(
     chainId: integer("chain_id").notNull(),
     lockedBy: text("locked_by"), // execution ID that holds the lock (null = unlocked)
     lockedAt: timestamp("locked_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
   (table) => [primaryKey({ columns: [table.walletAddress, table.chainId] })]
 );

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -36,6 +36,9 @@ const HIGH_CARDINALITY_LABELS = new Set<string>([
   "execution_id",
   "org_id",
   "owner_id",
+  // KEEP-344: wallet addresses are unbounded across users. Console and Sentry
+  // still see this label; Prometheus does not.
+  "wallet_address",
 ]);
 
 function mergeLabels(

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -1,28 +1,24 @@
 /**
  * Nonce Manager for KeeperHub Web3 Operations
  *
- * Provides distributed nonce management using PostgreSQL advisory locks
- * to prevent nonce collisions between concurrent workflow executions.
+ * Provides distributed nonce management using a row-based TTL lock to prevent
+ * nonce collisions between concurrent workflow executions on the same
+ * (wallet_address, chain_id).
  *
- * Key features:
- * - Chain as source of truth (fetches nonce from RPC at session start)
- * - PostgreSQL advisory locks for distributed coordination
- * - Dedicated connection per session (not from pool) ensures lock cleanup on crash
- * - Pending transaction tracking for validation and recovery
+ * Lock primitive: the wallet_locks row IS the lock. A row with locked_by != NULL
+ * AND expires_at > NOW() is held; everything else is takeable. Acquire is an
+ * atomic conditional UPSERT (INSERT ON CONFLICT DO NOTHING, then UPDATE WHERE
+ * expired). Release clears the holder. The expires_at TTL is the safety net:
+ * a crashed holder cannot wedge the wallet+chain forever.
  *
- * IMPORTANT: Advisory locks are session-level (tied to connection). Using the
- * connection pool would cause stale locks when processes crash. Each NonceSession
- * now uses a dedicated connection that is closed when the session ends, ensuring
- * PostgreSQL automatically releases the advisory lock.
- *
- * @see docs/keeperhub/KEEP-1240/nonce.md for full specification
+ * KEEP-344: replaces the previous pg_advisory_lock + dedicated-connection model,
+ * which leaked locks indefinitely if the holding connection survived a missed
+ * release path.
  */
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import type { ethers } from "ethers";
-import postgres from "postgres";
 import { db } from "@/lib/db";
-import { getDatabaseUrl } from "@/lib/db/connection-utils";
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
 
 export type NonceSession = {
@@ -31,8 +27,6 @@ export type NonceSession = {
   executionId: string;
   currentNonce: number;
   startedAt: Date;
-  /** Internal: dedicated connection for this session's advisory lock */
-  _lockConnection?: postgres.Sql;
 };
 
 export type ValidationResult = {
@@ -44,29 +38,28 @@ export type ValidationResult = {
 };
 
 export type NonceManagerOptions = {
-  lockTimeoutMs?: number;
+  lockTtlMs?: number;
   maxLockRetries?: number;
   lockRetryDelayMs?: number;
 };
 
-// Retry budget must outwait one full RPC failover round (up to ~90s per
-// provider including 30s timeouts + exponential backoff) since preflight
-// failover runs while the nonce lock is held.
 const DEFAULT_OPTIONS: Required<NonceManagerOptions> = {
-  lockTimeoutMs: 60_000,
-  maxLockRetries: 600,
+  // Worst-case credentialed write is ~90s (full RPC failover round). 5min
+  // gives generous headroom; a wedged lock auto-clears at expires_at.
+  lockTtlMs: 300_000,
+  // 150 * 200ms = 30s acquire budget. Waiting longer than the TTL is pointless;
+  // fail fast and let the caller decide.
+  maxLockRetries: 150,
   lockRetryDelayMs: 200,
 };
 
-const getConnectionString = () => getDatabaseUrl();
-
 export class NonceManager {
-  private readonly lockTimeoutMs: number;
+  private readonly lockTtlMs: number;
   private readonly maxLockRetries: number;
   private readonly lockRetryDelayMs: number;
 
   constructor(options: NonceManagerOptions = {}) {
-    this.lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_OPTIONS.lockTimeoutMs;
+    this.lockTtlMs = options.lockTtlMs ?? DEFAULT_OPTIONS.lockTtlMs;
     this.maxLockRetries =
       options.maxLockRetries ?? DEFAULT_OPTIONS.maxLockRetries;
     this.lockRetryDelayMs =
@@ -75,7 +68,7 @@ export class NonceManager {
 
   /**
    * Start a nonce session for workflow execution.
-   * 1. Acquires distributed lock (with dedicated connection)
+   * 1. Acquires distributed lock (row-based, with TTL)
    * 2. Fetches nonce from chain (source of truth)
    * 3. Validates and reconciles pending transactions
    */
@@ -87,21 +80,16 @@ export class NonceManager {
   ): Promise<{ session: NonceSession; validation: ValidationResult }> {
     const normalizedAddress = walletAddress.toLowerCase();
 
-    // Step 1: Acquire lock with dedicated connection
-    const lockConnection = await this.acquireLock(
-      normalizedAddress,
-      chainId,
-      executionId
-    );
+    await this.acquireLock(normalizedAddress, chainId, executionId);
 
     try {
-      // Step 2: Fetch nonce from chain (source of truth)
+      // Fetch nonce from chain (source of truth)
       const chainNonce = await provider.getTransactionCount(
         normalizedAddress,
         "pending"
       );
 
-      // Step 2.5: Check DB pending transactions and advance past any in-flight nonces
+      // Advance past any in-flight nonces tracked in the DB
       const maxDbPending = await db
         .select({ maxNonce: sql<number>`max(${pendingTransactions.nonce})` })
         .from(pendingTransactions)
@@ -118,7 +106,6 @@ export class NonceManager {
           ? chainNonce
           : Math.max(chainNonce, maxPendingNonce + 1);
 
-      // Step 3: Validate and reconcile pending transactions
       const validation = await this.validateAndReconcile(
         normalizedAddress,
         chainId,
@@ -126,14 +113,12 @@ export class NonceManager {
         provider
       );
 
-      // Create session with dedicated connection reference
       const session: NonceSession = {
         walletAddress: normalizedAddress,
         chainId,
         executionId,
         currentNonce: safeNonce,
         startedAt: new Date(),
-        _lockConnection: lockConnection,
       };
 
       console.log(
@@ -150,13 +135,9 @@ export class NonceManager {
 
       return { session, validation };
     } catch (error) {
-      // Release lock on failure - close dedicated connection
-      await this.releaseLockConnection(
-        lockConnection,
-        normalizedAddress,
-        chainId,
-        executionId
-      );
+      // Release lock on setup failure so the wallet isn't held by a session
+      // that never actually started.
+      await this.releaseLock(normalizedAddress, chainId, executionId);
       throw error;
     }
   }
@@ -174,7 +155,6 @@ export class NonceManager {
     const warnings: string[] = [];
     let reconciledCount = 0;
 
-    // Get our pending transactions
     const pending = await db
       .select()
       .from(pendingTransactions)
@@ -187,14 +167,11 @@ export class NonceManager {
       )
       .orderBy(pendingTransactions.nonce);
 
-    // Check each pending transaction against chain
     for (const tx of pending) {
-      // If nonce is less than chain nonce, tx should be confirmed or dropped
       if (tx.nonce < chainNonce) {
         const receipt = await provider.getTransactionReceipt(tx.txHash);
 
         if (receipt) {
-          // Confirmed - update status
           await db
             .update(pendingTransactions)
             .set({ status: "confirmed", confirmedAt: new Date() })
@@ -207,7 +184,6 @@ export class NonceManager {
             );
           reconciledCount += 1;
         } else {
-          // Nonce used but our tx not confirmed - likely replaced or dropped
           await db
             .update(pendingTransactions)
             .set({ status: "replaced" })
@@ -224,17 +200,14 @@ export class NonceManager {
           reconciledCount += 1;
         }
       } else if (tx.nonce === chainNonce) {
-        // Our pending tx has the next nonce - check if still in mempool
         const mempoolTx = await provider.getTransaction(tx.txHash);
 
         if (mempoolTx) {
-          // Still pending in mempool - this could block us
           warnings.push(
             `Transaction ${tx.txHash} (nonce ${tx.nonce}) still pending in mempool ` +
               `since ${tx.submittedAt?.toISOString()}`
           );
         } else {
-          // Dropped from mempool - mark as dropped
           await db
             .update(pendingTransactions)
             .set({ status: "dropped" })
@@ -251,14 +224,12 @@ export class NonceManager {
           reconciledCount += 1;
         }
       } else {
-        // Future nonce - shouldn't happen, but log it
         warnings.push(
           `Found pending tx with future nonce: ${tx.nonce} > chain nonce ${chainNonce}`
         );
       }
     }
 
-    // Count remaining pending after reconciliation
     const remainingPending = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(pendingTransactions)
@@ -349,18 +320,13 @@ export class NonceManager {
   /**
    * End the session and release the lock.
    * Call when workflow execution completes (success or failure).
-   * Closes the dedicated connection, which automatically releases the advisory lock.
    */
   async endSession(session: NonceSession): Promise<void> {
-    if (session._lockConnection) {
-      await this.releaseLockConnection(
-        session._lockConnection,
-        session.walletAddress,
-        session.chainId,
-        session.executionId
-      );
-      session._lockConnection = undefined;
-    }
+    await this.releaseLock(
+      session.walletAddress,
+      session.chainId,
+      session.executionId
+    );
 
     console.log(
       `[NonceManager] Session ended for ${session.walletAddress}:${session.chainId}, ` +
@@ -369,101 +335,73 @@ export class NonceManager {
   }
 
   /**
-   * Acquire distributed lock using PostgreSQL advisory lock.
-   *
-   * IMPORTANT: Creates a dedicated connection (not from pool) for the advisory lock.
-   * Advisory locks are session-level - tied to the database connection. Using the
-   * connection pool would cause stale locks when processes crash, because the
-   * connection returns to the pool still holding the lock.
-   *
-   * The dedicated connection is returned and must be closed via releaseLockConnection()
-   * when the session ends. Closing the connection automatically releases the lock.
+   * Acquire the wallet+chain lock. Each attempt runs two atomic statements:
+   *   1. INSERT ... ON CONFLICT DO NOTHING — wins if no row exists for this
+   *      wallet+chain yet.
+   *   2. UPDATE ... WHERE locked_by IS NULL OR expires_at < NOW() — takes over
+   *      an unheld or expired lock. Postgres serializes concurrent UPDATEs on
+   *      the same row, so only one of N concurrent takers wins per round.
+   * On real contention (lock held, not yet expired), sleep and retry.
    */
   private async acquireLock(
     walletAddress: string,
     chainId: number,
     executionId: string
-  ): Promise<postgres.Sql> {
-    const lockId = this.generateLockId(walletAddress, chainId);
-
-    // Create dedicated connection for this lock (max: 1, not pooled)
-    const lockConnection = postgres(getConnectionString(), { max: 1 });
-
+  ): Promise<void> {
     for (let attempt = 0; attempt < this.maxLockRetries; attempt++) {
-      // Try non-blocking advisory lock on dedicated connection
-      const result =
-        await lockConnection`SELECT pg_try_advisory_lock(${lockId}) as acquired`;
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + this.lockTtlMs);
 
-      const acquired = result[0]?.acquired as boolean | undefined;
+      const inserted = await db
+        .insert(walletLocks)
+        .values({
+          walletAddress,
+          chainId,
+          lockedBy: executionId,
+          lockedAt: now,
+          expiresAt,
+        })
+        .onConflictDoNothing()
+        .returning({ walletAddress: walletLocks.walletAddress });
 
-      if (acquired) {
-        // Update lock tracking table (use pooled db for metadata)
-        await db
-          .insert(walletLocks)
-          .values({
-            walletAddress,
-            chainId,
-            lockedBy: executionId,
-            lockedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: [walletLocks.walletAddress, walletLocks.chainId],
-            set: {
-              lockedBy: executionId,
-              lockedAt: new Date(),
-            },
-          });
-
+      if (inserted.length > 0) {
         console.log(
           `[NonceManager] Lock acquired for ${walletAddress}:${chainId}, ` +
-            `execution=${executionId}`
+            `execution=${executionId}, expires=${expiresAt.toISOString()}`
         );
-        return lockConnection;
+        return;
       }
 
-      // Check for stale lock in metadata table
-      const existingLock = await db
-        .select()
-        .from(walletLocks)
+      const taken = await db
+        .update(walletLocks)
+        .set({
+          lockedBy: executionId,
+          lockedAt: now,
+          expiresAt,
+        })
         .where(
           and(
             eq(walletLocks.walletAddress, walletAddress),
-            eq(walletLocks.chainId, chainId)
+            eq(walletLocks.chainId, chainId),
+            or(
+              isNull(walletLocks.lockedBy),
+              lt(walletLocks.expiresAt, sql`NOW()`)
+            )
           )
         )
-        .limit(1);
+        .returning({ walletAddress: walletLocks.walletAddress });
 
-      if (existingLock[0]?.lockedAt) {
-        const lockAge = Date.now() - existingLock[0].lockedAt.getTime();
-        if (lockAge > this.lockTimeoutMs) {
-          // Stale lock detected - the holder's connection likely died
-          // With dedicated connections, this should auto-release, but clear metadata
-          console.warn(
-            `[NonceManager] Stale lock detected for ${walletAddress}:${chainId}, ` +
-              `holder=${existingLock[0].lockedBy}, age=${lockAge}ms. ` +
-              "Clearing stale metadata and retrying."
-          );
-
-          // Clear the stale metadata - the advisory lock should be gone
-          // if the holding connection died
-          await db
-            .update(walletLocks)
-            .set({ lockedBy: null, lockedAt: null })
-            .where(
-              and(
-                eq(walletLocks.walletAddress, walletAddress),
-                eq(walletLocks.chainId, chainId)
-              )
-            );
-          continue;
-        }
+      if (taken.length > 0) {
+        console.log(
+          `[NonceManager] Lock acquired for ${walletAddress}:${chainId}, ` +
+            `execution=${executionId}, expires=${expiresAt.toISOString()}, ` +
+            `attempt=${attempt + 1}`
+        );
+        return;
       }
 
       await this.sleep(this.lockRetryDelayMs);
     }
-
-    // Failed to acquire - close the dedicated connection
-    await lockConnection.end();
 
     throw new Error(
       `Failed to acquire nonce lock for ${walletAddress}:${chainId} ` +
@@ -472,19 +410,21 @@ export class NonceManager {
   }
 
   /**
-   * Release the lock by closing the dedicated connection.
-   * PostgreSQL automatically releases advisory locks when the connection closes.
+   * Release the lock if (and only if) we still hold it. No-op if another
+   * holder has already taken over an expired lock from us.
    */
-  private async releaseLockConnection(
-    lockConnection: postgres.Sql,
+  private async releaseLock(
     walletAddress: string,
     chainId: number,
     executionId: string
   ): Promise<void> {
-    // Clear lock tracking metadata (only if we hold it)
     await db
       .update(walletLocks)
-      .set({ lockedBy: null, lockedAt: null })
+      .set({
+        lockedBy: null,
+        lockedAt: null,
+        expiresAt: sql`NOW()`,
+      })
       .where(
         and(
           eq(walletLocks.walletAddress, walletAddress),
@@ -493,26 +433,16 @@ export class NonceManager {
         )
       );
 
-    // Close the dedicated connection - this releases the advisory lock
-    await lockConnection.end();
-
     console.log(
       `[NonceManager] Lock released for ${walletAddress}:${chainId}, ` +
         `execution=${executionId}`
     );
   }
 
-  /**
-   * Generate advisory lock ID from wallet address and chain ID.
-   * Uses XOR to combine address prefix and chain ID into a 32-bit signed integer.
-   */
-  private generateLockId(walletAddress: string, chainId: number): number {
-    const addressPart = Number.parseInt(walletAddress.slice(2, 10), 16);
-    return (addressPart ^ chainId) & 0x7f_ff_ff_ff;
-  }
-
   private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
   }
 }
 

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -20,6 +20,7 @@ import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import type { ethers } from "ethers";
 import { db } from "@/lib/db";
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 export type NonceSession = {
   walletAddress: string;
@@ -372,6 +373,23 @@ export class NonceManager {
         return;
       }
 
+      // Read the prior holder before the takeover so observability can
+      // distinguish "took over from a wedged execution" from "took over a
+      // never-held row." We only log this if the takeover actually wins.
+      const priorHolderRow = await db
+        .select({
+          lockedBy: walletLocks.lockedBy,
+          expiresAt: walletLocks.expiresAt,
+        })
+        .from(walletLocks)
+        .where(
+          and(
+            eq(walletLocks.walletAddress, walletAddress),
+            eq(walletLocks.chainId, chainId)
+          )
+        )
+        .limit(1);
+
       const taken = await db
         .update(walletLocks)
         .set({
@@ -392,6 +410,21 @@ export class NonceManager {
         .returning({ walletAddress: walletLocks.walletAddress });
 
       if (taken.length > 0) {
+        const priorHolder = priorHolderRow[0]?.lockedBy ?? null;
+        const priorExpires = priorHolderRow[0]?.expiresAt;
+        if (priorHolder !== null) {
+          // Takeover from an expired holder is the operational smoke signal
+          // for KEEP-344-class incidents — log it loudly so we can correlate
+          // with whichever execution leaked the lock.
+          const expiredAgoMs = priorExpires
+            ? Date.now() - priorExpires.getTime()
+            : null;
+          console.warn(
+            `[NonceManager] Lock takeover for ${walletAddress}:${chainId}, ` +
+              `priorHolder=${priorHolder}, expiredAgoMs=${expiredAgoMs}, ` +
+              `newHolder=${executionId}`
+          );
+        }
         console.log(
           `[NonceManager] Lock acquired for ${walletAddress}:${chainId}, ` +
             `execution=${executionId}, expires=${expiresAt.toISOString()}, ` +
@@ -403,10 +436,25 @@ export class NonceManager {
       await this.sleep(this.lockRetryDelayMs);
     }
 
-    throw new Error(
+    // Acquire failure after the full retry budget — emit a metric so the
+    // operations team gets paged on repeated failures rather than finding
+    // out via support tickets like in KEEP-344.
+    const failure = new Error(
       `Failed to acquire nonce lock for ${walletAddress}:${chainId} ` +
         `after ${this.maxLockRetries} attempts`
     );
+    logSystemError(
+      ErrorCategory.INFRASTRUCTURE,
+      "[NonceManager] acquire_failed",
+      failure,
+      {
+        wallet_address: walletAddress,
+        chain_id: String(chainId),
+        execution_id: executionId,
+        max_retries: String(this.maxLockRetries),
+      }
+    );
+    throw failure;
   }
 
   /**

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -48,9 +48,12 @@ const DEFAULT_OPTIONS: Required<NonceManagerOptions> = {
   // Worst-case credentialed write is ~90s (full RPC failover round). 5min
   // gives generous headroom; a wedged lock auto-clears at expires_at.
   lockTtlMs: 300_000,
-  // 150 * 200ms = 30s acquire budget. Waiting longer than the TTL is pointless;
-  // fail fast and let the caller decide.
-  maxLockRetries: 150,
+  // 600 * 200ms = 120s acquire budget. Must outwait one full RPC failover
+  // round (~90s per provider including timeouts and exponential backoff),
+  // since preflight failover runs while a legitimate holder still has the
+  // lock. The TTL bounds *stuck* holders; the retry budget bounds the wait
+  // for *legitimate* holders to finish.
+  maxLockRetries: 600,
   lockRetryDelayMs: 200,
 };
 

--- a/tests/e2e/vitest/nonce-manager.test.ts
+++ b/tests/e2e/vitest/nonce-manager.test.ts
@@ -1,16 +1,11 @@
 /**
  * E2E Tests for Nonce Manager
  *
- * These tests verify the full nonce management flow including:
- * - Lock acquisition and release with real PostgreSQL advisory locks
- * - Session management with database state
- * - Transaction recording and status updates
- * - Validation and reconciliation of pending transactions
- * - Concurrent access handling
+ * Verifies the row-based TTL lock against a real PostgreSQL.
  *
  * Prerequisites:
  * - Database running with nonce manager tables
- * - Run: pnpm db:push
+ * - Run: pnpm db:migrate
  */
 
 import { and, eq } from "drizzle-orm";
@@ -625,19 +620,19 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
     });
   });
 
-  describe("Stale Lock Detection", () => {
-    it("should release stale locks and allow new session", async () => {
-      // Manually insert a stale lock (2 minutes old)
+  describe("Expired Lock Takeover", () => {
+    it("should take over an expired lock and allow new session", async () => {
+      // Insert a lock whose expires_at is in the past — any caller can take it.
       await db.insert(walletLocks).values({
         walletAddress: TEST_WALLET_NORMALIZED,
         chainId: TEST_CHAIN_ID,
         lockedBy: "stale_execution",
-        lockedAt: new Date(Date.now() - 120_000), // 2 minutes ago
+        lockedAt: new Date(Date.now() - 120_000),
+        expiresAt: new Date(Date.now() - 60_000),
       });
 
-      // New manager with 60s timeout should detect and release stale lock
       const manager = new NonceManager({
-        lockTimeoutMs: 60_000, // 60 second timeout
+        lockTtlMs: 60_000,
         maxLockRetries: 3,
         lockRetryDelayMs: 100,
       });
@@ -670,66 +665,34 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
     }, 15_000);
   });
 
-  describe("Dedicated Connection Lock Cleanup", () => {
-    it("should release advisory lock when dedicated connection is closed (crash simulation)", async () => {
-      const manager1 = new NonceManager();
-      const provider = createMockProvider(5);
-
-      // Start first session
-      const { session: session1 } = await manager1.startSession(
-        TEST_WALLET,
-        TEST_CHAIN_ID,
-        `${testExecutionId}_crash`,
-        provider as any
-      );
-
-      // Verify lock is held
-      const locksBefore = await db
-        .select()
-        .from(walletLocks)
-        .where(
-          and(
-            eq(walletLocks.walletAddress, TEST_WALLET_NORMALIZED),
-            eq(walletLocks.chainId, TEST_CHAIN_ID)
-          )
-        );
-      expect(locksBefore[0]?.lockedBy).toBe(`${testExecutionId}_crash`);
-
-      // Simulate crash: close the dedicated connection directly without calling endSession
-      // This simulates what happens when a process crashes - the connection dies
-      if (session1._lockConnection) {
-        await session1._lockConnection.end();
-        session1._lockConnection = undefined;
-      }
-
-      // Clear the lock metadata (simulating what would happen after stale detection)
-      await db
-        .update(walletLocks)
-        .set({ lockedBy: null, lockedAt: null })
-        .where(
-          and(
-            eq(walletLocks.walletAddress, TEST_WALLET_NORMALIZED),
-            eq(walletLocks.chainId, TEST_CHAIN_ID)
-          )
-        );
-
-      // Now a new session should be able to acquire the lock immediately
-      const manager2 = new NonceManager({
-        maxLockRetries: 3, // Low retries since it should work immediately
-        lockRetryDelayMs: 50,
+  describe("TTL-based Lock Recovery", () => {
+    it("recovers a wedged lock once expires_at passes (no live holder needed)", async () => {
+      // Simulate a crashed holder: row exists with locked_by set but
+      // expires_at already in the past. With the old advisory-lock model
+      // this could only be cleared by closing the holder's connection.
+      await db.insert(walletLocks).values({
+        walletAddress: TEST_WALLET_NORMALIZED,
+        chainId: TEST_CHAIN_ID,
+        lockedBy: `${testExecutionId}_crash`,
+        lockedAt: new Date(Date.now() - 10_000),
+        expiresAt: new Date(Date.now() - 1000),
       });
 
-      const { session: session2 } = await manager2.startSession(
+      const manager = new NonceManager({
+        maxLockRetries: 3,
+        lockRetryDelayMs: 50,
+      });
+      const provider = createMockProvider(5);
+
+      const { session } = await manager.startSession(
         TEST_WALLET,
         TEST_CHAIN_ID,
         `${testExecutionId}_recovery`,
         provider as any
       );
 
-      // Should have acquired lock successfully
-      expect(session2.executionId).toBe(`${testExecutionId}_recovery`);
+      expect(session.executionId).toBe(`${testExecutionId}_recovery`);
 
-      // Verify new lock holder in database
       const locksAfter = await db
         .select()
         .from(walletLocks)
@@ -741,10 +704,10 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
         );
       expect(locksAfter[0]?.lockedBy).toBe(`${testExecutionId}_recovery`);
 
-      await manager2.endSession(session2);
+      await manager.endSession(session);
     }, 15_000);
 
-    it("should block concurrent sessions on same wallet/chain until lock is released", async () => {
+    it("blocks concurrent sessions on the same wallet+chain until release", async () => {
       const manager1 = new NonceManager();
       const manager2 = new NonceManager({
         maxLockRetries: 5,
@@ -752,7 +715,6 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
       });
       const provider = createMockProvider(5);
 
-      // Start first session
       const { session: session1 } = await manager1.startSession(
         TEST_WALLET,
         TEST_CHAIN_ID,
@@ -760,7 +722,6 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
         provider as any
       );
 
-      // Try to start second session - should block until first releases
       const session2Promise = manager2.startSession(
         TEST_WALLET,
         TEST_CHAIN_ID,
@@ -768,29 +729,24 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
         provider as any
       );
 
-      // Wait a bit to let second session start retrying
       await new Promise((resolve) => setTimeout(resolve, 200));
-
-      // Release first session
       await manager1.endSession(session1);
 
-      // Second session should now succeed
       const { session: session2 } = await session2Promise;
       expect(session2.executionId).toBe(`${testExecutionId}_waiter`);
 
       await manager2.endSession(session2);
     }, 15_000);
 
-    it("should fail to acquire lock if holder never releases within timeout", async () => {
+    it("fails to acquire if holder never releases and TTL has not expired", async () => {
       const manager1 = new NonceManager();
       const manager2 = new NonceManager({
-        maxLockRetries: 3, // Very low
+        maxLockRetries: 3,
         lockRetryDelayMs: 50,
-        lockTimeoutMs: 60_000, // But timeout is 60s, so stale detection won't help
+        lockTtlMs: 60_000,
       });
       const provider = createMockProvider(5);
 
-      // Start first session and hold the lock
       const { session: session1 } = await manager1.startSession(
         TEST_WALLET,
         TEST_CHAIN_ID,
@@ -798,7 +754,6 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
         provider as any
       );
 
-      // Second session should fail after retries (lock is not stale)
       await expect(
         manager2.startSession(
           TEST_WALLET,
@@ -808,29 +763,7 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
         )
       ).rejects.toThrow(FAILED_LOCK_REGEX);
 
-      // Cleanup
       await manager1.endSession(session1);
     }, 15_000);
-
-    it("should have _lockConnection on session object", async () => {
-      const manager = new NonceManager();
-      const provider = createMockProvider(5);
-
-      const { session } = await manager.startSession(
-        TEST_WALLET,
-        TEST_CHAIN_ID,
-        testExecutionId,
-        provider as any
-      );
-
-      // Session should have a dedicated lock connection
-      expect(session._lockConnection).toBeDefined();
-      expect(typeof session._lockConnection?.end).toBe("function");
-
-      await manager.endSession(session);
-
-      // After ending, _lockConnection should be undefined
-      expect(session._lockConnection).toBeUndefined();
-    });
   });
 });

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -54,28 +54,40 @@ vi.mock("@/lib/db", () => ({
 
 // vi.mock factories are hoisted; use vi.hoisted for shared identity with
 // assertions so `target === workflowExecutionsMock` works in tests.
-const { workflowExecutionsMock, workflowExecutionLogsMock } = vi.hoisted(() => ({
-  workflowExecutionsMock: {
-    id: "id",
-    workflowId: "workflow_id",
-    startedAt: "started_at",
-    status: "status",
-    completedAt: "completed_at",
-    error: "error",
-    duration: "duration",
-  },
-  workflowExecutionLogsMock: {
-    id: "id",
-    executionId: "execution_id",
-    status: "status",
-    error: "error",
-    completedAt: "completed_at",
-  },
-}));
+const { workflowExecutionsMock, workflowExecutionLogsMock, walletLocksMock } =
+  vi.hoisted(() => ({
+    workflowExecutionsMock: {
+      id: "id",
+      workflowId: "workflow_id",
+      startedAt: "started_at",
+      status: "status",
+      completedAt: "completed_at",
+      error: "error",
+      duration: "duration",
+    },
+    workflowExecutionLogsMock: {
+      id: "id",
+      executionId: "execution_id",
+      status: "status",
+      error: "error",
+      completedAt: "completed_at",
+    },
+    walletLocksMock: {
+      walletAddress: "wallet_address",
+      chainId: "chain_id",
+      lockedBy: "locked_by",
+      lockedAt: "locked_at",
+      expiresAt: "expires_at",
+    },
+  }));
 
 vi.mock("@/lib/db/schema", () => ({
   workflowExecutions: workflowExecutionsMock,
   workflowExecutionLogs: workflowExecutionLogsMock,
+}));
+
+vi.mock("@/lib/db/schema-extensions", () => ({
+  walletLocks: walletLocksMock,
 }));
 
 import { GET } from "@/app/api/internal/reaper/route";
@@ -93,6 +105,10 @@ function getExecUpdate(): UpdateCall | undefined {
 
 function getLogUpdate(): UpdateCall | undefined {
   return updateCalls.find((c) => c.target === workflowExecutionLogsMock);
+}
+
+function getWalletLocksUpdate(): UpdateCall | undefined {
+  return updateCalls.find((c) => c.target === walletLocksMock);
 }
 
 describe("/api/internal/reaper", () => {
@@ -183,8 +199,9 @@ describe("/api/internal/reaper", () => {
     expect(data.reapedCount).toBe(3);
     expect(data.reapedIds).toEqual(["exec_1", "exec_2", "exec_3"]);
     // Exactly one UPDATE against workflow_executions, one against logs.
-    expect(updateCalls.filter((c) => c.target === workflowExecutionsMock))
-      .toHaveLength(1);
+    expect(
+      updateCalls.filter((c) => c.target === workflowExecutionsMock)
+    ).toHaveLength(1);
   });
 
   it("uses configurable threshold from env var", async () => {
@@ -229,5 +246,31 @@ describe("/api/internal/reaper", () => {
     await GET(createRequest());
 
     expect(getLogUpdate()).toBeUndefined();
+  });
+
+  // KEEP-344: any nonce lock held by a reaped execution is released eagerly
+  // so the affected wallet+chain unblocks at reaper time instead of waiting
+  // for the wallet_locks TTL to expire.
+  it("releases nonce locks held by reaped executions", async () => {
+    mockReapedRows = [{ id: "exec_1" }, { id: "exec_2" }];
+
+    await GET(createRequest());
+
+    const lockUpdate = getWalletLocksUpdate();
+    expect(lockUpdate).toBeDefined();
+    expect(lockUpdate?.set).toEqual(
+      expect.objectContaining({
+        lockedBy: null,
+        lockedAt: null,
+      })
+    );
+  });
+
+  it("does not touch wallet_locks when nothing was reaped", async () => {
+    mockReapedRows = [];
+
+    await GET(createRequest());
+
+    expect(getWalletLocksUpdate()).toBeUndefined();
   });
 });

--- a/tests/integration/wallet-unlock-route.test.ts
+++ b/tests/integration/wallet-unlock-route.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/logging", () => ({
 }));
 
 let mockSelectResult: { lockedBy: string | null; expiresAt: Date }[] = [];
+let mockUpdateRows: { walletAddress: string }[] = [];
 let updateInvoked = false;
 let selectThrows = false;
 
@@ -37,10 +38,12 @@ vi.mock("@/lib/db", () => ({
     })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
-        where: vi.fn(() => {
-          updateInvoked = true;
-          return Promise.resolve(undefined);
-        }),
+        where: vi.fn(() => ({
+          returning: vi.fn(() => {
+            updateInvoked = true;
+            return Promise.resolve(mockUpdateRows);
+          }),
+        })),
       })),
     })),
   },
@@ -78,6 +81,7 @@ describe("POST /api/internal/wallet-unlock", () => {
     vi.clearAllMocks();
     mockAuthResult.authenticated = true;
     mockSelectResult = [];
+    mockUpdateRows = [];
     updateInvoked = false;
     selectThrows = false;
   });
@@ -168,6 +172,10 @@ describe("POST /api/internal/wallet-unlock", () => {
         expiresAt: new Date(Date.now() + 60_000),
       },
     ];
+    // The conditional UPDATE finds the row (still held by exec_wedged).
+    mockUpdateRows = [
+      { walletAddress: "0x1234567890123456789012345678901234567890" },
+    ];
 
     const response = await POST(
       createRequest({
@@ -182,12 +190,41 @@ describe("POST /api/internal/wallet-unlock", () => {
     expect(updateInvoked).toBe(true);
   });
 
+  // Race protection: the lock can be legitimately released and re-acquired
+  // between our SELECT and our UPDATE. The conditional UPDATE (WHERE
+  // locked_by = previousHolder) returns 0 rows in that case; we must not
+  // report success and must not have killed an unrelated holder.
+  it("returns released:false when the holder changed between SELECT and UPDATE", async () => {
+    mockSelectResult = [
+      {
+        lockedBy: "exec_first",
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ];
+    // Conditional UPDATE matches no row — someone else now holds it.
+    mockUpdateRows = [];
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ released: false, previousHolder: null });
+  });
+
   it("normalizes wallet address to lowercase before lookup", async () => {
     mockSelectResult = [
       {
         lockedBy: "exec_wedged",
         expiresAt: new Date(Date.now() + 60_000),
       },
+    ];
+    mockUpdateRows = [
+      { walletAddress: "0xabcdef1234567890123456789012345678901234" },
     ];
 
     const response = await POST(

--- a/tests/integration/wallet-unlock-route.test.ts
+++ b/tests/integration/wallet-unlock-route.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const INVALID_JSON_REGEX = /Invalid JSON/;
+
+vi.mock("server-only", () => ({}));
+
+const mockAuthResult = {
+  authenticated: true,
+  service: "scheduler" as const,
+};
+vi.mock("@/lib/internal-service-auth", () => ({
+  authenticateInternalService: vi.fn(() => mockAuthResult),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+let mockSelectResult: { lockedBy: string | null; expiresAt: Date }[] = [];
+let updateInvoked = false;
+let selectThrows = false;
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => {
+            if (selectThrows) {
+              throw new Error("db blew up");
+            }
+            return Promise.resolve(mockSelectResult);
+          }),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => {
+          updateInvoked = true;
+          return Promise.resolve(undefined);
+        }),
+      })),
+    })),
+  },
+}));
+
+const { walletLocksMock } = vi.hoisted(() => ({
+  walletLocksMock: {
+    walletAddress: "wallet_address",
+    chainId: "chain_id",
+    lockedBy: "locked_by",
+    lockedAt: "locked_at",
+    expiresAt: "expires_at",
+  },
+}));
+
+vi.mock("@/lib/db/schema-extensions", () => ({
+  walletLocks: walletLocksMock,
+}));
+
+import { POST } from "@/app/api/internal/wallet-unlock/route";
+
+function createRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/internal/wallet-unlock", {
+    method: "POST",
+    headers: {
+      "X-Service-Key": "test-key",
+      "Content-Type": "application/json",
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/wallet-unlock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthResult.authenticated = true;
+    mockSelectResult = [];
+    updateInvoked = false;
+    selectThrows = false;
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuthResult.authenticated = false;
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const response = await POST(createRequest("not-json"));
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toMatch(INVALID_JSON_REGEX);
+  });
+
+  it("returns 400 when walletAddress is missing", async () => {
+    const response = await POST(createRequest({ chainId: 1 }));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when chainId is missing", async () => {
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+      })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when chainId is not an integer", async () => {
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1.5,
+      })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns released:false when no lock is held", async () => {
+    mockSelectResult = [];
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ released: false, previousHolder: null });
+    expect(updateInvoked).toBe(false);
+  });
+
+  it("returns released:false when row exists but lockedBy is null", async () => {
+    mockSelectResult = [
+      { lockedBy: null, expiresAt: new Date(Date.now() - 1000) },
+    ];
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ released: false, previousHolder: null });
+    expect(updateInvoked).toBe(false);
+  });
+
+  it("releases an active lock and returns the previous holder", async () => {
+    mockSelectResult = [
+      {
+        lockedBy: "exec_wedged",
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ];
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ released: true, previousHolder: "exec_wedged" });
+    expect(updateInvoked).toBe(true);
+  });
+
+  it("normalizes wallet address to lowercase before lookup", async () => {
+    mockSelectResult = [
+      {
+        lockedBy: "exec_wedged",
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ];
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0xABCDEF1234567890123456789012345678901234",
+        chainId: 1,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateInvoked).toBe(true);
+  });
+
+  it("returns 500 if the database errors", async () => {
+    selectThrows = true;
+
+    const response = await POST(
+      createRequest({
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      })
+    );
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -38,6 +38,15 @@ vi.mock("@/lib/db/schema-extensions", () => ({
   },
 }));
 
+const { mockLogSystemError } = vi.hoisted(() => ({
+  mockLogSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { INFRASTRUCTURE: "infrastructure" },
+  logSystemError: mockLogSystemError,
+}));
+
 import {
   getNonceManager,
   NonceManager,
@@ -210,7 +219,7 @@ describe("NonceManager", () => {
       expect(mockUpdate).toHaveBeenCalled();
     });
 
-    it("throws if lock cannot be acquired after max retries", async () => {
+    it("throws and emits a metric when lock cannot be acquired", async () => {
       // Both INSERT and UPDATE return 0 rows on every attempt.
       setupLockMocks({ insertedRows: 0, updatedRows: 0 });
 
@@ -228,6 +237,73 @@ describe("NonceManager", () => {
           provider as unknown as import("ethers").Provider
         )
       ).rejects.toThrow(FAILED_LOCK_REGEX);
+
+      // Observability: failure emits a structured log so ops gets paged
+      // instead of waiting for support tickets (KEEP-344).
+      expect(mockLogSystemError).toHaveBeenCalledWith(
+        "infrastructure",
+        expect.stringContaining("acquire_failed"),
+        expect.any(Error),
+        expect.objectContaining({
+          wallet_address: "0x1234567890123456789012345678901234567890",
+          chain_id: "1",
+          execution_id: "exec_123",
+        })
+      );
+    });
+
+    it("warns when taking over an expired lock from a prior holder", async () => {
+      // INSERT returns 0 rows, SELECT returns a stale prior holder, UPDATE
+      // takes it over.
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ walletAddress: "0x" }]),
+          }),
+        }),
+      });
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                lockedBy: "exec_wedged",
+                expiresAt: new Date(Date.now() - 30_000),
+              },
+            ]),
+            orderBy: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+        // suppress test output
+      });
+
+      const manager = new NonceManager();
+      const provider = createMockProvider();
+
+      await manager.startSession(
+        "0x1234567890123456789012345678901234567890",
+        1,
+        "exec_takeover",
+        provider as unknown as import("ethers").Provider
+      );
+
+      const takeoverLogged = warnSpy.mock.calls.some((call) =>
+        String(call[0] ?? "").includes("Lock takeover")
+      );
+      expect(takeoverLogged).toBe(true);
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -1,37 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Regex patterns for testing
 const FAILED_LOCK_REGEX = /Failed to acquire nonce lock/;
 
-// Mock server-only
 vi.mock("server-only", () => ({}));
 
-// Use vi.hoisted() to define mocks before vi.mock hoisting
-const {
-  mockSelect,
-  mockInsert,
-  mockUpdate,
-  mockPostgresQuery,
-  mockPostgresEnd,
-} = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockUpdate } = vi.hoisted(() => ({
   mockSelect: vi.fn(),
   mockInsert: vi.fn(),
   mockUpdate: vi.fn(),
-  mockPostgresQuery: vi.fn(),
-  mockPostgresEnd: vi.fn(),
 }));
-
-// Mock postgres module for dedicated lock connections
-vi.mock("postgres", () => {
-  // Create a mock connection that's callable as tagged template
-  const createMockConnection = () => {
-    const queryFn = (strings: TemplateStringsArray, ...values: unknown[]) =>
-      mockPostgresQuery(strings, ...values);
-    queryFn.end = mockPostgresEnd;
-    return queryFn;
-  };
-  return { default: vi.fn(() => createMockConnection()) };
-});
 
 vi.mock("@/lib/db", () => ({
   db: {
@@ -41,7 +18,6 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-// Mock schema
 vi.mock("@/lib/db/schema-extensions", () => ({
   pendingTransactions: {
     walletAddress: "wallet_address",
@@ -58,10 +34,10 @@ vi.mock("@/lib/db/schema-extensions", () => ({
     chainId: "chain_id",
     lockedBy: "locked_by",
     lockedAt: "locked_at",
+    expiresAt: "expires_at",
   },
 }));
 
-// Import after mocks
 import {
   getNonceManager,
   NonceManager,
@@ -69,7 +45,6 @@ import {
   resetNonceManager,
 } from "@/lib/web3/nonce-manager";
 
-// Mock provider
 function createMockProvider(
   options: {
     transactionCount?: number;
@@ -88,15 +63,50 @@ function createMockProvider(
   };
 }
 
+/**
+ * Build a default chain of mocks for the row-based lock acquire path.
+ * - INSERT ... ON CONFLICT DO NOTHING RETURNING — `insertedRows` controls
+ *   how many rows the INSERT returned. 1 = lock acquired on insert.
+ * - UPDATE ... WHERE locked_by IS NULL OR expires_at < NOW() RETURNING —
+ *   `updatedRows` controls how many rows the UPDATE returned. 1 = lock
+ *   acquired by taking over an unheld/expired row.
+ * Both default to acquired-on-insert for happy-path tests.
+ */
+function setupLockMocks(
+  opts: { insertedRows?: number; updatedRows?: number } = {}
+) {
+  const insertedRows = opts.insertedRows ?? 1;
+  const updatedRows = opts.updatedRows ?? 0;
+
+  mockInsert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      onConflictDoNothing: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue(insertedRows > 0 ? [{ walletAddress: "0x" }] : []),
+      }),
+      // recordTransaction uses onConflictDoUpdate
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+
+  mockUpdate.mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue(updatedRows > 0 ? [{ walletAddress: "0x" }] : []),
+      }),
+    }),
+  });
+}
+
 describe("NonceManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetNonceManager();
 
-    // Default mock implementations
-    // Mock postgres query for advisory lock - returns acquired: true by default
-    mockPostgresQuery.mockResolvedValue([{ acquired: true }]);
-    mockPostgresEnd.mockResolvedValue(undefined);
+    setupLockMocks();
 
     mockSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -106,27 +116,17 @@ describe("NonceManager", () => {
         }),
       }),
     });
-    mockInsert.mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-      }),
-    });
-    mockUpdate.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
-    });
   });
 
   describe("constructor", () => {
-    it("should create instance with default options", () => {
+    it("creates instance with default options", () => {
       const manager = new NonceManager();
       expect(manager).toBeInstanceOf(NonceManager);
     });
 
-    it("should create instance with custom options", () => {
+    it("accepts custom TTL and retry options", () => {
       const manager = new NonceManager({
-        lockTimeoutMs: 30_000,
+        lockTtlMs: 30_000,
         maxLockRetries: 10,
         lockRetryDelayMs: 50,
       });
@@ -135,7 +135,7 @@ describe("NonceManager", () => {
   });
 
   describe("startSession", () => {
-    it("should acquire lock and return session with chain nonce", async () => {
+    it("acquires lock via INSERT and returns session with chain nonce", async () => {
       const manager = new NonceManager();
       const provider = createMockProvider({ transactionCount: 10 });
 
@@ -154,9 +154,28 @@ describe("NonceManager", () => {
       expect(session.currentNonce).toBe(10);
       expect(session.startedAt).toBeInstanceOf(Date);
       expect(validation.chainNonce).toBe(10);
+      expect(mockInsert).toHaveBeenCalled();
     });
 
-    it("should normalize wallet address to lowercase", async () => {
+    it("acquires lock via UPDATE when an expired row already exists", async () => {
+      // INSERT returns 0 rows (row exists), UPDATE returns 1 (we took over).
+      setupLockMocks({ insertedRows: 0, updatedRows: 1 });
+
+      const manager = new NonceManager();
+      const provider = createMockProvider({ transactionCount: 10 });
+
+      const { session } = await manager.startSession(
+        "0x1234567890123456789012345678901234567890",
+        1,
+        "exec_takeover",
+        provider as unknown as import("ethers").Provider
+      );
+
+      expect(session.executionId).toBe("exec_takeover");
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+
+    it("normalizes wallet address to lowercase", async () => {
       const manager = new NonceManager();
       const provider = createMockProvider();
 
@@ -172,11 +191,9 @@ describe("NonceManager", () => {
       );
     });
 
-    it("should release lock if validation fails", async () => {
+    it("releases lock if RPC fails after acquire", async () => {
       const manager = new NonceManager();
       const provider = createMockProvider();
-
-      // Make getTransactionCount throw
       provider.getTransactionCount.mockRejectedValue(new Error("RPC error"));
 
       await expect(
@@ -188,26 +205,18 @@ describe("NonceManager", () => {
         )
       ).rejects.toThrow("RPC error");
 
-      // Should have acquired lock, then closed connection on error
-      expect(mockPostgresQuery).toHaveBeenCalled();
-      expect(mockPostgresEnd).toHaveBeenCalled();
+      // Acquire (insert) + release (update) both ran.
+      expect(mockInsert).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalled();
     });
 
-    it("should throw if lock cannot be acquired after max retries", async () => {
-      // Make lock acquisition always fail
-      mockPostgresQuery.mockResolvedValue([{ acquired: false }]);
-      mockSelect.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockResolvedValue([]),
-            limit: vi.fn().mockResolvedValue([]), // No existing lock
-          }),
-        }),
-      });
+    it("throws if lock cannot be acquired after max retries", async () => {
+      // Both INSERT and UPDATE return 0 rows on every attempt.
+      setupLockMocks({ insertedRows: 0, updatedRows: 0 });
 
       const manager = new NonceManager({
         maxLockRetries: 3,
-        lockRetryDelayMs: 10,
+        lockRetryDelayMs: 1,
       });
       const provider = createMockProvider();
 
@@ -219,14 +228,11 @@ describe("NonceManager", () => {
           provider as unknown as import("ethers").Provider
         )
       ).rejects.toThrow(FAILED_LOCK_REGEX);
-
-      // Should have closed the connection after failing
-      expect(mockPostgresEnd).toHaveBeenCalled();
     });
   });
 
   describe("getNextNonce", () => {
-    it("should return current nonce and increment", () => {
+    it("returns current nonce and increments", () => {
       const manager = new NonceManager();
       const session: NonceSession = {
         walletAddress: "0x1234",
@@ -238,17 +244,23 @@ describe("NonceManager", () => {
 
       expect(manager.getNextNonce(session)).toBe(5);
       expect(session.currentNonce).toBe(6);
-
       expect(manager.getNextNonce(session)).toBe(6);
       expect(session.currentNonce).toBe(7);
-
-      expect(manager.getNextNonce(session)).toBe(7);
-      expect(session.currentNonce).toBe(8);
     });
   });
 
   describe("recordTransaction", () => {
-    it("should insert transaction record", async () => {
+    it("calls insert with onConflictDoUpdate", async () => {
+      const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ walletAddress: "0x" }]),
+          }),
+          onConflictDoUpdate,
+        }),
+      });
+
       const manager = new NonceManager();
       const session: NonceSession = {
         walletAddress: "0x1234",
@@ -266,57 +278,31 @@ describe("NonceManager", () => {
         "1000000000"
       );
 
-      expect(mockInsert).toHaveBeenCalled();
-    });
-
-    it("should handle upsert on conflict", async () => {
-      const mockOnConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
-      mockInsert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          onConflictDoUpdate: mockOnConflictDoUpdate,
-        }),
-      });
-
-      const manager = new NonceManager();
-      const session: NonceSession = {
-        walletAddress: "0x1234",
-        chainId: 1,
-        executionId: "exec_123",
-        currentNonce: 5,
-        startedAt: new Date(),
-      };
-
-      await manager.recordTransaction(session, 5, "0xtxhash123");
-
-      expect(mockOnConflictDoUpdate).toHaveBeenCalled();
+      expect(onConflictDoUpdate).toHaveBeenCalled();
     });
   });
 
   describe("confirmTransaction", () => {
-    it("should update transaction status to confirmed", async () => {
-      const mockWhere = vi.fn().mockResolvedValue(undefined);
-      const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-      mockUpdate.mockReturnValue({ set: mockSet });
+    it("updates transaction status to confirmed", async () => {
+      const set = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockUpdate.mockReturnValue({ set });
 
       const manager = new NonceManager();
-
       await manager.confirmTransaction("0xtxhash123");
 
-      expect(mockUpdate).toHaveBeenCalled();
-      expect(mockSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: "confirmed",
-        })
+      expect(set).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "confirmed" })
       );
     });
   });
 
   describe("endSession", () => {
-    it("should release lock and clear active session", async () => {
+    it("releases the lock for the session's holder", async () => {
       const manager = new NonceManager();
       const provider = createMockProvider();
 
-      // Start a session first
       const { session } = await manager.startSession(
         "0x1234567890123456789012345678901234567890",
         1,
@@ -324,9 +310,7 @@ describe("NonceManager", () => {
         provider as unknown as import("ethers").Provider
       );
 
-      // Clear mocks to track endSession calls
       vi.clearAllMocks();
-      mockPostgresEnd.mockResolvedValue(undefined);
       mockUpdate.mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue(undefined),
@@ -335,62 +319,12 @@ describe("NonceManager", () => {
 
       await manager.endSession(session);
 
-      // Should update wallet_locks and close dedicated connection
-      expect(mockUpdate).toHaveBeenCalled();
-      expect(mockPostgresEnd).toHaveBeenCalled();
-    });
-  });
-
-  describe("stale lock detection", () => {
-    it("should detect and clear stale lock metadata", async () => {
-      // First attempt fails, lock exists and is stale
-      let attemptCount = 0;
-      mockPostgresQuery.mockImplementation(() => {
-        attemptCount += 1;
-        if (attemptCount === 1) {
-          // First attempt: lock not acquired
-          return Promise.resolve([{ acquired: false }]);
-        }
-        // After stale lock cleared: lock acquired
-        return Promise.resolve([{ acquired: true }]);
-      });
-
-      // Return stale lock info
-      mockSelect.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockResolvedValue([]),
-            limit: vi.fn().mockResolvedValue([
-              {
-                lockedBy: "old_exec",
-                lockedAt: new Date(Date.now() - 120_000), // 2 minutes old (stale)
-              },
-            ]),
-          }),
-        }),
-      });
-
-      const manager = new NonceManager({ lockTimeoutMs: 60_000 });
-      const provider = createMockProvider();
-
-      const { session } = await manager.startSession(
-        "0x1234567890123456789012345678901234567890",
-        1,
-        "exec_123",
-        provider as unknown as import("ethers").Provider
-      );
-
-      expect(session).toBeDefined();
-      // Should have tried to acquire, detected stale, cleared metadata, then acquired
-      expect(mockPostgresQuery.mock.calls.length).toBeGreaterThanOrEqual(2);
-      // Should have cleared the stale lock metadata
       expect(mockUpdate).toHaveBeenCalled();
     });
   });
 
   describe("validation and reconciliation", () => {
-    it("should reconcile confirmed transactions", async () => {
-      // Mock pending transaction that is now confirmed
+    it("reconciles confirmed transactions", async () => {
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -398,7 +332,7 @@ describe("NonceManager", () => {
               {
                 walletAddress: "0x1234567890123456789012345678901234567890",
                 chainId: 1,
-                nonce: 4, // Less than chain nonce (5)
+                nonce: 4,
                 txHash: "0xconfirmed",
                 status: "pending",
               },
@@ -411,7 +345,7 @@ describe("NonceManager", () => {
       const manager = new NonceManager();
       const provider = createMockProvider({
         transactionCount: 5,
-        transactionReceipt: { blockNumber: 123 }, // Transaction is confirmed
+        transactionReceipt: { blockNumber: 123 },
       });
 
       const { validation } = await manager.startSession(
@@ -422,11 +356,9 @@ describe("NonceManager", () => {
       );
 
       expect(validation.reconciledCount).toBe(1);
-      expect(mockUpdate).toHaveBeenCalled();
     });
 
-    it("should detect replaced transactions", async () => {
-      // Mock pending transaction that was replaced (nonce < chainNonce, receipt null)
+    it("detects replaced transactions", async () => {
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -434,7 +366,7 @@ describe("NonceManager", () => {
               {
                 walletAddress: "0x1234567890123456789012345678901234567890",
                 chainId: 1,
-                nonce: 4, // Less than chain nonce (5)
+                nonce: 4,
                 txHash: "0xreplaced",
                 status: "pending",
               },
@@ -445,7 +377,6 @@ describe("NonceManager", () => {
       });
 
       const manager = new NonceManager();
-      // Create provider with explicit null receipt to trigger "replaced" path
       const provider = {
         getTransactionCount: vi.fn().mockResolvedValue(5),
         getTransactionReceipt: vi.fn().mockResolvedValue(null),
@@ -459,22 +390,14 @@ describe("NonceManager", () => {
         provider as unknown as import("ethers").Provider
       );
 
-      // Verify provider.getTransactionReceipt was called with the tx hash
       expect(provider.getTransactionReceipt).toHaveBeenCalledWith("0xreplaced");
-
-      // The validation should have reconciled a transaction
-      expect(validation.reconciledCount).toBeGreaterThanOrEqual(0);
-
-      // Check warnings - if the replaced path was taken, it should contain the warning
       const hasReplacedWarning = validation.warnings.some((w) =>
         w.includes("replaced or dropped")
       );
-      // Also accept if no warnings but reconciled (confirmed path taken)
       expect(hasReplacedWarning || validation.reconciledCount > 0).toBe(true);
     });
 
-    it("should detect dropped mempool transactions", async () => {
-      // Mock pending transaction with nonce === chainNonce (checks mempool)
+    it("detects dropped mempool transactions", async () => {
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -482,7 +405,7 @@ describe("NonceManager", () => {
               {
                 walletAddress: "0x1234567890123456789012345678901234567890",
                 chainId: 1,
-                nonce: 5, // Same as chain nonce
+                nonce: 5,
                 txHash: "0xdropped",
                 status: "pending",
                 submittedAt: new Date(),
@@ -494,11 +417,10 @@ describe("NonceManager", () => {
       });
 
       const manager = new NonceManager();
-      // Create provider with null transaction (not in mempool)
       const provider = {
         getTransactionCount: vi.fn().mockResolvedValue(5),
         getTransactionReceipt: vi.fn().mockResolvedValue(null),
-        getTransaction: vi.fn().mockResolvedValue(null), // Not in mempool
+        getTransaction: vi.fn().mockResolvedValue(null),
       };
 
       const { validation } = await manager.startSession(
@@ -508,18 +430,13 @@ describe("NonceManager", () => {
         provider as unknown as import("ethers").Provider
       );
 
-      // For nonce === chainNonce, getTransaction should be called (not getTransactionReceipt)
       expect(provider.getTransaction).toHaveBeenCalledWith("0xdropped");
-
-      // Check if we got the expected warning or if tx was reconciled
       const hasDroppedWarning = validation.warnings.some((w) =>
         w.includes("dropped from mempool")
       );
       const hasStillPendingWarning = validation.warnings.some((w) =>
         w.includes("still pending in mempool")
       );
-
-      // Should have either dropped or still pending warning
       expect(
         hasDroppedWarning ||
           hasStillPendingWarning ||
@@ -529,21 +446,17 @@ describe("NonceManager", () => {
   });
 
   describe("DB-aware nonce selection", () => {
-    it("should advance starting nonce past DB pending transactions", async () => {
-      // Arrange: DB has a pending tx at nonce 7, chain says nonce is 5
-      // The new max-nonce query returns [{ maxNonce: 7 }] on first call
+    it("advances starting nonce past DB pending transactions", async () => {
       let selectCallCount = 0;
       mockSelect.mockImplementation(() => {
         selectCallCount += 1;
         if (selectCallCount === 1) {
-          // First call: the Step 2.5 max-nonce query
           return {
             from: vi.fn().mockReturnValue({
               where: vi.fn().mockResolvedValue([{ maxNonce: 7 }]),
             }),
           };
         }
-        // Subsequent calls: validateAndReconcile queries (return empty)
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -564,24 +477,20 @@ describe("NonceManager", () => {
         provider as unknown as import("ethers").Provider
       );
 
-      // max(5, 7+1) = 8
       expect(session.currentNonce).toBe(8);
     });
 
-    it("should use chain nonce when no DB pending rows exist", async () => {
-      // Arrange: DB has no pending transactions (default mock returns empty)
+    it("uses chain nonce when no DB pending rows exist", async () => {
       let selectCallCount = 0;
       mockSelect.mockImplementation(() => {
         selectCallCount += 1;
         if (selectCallCount === 1) {
-          // First call: the Step 2.5 max-nonce query — returns empty (no pending)
           return {
             from: vi.fn().mockReturnValue({
               where: vi.fn().mockResolvedValue([{ maxNonce: null }]),
             }),
           };
         }
-        // Subsequent calls: validateAndReconcile queries
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -602,77 +511,22 @@ describe("NonceManager", () => {
         provider as unknown as import("ethers").Provider
       );
 
-      // No pending transactions — use chain nonce directly
       expect(session.currentNonce).toBe(10);
     });
   });
 
   describe("singleton pattern", () => {
-    it("should return same instance from getNonceManager", () => {
+    it("returns same instance from getNonceManager", () => {
       const manager1 = getNonceManager();
       const manager2 = getNonceManager();
-
       expect(manager1).toBe(manager2);
     });
 
-    it("should return new instance after reset", () => {
+    it("returns new instance after reset", () => {
       const manager1 = getNonceManager();
       resetNonceManager();
       const manager2 = getNonceManager();
-
       expect(manager1).not.toBe(manager2);
-    });
-  });
-
-  describe("lock ID generation", () => {
-    it("should generate consistent lock IDs for same wallet/chain", async () => {
-      const manager = new NonceManager();
-      const provider = createMockProvider();
-
-      // Start two sessions with same wallet/chain
-      const { session: session1 } = await manager.startSession(
-        "0x1234567890123456789012345678901234567890",
-        1,
-        "exec_1",
-        provider as unknown as import("ethers").Provider
-      );
-      await manager.endSession(session1);
-
-      // Reset mock call history
-      mockPostgresQuery.mockClear();
-
-      await manager.startSession(
-        "0x1234567890123456789012345678901234567890",
-        1,
-        "exec_2",
-        provider as unknown as import("ethers").Provider
-      );
-
-      // Both calls should use the same lock ID (same wallet/chain)
-      expect(mockPostgresQuery).toHaveBeenCalled();
-    });
-
-    it("should generate different lock IDs for different chains", async () => {
-      const manager1 = new NonceManager();
-      const manager2 = new NonceManager();
-      const provider = createMockProvider();
-
-      await manager1.startSession(
-        "0x1234567890123456789012345678901234567890",
-        1, // Chain 1
-        "exec_1",
-        provider as unknown as import("ethers").Provider
-      );
-
-      await manager2.startSession(
-        "0x1234567890123456789012345678901234567890",
-        137, // Polygon
-        "exec_2",
-        provider as unknown as import("ethers").Provider
-      );
-
-      // Different chains should both acquire locks
-      expect(mockPostgresQuery).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

The previous nonce manager held a PostgreSQL session-scoped advisory lock on a dedicated `postgres.js` connection. If anything kept that connection alive past the `withNonceSession` finally block (process suspended, async leak, Workflow DevKit durability error), the lock leaked indefinitely. The 60s "stale lock detection" only cleared the `wallet_locks` metadata row — never the advisory lock itself — so the wallet+chain remained wedged with no recovery path short of a database restart. This is the root cause of [GitHub issue #985](https://github.com/KeeperHub/keeperhub/issues/985).

This branch lands four layered fixes — A is the structural change, C/D/E are defense in depth.

## Changes

- **`fix: replace nonce advisory lock with row-based TTL lock`** (commit 1)
  The `wallet_locks` row IS the lock. Acquire is two atomic statements (INSERT ON CONFLICT DO NOTHING; UPDATE WHERE `locked_by IS NULL OR expires_at < NOW()`). `expires_at` TTL (5min default) means a crashed holder cannot wedge the wallet past TTL. Drops `postgres` dependency, dedicated-connection plumbing, and the XOR lock-id scheme. New migration `0060_keep_344_wallet_lock_ttl.sql` adds `expires_at` column.

- **`fix: reaper releases nonce locks for reaped executions`** (commit 2)
  When the reaper marks an execution stale, it now also clears any `wallet_locks` row whose `locked_by` points at that execution. Currently redundant with the 5min TTL but becomes load-bearing if we ever extend TTL or add heartbeat.

- **`feat: add internal wallet-unlock endpoint for ops`** (commit 3)
  `POST /api/internal/wallet-unlock` with `X-Service-Key` auth, body `{walletAddress, chainId}`. Returns `{released, previousHolder}`. Ops escape valve for unwedging users without DB access.

- **`feat: observability for nonce lock failures and takeovers`** (commit 4)
  `acquireLock` failure now flows through `logSystemError(INFRASTRUCTURE, ...)` so it emits a Prometheus metric and Sentry capture. Lock takeover from a non-null prior holder logs a warn with `priorHolder`, `expiredAgoMs`, `newHolder` — the diagnostic signal for the next KEEP-344-class incident.


## Test plan

- [x] `tests/unit/nonce-manager.test.ts` — 19 unit tests covering INSERT path, UPDATE-takeover path, RPC-fail release, max-retries failure with metric assertion, takeover warn log
- [x] `tests/e2e/vitest/nonce-manager.test.ts` — 17 e2e tests against real Postgres (KEEP-344 db), including TTL-based recovery from a wedged lock
- [x] `tests/integration/reaper-route.test.ts` — 13 tests including 2 new ones for the wallet_locks cleanup branch
- [x] `tests/integration/wallet-unlock-route.test.ts` — 10 tests for auth, validation, no-op, success, address normalization, DB error path
- [x] `pnpm check` clean for all touched files
- [x] `pnpm type-check` clean
- [ ] Verify in staging that operating against a wedged wallet via the new endpoint actually clears it
- [ ] Confirm the new `logSystemError` call shows up in Grafana as a `nonce_lock` infrastructure error metric