### PR TITLE
refactor: KEEP-242 require MCP_SESSION_SECRET, eliminate fallback chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,17 @@ DATABASE_URL=
 # better-auth signing key. Generate with: openssl rand -hex 32
 BETTER_AUTH_SECRET=
 
+# OAuth JWT signing key for MCP OAuth access tokens. Generate with:
+#   openssl rand -hex 32
+# Must be distinct from BETTER_AUTH_SECRET and MCP_SESSION_SECRET to keep
+# cryptographic contexts separated.
+OAUTH_JWT_SECRET=
+
+# MCP session JWT signing key. Generate with: openssl rand -hex 32
+# Must be distinct from BETTER_AUTH_SECRET and OAUTH_JWT_SECRET to keep
+# cryptographic contexts separated.
+MCP_SESSION_SECRET=
+
 # better-auth callback URL (matches the dev server)
 BETTER_AUTH_URL=http://localhost:3000
 

--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -79,6 +79,8 @@ runs:
         printf '%s\n' \
           "DATABASE_URL=${DATABASE_URL}" \
           "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}" \
+          "OAUTH_JWT_SECRET=ci-oauth-jwt-test-secret" \
+          "MCP_SESSION_SECRET=ci-mcp-session-test-secret" \
           "NODE_ENV=production" \
           "HOSTNAME=0.0.0.0" \
           "CI=true" \
@@ -146,6 +148,8 @@ runs:
       env:
         DATABASE_URL: ${{ inputs.database_url }}
         BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
+        OAUTH_JWT_SECRET: ci-oauth-jwt-test-secret
+        MCP_SESSION_SECRET: ci-mcp-session-test-secret
         CI: true
         TEST_API_KEY: ${{ inputs.test_api_key }}
         WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -176,6 +176,10 @@ env:
     type: parameterStore
     name: oauth-jwt-secret
     parameter_name: /eks/techops-prod/keeperhub/oauth-jwt-secret
+  MCP_SESSION_SECRET:
+    type: parameterStore
+    name: mcp-session-secret
+    parameter_name: /eks/techops-prod/keeperhub/mcp-session-secret
   DISCORD_WEBHOOK_SIGNUPS:
     type: parameterStore
     name: discord-webhook-signups

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -173,6 +173,10 @@ env:
     type: parameterStore
     name: oauth-jwt-secret
     parameter_name: /eks/techops-staging/keeperhub/oauth-jwt-secret
+  MCP_SESSION_SECRET:
+    type: parameterStore
+    name: mcp-session-secret
+    parameter_name: /eks/techops-staging/keeperhub/mcp-session-secret
   # Auth and social providers (GitHub, Google)
   NEXT_PUBLIC_AUTH_PROVIDERS:
     type: kv

--- a/deploy/local/values-keeperhub.template.yaml
+++ b/deploy/local/values-keeperhub.template.yaml
@@ -58,6 +58,12 @@ env:
   BETTER_AUTH_SECRET:
     type: kv
     value: "local-dev-secret-change-in-production"
+  OAUTH_JWT_SECRET:
+    type: kv
+    value: "local-dev-oauth-jwt-secret-change-in-production"
+  MCP_SESSION_SECRET:
+    type: kv
+    value: "local-dev-mcp-session-secret-change-in-production"
   BETTER_AUTH_URL:
     type: kv
     value: "https://workflow.keeperhub.local"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -198,6 +198,10 @@ env:
     type: parameterStore
     name: oauth-jwt-secret
     parameter_name: /eks/techops-staging/keeperhub/oauth-jwt-secret
