### PR TITLE
hotfix(agentic-wallet): cap MPP charge validBefore to 25s for TIP-1009

### DIFF
--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -51,7 +51,14 @@ const MPP_AUTH_PREFIX = "Payment ";
 // VerificationFailedError.
 const MPP_TX_GAS = BigInt(500_000);
 const MPP_TX_MAX_FEE_PER_GAS = BigInt(50_000_000_000); // 50 gwei
-const MPP_TX_VALIDITY_WINDOW_SECONDS = 300; // 5 minutes
+// TIP-1009 expiring-nonce hard limit: validBefore must fall within 30s of the
+// chain's block timestamp at broadcast time. Tempo's nonce manager rejects
+// `eth_sendRawTransactionSync` outright if the envelope sets a longer window
+// (`nonce manager error: expiring nonce valid_before too far in the future`).
+// Match mppx/client/Charge.js's 25s budget so the round-trip
+// (sign -> /sign returns -> client retry -> server broadcasts) stays well
+// inside the 30s ceiling even with a multi-second Turnkey latency.
+const MPP_TX_VALIDITY_WINDOW_SECONDS = 25;
 
 // TIP-1009 expiring-nonce marker. viem/tempo/chainConfig.js rewrites
 // `{nonceKey: 'expiring'}` to `{nonceKey: 2**256-1, nonce: 0}`; we hardcode


### PR DESCRIPTION
## Summary

Fifth hotfix in the MPP charge transaction-mode chain (after #976 / #979 / #984 / #1000). Prod smoke after #1005 deployed still failed with the same reason-less 402. Prod app log finally surfaced the real RPC error suppressed by `mppx/server/Mppx.js:247`'s catch-all:

```
mpp: internal verification error
Error [InvalidInputRpcError]: Missing or invalid parameters.
URL: https://rpc.tempo.xyz
details: 'nonce manager error: expiring nonce valid_before (1777298373) too far in the future: must be within 30s of block timestamp (1777298073), max allowed is 1777298103'
```

## Root cause

Tempo's TIP-1009 expiring-nonce mechanism enforces a hard **30-second** ceiling on `validBefore` relative to the broadcast-time block timestamp. We were setting `validBefore = nowSec + 300` (5 minutes) which exceeded the cap by 270 seconds. `eth_sendRawTransactionSync` rejected the broadcast with a plain `InvalidInputRpcError`, mppx's outer catch wrapped it as a reason-less `VerificationFailedError` 402 -- same shape as the previous four hotfixes already trained us to read as "something downstream threw with no reason".

The canonical mppx client (`mppx/client/Charge.js`) caps its window at `nowSec + 25` for exactly this reason. I spotted that diff during #984 analysis but mistook it for stylistic and didn't propagate; that mistake cost us this round-trip.

## Fix

- `MPP_TX_VALIDITY_WINDOW_SECONDS`: `300` -> `25` (matches canonical client). 25s leaves ~5s of headroom under the 30s on-chain cap for Turnkey latency in the round-trip.
- Comment block now explicitly documents the 30s on-chain cap so a future reader doesn't relax this back to "5 minutes for safety".

## Test plan

- [x] `pnpm vitest run --dir=tests tests/unit/agentic-wallet-sign.test.ts tests/integration/agentic-wallet-sign-route.test.ts` -- 32 tests pass (the validBefore value isn't pinned by any current test; tests assert envelope shape + presence).
- [x] `pnpm type-check` clean.
- [ ] After merge + prod deploy: rerun prod MPP smoke against `mcp-test`; expect 200 + executionId + 0.01 USDC.e debit on Tempo. With this in place the full MPP charge chain should finally settle end-to-end.

## Bug-chain so far

| # | PR    | Bug                                                                 |
|---|-------|---------------------------------------------------------------------|
| 1 | #976  | Missing `type` discriminator on credential payload                  |
| 2 | #979  | Wrong `nonceKey` (TIP-1009 expiring marker required for fee-payer)  |
| 3 | #984  | `maxFeePerGas` below Tempo's live base fee                          |
| 4 | #1000 | Attribution memo tag was `"MPP\0"` instead of `keccak256("mpp")[0..3]` |
| 5 | this  | `validBefore` window > 30s breaches TIP-1009 cap                    |

Each surfaced as the same generic `VerificationFailedError` because `mppx/server/Mppx.js:247` swallows non-`PaymentError` throws.

## Related

- Builds on #976 / #979 / #984 / #1000.
- KEEP-361 (in flight) -- adding a `paymentHint` so agents can force MPP without our smoke script's manual `/sign` call.