### PR TITLE
docs: KEEP-353 narrow API auth scope and split kh/wfb key docs

### DIFF
--- a/docs/api/api-keys.md
+++ b/docs/api/api-keys.md
@@ -9,50 +9,65 @@ Manage API keys for programmatic access to the KeeperHub API.
 
 ## Key Types
 
-| Prefix | Scope | Used for |
-|--------|-------|----------|
-| `kh_` | Organization | REST API, MCP server, Claude Code plugin |
-| `wfb_` | User | Webhook triggers |
+KeeperHub has two distinct key systems, managed at different endpoints. They are not interchangeable.
 
-## List API Keys
+| Prefix | Scope | Managed at | Used for |
+|--------|-------|------------|----------|
+| `kh_` | Organization | `/api/keys` | REST API, MCP server, Claude Code plugin |
+| `wfb_` | User | `/api/api-keys` | Webhook triggers |
+
+For typical programmatic API access use organization (`kh_`) keys.
+
+## Organization Keys (`kh_`)
+
+Issued per-organization. Create them from Settings > API Keys > Organisation in the dashboard, or via the endpoints below.
+
+### List Organization Keys
 
 ```http
-GET /api/api-keys
+GET /api/keys
 ```
 
-### Response
+Accepts session or API-key authentication. Returns non-revoked keys for the active organization.
+
+#### Response
+
+```json
+[
+  {
+    "id": "key_123",
+    "name": "Production Key",
+    "keyPrefix": "kh_abc",
+    "createdAt": "2024-01-01T00:00:00Z",
+    "lastUsedAt": "2024-01-15T12:00:00Z",
+    "createdByName": "Jane Doe",
+    "expiresAt": null
+  }
+]
+```
+
+The full key is never returned after creation.
+
+### Create Organization Key
+
+```http
+POST /api/keys
+```
+
+**Session authentication required.** Cannot be invoked with an API key -- otherwise a leaked key could mint additional keys for the same organization.
+
+#### Request Body
 
 ```json
 {
-  "data": [
-    {
-      "id": "key_123",
-      "name": "Production Key",
-      "keyPrefix": "kh_abc",
-      "createdAt": "2024-01-01T00:00:00Z",
-      "lastUsedAt": "2024-01-15T12:00:00Z"
-    }
-  ]
+  "name": "My API Key",
+  "expiresAt": "2025-01-01T00:00:00Z"
 }
 ```
 
-Note: The full key is never returned after creation.
+`expiresAt` is optional. Omit for a non-expiring key.
 
-## Create API Key
-
-```http
-POST /api/api-keys
-```
-
-### Request Body
-
-```json
-{
-  "name": "My API Key"
-}
-```
-
-### Response
+#### Response
 
 ```json
 {
@@ -60,21 +75,22 @@ POST /api/api-keys
   "name": "My API Key",
   "key": "kh_full_api_key_here",
   "keyPrefix": "kh_full_",
-  "createdAt": "2024-01-01T00:00:00Z"
+  "createdAt": "2024-01-01T00:00:00Z",
+  "expiresAt": null
 }
 ```
 
-Important: Copy the `key` value immediately. It will only be shown once.
+Copy the `key` value immediately. It is only shown once.
 
-## Delete API Key
+### Revoke Organization Key
 
 ```http
-DELETE /api/api-keys/{keyId}
+DELETE /api/keys/{keyId}
 ```
 
-Revokes the API key. This action cannot be undone.
+Soft-revokes the key. Subsequent requests with that key return `401`.
 
-### Response
+#### Response
 
 ```json
 {
@@ -82,10 +98,46 @@ Revokes the API key. This action cannot be undone.
 }
 ```
 
+## User Keys (`wfb_`)
+
+Issued per-user. Intended for webhook triggers, not for general REST API access.
+
+### List User Keys
+
+```http
+GET /api/api-keys
+```
+
+Session authentication required.
+
+### Create User Key
+
+```http
+POST /api/api-keys
+```
+
+Session authentication required.
+
+#### Request Body
+
+```json
+{
+  "name": "My Webhook Key"
+}
+```
+
+### Delete User Key
+
+```http
+DELETE /api/api-keys/{keyId}
+```
+
+Session authentication required. Revokes the key. This action cannot be undone.
+
 ## Security Notes
 
-- Keys are hashed with SHA256 before storage
-- Only the key prefix is stored for identification
-- Anonymous users cannot create API keys
-- Revoke keys immediately if compromised
-- Use environment variables to store keys in applications
+- Keys are hashed with SHA256 before storage; only the prefix is kept for identification.
+- Anonymous users cannot create API keys.
+- Revoke compromised keys immediately.
+- Store keys in environment variables, not in source code.
+- Key creation and personal-key deletion require session authentication, so a leaked API key cannot mint or delete other keys.

