### PR TITLE
fix: statically import plugin barrel into action grid client bundle

### DIFF
--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+// Side-effect import: forces the plugin barrel into the client bundle so each
+// plugin's index.ts runs and calls registerIntegration() before getAllActions
+// is read below. The dynamic require("@/plugins") in plugins/registry.ts is
+// not reliably included in the client bundle by webpack, which leaves the
+// registry empty and the action grid showing "No actions found".
+import "@/plugins";
 import {
   ChevronRight,
   Eye,


### PR DESCRIPTION
## Summary

- The action grid relies on `getAllActions()` → `ensurePluginsLoaded()` → `require("@/plugins")` in `plugins/registry.ts` to register integrations on the client. Webpack does not reliably emit the plugin barrel into the production client bundle, so on the prod docker build the integration registry stays empty and the action grid renders "No actions found" for every plugin action.
- Added a static side-effect `import "@/plugins";` at the top of `components/workflow/config/action-grid.tsx`. Webpack always emits side-effect imports, so the plugin barrel is now guaranteed to be in the chunk that loads the action grid; each plugin's `index.ts` runs and calls `registerIntegration()` before `getAllActions()` is read.
- This unblocks the prod release: the two failing e2e tests (`happy-paths/web3-balance.test.ts`, `happy-paths/scheduled-workflow.test.ts`) are blocked on the action grid being empty.

## Notes

- After the fix, `pnpm build` produces a chunk under `.next/static/chunks/` that contains both `"Get Native Token Balance"` and `"Send Webhook"` action labels, confirming the plugin barrel is now in the client bundle.
- The same class of bug was fixed for the server-side credential fetcher in #1019 via the build-time `PLUGIN_CREDENTIAL_MAP`. The client-side action grid still relied on the original brittle `require()` pattern.