### PR TITLE
fix(ci): pass INTEGRATION_ENCRYPTION_KEY to e2e app container

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: 'CHAIN_RPC_CONFIG JSON for reliable RPC endpoints (avoids flaky public RPCs)'
     required: false
     default: ''
+  integration_encryption_key:
+    description: 'INTEGRATION_ENCRYPTION_KEY for decrypting integration config (must match the key used by tests when seeding integrations)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -71,6 +75,7 @@ runs:
         DATABASE_URL: ${{ inputs.database_url }}
         TEST_API_KEY: ${{ inputs.test_api_key }}
         CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}
+        INTEGRATION_ENCRYPTION_KEY: ${{ inputs.integration_encryption_key }}
       run: |
         IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
@@ -86,9 +91,16 @@ runs:
           "WORKFLOW_TARGET_WORLD=@workflow/world-postgres" \
           > /tmp/keeperhub-app.env
 
+        # Pass CHAIN_RPC_CONFIG and INTEGRATION_ENCRYPTION_KEY via -e (not the
+        # env-file) because their values can contain JSON / characters that
+        # docker's env-file parser does not handle. INTEGRATION_ENCRYPTION_KEY
+        # must match the key the test process uses to encrypt integration
+        # config rows -- otherwise getIntegrationById's decryptConfig fails
+        # silently and credentials never reach step bundles.
         docker run -d --name keeperhub-app --network host \
           --env-file /tmp/keeperhub-app.env \
           -e "CHAIN_RPC_CONFIG=${CHAIN_RPC_CONFIG}" \
+          -e "INTEGRATION_ENCRYPTION_KEY=${INTEGRATION_ENCRYPTION_KEY}" \
           "${IMAGE}"
 
         for i in $(seq 1 30); do
@@ -148,5 +160,6 @@ runs:
         BETTER_AUTH_SECRET: ${{ inputs.better_auth_secret }}
         CI: true
         TEST_API_KEY: ${{ inputs.test_api_key }}
+        INTEGRATION_ENCRYPTION_KEY: ${{ inputs.integration_encryption_key }}
         WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
         CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -198,6 +198,7 @@ jobs:
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
           test_api_key: ${{ secrets.TEST_API_KEY }}
           chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
+          integration_encryption_key: ${{ secrets.TEST_INTEGRATION_ENCRYPTION_KEY }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -290,6 +291,7 @@ jobs:
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
           test_api_key: ${{ secrets.TEST_API_KEY }}
           chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
+          integration_encryption_key: ${{ secrets.TEST_INTEGRATION_ENCRYPTION_KEY }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e


### PR DESCRIPTION
## Summary

Unblocks the staging->prod release ([#1030](https://github.com/KeeperHub/keeperhub/pull/1030)) by fixing the `e2e-tests / e2e-playwright-ephemeral` job that's been failing since [#1021](https://github.com/KeeperHub/keeperhub/pull/1021) added `tests/e2e/playwright/credential-bundle.test.ts`.

## Root cause

The credential-bundle e2e seeds integrations directly into postgres, encrypting the config rows with `INTEGRATION_ENCRYPTION_KEY` (sourced from `secrets.TEST_INTEGRATION_ENCRYPTION_KEY` on the test step). `.github/actions/start-app/action.yml` never threaded that key into the Docker app container. The container's `INTEGRATION_ENCRYPTION_KEY` was unset; `lib/db/integrations.ts:decryptConfig` caught the resulting failure and silently returned `{}` (only `console.error` was emitted). Downstream, `lib/credential-fetcher.ts:mapIntegrationConfig` looked up keys like `config.botToken` on an empty object, returned `{}`, and the step's local guard fired with messages such as:

```
Telegram bot token is required. Please configure it in the integration settings.
SLACK_API_KEY is not configured. Please add it in Project Integrations.
Discord webhook URL is required. Please configure it in the integration settings.
```

The test was specifically written to detect this regression class -- the `.not.toMatch(localGuardErrorRe)` assertion catches exactly the symptom.

## Why it only surfaced on push CI

PR-context CI uses the bare-metal `pnpm start` path, which inherits the runner env -- so the secret was visible there even though it wasn't explicitly threaded. Push-context CI uses the Docker path, which only sees env vars explicitly listed in `start-app/action.yml`. No prior test created an encrypted integration and ran a workflow against it through the Docker image, so the gap wasn't visible until #1021 added the test.

## What changed

- `.github/actions/start-app/action.yml`: new optional `integration_encryption_key` input. Threaded into both Docker (`-e INTEGRATION_ENCRYPTION_KEY=...`, separate from `--env-file` because hex strings + `=` don't tokenise cleanly there) and bare-metal `pnpm start` env.
- `.github/workflows/e2e-tests-ephemeral.yml`: pass `secrets.TEST_INTEGRATION_ENCRYPTION_KEY` to both `start-app` invocations (vitest and playwright jobs).

## Test plan

- [ ] CI `e2e-tests / e2e-playwright-ephemeral` goes green.
- [ ] After merge, [#1030](https://github.com/KeeperHub/keeperhub/pull/1030) picks up the new SHA.

Cannot run this end-to-end locally without ECR access. Confirmed manually that the docker run line will receive the env var via `-e`, and that `decryptConfig` returns `{}` on missing key (`lib/db/integrations.ts:96-99`).