### PR TITLE
feat: KEEP-355 add llms.txt to docs site

### DIFF
--- a/docs-site/middleware.ts
+++ b/docs-site/middleware.ts
@@ -48,6 +48,6 @@ export function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     // Match all paths except static files
-    "/((?!_next/static|_next/image|favicon.ico).*)",
+    "/((?!_next/static|_next/image|favicon.ico|llms.txt).*)",
   ],
 };

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -1,0 +1,74 @@
+# KeeperHub
+
+> KeeperHub is a Web3 workflow automation platform that lets users and AI agents build, schedule, and execute on-chain workflows — smart contract monitoring, token transfers, DeFi operations, multi-channel notifications — through a visual builder, a CLI, a REST API, or an MCP server.
+
+A KeeperHub workflow is a directed graph of **nodes**. A node is either a **trigger** (Manual, Schedule, Webhook, Event, Block) or an **action** (provided by a **plugin**). Nodes connect via **edges** with named **source handles** (e.g. `true`/`false` outputs on a Condition node). Runtime values flow between nodes using template syntax: `{{@nodeId:Label.field}}`. A single run of a workflow is an **execution**, tracked with status, logs, and metrics.
+
+Agents have three programmatic surfaces: (1) the **MCP server** at `https://app.keeperhub.com/mcp` for direct tool use from Claude Desktop, Claude Code, and other MCP clients; (2) the **REST API** under `https://app.keeperhub.com/api` for general programmatic control; (3) the **Claude Code plugin marketplace** at `github.com/KeeperHub/claude-plugins` for an opinionated workflow-building skill set.
+
+## Docs
+
+- [Introduction](https://docs.keeperhub.com/intro/overview): What KeeperHub is and the problem it solves
+- [Concepts](https://docs.keeperhub.com/intro/concepts): Workflow, node, trigger, action, edge, execution
+- [Benefits](https://docs.keeperhub.com/intro/benefits): Why use KeeperHub over rolling your own automation
+- [Getting Started](https://docs.keeperhub.com/getting-started): Build your first workflow
+- [Node Types](https://docs.keeperhub.com/keepers/overview): Triggers, actions, system steps, conditionals
+- [Node Configuration](https://docs.keeperhub.com/keepers/configuration): Configuring nodes and template references
+- [Workflow Introduction](https://docs.keeperhub.com/workflows/introduction): Workflow model and lifecycle
+- [Creating Workflows](https://docs.keeperhub.com/workflows/creating): Builder walkthrough
+- [Paid Workflows](https://docs.keeperhub.com/workflows/paid-workflows): Monetised workflows
+- [Workflow Examples](https://docs.keeperhub.com/workflows/examples): End-to-end patterns
+- [Keeper Runs](https://docs.keeperhub.com/keeper-runs): Execution status, logs, performance, troubleshooting
+- [Wallet Management](https://docs.keeperhub.com/wallet-management): Para MPC wallets, gas, address book
+- [Notifications](https://docs.keeperhub.com/notifications): Connections and message templates
+- [Best Practices](https://docs.keeperhub.com/practices): Security and reliability
+- [Users and Organizations](https://docs.keeperhub.com/users-teams-orgs): Team and org model
+- [API](https://docs.keeperhub.com/api): REST API reference
+- [CLI](https://docs.keeperhub.com/cli): Command-line interface
+- [Guides](https://docs.keeperhub.com/guides): Migration from OpenZeppelin Defender, Gelato
+- [FAQ](https://docs.keeperhub.com/FAQ): Common questions
+
+## AI tools
+
+- [AI Tools Overview](https://docs.keeperhub.com/ai-tools/overview): How agents interact with KeeperHub
+- [MCP Server](https://docs.keeperhub.com/ai-tools/mcp-server): OAuth-authenticated MCP server exposing workflow catalog, schema introspection, and execution
+- [Claude Code Plugin](https://docs.keeperhub.com/ai-tools/claude-code-plugin): Marketplace install and skill set
+- [Agentic Wallets](https://docs.keeperhub.com/ai-tools/agentic-wallet): Para MPC wallet model for autonomous agents
+
+## Plugins
+
+- [Plugin Overview](https://docs.keeperhub.com/plugins/overview): Plugin model and authoring
+- [Web3](https://docs.keeperhub.com/plugins/web3): Read and write smart contracts, transfer funds and tokens; auto-detects EIP-1967/1822/Diamond proxies; auto-fetches verified ABIs
+- [Code](https://docs.keeperhub.com/plugins/code): Execute JavaScript steps with access to prior node outputs
+- [Math](https://docs.keeperhub.com/plugins/math): Numeric operations and conversions
+- [Safe](https://docs.keeperhub.com/plugins/safe): Gnosis Safe interactions
+
+### DeFi protocol plugins
+
+- [Aave V3](https://docs.keeperhub.com/plugins/aave-v3)
+- [Aerodrome](https://docs.keeperhub.com/plugins/aerodrome)
+- [Ajna](https://docs.keeperhub.com/plugins/ajna)
+- [Chainlink](https://docs.keeperhub.com/plugins/chainlink)
+- [Compound V3](https://docs.keeperhub.com/plugins/compound)
+- [CoW Swap](https://docs.keeperhub.com/plugins/cowswap)
+- [Curve](https://docs.keeperhub.com/plugins/curve)
+- [Lido](https://docs.keeperhub.com/plugins/lido)
+- [Morpho](https://docs.keeperhub.com/plugins/morpho)
+- [Pendle](https://docs.keeperhub.com/plugins/pendle)
+- [Rocket Pool](https://docs.keeperhub.com/plugins/rocket-pool)
+- [Sky](https://docs.keeperhub.com/plugins/sky)
+- [Spark](https://docs.keeperhub.com/plugins/spark)
+- [Uniswap](https://docs.keeperhub.com/plugins/uniswap)
+
+### Notification plugins
+
+- [Discord](https://docs.keeperhub.com/plugins/discord): Send messages to Discord channels via webhooks
+- [Telegram](https://docs.keeperhub.com/plugins/telegram): Send messages to Telegram chats via bot API
+- [SendGrid](https://docs.keeperhub.com/plugins/sendgrid): Transactional email
+- [Webhook](https://docs.keeperhub.com/plugins/webhook): Send HTTP requests to arbitrary endpoints
+
+## Optional
+
+- [GitHub: KeeperHub/claude-plugins](https://github.com/KeeperHub/claude-plugins): Claude Code plugin marketplace source
+- [App](https://app.keeperhub.com): Web app
+- [Contact](mailto:sales@keeperhub.io)

--- a/next.config.ts
+++ b/next.config.ts
@@ -278,6 +278,15 @@ const nextConfig = {
   async rewrites() {
     return [{ source: "/openapi.json", destination: "/api/openapi" }];
   },
+  async redirects() {
+    return [
+      {
+        source: "/llms.txt",
+        destination: "https://docs.keeperhub.com/llms.txt",
+        permanent: true,
+      },
+    ];
+  },
 } satisfies NextConfig & { eslint?: { ignoreDuringBuilds?: boolean } };
 
 const { SENTRY_ORG, SENTRY_PROJECT, SENTRY_RELEASE } = process.env;


### PR DESCRIPTION
## Summary

- Adds curated `llms.txt` at `docs.keeperhub.com/llms.txt` following the [llmstxt.org spec](https://llmstxt.org). 46 links, all verified to map to real `docs-site/content/` pages.
- Excludes `/llms.txt` from the docs middleware matcher so it bypasses the `VALID_ROUTES` rewrite-to-404 and is served as a normal Next.js public asset (same pattern as `favicon.ico`).

## Why

KeeperHub is AI-facing. A static, hand-curated llms.txt gives LLMs (Claude, GPT, etc., and any tool that consumes the spec) a concise entry point to the project: what KeeperHub is, the core domain vocabulary (workflow / node / trigger / action / edge / execution), the three programmatic surfaces (MCP, REST, Claude Code marketplace), and direct links to canonical doc pages.

## Scope notes

- **Static, not a route handler.** The spec calls for hand-curated content; auto-generation defeats the purpose. (`llms-full.txt` — the full-corpus dump — is intentionally out of scope here; tracked separately if we want it.)
- **Plugin list curated.** Only plugins with actual doc pages in `docs-site/content/plugins/` are linked. Plugins without docs (e.g. `slack`, `resend`, `ai-gateway`, `linear`, `webflow`) are omitted on purpose.

## Test plan

- [x] All 46 doc URLs in `llms.txt` verified against `docs-site/content/` (script-checked: 46 OK, 0 broken)
- [x] Middleware change verified by inspection: matcher negative-lookahead now excludes `llms.txt`, so middleware never runs and Next.js falls through to the public asset
- [ ] **Not verified end-to-end:** local dev server hit `inotify` watch limit on this host (90+ worktrees in `keeperhub`), so I could not curl `localhost:3457/llms.txt` to confirm the served response. Reviewer should either smoke-test locally or rely on the staging deploy.
- [ ] After staging deploy: `curl -I https://docs-staging.keeperhub.com/llms.txt` should return `200 text/plain` (not `404` or HTML)