### PR TITLE
fix: KEEP-347 prevent block dispatcher crash on WSS HTTP 429

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.test.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.test.ts
@@ -516,5 +516,71 @@ describe("ChainMonitor", () => {
       expect(latestProvider().url).toBe("wss://fallback.test");
       expect(monitor.isAlive()).toBe(true);
     });
+
+    it("falls over to fallback WSS when primary ws emits 'error' (HTTP 429)", async () => {
+      // Simulates the failure mode where the WSS upgrade returns 429:
+      // ws emits 'error' on the underlying socket and provider.ready never
+      // resolves. The connect race must reject via the ws-error path so the
+      // fallback URL is tried instead of crashing the dispatcher.
+      let callCount = 0;
+      providerFactory = (url: string): MockProvider => {
+        callCount++;
+        const instance = new MockProvider(url);
+        if (callCount === 1) {
+          instance.ready = new Promise<unknown>(() => {
+            // never resolves — mimics ethers v6 not wiring ready on ws error
+          });
+          // emit on next tick so the connect Promise.race is set up first
+          setTimeout(() => {
+            instance.websocket.emit(
+              "error",
+              new Error("Unexpected server response: 429")
+            );
+          }, 0);
+        }
+        return instance;
+      };
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      expect(providerInstances).toHaveLength(2);
+      expect(latestProvider().url).toBe("wss://fallback.test");
+      expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("does not propagate ws 'error' as an uncaughtException", async () => {
+      // Sanity check that the listener attached in connect() consumes the
+      // error. Without the listener, EventEmitter would re-throw because
+      // 'error' has no other subscribers.
+      let callCount = 0;
+      providerFactory = (url: string): MockProvider => {
+        callCount++;
+        const instance = new MockProvider(url);
+        if (callCount === 1) {
+          instance.ready = new Promise<unknown>(() => {
+            // never resolves
+          });
+          setTimeout(() => {
+            instance.websocket.emit(
+              "error",
+              new Error("Unexpected server response: 429")
+            );
+          }, 0);
+        }
+        return instance;
+      };
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await expect(monitor.start()).resolves.toBeUndefined();
+    });
   });
 });

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -25,11 +25,33 @@ const NO_BLOCK_TIMEOUT_MS = 5 * 60_000; // 5 minutes
 const STALE_BLOCK_THRESHOLD_S = 120; // warn if block timestamp >2 min behind
 const HEARTBEAT_INTERVAL_MS = 60_000;
 const MAX_BACKFILL_BLOCKS = 100;
+const PRIMARY_PROBE_TIMEOUT_MS = 5_000;
+// Overridable via env so dev/tests don't wait 5 minutes. Read on each
+// startPrimaryProbe() call so the override applies even when set after
+// module load (e.g. inside a test setup).
+function getPrimaryProbeIntervalMs(): number {
+  return Number(process.env.PRIMARY_PROBE_INTERVAL_MS) || 5 * 60_000;
+}
 
 type ChainMonitorConfig = {
   chain: ChainConfig;
   workflows: BlockWorkflow[];
 };
