### PR TITLE
fix: route gas-strategy RPC calls through executeWithFailover

### DIFF
--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -80,7 +80,8 @@ export class EvmChainAdapter implements ChainAdapter {
       estimatedGas,
       this.chainId,
       options.gasOverrides.multiplierOverride,
-      options.gasOverrides.gasLimitOverride
+      options.gasOverrides.gasLimitOverride,
+      options.rpcManager
     );
 
     const tx = await signer.sendTransaction({
@@ -174,7 +175,8 @@ export class EvmChainAdapter implements ChainAdapter {
       estimatedGas,
       this.chainId,
       options.gasOverrides.multiplierOverride,
-      options.gasOverrides.gasLimitOverride
+      options.gasOverrides.gasLimitOverride,
+      options.rpcManager
     );
 
     const tx = await contract[request.functionKey](...request.args, {

--- a/lib/web3/gas-strategy.ts
+++ b/lib/web3/gas-strategy.ts
@@ -13,6 +13,29 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
 import { chains } from "@/lib/db/schema";
+import type { RpcProviderManager } from "@/lib/rpc-provider";
+
+/**
+ * Route an RPC call through the failover-aware RpcProviderManager when one
+ * is supplied; otherwise fall back to the raw provider. Centralised so every
+ * RPC call path in this file has the same behavior — without this helper, a
+ * primary-RPC failure inside fee estimation would not trigger failover even
+ * if every other call in the same workflow does.
+ *
+ * KEEP-344 follow-up: prior to this helper, gas-strategy called the raw
+ * ethers provider directly, so an Infura 402 (or similar) propagated as a
+ * hard failure even when a working fallback was configured.
+ */
+async function runRpc<T>(
+  rpcManager: RpcProviderManager | undefined,
+  provider: ethers.Provider,
+  fn: (provider: ethers.JsonRpcProvider) => Promise<T>
+): Promise<T> {
+  if (rpcManager) {
+    return await rpcManager.executeWithFailover(fn, "read");
+  }
+  return await fn(provider as ethers.JsonRpcProvider);
+}
 
 export type TriggerType = "event" | "webhook" | "scheduled" | "manual";
 
@@ -101,18 +124,18 @@ function parseGwei(gwei: string | number): bigint {
  */
 async function measureVolatility(
   provider: ethers.Provider,
-  blockCount = 40
+  blockCount = 40,
+  rpcManager?: RpcProviderManager
 ): Promise<VolatilityMetrics> {
   try {
-    // Cast to JsonRpcProvider to access send method
-    const jsonRpcProvider = provider as ethers.JsonRpcProvider;
-
     // Fetch fee history for last N blocks
-    const history = await jsonRpcProvider.send("eth_feeHistory", [
-      `0x${blockCount.toString(16)}`,
-      "latest",
-      [], // No percentiles needed, just base fees
-    ]);
+    const history = await runRpc(rpcManager, provider, (p) =>
+      p.send("eth_feeHistory", [
+        `0x${blockCount.toString(16)}`,
+        "latest",
+        [], // No percentiles needed, just base fees
+      ])
+    );
 
     const baseFees = history.baseFeePerGas
       .slice(0, -1) // Last entry is for next block (prediction)
@@ -172,17 +195,17 @@ async function measureVolatility(
 async function getPercentileFees(
   provider: ethers.Provider,
   blockCount: number,
-  percentile: number
+  percentile: number,
+  rpcManager?: RpcProviderManager
 ): Promise<{ baseFee: bigint; priorityFee: bigint }> {
   try {
-    // Cast to JsonRpcProvider to access send method
-    const jsonRpcProvider = provider as ethers.JsonRpcProvider;
-
-    const history = await jsonRpcProvider.send("eth_feeHistory", [
-      `0x${blockCount.toString(16)}`,
-      "latest",
-      [percentile],
-    ]);
+    const history = await runRpc(rpcManager, provider, (p) =>
+      p.send("eth_feeHistory", [
+        `0x${blockCount.toString(16)}`,
+        "latest",
+        [percentile],
+      ])
+    );
 
     // Get latest base fee (for next block)
     const baseFee = BigInt(history.baseFeePerGas.at(-1));
@@ -214,7 +237,7 @@ async function getPercentileFees(
   } catch (error) {
     // Fallback if fee history fails
     console.warn("[GasStrategy] Failed to get percentile fees:", error);
-    const feeData = await provider.getFeeData();
+    const feeData = await runRpc(rpcManager, provider, (p) => p.getFeeData());
     return {
       baseFee: feeData.maxFeePerGas ?? parseGwei("50"),
       priorityFee: feeData.maxPriorityFeePerGas ?? parseGwei("1.5"),
@@ -241,7 +264,8 @@ export class AdaptiveGasStrategy {
     estimatedGas: bigint,
     chainId: number,
     gasLimitMultiplierOverride?: number,
-    gasLimitOverride?: bigint
+    gasLimitOverride?: bigint,
+    rpcManager?: RpcProviderManager
   ): Promise<GasConfig> {
     // Apply chain-specific overrides (from DB with hardcoded fallback)
     const chainConfig = await this.getChainConfig(chainId);
@@ -259,7 +283,8 @@ export class AdaptiveGasStrategy {
     const feeConfig = await this.calculateFees(
       provider,
       triggerType,
-      chainConfig
+      chainConfig,
+      rpcManager
     );
 
     return {
@@ -305,35 +330,38 @@ export class AdaptiveGasStrategy {
   private async calculateFees(
     provider: ethers.Provider,
     triggerType: TriggerType,
-    chainConfig: ChainGasConfig
+    chainConfig: ChainGasConfig,
+    rpcManager?: RpcProviderManager
   ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
     // Time-sensitive triggers always use conservative strategy
     if (this.isTimeSensitive(triggerType)) {
-      return this.getConservativeFees(provider, chainConfig);
+      return this.getConservativeFees(provider, chainConfig, rpcManager);
     }
 
     // Check volatility for scheduled/manual triggers
     const volatility = await measureVolatility(
       provider,
-      this.config.volatilitySampleBlocks
+      this.config.volatilitySampleBlocks,
+      rpcManager
     );
 
     if (volatility.isVolatile) {
       console.log(
         `[GasStrategy] High volatility detected (CV=${volatility.coefficientOfVariation.toFixed(3)}), using conservative fees`
       );
-      return this.getConservativeFees(provider, chainConfig);
+      return this.getConservativeFees(provider, chainConfig, rpcManager);
     }
 
     // Low volatility - use percentile-based estimation
-    return this.getOptimizedFees(provider, chainConfig, volatility);
+    return this.getOptimizedFees(provider, chainConfig, volatility, rpcManager);
   }
 
   private async getConservativeFees(
     provider: ethers.Provider,
-    chainConfig: ChainGasConfig
+    chainConfig: ChainGasConfig,
+    rpcManager?: RpcProviderManager
   ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
-    const feeData = await provider.getFeeData();
+    const feeData = await runRpc(rpcManager, provider, (p) => p.getFeeData());
 
     if (!(feeData.maxFeePerGas && feeData.maxPriorityFeePerGas)) {
       // Fallback for non-EIP-1559 chains (legacy gas price)
@@ -358,7 +386,8 @@ export class AdaptiveGasStrategy {
   private async getOptimizedFees(
     provider: ethers.Provider,
     chainConfig: ChainGasConfig,
-    volatility: VolatilityMetrics
+    volatility: VolatilityMetrics,
+    rpcManager?: RpcProviderManager
   ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
     // Use percentile based on volatility gradient
     const percentile = this.selectPercentile(volatility.coefficientOfVariation);
@@ -366,7 +395,8 @@ export class AdaptiveGasStrategy {
     const { baseFee, priorityFee } = await getPercentileFees(
       provider,
       this.config.volatilitySampleBlocks,
-      percentile
+      percentile,
+      rpcManager
     );
 
     const maxPriorityFeePerGas = this.clampPriorityFee(

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -317,7 +317,10 @@ export async function executeTransaction(
       provider,
       context.triggerType ?? "manual",
       estimatedGas,
-      context.chainId
+      context.chainId,
+      undefined,
+      undefined,
+      context.rpcManager
     );
 
     const txRequest: ethers.TransactionRequest = {
@@ -403,7 +406,10 @@ export async function executeContractTransaction(
       provider as ethers.Provider,
       context.triggerType ?? "manual",
       estimatedGas,
-      context.chainId
+      context.chainId,
+      undefined,
+      undefined,
+      context.rpcManager
     );
 
     const tx = await contract[method](...args, {
@@ -463,11 +469,7 @@ export async function withNonceSession<T>(
   const nonceManager = getNonceManager();
   const rpcManager =
     context.rpcManager ??
-    (await getRpcProviderFromUrls(
-      context.rpcUrl,
-      undefined,
-      context.chainId
-    ));
+    (await getRpcProviderFromUrls(context.rpcUrl, undefined, context.chainId));
   const provider = rpcManager.getProvider();
 
   const { session, validation } = await nonceManager.startSession(

--- a/tests/e2e/vitest/gas-strategy.test.ts
+++ b/tests/e2e/vitest/gas-strategy.test.ts
@@ -26,28 +26,53 @@ import {
 vi.unmock("@/lib/db");
 vi.unmock("server-only");
 
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
+import type { RpcProviderManager } from "@/lib/rpc-provider";
 import { AdaptiveGasStrategy, resetGasStrategy } from "@/lib/web3/gas-strategy";
 
 // Skip if SKIP_INFRA_TESTS is true (no network access)
 const shouldSkip = process.env.SKIP_INFRA_TESTS === "true";
 
-// Real RPC endpoints - resolved from CHAIN_RPC_CONFIG with public fallbacks
-const SEPOLIA_RPC = getRpcUrlByChainId(11_155_111, "primary");
-const BASE_SEPOLIA_RPC = getRpcUrlByChainId(84_532, "primary");
+// Real RPC endpoints — primary + fallback so the failover path is actually
+// exercised. KEEP-344 follow-up: previously these tests bypassed failover
+// entirely (raw JsonRpcProvider), so a 402 from Infura would propagate as a
+// hard failure. With both URLs wired through RpcProviderManager, the same
+// 402 now triggers failover to the secondary.
+const SEPOLIA_PRIMARY = getRpcUrlByChainId(11_155_111, "primary");
+const SEPOLIA_FALLBACK = getRpcUrlByChainId(11_155_111, "fallback");
+const BASE_SEPOLIA_PRIMARY = getRpcUrlByChainId(84_532, "primary");
+const BASE_SEPOLIA_FALLBACK = getRpcUrlByChainId(84_532, "fallback");
 
 describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
   let sepoliaProvider: ethers.JsonRpcProvider;
   let baseSepoliaProvider: ethers.JsonRpcProvider;
+  let sepoliaManager: RpcProviderManager;
+  let baseSepoliaManager: RpcProviderManager;
 
   beforeAll(async () => {
-    // Initialize providers
-    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC);
-    baseSepoliaProvider = new ethers.JsonRpcProvider(BASE_SEPOLIA_RPC);
+    // Initialize providers (used as the raw provider arg) plus the failover
+    // manager (used to actually route RPC calls through executeWithFailover).
+    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_PRIMARY);
+    baseSepoliaProvider = new ethers.JsonRpcProvider(BASE_SEPOLIA_PRIMARY);
 
-    // Verify connectivity
+    sepoliaManager = await getRpcProviderFromUrls(
+      SEPOLIA_PRIMARY,
+      SEPOLIA_FALLBACK,
+      11_155_111,
+      "sepolia"
+    );
+    baseSepoliaManager = await getRpcProviderFromUrls(
+      BASE_SEPOLIA_PRIMARY,
+      BASE_SEPOLIA_FALLBACK,
+      84_532,
+      "base-sepolia"
+    );
+
+    // Verify connectivity (via the manager so a primary 402 still falls
+    // over to the secondary instead of skipping the whole suite).
     try {
-      await sepoliaProvider.getBlockNumber();
+      await sepoliaManager.executeWithFailover((p) => p.getBlockNumber());
     } catch (_error) {
       console.warn("Sepolia RPC not available, some tests may be skipped");
     }
@@ -69,7 +94,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         BigInt(21_000),
-        11_155_111 // Sepolia
+        11_155_111, // Sepolia
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Should return valid gas config
@@ -94,7 +122,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         baseSepoliaProvider,
         "scheduled",
         BigInt(21_000),
-        84_532 // Base Sepolia
+        84_532, // Base Sepolia
+        undefined,
+        undefined,
+        baseSepoliaManager
       );
 
       expect(config.gasLimit).toBeGreaterThan(BigInt(21_000));
@@ -116,7 +147,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         estimatedGas,
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Gas limit should be estimated * multiplier (default 2.0)
@@ -135,14 +169,20 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         BigInt(21_000),
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       const scheduledConfig = await strategy.getGasConfig(
         sepoliaProvider,
         "scheduled",
         BigInt(21_000),
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Manual triggers may use higher percentile fees for faster inclusion
@@ -163,7 +203,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "webhook",
         BigInt(50_000),
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       expect(config.gasLimit).toBeGreaterThan(BigInt(50_000));
@@ -180,7 +223,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "scheduled",
         BigInt(21_000),
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Config should be reasonable for Sepolia
@@ -240,7 +286,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         BigInt(21_000),
-        1 // Mainnet chain ID
+        1, // Mainnet chain ID
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Should apply mainnet gas limit multiplier (2.0 default)
@@ -256,7 +305,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "scheduled",
         BigInt(21_000),
-        42_161 // Arbitrum
+        42_161, // Arbitrum
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Arbitrum has different gas model
@@ -272,7 +324,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         baseSepoliaProvider,
         "manual",
         BigInt(21_000),
-        8453 // Base mainnet
+        8453, // Base mainnet
+        undefined,
+        undefined,
+        baseSepoliaManager
       );
 
       expect(config.gasLimit).toBeGreaterThan(BigInt(21_000));
@@ -288,7 +343,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         BigInt(21_000),
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Default min priority fee is 0.1 gwei
@@ -309,7 +367,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         BigInt(1000),
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Should still apply multiplier
@@ -324,7 +385,10 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
         sepoliaProvider,
         "manual",
         highGas,
-        11_155_111
+        11_155_111,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       // Should apply multiplier even to high estimates
@@ -337,10 +401,16 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
     it("should handle RPC timeout gracefully", async () => {
       const strategy = new AdaptiveGasStrategy();
 
-      // Create a provider with very short timeout
-      const slowProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC, undefined, {
-        staticNetwork: ethers.Network.from(11_155_111),
-      });
+      // Create a provider with very short timeout. Intentionally NOT routed
+      // through the failover manager — this test asserts graceful degradation
+      // in single-provider configurations.
+      const slowProvider = new ethers.JsonRpcProvider(
+        SEPOLIA_PRIMARY,
+        undefined,
+        {
+          staticNetwork: ethers.Network.from(11_155_111),
+        }
+      );
 
       // Should still return a config (may use fallback values)
       const config = await strategy.getGasConfig(
@@ -380,9 +450,16 @@ describe.skipIf(shouldSkip)("Gas Strategy E2E", () => {
 
 describe.skipIf(shouldSkip)("Gas Strategy Real Transaction Estimation", () => {
   let sepoliaProvider: ethers.JsonRpcProvider;
+  let sepoliaManager: RpcProviderManager;
 
-  beforeAll(() => {
-    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC);
+  beforeAll(async () => {
+    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_PRIMARY);
+    sepoliaManager = await getRpcProviderFromUrls(
+      SEPOLIA_PRIMARY,
+      SEPOLIA_FALLBACK,
+      11_155_111,
+      "sepolia"
+    );
   });
 
   beforeEach(() => {
@@ -400,7 +477,10 @@ describe.skipIf(shouldSkip)("Gas Strategy Real Transaction Estimation", () => {
       sepoliaProvider,
       "manual",
       estimatedGas,
-      11_155_111
+      11_155_111,
+      undefined,
+      undefined,
+      sepoliaManager
     );
 
     // Should have buffer for ERC20 transfer
@@ -423,7 +503,10 @@ describe.skipIf(shouldSkip)("Gas Strategy Real Transaction Estimation", () => {
       sepoliaProvider,
       "webhook",
       estimatedGas,
-      11_155_111
+      11_155_111,
+      undefined,
+      undefined,
+      sepoliaManager
     );
 
     expect(config.gasLimit).toBeGreaterThan(estimatedGas);


### PR DESCRIPTION
## Summary

`gas-strategy.ts` called the raw ethers provider directly for fee estimation, bypassing `RpcProviderManager.executeWithFailover` entirely. A primary RPC failure (e.g., Infura `402 Payment Required`) propagated as a hard failure even when a working fallback URL was configured. Surfaced by `tests/e2e/vitest/gas-strategy.test.ts` failing on Base Sepolia with no failover taking place.

This bypass was discovered while reviewing PR #986 (KEEP-344 nonce-lock fixes); fixing it ended up motivating threading `RpcProviderManager` through gas-strategy's API. Splitting it out from #986 because it's a separate bug class and worth landing on its own merit.

## Changes

- **`lib/web3/gas-strategy.ts`** — adds `runRpc(rpcManager, provider, fn)` helper that routes through `executeWithFailover` when a manager is supplied, falling back to raw provider otherwise. Threads optional `rpcManager` through `getGasConfig`, `calculateFees`, `getConservativeFees`, `getOptimizedFees`, `measureVolatility`, `getPercentileFees`. Four direct provider calls now go through the helper.
- **`lib/web3/chain-adapter/evm.ts`** — `executeTransaction` and `executeContractCall` now pass `options.rpcManager` to `getGasConfig`.
- **`lib/web3/transaction-manager.ts`** — `sendTransaction` and `executeContractTransaction` pass `context.rpcManager` to `getGasConfig`.
- **`tests/e2e/vitest/gas-strategy.test.ts`** — constructs real `RpcProviderManager` instances with both primary and fallback URLs for Sepolia and Base Sepolia, threads them through every `getGasConfig` call. Previously failing Base Sepolia tests now recover from Infura 402 via the Alchemy fallback.

## Out of scope

The same failover-bypass pattern exists in two other places that I did NOT touch in this PR:

- `lib/web3/nonce-manager.ts:91` — `provider.getTransactionCount(...)` inside `startSession`
- `lib/web3/chain-adapter/evm.ts:219` — `provider.getBalance(address)`

Worth a follow-up sweep, but neither directly correlates to a known failure today, so I'd rather land this scoped fix and address those separately.

## Test plan

- [x] `pnpm vitest run tests/e2e/vitest/gas-strategy.test.ts` — 18/18 pass, including the previously-failing `should get gas config from Base Sepolia` and `should apply Base config`.
- [x] `pnpm vitest run tests/unit/nonce-manager.test.ts tests/unit/gas-strategy.test.ts tests/integration/wallet-unlock-route.test.ts tests/integration/reaper-route.test.ts tests/e2e/vitest/nonce-manager.test.ts` — 106/106, no regression from the API addition.
- [x] `pnpm check` clean for touched files.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm type-check` clean.
- [ ] Verify in staging that real workflow execution against a chain whose primary RPC is currently flaky still produces a gas config (i.e., failover for fee estimation works end-to-end, not just in tests).