### PR TITLE
fix: KEEP-348 reconcile future-nonce pending txs against mempool

### DIFF
--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -93,7 +93,17 @@ export class NonceManager {
         "pending"
       );
 
-      // Advance past any in-flight nonces tracked in the DB
+      // Reconcile pending rows against chain state BEFORE computing safeNonce
+      // so future-nonce phantom rows (broadcast failed / evicted from mempool)
+      // don't poison the max-nonce read below and permanently widen the gap.
+      const validation = await this.validateAndReconcile(
+        normalizedAddress,
+        chainId,
+        chainNonce,
+        provider
+      );
+
+      // Advance past any in-flight nonces still pending after reconciliation
       const maxDbPending = await db
         .select({ maxNonce: sql<number>`max(${pendingTransactions.nonce})` })
         .from(pendingTransactions)
@@ -109,13 +119,6 @@ export class NonceManager {
         maxPendingNonce === null
           ? chainNonce
           : Math.max(chainNonce, maxPendingNonce + 1);
-
-      const validation = await this.validateAndReconcile(
-        normalizedAddress,
-        chainId,
-        chainNonce,
-        provider
-      );
 
       const session: NonceSession = {
         walletAddress: normalizedAddress,
@@ -228,9 +231,33 @@ export class NonceManager {
           reconciledCount += 1;
         }
       } else {
-        warnings.push(
-          `Found pending tx with future nonce: ${tx.nonce} > chain nonce ${chainNonce}`
-        );
+        // tx.nonce > chainNonce: row claims a future nonce. If the tx is no
+        // longer in the mempool (broadcast failed / evicted), reap it so the
+        // gap with chainNonce doesn't permanently wedge nonce selection.
+        const mempoolTx = await provider.getTransaction(tx.txHash);
+
+        if (mempoolTx) {
+          warnings.push(
+            `Future-nonce tx ${tx.txHash} (nonce ${tx.nonce} > chain nonce ${chainNonce}) ` +
+              "still in mempool, queued behind predecessors"
+          );
+        } else {
+          await db
+            .update(pendingTransactions)
+            .set({ status: "dropped" })
+            .where(
+              and(
+                eq(pendingTransactions.walletAddress, tx.walletAddress),
+                eq(pendingTransactions.chainId, tx.chainId),
+                eq(pendingTransactions.nonce, tx.nonce)
+              )
+            );
+          warnings.push(
+            `Future-nonce tx ${tx.txHash} (nonce ${tx.nonce} > chain nonce ${chainNonce}) ` +
+              "not in mempool, marked dropped"
+          );
+          reconciledCount += 1;
+        }
       }
     }
 

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -519,6 +519,87 @@ describe("NonceManager", () => {
           validation.reconciledCount > 0
       ).toBe(true);
     });