+  MCP_SESSION_SECRET:
+    type: parameterStore
+    name: mcp-session-secret
+    parameter_name: /eks/techops-staging/keeperhub/mcp-session-secret
   OPENAI_API_KEY:
     type: parameterStore
     name: openai-api-key

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -44,6 +44,21 @@ export async function register() {
 
   // Only register process handlers in Node.js runtime (not Edge)
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Each secret signs a distinct cryptographic context (better-auth session
+    // cookies, OAuth access tokens, MCP session tokens). They must be set
+    // independently so a leak or rotation in one context does not cascade.
+    const requiredSecrets = [
+      "BETTER_AUTH_SECRET",
+      "OAUTH_JWT_SECRET",
+      "MCP_SESSION_SECRET",
+    ];
+    const missingSecrets = requiredSecrets.filter((name) => !process.env[name]);
+    if (missingSecrets.length > 0) {
+      throw new Error(
+        `Missing required environment variables: ${missingSecrets.join(", ")}`
+      );
+    }
+
     // Register AsyncLocalStorage for the workflow error context. The context
     // module avoids any static `node:async_hooks` import so it can be safely
     // pulled into the workflow runtime bundle; the storage is only available

--- a/lib/mcp/session-token.ts
+++ b/lib/mcp/session-token.ts
@@ -16,14 +16,9 @@ export const MAX_SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60; // 30 days
 let cachedSessionSecret: { raw: string; encoded: Uint8Array } | null = null;
 
 function getSessionSecret(): Uint8Array {
-  const secret =
-    process.env.MCP_SESSION_SECRET ??
-    process.env.OAUTH_JWT_SECRET ??
-    process.env.BETTER_AUTH_SECRET;
+  const secret = process.env.MCP_SESSION_SECRET;
   if (!secret) {
-    throw new Error(
-      "No session secret configured. Set MCP_SESSION_SECRET, OAUTH_JWT_SECRET, or BETTER_AUTH_SECRET."
-    );
+    throw new Error("MCP_SESSION_SECRET environment variable is not set");
   }
   if (cachedSessionSecret?.raw === secret) {
     return cachedSessionSecret.encoded;

--- a/tests/unit/code-run-code.test.ts
+++ b/tests/unit/code-run-code.test.ts
@@ -442,6 +442,7 @@ describe("code/run-code - sandbox globals", () => {
         "DATABASE_URL",
         "BETTER_AUTH_SECRET",
         "OAUTH_JWT_SECRET",
+        "MCP_SESSION_SECRET",
         "STRIPE_SECRET_KEY",
         "GITHUB_CLIENT_SECRET",
         "GOOGLE_CLIENT_SECRET",


### PR DESCRIPTION
## Summary

Eliminates the `MCP_SESSION_SECRET -> OAUTH_JWT_SECRET -> BETTER_AUTH_SECRET` fallback chain in `lib/mcp/session-token.ts`. MCP session JWTs are now signed with a dedicated secret only. Startup validation in `instrumentation.ts` fails the boot loudly if any of the three signing secrets are missing.

Linear: [KEEP-242](https://linear.app/keeperhubapp/issue/KEEP-242/eliminate-mcp-session-secret-fallback-chain-use-single-dedicated-env)

## Why

Sharing one secret across multiple cryptographic contexts is an audit smell, even when payload type guards happen to block direct token confusion today. Defense in depth: each context (better-auth session cookies, OAuth access tokens, MCP session JWTs) gets its own key, rotatable independently.

The original ticket worried about the tier-3 fallback to `BETTER_AUTH_SECRET`. Investigation found the actually-active fallback in staging/prod is tier-2 (`OAUTH_JWT_SECRET`); tier-3 only triggers in CI/dev where `OAUTH_JWT_SECRET` is unset. Both paths are now eliminated.

## Changes

- `lib/mcp/session-token.ts` - drop fallback; require `MCP_SESSION_SECRET`, throw if missing.
- `instrumentation.ts` - startup validation requires `BETTER_AUTH_SECRET`, `OAUTH_JWT_SECRET`, `MCP_SESSION_SECRET` (Node.js runtime only).
- `.env.example` - document `OAUTH_JWT_SECRET` and `MCP_SESSION_SECRET`. Both were undocumented before; the ticket originally only listed the new one but the OAuth secret has the same silent-fallback gap.
- `deploy/keeperhub/{staging,prod}/values.yaml`, `deploy/pr-environment/values.template.yaml` - new `MCP_SESSION_SECRET` parameterStore entries.
- `deploy/local/values-keeperhub.template.yaml` - add literal `OAUTH_JWT_SECRET` and `MCP_SESSION_SECRET` for local kind dev.
- `.github/actions/start-app/action.yml` - set distinct CI test literals on Docker and bare-metal start paths.
- `tests/unit/code-run-code.test.ts` - add `MCP_SESSION_SECRET` to the sandbox-leak deny-list.

## Operational dependencies (must land before deploy)

This PR will fail boot if `MCP_SESSION_SECRET` is unset.

**Blocked on [infrastructure PR #172](https://github.com/techops-services/infrastructure/pull/172)** which creates the new SSM parameters via terraform. Per-environment rollout:

1. Merge infra PR #172, apply in the target environment (staging first, then prod). Terraform creates the SSM parameter with a fresh random value.
2. Verify with `aws ssm get-parameter --name /eks/<env>/keeperhub/mcp-session-secret --with-decryption`.
3. Merge this PR to that environment.

## Cutover behavior: relogin storm

Active MCP sessions today are signed with `OAUTH_JWT_SECRET` (via the tier-2 fallback). The new `MCP_SESSION_SECRET` is a fresh random value, so on deploy the app stops accepting any in-flight MCP session - active MCP users have to reauthenticate.

This is accepted as the simplest correct cutover for a Medium-severity audit fix. Session lifetime is 24h TTL with 48h renewal grace and 30d max, so the impact window is bounded. Subsequent rotations of `MCP_SESSION_SECRET` are independent of OAuth and better-auth.

## Test plan

- [x] `npx biome check` on edited source files: clean (3 pre-existing errors in `tests/unit/code-run-code.test.ts` at unrelated lines)
- [x] `pnpm type-check`: clean (after `pnpm discover-plugins`)
- [x] `pnpm test tests/unit/mcp-session-longevity.test.ts tests/unit/oauth-auth-deactivated.test.ts`: 27/27 pass
- [x] `pnpm test tests/unit/code-run-code.test.ts`: 76/76 pass
- [ ] Verify staging boot succeeds after infra PR #172 has been applied
- [ ] Smoke-test an MCP session creation/verification flow against staging after deploy