--- a/docs/api/api-keys.md
+++ b/docs/api/api-keys.md
@@ -54,7 +54,7 @@ The full key is never returned after creation.
 POST /api/keys
 ```
 
-**Session authentication required.** Cannot be invoked with an API key -- otherwise a leaked key could mint additional keys for the same organization.
+**Session authentication required.** Cannot be invoked with an API key. Otherwise a leaked key could mint additional keys for the same organization.
 
 #### Request Body
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -72,6 +72,16 @@ Endpoints that act on a user account, hold credential material, or sit on a huma
 
 If you have a use case for session-only behavior over an API key, open an issue describing it. The boundary is deliberate: it keeps a leaked API key from escalating into account control or wallet drainage.
 
+## Deactivated accounts
+
+Deactivating a user account from the dashboard immediately revokes the credentials that user holds, across every supported auth method:
+
+- **Sessions** are deleted server-side. The user is signed out everywhere they were logged in.
+- **Organization API keys** (`kh_`) the user created are soft-revoked (`revokedAt` is stamped). Subsequent requests with those keys return `401`.
+- **MCP OAuth tokens** for the user are rejected at the next request, even if their TTL has not yet elapsed.
+
+There is currently no reactivation flow. If a deactivated user wants to come back, they sign up again and provision new credentials.
+
 ## Webhook Authentication
 
 For webhook triggers, use a user-scoped key (`wfb_`) with the workflow-specific webhook URL:

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -5,7 +5,7 @@ description: "KeeperHub API authentication methods - session auth and API keys."
 
 # Authentication
 
-The KeeperHub API supports two authentication methods.
+The KeeperHub API supports two authentication methods. They are not interchangeable: their accepted scopes differ. See [Endpoint scope](#endpoint-scope) for the rules.
 
 ## Session Authentication
 
@@ -42,6 +42,35 @@ KeeperHub has two types of API keys:
 - Keys are hashed with SHA256 before storage
 - Only the key prefix is stored for identification
 - Revoke keys immediately if compromised
+
+## Endpoint scope
+
+Session authentication is accepted everywhere. API keys (`kh_`) are accepted only on **organization-scoped** endpoints -- those whose action and result depend on the caller's organization, not on the individual user behind the key.
+
+### Accepted on API keys
+
+Endpoints whose semantics are organization-scoped accept `kh_` keys:
+
+- Workflow CRUD and execution: `/api/workflows`, `/api/executions`, `/api/execute`
+- Integrations: `/api/integrations`
+- Projects, tags, public tags, supported chains
+- Organization-scoped billing and analytics
+- Organization management (e.g. renaming an organization)
+- Organization API keys (`GET /api/keys`, `DELETE /api/keys/{keyId}`) -- creation requires session
+- Address book entries (organization-scoped)
+
+### Session-only
+
+Endpoints that act on a user account, hold credential material, or sit on a human approval boundary require session authentication. API keys are rejected with `401`:
+
+- **User-account operations** -- profile mutation (`PATCH /api/user`), password change, account deactivation, forgot-password
+- **Per-user preferences** -- RPC preferences
+- **Wallet write operations** -- provisioning, deletion, withdrawal, fee estimation, switching the active signing wallet, retrieving or refreshing the user share, and private-key export
+- **Authentication primitives** -- creating organization API keys (`POST /api/keys`), creating/listing/deleting personal webhook keys (`/api/api-keys/*`), AI Gateway OAuth flows
+- **Human-in-the-loop wallet approvals** -- agentic-wallet linking and approve/reject endpoints
+- **Per-user state** -- workflow drafts, workflow ratings, leaving an organization
+
+If you have a use case for session-only behavior over an API key, open an issue describing it. The boundary is deliberate: it keeps a leaked API key from escalating into account control or wallet drainage.
 
 ## Webhook Authentication
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -35,7 +35,7 @@ KeeperHub has two types of API keys:
 2. Select "API Keys"
 3. For organization keys (`kh_`), switch to the Organisation tab
 4. Click "Create New Key"
-5. Copy the key immediately -- it will only be shown once
+5. Copy the key immediately. It will only be shown once.
 
 ### Key Security
 
@@ -45,7 +45,7 @@ KeeperHub has two types of API keys:
 
 ## Endpoint scope
 
-Session authentication is accepted everywhere. API keys (`kh_`) are accepted only on **organization-scoped** endpoints -- those whose action and result depend on the caller's organization, not on the individual user behind the key.
+Session authentication is accepted everywhere. API keys (`kh_`) are accepted only on **organization-scoped** endpoints, the ones whose action and result depend on the caller's organization rather than on the individual user behind the key.
 
 ### Accepted on API keys
 
@@ -56,19 +56,19 @@ Endpoints whose semantics are organization-scoped accept `kh_` keys:
 - Projects, tags, public tags, supported chains
 - Organization-scoped billing and analytics
 - Organization management (e.g. renaming an organization)
-- Organization API keys (`GET /api/keys`, `DELETE /api/keys/{keyId}`) -- creation requires session
+- Organization API keys (`GET /api/keys`, `DELETE /api/keys/{keyId}`); creation requires session
 - Address book entries (organization-scoped)
 
 ### Session-only
 
 Endpoints that act on a user account, hold credential material, or sit on a human approval boundary require session authentication. API keys are rejected with `401`:
 
-- **User-account operations** -- profile mutation (`PATCH /api/user`), password change, account deactivation, forgot-password
-- **Per-user preferences** -- RPC preferences
-- **Wallet write operations** -- provisioning, deletion, withdrawal, fee estimation, switching the active signing wallet, retrieving or refreshing the user share, and private-key export
-- **Authentication primitives** -- creating organization API keys (`POST /api/keys`), creating/listing/deleting personal webhook keys (`/api/api-keys/*`), AI Gateway OAuth flows
-- **Human-in-the-loop wallet approvals** -- agentic-wallet linking and approve/reject endpoints
-- **Per-user state** -- workflow drafts, workflow ratings, leaving an organization
+- **User-account operations**: profile mutation (`PATCH /api/user`), password change, account deactivation, forgot-password
+- **Per-user preferences**: RPC preferences
+- **Wallet write operations**: provisioning, deletion, withdrawal, fee estimation, switching the active signing wallet, retrieving or refreshing the user share, and private-key export
+- **Authentication primitives**: creating organization API keys (`POST /api/keys`), creating/listing/deleting personal webhook keys (`/api/api-keys/*`), AI Gateway OAuth flows
+- **Human-in-the-loop wallet approvals**: agentic-wallet linking and approve/reject endpoints
+- **Per-user state**: workflow drafts, workflow ratings, leaving an organization
 
 If you have a use case for session-only behavior over an API key, open an issue describing it. The boundary is deliberate: it keeps a leaked API key from escalating into account control or wallet drainage.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,9 +15,12 @@ https://app.keeperhub.com/api
 
 ## Authentication
 
-All API requests require authentication via either:
-- **Session**: Browser-based authentication via Better Auth
-- **API Key**: For programmatic access (see [API Keys](/api/api-keys))
+API requests require authentication. Two methods are supported, but their accepted scope differs:
+
+- **Session**: Browser-based authentication via Better Auth. Accepted on every endpoint.
+- **API Key** (`kh_`): For programmatic access to organization-scoped endpoints (workflows, integrations, billing, organization management). Not accepted on user-account, wallet write, OAuth-account-bound, or per-user endpoints.
+
+See [Authentication](/api/authentication) for the full scope.
 
 ## Response Format
 

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -7,7 +7,7 @@ description: "KeeperHub User API - manage user profile, wallet, and RPC preferen
 
 Manage user profile and preferences.
 
-> **Authentication.** User endpoints below require **session authentication**. API keys (`kh_`) are not accepted on profile mutation, password change, forgot-password, account deactivation, RPC preferences, or any wallet write operation (withdraw, share, refresh-share, export-key, active wallet switch, fee estimation). The address book endpoints are organization-scoped and accept either method. See [Authentication](/api/authentication#endpoint-scope) for the full scope rules.
+> **Authentication.** Profile and wallet read operations in this section accept either a session cookie or an organization API key (`kh_`). Mutating operations require **session authentication** and reject API keys with `401`: profile mutation, password change, forgot-password, account deactivation, RPC preferences, and every wallet write operation (withdraw, share, refresh-share, export-key, active wallet switch, fee estimation). Address book entries are organization-scoped and accept either method. See [Authentication](/api/authentication#endpoint-scope) for the full scope rules.
 
 ## Get User Profile
 

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -7,6 +7,8 @@ description: "KeeperHub User API - manage user profile, wallet, and RPC preferen
 
 Manage user profile and preferences.
 
+> **Authentication.** User endpoints below require **session authentication**. API keys (`kh_`) are not accepted on profile mutation, password change, forgot-password, account deactivation, RPC preferences, or any wallet write operation (withdraw, share, refresh-share, export-key, active wallet switch, fee estimation). The address book endpoints are organization-scoped and accept either method. See [Authentication](/api/authentication#endpoint-scope) for the full scope rules.
+
 ## Get User Profile
 
 ```http


### PR DESCRIPTION
## Summary

Fix the API authentication docs that incorrectly imply every endpoint accepts both session cookies and API keys (`kh_`). In practice ~35 of ~58 endpoints are session-only, so a reader following the docs literally hits 401 on user/wallet/auth-primitive operations.

User-reported the discrepancy after trying `Authorization: Bearer kh_...` against `GET /api/user` (which only checks Better Auth sessions today).

## Changes (docs only, no behavior changes)

- `docs/api/index.md` -- replace the "All API requests require..." line with explicit per-method scope.
- `docs/api/authentication.md` -- add an "Endpoint scope" section listing what `kh_` keys are accepted on and what is session-only, with the rationale (deliberate boundary so a leaked key cannot escalate into account control or wallet drainage).
- `docs/api/user.md` -- top-of-page authentication note flagging which subsections are session-only.
- `docs/api/api-keys.md` -- split into separate \`kh_\` (organization, managed at \`/api/keys\`) and \`wfb_\` (user, managed at \`/api/api-keys\`) sections. The previous page documented the wfb_ endpoints under a heading that implied they were the kh_ org REST API endpoints.

## Test plan

- [ ] Preview the docs site locally
- [ ] Confirm the four pages line up on which auth method works on which class of endpoint
- [ ] Confirm no emojis, internal ticket IDs, PR numbers, or phase names in any docs/ file

## Linear

KEEP-353