+
+    it("marks future-nonce row dropped when not in mempool (KEEP-348)", async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([
+              {
+                walletAddress: "0x1234567890123456789012345678901234567890",
+                chainId: 1,
+                nonce: 3,
+                txHash: "0xfuturedropped",
+                status: "pending",
+              },
+            ]),
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const manager = new NonceManager();
+      const provider = {
+        getTransactionCount: vi.fn().mockResolvedValue(0),
+        getTransactionReceipt: vi.fn().mockResolvedValue(null),
+        getTransaction: vi.fn().mockResolvedValue(null),
+      };
+
+      const { validation } = await manager.startSession(
+        "0x1234567890123456789012345678901234567890",
+        1,
+        "exec_future_dropped",
+        provider as unknown as import("ethers").Provider
+      );
+
+      expect(provider.getTransaction).toHaveBeenCalledWith("0xfuturedropped");
+      expect(mockUpdate).toHaveBeenCalled();
+      expect(validation.reconciledCount).toBe(1);
+      const hasDroppedWarning = validation.warnings.some((w) =>
+        w.includes("not in mempool, marked dropped")
+      );
+      expect(hasDroppedWarning).toBe(true);
+    });
+
+    it("keeps future-nonce row pending when still in mempool (KEEP-348)", async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([
+              {
+                walletAddress: "0x1234567890123456789012345678901234567890",
+                chainId: 1,
+                nonce: 3,
+                txHash: "0xfuturequeued",
+                status: "pending",
+              },
+            ]),
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const manager = new NonceManager();
+      const provider = {
+        getTransactionCount: vi.fn().mockResolvedValue(0),
+        getTransactionReceipt: vi.fn().mockResolvedValue(null),
+        getTransaction: vi.fn().mockResolvedValue({ hash: "0xfuturequeued" }),
+      };
+
+      const { validation } = await manager.startSession(
+        "0x1234567890123456789012345678901234567890",
+        1,
+        "exec_future_queued",
+        provider as unknown as import("ethers").Provider
+      );
+
+      expect(provider.getTransaction).toHaveBeenCalledWith("0xfuturequeued");
+      expect(validation.reconciledCount).toBe(0);
+      const hasQueuedWarning = validation.warnings.some((w) =>
+        w.includes("queued behind predecessors")
+      );
+      expect(hasQueuedWarning).toBe(true);
+    });
   });
 
   describe("DB-aware nonce selection", () => {
@@ -526,7 +607,9 @@ describe("NonceManager", () => {
       let selectCallCount = 0;
       mockSelect.mockImplementation(() => {
         selectCallCount += 1;
-        if (selectCallCount === 1) {
+        // After KEEP-348 reorder: validateAndReconcile runs first (calls 1 + 2),
+        // then the maxNonce query (call 3).
+        if (selectCallCount === 3) {
           return {
             from: vi.fn().mockReturnValue({
               where: vi.fn().mockResolvedValue([{ maxNonce: 7 }]),
@@ -560,7 +643,7 @@ describe("NonceManager", () => {
       let selectCallCount = 0;
       mockSelect.mockImplementation(() => {
         selectCallCount += 1;
-        if (selectCallCount === 1) {
+        if (selectCallCount === 3) {
           return {
             from: vi.fn().mockReturnValue({
               where: vi.fn().mockResolvedValue([{ maxNonce: null }]),
@@ -588,6 +671,69 @@ describe("NonceManager", () => {
       );
 
       expect(session.currentNonce).toBe(10);
+    });
+
+    it("recovers from future-nonce phantom rows after reconcile (KEEP-348)", async () => {
+      // Reproduces issue #985: chainNonce=0, DB has phantom pending nonces 1-4.
+      // After reconcile (mempool returns null for all), max(pending) returns
+      // null and safeNonce collapses back to chainNonce=0.
+      let selectCallCount = 0;
+      mockSelect.mockImplementation(() => {
+        selectCallCount += 1;
+        if (selectCallCount === 1) {
+          // validateAndReconcile pending-rows fetch
+          return {
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockResolvedValue(
+                  [1, 2, 3, 4].map((n) => ({
+                    walletAddress: "0x1234567890123456789012345678901234567890",
+                    chainId: 8453,
+                    nonce: n,
+                    txHash: `0xphantom${n}`,
+                    status: "pending",
+                  }))
+                ),
+                limit: vi.fn().mockResolvedValue([]),
+              }),
+            }),
+          };
+        }
+        if (selectCallCount === 3) {
+          // maxNonce query, AFTER reconcile would have dropped all phantoms
+          return {
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ maxNonce: null }]),
+            }),
+          };
+        }
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([]),
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        };
+      });
+
+      const manager = new NonceManager();
+      const provider = {
+        getTransactionCount: vi.fn().mockResolvedValue(0),
+        getTransactionReceipt: vi.fn().mockResolvedValue(null),
+        getTransaction: vi.fn().mockResolvedValue(null),
+      };
+
+      const { session, validation } = await manager.startSession(
+        "0x1234567890123456789012345678901234567890",
+        8453,
+        "exec_recover",
+        provider as unknown as import("ethers").Provider
+      );
+
+      expect(session.currentNonce).toBe(0);
+      expect(validation.reconciledCount).toBe(4);
+      expect(provider.getTransaction).toHaveBeenCalledTimes(4);
     });
   });
 


### PR DESCRIPTION
## Summary

- `validateAndReconcile` in `lib/web3/nonce-manager.ts` now reaps `pending_transactions` rows whose nonce exceeds the chain nonce when the tx hash is no longer in the mempool. Previously the `> chainNonce` branch only logged a warning, so phantom rows survived forever.
- `startSession` now runs the reconciler **before** reading `max(pending.nonce)`. Without the reorder a wallet that was already trapped by a failed broadcast would still allocate the bad nonce on the first run after deploy.

## Background

After KEEP-344 (PR #986) shipped the row-based wallet lock with TTL, GitHub issue #985 reported that credentialed writes against `0x5623d4a6a316cf9b16ff92808e3931e17ccb960c` on Base 8453 were still failing with `Step did not record completion` after about five minutes per attempt. Inspection of prod showed the wallet had four `pending_transactions` rows at nonces 1-4 while `eth_getTransactionCount` returned 0 — none of them were on chain. Each retry was selecting `safeNonce = max(pending) + 1`, signing a far-future-nonce tx that ethers happily broadcast (the RPC accepts queued nonces), but Base never mined the new tx because predecessors did not exist anywhere. `tx.wait()` blocked until the workflow SDK timed out, the lock TTL released cleanly per KEEP-344, and the next attempt did the same thing one nonce higher.

The lock layer was healthy. The bug lived in the pending-transactions layer.

## Why both changes are needed

The `<` and `===` branches of the reconciler do real reconciliation work; the `>` branch was a no-op. Marking absent future-nonce rows as `dropped` is the symmetric fix.

The reorder is required for self-healing. With the original ordering `max(pending.nonce)` was computed before the reconciler ran, so even after the branch fix a wedged wallet would re-wedge on its first post-deploy run. After the reorder the reconciler drops the phantoms first, the `max()` query then returns null, `safeNonce` collapses back to `chainNonce`, and the broadcast goes out at the correct nonce.

## Scope

Single file change in production logic. Affects every credentialed write across web3 (`approve-token`, `transfer-funds`, `transfer-token`, `write-contract`), protocol writes (`protocol-write`), and `app/api/user/wallet/withdraw`, since they all flow through `nonceManager.startSession` -> `getNextNonce`. EVM-chain-agnostic; non-EVM chains have their own adapter and were never affected.

## Out of scope

- Recovery of trapped Base mainnet wallet `0x5623...` for the original reporter — self-heals on next workflow attempt after deploy.
- `tx.wait()` lacks an explicit timeout, so any other class of unminable broadcast (gas underpricing, mempool eviction) still produces the same `Step did not record completion` symptom. Tracked separately.
- `await provider.ready` misuse in `keeperhub-events/event-tracker` (read path; cannot cause this symptom). Tracked separately.

## Linear

KEEP-348