### PR TITLE
fix: mock server-only in rpc e2e suites broken by KEEP-233

### DIFF
--- a/tests/e2e/vitest/check-balance.test.ts
+++ b/tests/e2e/vitest/check-balance.test.ts
@@ -14,7 +14,13 @@
 
 import "dotenv/config";
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// `lib/rpc/providers/index.ts` (transitively imported via provider-factory)
+// pulls in `lib/rpc/safe-ethers-fetch.ts`, which guards itself with
+// `import "server-only"`. Without this mock the file-load throws under vitest.
+vi.mock("server-only", () => ({}));
+
 import {
   getRpcProviderFromUrls,
   getSolanaProviderFromUrls,

--- a/tests/e2e/vitest/gas-strategy.test.ts
+++ b/tests/e2e/vitest/gas-strategy.test.ts
@@ -22,9 +22,13 @@ import {
   vi,
 } from "vitest";
 
-// Unmock for e2e tests
+// `@/lib/rpc/providers` (transitively imported via provider-factory) pulls in
+// `lib/rpc/safe-ethers-fetch.ts`, which guards itself with
+// `import "server-only"`. Without this mock the file-load throws under vitest.
+vi.mock("server-only", () => ({}));
+
+// Unmock for e2e tests so the real DB module is loaded.
 vi.unmock("@/lib/db");
-vi.unmock("server-only");
 
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";

--- a/tests/e2e/vitest/rpc-failover.test.ts
+++ b/tests/e2e/vitest/rpc-failover.test.ts
@@ -14,7 +14,21 @@
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// `@/lib/rpc/providers` pulls in `lib/rpc/safe-ethers-fetch.ts`, which guards
+// itself with `import "server-only"`. Without this mock the file-load throws
+// under vitest.
+vi.mock("server-only", () => ({}));
+
 import { type Chain, chains, userRpcPreferences, users } from "@/lib/db/schema";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import {


### PR DESCRIPTION
## Summary

Unblocks the staging->prod release ([#1030](https://github.com/KeeperHub/keeperhub/pull/1030)) by fixing the `e2e-vitest-ephemeral` job that has been failing on every staging push since [#1026](https://github.com/KeeperHub/keeperhub/pull/1026) (KEEP-233 SSRF guard) merged at 2026-04-28T06:35Z.

## Root cause

#1026 added `lib/rpc/safe-ethers-fetch.ts` (`import "server-only"`) and wired it into `lib/rpc/providers/index.ts`. The three e2e suites that import from `@/lib/rpc/providers` / `@/lib/rpc/provider-factory` (`check-balance.test.ts`, `gas-strategy.test.ts`, `rpc-failover.test.ts`) now transitively pull in that guard, so vitest fails at file-load:

```
Error: This module cannot be imported from a Client Component module.
It should only be used from a Server Component.
  node_modules/.pnpm/server-only@0.0.1/node_modules/server-only/index.js:1:7
```

`gas-strategy.test.ts` had `vi.unmock(\"server-only\")` from a previous iteration of the file — that's the wrong call (it forces the real package to load and throw). Every passing unit test in `tests/unit/` uses `vi.mock(\"server-only\", () => ({}))`.

## Fix

Per-file `vi.mock(\"server-only\", () => ({}))` in each of the three affected e2e suites, matching the established pattern. Removes the misplaced `vi.unmock` line in `gas-strategy.test.ts`.

## Test plan

- [x] Local smoke test: `SKIP_INFRA_TESTS=true pnpm exec vitest run --exclude '**/.claude/**' tests/e2e/vitest/{check-balance,gas-strategy,rpc-failover}.test.ts` -> 1 file passed (13 tests), 2 skipped (no DB/RPC), zero `server-only` errors.
- [ ] CI `e2e-tests / e2e-vitest-ephemeral` goes green.
- [ ] After merge, re-cut [#1030](https://github.com/KeeperHub/keeperhub/pull/1030) on the new staging SHA.