### PR TITLE
fix: KEEP-350 hoist next runtime deps so standalone bundle resolves them

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,6 +8,20 @@ minimum-release-age=3d
 # outputFileTracingIncludes globs in next.config.ts can't reach them.
 #
 # Regenerate with: tsx scripts/list-world-deps.ts
+
+# Next 16 runtime deps. Same reason as world-postgres above: standalone
+# tracing can't reach them in pnpm's .pnpm/ store, so the
+# outputFileTracingIncludes globs in next.config.ts ("./node_modules/X/**/*")
+# need a top-level symlink to match. Hoisted here so the boot path
+# (server.js -> next -> @swc/helpers etc.) resolves on prod.
+public-hoist-pattern[]=@next/env
+public-hoist-pattern[]=@next/swc-linux-x64-musl
+public-hoist-pattern[]=@swc/helpers
+public-hoist-pattern[]=baseline-browser-mapping
+public-hoist-pattern[]=caniuse-lite
+public-hoist-pattern[]=postcss
+public-hoist-pattern[]=styled-jsx
+
 public-hoist-pattern[]=@babel/code-frame
 public-hoist-pattern[]=@babel/helper-validator-identifier
 public-hoist-pattern[]=@cbor-extract/cbor-extract-darwin-arm64

--- a/next.config.ts
+++ b/next.config.ts
@@ -149,6 +149,17 @@ const nextConfig = {
       // explicitly here makes the bundle robust regardless of which other
       // pageExtensions are active. See KEEP-348 follow-up incident.
       "./node_modules/next/**/*",
+      // Next 16's standalone tracer doesn't follow next's own runtime
+      // dependencies through pnpm's .pnpm/ store. Force-include the full
+      // set listed in next/package.json `dependencies` plus the
+      // architecture-specific @next/swc binary used on Alpine (musl).
+      "./node_modules/@next/env/**/*",
+      "./node_modules/@next/swc-linux-x64-musl/**/*",
+      "./node_modules/@swc/helpers/**/*",
+      "./node_modules/baseline-browser-mapping/**/*",
+      "./node_modules/caniuse-lite/**/*",
+      "./node_modules/postcss/**/*",
+      "./node_modules/styled-jsx/**/*",
       "./node_modules/@babel/code-frame/**/*",
       "./node_modules/@babel/helper-validator-identifier/**/*",
       "./node_modules/@cbor-extract/cbor-extract-darwin-arm64/**/*",


### PR DESCRIPTION
## Summary

Follow-up to PR #993. That PR force-included `node_modules/next/**` in the standalone trace, which fixed the bare `require('next')` boot failure. Booting the image then surfaced the next layer of the same bug: `next/dist/shared/lib/constants.js` does `require('@swc/helpers/_/_interop_require_default')`, which fails because `@swc/helpers` lives in pnpm's `.pnpm/` store and the standalone tracer never copies it.

This PR force-includes the full set of next 16.2.2 runtime dependencies and adds the matching pnpm public-hoist patterns so they actually appear at top-level `node_modules` for the tracer-include globs to match.

## Scope

`next.config.ts` `outputFileTracingIncludes` and `.npmrc` `public-hoist-pattern[]` now cover:

- `@next/env`
- `@next/swc-linux-x64-musl` (Alpine runtime architecture)
- `@swc/helpers`
- `baseline-browser-mapping`
- `caniuse-lite`
- `postcss`
- `styled-jsx`

That's the complete `dependencies` block from `next/package.json` plus the SWC binary the Linux Alpine image actually loads at runtime.

## Verified

Rebuilt the runner image locally with `--no-cache --build-arg INCLUDE_TEST_ENDPOINTS=""`, started it against the local database with realistic env, hit `/` and got HTTP 200. Next.js 16.2.2 logs `Ready in 0ms`, no `Cannot find module` anywhere in the require chain.

## Linear

KEEP-350