### PR TITLE
fix: KEEP-348 align transaction-flow e2e mock with reordered reconciler

### DIFF
--- a/tests/e2e/vitest/transaction-flow.test.ts
+++ b/tests/e2e/vitest/transaction-flow.test.ts
@@ -473,11 +473,19 @@ describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
       // This test verifies lock tracking and sequential session management.
 
       const manager = new NonceManager();
+      const wf1TxHash = `0x${"wf1tx".repeat(12)}abc`;
 
+      // After KEEP-348, validateAndReconcile runs before max(pending) is read.
+      // The recorded tx at nonce 40 is "still pending in mempool" for the
+      // duration of this test, so getTransaction must return a truthy response
+      // for that hash. Otherwise the reconciler would correctly mark the row
+      // dropped (matching its actual chain state) and workflow2 would reuse
+      // nonce 40 instead of advancing to 41.
       const mockProvider = {
         getTransactionCount: async () => 40,
         getTransactionReceipt: async () => null,
-        getTransaction: async () => null,
+        getTransaction: async (hash: string) =>
+          hash === wf1TxHash ? { hash } : null,
       };
 
       // First workflow
@@ -506,12 +514,7 @@ describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
       expect(nonce1).toBe(40);
 
       // Record transaction
-      await manager.recordTransaction(
-        session1,
-        nonce1,
-        `0x${"wf1tx".repeat(12)}abc`,
-        "workflow1"
-      );
+      await manager.recordTransaction(session1, nonce1, wf1TxHash, "workflow1");
 
       // End first workflow
       await manager.endSession(session1);


### PR DESCRIPTION
## Summary

Fixes the `Sequential Workflow Management > should manage sequential workflows correctly` test in `tests/e2e/vitest/transaction-flow.test.ts`, which broke on staging after PR #990 merged.

## Why it broke

The test sets up workflow1 to record a pending tx at nonce 40 with `chainNonce=40`, ends the session, then expects workflow2's session to allocate nonce 41 via the DB-aware nonce advancement path (`max(chainNonce, maxPendingDbNonce + 1)`).

The mock provider returned `null` from `getTransaction`. Under the pre-#990 ordering this never mattered, because `max(pending.nonce)` was read before `validateAndReconcile` ran. After #990, reconcile runs first, so the `nonce === chainNonce` branch sees the pending row, calls `getTransaction(txHash)`, gets `null`, and correctly marks the row dropped — making `safeNonce` collapse back to `chainNonce` 40.

The mock state was internally inconsistent: claiming `chainNonce=40` and "this tx is gone from the mempool" simultaneously means the tx was either replaced or evicted, in which case the test's premise (advance to 41 because of a still-pending row) doesn't hold.

## Fix

The mock now returns a truthy `TransactionResponse` only for the workflow1 tx hash. That matches the test's actual intent — the tx is still pending in the mempool, the row is correctly left as pending, and DB-aware nonce selection advances to 41 as the assertion expects.

## Linear

KEEP-348