### PR TITLE
fix: KEEP-350 force-include next package in standalone output tracing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -137,6 +137,18 @@ const nextConfig = {
   ],
   outputFileTracingIncludes: {
     "/*": [
+      // Force-include the next package itself. The standalone server.js
+      // emitted by `output: "standalone"` does a bare `require('next')`,
+      // which needs next/package.json to resolve. Next's tracer only
+      // catches that bare specifier when some other file in the bundle
+      // also imports next directly. In prod builds INCLUDE_TEST_ENDPOINTS
+      // is empty, the staging-only `*.staging.ts` files that triggered
+      // the side-effect are excluded, and the standalone output ends up
+      // with next/dist/ but no next/package.json -- runtime crashes with
+      // "Cannot find module 'next'" on server.js line 16. Including next
+      // explicitly here makes the bundle robust regardless of which other
+      // pageExtensions are active. See KEEP-348 follow-up incident.
+      "./node_modules/next/**/*",
       "./node_modules/@babel/code-frame/**/*",
       "./node_modules/@babel/helper-validator-identifier/**/*",
       "./node_modules/@cbor-extract/cbor-extract-darwin-arm64/**/*",


### PR DESCRIPTION
## Summary

Prod was crashing on container start with `Cannot find module 'next'` thrown from `/app/server.js` line 16. The standalone bundle had `node_modules/next/dist/` but no `node_modules/next/package.json`, so the bare `require('next')` could not resolve.

Adds `./node_modules/next/**/*` to `outputFileTracingIncludes` in `next.config.ts` so the standalone output always carries the full `next` package, independent of which other files in the bundle happen to bare-import it.

## Why both bundles were not affected

Staging compiles `*.staging.ts` (KEEP-237's `INCLUDE_TEST_ENDPOINTS=true` gate). Some of those files bare-import `next`, which incidentally caused the standalone tracer to copy `next/package.json` into the staging image. Prod with `INCLUDE_TEST_ENDPOINTS=""` skips those files, no bundle file bare-imports `next` directly, and the tracer silently drops the package metadata. The bug stayed latent until a recent dep-tree change (sandbox / wallet workspace bootstraps, monaco pin) rebuilt the prod ECR cache and crystallized the broken state.

## Why this is the right shape of fix

Same pattern this repo has applied repeatedly for other packages whose metadata the standalone tracer skips. `git log -- next.config.ts` shows prior fixes for world-postgres, pg-boss, @vercel/og, @vercel/oidc, mixpart, cron-parser, minimatch. This one covers the framework itself, which should never need to be force-included again.

## Linear

KEEP-350