### PR TITLE
fix: KEEP-367 read-contract uint256 input clears on blur

### DIFF
--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -9,6 +9,7 @@ import {
   TemplateAutocomplete,
   type TemplateAutocompleteCloseReason,
 } from "./template-autocomplete";
+import { toStringValue } from "./template-badge-utils";
 
 // Guards `selection.getRangeAt(0)`, which throws IndexSizeError when
 // rangeCount is 0 (e.g. focus moved off the editable before keydown fired).
@@ -101,14 +102,6 @@ function findActiveAtSign(text: string, cursorOffset?: number): number {
  * An input component that renders template variables as styled badges
  * Converts {{@nodeId:DisplayName.field}} to badges showing "DisplayName.field"
  */
-// Defensive: parent components type `value` as string but TS-only `as string`
-// casts at call sites can leak non-strings (numbers, booleans) to us at runtime.
-// internalValue.match() in handleInput would throw "match is not a function"
-// in that case, blocking handleInput from propagating the user's edit (KEEP-367).
-function toStringValue(value: unknown): string {
-  return typeof value === "string" ? value : String(value ?? "");
-}
-
 export function TemplateBadgeInput({
   value = "",
   onChange,

--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -101,6 +101,14 @@ function findActiveAtSign(text: string, cursorOffset?: number): number {
  * An input component that renders template variables as styled badges
  * Converts {{@nodeId:DisplayName.field}} to badges showing "DisplayName.field"
  */
+// Defensive: parent components type `value` as string but TS-only `as string`
+// casts at call sites can leak non-strings (numbers, booleans) to us at runtime.
+// internalValue.match() in handleInput would throw "match is not a function"
+// in that case, blocking handleInput from propagating the user's edit (KEEP-367).
+function toStringValue(value: unknown): string {
+  return typeof value === "string" ? value : String(value ?? "");
+}
+
 export function TemplateBadgeInput({
   value = "",
   onChange,
@@ -111,7 +119,9 @@ export function TemplateBadgeInput({
 }: TemplateBadgeInputProps) {
   const [isFocused, setIsFocused] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
-  const [internalValue, setInternalValue] = useState(value);
+  const [internalValue, setInternalValue] = useState<string>(() =>
+    toStringValue(value)
+  );
   const shouldUpdateDisplay = useRef(true);
   const [selectedNodeId] = useAtom(selectedNodeAtom);
   const [nodes] = useAtom(nodesAtom);
@@ -153,8 +163,9 @@ export function TemplateBadgeInput({
 
   // Update internal value when prop changes from outside
   useEffect(() => {
-    if (value !== internalValue && !isFocused) {
-      setInternalValue(value);
+    const safeValue = toStringValue(value);
+    if (safeValue !== internalValue && !isFocused) {
+      setInternalValue(safeValue);
       shouldUpdateDisplay.current = true;
     }
   }, [value, isFocused, internalValue]);

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -97,6 +97,12 @@ function findActiveAtSign(text: string, cursorOffset?: number): number {
  * A textarea component that renders template variables as styled badges
  * Converts {{@nodeId:DisplayName.field}} to badges showing "DisplayName.field"
  */
+// See toStringValue in template-badge-input.tsx -- same defense against
+// non-string values leaking through TS-only `as string` casts at call sites.
+function toStringValue(value: unknown): string {
+  return typeof value === "string" ? value : String(value ?? "");
+}
+
 export function TemplateBadgeTextarea({
   value = "",
   onChange,
@@ -109,7 +115,9 @@ export function TemplateBadgeTextarea({
 }: TemplateBadgeTextareaProps) {
   const [isFocused, setIsFocused] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
-  const [internalValue, setInternalValue] = useState(value);
+  const [internalValue, setInternalValue] = useState<string>(() =>
+    toStringValue(value)
+  );
   const shouldUpdateDisplay = useRef(true);
   const [selectedNodeId] = useAtom(selectedNodeAtom);
   const [nodes] = useAtom(nodesAtom);
@@ -151,8 +159,9 @@ export function TemplateBadgeTextarea({
 
   // Update internal value when prop changes from outside
   useEffect(() => {
-    if (value !== internalValue && !isFocused) {
-      setInternalValue(value);
+    const safeValue = toStringValue(value);
+    if (safeValue !== internalValue && !isFocused) {
+      setInternalValue(safeValue);
       shouldUpdateDisplay.current = true;
     }
   }, [value, isFocused, internalValue]);

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -10,6 +10,7 @@ import {
   TemplateAutocomplete,
   type TemplateAutocompleteCloseReason,
 } from "./template-autocomplete";
+import { toStringValue } from "./template-badge-utils";
 
 export interface TemplateBadgeTextareaProps {
   value?: string;
@@ -97,12 +98,6 @@ function findActiveAtSign(text: string, cursorOffset?: number): number {
  * A textarea component that renders template variables as styled badges
  * Converts {{@nodeId:DisplayName.field}} to badges showing "DisplayName.field"
  */
-// See toStringValue in template-badge-input.tsx -- same defense against
-// non-string values leaking through TS-only `as string` casts at call sites.
-function toStringValue(value: unknown): string {
-  return typeof value === "string" ? value : String(value ?? "");
-}
-
 export function TemplateBadgeTextarea({
   value = "",
   onChange,

--- a/components/ui/template-badge-utils.ts
+++ b/components/ui/template-badge-utils.ts
@@ -1,0 +1,10 @@
+// Shared helpers for the template-badge editable surfaces.
+
+// Defensive: parent components type `value` as string, but TS-only `as string`
+// casts at call sites can leak non-strings (numbers, booleans) to us at
+// runtime. internalValue.match() in the badge inputs would throw "match is
+// not a function" in that case, blocking the user's edit from propagating
+// (KEEP-367).
+export function toStringValue(value: unknown): string {
+  return typeof value === "string" ? value : String(value ?? "");
+}

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -22,6 +22,7 @@ import { SaveAddressBookmark } from "@/components/address-book/save-address-book
 import type { AbiComponent } from "@/components/workflow/config/abi-types";
 import { ArrayInputField } from "@/components/workflow/config/array-input-field";
 import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
+import { parseAbiFunctionArgs } from "@/lib/abi/parse-args";
 import { computeSelector, findAbiFunction } from "@/lib/abi/utils";
 import { evaluateShowWhen } from "@/lib/workflow/editor/show-when";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
@@ -277,38 +278,6 @@ export type AbiFunctionArgsProps = FieldProps & {
   abiValue: string;
   functionValue: string;
 };
-
-// Coerce a single arg value into a shape the renderers expect:
-//   - arrays stay arrays (ArrayInputField)
-//   - non-array objects stay objects (TupleInputField)
-//   - primitives become strings (TemplateBadgeInput, ProtocolUintField, etc.)
-//   - null/undefined become "" so the input renders empty
-// Without this coercion, a stored JSON like "[1]" yields a number that flows
-// into TemplateBadgeInput and throws on internalValue.match() (KEEP-367).
-function coerceAbiArgValue(item: unknown): unknown {
-  if (Array.isArray(item)) {
-    return item;
-  }
-  if (typeof item === "object" && item !== null) {
-    return item;
-  }
-  if (item === undefined || item === null) {
-    return "";
-  }
-  return String(item);
-}
-
-export function parseAbiFunctionArgs(value: string): unknown[] {
-  if (!value || value.trim() === "") {
-    return [];
-  }
-  try {
-    const parsed: unknown = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed.map(coerceAbiArgValue) : [];
-  } catch {
-    return [];
-  }
-}
 
 export function AbiFunctionArgsField({
   field,

--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -278,6 +278,38 @@ export type AbiFunctionArgsProps = FieldProps & {
   functionValue: string;
 };
 
+// Coerce a single arg value into a shape the renderers expect:
+//   - arrays stay arrays (ArrayInputField)
+//   - non-array objects stay objects (TupleInputField)
+//   - primitives become strings (TemplateBadgeInput, ProtocolUintField, etc.)
+//   - null/undefined become "" so the input renders empty
+// Without this coercion, a stored JSON like "[1]" yields a number that flows
+// into TemplateBadgeInput and throws on internalValue.match() (KEEP-367).
+function coerceAbiArgValue(item: unknown): unknown {
+  if (Array.isArray(item)) {
+    return item;
+  }
+  if (typeof item === "object" && item !== null) {
+    return item;
+  }
+  if (item === undefined || item === null) {
+    return "";
+  }
+  return String(item);
+}
+
+export function parseAbiFunctionArgs(value: string): unknown[] {
+  if (!value || value.trim() === "") {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(coerceAbiArgValue) : [];
+  } catch {
+    return [];
+  }
+}
+
 export function AbiFunctionArgsField({
   field,
   value,
@@ -318,22 +350,9 @@ export function AbiFunctionArgsField({
     }
   }, [abiValue, functionValue]);
 
-  // Parse prop value into array
-  const parsePropValue = React.useCallback((val: string): unknown[] => {
-    if (!val || val.trim() === "") {
-      return [];
-    }
-    try {
-      const parsed = JSON.parse(val);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }, []);
-
   // Use local state to manage arg values - this prevents race conditions on blur
   const [localArgValues, setLocalArgValues] = React.useState<unknown[]>(() =>
-    parsePropValue(value)
+    parseAbiFunctionArgs(value)
   );
 
   // Track the last function to detect when user selects a different function
@@ -343,10 +362,10 @@ export function AbiFunctionArgsField({
   React.useEffect(() => {
     if (functionValue !== lastFunctionRef.current) {
       // Function changed - reset to prop value (which should be empty for new function)
-      setLocalArgValues(parsePropValue(value));
+      setLocalArgValues(parseAbiFunctionArgs(value));
       lastFunctionRef.current = functionValue;
     }
-  }, [functionValue, value, parsePropValue]);
+  }, [functionValue, value]);
 
   // Handle individual arg change - update local state and propagate to parent
   const handleArgChange = (index: number, newValue: unknown) => {

--- a/components/workflow/config/args-list-field.tsx
+++ b/components/workflow/config/args-list-field.tsx
@@ -7,6 +7,7 @@ import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import type { AbiComponent } from "@/components/workflow/config/abi-types";
 import { ArrayInputField } from "@/components/workflow/config/array-input-field";
 import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
+import { coerceAbiArgValue } from "@/lib/abi/parse-args";
 import { findAbiFunction } from "@/lib/abi/utils";
 import type { ActionConfigFieldBase } from "@/plugins/registry";
 
@@ -70,14 +71,7 @@ export function parseArgsListValue(
       const arr = Array.isArray(argSet) ? argSet : [];
       const values: unknown[] = [];
       for (let i = 0; i < paramCount; i++) {
-        const item = arr[i];
-        if (Array.isArray(item)) {
-          values.push(item);
-        } else if (item !== undefined && item !== null) {
-          values.push(String(item));
-        } else {
-          values.push("");
-        }
+        values.push(coerceAbiArgValue(arr[i]));
       }
       return { id: nextId(), values };
     });

--- a/components/workflow/config/protocol-fields/protocol-uint-field.tsx
+++ b/components/workflow/config/protocol-fields/protocol-uint-field.tsx
@@ -38,7 +38,7 @@ export function ProtocolUintField({
         id={fieldKey}
         onChange={onChange}
         placeholder={placeholder ?? "0"}
-        value={value ?? ""}
+        value={String(value ?? "")}
       />
       {validation && (
         <p className="mt-1 text-xs text-destructive">{validation}</p>

--- a/components/workflow/config/tuple-input-field.tsx
+++ b/components/workflow/config/tuple-input-field.tsx
@@ -99,7 +99,7 @@ export function TupleInputField({
                 fieldKey={`${fieldKey}-${comp.name}`}
                 onChange={(val) => handleFieldChange(comp.name, String(val))}
                 placeholder="0x..."
-                value={(obj[comp.name] as string) ?? ""}
+                value={String(obj[comp.name] ?? "")}
               />
             ) : comp.type.startsWith("uint") ? (
               <ProtocolUintField
@@ -108,7 +108,7 @@ export function TupleInputField({
                 onChange={(val) => handleFieldChange(comp.name, String(val))}
                 placeholder=""
                 solidityType={comp.type}
-                value={(obj[comp.name] as string) ?? ""}
+                value={String(obj[comp.name] ?? "")}
               />
             ) : (
               <TemplateBadgeInput
@@ -116,7 +116,7 @@ export function TupleInputField({
                 id={`${fieldKey}-${comp.name}`}
                 onChange={(val) => handleFieldChange(comp.name, String(val))}
                 placeholder={`Enter ${comp.type} value or {{NodeName.value}}`}
-                value={(obj[comp.name] as string) ?? ""}
+                value={String(obj[comp.name] ?? "")}
               />
             )}
           </div>

--- a/lib/abi/parse-args.ts
+++ b/lib/abi/parse-args.ts
@@ -1,0 +1,40 @@
+// Pure helpers for parsing serialized ABI function arg arrays out of stored
+// workflow config. Kept dependency-free (no React, no DOM) so they can be
+// shared by the args-list and abi-function-args field renderers and tested
+// in isolation.
+
+// Coerce a single arg value into the shape the renderers expect:
+//   - arrays stay arrays            (ArrayInputField)
+//   - non-array objects stay objects (TupleInputField)
+//   - null/undefined become ""       (so the input renders empty)
+//   - everything else becomes String(item)
+//
+// Without this, a stored JSON like "[1]" surfaces a number that flows into
+// TemplateBadgeInput and throws on internalValue.match() (KEEP-367).
+export function coerceAbiArgValue(item: unknown): unknown {
+  if (Array.isArray(item)) {
+    return item;
+  }
+  if (typeof item === "object" && item !== null) {
+    return item;
+  }
+  if (item === undefined || item === null) {
+    return "";
+  }
+  return String(item);
+}
+
+// Parse a JSON-serialized arg array (`"[1, \"0xabc\"]"`) into the shape
+// AbiFunctionArgsField expects. Returns [] for empty / invalid / non-array
+// input so callers don't need to guard.
+export function parseAbiFunctionArgs(value: string): unknown[] {
+  if (!value || value.trim() === "") {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(coerceAbiArgValue) : [];
+  } catch {
+    return [];
+  }
+}

--- a/tests/unit/abi-function-args.test.ts
+++ b/tests/unit/abi-function-args.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAbiFunctionArgs } from "@/components/workflow/config/action-config-renderer";
+
+describe("parseAbiFunctionArgs", () => {
+  it("returns empty array for empty string", () => {
+    expect(parseAbiFunctionArgs("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(parseAbiFunctionArgs("   ")).toEqual([]);
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    expect(parseAbiFunctionArgs("not json")).toEqual([]);
+  });
+
+  it("returns empty array when parsed value is not an array", () => {
+    expect(parseAbiFunctionArgs('{"a": 1}')).toEqual([]);
+    expect(parseAbiFunctionArgs("42")).toEqual([]);
+    expect(parseAbiFunctionArgs('"hello"')).toEqual([]);
+  });
+
+  // The KEEP-367 regression tests: stored numeric args must surface as strings
+  // so TemplateBadgeInput's internalValue.match() does not throw.
+  it("coerces raw numbers to strings", () => {
+    const result = parseAbiFunctionArgs("[1]");
+    expect(result).toEqual(["1"]);
+    expect(typeof result[0]).toBe("string");
+  });
+
+  it("coerces multiple raw numbers to strings", () => {
+    const result = parseAbiFunctionArgs("[1, 42, 0]");
+    expect(result).toEqual(["1", "42", "0"]);
+  });
+
+  it("coerces booleans to strings", () => {
+    expect(parseAbiFunctionArgs("[true, false]")).toEqual(["true", "false"]);
+  });
+
+  it("converts null and undefined entries to empty strings", () => {
+    expect(parseAbiFunctionArgs("[null]")).toEqual([""]);
+  });
+
+  it("preserves string entries unchanged", () => {
+    expect(parseAbiFunctionArgs('["0xabc", "1"]')).toEqual(["0xabc", "1"]);
+  });
+
+  it("preserves arrays as arrays (for ArrayInputField)", () => {
+    const result = parseAbiFunctionArgs("[[1, 2, 3]]");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual([1, 2, 3]);
+    expect(Array.isArray(result[0])).toBe(true);
+  });
+
+  it("preserves objects as objects (for TupleInputField)", () => {
+    const result = parseAbiFunctionArgs('[{"x": 1, "y": "a"}]');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ x: 1, y: "a" });
+  });
+
+  it("handles a mix of primitives, arrays, and objects in one call", () => {
+    const result = parseAbiFunctionArgs('[1, "0xabc", [1, 2], {"x": 3}]');
+    expect(result).toEqual(["1", "0xabc", [1, 2], { x: 3 }]);
+  });
+});

--- a/tests/unit/abi-function-args.test.ts
+++ b/tests/unit/abi-function-args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseAbiFunctionArgs } from "@/components/workflow/config/action-config-renderer";
+import { parseAbiFunctionArgs } from "@/lib/abi/parse-args";
 
 describe("parseAbiFunctionArgs", () => {
   it("returns empty array for empty string", () => {


### PR DESCRIPTION
## Summary

Fix a bug where typing a number (e.g. `1`) into a `uint256` argument on a Read Contract node disappeared on blur, with `TypeError: g.match is not a function` in the console. Reported during the ETHGlobal Open Agents hackathon (KEEP-367).

## Root cause

Stored `functionArgs` JSON containing raw numbers (e.g. `"[1]"` from a Code-tab edit, an MCP/AI-generated workflow, or an imported template) flowed unchanged through the prop-value parser into `TemplateBadgeInput`. The `(localArgValues[index] as string) || ""` cast at the call site is TypeScript-only -- at runtime the number reaches `useState(value)`, so `internalValue.match()` in `handleInput` throws `match is not a function` on the first keystroke.

`handleInput` then never propagates the edit, and the blur effect re-runs `updateDisplay` where `text.slice` on a number wipes the DOM -- so the value visibly disappears.

The bug-reporter's hypothesis ("onBlur parses to Number then validates with `.match()`") was the right symptom in the wrong order: the value is already a number on entry; `.match()` is on `internalValue`, not from a parser.

## Fix

**Primary fix at the leak sites:**
- New `lib/abi/parse-args.ts` exporting `parseAbiFunctionArgs` and `coerceAbiArgValue`. Coerces parsed primitives (numbers, booleans) to strings while leaving arrays and tuple objects intact for `ArrayInputField` / `TupleInputField`. `null` / `undefined` become `""`.
- `args-list-field.tsx` now uses the same `coerceAbiArgValue` -- previously it stringified non-array objects to `"[object Object]"` via `String({})`. Sharing the helper gives args-list tuple-object passthrough for free.
- Replace 3 unsafe `(... as string) ?? ""` casts in `tuple-input-field.tsx` with `String(... ?? "")`.
- Same coercion at the `TemplateBadgeInput` call site in `protocol-uint-field.tsx`.

**Defensive guard at the consumer:**
- New `components/ui/template-badge-utils.ts` with shared `toStringValue` helper.
- `TemplateBadgeInput` and `TemplateBadgeTextarea` now coerce `value` to a string at `useState` init and in the prop-sync effect, so a future caller leaking a non-string cannot crash the input on `.match()`.

## Tests

Added `tests/unit/abi-function-args.test.ts` (12 cases) covering: raw numbers, multiple numbers, booleans, `null`/`undefined`, strings preserved, nested arrays preserved (for ArrayInputField), nested objects preserved (for TupleInputField), mixed primitives + structures, empty input, whitespace, invalid JSON, and non-array JSON.

Existing `args-list-field.test.ts` covers the same coercion through the now-shared helper.

## Test plan

- [x] `pnpm vitest run tests/unit/abi-function-args.test.ts` -- 12/12 pass
- [x] `pnpm vitest run tests/unit/args-list-field.test.ts` -- 33/33 pass
- [x] `pnpm vitest run tests/unit` -- 3173/3173 pass
- [x] `pnpm type-check` -- pass
- [x] `pnpm check` -- 0 diagnostics on changed files
- [ ] Manual repro on staging: load a workflow with `functionArgs: "[1]"` (e.g. via Code tab), open UI tab, edit the input, blur -- value should persist and not throw

## Commits

1. `fix: KEEP-367 coerce non-string ABI function args to strings` -- the primary bug fix.
2. `refactor: KEEP-367 extract toStringValue to shared template-badge-utils` -- removes a copy-pasted helper between `template-badge-input` and `template-badge-textarea`. Also restores the JSDoc association on both components (the helper had been wedged between the doc comment and the export).
3. `refactor: KEEP-367 move ABI arg parser to lib/abi and share with args-list` -- pulls `parseAbiFunctionArgs` / `coerceAbiArgValue` out of the React module into a pure-TS sibling so the unit test does not transitively import the entire renderer. `args-list-field` now uses the shared coercion and gains tuple-object passthrough.

## Linear

[KEEP-367](https://linear.app/keeperhub/issue/KEEP-367)