### PR TITLE
fix: surface listed-workflow inputSchema fields in template autocomplete

### DIFF
--- a/components/ui/sql-template-editor.tsx
+++ b/components/ui/sql-template-editor.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { CodeEditor } from "@/components/ui/code-editor";
 import { api } from "@/lib/api-client";
+import { getInputSchemaFields } from "@/lib/workflow/editor/input-schema-fields";
 import {
   buildExecutionLogsMap,
   type ExecutionLogsByNodeId,
@@ -19,6 +20,7 @@ import { useStableRef } from "@/lib/use-stable-ref";
 import { getAvailableFields, type NodeOutputs } from "@/lib/utils/template";
 import {
   currentWorkflowIdAtom,
+  currentWorkflowInputSchemaAtom,
   edgesAtom,
   executionLogsAtom,
   lastExecutionLogsAtom,
@@ -49,6 +51,7 @@ export function SqlTemplateEditor({
   const [selectedNodeId] = useAtom(selectedNodeAtom);
   const executionLogs = useAtomValue(executionLogsAtom);
   const currentWorkflowId = useAtomValue(currentWorkflowIdAtom);
+  const workflowInputSchema = useAtomValue(currentWorkflowInputSchemaAtom);
   const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
   const setLastExecutionLogs = useSetAtom(lastExecutionLogsAtom);
 
@@ -59,6 +62,7 @@ export function SqlTemplateEditor({
   const executionLogsRef = useStableRef(executionLogs);
   const lastExecutionLogsRef = useStableRef(lastExecutionLogs);
   const currentWorkflowIdRef = useStableRef(currentWorkflowId);
+  const workflowInputSchemaRef = useStableRef(workflowInputSchema);
   const lastFetchWorkflowIdRef = useRef<string | null>(null);
 
   // Template mapping: "Label.field" -> nodeId (for display <-> stored conversion)
@@ -282,6 +286,36 @@ export function SqlTemplateEditor({
     return result;
   }
 
+  function inputSchemaSuggestions(
+    node: WorkflowNode,
+    nodeName: string,
+    existingFields: Set<string>
+  ): Suggestion[] {
+    if (node.data.type !== "trigger") {
+      return [];
+    }
+    const schemaFields = getInputSchemaFields(workflowInputSchemaRef.current);
+    if (schemaFields.length === 0) {
+      return [];
+    }
+    const result: Suggestion[] = [];
+    for (const f of schemaFields) {
+      if (existingFields.has(f.field)) {
+        continue;
+      }
+      const displayKey = `${nodeName}.${f.field}`;
+      templateMapRef.current.set(displayKey, node.id);
+      result.push({
+        label: displayKey,
+        insertText: `{{${displayKey}}}`,
+        detail: f.description,
+        nodeId: node.id,
+        field: f.field,
+      });
+    }
+    return result;
+  }
+
   // Build completion suggestions from upstream nodes
   function buildSuggestions(): Suggestion[] {
     const upstreamNodes = getUpstreamNodes();
@@ -295,6 +329,16 @@ export function SqlTemplateEditor({
           ? suggestionsFromOutput(node, nodeName, output)
           : suggestionsFromStaticFields(node, nodeName);
       suggestions.push(...nodeSuggestions);
+
+      // Listed-workflow inputSchema fields (data.<fieldName>) are exposed for
+      // trigger nodes regardless of whether a runtime execution captured them.
+      const existing = new Set<string>();
+      for (const s of nodeSuggestions) {
+        if (s.field) {
+          existing.add(s.field);
+        }
+      }
+      suggestions.push(...inputSchemaSuggestions(node, nodeName, existing));
     }
 
     return suggestions;

--- a/components/ui/template-autocomplete.tsx
+++ b/components/ui/template-autocomplete.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/utils/template";
 import {
   currentWorkflowIdAtom,
+  currentWorkflowInputSchemaAtom,
   edgesAtom,
   executionLogsAtom,
   type ExecutionLogEntry,
@@ -38,6 +39,7 @@ import {
   buildHaystack,
   filterOptionsByQuery,
 } from "@/lib/workflow/editor/template-autocomplete-filter";
+import { getInputSchemaFields } from "@/lib/workflow/editor/input-schema-fields";
 import { getTriggerOutputFields } from "@/lib/workflow/editor/trigger-output-fields";
 
 /**
@@ -205,6 +207,7 @@ export function TemplateAutocomplete({
   const [edges] = useAtom(edgesAtom);
   const executionLogs = useAtomValue(executionLogsAtom);
   const currentWorkflowId = useAtomValue(currentWorkflowIdAtom);
+  const workflowInputSchema = useAtomValue(currentWorkflowInputSchemaAtom);
   const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
   const setLastExecutionLogs = useSetAtom(lastExecutionLogsAtom);
   const currentWorkflowIdRef = useRef<string | null>(null);
@@ -477,6 +480,37 @@ export function TemplateAutocomplete({
           });
         }
       }
+
+      // Listed-workflow inputSchema fields are exposed under data.<fieldName>
+      // because the executor merges request body into the trigger output's
+      // data at runtime. Inject them on both the runtime and static paths so
+      // they are available even before an agent has called the workflow, and
+      // dedupe against fields already pushed for this node so a runtime log
+      // that already captured them does not double-list.
+      if (node.data.type === "trigger" && workflowInputSchema) {
+        const schemaFields = getInputSchemaFields(workflowInputSchema);
+        if (schemaFields.length > 0) {
+          const existing = new Set<string>();
+          for (const opt of result) {
+            if (opt.nodeId === node.id && opt.type === "field" && opt.field) {
+              existing.add(opt.field);
+            }
+          }
+          for (const field of schemaFields) {
+            if (existing.has(field.field)) {
+              continue;
+            }
+            pushOption({
+              type: "field",
+              nodeId: node.id,
+              nodeName,
+              field: field.field,
+              description: field.description,
+              template: `{{@${node.id}:${nodeName}.${field.field}}}`,
+            });
+          }
+        }
+      }
     }
 
     // Built-in system variables (available to all nodes, evaluated at execution time)
@@ -492,7 +526,13 @@ export function TemplateAutocomplete({
     }
 
     return result;
-  }, [upstreamNodes, executionLogs, lastExecutionLogs, currentWorkflowId]);
+  }, [
+    upstreamNodes,
+    executionLogs,
+    lastExecutionLogs,
+    currentWorkflowId,
+    workflowInputSchema,
+  ]);
 
   // Case-insensitive substring search: each whitespace-separated token must
   // appear as a contiguous substring somewhere in the precomputed haystack.

--- a/components/ui/template-code-editor.tsx
+++ b/components/ui/template-code-editor.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { CodeEditor } from "@/components/ui/code-editor";
 import { api } from "@/lib/api-client";
+import { getInputSchemaFields } from "@/lib/workflow/editor/input-schema-fields";
 import {
   buildExecutionLogsMap,
   type ExecutionLogsByNodeId,
@@ -19,6 +20,7 @@ import { useStableRef } from "@/lib/use-stable-ref";
 import { getAvailableFields, type NodeOutputs } from "@/lib/utils/template";
 import {
   currentWorkflowIdAtom,
+  currentWorkflowInputSchemaAtom,
   edgesAtom,
   executionLogsAtom,
   lastExecutionLogsAtom,
@@ -53,6 +55,7 @@ export function TemplateCodeEditor({
   const selectedNodeId = useAtomValue(selectedNodeAtom);
   const executionLogs = useAtomValue(executionLogsAtom);
   const currentWorkflowId = useAtomValue(currentWorkflowIdAtom);
+  const workflowInputSchema = useAtomValue(currentWorkflowInputSchemaAtom);
   const lastExecutionLogs = useAtomValue(lastExecutionLogsAtom);
   const setLastExecutionLogs = useSetAtom(lastExecutionLogsAtom);
 
@@ -62,6 +65,7 @@ export function TemplateCodeEditor({
   const executionLogsRef = useStableRef(executionLogs);
   const lastExecutionLogsRef = useStableRef(lastExecutionLogs);
   const currentWorkflowIdRef = useStableRef(currentWorkflowId);
+  const workflowInputSchemaRef = useStableRef(workflowInputSchema);
   const lastFetchWorkflowIdRef = useRef<string | null>(null);
 
   const templateMapRef = useRef(new Map<string, string>());
@@ -275,6 +279,36 @@ export function TemplateCodeEditor({
     return result;
   }
 
+  function inputSchemaSuggestions(
+    node: WorkflowNode,
+    nodeName: string,
+    existingFields: Set<string>
+  ): Suggestion[] {
+    if (node.data.type !== "trigger") {
+      return [];
+    }
+    const schemaFields = getInputSchemaFields(workflowInputSchemaRef.current);
+    if (schemaFields.length === 0) {
+      return [];
+    }
+    const result: Suggestion[] = [];
+    for (const f of schemaFields) {
+      if (existingFields.has(f.field)) {
+        continue;
+      }
+      const displayKey = `${nodeName}.${f.field}`;
+      templateMapRef.current.set(displayKey, node.id);
+      result.push({
+        label: displayKey,
+        insertText: `{{${displayKey}}}`,
+        detail: f.description,
+        nodeId: node.id,
+        field: f.field,
+      });
+    }
+    return result;
+  }
+
   function buildSuggestions(): Suggestion[] {
     const upstreamNodes = getUpstreamNodes();
     const suggestions: Suggestion[] = [];
@@ -287,6 +321,16 @@ export function TemplateCodeEditor({
           ? suggestionsFromOutput(node, nodeName, output)
           : suggestionsFromStaticFields(node, nodeName);
       suggestions.push(...nodeSuggestions);
+
+      // Listed-workflow inputSchema fields (data.<fieldName>) are exposed for
+      // trigger nodes regardless of whether a runtime execution captured them.
+      const existing = new Set<string>();
+      for (const s of nodeSuggestions) {
+        if (s.field) {
+          existing.add(s.field);
+        }
+      }
+      suggestions.push(...inputSchemaSuggestions(node, nodeName, existing));
     }
 
     return suggestions;

--- a/lib/workflow/editor/input-schema-fields.ts
+++ b/lib/workflow/editor/input-schema-fields.ts
@@ -1,0 +1,45 @@
+/**
+ * Listing inputSchema field extraction.
+ *
+ * Listed (agent-callable) workflows declare an inputSchema -- a JSON-Schema-like
+ * shape describing the parameters callers must provide. At runtime the executor
+ * merges the request body into the trigger output's `data` (see
+ * lib/workflow/executor/executor.workflow.ts), so each declared property is
+ * accessible to downstream nodes as `<TriggerName>.data.<fieldName>`.
+ *
+ * Without this helper, autocomplete only surfaces those paths after the
+ * workflow has been called by an agent (so a runtime execution log captured
+ * them). This helper exposes them statically based on the schema declaration.
+ */
+
+import type { FieldEntry } from "@/lib/workflow/editor/template-helpers";
+
+const DESCRIPTION_FALLBACK = "Listed workflow input";
+
+export function getInputSchemaFields(
+  inputSchema: Record<string, unknown> | null | undefined
+): FieldEntry[] {
+  if (!inputSchema || typeof inputSchema !== "object") {
+    return [];
+  }
+  const properties = (inputSchema as Record<string, unknown>).properties;
+  if (!properties || typeof properties !== "object") {
+    return [];
+  }
+
+  const result: FieldEntry[] = [];
+  for (const [name, rawProp] of Object.entries(
+    properties as Record<string, unknown>
+  )) {
+    const prop = (rawProp ?? {}) as Record<string, unknown>;
+    const description =
+      typeof prop.description === "string" && prop.description
+        ? prop.description
+        : DESCRIPTION_FALLBACK;
+    result.push({
+      field: `data.${name}`,
+      description,
+    });
+  }
+  return result;
+}

--- a/lib/workflow/editor/template-helpers.ts
+++ b/lib/workflow/editor/template-helpers.ts
@@ -1,4 +1,5 @@
 import { getReadContractOutputFields } from "@/lib/workflow/editor/action-output-fields";
+import { getInputSchemaFields } from "@/lib/workflow/editor/input-schema-fields";
 import { getTriggerOutputFields } from "@/lib/workflow/editor/trigger-output-fields";
 import type { ExecutionLogEntry, WorkflowNode } from "@/lib/workflow/store";
 import { WorkflowTriggerEnum } from "@/lib/workflow/store";
@@ -206,7 +207,43 @@ export function getActionFields(node: WorkflowNode): FieldEntry[] | null {
   return null;
 }
 
-export function getTriggerFields(node: WorkflowNode): FieldEntry[] {
+export type TriggerFieldOptions = {
+  /**
+   * Listing inputSchema for the workflow. When present, declared properties
+   * are appended as `data.<fieldName>` entries so listed-workflow inputs are
+   * available in autocomplete even before an agent has called the workflow.
+   */
+  inputSchema?: Record<string, unknown> | null;
+};
+
+/**
+ * Merge declared listing inputSchema fields into a base set of trigger
+ * fields without producing duplicates.
+ */
+function withInputSchemaFields(
+  baseFields: FieldEntry[],
+  options: TriggerFieldOptions | undefined
+): FieldEntry[] {
+  const schemaFields = getInputSchemaFields(options?.inputSchema);
+  if (schemaFields.length === 0) {
+    return baseFields;
+  }
+  const seen = new Set(baseFields.map((f) => f.field));
+  const merged = [...baseFields];
+  for (const field of schemaFields) {
+    if (seen.has(field.field)) {
+      continue;
+    }
+    merged.push(field);
+    seen.add(field.field);
+  }
+  return merged;
+}
+
+export function getTriggerFields(
+  node: WorkflowNode,
+  options?: TriggerFieldOptions
+): FieldEntry[] {
   const triggerType = node.data.config?.triggerType as string | undefined;
   const webhookSchema = node.data.config?.webhookSchema as string | undefined;
   const config = node.data.config || {};
@@ -214,39 +251,45 @@ export function getTriggerFields(node: WorkflowNode): FieldEntry[] {
   if (triggerType === WorkflowTriggerEnum.EVENT) {
     const fields = getTriggerOutputFields(triggerType, config);
     if (fields.length > 0) {
-      return fields;
+      return withInputSchemaFields(fields, options);
     }
   }
 
   if (triggerType === "Webhook") {
     const parsed = tryParseSchemaFields(webhookSchema);
     if (parsed) {
-      return parsed;
+      return withInputSchemaFields(parsed, options);
     }
   }
 
   if (triggerType) {
     const fields = getTriggerOutputFields(triggerType, config);
     if (fields.length > 0) {
-      return fields;
+      return withInputSchemaFields(fields, options);
     }
   }
 
-  return [
-    { field: "triggered", description: "Trigger status" },
-    { field: "timestamp", description: "Trigger timestamp" },
-    { field: "input", description: "Input data" },
-  ];
+  return withInputSchemaFields(
+    [
+      { field: "triggered", description: "Trigger status" },
+      { field: "timestamp", description: "Trigger timestamp" },
+      { field: "input", description: "Input data" },
+    ],
+    options
+  );
 }
 
-export function getCommonFields(node: WorkflowNode): FieldEntry[] {
+export function getCommonFields(
+  node: WorkflowNode,
+  options?: TriggerFieldOptions
+): FieldEntry[] {
   if (node.data.type === "action") {
     return (
       getActionFields(node) ?? [{ field: "data", description: "Output data" }]
     );
   }
   if (node.data.type === "trigger") {
-    return getTriggerFields(node);
+    return getTriggerFields(node, options);
   }
   return [{ field: "data", description: "Output data" }];
 }

--- a/tests/unit/input-schema-fields.test.ts
+++ b/tests/unit/input-schema-fields.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { getInputSchemaFields } from "@/lib/workflow/editor/input-schema-fields";
+
+describe("getInputSchemaFields", () => {
+  it("returns an empty list when the schema is null", () => {
+    expect(getInputSchemaFields(null)).toEqual([]);
+  });
+
+  it("returns an empty list when the schema is undefined", () => {
+    expect(getInputSchemaFields(undefined)).toEqual([]);
+  });
+
+  it("returns an empty list when properties are missing", () => {
+    expect(getInputSchemaFields({ type: "object" })).toEqual([]);
+  });
+
+  it("returns an empty list when properties is not an object", () => {
+    expect(
+      getInputSchemaFields({ type: "object", properties: "not-an-object" })
+    ).toEqual([]);
+  });
+
+  it("emits each declared property as data.<name>", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        address: { type: "string" },
+        chainId: { type: "number" },
+      },
+      required: ["address"],
+    };
+
+    const fields = getInputSchemaFields(schema);
+
+    expect(fields).toEqual([
+      { field: "data.address", description: "Listed workflow input" },
+      { field: "data.chainId", description: "Listed workflow input" },
+    ]);
+  });
+
+  it("preserves the user-provided description", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        address: {
+          type: "string",
+          description: "Wallet address to inspect",
+        },
+      },
+    };
+
+    expect(getInputSchemaFields(schema)).toEqual([
+      { field: "data.address", description: "Wallet address to inspect" },
+    ]);
+  });
+
+  it("falls back when description is not a non-empty string", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        address: { type: "string", description: "" },
+        chainId: { type: "number", description: 42 },
+      },
+    };
+
+    expect(getInputSchemaFields(schema)).toEqual([
+      { field: "data.address", description: "Listed workflow input" },
+      { field: "data.chainId", description: "Listed workflow input" },
+    ]);
+  });
+
+  it("ignores non-object property entries without crashing", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        ok: { type: "string", description: "fine" },
+        broken: null,
+      },
+    };
+
+    expect(getInputSchemaFields(schema)).toEqual([
+      { field: "data.ok", description: "fine" },
+      { field: "data.broken", description: "Listed workflow input" },
+    ]);
+  });
+});

--- a/tests/unit/template-helpers-trigger-fields.test.ts
+++ b/tests/unit/template-helpers-trigger-fields.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCommonFields,
+  getTriggerFields,
+} from "@/lib/workflow/editor/template-helpers";
+import type { WorkflowNode } from "@/lib/workflow/store";
+
+function manualTriggerNode(
+  config: Record<string, unknown> = { triggerType: "Manual" }
+): WorkflowNode {
+  return {
+    id: "trigger-1",
+    type: "trigger",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "Manual",
+      type: "trigger",
+      config,
+    },
+  };
+}
+
+const ADDRESS_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    address: { type: "string", description: "Wallet address" },
+  },
+  required: ["address"],
+};
+
+describe("getTriggerFields with listing inputSchema", () => {
+  it("returns base trigger fields when inputSchema is omitted", () => {
+    const fields = getTriggerFields(manualTriggerNode());
+    expect(fields.map((f) => f.field)).toEqual(["triggeredAt"]);
+  });
+
+  it("merges inputSchema fields under data.<name> for Manual trigger", () => {
+    const fields = getTriggerFields(manualTriggerNode(), {
+      inputSchema: ADDRESS_INPUT_SCHEMA,
+    });
+    expect(fields).toEqual([
+      { field: "triggeredAt", description: expect.any(String) },
+      { field: "data.address", description: "Wallet address" },
+    ]);
+  });
+
+  it("merges inputSchema fields for Schedule trigger", () => {
+    const fields = getTriggerFields(
+      manualTriggerNode({ triggerType: "Schedule" }),
+      { inputSchema: ADDRESS_INPUT_SCHEMA }
+    );
+    expect(fields.map((f) => f.field)).toEqual(["triggeredAt", "data.address"]);
+  });
+
+  it("does not double-list a field that already exists in the base set", () => {
+    const fields = getTriggerFields(manualTriggerNode(), {
+      inputSchema: {
+        type: "object",
+        properties: {
+          triggeredAt: { type: "string" },
+          address: { type: "string" },
+        },
+      },
+    });
+    const fieldNames = fields.map((f) => f.field);
+    expect(fieldNames.filter((n) => n === "triggeredAt")).toHaveLength(1);
+    expect(fieldNames).toContain("data.address");
+    expect(fieldNames).toContain("data.triggeredAt");
+  });
+
+  it("falls back to default fields plus inputSchema when triggerType is missing", () => {
+    const fields = getTriggerFields(manualTriggerNode({}), {
+      inputSchema: ADDRESS_INPUT_SCHEMA,
+    });
+    expect(fields.map((f) => f.field)).toEqual([
+      "triggered",
+      "timestamp",
+      "input",
+      "data.address",
+    ]);
+  });
+});
+
+describe("getCommonFields routes inputSchema to trigger nodes only", () => {
+  it("forwards options to getTriggerFields for trigger nodes", () => {
+    const fields = getCommonFields(manualTriggerNode(), {
+      inputSchema: ADDRESS_INPUT_SCHEMA,
+    });
+    expect(fields.map((f) => f.field)).toContain("data.address");
+  });
+
+  it("ignores inputSchema for action nodes", () => {
+    const actionNode: WorkflowNode = {
+      id: "action-1",
+      type: "action",
+      position: { x: 0, y: 0 },
+      data: {
+        label: "HTTP Request",
+        type: "action",
+        config: { actionType: "HTTP Request" },
+      },
+    };
+    const fields = getCommonFields(actionNode, {
+      inputSchema: ADDRESS_INPUT_SCHEMA,
+    });
+    expect(fields.map((f) => f.field)).not.toContain("data.address");
+  });
+});


