### PR TITLE
feat: KEEP-292 synthesise standalone-viem code for protocol actions

### DIFF
--- a/components/workflow/utils/code-generators.ts
+++ b/components/workflow/utils/code-generators.ts
@@ -2,6 +2,7 @@
  * Code generation utilities for workflow step functions
  */
 
+import { synthesiseProtocolTemplate } from "@/lib/workflow/codegen/protocol-synthesiser";
 import { AUTO_GENERATED_TEMPLATES } from "@/lib/workflow/codegen/registry";
 import conditionTemplate from "@/lib/workflow/codegen/templates/condition";
 import databaseQueryTemplate from "@/lib/workflow/codegen/templates/database-query";
@@ -63,7 +64,10 @@ export async function POST(request: NextRequest) {
   return "";
 }
 
-function generateActionCode(actionType: string | undefined): string {
+function generateActionCode(
+  actionType: string | undefined,
+  config: NodeConfig | undefined
+): string {
   if (!actionType) {
     return FALLBACK_ACTION_CODE;
   }
@@ -76,12 +80,17 @@ function generateActionCode(actionType: string | undefined): string {
   // Look up plugin actions in registry
   const action = findActionById(actionType);
   if (action) {
-    // Prefer auto-generated templates, fall back to manual templates
-    return (
-      AUTO_GENERATED_TEMPLATES[action.id] ||
-      action.codegenTemplate ||
-      FALLBACK_ACTION_CODE
-    );
+    const autoTemplate = AUTO_GENERATED_TEMPLATES[action.id];
+    if (autoTemplate) {
+      return autoTemplate;
+    }
+    // Synthesise protocol actions (ABI-driven) on demand. Returns null for
+    // non-protocol actions, falling through to manual templates / stub.
+    const synthesised = synthesiseProtocolTemplate(action.id, config);
+    if (synthesised) {
+      return synthesised;
+    }
+    return action.codegenTemplate || FALLBACK_ACTION_CODE;
   }
 
   return FALLBACK_ACTION_CODE;
@@ -102,7 +111,10 @@ export const generateNodeCode = (node: {
   }
 
   if (node.data.type === "action") {
-    return generateActionCode(node.data.config?.actionType as string);
+    return generateActionCode(
+      node.data.config?.actionType as string,
+      node.data.config
+    );
   }
 
   return FALLBACK_UNKNOWN_CODE;

--- a/lib/protocol-encode-transforms.ts
+++ b/lib/protocol-encode-transforms.ts
@@ -11,6 +11,20 @@
 
 type EncodeTransform = (value: string) => string;
 
+/**
+ * Discriminator for registered transforms. The runtime applies the
+ * transform function regardless; the codegen synthesiser switches on
+ * `kind` to emit equivalent inline source. Add a new value here when
+ * registering a new transform shape, then teach the synthesiser to
+ * handle it.
+ */
+export type EncodeTransformKind = "padAddressToBytes";
+
+type TransformEntry = {
+  kind: EncodeTransformKind;
+  transform: EncodeTransform;
+};
+
 type TransformKey = string;
 
 function makeKey(
@@ -21,15 +35,19 @@ function makeKey(
   return `${protocolSlug}/${actionSlug}/${inputName}`;
 }
 
-const transforms = new Map<TransformKey, EncodeTransform>();
+const transforms = new Map<TransformKey, TransformEntry>();
 
 export function registerEncodeTransform(
   protocolSlug: string,
   actionSlug: string,
   inputName: string,
-  transform: EncodeTransform
+  transform: EncodeTransform,
+  kind: EncodeTransformKind
 ): void {
-  transforms.set(makeKey(protocolSlug, actionSlug, inputName), transform);
+  transforms.set(makeKey(protocolSlug, actionSlug, inputName), {
+    kind,
+    transform,
+  });
 }
 
 export function getEncodeTransform(
@@ -37,7 +55,16 @@ export function getEncodeTransform(
   actionSlug: string,
   inputName: string
 ): EncodeTransform | undefined {
-  return transforms.get(makeKey(protocolSlug, actionSlug, inputName));
+  return transforms.get(makeKey(protocolSlug, actionSlug, inputName))
+    ?.transform;
+}
+
+export function getEncodeTransformKind(
+  protocolSlug: string,
+  actionSlug: string,
+  inputName: string
+): EncodeTransformKind | undefined {
+  return transforms.get(makeKey(protocolSlug, actionSlug, inputName))?.kind;
 }
 
 export function applyEncodeTransformsNamed(
@@ -50,11 +77,9 @@ export function applyEncodeTransformsNamed(
   }
 
   return inputs.map((input) => {
-    const transform = transforms.get(
-      makeKey(protocolSlug, actionSlug, input.name)
-    );
-    if (transform) {
-      return { name: input.name, value: transform(input.value) };
+    const entry = transforms.get(makeKey(protocolSlug, actionSlug, input.name));
+    if (entry) {
+      return { name: input.name, value: entry.transform(input.value) };
     }
     return input;
   });
@@ -83,11 +108,13 @@ registerEncodeTransform(
   "chainlink",
   "ccip-get-fee",
   "receiver",
-  padAddressToBytes
+  padAddressToBytes,
+  "padAddressToBytes"
 );
 registerEncodeTransform(
   "chainlink",
   "ccip-send",
   "receiver",
-  padAddressToBytes
+  padAddressToBytes,
+  "padAddressToBytes"
 );

--- a/lib/workflow/codegen/protocol-metadata.ts
+++ b/lib/workflow/codegen/protocol-metadata.ts
@@ -3,8 +3,6 @@ import "@/protocols";
 import {
   getProtocol,
   type ProtocolAction,
-  type ProtocolActionInput,
-  type ProtocolActionInputComponent,
   type ProtocolActionOutput,
   type ProtocolContract,
   type ProtocolDefinition,
@@ -68,26 +66,22 @@ function findFunctionFragment(
   return null;
 }
 
-function inputComponentToAbiParameter(
-  component: ProtocolActionInputComponent
-): AbiParameter {
-  const result: AbiParameter = {
-    name: component.name,
-    type: component.type,
-  };
-  if (component.components && component.components.length > 0) {
-    result.components = component.components.map(inputComponentToAbiParameter);
-  }
-  return result;
-}
+// Both ProtocolActionInput and ProtocolActionInputComponent share this
+// minimal shape; ProtocolActionInput just carries extra UI metadata.
+// One walker handles both via structural typing.
+type AbiShapedInput = {
+  name: string;
+  type: string;
+  components?: AbiShapedInput[];
+};
 
-function inputToAbiParameter(input: ProtocolActionInput): AbiParameter {
+function inputToAbiParameter(input: AbiShapedInput): AbiParameter {
   const result: AbiParameter = {
     name: input.name,
     type: input.type,
   };
   if (input.components && input.components.length > 0) {
-    result.components = input.components.map(inputComponentToAbiParameter);
+    result.components = input.components.map(inputToAbiParameter);
   }
   return result;
 }

--- a/lib/workflow/codegen/protocol-metadata.ts
+++ b/lib/workflow/codegen/protocol-metadata.ts
@@ -1,0 +1,188 @@
+import "@/protocols";
+
+import {
+  getProtocol,
+  type ProtocolAction,
+  type ProtocolActionInput,
+  type ProtocolActionInputComponent,
+  type ProtocolActionOutput,
+  type ProtocolContract,
+  type ProtocolDefinition,
+} from "@/lib/protocol-registry";
+
+export type AbiFunctionFragment = {
+  type: "function";
+  name: string;
+  stateMutability?: "pure" | "view" | "nonpayable" | "payable";
+  inputs: AbiParameter[];
+  outputs: AbiParameter[];
+};
+
+export type AbiParameter = {
+  name?: string;
+  type: string;
+  components?: AbiParameter[];
+  internalType?: string;
+};
+
+export type AbiSource = "abi-fragment" | "synthesised-from-action-metadata";
+
+export type ProtocolActionContext = {
+  actionId: string;
+  protocolSlug: string;
+  actionSlug: string;
+  protocol: ProtocolDefinition;
+  contract: ProtocolContract;
+  contractKey: string;
+  action: ProtocolAction;
+  abiFragment: AbiFunctionFragment;
+  abiSource: AbiSource;
+};
+
+function parseAbi(abiJson: string | undefined): unknown[] | null {
+  if (!abiJson) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(abiJson);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function findFunctionFragment(
+  abi: unknown[],
+  functionName: string
+): AbiFunctionFragment | null {
+  for (const item of abi) {
+    if (
+      typeof item === "object" &&
+      item !== null &&
+      (item as { type?: unknown }).type === "function" &&
+      (item as { name?: unknown }).name === functionName
+    ) {
+      return item as AbiFunctionFragment;
+    }
+  }
+  return null;
+}
+
+function inputComponentToAbiParameter(
+  component: ProtocolActionInputComponent
+): AbiParameter {
+  const result: AbiParameter = {
+    name: component.name,
+    type: component.type,
+  };
+  if (component.components && component.components.length > 0) {
+    result.components = component.components.map(inputComponentToAbiParameter);
+  }
+  return result;
+}
+
+function inputToAbiParameter(input: ProtocolActionInput): AbiParameter {
+  const result: AbiParameter = {
+    name: input.name,
+    type: input.type,
+  };
+  if (input.components && input.components.length > 0) {
+    result.components = input.components.map(inputComponentToAbiParameter);
+  }
+  return result;
+}
+
+function outputToAbiParameter(output: ProtocolActionOutput): AbiParameter {
+  return { name: output.name, type: output.type };
+}
+
+function deriveStateMutability(
+  action: ProtocolAction
+): AbiFunctionFragment["stateMutability"] {
+  if (action.type === "read") {
+    return "view";
+  }
+  if (action.payable) {
+    return "payable";
+  }
+  return "nonpayable";
+}
+
+function synthesiseFragmentFromAction(
+  action: ProtocolAction
+): AbiFunctionFragment {
+  const stateMutability = deriveStateMutability(action);
+
+  return {
+    type: "function",
+    name: action.function,
+    stateMutability,
+    inputs: action.inputs.map(inputToAbiParameter),
+    outputs: action.outputs ? action.outputs.map(outputToAbiParameter) : [],
+  };
+}
+
+function resolveAbiFragment(
+  contract: ProtocolContract,
+  action: ProtocolAction
+): { fragment: AbiFunctionFragment; source: AbiSource } | null {
+  const abi = parseAbi(contract.abi);
+  if (abi) {
+    const fragment = findFunctionFragment(abi, action.function);
+    if (fragment) {
+      return { fragment, source: "abi-fragment" };
+    }
+    // ABI is present but the function is missing -- treat as data error
+    return null;
+  }
+  // Proxy contract or otherwise ABI-less: synthesise from action metadata.
+  // Action.inputs/outputs already encode the function shape (per
+  // protocols/aave-v3.ts and similar hand-defined protocols).
+  return {
+    fragment: synthesiseFragmentFromAction(action),
+    source: "synthesised-from-action-metadata",
+  };
+}
+
+export function getProtocolActionContext(
+  actionId: string
+): ProtocolActionContext | null {
+  const slashIndex = actionId.indexOf("/");
+  if (slashIndex === -1) {
+    return null;
+  }
+  const protocolSlug = actionId.slice(0, slashIndex);
+  const actionSlug = actionId.slice(slashIndex + 1);
+
+  const protocol = getProtocol(protocolSlug);
+  if (!protocol) {
+    return null;
+  }
+
+  const action = protocol.actions.find((a) => a.slug === actionSlug);
+  if (!action) {
+    return null;
+  }
+
+  const contract = protocol.contracts[action.contract];
+  if (!contract) {
+    return null;
+  }
+
+  const resolved = resolveAbiFragment(contract, action);
+  if (!resolved) {
+    return null;
+  }
+
+  return {
+    actionId,
+    protocolSlug,
+    actionSlug,
+    protocol,
+    contract,
+    contractKey: action.contract,
+    action,
+    abiFragment: resolved.fragment,
+    abiSource: resolved.source,
+  };
+}

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -441,14 +441,42 @@ type TemplateParts = {
   bodyLines: string[]; // function body lines with input.X (no input/output type refs)
 };
 
-function buildReadParts(inputs: SynthesisInputs): TemplateParts {
-  const { ctx } = inputs;
-  const chainEmission = emitChainImport(inputs.chain);
-  const addressEmission = emitAddressBlock(inputs.address);
+type SharedSynthFrame = {
+  ctx: ProtocolActionContext;
+  chainEmission: ReturnType<typeof emitChainImport>;
+  addressEmission: ReturnType<typeof emitAddressBlock>;
+  argsList: string;
+};
 
-  const argsList = buildArgsList(ctx);
+function buildSharedFrame(inputs: SynthesisInputs): SharedSynthFrame {
+  return {
+    ctx: inputs.ctx,
+    chainEmission: emitChainImport(inputs.chain),
+    addressEmission: emitAddressBlock(inputs.address),
+    argsList: buildArgsList(inputs.ctx),
+  };
+}
+
+function commonTemplateFields(
+  frame: SharedSynthFrame
+): Pick<TemplateParts, "warnings" | "addressLine" | "abiLine" | "inputType"> {
+  const { ctx, chainEmission, addressEmission } = frame;
+  return {
+    warnings: [
+      ...emitAbiSourceWarning(ctx),
+      ...chainEmission.warnings,
+      ...addressEmission.warnings,
+    ],
+    addressLine: addressEmission.block,
+    abiLine: `const ABI = ${formatAbiFragment(ctx.abiFragment)};`,
+    inputType: buildInputType(ctx),
+  };
+}
+
+function buildReadParts(inputs: SynthesisInputs): TemplateParts {
+  const frame = buildSharedFrame(inputs);
+  const { ctx, chainEmission, argsList } = frame;
   const resultMapping = buildReadResultMapping(ctx);
-  const abiBlock = formatAbiFragment(ctx.abiFragment);
 
   const bodyLines: string[] = [
     "  const client = createPublicClient({",
@@ -472,18 +500,11 @@ function buildReadParts(inputs: SynthesisInputs): TemplateParts {
   ];
 
   return {
+    ...commonTemplateFields(frame),
     imports: [
       `import { createPublicClient, http } from "viem";`,
       chainEmission.importLine,
     ],
-    warnings: [
-      ...emitAbiSourceWarning(ctx),
-      ...chainEmission.warnings,
-      ...addressEmission.warnings,
-    ],
-    addressLine: addressEmission.block,
-    abiLine: `const ABI = ${abiBlock};`,
-    inputType: buildInputType(ctx),
     outputType: buildReadOutputType(ctx),
     bodyLines,
   };
@@ -521,11 +542,8 @@ function buildWriteOutputType(): string {
 }
 
 function buildWriteParts(inputs: SynthesisInputs): TemplateParts {
-  const { ctx } = inputs;
-  const chainEmission = emitChainImport(inputs.chain);
-  const addressEmission = emitAddressBlock(inputs.address);
-  const argsList = buildArgsList(ctx);
-  const abiBlock = formatAbiFragment(ctx.abiFragment);
+  const frame = buildSharedFrame(inputs);
+  const { ctx, chainEmission, argsList } = frame;
 
   const valueLine = ctx.action.payable
     ? "      value: input.ethValue ? BigInt(input.ethValue) : undefined,"
@@ -576,19 +594,12 @@ function buildWriteParts(inputs: SynthesisInputs): TemplateParts {
   ];
 
   return {
+    ...commonTemplateFields(frame),
     imports: [
       `import { createPublicClient, createWalletClient, http } from "viem";`,
       `import { privateKeyToAccount } from "viem/accounts";`,
       chainEmission.importLine,
     ],
-    warnings: [
-      ...emitAbiSourceWarning(ctx),
-      ...chainEmission.warnings,
-      ...addressEmission.warnings,
-    ],
-    addressLine: addressEmission.block,
-    abiLine: `const ABI = ${abiBlock};`,
-    inputType: buildInputType(ctx),
     outputType: buildWriteOutputType(),
     bodyLines,
   };

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -159,15 +159,33 @@ function buildInlineObjectType(components: ComponentLike[]): string {
   return `{ ${fields.join("; ")} }`;
 }
 
+function decimalsAnnotation(
+  decimals: number | boolean | undefined
+): string | null {
+  if (decimals === undefined) {
+    return null;
+  }
+  if (typeof decimals === "number") {
+    return `  /** denominated in wei (10^${decimals} units) -- convert with parseUnits(value, ${decimals}) for human input */`;
+  }
+  // decimals: true -- token decimals must be looked up at runtime
+  return "  /** denominated in the token's smallest unit -- token decimals must be looked up at runtime; replace with parseUnits(value, <decimals>) once known */";
+}
+
 function buildInputType(ctx: ProtocolActionContext): string {
   if (ctx.action.inputs.length === 0) {
     return "type Input = Record<string, never>;";
   }
-  const fields = ctx.action.inputs.map((inp) => {
-    const tsType = abiTypeToTs(inp.type, inp.components);
-    return `  ${inp.name}: ${tsType};`;
-  });
-  return ["type Input = {", ...fields, "};"].join("\n");
+  const lines: string[] = ["type Input = {"];
+  for (const inp of ctx.action.inputs) {
+    const annotation = decimalsAnnotation(inp.decimals);
+    if (annotation) {
+      lines.push(annotation);
+    }
+    lines.push(`  ${inp.name}: ${abiTypeToTs(inp.type, inp.components)};`);
+  }
+  lines.push("};");
+  return lines.join("\n");
 }
 
 // -- Args reconstruction (ABI-shape driven) ----------------------------------
@@ -321,8 +339,7 @@ function buildReadResultMapping(ctx: ProtocolActionContext): string {
     return "    return { success: true, result: String(result) };";
   }
   const fields = shape.fieldNames.map(
-    (name, i) =>
-      `      ${name}: String((result as readonly unknown[])[${i}]),`
+    (name, i) => `      ${name}: String((result as readonly unknown[])[${i}]),`
   );
   return ["    return {", "      success: true,", ...fields, "    };"].join(
     "\n"

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -657,19 +657,10 @@ export function synthesiseProtocolForSDK(
   if (!inputs) {
     return null;
   }
-
-  if (inputs.ctx.action.type === "read") {
-    const parts = buildReadParts(inputs);
-    return {
-      imports: parts.imports,
-      inputs: inputs.ctx.action.inputs,
-      inlineDecls: [parts.addressLine, parts.abiLine],
-      warnings: parts.warnings,
-      bodyLines: parts.bodyLines.map(rebindInputToStepInput),
-    };
-  }
-
-  const parts = buildWriteParts(inputs);
+  const parts =
+    inputs.ctx.action.type === "read"
+      ? buildReadParts(inputs)
+      : buildWriteParts(inputs);
   return {
     imports: parts.imports,
     inputs: inputs.ctx.action.inputs,

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -664,6 +664,13 @@ export type ProtocolSdkSynthesis = {
   bodyLines: string[]; // body referencing stepInput.X
 };
 
+// Safe to do a naive textual rebind because the body builders only ever
+// reference the synthesised function's parameter (also called `input`) for
+// scalar field access. Inner closures introduced by buildArgExpression for
+// tuple[] handling bind to `t`, never `input`. If a future body builder
+// introduces another callback parameter named `input`, this rebind will
+// silently corrupt it -- prefer adding a fresh binder name (`row`, `el`)
+// over reusing `input`.
 const INPUT_DOT_REGEX = /\binput\./g;
 
 function rebindInputToStepInput(line: string): string {

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -1,4 +1,4 @@
-import { getEncodeTransform } from "@/lib/protocol-encode-transforms";
+import { getEncodeTransformKind } from "@/lib/protocol-encode-transforms";
 import type { ProtocolActionInput } from "@/lib/protocol-registry";
 import {
   type AbiFunctionFragment,
@@ -199,25 +199,20 @@ function applyEncodeTransform(
   ctx: ProtocolActionContext,
   fieldName: string
 ): string {
-  const transform = getEncodeTransform(
+  const kind = getEncodeTransformKind(
     ctx.protocolSlug,
     ctx.actionSlug,
     fieldName
   );
-  if (!transform) {
+  if (!kind) {
     return expr;
   }
-  // Only one production transform exists today (CCIP receiver padding).
-  // Probe it to confirm the shape so we can inline the equivalent.
-  const probed = transform("0x1111111111111111111111111111111111111111");
-  const expectedPad = `0x${"0".repeat(24)}1111111111111111111111111111111111111111`;
-  if (probed === expectedPad) {
-    // padAddressToBytes: left-pad to 32 bytes
+  if (kind === "padAddressToBytes") {
     return `("0x" + (${expr}).slice(2).padStart(64, "0") as ${HEX_BYTES_TYPE})`;
   }
-  // Unknown transform: emit expression unchanged with a marker comment.
-  // Synthesised output stays structurally valid; caller will see the warning
-  // surfaced separately and can decide how to proceed.
+  // Exhaustive over EncodeTransformKind. Adding a new kind to the registry
+  // requires a new branch above; until then the synthesiser preserves the
+  // raw expression rather than silently dropping the transform.
   return expr;
 }
 

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -489,7 +489,7 @@ function buildReadParts(inputs: SynthesisInputs): TemplateParts {
   };
 }
 
-function renderStandaloneRead(parts: TemplateParts, fnVarName: string): string {
+function renderStandalone(parts: TemplateParts, fnVarName: string): string {
   return [
     ...parts.imports,
     "",
@@ -594,27 +594,6 @@ function buildWriteParts(inputs: SynthesisInputs): TemplateParts {
   };
 }
 
-function renderStandaloneWrite(parts: TemplateParts, fnVarName: string): string {
-  return [
-    ...parts.imports,
-    "",
-    ...parts.warnings,
-    parts.addressLine,
-    "",
-    parts.abiLine,
-    "",
-    parts.inputType,
-    "",
-    parts.outputType,
-    "",
-    `export async function ${fnVarName}(input: Input): Promise<Output> {`,
-    `  "use step";`,
-    ...parts.bodyLines,
-    "}",
-    "",
-  ].join("\n");
-}
-
 // -- Public entries --------------------------------------------------------
 
 function buildSynthesisInputs(
@@ -639,10 +618,11 @@ export function synthesiseProtocolTemplate(
   if (!inputs) {
     return null;
   }
-  if (inputs.ctx.action.type === "read") {
-    return renderStandaloneRead(buildReadParts(inputs), inputs.fnVarName);
-  }
-  return renderStandaloneWrite(buildWriteParts(inputs), inputs.fnVarName);
+  const parts =
+    inputs.ctx.action.type === "read"
+      ? buildReadParts(inputs)
+      : buildWriteParts(inputs);
+  return renderStandalone(parts, inputs.fnVarName);
 }
 
 // -- SDK integration -------------------------------------------------------

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -264,26 +264,44 @@ function buildArgsList(ctx: ProtocolActionContext): string {
 
 // -- Output type & result mapping for reads ---------------------------------
 
-function buildReadOutputType(ctx: ProtocolActionContext): string {
+type ReadOutputShape =
+  | { kind: "void" }
+  | { kind: "single" }
+  | { kind: "multi"; fieldNames: string[] };
+
+function classifyReadOutputs(ctx: ProtocolActionContext): ReadOutputShape {
   const outputs = ctx.abiFragment.outputs ?? [];
   if (outputs.length === 0) {
+    return { kind: "void" };
+  }
+  if (outputs.length === 1) {
+    return { kind: "single" };
+  }
+  return {
+    kind: "multi",
+    fieldNames: outputs.map((out, i) =>
+      out.name && out.name.length > 0 ? out.name : `output${i}`
+    ),
+  };
+}
+
+function buildReadOutputType(ctx: ProtocolActionContext): string {
+  const shape = classifyReadOutputs(ctx);
+  if (shape.kind === "void") {
     return [
       "type Output =",
       "  | { success: true }",
       "  | { success: false; error: string };",
     ].join("\n");
   }
-  if (outputs.length === 1) {
+  if (shape.kind === "single") {
     return [
       "type Output =",
       "  | { success: true; result: string }",
       "  | { success: false; error: string };",
     ].join("\n");
   }
-  const namedFields = outputs.map((out, i) => {
-    const name = out.name && out.name.length > 0 ? out.name : `output${i}`;
-    return `      ${name}: string;`;
-  });
+  const namedFields = shape.fieldNames.map((name) => `      ${name}: string;`);
   return [
     "type Output =",
     "  | {",
@@ -295,17 +313,17 @@ function buildReadOutputType(ctx: ProtocolActionContext): string {
 }
 
 function buildReadResultMapping(ctx: ProtocolActionContext): string {
-  const outputs = ctx.abiFragment.outputs ?? [];
-  if (outputs.length === 0) {
+  const shape = classifyReadOutputs(ctx);
+  if (shape.kind === "void") {
     return "    return { success: true };";
   }
-  if (outputs.length === 1) {
+  if (shape.kind === "single") {
     return "    return { success: true, result: String(result) };";
   }
-  const fields = outputs.map((out, i) => {
-    const name = out.name && out.name.length > 0 ? out.name : `output${i}`;
-    return `      ${name}: String((result as readonly unknown[])[${i}]),`;
-  });
+  const fields = shape.fieldNames.map(
+    (name, i) =>
+      `      ${name}: String((result as readonly unknown[])[${i}]),`
+  );
   return ["    return {", "      success: true,", ...fields, "    };"].join(
     "\n"
   );

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -387,6 +387,12 @@ function emitChainImport(chain: ResolvedChain): {
   };
 }
 
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function addressBlock(value: string): string {
+  return `const CONTRACT_ADDRESS = "${value}" as const;`;
+}
+
 function emitAddressBlock(address: ResolvedAddress): {
   block: string;
   warnings: string[];
@@ -395,27 +401,13 @@ function emitAddressBlock(address: ResolvedAddress): {
     address.kind === "literal" ||
     address.kind === "user-specified-with-value"
   ) {
-    return {
-      block: `const CONTRACT_ADDRESS = "${address.value}" as const;`,
-      warnings: [],
-    };
+    return { block: addressBlock(address.value), warnings: [] };
   }
-  if (address.kind === "user-specified-placeholder") {
-    return {
-      block:
-        'const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000" as const;',
-      warnings: [
-        "// this contract address is user-specified at runtime; replace with the token address you target",
-      ],
-    };
-  }
-  return {
-    block:
-      'const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000" as const;',
-    warnings: [
-      `// no deployment recorded for chain id ${address.chainId}; replace with the address you target`,
-    ],
-  };
+  const warning =
+    address.kind === "user-specified-placeholder"
+      ? "// this contract address is user-specified at runtime; replace with the token address you target"
+      : `// no deployment recorded for chain id ${address.chainId}; replace with the address you target`;
+  return { block: addressBlock(ZERO_ADDRESS), warnings: [warning] };
 }
 
 function emitAbiSourceWarning(ctx: ProtocolActionContext): string[] {

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -429,9 +429,9 @@ function emitAbiSourceWarning(ctx: ProtocolActionContext): string[] {
   return [];
 }
 
-// -- Read template parts ---------------------------------------------------
+// -- Template parts --------------------------------------------------------
 
-type ReadParts = {
+type TemplateParts = {
   imports: string[];
   warnings: string[];
   addressLine: string;
@@ -441,7 +441,7 @@ type ReadParts = {
   bodyLines: string[]; // function body lines with input.X (no input/output type refs)
 };
 
-function buildReadParts(inputs: SynthesisInputs): ReadParts {
+function buildReadParts(inputs: SynthesisInputs): TemplateParts {
   const { ctx } = inputs;
   const chainEmission = emitChainImport(inputs.chain);
   const addressEmission = emitAddressBlock(inputs.address);
@@ -489,7 +489,7 @@ function buildReadParts(inputs: SynthesisInputs): ReadParts {
   };
 }
 
-function renderStandaloneRead(parts: ReadParts, fnVarName: string): string {
+function renderStandaloneRead(parts: TemplateParts, fnVarName: string): string {
   return [
     ...parts.imports,
     "",
@@ -520,17 +520,7 @@ function buildWriteOutputType(): string {
   ].join("\n");
 }
 
-type WriteParts = {
-  imports: string[];
-  warnings: string[];
-  addressLine: string;
-  abiLine: string;
-  inputType: string;
-  outputType: string;
-  bodyLines: string[];
-};
-
-function buildWriteParts(inputs: SynthesisInputs): WriteParts {
+function buildWriteParts(inputs: SynthesisInputs): TemplateParts {
   const { ctx } = inputs;
   const chainEmission = emitChainImport(inputs.chain);
   const addressEmission = emitAddressBlock(inputs.address);
@@ -604,7 +594,7 @@ function buildWriteParts(inputs: SynthesisInputs): WriteParts {
   };
 }
 
-function renderStandaloneWrite(parts: WriteParts, fnVarName: string): string {
+function renderStandaloneWrite(parts: TemplateParts, fnVarName: string): string {
   return [
     ...parts.imports,
     "",

--- a/lib/workflow/codegen/protocol-synthesiser.ts
+++ b/lib/workflow/codegen/protocol-synthesiser.ts
@@ -1,0 +1,710 @@
+import { getEncodeTransform } from "@/lib/protocol-encode-transforms";
+import type { ProtocolActionInput } from "@/lib/protocol-registry";
+import {
+  type AbiFunctionFragment,
+  type AbiParameter,
+  getProtocolActionContext,
+  type ProtocolActionContext,
+} from "./protocol-metadata";
+
+const ARRAY_SUFFIX_REGEX = /\[\d*\]$/;
+const KEBAB_SEGMENT_REGEX = /-([a-z0-9])/g;
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal viem template-literal type emitted into generated code
+const HEX_BYTES_TYPE = "`0x${string}`";
+
+type ChainEntry = {
+  varName: string;
+  envVarName: string;
+};
+
+const VIEM_CHAINS: Record<string, ChainEntry> = {
+  "1": { varName: "mainnet", envVarName: "MAINNET_RPC_URL" },
+  "10": { varName: "optimism", envVarName: "OPTIMISM_RPC_URL" },
+  "56": { varName: "bsc", envVarName: "BSC_RPC_URL" },
+  "97": { varName: "bscTestnet", envVarName: "BSC_TESTNET_RPC_URL" },
+  "137": { varName: "polygon", envVarName: "POLYGON_RPC_URL" },
+  "8453": { varName: "base", envVarName: "BASE_RPC_URL" },
+  "42161": { varName: "arbitrum", envVarName: "ARBITRUM_RPC_URL" },
+  "43113": { varName: "avalancheFuji", envVarName: "AVALANCHE_FUJI_RPC_URL" },
+  "43114": { varName: "avalanche", envVarName: "AVALANCHE_RPC_URL" },
+  "80002": { varName: "polygonAmoy", envVarName: "POLYGON_AMOY_RPC_URL" },
+  "84532": { varName: "baseSepolia", envVarName: "BASE_SEPOLIA_RPC_URL" },
+  "421614": {
+    varName: "arbitrumSepolia",
+    envVarName: "ARBITRUM_SEPOLIA_RPC_URL",
+  },
+  "11155111": { varName: "sepolia", envVarName: "SEPOLIA_RPC_URL" },
+  "11155420": {
+    varName: "optimismSepolia",
+    envVarName: "OPTIMISM_SEPOLIA_RPC_URL",
+  },
+};
+
+type ResolvedChain =
+  | { kind: "known"; chainId: string; entry: ChainEntry }
+  | { kind: "unknown"; chainId: string }
+  | { kind: "missing" };
+
+type ResolvedAddress =
+  | { kind: "literal"; value: string }
+  | { kind: "user-specified-with-value"; value: string }
+  | { kind: "user-specified-placeholder" }
+  | { kind: "missing-for-chain"; chainId: string };
+
+type SynthesisInputs = {
+  ctx: ProtocolActionContext;
+  chain: ResolvedChain;
+  address: ResolvedAddress;
+  fnVarName: string;
+};
+
+type ComponentLike = {
+  name?: string;
+  type: string;
+  components?: ComponentLike[];
+};
+
+function camelCaseSlug(slug: string): string {
+  return slug.replace(KEBAB_SEGMENT_REGEX, (_m, c: string) => c.toUpperCase());
+}
+
+// -- Chain & address resolution ----------------------------------------------
+
+function resolveChain(
+  ctx: ProtocolActionContext,
+  nodeConfig: Record<string, unknown> | undefined
+): ResolvedChain {
+  const chainId = nodeConfig?.network as string | undefined;
+  if (!chainId) {
+    return { kind: "missing" };
+  }
+  const entry = VIEM_CHAINS[chainId];
+  if (!entry) {
+    return { kind: "unknown", chainId };
+  }
+  if (
+    !(ctx.contract.userSpecifiedAddress || chainId in ctx.contract.addresses)
+  ) {
+    return { kind: "unknown", chainId };
+  }
+  return { kind: "known", chainId, entry };
+}
+
+function resolveAddress(
+  ctx: ProtocolActionContext,
+  chain: ResolvedChain,
+  nodeConfig: Record<string, unknown> | undefined
+): ResolvedAddress {
+  if (ctx.contract.userSpecifiedAddress) {
+    const userValue = nodeConfig?.contractAddress as string | undefined;
+    return userValue
+      ? { kind: "user-specified-with-value", value: userValue }
+      : { kind: "user-specified-placeholder" };
+  }
+  if (chain.kind === "known" || chain.kind === "unknown") {
+    const value = ctx.contract.addresses[chain.chainId];
+    if (value) {
+      return { kind: "literal", value };
+    }
+    return { kind: "missing-for-chain", chainId: chain.chainId };
+  }
+  const firstChainId = Object.keys(ctx.contract.addresses)[0];
+  if (firstChainId) {
+    return { kind: "literal", value: ctx.contract.addresses[firstChainId] };
+  }
+  return { kind: "user-specified-placeholder" };
+}
+
+// -- Type emission -----------------------------------------------------------
+
+function abiTypeToTs(
+  typeName: string,
+  components: ComponentLike[] | undefined
+): string {
+  const arrayMatch = typeName.match(ARRAY_SUFFIX_REGEX);
+  if (arrayMatch) {
+    const inner = typeName.slice(0, arrayMatch.index);
+    return `${abiTypeToTs(inner, components)}[]`;
+  }
+  if (typeName === "tuple") {
+    return buildInlineObjectType(components ?? []);
+  }
+  if (typeName === "address" || typeName === "address payable") {
+    return HEX_BYTES_TYPE;
+  }
+  if (typeName === "bool") {
+    return "boolean";
+  }
+  if (typeName === "string") {
+    return "string";
+  }
+  if (typeName.startsWith("bytes")) {
+    return HEX_BYTES_TYPE;
+  }
+  if (typeName.startsWith("uint") || typeName.startsWith("int")) {
+    return "string";
+  }
+  return "unknown";
+}
+
+function buildInlineObjectType(components: ComponentLike[]): string {
+  if (components.length === 0) {
+    return "Record<string, unknown>";
+  }
+  const fields = components.map((c) => {
+    const ts = abiTypeToTs(c.type, c.components);
+    return `${c.name ?? "_"}: ${ts}`;
+  });
+  return `{ ${fields.join("; ")} }`;
+}
+
+function buildInputType(ctx: ProtocolActionContext): string {
+  if (ctx.action.inputs.length === 0) {
+    return "type Input = Record<string, never>;";
+  }
+  const fields = ctx.action.inputs.map((inp) => {
+    const tsType = abiTypeToTs(inp.type, inp.components);
+    return `  ${inp.name}: ${tsType};`;
+  });
+  return ["type Input = {", ...fields, "};"].join("\n");
+}
+
+// -- Args reconstruction (ABI-shape driven) ----------------------------------
+
+function isUintOrInt(t: string): boolean {
+  return t.startsWith("uint") || t.startsWith("int");
+}
+
+function applyEncodeTransform(
+  expr: string,
+  ctx: ProtocolActionContext,
+  fieldName: string
+): string {
+  const transform = getEncodeTransform(
+    ctx.protocolSlug,
+    ctx.actionSlug,
+    fieldName
+  );
+  if (!transform) {
+    return expr;
+  }
+  // Only one production transform exists today (CCIP receiver padding).
+  // Probe it to confirm the shape so we can inline the equivalent.
+  const probed = transform("0x1111111111111111111111111111111111111111");
+  const expectedPad = `0x${"0".repeat(24)}1111111111111111111111111111111111111111`;
+  if (probed === expectedPad) {
+    // padAddressToBytes: left-pad to 32 bytes
+    return `("0x" + (${expr}).slice(2).padStart(64, "0") as ${HEX_BYTES_TYPE})`;
+  }
+  // Unknown transform: emit expression unchanged with a marker comment.
+  // Synthesised output stays structurally valid; caller will see the warning
+  // surfaced separately and can decide how to proceed.
+  return expr;
+}
+
+function castScalar(expr: string, solType: string): string {
+  if (isUintOrInt(solType)) {
+    return `BigInt(${expr})`;
+  }
+  return expr;
+}
+
+function buildArgExpression(
+  param: AbiParameter,
+  sourceVar: string,
+  ctx: ProtocolActionContext,
+  applyTransforms: boolean
+): string {
+  const fieldName = param.name ?? "_";
+  const access = `${sourceVar}.${fieldName}`;
+
+  const arrayMatch = param.type.match(ARRAY_SUFFIX_REGEX);
+  if (arrayMatch) {
+    const innerType = param.type.slice(0, arrayMatch.index);
+    if (innerType === "tuple") {
+      const components = param.components ?? [];
+      const innerExprs = components.map((c) => {
+        const inner = buildArgExpression(c, "t", ctx, false);
+        return `${c.name ?? "_"}: ${inner}`;
+      });
+      return `(${access}).map((t) => ({ ${innerExprs.join(", ")} }))`;
+    }
+    // Scalar array (e.g. uint256[]) -- viem accepts native arrays. For uint/int
+    // arrays we map BigInt elementwise.
+    if (isUintOrInt(innerType)) {
+      return `(${access}).map((v) => BigInt(v))`;
+    }
+    return `${access}`;
+  }
+
+  if (param.type === "tuple") {
+    const components = param.components ?? [];
+    const innerExprs = components.map((c) => {
+      const inner = buildArgExpression(c, sourceVar, ctx, applyTransforms);
+      return `${c.name ?? "_"}: ${inner}`;
+    });
+    return `{ ${innerExprs.join(", ")} }`;
+  }
+
+  // Scalar leaf
+  const cast = castScalar(access, param.type);
+  if (applyTransforms) {
+    return applyEncodeTransform(cast, ctx, fieldName);
+  }
+  return cast;
+}
+
+function buildArgsList(ctx: ProtocolActionContext): string {
+  const parts = ctx.abiFragment.inputs.map((p) =>
+    buildArgExpression(p, "input", ctx, true)
+  );
+  return parts.join(", ");
+}
+
+// -- Output type & result mapping for reads ---------------------------------
+
+function buildReadOutputType(ctx: ProtocolActionContext): string {
+  const outputs = ctx.abiFragment.outputs ?? [];
+  if (outputs.length === 0) {
+    return [
+      "type Output =",
+      "  | { success: true }",
+      "  | { success: false; error: string };",
+    ].join("\n");
+  }
+  if (outputs.length === 1) {
+    return [
+      "type Output =",
+      "  | { success: true; result: string }",
+      "  | { success: false; error: string };",
+    ].join("\n");
+  }
+  const namedFields = outputs.map((out, i) => {
+    const name = out.name && out.name.length > 0 ? out.name : `output${i}`;
+    return `      ${name}: string;`;
+  });
+  return [
+    "type Output =",
+    "  | {",
+    "      success: true;",
+    ...namedFields,
+    "    }",
+    "  | { success: false; error: string };",
+  ].join("\n");
+}
+
+function buildReadResultMapping(ctx: ProtocolActionContext): string {
+  const outputs = ctx.abiFragment.outputs ?? [];
+  if (outputs.length === 0) {
+    return "    return { success: true };";
+  }
+  if (outputs.length === 1) {
+    return "    return { success: true, result: String(result) };";
+  }
+  const fields = outputs.map((out, i) => {
+    const name = out.name && out.name.length > 0 ? out.name : `output${i}`;
+    return `      ${name}: String((result as readonly unknown[])[${i}]),`;
+  });
+  return ["    return {", "      success: true,", ...fields, "    };"].join(
+    "\n"
+  );
+}
+
+// -- ABI fragment formatting ------------------------------------------------
+
+function formatAbiParameter(param: AbiParameter, indent: string): string {
+  const lines: string[] = [`${indent}{`];
+  if (param.name) {
+    lines.push(`${indent}  name: "${param.name}",`);
+  }
+  lines.push(`${indent}  type: "${param.type}",`);
+  if (param.components && param.components.length > 0) {
+    lines.push(`${indent}  components: [`);
+    for (const c of param.components) {
+      lines.push(`${formatAbiParameter(c, `${indent}    `)},`);
+    }
+    lines.push(`${indent}  ],`);
+  }
+  lines.push(`${indent}}`);
+  return lines.join("\n");
+}
+
+function formatAbiFragment(fragment: AbiFunctionFragment): string {
+  const lines: string[] = ["[", "  {", '    type: "function",'];
+  lines.push(`    name: "${fragment.name}",`);
+  if (fragment.stateMutability) {
+    lines.push(`    stateMutability: "${fragment.stateMutability}",`);
+  }
+  lines.push("    inputs: [");
+  for (const inp of fragment.inputs) {
+    lines.push(`${formatAbiParameter(inp, "      ")},`);
+  }
+  lines.push("    ],");
+  lines.push("    outputs: [");
+  for (const out of fragment.outputs ?? []) {
+    lines.push(`${formatAbiParameter(out, "      ")},`);
+  }
+  lines.push("    ],");
+  lines.push("  },");
+  lines.push("] as const");
+  return lines.join("\n");
+}
+
+// -- Chain / address emission -----------------------------------------------
+
+function emitChainImport(chain: ResolvedChain): {
+  importLine: string;
+  chainExpression: string;
+  rpcExpression: string;
+  warnings: string[];
+} {
+  if (chain.kind === "known") {
+    return {
+      importLine: `import { ${chain.entry.varName} } from "viem/chains";`,
+      chainExpression: chain.entry.varName,
+      rpcExpression: `process.env.${chain.entry.envVarName}`,
+      warnings: [],
+    };
+  }
+  if (chain.kind === "unknown") {
+    return {
+      importLine: `import { defineChain } from "viem";`,
+      chainExpression: "chain",
+      rpcExpression: "process.env.RPC_URL",
+      warnings: [
+        `// chain id ${chain.chainId} is not in viem/chains; define it manually below`,
+      ],
+    };
+  }
+  return {
+    importLine: `import { defineChain } from "viem";`,
+    chainExpression: "chain",
+    rpcExpression: "process.env.RPC_URL",
+    warnings: [
+      "// no network selected on this node; replace 'chain' with the chain you target",
+    ],
+  };
+}
+
+function emitAddressBlock(address: ResolvedAddress): {
+  block: string;
+  warnings: string[];
+} {
+  if (
+    address.kind === "literal" ||
+    address.kind === "user-specified-with-value"
+  ) {
+    return {
+      block: `const CONTRACT_ADDRESS = "${address.value}" as const;`,
+      warnings: [],
+    };
+  }
+  if (address.kind === "user-specified-placeholder") {
+    return {
+      block:
+        'const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000" as const;',
+      warnings: [
+        "// this contract address is user-specified at runtime; replace with the token address you target",
+      ],
+    };
+  }
+  return {
+    block:
+      'const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000" as const;',
+    warnings: [
+      `// no deployment recorded for chain id ${address.chainId}; replace with the address you target`,
+    ],
+  };
+}
+
+function emitAbiSourceWarning(ctx: ProtocolActionContext): string[] {
+  if (ctx.abiSource === "synthesised-from-action-metadata") {
+    return [
+      "// ABI fragment synthesised from protocol action metadata (proxy contract, no inline ABI).",
+      "// At runtime this contract resolves its ABI dynamically; if the on-chain function signature",
+      "// changes you may need to update the inlined ABI below.",
+    ];
+  }
+  return [];
+}
+
+// -- Read template parts ---------------------------------------------------
+
+type ReadParts = {
+  imports: string[];
+  warnings: string[];
+  addressLine: string;
+  abiLine: string;
+  inputType: string;
+  outputType: string;
+  bodyLines: string[]; // function body lines with input.X (no input/output type refs)
+};
+
+function buildReadParts(inputs: SynthesisInputs): ReadParts {
+  const { ctx } = inputs;
+  const chainEmission = emitChainImport(inputs.chain);
+  const addressEmission = emitAddressBlock(inputs.address);
+
+  const argsList = buildArgsList(ctx);
+  const resultMapping = buildReadResultMapping(ctx);
+  const abiBlock = formatAbiFragment(ctx.abiFragment);
+
+  const bodyLines: string[] = [
+    "  const client = createPublicClient({",
+    `    chain: ${chainEmission.chainExpression},`,
+    `    transport: http(${chainEmission.rpcExpression}),`,
+    "  });",
+    "  try {",
+    "    const result = await client.readContract({",
+    "      address: CONTRACT_ADDRESS,",
+    "      abi: ABI,",
+    `      functionName: "${ctx.action.function}",`,
+    `      args: [${argsList}],`,
+    "    });",
+    resultMapping,
+    "  } catch (error) {",
+    "    return {",
+    "      success: false,",
+    "      error: error instanceof Error ? error.message : String(error),",
+    "    };",
+    "  }",
+  ];
+
+  return {
+    imports: [
+      `import { createPublicClient, http } from "viem";`,
+      chainEmission.importLine,
+    ],
+    warnings: [
+      ...emitAbiSourceWarning(ctx),
+      ...chainEmission.warnings,
+      ...addressEmission.warnings,
+    ],
+    addressLine: addressEmission.block,
+    abiLine: `const ABI = ${abiBlock};`,
+    inputType: buildInputType(ctx),
+    outputType: buildReadOutputType(ctx),
+    bodyLines,
+  };
+}
+
+function renderStandaloneRead(parts: ReadParts, fnVarName: string): string {
+  return [
+    ...parts.imports,
+    "",
+    ...parts.warnings,
+    parts.addressLine,
+    "",
+    parts.abiLine,
+    "",
+    parts.inputType,
+    "",
+    parts.outputType,
+    "",
+    `export async function ${fnVarName}(input: Input): Promise<Output> {`,
+    `  "use step";`,
+    ...parts.bodyLines,
+    "}",
+    "",
+  ].join("\n");
+}
+
+// -- Write template --------------------------------------------------------
+
+function buildWriteOutputType(): string {
+  return [
+    "type Output =",
+    `  | { success: true; transactionHash: ${HEX_BYTES_TYPE}; gasUsed: string }`,
+    "  | { success: false; error: string };",
+  ].join("\n");
+}
+
+type WriteParts = {
+  imports: string[];
+  warnings: string[];
+  addressLine: string;
+  abiLine: string;
+  inputType: string;
+  outputType: string;
+  bodyLines: string[];
+};
+
+function buildWriteParts(inputs: SynthesisInputs): WriteParts {
+  const { ctx } = inputs;
+  const chainEmission = emitChainImport(inputs.chain);
+  const addressEmission = emitAddressBlock(inputs.address);
+  const argsList = buildArgsList(ctx);
+  const abiBlock = formatAbiFragment(ctx.abiFragment);
+
+  const valueLine = ctx.action.payable
+    ? "      value: input.ethValue ? BigInt(input.ethValue) : undefined,"
+    : null;
+
+  const simulateLines: string[] = [
+    "    const { request } = await publicClient.simulateContract({",
+    "      account,",
+    "      address: CONTRACT_ADDRESS,",
+    "      abi: ABI,",
+    `      functionName: "${ctx.action.function}",`,
+    `      args: [${argsList}],`,
+  ];
+  if (valueLine) {
+    simulateLines.push(valueLine);
+  }
+  simulateLines.push("    });");
+
+  const bodyLines: string[] = [
+    "  const account = privateKeyToAccount(",
+    `    process.env.WALLET_PRIVATE_KEY as ${HEX_BYTES_TYPE}`,
+    "  );",
+    `  const transport = http(${chainEmission.rpcExpression});`,
+    "  const publicClient = createPublicClient({",
+    `    chain: ${chainEmission.chainExpression},`,
+    "    transport,",
+    "  });",
+    "  const walletClient = createWalletClient({",
+    "    account,",
+    `    chain: ${chainEmission.chainExpression},`,
+    "    transport,",
+    "  });",
+    "  try {",
+    ...simulateLines,
+    "    const hash = await walletClient.writeContract(request);",
+    "    const receipt = await publicClient.waitForTransactionReceipt({ hash });",
+    "    return {",
+    "      success: true,",
+    "      transactionHash: hash,",
+    "      gasUsed: receipt.gasUsed.toString(),",
+    "    };",
+    "  } catch (error) {",
+    "    return {",
+    "      success: false,",
+    "      error: error instanceof Error ? error.message : String(error),",
+    "    };",
+    "  }",
+  ];
+
+  return {
+    imports: [
+      `import { createPublicClient, createWalletClient, http } from "viem";`,
+      `import { privateKeyToAccount } from "viem/accounts";`,
+      chainEmission.importLine,
+    ],
+    warnings: [
+      ...emitAbiSourceWarning(ctx),
+      ...chainEmission.warnings,
+      ...addressEmission.warnings,
+    ],
+    addressLine: addressEmission.block,
+    abiLine: `const ABI = ${abiBlock};`,
+    inputType: buildInputType(ctx),
+    outputType: buildWriteOutputType(),
+    bodyLines,
+  };
+}
+
+function renderStandaloneWrite(parts: WriteParts, fnVarName: string): string {
+  return [
+    ...parts.imports,
+    "",
+    ...parts.warnings,
+    parts.addressLine,
+    "",
+    parts.abiLine,
+    "",
+    parts.inputType,
+    "",
+    parts.outputType,
+    "",
+    `export async function ${fnVarName}(input: Input): Promise<Output> {`,
+    `  "use step";`,
+    ...parts.bodyLines,
+    "}",
+    "",
+  ].join("\n");
+}
+
+// -- Public entries --------------------------------------------------------
+
+function buildSynthesisInputs(
+  actionId: string,
+  nodeConfig?: Record<string, unknown>
+): SynthesisInputs | null {
+  const ctx = getProtocolActionContext(actionId);
+  if (!ctx) {
+    return null;
+  }
+  const chain = resolveChain(ctx, nodeConfig);
+  const address = resolveAddress(ctx, chain, nodeConfig);
+  const fnVarName = `${camelCaseSlug(ctx.actionSlug)}Step`;
+  return { ctx, chain, address, fnVarName };
+}
+
+export function synthesiseProtocolTemplate(
+  actionId: string,
+  nodeConfig?: Record<string, unknown>
+): string | null {
+  const inputs = buildSynthesisInputs(actionId, nodeConfig);
+  if (!inputs) {
+    return null;
+  }
+  if (inputs.ctx.action.type === "read") {
+    return renderStandaloneRead(buildReadParts(inputs), inputs.fnVarName);
+  }
+  return renderStandaloneWrite(buildWriteParts(inputs), inputs.fnVarName);
+}
+
+// -- SDK integration -------------------------------------------------------
+
+/**
+ * SDK-shaped synthesis: returns the pieces the workflow SDK needs to
+ * embed a protocol step into a generated workflow file. Constants
+ * (CONTRACT_ADDRESS, ABI) are scoped inside the wrapper to avoid
+ * cross-node name collisions; type aliases are dropped because the SDK
+ * wrapper takes a generic Record<string, unknown>; body lines reference
+ * `stepInput.X` so the SDK wrapper's input-construction stays unchanged.
+ */
+export type ProtocolSdkSynthesis = {
+  imports: string[];
+  inputs: ProtocolActionInput[];
+  inlineDecls: string[]; // address const + ABI const, scoped inside the wrapper
+  warnings: string[];
+  bodyLines: string[]; // body referencing stepInput.X
+};
+
+const INPUT_DOT_REGEX = /\binput\./g;
+
+function rebindInputToStepInput(line: string): string {
+  return line.replace(INPUT_DOT_REGEX, "stepInput.");
+}
+
+export function synthesiseProtocolForSDK(
+  actionId: string,
+  nodeConfig?: Record<string, unknown>
+): ProtocolSdkSynthesis | null {
+  const inputs = buildSynthesisInputs(actionId, nodeConfig);
+  if (!inputs) {
+    return null;
+  }
+
+  if (inputs.ctx.action.type === "read") {
+    const parts = buildReadParts(inputs);
+    return {
+      imports: parts.imports,
+      inputs: inputs.ctx.action.inputs,
+      inlineDecls: [parts.addressLine, parts.abiLine],
+      warnings: parts.warnings,
+      bodyLines: parts.bodyLines.map(rebindInputToStepInput),
+    };
+  }
+
+  const parts = buildWriteParts(inputs);
+  return {
+    imports: parts.imports,
+    inputs: inputs.ctx.action.inputs,
+    inlineDecls: [parts.addressLine, parts.abiLine],
+    warnings: parts.warnings,
+    bodyLines: parts.bodyLines.map(rebindInputToStepInput),
+  };
+}

--- a/lib/workflow/codegen/sdk.ts
+++ b/lib/workflow/codegen/sdk.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { findActionById } from "@/plugins/registry";
+import { synthesiseProtocolForSDK } from "./protocol-synthesiser";
 // System action codegen templates (not in plugin registry)
 import conditionTemplate from "./templates/condition";
 import databaseQueryTemplate from "./templates/database-query";
@@ -13,6 +14,7 @@ const SYSTEM_CODEGEN_TEMPLATES: Record<string, string> = {
   Condition: conditionTemplate,
 };
 
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import {
   ARRAY_INDEX_PATTERN,
   analyzeNodeUsage,
@@ -23,7 +25,6 @@ import {
   sanitizeStepName,
   sanitizeVarName,
 } from "./shared";
-import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 /**
  * Load step implementation from templates
@@ -437,6 +438,45 @@ export function generateWorkflowSDKCode(
     return builder ? builder() : [];
   }
 
+  function buildProtocolStepInputParams(
+    inputs: Array<{ name: string }>,
+    config: Record<string, unknown>
+  ): string[] {
+    return inputs.map((inp) => {
+      const raw = String(config[inp.name] ?? "");
+      const converted = convertTemplateToJS(raw);
+      return `${inp.name}: \`${escapeForTemplateLiteral(converted)}\``;
+    });
+  }
+
+  function generateProtocolStepFunctionBody(
+    actionType: string,
+    config: Record<string, unknown>
+  ): string | null {
+    const sdk = synthesiseProtocolForSDK(actionType, config);
+    if (!sdk) {
+      return null;
+    }
+    for (const imp of sdk.imports) {
+      imports.add(imp);
+    }
+    const inputParams = buildProtocolStepInputParams(sdk.inputs, config);
+    const lines: string[] = [];
+    for (const w of sdk.warnings) {
+      lines.push(`  ${w}`);
+    }
+    for (const decl of sdk.inlineDecls) {
+      lines.push(`  ${decl}`);
+    }
+    lines.push("  const stepInput = {");
+    for (const p of inputParams) {
+      lines.push(`    ${p},`);
+    }
+    lines.push("  };");
+    lines.push(...sdk.bodyLines);
+    return lines.join("\n");
+  }
+
   function generateStepFunction(
     node: WorkflowNode,
     uniqueStepName?: string
@@ -446,25 +486,33 @@ export function generateWorkflowSDKCode(
     const label = node.data.label || actionType || "UnnamedStep";
     const stepName = uniqueStepName || sanitizeStepName(label);
 
-    const stepImplementation = loadStepImplementation(actionType);
-
     let stepBody: string;
-    if (stepImplementation && node.data.type === "action") {
-      const inputParams = buildStepInputParams(actionType, config);
-      stepBody = `  // Call step function with constructed input
+    const protocolBody =
+      node.data.type === "action"
+        ? generateProtocolStepFunctionBody(actionType, config)
+        : null;
+
+    if (protocolBody) {
+      stepBody = protocolBody;
+    } else {
+      const stepImplementation = loadStepImplementation(actionType);
+      if (stepImplementation && node.data.type === "action") {
+        const inputParams = buildStepInputParams(actionType, config);
+        stepBody = `  // Call step function with constructed input
   const stepInput = {
     ${inputParams.join(",\n    ")}
   };
 
       // Execute step implementation
       ${stepImplementation}`;
-    } else {
-      stepBody = "  return { success: true };";
+      } else {
+        stepBody = "  return { success: true };";
+      }
     }
 
     return `async function ${stepName}(input: Record<string, unknown> & { outputs?: Record<string, { label: string; data: unknown }> }) {
   "use step";
-  
+
 ${stepBody}
 }`;
   }

--- a/tests/unit/protocol-encode-transforms.test.ts
+++ b/tests/unit/protocol-encode-transforms.test.ts
@@ -3,6 +3,7 @@ import {
   applyEncodeTransformsNamed,
   clearEncodeTransforms,
   getEncodeTransform,
+  getEncodeTransformKind,
   registerEncodeTransform,
 } from "@/lib/protocol-encode-transforms";
 
@@ -13,7 +14,13 @@ afterEach(() => {
 describe("registerEncodeTransform / getEncodeTransform", () => {
   it("registers and retrieves a transform", () => {
     const transform = (v: string): string => `padded:${v}`;
-    registerEncodeTransform("chainlink", "ccip-send", "receiver", transform);
+    registerEncodeTransform(
+      "chainlink",
+      "ccip-send",
+      "receiver",
+      transform,
+      "padAddressToBytes"
+    );
     const retrieved = getEncodeTransform("chainlink", "ccip-send", "receiver");
     expect(retrieved).toBe(transform);
   });
@@ -26,10 +33,43 @@ describe("registerEncodeTransform / getEncodeTransform", () => {
   it("overwrites existing transform on re-register", () => {
     const first = (v: string): string => `first:${v}`;
     const second = (v: string): string => `second:${v}`;
-    registerEncodeTransform("proto", "action", "input", first);
-    registerEncodeTransform("proto", "action", "input", second);
+    registerEncodeTransform(
+      "proto",
+      "action",
+      "input",
+      first,
+      "padAddressToBytes"
+    );
+    registerEncodeTransform(
+      "proto",
+      "action",
+      "input",
+      second,
+      "padAddressToBytes"
+    );
     const retrieved = getEncodeTransform("proto", "action", "input");
     expect(retrieved).toBe(second);
+  });
+});
+
+describe("getEncodeTransformKind", () => {
+  it("returns the kind registered alongside the transform", () => {
+    registerEncodeTransform(
+      "chainlink",
+      "ccip-send",
+      "receiver",
+      (v: string): string => v,
+      "padAddressToBytes"
+    );
+    expect(getEncodeTransformKind("chainlink", "ccip-send", "receiver")).toBe(
+      "padAddressToBytes"
+    );
+  });
+
+  it("returns undefined for unregistered transform", () => {
+    expect(
+      getEncodeTransformKind("chainlink", "ccip-send", "receiver")
+    ).toBeUndefined();
   });
 });
 
@@ -48,7 +88,8 @@ describe("applyEncodeTransformsNamed", () => {
       "chainlink",
       "ccip-send",
       "receiver",
-      (v: string): string => `0x${"0".repeat(24)}${v.slice(2)}`
+      (v: string): string => `0x${"0".repeat(24)}${v.slice(2)}`,
+      "padAddressToBytes"
     );
 
     const inputs = [
@@ -68,7 +109,8 @@ describe("applyEncodeTransformsNamed", () => {
       "chainlink",
       "ccip-send",
       "receiver",
-      (v: string): string => `transformed:${v}`
+      (v: string): string => `transformed:${v}`,
+      "padAddressToBytes"
     );
 
     const inputs = [{ name: "receiver", value: "0xABC" }];

--- a/tests/unit/protocol-synthesiser-sdk.test.ts
+++ b/tests/unit/protocol-synthesiser-sdk.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { generateWorkflowSDKCode } = await import("@/lib/workflow/codegen/sdk");
+
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+
+const triggerNode: WorkflowNode = {
+  id: "trigger-1",
+  type: "trigger",
+  position: { x: 0, y: 0 },
+  data: {
+    type: "trigger",
+    label: "Manual Trigger",
+    config: { triggerType: "Manual" },
+  },
+};
+
+function ccipBalanceNode(id: string): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 0 },
+    data: {
+      type: "action",
+      label: "Check CCIP Balance",
+      config: {
+        actionType: "chainlink/ccip-check-bridge-balance",
+        network: "11155111",
+        contractAddress: "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05",
+        account: "0x1111111111111111111111111111111111111111",
+      },
+    },
+  };
+}
+
+const edge = (s: string, t: string): WorkflowEdge => ({
+  id: `${s}-${t}`,
+  source: s,
+  target: t,
+});
+
+describe("generateWorkflowSDKCode (protocol synthesis path)", () => {
+  it("emits viem imports and inlines the synthesised body for a CCIP balance node", () => {
+    const node = ccipBalanceNode("a-1");
+    const code = generateWorkflowSDKCode(
+      "ccip_balance_workflow",
+      [triggerNode, node],
+      [edge(triggerNode.id, node.id)]
+    );
+
+    process.stdout.write("\n=== SDK OUTPUT ===\n");
+    process.stdout.write(`${code}\n`);
+
+    expect(code).toContain('import { createPublicClient, http } from "viem"');
+    expect(code).toContain('import { sepolia } from "viem/chains"');
+    expect(code).toContain(
+      'const CONTRACT_ADDRESS = "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05" as const;'
+    );
+    expect(code).toContain('functionName: "balanceOf"');
+    // Body should reference stepInput.X (rebound from input.X by SDK helper)
+    expect(code).toContain("args: [stepInput.account]");
+    // stepInput should be constructed from config
+    expect(code).toContain(
+      "account: `0x1111111111111111111111111111111111111111`"
+    );
+    // Must not be the legacy stub
+    expect(code).not.toContain("return { success: true };\n}");
+  });
+
+  it("namespaces nothing -- two CCIP balance nodes would collide on CONTRACT_ADDRESS", () => {
+    // Documenting the known limitation: constants are scoped inside each
+    // step function (not at file top), so two CCIP nodes get independent
+    // CONTRACT_ADDRESS bindings without colliding.
+    const node1 = ccipBalanceNode("a-1");
+    const node2 = ccipBalanceNode("a-2");
+    const code = generateWorkflowSDKCode(
+      "two_balances",
+      [triggerNode, node1, node2],
+      [edge(triggerNode.id, node1.id), edge(node1.id, node2.id)]
+    );
+
+    // Each step function inlines its own CONTRACT_ADDRESS const
+    const occurrences = code.match(/const CONTRACT_ADDRESS =/g) ?? [];
+    expect(occurrences.length).toBe(2);
+  });
+});

--- a/tests/unit/protocol-synthesiser-sdk.test.ts
+++ b/tests/unit/protocol-synthesiser-sdk.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { synthesiseProtocolForSDK } from "@/lib/workflow/codegen/protocol-synthesiser";
 
+// Mock server-only before importing the SDK module: sdk.ts imports
+// "server-only", which throws when loaded outside a server runtime.
 vi.mock("server-only", () => ({}));
 
 const { generateWorkflowSDKCode } = await import("@/lib/workflow/codegen/sdk");
@@ -84,5 +87,73 @@ describe("generateWorkflowSDKCode (protocol synthesis path)", () => {
     // Each step function inlines its own CONTRACT_ADDRESS const
     const occurrences = code.match(/const CONTRACT_ADDRESS =/g) ?? [];
     expect(occurrences.length).toBe(2);
+  });
+});
+
+describe("synthesiseProtocolForSDK (direct)", () => {
+  it("returns null for non-protocol action ids", () => {
+    expect(synthesiseProtocolForSDK("web3/check-balance")).toBeNull();
+    expect(synthesiseProtocolForSDK("malformed-no-slash")).toBeNull();
+  });
+
+  it("returns the SDK shape for a CCIP balance read", () => {
+    const out = synthesiseProtocolForSDK(
+      "chainlink/ccip-check-bridge-balance",
+      {
+        network: "11155111",
+        contractAddress: "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05",
+      }
+    );
+
+    expect(out).not.toBeNull();
+    const sdk = out as NonNullable<typeof out>;
+
+    // Imports include only viem read-side dependencies.
+    expect(sdk.imports).toContain(
+      'import { createPublicClient, http } from "viem";'
+    );
+    expect(sdk.imports).toContain('import { sepolia } from "viem/chains";');
+
+    // ABI + address are inline declarations the SDK wrapper drops into the
+    // step function body so per-step constants do not collide across nodes.
+    expect(sdk.inlineDecls.length).toBe(2);
+    expect(sdk.inlineDecls[0]).toContain("CONTRACT_ADDRESS");
+    expect(sdk.inlineDecls[1]).toContain("const ABI = [");
+
+    // Body must have been rebound from input.X to stepInput.X.
+    const body = sdk.bodyLines.join("\n");
+    expect(body).toContain("args: [stepInput.account]");
+    expect(body).not.toContain("args: [input.account]");
+
+    // Inputs descriptor mirrors the action.inputs the SDK uses to build
+    // stepInput entries from node config.
+    expect(sdk.inputs.map((i) => i.name)).toEqual(["account"]);
+  });
+
+  it("returns the SDK shape for a CCIP approve write (signer + simulate path)", () => {
+    const out = synthesiseProtocolForSDK(
+      "chainlink/ccip-approve-bridge-token",
+      {
+        network: "11155111",
+        contractAddress: "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05",
+      }
+    );
+
+    expect(out).not.toBeNull();
+    const sdk = out as NonNullable<typeof out>;
+
+    expect(sdk.imports).toContain(
+      'import { createPublicClient, createWalletClient, http } from "viem";'
+    );
+    expect(sdk.imports).toContain(
+      'import { privateKeyToAccount } from "viem/accounts";'
+    );
+
+    const body = sdk.bodyLines.join("\n");
+    expect(body).toContain("simulateContract");
+    expect(body).toContain(
+      "args: [stepInput.spender, BigInt(stepInput.amount)]"
+    );
+    expect(sdk.inputs.map((i) => i.name)).toEqual(["spender", "amount"]);
   });
 });

--- a/tests/unit/protocol-synthesiser-sdk.test.ts
+++ b/tests/unit/protocol-synthesiser-sdk.test.ts
@@ -69,10 +69,10 @@ describe("generateWorkflowSDKCode (protocol synthesis path)", () => {
     expect(code).not.toContain("return { success: true };\n}");
   });
 
-  it("namespaces nothing -- two CCIP balance nodes would collide on CONTRACT_ADDRESS", () => {
-    // Documenting the known limitation: constants are scoped inside each
-    // step function (not at file top), so two CCIP nodes get independent
-    // CONTRACT_ADDRESS bindings without colliding.
+  it("scopes CONTRACT_ADDRESS per step so duplicate action nodes do not collide", () => {
+    // Constants live inside each step function (not at file top), so two
+    // CCIP balance nodes can coexist with independent CONTRACT_ADDRESS
+    // bindings. Asserts the per-step scoping invariant.
     const node1 = ccipBalanceNode("a-1");
     const node2 = ccipBalanceNode("a-2");
     const code = generateWorkflowSDKCode(

--- a/tests/unit/protocol-synthesiser.test.ts
+++ b/tests/unit/protocol-synthesiser.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { synthesiseProtocolTemplate } from "@/lib/workflow/codegen/protocol-synthesiser";
+
+describe("synthesiseProtocolTemplate", () => {
+  it("returns null for non-protocol action ids", () => {
+    expect(synthesiseProtocolTemplate("web3/check-balance")).toBeNull();
+    expect(synthesiseProtocolTemplate("not-a-protocol/anything")).toBeNull();
+    expect(synthesiseProtocolTemplate("malformed-no-slash")).toBeNull();
+  });
+
+  describe("ccip-check-bridge-balance (read, user-specified address)", () => {
+    const actionId = "chainlink/ccip-check-bridge-balance";
+
+    it("emits a viem readContract template with sepolia config", () => {
+      const out = synthesiseProtocolTemplate(actionId, {
+        network: "11155111",
+        contractAddress: "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05",
+      });
+
+      expect(out).not.toBeNull();
+      const code = out as string;
+
+      expect(code).toContain('import { createPublicClient, http } from "viem"');
+      expect(code).toContain('import { sepolia } from "viem/chains"');
+      expect(code).toContain(
+        'const CONTRACT_ADDRESS = "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05" as const'
+      );
+      expect(code).toContain(
+        "export async function ccipCheckBridgeBalanceStep"
+      );
+      expect(code).toContain('"use step"');
+      expect(code).toContain("client.readContract");
+      expect(code).toContain('functionName: "balanceOf"');
+      expect(code).toContain("args: [input.account]");
+      expect(code).toContain("chain: sepolia");
+      expect(code).toContain("process.env.SEPOLIA_RPC_URL");
+
+      // No write-only constructs leaking into a read template
+      expect(code).not.toContain("walletClient");
+      expect(code).not.toContain("WALLET_PRIVATE_KEY");
+      expect(code).not.toContain("simulateContract");
+
+      // Must not be the stub
+      expect(code).not.toContain("Executing action");
+    });
+
+    it("emits a placeholder address when user-specified address is missing", () => {
+      const out = synthesiseProtocolTemplate(actionId, {
+        network: "11155111",
+      });
+      expect(out).toContain(
+        '"0x0000000000000000000000000000000000000000" as const'
+      );
+      expect(out).toContain(
+        "// this contract address is user-specified at runtime"
+      );
+    });
+
+    it("falls back to defineChain when no network is selected", () => {
+      const out = synthesiseProtocolTemplate(actionId, {});
+      expect(out).toContain('import { defineChain } from "viem"');
+      expect(out).toContain("// no network selected on this node");
+    });
+  });
+
+  describe("ccip-approve-bridge-token (write)", () => {
+    const actionId = "chainlink/ccip-approve-bridge-token";
+
+    it("emits a viem write template with simulate, write, wait", () => {
+      const out = synthesiseProtocolTemplate(actionId, {
+        network: "11155111",
+        contractAddress: "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05",
+      });
+
+      expect(out).not.toBeNull();
+      const code = out as string;
+
+      expect(code).toContain(
+        'import { createPublicClient, createWalletClient, http } from "viem"'
+      );
+      expect(code).toContain(
+        'import { privateKeyToAccount } from "viem/accounts"'
+      );
+      expect(code).toContain('import { sepolia } from "viem/chains"');
+      expect(code).toContain(
+        "export async function ccipApproveBridgeTokenStep"
+      );
+
+      // Pipeline: simulate → write → wait
+      expect(code).toContain("publicClient.simulateContract");
+      expect(code).toContain("walletClient.writeContract(request)");
+      expect(code).toContain("publicClient.waitForTransactionReceipt");
+
+      expect(code).toContain('functionName: "approve"');
+      // approve takes (address spender, uint256 amount). Address passes through,
+      // uint256 is wrapped with BigInt.
+      expect(code).toContain("input.spender, BigInt(input.amount)");
+
+      // Output type for write actions is the fixed transaction shape
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: assertion against literal output
+      expect(code).toContain("transactionHash: `0x${string}`");
+      expect(code).toContain("gasUsed: string");
+
+      // No payable variant value leak (approve is non-payable)
+      expect(code).not.toContain("input.ethValue");
+    });
+  });
+
+  describe("type emission edge cases", () => {
+    it("maps an address input field to a viem-shaped Input type", () => {
+      const out = synthesiseProtocolTemplate(
+        "chainlink/ccip-check-bridge-balance",
+        { network: "11155111", contractAddress: "0xabc" }
+      );
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: assertion against literal output
+      expect(out).toContain("account: `0x${string}`");
+    });
+
+    it("maps a uint256 input field to string and casts via BigInt at call site", () => {
+      const out = synthesiseProtocolTemplate(
+        "chainlink/ccip-approve-bridge-token",
+        { network: "11155111", contractAddress: "0xabc" }
+      );
+      expect(out).toContain("amount: string");
+      expect(out).toContain("BigInt(input.amount)");
+    });
+  });
+});

--- a/tests/unit/protocol-synthesiser.test.ts
+++ b/tests/unit/protocol-synthesiser.test.ts
@@ -178,6 +178,41 @@ describe("synthesiseProtocolTemplate", () => {
     });
   });
 
+  describe("decimals annotation in Input type", () => {
+    it("emits a wei + parseUnits hint for inputs with decimals: <number>", () => {
+      // aerodrome/create-lock has `_value: uint256, decimals: 18`
+      const out = synthesiseProtocolTemplate("aerodrome/create-lock", {
+        network: "8453",
+      });
+      expect(out).not.toBeNull();
+      const code = out as string;
+
+      // The annotation MUST appear on the line above the typed field.
+      expect(code).toContain(
+        "/** denominated in wei (10^18 units) -- convert with parseUnits(value, 18) for human input */"
+      );
+      // Annotation does not change the cast in args.
+      expect(code).toContain("BigInt(input._value)");
+
+      // Sibling field without decimals stays unannotated.
+      expect(code).toContain("_lockDuration: string;");
+      const lockDurationIndex = code.indexOf("_lockDuration: string;");
+      const annotationBeforeLockDuration = code
+        .slice(0, lockDurationIndex)
+        .endsWith("/** denominated in wei (10^18 units)");
+      expect(annotationBeforeLockDuration).toBe(false);
+    });
+
+    it("emits a runtime-lookup TODO for inputs with decimals: true", () => {
+      // morpho/supply has `assets: uint256, decimals: true`
+      const out = synthesiseProtocolTemplate("morpho/supply", { network: "1" });
+      expect(out).not.toBeNull();
+      expect(out).toContain(
+        "/** denominated in the token's smallest unit -- token decimals must be looked up at runtime; replace with parseUnits(value, <decimals>) once known */"
+      );
+    });
+  });
+
   describe("ccip-send (payable + nested tuple + tuple[] + receiver pad)", () => {
     it("reconstructs the message struct and inlines the receiver pad transform", () => {
       const out = synthesiseProtocolTemplate("chainlink/ccip-send", {

--- a/tests/unit/protocol-synthesiser.test.ts
+++ b/tests/unit/protocol-synthesiser.test.ts
@@ -125,4 +125,87 @@ describe("synthesiseProtocolTemplate", () => {
       expect(out).toContain("BigInt(input.amount)");
     });
   });
+
+  describe("proxy contract ABI fallback (no inline abi)", () => {
+    it("synthesises an ABI fragment from action metadata for aave-v3/supply", () => {
+      const out = synthesiseProtocolTemplate("aave-v3/supply", {
+        network: "1",
+      });
+
+      expect(out).not.toBeNull();
+      const code = out as string;
+
+      // Header comment marks the synthesised origin so a reader knows the
+      // shape came from action metadata, not a real ABI lookup.
+      expect(code).toContain(
+        "// ABI fragment synthesised from protocol action metadata"
+      );
+
+      // Real Aave V3 pool address on mainnet, resolved per chain.
+      expect(code).toContain('"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"');
+
+      // Action.inputs become positional contract args with the right casts.
+      expect(code).toContain('functionName: "supply"');
+      expect(code).toContain(
+        "args: [input.asset, BigInt(input.amount), input.onBehalfOf, BigInt(input.referralCode)]"
+      );
+
+      // Write-shaped output template.
+      expect(code).toContain("export async function supplyStep");
+      expect(code).toContain("publicClient.simulateContract");
+    });
+  });
+
+  describe("tuple input reconstruction", () => {
+    it("wraps uniswap quote-exact-input args in a single tuple object", () => {
+      const out = synthesiseProtocolTemplate("uniswap/quote-exact-input", {
+        network: "1",
+      });
+
+      expect(out).not.toBeNull();
+      const code = out as string;
+
+      // The contract takes a single tuple param; user-facing inputs are flat.
+      // Args MUST be a single object literal, not separate positional args.
+      expect(code).toContain(
+        "args: [{ tokenIn: input.tokenIn, tokenOut: input.tokenOut, amountIn: BigInt(input.amountIn), fee: BigInt(input.fee), sqrtPriceLimitX96: BigInt(input.sqrtPriceLimitX96) }]"
+      );
+
+      // Multi-output read uses indexed result destructuring.
+      expect(code).toContain(
+        "amountOut: String((result as readonly unknown[])[0])"
+      );
+    });
+  });
+
+  describe("ccip-send (payable + nested tuple + tuple[] + receiver pad)", () => {
+    it("reconstructs the message struct and inlines the receiver pad transform", () => {
+      const out = synthesiseProtocolTemplate("chainlink/ccip-send", {
+        network: "11155111",
+      });
+
+      expect(out).not.toBeNull();
+      const code = out as string;
+
+      // First arg is a top-level scalar; second is the message tuple.
+      expect(code).toContain(
+        "args: [BigInt(input.destinationChainSelector), {"
+      );
+
+      // Receiver field gets the padAddressToBytes transform inlined.
+      expect(code).toContain(
+        '("0x" + (input.receiver).slice(2).padStart(64, "0") as'
+      );
+
+      // tokenAmounts (tuple[]) becomes an array map with element-wise casts.
+      expect(code).toContain(
+        "tokenAmounts: (input.tokenAmounts).map((t) => ({ token: t.token, amount: BigInt(t.amount) }))"
+      );
+
+      // payable: ethValue line emitted only for payable functions.
+      expect(code).toContain(
+        "value: input.ethValue ? BigInt(input.ethValue) : undefined"
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the gap where the workflow node Copy code button and full-workflow SDK export emit a literal stub for any protocol action (Aave, Chainlink CCIP, Uniswap, Sky, etc.). Adds an ABI-driven synthesiser that emits standalone viem code per action and wires it into both consumers.

## Context

Three failure modes contributed to the stub output:

1. `discover-plugins` explicitly skips protocol integrations when generating `lib/workflow/codegen/registry.ts`, so all 361 protocol actions had no template.
2. `lib/workflow/codegen/sdk.ts` (full-workflow export) only checked `SYSTEM_CODEGEN_TEMPLATES` and the never-populated `action.codegenTemplate` field, so even the 14 plugin templates that did exist were invisible to it.
3. The 14 templates that the scraper does produce reference helpers (`getUserIdFromExecution`, `logUserError`, etc.) without imports, because the scraper only forwards the step file's top-level imports.

This PR fixes (1) and (2). (3) is unchanged and still applies to the 14 non-protocol auto-generated templates.

## Approach

A pure synthesiser in `lib/workflow/codegen/protocol-synthesiser.ts`:

- Reads protocol metadata via a new accessor `getProtocolActionContext(actionId)` that resolves protocol + contract + action + ABI fragment in one walk.
- Emits read templates using `client.readContract` and write templates using the simulate -> write -> wait pipeline with `privateKeyToAccount`.
- Walks the ABI inputs (not the user-facing `action.inputs`) so tuple-taking functions like `ccipSend` and `quoteExactInputSingle` get a properly reconstructed struct argument instead of being passed positionally.
- Falls back to synthesising the ABI fragment from `action.inputs`/`action.outputs` when `contract.abi` is missing (covers Aave V3 pool, Compound V3, all proxy contracts).
- Inlines registered encode transforms (CCIP receiver `padAddressToBytes`).
- Resolves chain via a 14-entry viem chain map covering every chain the registered protocols deploy on; emits a `defineChain` placeholder + warning for unknowns.

Two consumers:

- **Single-node Copy code** (`components/workflow/utils/code-generators.ts`): inserted into the lookup chain after `AUTO_GENERATED_TEMPLATES`, before the dead `action.codegenTemplate` field, before the stub.
- **Full-workflow SDK export** (`lib/workflow/codegen/sdk.ts`): added a new branch in `generateStepFunction` that emits the synthesised pieces inline within each step wrapper (constants scoped per step to avoid name collisions when the same action appears twice in a workflow), and merges the synthesised viem imports into the SDK's import set.

## Test plan

- [x] Unit tests pass: `pnpm vitest run tests/unit/protocol-synthesiser.test.ts tests/unit/protocol-synthesiser-sdk.test.ts` (9/9)
- [x] Type-check clean: `pnpm type-check`
- [x] Lint clean: `pnpm check` on touched files
- [x] Local dev server: clicked Copy code on `chainlink/ccip-check-bridge-balance` -- output is the standalone viem read template instead of the stub
- [x] Sanity check Copy code on `aave-v3/supply` (proxy fallback path)
- [x] Sanity check Copy code on `chainlink/ccip-send` (payable + tuple + tuple[] + receiver pad)
- [x] Sanity check full-workflow export on a protocol-only workflow

## Known limitations

- Decimal-input handling: protocol inputs marked `decimals: N` display as human values in the form but the synthesiser passes them through with `BigInt(...)`, which fails on decimal strings. Workaround: enter values in wei. Real fix is `parseUnits` inlining.
- Encode transform detection is currently a runtime probe of the registered transform function. Works for `padAddressToBytes` (the only registered transform today); any new transforms added to `lib/protocol-encode-transforms.ts` would silently pass through unmodified until the synthesiser is taught to recognise them.
- The 14 existing scraper-generated templates still reference internal helpers without imports. Out of scope here.