### PR TITLE
docs: clarify webhook key scope and wallet rationale

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -45,7 +45,7 @@ KeeperHub has two types of API keys:
 
 ## Endpoint scope
 
-Session authentication is accepted everywhere. API keys (`kh_`) are accepted only on **organization-scoped** endpoints, the ones whose action and result depend on the caller's organization rather than on the individual user behind the key.
+Session authentication is accepted everywhere. API keys (`kh_`) are accepted only on **organization-scoped** endpoints, the ones whose action and result depend on the caller's organization rather than on the individual user behind the key. Wallets, billing, and spending caps are all attached to the organization, so a key that authorizes on-chain spend or billable usage is necessarily organization-scoped.
 
 ### Accepted on API keys
 
@@ -71,6 +71,10 @@ Endpoints that act on a user account, hold credential material, or sit on a huma
 - **Per-user state**: workflow drafts, workflow ratings, leaving an organization
 
 If you have a use case for session-only behavior over an API key, open an issue describing it. The boundary is deliberate: it keeps a leaked API key from escalating into account control or wallet drainage.
+
+### Webhook keys
+
+Workflow webhook triggers (`POST /api/workflows/{workflowId}/webhook`) accept only user-scoped (`wfb_`) keys. The route reads the `Authorization` header directly; session cookies are not consulted, and `kh_` keys are rejected with `401`. The `wfb_` key must belong to the same user that owns the target workflow; a key created by another member of the same organization is rejected with `403`. Webhook executions are attributed to the individual triggering user rather than to the organization, which is why the user-binding is enforced.
 
 ## Deactivated accounts
 


### PR DESCRIPTION
## Summary

Three small follow-up clarifications to `docs/api/authentication.md`, on top of the recent auth-scope overhaul:

- **Endpoint scope intro** now says *why* `kh_` is organization-scoped: wallets, billing, and spending caps are all attached to the organization, so any key that authorizes on-chain spend or billable usage is necessarily org-scoped.
- **New `Webhook keys` subsection** explicitly covers `POST /api/workflows/{workflowId}/webhook`:
  - Only `wfb_` keys accepted; `kh_` keys returned `401`, session cookies not consulted.
  - `wfb_` must belong to the same user who owns the target workflow; another org member's `wfb_` returns `403`.
- **Stated rationale** for the user-binding: webhook executions are attributed to the triggering user, not to the organization.

These came up while testing the standalone-execute and webhook endpoints with both key types. The previous doc revision covered which endpoints accept `kh_` vs session, but did not call out the webhook endpoint specifically or explain the `wfb_` ownership constraint, which is the kind of thing that produces a confused 403 in production.

## Test plan

- [x] Render the docs site locally and confirm the new subsection appears under `## Endpoint scope` and renders correctly
- [x] Sanity-check that the rendered link target `#webhook-keys` works from the section above
- [x] Confirm no other docs reference contradicts the new statements about `wfb_` user-binding