### PR TITLE
hotfix(db): remove drizzle breakpoint phrase from 0061 comment text

### DIFF
--- a/drizzle/0061_tempo_testnet_chain_id.sql
+++ b/drizzle/0061_tempo_testnet_chain_id.sql
@@ -11,10 +11,17 @@
 -- scoped to the explicit "network":"42429" key/value pair so we cannot
 -- accidentally rewrite unrelated literal strings.
 
--- This migration deliberately contains no `--> statement-breakpoint` markers
--- so drizzle-kit runs the whole file as a single query inside its implicit
+-- This migration deliberately contains no statement breakpoint markers so
+-- drizzle-kit runs the whole file as a single query inside its implicit
 -- per-migration transaction (matches the precedent set by 0025). If any UPDATE
 -- fails the FK drop is rolled back with it.
+--
+-- IMPORTANT: do NOT write the drizzle breakpoint marker phrase verbatim
+-- anywhere in this file -- not even inside comments or quoted strings.
+-- drizzle-orm's readMigrationFiles (drizzle-orm/src/migrator.ts) does a
+-- context-free string split for that phrase across the whole file, which
+-- shreds the migration into separate statements regardless of where the
+-- phrase appears.
 
 -- Precondition: refuse to run if any 42431 rows already coexist with 42429
 -- rows in any of the affected tables. This avoids unique- or PK-collision


### PR DESCRIPTION
## Summary

PR #1005 (`release: To Prod`) is failing on the `e2e-tests / e2e-vitest-ephemeral` migration step:

```
[⣟] applying migrations... ELIFECYCLE  Command failed with exit code 1.
postgres ERROR: syntax error at or near "`" at character 1
```

## Root cause

The `0061_tempo_testnet_chain_id.sql` migration's header comment quotes drizzle's breakpoint marker phrase verbatim (wrapped in backticks):

```sql
-- This migration deliberately contains no `--> statement-breakpoint` markers
```

`drizzle-orm`'s `readMigrationFiles` (`drizzle-orm/src/migrator.ts:42`) splits the file with a context-free `query.split('--> statement-breakpoint')`. It does **not** skip occurrences inside SQL line comments. So the file is torn into two statements mid-comment. The second chunk begins with the closing backtick from the comment, and Postgres rejects it with `syntax error at or near "\`" at character 1`.

## Fix

Rewrite the header comment so the literal marker phrase no longer appears anywhere in the file (not even inside backticks or quoted strings), and warn future editors against reintroducing it. The migration body is unchanged.

## Why no new migration file

The migration has never successfully applied on any environment (every CI run errored out during the same migrate step), so no DB has it recorded in `__drizzle_migrations`. Editing the file in place is safe and avoids the renumbering churn a new 0062 would impose.

## Test plan

- [x] `grep "statement-breakpoint" drizzle/0061_tempo_testnet_chain_id.sql` returns no matches.
- [ ] After this lands on staging, retrigger #1005 CI -- expect `e2e-vitest-ephemeral` to clear the migrate step and complete the rest of the pipeline.

## Related

Blocks #1005 (release: staging -> prod). Unrelated to the four agentic-wallet MPP charge hotfixes (#976, #979, #984, #1000) that share the same release window.