### PR TITLE
test: KEEP-359 route real-RPC tests through the RPC failover manager

### DIFF
--- a/tests/e2e/vitest/transaction-flow.test.ts
+++ b/tests/e2e/vitest/transaction-flow.test.ts
@@ -32,6 +32,8 @@ vi.unmock("@/lib/db");
 vi.mock("server-only", () => ({}));
 
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import { AdaptiveGasStrategy, resetGasStrategy } from "@/lib/web3/gas-strategy";
 import { NonceManager, resetNonceManager } from "@/lib/web3/nonce-manager";
@@ -45,10 +47,27 @@ const TEST_WALLET = "0xTestWallet1234567890123456789012345678";
 const TEST_WALLET_NORMALIZED = TEST_WALLET.toLowerCase();
 const TEST_CHAIN_ID = 11_155_111; // Sepolia
 const SEPOLIA_RPC = getRpcUrlByChainId(11_155_111, "primary");
+const SEPOLIA_FALLBACK_RPC = getRpcUrlByChainId(11_155_111, "fallback");
+
+// Build a failover-aware Sepolia manager. Each describe block reuses this
+// shape: construct a manager, take its current primary as the
+// ethers.JsonRpcProvider that library calls (Para signer, NonceManager
+// startSession, etc.) need, and route explicit reads in this test through
+// manager.executeWithFailover so a primary-endpoint hiccup falls back to
+// the configured secondary.
+async function buildSepoliaManager(): Promise<RpcProviderManager> {
+  return getRpcProviderFromUrls(
+    SEPOLIA_RPC,
+    SEPOLIA_FALLBACK_RPC,
+    TEST_CHAIN_ID,
+    "sepolia"
+  );
+}
 
 describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
+  let sepoliaManager: RpcProviderManager;
   let sepoliaProvider: ethers.JsonRpcProvider;
   let testExecutionId: string;
 
@@ -61,12 +80,15 @@ describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
     client = postgres(connectionString, { max: 5 });
     db = drizzle(client);
 
-    // Initialize RPC provider
-    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC);
+    // Initialize RPC provider via failover manager
+    sepoliaManager = await buildSepoliaManager();
+    sepoliaProvider = sepoliaManager.getProvider();
 
-    // Verify connectivity
+    // Verify connectivity through failover so a primary-endpoint blip falls
+    // through to the configured secondary instead of triggering the
+    // "RPC not available" branch.
     try {
-      await sepoliaProvider.getBlockNumber();
+      await sepoliaManager.executeWithFailover((p) => p.getBlockNumber());
     } catch (_error) {
       console.warn("Sepolia RPC not available");
     }
@@ -128,12 +150,17 @@ describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
       expect(session.currentNonce).toBe(mockNonce);
       expect(validation.chainNonce).toBe(mockNonce);
 
-      // Get gas config for transaction
+      // Get gas config for transaction. Pass the failover manager so the
+      // gas strategy's internal RPC calls (fee history, getFeeData) route
+      // through executeWithFailover instead of dialing the primary directly.
       const gasConfig = await gasStrategy.getGasConfig(
         sepoliaProvider,
         "manual",
         BigInt(21_000),
-        TEST_CHAIN_ID
+        TEST_CHAIN_ID,
+        undefined,
+        undefined,
+        sepoliaManager
       );
 
       expect(gasConfig.gasLimit).toBeGreaterThan(BigInt(21_000));
@@ -198,7 +225,10 @@ describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
           sepoliaProvider,
           "scheduled",
           BigInt(50_000 + i * 10_000), // Varying gas
-          TEST_CHAIN_ID
+          TEST_CHAIN_ID,
+          undefined,
+          undefined,
+          sepoliaManager
         );
 
         const txHash = `0x${"def".repeat(21)}${i}`;
