### PR TITLE
feat: KEEP-241 add static security response headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -278,6 +278,22 @@ const nextConfig = {
   async rewrites() {
     return [{ source: "/openapi.json", destination: "/api/openapi" }];
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
Closes part of KEEP-241. The CSP portion is being split out into a separate follow-up ticket — see the Linear comment on KEEP-241 for the rationale.

## Summary

Adds four static security headers to every response via `next.config.ts headers()`:

| Header | Value |
|---|---|
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` |

## Why these four (and not CSP yet)

**Current state has zero defense-in-depth at any layer.** `curl -I` against `app.keeperhub.com` and `app-staging.keeperhub.com` returns only `server: cloudflare` and `cf-ray` — Cloudflare fronts both but injects none of these headers. Origin sends nothing either (grep for the header names in `.ts`/`.tsx` returns zero matches).

These four are the cheap wins:
- **Pure config change** (16 lines). No runtime cost.
- **No UX impact**: no embed/widget use case in the codebase, so `X-Frame-Options: DENY` doesn't break anything. The one iframe in `components/workflow/workflow-runs.tsx` embeds external URLs, it is not the embeddee.
- **Free credit on the next pen test / SOC2 audit.**

CSP, by contrast, is a real engineering project: Monaco's TS/JSON workers historically need `'unsafe-eval'`, Tailwind 4 + Radix inject inline `<style>`, and the workflow-output iframe needs `frame-src` for arbitrary user URLs. That work needs a report-only iteration phase and will be tracked separately.

## Specific value choices

- **`X-Frame-Options: DENY`** — verified no embed use case. If a future requirement needs same-origin embedding, swap to `SAMEORIGIN`.
- **HSTS `max-age=63072000` (2 years), `includeSubDomains`, no `preload`** — matches the value the ticket itself suggested. `preload` is intentionally deferred: it requires explicit submission to hstspreload.org and is hard to revert if any subdomain ever needs HTTP. Cloudflare is not currently emitting HSTS, so app-level is the source of truth — no duplicate to worry about.
- **`Referrer-Policy: strict-origin-when-cross-origin`** — modern default, also Chrome's default since 85.

## Test plan

- [x] CI passes (type-check, lint).
- [ ] After deploy to staging: `curl -I https://app-staging.keeperhub.com/` shows all four headers.
- [ ] Spot-check that the workflow editor (Monaco) and the workflow-output iframe still render.
- [ ] Spot-check API routes (e.g. `curl -I https://app-staging.keeperhub.com/api/openapi`) also receive the headers.

## Related

- Depends on: #1027 (merged) — removed Vercel Analytics so `va.vercel-scripts.com` no longer needs to be considered in future CSP work.
- Follow-up: separate ticket to be filed for CSP.