### PR DESCRIPTION
## Summary

When a workflow is listed on the marketplace with declared `inputSchema` fields (e.g. `address`), those fields previously only appeared in the `@`-autocomplete dropdown if the workflow had already been called by an agent and a runtime execution log captured them. After a manual UI run (which doesn't pass listing-input fields), the runtime path showed only `data.timestamp`, `data.triggered`, `data.triggeredAt`, `success` — declared inputs were invisible.

The static fallback (`getTriggerOutputFields("Manual", ...)`) didn't know about `inputSchema` either, so the dropdown couldn't help users wire up listing inputs to downstream nodes — defeating the listing overlay's own help text ("type @ and select Schedule.data.<fieldName>").

## What changed

- New `lib/workflow/editor/input-schema-fields.ts` helper that turns a JSON-Schema-like `inputSchema` into `data.<fieldName>` field entries with descriptions, matching how the executor merges request body into trigger output (`lib/workflow/executor/executor.workflow.ts:1786`).
- `getTriggerFields` / `getCommonFields` in `lib/workflow/editor/template-helpers.ts` now accept an optional `inputSchema` and merge those fields into the returned set without duplicating any already-present field name.
- `template-autocomplete.tsx`, `template-code-editor.tsx`, and `sql-template-editor.tsx` read `currentWorkflowInputSchemaAtom` and inject the schema-derived fields for trigger nodes on both the runtime and static paths. Dedupe against fields already present so a runtime log that captured the inputs doesn't double-list.

Result: opening the autocomplete on a listed workflow with `address` declared now offers `Manual.data.address` immediately, regardless of whether the workflow has been executed.

## Test plan

- [x] New unit tests: `tests/unit/input-schema-fields.test.ts` (helper edge cases) and `tests/unit/template-helpers-trigger-fields.test.ts` (merge behaviour, dedupe, action-node guard).
- [x] All 130 related tests pass (`pnpm vitest run --dir tests/unit ...`).
- [x] `pnpm type-check` clean.
- [ ] Manual: list a workflow with an `address` input, open autocomplete on a Web3 step's Address field, confirm `Manual.data.address` appears (works whether or not the workflow has been executed).
- [ ] Manual: re-run after an agent call to confirm the runtime path still surfaces the same path without duplicating it.