### PR TITLE
fix: KEEP-366 prevent template-badge crash on undefined value

### DIFF
--- a/components/ui/template-badge-input.tsx
+++ b/components/ui/template-badge-input.tsx
@@ -9,7 +9,7 @@ import {
   TemplateAutocomplete,
   type TemplateAutocompleteCloseReason,
 } from "./template-autocomplete";
-import { toStringValue } from "./template-badge-utils";
+import { countTemplateTokens, toStringValue } from "./template-badge-utils";
 
 // Guards `selection.getRangeAt(0)`, which throws IndexSizeError when
 // rangeCount is 0 (e.g. focus moved off the editable before keydown fired).
@@ -412,8 +412,8 @@ export function TemplateBadgeInput({
     }
     
     // Count templates in old and new values
-    const oldTemplates = (internalValue.match(/\{\{@([^:]+):([^}]+)\}\}/g) || []).length;
-    const newTemplates = (newValue.match(/\{\{@([^:]+):([^}]+)\}\}/g) || []).length;
+    const oldTemplates = countTemplateTokens(internalValue);
+    const newTemplates = countTemplateTokens(newValue);
     
     if (newTemplates > oldTemplates) {
       // A new template was added, update display to show badge

--- a/components/ui/template-badge-textarea.tsx
+++ b/components/ui/template-badge-textarea.tsx
@@ -10,7 +10,7 @@ import {
   TemplateAutocomplete,
   type TemplateAutocompleteCloseReason,
 } from "./template-autocomplete";
-import { toStringValue } from "./template-badge-utils";
+import { countTemplateTokens, toStringValue } from "./template-badge-utils";
 
 export interface TemplateBadgeTextareaProps {
   value?: string;
@@ -439,8 +439,8 @@ export function TemplateBadgeTextarea({
     }
 
     // Count templates in old and new values
-    const oldTemplates = (internalValue.match(/\{\{@([^:]+):([^}]+)\}\}/g) ?? []).length;
-    const newTemplates = (newValue.match(/\{\{@([^:]+):([^}]+)\}\}/g) ?? []).length;
+    const oldTemplates = countTemplateTokens(internalValue);
+    const newTemplates = countTemplateTokens(newValue);
 
     if (newTemplates > oldTemplates) {
       // A new template was added, update display to show badge

--- a/components/ui/template-badge-utils.ts
+++ b/components/ui/template-badge-utils.ts
@@ -8,3 +8,12 @@
 export function toStringValue(value: unknown): string {
   return typeof value === "string" ? value : String(value ?? "");
 }
+
+// Matches `{{@nodeId:field}}` template tokens used by the workflow editor.
+export const TEMPLATE_TOKEN_PATTERN = /\{\{@([^:]+):([^}]+)\}\}/g;
+
+// Counts template tokens in a value, coercing non-strings/undefined safely.
+// Direct `value.match(...)` calls throw when `value` is undefined (KEEP-366).
+export function countTemplateTokens(value: unknown): number {
+  return (toStringValue(value).match(TEMPLATE_TOKEN_PATTERN) ?? []).length;
+}

--- a/tests/unit/template-badge-utils.test.ts
+++ b/tests/unit/template-badge-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  countTemplateTokens,
+  TEMPLATE_TOKEN_PATTERN,
+  toStringValue,
+} from "@/components/ui/template-badge-utils";
+
+describe("toStringValue", () => {
+  it("returns the value unchanged when it is a string", () => {
+    expect(toStringValue("hello")).toBe("hello");
+  });
+
+  it("returns an empty string for undefined", () => {
+    expect(toStringValue(undefined)).toBe("");
+  });
+
+  it("returns an empty string for null", () => {
+    expect(toStringValue(null)).toBe("");
+  });
+
+  it("coerces numbers to strings", () => {
+    expect(toStringValue(42)).toBe("42");
+  });
+
+  it("coerces booleans to strings", () => {
+    expect(toStringValue(true)).toBe("true");
+  });
+});
+
+describe("countTemplateTokens", () => {
+  it("returns 0 when value is undefined (KEEP-366 regression)", () => {
+    expect(countTemplateTokens(undefined)).toBe(0);
+  });
+
+  it("returns 0 when value is null", () => {
+    expect(countTemplateTokens(null)).toBe(0);
+  });
+
+  it("returns 0 for an empty string", () => {
+    expect(countTemplateTokens("")).toBe(0);
+  });
+
+  it("returns 0 when no tokens are present", () => {
+    expect(countTemplateTokens("just plain text")).toBe(0);
+  });
+
+  it("counts a single token", () => {
+    expect(countTemplateTokens("hello {{@node1:field}}")).toBe(1);
+  });
+
+  it("counts multiple tokens", () => {
+    expect(countTemplateTokens("{{@a:x}} and {{@b:y}} plus {{@c:z}}")).toBe(3);
+  });
+
+  it("does not throw when value is a non-string (numeric leaks)", () => {
+    expect(() => countTemplateTokens(123)).not.toThrow();
+    expect(countTemplateTokens(123)).toBe(0);
+  });
+
+  it("does not match malformed tokens", () => {
+    expect(countTemplateTokens("{{@node1}}")).toBe(0);
+    expect(countTemplateTokens("{@node1:field}")).toBe(0);
+  });
+});
+
+describe("TEMPLATE_TOKEN_PATTERN", () => {
+  it("is a global regex so match() returns all occurrences", () => {
+    expect(TEMPLATE_TOKEN_PATTERN.global).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Production crash on `/workflows/:workflowId` when typing or pasting in a template-badge input/textarea rendered without a `value` prop (Sentry KEEPERHUB-PRODUCTION-11 / -10, `TypeError: g.match is not a function`).
- `handleInput` called `.match()` directly on `internalValue`, which is typed `string | undefined`; the first input event hit the undefined path before any coercion.
- Centralised the `{{@nodeId:field}}` regex into `TEMPLATE_TOKEN_PATTERN` and a new `countTemplateTokens()` helper in `template-badge-utils.ts` that reuses the existing `toStringValue()` coercion. Both `template-badge-input.tsx` and `template-badge-textarea.tsx` now call it from `handleInput`.

Closes KEEP-366.