### PR TITLE
feat: keeperhub managed org metrics

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -4,6 +4,7 @@ import { start } from "workflow/api";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { db } from "@/lib/db";
+import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { tags, workflowExecutions, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
@@ -122,11 +123,15 @@ async function prepareExecution(
  * Fire-and-forget: kicks off the workflow in the background. The HTTP response
  * is returned to the caller immediately while the workflow runs.
  */
-function startExecutionInBackground(
+async function startExecutionInBackground(
   workflow: CallRouteWorkflow,
   body: Record<string, unknown>,
   executionId: string
-): void {
+): Promise<void> {
+  const [organizationSlug, organizationPlan] = await Promise.all([
+    getOrgSlug(workflow.organizationId),
+    getOrgPlanLabel(workflow.organizationId),
+  ]);
   start(executeWorkflow, [
     {
       nodes: workflow.nodes as WorkflowNode[],
@@ -135,6 +140,8 @@ function startExecutionInBackground(
       executionId,
       workflowId: workflow.id,
       organizationId: workflow.organizationId ?? undefined,
+      organizationSlug,
+      organizationPlan,
     },
   ]).catch((err: unknown) => {
     logSystemError(
@@ -159,7 +166,7 @@ async function createAndStartExecution(
   if ("error" in prepared) {
     return prepared.error;
   }
-  startExecutionInBackground(workflow, body, prepared.executionId);
+  await startExecutionInBackground(workflow, body, prepared.executionId);
   const responseBody = await buildCallCompletionResponse(
     prepared.executionId,
     workflow.outputMapping
@@ -335,7 +342,7 @@ async function handlePaidWorkflow(
           throw err;
         }
 
-        startExecutionInBackground(workflow, body, executionId);
+        await startExecutionInBackground(workflow, body, executionId);
 
         const responseBody = await buildCallCompletionResponse(
           executionId,

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -10,7 +10,7 @@ import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
-import { getOrgSlug } from "@/lib/db/org-helpers";
+import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
@@ -23,8 +23,9 @@ async function executeWorkflowBackground(
   input: Record<string, unknown>,
   organizationId?: string | null,
   ownerId?: string,
-  organizationSlug?: string
-) {
+  organizationSlug?: string,
+  organizationPlan?: string
+): Promise<void> {
   try {
     console.log("[Workflow Execute] Starting execution:", executionId);
 
@@ -49,6 +50,7 @@ async function executeWorkflowBackground(
         organizationId: organizationId ?? undefined,
         ownerId,
         organizationSlug,
+        organizationPlan,
       },
     ]);
 
@@ -222,8 +224,11 @@ export async function POST(
       [LabelKeys.WORKFLOW_ID]: workflowId,
     });
 
-    // Resolve org slug for log labels (cached per request)
-    const organizationSlug = await getOrgSlug(workflow.organizationId);
+    // Resolve org slug + plan for log labels (cached per request)
+    const [organizationSlug, organizationPlan] = await Promise.all([
+      getOrgSlug(workflow.organizationId),
+      getOrgPlanLabel(workflow.organizationId),
+    ]);
 
     // Execute the workflow in the background (don't await)
     executeWorkflowBackground(
@@ -234,7 +239,8 @@ export async function POST(
       input,
       workflow.organizationId,
       workflow.userId,
-      organizationSlug
+      organizationSlug,
+      organizationPlan
     );
 
     // Return immediately with the execution ID

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -17,7 +17,7 @@ import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
-import { getOrgSlug } from "@/lib/db/org-helpers";
+import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 // Validate API key and return the user ID if valid
@@ -111,8 +111,9 @@ async function executeWorkflowBackground(
   input: Record<string, unknown>,
   organizationId?: string | null,
   ownerId?: string,
-  organizationSlug?: string
-) {
+  organizationSlug?: string,
+  organizationPlan?: string
+): Promise<void> {
   try {
     console.log("[Webhook] Starting execution:", executionId);
 
@@ -133,6 +134,7 @@ async function executeWorkflowBackground(
         organizationId: organizationId ?? undefined,
         ownerId,
         organizationSlug,
+        organizationPlan,
       },
     ]);
 
@@ -284,8 +286,11 @@ export async function POST(
       [LabelKeys.WORKFLOW_ID]: workflowId,
     });
 
-    // Resolve org slug for log labels (cached per request)
-    const organizationSlug = await getOrgSlug(workflow.organizationId);
+    // Resolve org slug + plan for log labels (cached per request)
+    const [organizationSlug, organizationPlan] = await Promise.all([
+      getOrgSlug(workflow.organizationId),
+      getOrgPlanLabel(workflow.organizationId),
+    ]);
 
     // Execute the workflow in the background (don't await)
     executeWorkflowBackground(
@@ -296,7 +301,8 @@ export async function POST(
       body,
       workflow.organizationId,
       workflow.userId,
-      organizationSlug
+      organizationSlug,
+      organizationPlan
     );
 
     recordWebhookMetrics({

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -4,7 +4,7 @@
 import { eq } from "drizzle-orm";
 import { cache } from "react";
 import { db } from "@/lib/db";
-import { organization } from "@/lib/db/schema";
+import { organization, organizationSubscriptions } from "@/lib/db/schema";
 import { enterWorkflowErrorContext } from "@/lib/workflow/executor/error-context";
 
 /**
@@ -32,10 +32,34 @@ export const getOrgSlug = cache(
 );
 
 /**
+ * Resolve an organization's plan by id. Cached per request. Returns "free"
+ * when the org has no subscription row, undefined when the lookup fails or
+ * orgId is missing. Used as a low-cardinality label on error metrics so
+ * alerts can filter to managed clients.
+ */
+export const getOrgPlanLabel = cache(
+  async (orgId: string | null | undefined): Promise<string | undefined> => {
+    if (!orgId) {
+      return undefined;
+    }
+    try {
+      const rows = await db
+        .select({ plan: organizationSubscriptions.plan })
+        .from(organizationSubscriptions)
+        .where(eq(organizationSubscriptions.organizationId, orgId))
+        .limit(1);
+      return rows[0]?.plan ?? "free";
+    } catch {
+      return undefined;
+    }
+  }
+);
+
+/**
  * Convenience for direct-execute API routes (e.g.
  * /api/execute/check-and-execute) that bypass the workflow executor and
- * therefore don't get its ALS scope. Resolves the org slug and enters the
- * workflow error context for the rest of the request.
+ * therefore don't get its ALS scope. Resolves the org slug and plan and
+ * enters the workflow error context for the rest of the request.
  */
 export async function enterApiExecuteErrorContext(
   organizationId: string | null | undefined
@@ -43,9 +67,13 @@ export async function enterApiExecuteErrorContext(
   if (!organizationId) {
     return;
   }
-  const slug = await getOrgSlug(organizationId);
+  const [slug, plan] = await Promise.all([
+    getOrgSlug(organizationId),
+    getOrgPlanLabel(organizationId),
+  ]);
   enterWorkflowErrorContext({
     org_id: organizationId,
     org_slug: slug,
+    plan,
   });
 }

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -102,12 +102,15 @@ const workflowExecutionsTotal = getOrCreateGauge(
   ["status"]
 );
 
-// Workflow errors total (convenience gauge for alerting)
+// Workflow errors total (convenience gauge for alerting). Labeled by org_slug
+// so alerts can scope to managed clients. Personal/anonymous workflows are
+// emitted under org_slug="_anonymous" so the sum across labels matches the
+// global error count.
 const workflowErrorsTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_workflow_execution_errors_total",
-  "Total failed workflow executions (all-time)",
-  []
+  "Total failed workflow executions (all-time), broken down by org_slug",
+  ["org_slug"]
 );
 
 // Workflow duration histogram as gauges (replaces histogram)
@@ -1040,8 +1043,15 @@ export async function updateDbMetrics(): Promise<void> {
       workflowStats.totalCancelled
     );
 
-    // Update workflow errors total (convenience gauge for alerting)
-    workflowErrorsTotal.set(workflowStats.totalError);
+    // Update workflow errors total per org_slug (convenience gauge for
+    // alerting). Reset before populating so series for orgs that no longer
+    // have errors clear out instead of going stale.
+    workflowErrorsTotal.reset();
+    for (const [orgSlug, errorCount] of Object.entries(
+      workflowStats.errorByOrgSlug
+    )) {
+      workflowErrorsTotal.set({ org_slug: orgSlug }, errorCount);
+    }
 
     // Update workflow duration histogram buckets
     for (let i = 0; i < WORKFLOW_DURATION_BUCKETS.length; i++) {

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -611,7 +611,7 @@ const pluginInvocations = getOrCreateCounter(
   apiRegistry,
   "keeperhub_plugin_invocations_total",
   "Total plugin invocations",
-  ["plugin_name", "action_name"]
+  ["plugin_name", "action_name", "org_slug", "plan"]
 );
 
 // Error counters
@@ -619,14 +619,14 @@ const pluginErrors = getOrCreateCounter(
   apiRegistry,
   "keeperhub_plugin_action_errors_total",
   "Failed plugin actions",
-  ["plugin_name", "action_name", "error_type"]
+  ["plugin_name", "action_name", "error_type", "org_slug", "plan"]
 );
 
 const apiErrors = getOrCreateCounter(
   apiRegistry,
   "keeperhub_api_errors_total",
   "API errors by status code",
-  ["endpoint", "status_code", "error_type"]
+  ["endpoint", "status_code", "error_type", "org_slug", "plan"]
 );
 
 // Common labels for all error counters (allows any subset to be used)
@@ -646,6 +646,8 @@ const ERROR_LABELS = [
   "execution_id",
   "integration_id",
   "status_code",
+  "org_slug",
+  "plan",
 ];
 
 // User-caused error counters (from unified logging system)
@@ -730,10 +732,28 @@ const dbPoolUtilization = getOrCreateGauge(
 
 // Allowed labels per error metric (must match counter definitions)
 const errorLabelAllowlist: Record<string, string[]> = {
-  "workflow.execution.errors": ["workflow_id", "trigger_type", "error_type"],
-  "workflow.step.errors": ["step_type", "error_type"],
-  "plugin.action.errors": ["plugin_name", "action_name", "error_type"],
-  "api.errors.total": ["endpoint", "status_code", "error_type"],
+  "workflow.execution.errors": [
+    "workflow_id",
+    "trigger_type",
+    "error_type",
+    "org_slug",
+    "plan",
+  ],
+  "workflow.step.errors": ["step_type", "error_type", "org_slug", "plan"],
+  "plugin.action.errors": [
+    "plugin_name",
+    "action_name",
+    "error_type",
+    "org_slug",
+    "plan",
+  ],
+  "api.errors.total": [
+    "endpoint",
+    "status_code",
+    "error_type",
+    "org_slug",
+    "plan",
+  ],
 };
 
 /**

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -28,6 +28,11 @@ import {
   workflows,
 } from "@/lib/db/schema";
 
+// Label value used for workflow executions whose workflow has no organization
+// (personal/anonymous workflows). Keeps the per-org error gauge total equal
+// to the global error count instead of silently dropping these executions.
+const ANONYMOUS_ORG_SLUG = "_anonymous";
+
 // Histogram bucket boundaries in milliseconds (must match prometheus.ts)
 const WORKFLOW_DURATION_BUCKETS = [
   100, 250, 500, 1000, 2000, 5000, 10_000, 30_000,
@@ -41,6 +46,10 @@ export type WorkflowStats = {
   totalRunning: number;
   totalPending: number;
   totalCancelled: number;
+
+  // Error count per org slug. Personal/anonymous workflows are bucketed
+  // under ANONYMOUS_ORG_SLUG so the sum across this map matches totalError.
+  errorByOrgSlug: Record<string, number>;
 
   // Duration histogram data (count of executions in each bucket)
   durationBuckets: number[];
@@ -71,6 +80,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       totalRunning: 0,
       totalPending: 0,
       totalCancelled: 0,
+      errorByOrgSlug: {},
       durationBuckets: new Array(WORKFLOW_DURATION_BUCKETS.length + 1).fill(0),
       durationSum: 0,
       durationCount: 0,
@@ -97,6 +107,24 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
           // Ignore unknown status values
           break;
       }
+    }
+
+    // Per-org error breakdown: JOIN workflows + organization, LEFT JOIN so
+    // anonymous workflows still contribute (under ANONYMOUS_ORG_SLUG).
+    const orgSlugExpr = sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`;
+    const errorByOrg = await db
+      .select({
+        orgSlug: orgSlugExpr,
+        count: count(),
+      })
+      .from(workflowExecutions)
+      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+      .leftJoin(organization, eq(workflows.organizationId, organization.id))
+      .where(eq(workflowExecutions.status, "error"))
+      .groupBy(orgSlugExpr);
+
+    for (const row of errorByOrg) {
+      stats.errorByOrgSlug[row.orgSlug] = Number(row.count) || 0;
     }
 
     // Query duration histogram data for completed executions
@@ -150,6 +178,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       totalRunning: 0,
       totalPending: 0,
       totalCancelled: 0,
+      errorByOrgSlug: {},
       durationBuckets: new Array(WORKFLOW_DURATION_BUCKETS.length + 1).fill(0),
       durationSum: 0,
       durationCount: 0,

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -155,6 +155,7 @@ export const LabelKeys = {
   EXECUTION_ID: "execution_id",
   ORG_ID: "org_id",
   ORG_SLUG: "org_slug",
+  PLAN: "plan",
   OWNER_ID: "owner_id",
   PLUGIN_ID: "plugin_id",
   INTEGRATION_ID: "integration_id",

--- a/lib/workflow/executor/error-context.ts
+++ b/lib/workflow/executor/error-context.ts
@@ -18,6 +18,7 @@ export type WorkflowErrorContext = {
   execution_id?: string;
   org_id?: string;
   org_slug?: string;
+  plan?: string;
   owner_id?: string;
   plugin_id?: string;
   integration_id?: string;

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -114,6 +114,10 @@ export type WorkflowExecutionInput = {
   organizationName?: string; // Used for log filtering by org name
   // Identifiers attached to every workflow error log line
   organizationSlug?: string;
+  // Org plan ("free" | "pro" | "business" | "enterprise") used as a
+  // low-cardinality label on error metrics so alerts can filter to managed
+  // clients. Resolved by the caller via getOrgPlanLabel().
+  organizationPlan?: string;
   ownerId?: string;
 };
 
@@ -1065,6 +1069,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     organizationId,
     organizationName,
     organizationSlug,
+    organizationPlan,
     ownerId,
   } = input;
 
@@ -1084,6 +1089,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     ...(executionId ? { execution_id: executionId } : {}),
     ...(organizationId ? { org_id: organizationId } : {}),
     ...(organizationSlug ? { org_slug: organizationSlug } : {}),
+    ...(organizationPlan ? { plan: organizationPlan } : {}),
     ...(organizationName ? { org_name: organizationName } : {}),
     ...(ownerId ? { owner_id: ownerId } : {}),
   };
@@ -1096,6 +1102,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     execution_id: executionId,
     org_id: organizationId,
     org_slug: organizationSlug,
+    plan: organizationPlan,
     owner_id: ownerId,
   });
 


### PR DESCRIPTION
Adds org_slug and plan labels to every KeeperHub error metric so PromQL alerts can scope to specific orgs.

org_slug is used today by the paired infra PR to filter alerts to managed clients (Sky, Ajna). plan is emitted for future use — once organization_subscriptions rows get populated for paying customers, alerts can switch to {plan="enterprise"} with no further metric changes.

Covers the runtime error counters, plugin invocations (needed as rate denominator), and the DB-sourced workflow_execution_errors_total gauge (now grouped by org; anonymous workflows go under org_slug="_anonymous" so totals are preserved).
