### PR TITLE
fix: isolate SSRF guard so drizzle.config.ts stays import-clean

### DIFF
--- a/lib/db/connection-host-guard.ts
+++ b/lib/db/connection-host-guard.ts
@@ -1,0 +1,79 @@
+/**
+ * SSRF guards for the database connection-test endpoint.
+ *
+ * Lives in its own module (rather than connection-utils.ts) because it
+ * pulls in `lib/safe-fetch.ts`, which has `import "server-only"`.
+ * `drizzle.config.ts` imports `getDatabaseUrl` from connection-utils at
+ * CLI time (drizzle-kit, migrations, CI setup-db), and any transitive
+ * `server-only` import there blows up the config load with "This module
+ * cannot be imported from a Client Component module."
+ *
+ * Keeping the guard isolated lets `connection-utils.ts` stay
+ * import-clean for tooling that runs outside Next's server runtime.
+ */
+import "server-only";
+
+import type { LookupAddress } from "node:dns";
+import { promises as dns } from "node:dns";
+import { isIP } from "node:net";
+import { isBlockedIp } from "@/lib/safe-fetch";
+
+/**
+ * Reject connection-test attempts against private / loopback / link-local
+ * destinations. Used by the integration-test endpoint, which dials a
+ * user-supplied host over raw TCP via the `postgres` package, a path that
+ * does not go through `safe-fetch.ts` (HTTP-only). Always-on (no env
+ * flag): there is no legitimate reason for an `/api/integrations/test`
+ * request to resolve to a non-public address.
+ *
+ * Caveat: there is a small TOCTOU window between this DNS check and the
+ * subsequent TCP connect during which an attacker-controlled domain
+ * could rebind. Closing that window requires resolving once and
+ * dialling the resolved IP directly, which is out of scope for this
+ * fix (would mean rewriting how the postgres client is invoked). The
+ * TOCTOU surface for postgres TCP is much narrower than HTTP DNS
+ * rebinding (no scriptable client behind the connection), so we accept
+ * it here.
+ */
+export async function assertHostIsPublic(host: string): Promise<void> {
+  const trimmed = host.trim();
+  if (trimmed === "") {
+    throw new Error("Host is required");
+  }
+
+  if (isIP(trimmed) !== 0) {
+    const verdict = isBlockedIp(trimmed);
+    if (verdict.blocked) {
+      throw new Error("Host is not allowed: must resolve to a public address");
+    }
+    return;
+  }
+
+  let addresses: LookupAddress[];
+  try {
+    addresses = await dns.lookup(trimmed, { all: true });
+  } catch {
+    throw new Error("Host could not be resolved");
+  }
+
+  for (const addr of addresses) {
+    const verdict = isBlockedIp(addr.address);
+    if (verdict.blocked) {
+      throw new Error("Host is not allowed: must resolve to a public address");
+    }
+  }
+}
+
+/**
+ * Extract the hostname from a postgres connection URL.
+ *
+ * Returns null if the URL is malformed; callers should treat that as a
+ * validation failure.
+ */
+export function extractHostFromConnectionString(url: string): string | null {
+  try {
+    return new URL(url).hostname || null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -1,13 +1,10 @@
 /**
  * Database connection utilities
  *
- * Handles URL encoding of database credentials with special characters
+ * Handles URL encoding of database credentials with special characters.
+ * Imports must stay free of `server-only` (transitively) because
+ * `drizzle.config.ts` loads this file at CLI time.
  */
-
-import type { LookupAddress } from "node:dns";
-import { promises as dns } from "node:dns";
-import { isIP } from "node:net";
-import { isBlockedIp } from "@/lib/safe-fetch";
 
 /**
  * Protocol prefix for PostgreSQL connection strings
@@ -158,65 +155,6 @@ export type DatabaseConnectionConfig = {
   password?: string;
   database?: string;
 };
-
-/**
- * Reject connection-test attempts against private / loopback / link-local
- * destinations. Used by the integration-test endpoint, which dials a
- * user-supplied host over raw TCP via the `postgres` package -- a path that
- * does not go through `safe-fetch.ts` (HTTP-only). Always-on (no env flag):
- * there is no legitimate reason for an `/api/integrations/test` request to
- * resolve to a non-public address.
- *
- * Caveat: there is a small TOCTOU window between this DNS check and the
- * subsequent TCP connect during which an attacker-controlled domain could
- * rebind. Closing that window requires resolving once and dialling the
- * resolved IP directly, which is out of scope for this commit (would mean
- * rewriting how the postgres client is invoked). The TOCTOU surface for
- * postgres TCP is much narrower than HTTP DNS rebinding (no scriptable
- * client behind the connection), so we accept it here.
- */
-export async function assertHostIsPublic(host: string): Promise<void> {
-  const trimmed = host.trim();
-  if (trimmed === "") {
-    throw new Error("Host is required");
-  }
-
-  if (isIP(trimmed) !== 0) {
-    const verdict = isBlockedIp(trimmed);
-    if (verdict.blocked) {
-      throw new Error("Host is not allowed: must resolve to a public address");
-    }
-    return;
-  }
-
-  let addresses: LookupAddress[];
-  try {
-    addresses = await dns.lookup(trimmed, { all: true });
-  } catch {
-    throw new Error("Host could not be resolved");
-  }
-
-  for (const addr of addresses) {
-    const verdict = isBlockedIp(addr.address);
-    if (verdict.blocked) {
-      throw new Error("Host is not allowed: must resolve to a public address");
-    }
-  }
-}
-
-/**
- * Extract the hostname from a postgres connection URL.
- *
- * Returns null if the URL is malformed; callers should treat that as a
- * validation failure.
- */
-export function extractHostFromConnectionString(url: string): string | null {
-  try {
-    return new URL(url).hostname || null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Checks whether the given config has enough fields to attempt a database connection.

--- a/lib/db/test-connection.ts
+++ b/lib/db/test-connection.ts
@@ -1,9 +1,11 @@
 import postgres from "postgres";
 import {
   assertHostIsPublic,
+  extractHostFromConnectionString,
+} from "@/lib/db/connection-host-guard";
+import {
   buildDatabaseUrlFromConfig,
   type DatabaseConnectionConfig,
-  extractHostFromConnectionString,
   getDatabaseErrorMessage,
   getPostgresConnectionOptions,
 } from "@/lib/db/connection-utils";

--- a/tests/unit/connection-guards.test.ts
+++ b/tests/unit/connection-guards.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:dns", () => ({
 import {
   assertHostIsPublic,
   extractHostFromConnectionString,
-} from "@/lib/db/connection-utils";
+} from "@/lib/db/connection-host-guard";
 
 beforeEach(() => {
   vi.clearAllMocks();


### PR DESCRIPTION
## Summary

The KEEP-354 SSRF commit added `import { isBlockedIp } from "@/lib/safe-fetch"` to `lib/db/connection-utils.ts`. `safe-fetch.ts` declares `import "server-only"`, so `connection-utils` now transitively pulls in the server-only marker. `drizzle.config.ts` loads `connection-utils` (for `getDatabaseUrl`) at CLI time, which is not a Server Component context, so the config now throws on load:

> Error: This module cannot be imported from a Client Component module. It should only be used from a Server Component.

That blocks the `e2e-vitest-ephemeral` CI job at the Setup database step, which in turn skips the `deploy` job. Three staging-branch merges have failed to deploy as a result:

- #999 (the migration that introduced the bug)
- #998 (docs follow-up, same path)
- #1004 (unrelated llms.txt feature, blocked by the same upstream)

## Fix

Extract the SSRF guard into its own file `lib/db/connection-host-guard.ts` which keeps the `server-only` import. `connection-utils.ts` returns to its original CLI-safe shape with no transitive server-only chain. `test-connection.ts` and the unit test update their imports.

Behaviour is unchanged: the same guard fires on the same inputs and the unit-test suite still passes.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm vitest run tests/unit/connection-guards.test.ts` (29 cases, all passing)
- [x] Direct `import("./drizzle.config.ts")` under tsx resolves to the config object (previously threw the server-only error)
- [ ] CI: confirm `e2e-vitest-ephemeral` reaches the Run E2E step instead of failing at Setup database
- [ ] CI: `deploy` and `release` no longer skipped on the staging-branch run that includes this commit