@@ -551,19 +581,21 @@ describe.skipIf(shouldSkip)("Transaction Flow E2E", () => {
 });
 
 describe.skipIf(shouldSkip)("Transaction Flow with Real RPC", () => {
+  let sepoliaManager: RpcProviderManager;
   let sepoliaProvider: ethers.JsonRpcProvider;
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
   let testExecutionId: string;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     const connectionString =
       process.env.DATABASE_URL ||
       "postgresql://postgres:postgres@localhost:5433/KEEP-1240";
 
     client = postgres(connectionString, { max: 5 });
     db = drizzle(client);
-    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC);
+    sepoliaManager = await buildSepoliaManager();
+    sepoliaProvider = sepoliaManager.getProvider();
   });
 
   afterAll(async () => {
@@ -609,12 +641,17 @@ describe.skipIf(shouldSkip)("Transaction Flow with Real RPC", () => {
     expect(validation.chainNonce).toBe(0);
     expect(session.currentNonce).toBe(0);
 
-    // Get real gas prices
+    // Get real gas prices via the failover manager so the strategy's
+    // internal fee-history calls retry against the secondary endpoint when
+    // the primary hiccups.
     const gasConfig = await gasStrategy.getGasConfig(
       sepoliaProvider,
       "manual",
       BigInt(21_000),
-      TEST_CHAIN_ID
+      TEST_CHAIN_ID,
+      undefined,
+      undefined,
+      sepoliaManager
     );
 
     expect(gasConfig.maxFeePerGas).toBeGreaterThan(BigInt(0));
@@ -652,6 +689,7 @@ const skipRealTx =
 describe.skipIf(skipRealTx)("Real Transaction Tests (Sepolia)", () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
+  let sepoliaManager: RpcProviderManager;
   let sepoliaProvider: ethers.JsonRpcProvider;
   let wallet: ethers.AbstractSigner;
   let walletAddress: string;
@@ -714,13 +752,17 @@ describe.skipIf(skipRealTx)("Real Transaction Tests (Sepolia)", () => {
     const decryptedShare = decryptUserShare(paraWallet.userShare);
     await paraClient.setUserShare(decryptedShare);
 
-    sepoliaProvider = new ethers.JsonRpcProvider(SEPOLIA_RPC);
+    sepoliaManager = await buildSepoliaManager();
+    sepoliaProvider = sepoliaManager.getProvider();
     wallet = new ParaEthersSigner(paraClient as any, sepoliaProvider);
 
     console.log(`Test wallet (Para): ${walletAddress}`);
 
-    // Check balance
-    const balance = await sepoliaProvider.getBalance(walletAddress);
+    // Check balance through failover so a primary-endpoint blip falls back
+    // to the configured secondary instead of failing setup.
+    const balance = await sepoliaManager.executeWithFailover((p) =>
+      p.getBalance(walletAddress)
+    );
     console.log(`Balance: ${ethers.formatEther(balance)} ETH`);
 
     if (balance < ethers.parseEther("0.001")) {

--- a/tests/e2e/vitest/write-contract-workflow.test.ts
+++ b/tests/e2e/vitest/write-contract-workflow.test.ts
@@ -33,6 +33,8 @@ import {
   workflowExecutions,
   workflows,
 } from "@/lib/db/schema";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { generateId } from "@/lib/utils/id";
 import type { WriteContractInput } from "@/plugins/web3/steps/write-contract";
 
@@ -72,7 +74,7 @@ const MIN_BALANCE = ethers.parseEther("0.0001");
 describe.skipIf(shouldSkip)("Write Contract Workflow E2E", () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
-  let sepoliaProvider: ethers.JsonRpcProvider;
+  let sepoliaManager: RpcProviderManager;
   let orgId: string;
   let userId: string;
   let walletAddress: string;
@@ -104,7 +106,17 @@ describe.skipIf(shouldSkip)("Write Contract Workflow E2E", () => {
       );
     }
     sepoliaRpcUrl = sepoliaChain[0].defaultPrimaryRpc;
-    sepoliaProvider = new ethers.JsonRpcProvider(sepoliaRpcUrl);
+    // Route on-chain reads (balance check, contract.retrieve()) through the
+    // failover manager so a primary-RPC blip falls over to the secondary
+    // instead of failing the test. The manager pulls primary + fallback
+    // straight from the chains table -- same source the production runtime
+    // uses for this chain.
+    sepoliaManager = await getRpcProviderFromUrls(
+      sepoliaRpcUrl,
+      sepoliaChain[0].defaultFallbackRpc ?? undefined,
+      SEPOLIA_CHAIN_ID,
+      "sepolia"
+    );
 
     // Look up persistent test org
     const testOrg = await db
@@ -139,7 +151,9 @@ describe.skipIf(shouldSkip)("Write Contract Workflow E2E", () => {
     console.log(`Wallet:   ${walletAddress}`);
 
     // Verify the persistent wallet has sufficient gas
-    const balance = await sepoliaProvider.getBalance(walletAddress);
+    const balance = await sepoliaManager.executeWithFailover((p) =>
+      p.getBalance(walletAddress)
+    );
     console.log(`Wallet balance: ${ethers.formatEther(balance)} ETH`);
 
     if (balance < MIN_BALANCE) {
@@ -263,14 +277,17 @@ describe.skipIf(shouldSkip)("Write Contract Workflow E2E", () => {
     expect(result.transactionHash).toMatch(TX_HASH_PATTERN);
     console.log(`Transaction hash: ${result.transactionHash}`);
 
-    // Verify on-chain: call retrieve() and check the stored value
-    const contract = new ethers.Contract(
-      SIMPLE_STORAGE_ADDRESS,
-      JSON.parse(SIMPLE_STORAGE_ABI),
-      sepoliaProvider
-    );
-
-    const storedValue = await contract.retrieve();
+    // Verify on-chain: call retrieve() and check the stored value. Construct
+    // the Contract inside executeWithFailover so the read benefits from
+    // failover the same way every other RPC call in this test does.
+    const storedValue = await sepoliaManager.executeWithFailover((p) => {
+      const contract = new ethers.Contract(
+        SIMPLE_STORAGE_ADDRESS,
+        JSON.parse(SIMPLE_STORAGE_ABI),
+        p
+      );
+      return contract.retrieve();
+    });
     console.log(`On-chain retrieve(): ${storedValue}`);
     expect(storedValue).toBe(BigInt(randomValue));
   }, 180_000); // 3 minute timeout for real tx

--- a/tests/integration/eip7702-spike.test.ts
+++ b/tests/integration/eip7702-spike.test.ts
@@ -8,6 +8,9 @@ vi.mock("server-only", () => ({}));
 // needs real DB access for Para wallet lookups
 vi.unmock("@/lib/db");
 
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
+
 // ---------------------------------------------------------------------------
 // Environment gate -- entire suite skips if keys are missing
 // ---------------------------------------------------------------------------
@@ -20,6 +23,23 @@ const HAS_ALL = HAS_PIMLICO && HAS_PARA;
 
 // Base Sepolia
 const CHAIN_ID = 84_532;
+
+// Build a failover-aware ethers provider for Base Sepolia. Used by every
+// RPC read on the ethers code path so a primary-endpoint hiccup falls back
+// to the secondary instead of failing the whole test. Note: viem-side
+// callers (Pimlico bundler / publicClient below) do not go through this --
+// they use viem's own transport and Pimlico's bundler has independent
+// retry semantics.
+async function getBaseSepoliaManager(): ReturnType<
+  typeof getRpcProviderFromUrls
+> {
+  return getRpcProviderFromUrls(
+    getRpcUrlByChainId(CHAIN_ID, "primary"),
+    getRpcUrlByChainId(CHAIN_ID, "fallback"),
+    CHAIN_ID,
+    "base-sepolia"
+  );
+}
 
 // Top-level regex patterns for lint compliance
 const HEX_64_PATTERN = /^0x[a-f0-9]{64}$/;
@@ -140,9 +160,12 @@ describe.skipIf(!HAS_PARA)("Scenario B: Para signer accepts type-4 RLP", () => {
     await paraClient.setUserShare(decryptedShare);
     await paraClient.setUserId(wallet.userId);
 
-    const provider = new ethers.JsonRpcProvider(
-      "https://base-sepolia-rpc.publicnode.com"
-    );
+    // ParaEthersSigner expects a single ethers.Provider; this test only asks
+    // the signer to sign (no broadcast), so attaching the failover manager's
+    // current primary provider is sufficient. If the test is later extended
+    // to broadcast, wrap the broadcast call in manager.executeWithFailover.
+    const manager = await getBaseSepoliaManager();
+    const provider = manager.getProvider();
     const paraSigner = new ParaEthersSigner(paraClient as any, provider);
     const signerAddress = await paraSigner.getAddress();
 
@@ -310,10 +333,10 @@ describe.skipIf(!HAS_ALL)(
 
       const { ethers } = await import("ethers");
 
-      const provider = new ethers.JsonRpcProvider(
-        "https://base-sepolia-rpc.publicnode.com"
+      const manager = await getBaseSepoliaManager();
+      const accountNonce = await manager.executeWithFailover((p) =>
+        p.getTransactionCount(extractedAddress as string)
       );
-      const accountNonce = await provider.getTransactionCount(extractedAddress);
 
       const authHash = ethers.hashAuthorization({
         chainId: CHAIN_ID,

--- a/tests/integration/protocol-aave-v4-onchain.test.ts
+++ b/tests/integration/protocol-aave-v4-onchain.test.ts
@@ -13,17 +13,21 @@
  */
 
 import { ethers } from "ethers";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import type {
   ProtocolAction,
   ProtocolContract,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import aaveV4Def from "@/protocols/aave-v4";
 
 const RPC_URL = process.env.INTEGRATION_TEST_MAINNET_RPC_URL;
 const CHAIN_ID = "1";
+const MAINNET_CHAIN_ID = 1;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 const CORE_HUB = "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9";
 
@@ -84,8 +88,23 @@ function buildCalldata(
 //    on zero allowance); setUsingAsCollateral silently succeeds on
 //    reserveId=0 because the Spoke no-ops on nonexistent reserves.
 describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
-  const getProvider = (): ethers.JsonRpcProvider =>
-    new ethers.JsonRpcProvider(RPC_URL);
+  // Route every RPC call through the failover manager so a primary-endpoint
+  // hiccup falls back to the secondary instead of failing the test. The
+  // primary URL respects INTEGRATION_TEST_MAINNET_RPC_URL (the original
+  // gate); the fallback comes from the chains-config used in production.
+  let manager: RpcProviderManager;
+
+  beforeAll(async () => {
+    if (!RPC_URL) {
+      return;
+    }
+    manager = await getRpcProviderFromUrls(
+      RPC_URL,
+      getRpcUrlByChainId(MAINNET_CHAIN_ID, "fallback"),
+      MAINNET_CHAIN_ID,
+      "ethereum"
+    );
+  });
 
   it("getReserveId: eth_call returns a decodable uint256", async () => {
     const { to, data, contract } = buildCalldata(aaveV4Def, "get-reserve-id", {
@@ -93,8 +112,9 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
       assetId: "0",
     });
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({ to, data })
+    );
     const abi = JSON.parse(contract.abi as string);
     const iface = new ethers.Interface(abi);
     const decoded = iface.decodeFunctionResult("getReserveId", result);
@@ -109,8 +129,9 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
       { reserveId: "0", user: TEST_ADDRESS }
     );
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({ to, data })
+    );
     const abi = JSON.parse(contract.abi as string);
     const iface = new ethers.Interface(abi);
     const decoded = iface.decodeFunctionResult(
@@ -127,8 +148,9 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
       user: TEST_ADDRESS,
     });
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({ to, data })
+    );
     const abi = JSON.parse(contract.abi as string);
     const iface = new ethers.Interface(abi);
     const decoded = iface.decodeFunctionResult("getUserDebt", result);
@@ -145,8 +167,9 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
       { user: TEST_ADDRESS }
     );
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({ to, data })
+    );
     const abi = JSON.parse(contract.abi as string);
     const iface = new ethers.Interface(abi);
     const decoded = iface.decodeFunctionResult("getUserAccountData", result);
@@ -165,8 +188,7 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
       onBehalfOf: TEST_ADDRESS,
     });
 
-    const provider = getProvider();
-    await expectCallAcceptedByBytecode(provider, { to, data });
+    await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);
 
   it("setUsingAsCollateral: deployed bytecode accepts the calldata", async () => {
@@ -176,8 +198,7 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
       onBehalfOf: TEST_ADDRESS,
     });
 
-    const provider = getProvider();
-    await expectCallAcceptedByBytecode(provider, { to, data });
+    await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);
 });
 
@@ -185,14 +206,17 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
  * Asserts the deployed bytecode accepted our calldata: either the call
  * returned cleanly (void functions return "0x") or reverted at the contract
  * level (CALL_EXCEPTION). Any other error class means the ABI doesn't match
- * what's deployed.
+ * what's deployed. The call is routed through the failover manager so a
+ * primary-RPC hiccup falls back to the secondary endpoint.
  */
 async function expectCallAcceptedByBytecode(
-  provider: ethers.JsonRpcProvider,
+  manager: RpcProviderManager,
   tx: { to: string; data: string }
 ): Promise<void> {
   try {
-    const result = await provider.call({ ...tx, from: TEST_ADDRESS });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({ ...tx, from: TEST_ADDRESS })
+    );
     expect(result).toMatch(/^0x/);
   } catch (err: unknown) {
     expect(err).toMatchObject({ code: "CALL_EXCEPTION" });

--- a/tests/integration/protocol-wrapped-onchain.test.ts
+++ b/tests/integration/protocol-wrapped-onchain.test.ts
@@ -8,17 +8,21 @@
  */
 
 import { ethers } from "ethers";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import type {
   ProtocolAction,
   ProtocolContract,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import wrappedDef from "@/protocols/wrapped";
 
 const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
 const CHAIN_ID = "11155111";
+const SEPOLIA_CHAIN_ID = 11_155_111;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 
 function buildCalldata(
@@ -64,16 +68,32 @@ function buildCalldata(
 }
 
 describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
-  const getProvider = (): ethers.JsonRpcProvider =>
-    new ethers.JsonRpcProvider(RPC_URL);
+  // Route every RPC call through the failover manager so a primary-endpoint
+  // hiccup falls back to the secondary instead of failing the test. The
+  // primary URL respects INTEGRATION_TEST_RPC_URL (the original gate); the
+  // fallback comes from the same chains-config used in production.
+  let manager: RpcProviderManager;
+
+  beforeAll(async () => {
+    if (!RPC_URL) {
+      return;
+    }
+    manager = await getRpcProviderFromUrls(
+      RPC_URL,
+      getRpcUrlByChainId(SEPOLIA_CHAIN_ID, "fallback"),
+      SEPOLIA_CHAIN_ID,
+      "sepolia"
+    );
+  });
 
   it("balanceOf: eth_call returns a decodable uint256", async () => {
     const { to, data, contract } = buildCalldata(wrappedDef, "balance-of", {
       account: TEST_ADDRESS,
     });
 
-    const provider = getProvider();
-    const result = await provider.call({ to, data });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({ to, data })
+    );
 
     const abi = JSON.parse(contract.abi as string);
     const iface = new ethers.Interface(abi);
@@ -85,13 +105,14 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   it("deposit: estimateGas succeeds with ETH value", async () => {
     const { to, data } = buildCalldata(wrappedDef, "wrap", {});
 
-    const provider = getProvider();
-    const gas = await provider.estimateGas({
-      to,
-      data,
-      value: ethers.parseEther("0.001"),
-      from: TEST_ADDRESS,
-    });
+    const gas = await manager.executeWithFailover((p) =>
+      p.estimateGas({
+        to,
+        data,
+        value: ethers.parseEther("0.001"),
+        from: TEST_ADDRESS,
+      })
+    );
 
     expect(gas).toBeGreaterThan(BigInt(0));
   }, 15_000);
@@ -101,13 +122,14 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
       wad: "1000000000000000000",
     });
 
-    const provider = getProvider();
     try {
-      await provider.estimateGas({
-        to,
-        data,
-        from: TEST_ADDRESS,
-      });
+      await manager.executeWithFailover((p) =>
+        p.estimateGas({
+          to,
+          data,
+          from: TEST_ADDRESS,
+        })
+      );
     } catch (error) {
       const msg = String(error);
       expect(msg).not.toContain("INVALID_ARGUMENT");

--- a/tests/integration/web3-write-onchain.test.ts
+++ b/tests/integration/web3-write-onchain.test.ts
@@ -11,11 +11,15 @@
  */
 
 import { ethers } from "ethers";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import { validateArgsForAbi } from "@/lib/abi/validate-args";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 
 const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
+const SEPOLIA_CHAIN_ID = 11_155_111;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 
 const WETH_SEPOLIA = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14";
@@ -118,19 +122,34 @@ function buildWeb3Calldata(
 }
 
 describe.skipIf(!RPC_URL)("Web3 write-contract on-chain integration", () => {
-  const getProvider = (): ethers.JsonRpcProvider =>
-    new ethers.JsonRpcProvider(RPC_URL);
+  // Route every RPC call through the failover manager so a primary-endpoint
+  // hiccup falls back to the secondary instead of failing the test. Same
+  // gating as before: tests skipped without INTEGRATION_TEST_RPC_URL.
+  let manager: RpcProviderManager;
+
+  beforeAll(async () => {
+    if (!RPC_URL) {
+      return;
+    }
+    manager = await getRpcProviderFromUrls(
+      RPC_URL,
+      getRpcUrlByChainId(SEPOLIA_CHAIN_ID, "fallback"),
+      SEPOLIA_CHAIN_ID,
+      "sepolia"
+    );
+  });
 
   it("deposit (payable, no args): estimateGas with ETH value", async () => {
     const { data, value } = buildWeb3Calldata("deposit", undefined, "0.001");
 
-    const provider = getProvider();
-    const gas = await provider.estimateGas({
-      to: WETH_SEPOLIA,
-      data,
-      value,
-      from: TEST_ADDRESS,
-    });
+    const gas = await manager.executeWithFailover((p) =>
+      p.estimateGas({
+        to: WETH_SEPOLIA,
+        data,
+        value,
+        from: TEST_ADDRESS,
+      })
+    );
 
     expect(gas).toBeGreaterThan(BigInt(0));
   }, 15_000);
@@ -138,13 +157,14 @@ describe.skipIf(!RPC_URL)("Web3 write-contract on-chain integration", () => {
   it("withdraw (uint256 arg): calldata encodes correctly", async () => {
     const { data } = buildWeb3Calldata("withdraw", '["1000000000000000000"]');
 
-    const provider = getProvider();
     try {
-      await provider.estimateGas({
-        to: WETH_SEPOLIA,
-        data,
-        from: TEST_ADDRESS,
-      });
+      await manager.executeWithFailover((p) =>
+        p.estimateGas({
+          to: WETH_SEPOLIA,
+          data,
+          from: TEST_ADDRESS,
+        })
+      );
     } catch (error) {
       const msg = String(error);
       expect(msg).not.toContain("INVALID_ARGUMENT");
@@ -158,12 +178,13 @@ describe.skipIf(!RPC_URL)("Web3 write-contract on-chain integration", () => {
       `["${TEST_ADDRESS}", "1000000000000000000"]`
     );
 
-    const provider = getProvider();
-    const gas = await provider.estimateGas({
-      to: WETH_SEPOLIA,
-      data,
-      from: TEST_ADDRESS,
-    });
+    const gas = await manager.executeWithFailover((p) =>
+      p.estimateGas({
+        to: WETH_SEPOLIA,
+        data,
+        from: TEST_ADDRESS,
+      })
+    );
 
     expect(gas).toBeGreaterThan(BigInt(0));
   }, 15_000);
@@ -171,12 +192,13 @@ describe.skipIf(!RPC_URL)("Web3 write-contract on-chain integration", () => {
   it("transfer (address + uint256 args): calldata encodes correctly", async () => {
     const { data } = buildWeb3Calldata("transfer", `["${TEST_ADDRESS}", "0"]`);
 
-    const provider = getProvider();
-    const gas = await provider.estimateGas({
-      to: WETH_SEPOLIA,
-      data,
-      from: TEST_ADDRESS,
-    });
+    const gas = await manager.executeWithFailover((p) =>
+      p.estimateGas({
+        to: WETH_SEPOLIA,
+        data,
+        from: TEST_ADDRESS,
+      })
+    );
 
     expect(gas).toBeGreaterThan(BigInt(0));
   }, 15_000);
@@ -184,11 +206,12 @@ describe.skipIf(!RPC_URL)("Web3 write-contract on-chain integration", () => {
   it("balanceOf (read via eth_call): returns decodable uint256", async () => {
     const { data } = buildWeb3Calldata("balanceOf", `["${TEST_ADDRESS}"]`);
 
-    const provider = getProvider();
-    const result = await provider.call({
-      to: WETH_SEPOLIA,
-      data,
-    });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({
+        to: WETH_SEPOLIA,
+        data,
+      })
+    );
 
     const iface = new ethers.Interface(WETH_ABI);
     const decoded = iface.decodeFunctionResult("balanceOf", result);
@@ -202,11 +225,12 @@ describe.skipIf(!RPC_URL)("Web3 write-contract on-chain integration", () => {
       `["${TEST_ADDRESS}", "${TEST_ADDRESS}"]`
     );
 
-    const provider = getProvider();
-    const result = await provider.call({
-      to: WETH_SEPOLIA,
-      data,
-    });
+    const result = await manager.executeWithFailover((p) =>
+      p.call({
+        to: WETH_SEPOLIA,
+        data,
+      })
+    );
 
     const iface = new ethers.Interface(WETH_ABI);
     const decoded = iface.decodeFunctionResult("allowance", result);


### PR DESCRIPTION
## Summary

Several e2e and integration tests were constructing raw `ethers.JsonRpcProvider(URL)` against a single endpoint and calling live RPCs through it. When the chosen endpoint was slow or down (public testnets, free-tier rate limits, regional outages), the tests timed out — even when a working fallback was already configured in `lib/rpc/rpc-config.ts`. Most recent occurrence: `gas-strategy.test.ts > should get gas config from Base Sepolia` 30s timeout that blocked staging deploys earlier today.

This PR retrofits each of those tests to go through the codebase's existing failover-aware RPC layer (`RpcProviderManager` + `executeWithFailover`).

Tracked as KEEP-359.

## What changed (one commit per file)

- **`tests/integration/protocol-wrapped-onchain.test.ts`** — `INTEGRATION_TEST_RPC_URL` (primary) + chain-config Sepolia fallback, every `provider.call` / `provider.estimateGas` wrapped in `executeWithFailover`.
- **`tests/integration/protocol-aave-v4-onchain.test.ts`** — same pattern with `INTEGRATION_TEST_MAINNET_RPC_URL` + Ethereum fallback. The `expectCallAcceptedByBytecode` helper now takes the manager directly and wraps its single `.call()`.
- **`tests/integration/web3-write-onchain.test.ts`** — same pattern. The two pure-encoding tests at the bottom (no RPC) stay as they were.
- **`tests/e2e/vitest/write-contract-workflow.test.ts`** — manager built from chain-table primary + fallback. The wallet-balance check and `Contract.retrieve()` verification now run inside `executeWithFailover`. Construct the `Contract` instance inside the failover callback so each retry gets a fresh provider.
- **`tests/integration/eip7702-spike.test.ts`** — Scenario B's `ParaEthersSigner` now receives `manager.getProvider()` (signer only signs in this test, no broadcast). Scenario C.b's `getTransactionCount` runs through `executeWithFailover`. Scenarios C.c and D use viem through Pimlico's bundler — left raw with an inline note (failover layer is ethers-only; Pimlico has independent retry).
- **`tests/e2e/vitest/transaction-flow.test.ts`** — three describe blocks each construct a manager via a shared `buildSepoliaManager()` helper. Connectivity probe and balance check now use `executeWithFailover`. Every `gasStrategy.getGasConfig(...)` call now passes the manager as the 7th arg so `runRpc` (in `gas-strategy.ts`) routes its internal fee-history / `getFeeData` calls through failover.

## Out of scope

- `tests/e2e/vitest/gas-strategy.test.ts` lines 56-57, 456: vestigial raw-provider construction passed alongside a manager. `runRpc` already ignores the raw provider when a manager is present, so these are functionally unused. Cleanup-only; deferred to keep this PR mechanical.
- `tests/e2e/vitest/gas-strategy.test.ts` line 407: explicit single-endpoint `slowProvider` for the "should handle RPC timeout gracefully" assertion. Intentional bypass.
- viem-side transports in eip7702-spike (Pimlico bundler). Repo's `RpcProviderManager` is ethers-only.

## Test plan

- [x] `pnpm type-check` clean
- [ ] CI: gas-strategy / transaction-flow Real RPC tests run end-to-end against the failover manager
- [ ] Manual: introduce a deliberately broken primary URL and confirm the test still passes via the fallback (verifies wiring, not just compile)

## Why

Today's flake was both Base Sepolia primary and fallback slow within 30s — failover wouldn't have prevented it. This retrofit doesn't fix that case; it prevents the next flake when some other test calls a single endpoint that hiccups, by giving every real-RPC call a second-chance retry on the configured secondary URL.