### PR TITLE
fix: apply protocol input default when config value is missing or empty

### DIFF
--- a/plugins/protocol/steps/protocol-read.ts
+++ b/plugins/protocol/steps/protocol-read.ts
@@ -42,8 +42,8 @@ function buildFunctionArgs(
 
   const rawInputs = protocolAction.inputs.map((inp) => {
     const raw = input[inp.name];
-    if (raw === undefined) {
-      return { name: inp.name, value: "" };
+    if (raw === undefined || raw === "") {
+      return { name: inp.name, value: inp.default ?? "" };
     }
     const value = typeof raw === "object" ? JSON.stringify(raw) : String(raw);
     return { name: inp.name, value };

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -46,8 +46,8 @@ function buildFunctionArgs(
 
   const rawInputs = protocolAction.inputs.map((inp) => {
     const raw = input[inp.name];
-    if (raw === undefined) {
-      return { name: inp.name, value: "" };
+    if (raw === undefined || raw === "") {
+      return { name: inp.name, value: inp.default ?? "" };
     }
     const value = typeof raw === "object" ? JSON.stringify(raw) : String(raw);
     return { name: inp.name, value };


### PR DESCRIPTION
## Summary

Protocol definitions declare default values for optional inputs (e.g. `sqrtPriceLimitX96` on Uniswap V3 swap and quote actions defaults to `"0"`), but the runtime arg builder in `plugins/protocol/steps/protocol-{read,write}.ts` ignored the declared default and substituted an empty string when the user-provided value was missing.

The empty string then failed ABI encoding with errors like `params.sqrtPriceLimitX96: uint160 is missing`.

This fixes the arg builder to fall back to `inp.default` when the user-provided value is undefined or empty, so callers can rely on protocol-declared defaults without having to repeat them in every workflow config.