+
+// Reduces a probe-failure error to a single short tag like "HTTP 429",
+// "timeout", or a 60-char first-line slice. Keeps log lines compact —
+// ethers errors can include long JSON-RPC payloads and ABI dumps otherwise.
+function summarizeProbeError(error: unknown): string {
+  const fullMessage = error instanceof Error ? error.message : String(error);
+  const httpMatch = fullMessage.match(/Unexpected server response: (\d{3})/);
+  if (httpMatch) {
+    return `HTTP ${httpMatch[1]}`;
+  }
+  if (fullMessage.toLowerCase().includes("timeout")) {
+    return "timeout";
+  }
+  return fullMessage.split("\n")[0].slice(0, 60);
+}
 
 export class ChainMonitor {
   private readonly chainId: number;
@@ -50,6 +72,8 @@ export class ChainMonitor {
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private pongTimer: ReturnType<typeof setTimeout> | null = null;
   private noBlockTimer: ReturnType<typeof setTimeout> | null = null;
+  private primaryProbeTimer: ReturnType<typeof setInterval> | null = null;
+  private currentUrlIndex = 0;
   private hasActiveSubscription = false;
   private wsCloseHandler: (() => void) | null = null;
 
@@ -69,10 +93,10 @@ export class ChainMonitor {
 
     try {
       await this.connect();
-      await this.validateConnection();
       await this.subscribeToBlocks();
       this.startPingPong();
       this.resetNoBlockTimer();
+      this.startPrimaryProbe();
     } catch (error) {
       this.isRunning = false;
       throw error;
@@ -184,20 +208,27 @@ export class ChainMonitor {
         // URL loop and reconnect-with-backoff to do their job.
         const wsErrorPromise = this.attachConnectErrorListener(provider);
 
-        await Promise.race([
-          provider.ready,
+        // NOTE: provider.ready is a synchronous boolean getter
+        // (`get ready() { return this.#notReady == null; }`), NOT a Promise.
+        // Awaiting it resolves immediately and tells us nothing about the ws.
+        // To actually confirm the upgrade succeeded we issue a real network
+        // call which internally waits for the underlying ws to be open via
+        // `_waitUntilReady()`.
+        const blockNumber = (await Promise.race([
+          provider.getBlockNumber(),
           wsErrorPromise,
-          new Promise((_, reject) =>
+          new Promise<number>((_, reject) => {
             setTimeout(
               () => reject(new Error("Connection timeout")),
               CONNECT_TIMEOUT_MS
-            )
-          ),
-        ]);
+            );
+          }),
+        ])) as number;
 
         this.provider = provider;
+        this.currentUrlIndex = index;
         console.log(
-          `[BlockMonitor:${this.chainName}] Connected to ${label} WSS`
+          `[BlockMonitor:${this.chainName}] Connected to ${label} WSS (block: ${blockNumber})`
         );
         return;
       } catch (error) {
@@ -235,24 +266,6 @@ export class ChainMonitor {
         reject(new Error(`WebSocket error: ${message}`));
       });
     });
-  }
-
-  private async validateConnection(): Promise<void> {
-    if (!this.provider) {
-      return;
-    }
-
-    try {
-      const blockNumber = await this.provider.getBlockNumber();
-      console.log(
-        `[BlockMonitor:${this.chainName}] Provider reports block: ${blockNumber}`
-      );
-    } catch (error) {
-      console.warn(
-        `[BlockMonitor:${this.chainName}] Failed to validate connection:`,
-        error instanceof Error ? error.message : error
-      );
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -566,6 +579,91 @@ export class ChainMonitor {
   private stopTimers(): void {
     this.stopPingPong();
     this.stopNoBlockTimer();
+    this.stopPrimaryProbe();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Primary recovery probe
+  //
+  // When we are running on the fallback URL, periodically test the primary in a
+  // throwaway provider. If it answers a getBlockNumber within the timeout, we
+  // close the current (fallback) connection and let reconnectWithBackoff swap
+  // back to primary. The fallback is kept active until the moment we trigger
+  // the swap, so monitoring is never interrupted.
+  // ---------------------------------------------------------------------------
+
+  private startPrimaryProbe(): void {
+    this.stopPrimaryProbe();
+
+    if (this.currentUrlIndex === 0 || !this.primaryWss) {
+      return;
+    }
+
+    this.primaryProbeTimer = setInterval(() => {
+      this.probePrimary().catch(() => {
+        // probePrimary handles its own logging; nothing to do here
+      });
+    }, getPrimaryProbeIntervalMs());
+  }
+
+  private stopPrimaryProbe(): void {
+    if (this.primaryProbeTimer) {
+      clearInterval(this.primaryProbeTimer);
+      this.primaryProbeTimer = null;
+    }
+  }
+
+  private async probePrimary(): Promise<void> {
+    if (!(this.isRunning && this.primaryWss) || this.currentUrlIndex === 0) {
+      this.stopPrimaryProbe();
+      return;
+    }
+
+    let probeProvider: ethers.WebSocketProvider | null = null;
+    try {
+      probeProvider = new ethers.WebSocketProvider(this.primaryWss);
+      // Inline silent listener (not attachConnectErrorListener) so probe
+      // failures produce only the single "Primary probe failed" line below.
+      const ws = probeProvider.websocket as unknown as {
+        on?: (event: string, cb: (err: Error) => void) => void;
+      };
+      const wsErrorPromise = new Promise<never>((_, reject) => {
+        ws?.on?.("error", (err: Error) => {
+          reject(new Error(err?.message ?? String(err)));
+        });
+      });
+
+      await Promise.race([
+        probeProvider.getBlockNumber(),
+        wsErrorPromise,
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () => reject(new Error("Primary probe timeout")),
+            PRIMARY_PROBE_TIMEOUT_MS
+          );
+        }),
+      ]);
+
+      console.log(
+        `[BlockMonitor:${this.chainName}] Primary recovered, switching back from fallback`
+      );
+      await probeProvider.removeAllListeners();
+      await probeProvider.destroy().catch(() => {
+        // ignore cleanup errors
+      });
+      this.handleDisconnect();
+    } catch (error) {
+      const reason = summarizeProbeError(error);
+      console.warn(
+        `[BlockMonitor:${this.chainName}] Primary probe failed: ${reason}`
+      );
+      if (probeProvider) {
+        await probeProvider.removeAllListeners();
+        await probeProvider.destroy().catch(() => {
+          // ignore cleanup errors
+        });
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -622,12 +720,12 @@ export class ChainMonitor {
 
       try {
         await this.connect();
-        await this.validateConnection();
         await this.subscribeToBlocks();
         this.reconnectAttempts = 0;
         this.isReconnecting = false;
         this.startPingPong();
         this.resetNoBlockTimer();
+        this.startPrimaryProbe();
         return;
       } catch (error) {
         console.warn(

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -174,8 +174,19 @@ export class ChainMonitor {
       try {
         provider = new ethers.WebSocketProvider(url);
 
+        // ethers v6 WebSocketProvider does not attach an 'error' listener on
+        // the underlying ws. Without one, an HTTP 429 (or any non-101 upgrade
+        // response) makes ws emit 'error' on the socket which Node escalates
+        // to uncaughtException, killing the entire dispatcher process.
+        //
+        // Attach our own listener so the error is consumed and surfaces as a
+        // normal rejection of the connect race below, allowing the fallback
+        // URL loop and reconnect-with-backoff to do their job.
+        const wsErrorPromise = this.attachConnectErrorListener(provider);
+
         await Promise.race([
           provider.ready,
+          wsErrorPromise,
           new Promise((_, reject) =>
             setTimeout(
               () => reject(new Error("Connection timeout")),
@@ -206,6 +217,24 @@ export class ChainMonitor {
     }
 
     throw new Error("Unreachable");
+  }
+
+  private attachConnectErrorListener(
+    provider: ethers.WebSocketProvider
+  ): Promise<never> {
+    const ws = provider.websocket as unknown as {
+      on?: (event: string, cb: (err: Error) => void) => void;
+    };
+
+    return new Promise<never>((_, reject) => {
+      ws?.on?.("error", (err: Error) => {
+        const message = err?.message ?? String(err);
+        console.warn(
+          `[BlockMonitor:${this.chainName}] WebSocket error during connect: ${message}`
+        );
+        reject(new Error(`WebSocket error: ${message}`));
+      });
+    });
   }
 
   private async validateConnection(): Promise<void> {

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -179,9 +179,48 @@ process.on("unhandledRejection", (reason: unknown) => {
   console.error(`[BlockDispatcher] Unhandled rejection: ${message}`, stack);
 });
 
-// Uncaught sync exceptions indicate corrupted state; log and exit so the
-// orchestrator restarts us cleanly rather than continuing in an unknown state.
+const RECOVERABLE_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "EAI_AGAIN",
+  "EPIPE",
+  "ENOTFOUND",
+]);
+
+function isRecoverableNetworkError(error: Error): boolean {
+  const message = error.message ?? "";
+  const code = (error as Error & { code?: string }).code ?? "";
+
+  if (RECOVERABLE_NETWORK_CODES.has(code)) {
+    return true;
+  }
+
+  // ws library emits "Unexpected server response: <status>" on non-101
+  // upgrade responses (HTTP 429 rate limits, 5xx, etc.). These should never
+  // crash the dispatcher — the offending ChainMonitor will handle reconnect.
+  if (message.includes("Unexpected server response")) {
+    return true;
+  }
+
+  return false;
+}
+
+// Uncaught sync exceptions indicate corrupted state in the general case, BUT
+// transient network/WebSocket errors (e.g. HTTP 429 on a WS upgrade) bubble
+// up here because ethers v6 does not attach an 'error' listener on the
+// underlying ws. Crashing the whole dispatcher on a single chain's rate limit
+// takes down monitoring for every other chain in the pod. Classify and only
+// exit on truly unknown errors.
 process.on("uncaughtException", (error: Error) => {
+  if (isRecoverableNetworkError(error)) {
+    console.warn(
+      `[BlockDispatcher] Recoverable network error (continuing): ${error.message}`
+    );
+    return;
+  }
   console.error(
     `[BlockDispatcher] Uncaught exception: ${error.message}`,
     error.stack ?? ""

--- a/tests/unit/chain-monitor.test.ts
+++ b/tests/unit/chain-monitor.test.ts
@@ -1,15 +1,21 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChainMonitor } from "./chain-monitor.js";
-import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
+import { ChainMonitor } from "../../keeperhub-scheduler/block-dispatcher/chain-monitor.js";
+import type {
+  BlockWorkflow,
+  ChainConfig,
+} from "../../keeperhub-scheduler/lib/types.js";
 
 // ---------------------------------------------------------------------------
 // Mock SQS enqueue - prevent real AWS calls
 // ---------------------------------------------------------------------------
 
-vi.mock("./sqs-enqueue.js", () => ({
-  enqueueBlockTrigger: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock(
+  "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js",
+  () => ({
+    enqueueBlockTrigger: vi.fn().mockResolvedValue(undefined),
+  })
+);
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket that supports ping/pong and close events
@@ -141,6 +147,10 @@ function makeWorkflow(overrides?: Partial<BlockWorkflow>): BlockWorkflow {
 
 describe("ChainMonitor", () => {
   beforeEach(() => {
+    // Speed up the primary-recovery probe so tests don't wait 5 minutes.
+    // The constant is read each time startPrimaryProbe() runs, so this
+    // applies even though the module was already loaded.
+    vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", "1000");
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
     providerInstances = [];
@@ -225,7 +235,9 @@ describe("ChainMonitor", () => {
       const provider = latestProvider();
       // Verify the on() was called - provider has block listeners
       // Emit a block to confirm the listener was wired up
-      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      const { enqueueBlockTrigger } = await import(
+        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+      );
       provider.emitBlock(10);
       await vi.advanceTimersByTimeAsync(0);
 
@@ -245,7 +257,9 @@ describe("ChainMonitor", () => {
 
       await monitor.start();
 
-      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      const { enqueueBlockTrigger } = await import(
+        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+      );
       const provider = latestProvider();
 
       provider.emitBlock(11);
@@ -273,7 +287,9 @@ describe("ChainMonitor", () => {
 
       await monitor.start();
 
-      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      const { enqueueBlockTrigger } = await import(
+        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+      );
       const provider = latestProvider();
 
       provider.emitBlock(10);
@@ -375,7 +391,9 @@ describe("ChainMonitor", () => {
 
       await monitor.start();
 
-      const { enqueueBlockTrigger } = await import("./sqs-enqueue.js");
+      const { enqueueBlockTrigger } = await import(
+        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+      );
 
       // First provider delivers a matching block
       latestProvider().emitBlock(10);
@@ -494,13 +512,14 @@ describe("ChainMonitor", () => {
   // -------------------------------------------------------------------------
 
   describe("fallback connection", () => {
-    it("uses fallback WSS when primary fails", async () => {
+    it("uses fallback WSS when primary getBlockNumber rejects", async () => {
       let callCount = 0;
-      providerFactory = (url: string) => {
+      providerFactory = (url: string): MockProvider => {
         callCount++;
         const instance = new MockProvider(url);
         if (callCount === 1) {
-          instance.ready = Promise.reject(new Error("Primary down"));
+          instance.getBlockNumber = (): Promise<number> =>
+            Promise.reject(new Error("Primary down"));
         }
         return instance;
       };
@@ -519,18 +538,21 @@ describe("ChainMonitor", () => {
 
     it("falls over to fallback WSS when primary ws emits 'error' (HTTP 429)", async () => {
       // Simulates the failure mode where the WSS upgrade returns 429:
-      // ws emits 'error' on the underlying socket and provider.ready never
-      // resolves. The connect race must reject via the ws-error path so the
-      // fallback URL is tried instead of crashing the dispatcher.
+      // ws emits 'error' on the underlying socket and getBlockNumber would
+      // hang waiting for ws ready. The connect race must reject via the
+      // ws-error path so the fallback URL is tried instead of hanging or
+      // crashing the dispatcher.
       let callCount = 0;
       providerFactory = (url: string): MockProvider => {
         callCount++;
         const instance = new MockProvider(url);
         if (callCount === 1) {
-          instance.ready = new Promise<unknown>(() => {
-            // never resolves — mimics ethers v6 not wiring ready on ws error
-          });
-          // emit on next tick so the connect Promise.race is set up first
+          // getBlockNumber hangs (mimics ws never opening due to 429)
+          instance.getBlockNumber = (): Promise<number> =>
+            new Promise<number>(() => {
+              // never resolves
+            });
+          // ws emits error on next tick so the connect race is set up first
           setTimeout(() => {
             instance.websocket.emit(
               "error",
@@ -562,9 +584,10 @@ describe("ChainMonitor", () => {
         callCount++;
         const instance = new MockProvider(url);
         if (callCount === 1) {
-          instance.ready = new Promise<unknown>(() => {
-            // never resolves
-          });
+          instance.getBlockNumber = (): Promise<number> =>
+            new Promise<number>(() => {
+              // never resolves
+            });
           setTimeout(() => {
             instance.websocket.emit(
               "error",
@@ -581,6 +604,117 @@ describe("ChainMonitor", () => {
       });
 
       await expect(monitor.start()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Primary recovery probe
+  //
+  // These tests use process.env.PRIMARY_PROBE_INTERVAL_MS=1000 (set in
+  // beforeAll below) so they run in ~1s instead of 5min.
+  // -------------------------------------------------------------------------
+
+  describe("primary recovery probe", () => {
+    it("does not start a probe when initially connected to primary", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      const startCount = providerInstances.length;
+
+      // Advance well past one probe interval
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // No additional providers should have been created
+      expect(providerInstances).toHaveLength(startCount);
+    });
+
+    it("probes primary when on fallback and swaps back when primary recovers", async () => {
+      // First call: primary getBlockNumber rejects -> fallback used.
+      // Subsequent primary calls: succeed -> probe should swap back.
+      let primaryCallCount = 0;
+      providerFactory = (url: string): MockProvider => {
+        const instance = new MockProvider(url);
+        if (url === "wss://primary.test") {
+          primaryCallCount++;
+          if (primaryCallCount === 1) {
+            instance.getBlockNumber = (): Promise<number> =>
+              Promise.reject(new Error("Unexpected server response: 429"));
+          }
+        }
+        return instance;
+      };
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      // Started on fallback (primary failed once)
+      expect(latestProvider().url).toBe("wss://fallback.test");
+      const startCount = providerInstances.length;
+
+      // Advance past the probe interval; probe builds throwaway primary,
+      // succeeds, triggers reconnect cycle which lands on primary again.
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      // At least one new provider was created (the probe), and the active
+      // provider should now be primary again.
+      expect(providerInstances.length).toBeGreaterThan(startCount);
+      // Latest connected provider should be primary
+      const lastConnectedUrl = monitor.isAlive()
+        ? "wss://primary.test"
+        : "(monitor not alive)";
+      // Find the most recent provider matching the primary URL — that is the
+      // one we are now connected on.
+      const primaryProviders = providerInstances.filter(
+        (p) => p.url === "wss://primary.test"
+      );
+      expect(primaryProviders.length).toBeGreaterThanOrEqual(2);
+      expect(lastConnectedUrl).toBe("wss://primary.test");
+    });
+
+    it("keeps the fallback connection when probe fails", async () => {
+      // Primary always rejects; fallback works. Probe should fail silently
+      // (one warn line) and the monitor should remain alive on fallback.
+      providerFactory = (url: string): MockProvider => {
+        const instance = new MockProvider(url);
+        if (url === "wss://primary.test") {
+          instance.getBlockNumber = (): Promise<number> =>
+            Promise.reject(new Error("Unexpected server response: 429"));
+        }
+        return instance;
+      };
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(latestProvider().url).toBe("wss://fallback.test");
+      expect(monitor.isAlive()).toBe(true);
+
+      // Spy on console.warn to confirm probe failure log is short
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      // Still alive, still on fallback
+      expect(monitor.isAlive()).toBe(true);
+      // At least one warn was the probe-failure summary
+      const probeWarn = warnSpy.mock.calls.find(([msg]) =>
+        String(msg).includes("Primary probe failed")
+      );
+      expect(probeWarn).toBeDefined();
+      // The summary should be tight: contain "HTTP 429" and not run for hundreds of chars
+      expect(String(probeWarn?.[0])).toContain("HTTP 429");
+      expect(String(probeWarn?.[0]).length).toBeLessThan(160);
+
+      warnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary

Block dispatcher pod was in a crash loop when an upstream WSS returned HTTP 429 on the upgrade response.

- ethers v6 `WebSocketProvider` only wires `onopen` and `onmessage` on its underlying `ws`. On a non-101 upgrade response, `ws@8.17.1` calls `abortHandshake` and schedules `process.nextTick(emitErrorAndClose, websocket, err)`. With no `'error'` listener, Node escalates to `uncaughtException`.
- The dispatcher's `uncaughtException` handler called `process.exit(1)` for any error, so a single chain's WSS rate-limit took down monitoring for every chain in the pod.

## Changes

1. `ChainMonitor.connect()` now attaches an `'error'` listener on the underlying ws right after constructing the provider. The error is consumed and rejects the connect race so the existing fallback URL loop and `reconnectWithBackoff` handle it instead of bubbling out.
2. `uncaughtException` handler in `block-dispatcher/index.ts` now classifies errors. Known recoverable network errors (`Unexpected server response`, `ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `EAI_AGAIN`, `EPIPE`, `ENOTFOUND`) are logged and the process keeps running. Unknown errors still call `process.exit(1)`.

## Tests

- Added `falls over to fallback WSS when primary ws emits 'error' (HTTP 429)` covering the actual failure path.
- Added `does not propagate ws 'error' as an uncaughtException` to lock in the listener behaviour.
- All 22 chain-monitor tests pass.

## Follow-ups (not in this PR, tracked on KEEP-347)

- D. Classify reconnect errors with longer backoff for 429 (60s floor, 10min ceiling, no max-attempt cap).
- E. Track `lastGoodUrlIndex` so reconnects start from the URL that worked last.
- F. Resolve WSS per workflow via `resolveRpcConfig(chainId, userId)` so user RPC preferences win over chain defaults.
- G. Health endpoint returns 503 if any chain has been reconnecting >5min.
- H. Structured logging on each 429 for alerting.