### PR TITLE
fix: register plugins via static @/plugins barrel import

### DIFF
--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-// Side-effect import: forces the plugin barrel into the client bundle so each
-// plugin's index.ts runs and calls registerIntegration() before getAllActions
-// is read below. The dynamic require("@/plugins") in plugins/registry.ts is
-// not reliably included in the client bundle by webpack, which leaves the
-// registry empty and the action grid showing "No actions found".
-import "@/plugins";
 import {
   ChevronRight,
   Eye,

--- a/plugins/clerk/index.ts
+++ b/plugins/clerk/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "../registry";
-import { registerIntegration } from "../registry";
+import { registerIntegration } from "../registry-core";
 import { ClerkIcon } from "./icon";
 
 const clerkPlugin: IntegrationPlugin = {

--- a/plugins/code/index.ts
+++ b/plugins/code/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { CodeIcon } from "./icon";
 
 const codePlugin: IntegrationPlugin = {

--- a/plugins/discord/index.ts
+++ b/plugins/discord/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { DiscordIcon } from "./icon";
 
 const discordPlugin: IntegrationPlugin = {

--- a/plugins/math/index.ts
+++ b/plugins/math/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { MathIcon } from "./icon";
 
 const mathPlugin: IntegrationPlugin = {

--- a/plugins/registry-core.ts
+++ b/plugins/registry-core.ts
@@ -1,0 +1,15 @@
+import type { IntegrationType } from "@/lib/types/integration";
+import type { IntegrationPlugin } from "./registry";
+
+// Lives in its own module so plugins/registry.ts can statically
+// `import "@/plugins"` without a TDZ on this Map during circular module
+// resolution. Individual plugin index files import registerIntegration
+// from here directly to keep the load graph linear.
+export const integrationRegistry = new Map<
+  IntegrationType,
+  IntegrationPlugin
+>();
+
+export function registerIntegration(plugin: IntegrationPlugin): void {
+  integrationRegistry.set(plugin.type, plugin);
+}

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -1,5 +1,14 @@
 import type { IntegrationType } from "@/lib/types/integration";
 import { LEGACY_ACTION_MAPPINGS } from "./legacy-mappings";
+import { integrationRegistry, registerIntegration } from "./registry-core";
+
+// Side-effect import: forces every plugin's index.ts to evaluate (and call
+// registerIntegration) before any reader of this module runs. The Map and
+// register function live in registry-core to avoid a TDZ during the
+// circular load (registry → @/plugins → plugins/* → registry-core).
+import "@/plugins";
+
+export { registerIntegration };
 
 /**
  * Select Option
@@ -291,34 +300,6 @@ export type ActionWithFullId = PluginAction & {
 };
 
 /**
- * Integration Registry
- * Auto-populated by plugin files
- */
-const integrationRegistry = new Map<IntegrationType, IntegrationPlugin>();
-
-/**
- * Ensures all plugins have registered themselves.
- * Uses require() to avoid ESM hoisting, which would cause a TDZ error
- * on integrationRegistry during circular module resolution.
- * Guarded to run only once — subsequent calls are no-ops.
- * Falls back gracefully when require() cannot resolve the module
- * (e.g. in Vitest where @/ aliases and .ts files are not resolved
- * by Node's native require). In test environments, plugins should be
- * loaded via the test setup file instead.
- */
-let _pluginsLoaded = false;
-function ensurePluginsLoaded(): void {
-  if (_pluginsLoaded || integrationRegistry.size > 0) return;
-  _pluginsLoaded = true;
-  try {
-    require("@/plugins");
-  } catch {
-    // In Vitest, Node's require() can't resolve TypeScript path aliases.
-    // Plugins must be loaded via tests/setup.ts instead.
-  }
-}
-
-/**
  * Compute full action ID from integration type and action slug
  */
 export function computeActionId(
@@ -346,19 +327,11 @@ export function parseActionId(actionId: string | undefined | null): {
 }
 
 /**
- * Register an integration plugin
- */
-export function registerIntegration(plugin: IntegrationPlugin) {
-  integrationRegistry.set(plugin.type, plugin);
-}
-
-/**
  * Get an integration plugin
  */
 export function getIntegration(
   type: IntegrationType
 ): IntegrationPlugin | undefined {
-  ensurePluginsLoaded();
   return integrationRegistry.get(type);
 }
 
@@ -366,7 +339,6 @@ export function getIntegration(
  * Get all registered integrations
  */
 export function getAllIntegrations(): IntegrationPlugin[] {
-  ensurePluginsLoaded();
   return Array.from(integrationRegistry.values());
 }
 
@@ -374,7 +346,6 @@ export function getAllIntegrations(): IntegrationPlugin[] {
  * Get all integration types
  */
 export function getIntegrationTypes(): IntegrationType[] {
-  ensurePluginsLoaded();
   return Array.from(integrationRegistry.keys());
 }
 
@@ -382,7 +353,6 @@ export function getIntegrationTypes(): IntegrationType[] {
  * Get all actions across all integrations with full IDs
  */
 export function getAllActions(): ActionWithFullId[] {
-  ensurePluginsLoaded();
   const actions: ActionWithFullId[] = [];
 
   for (const plugin of integrationRegistry.values()) {
@@ -402,7 +372,6 @@ export function getAllActions(): ActionWithFullId[] {
  * Get actions by category
  */
 export function getActionsByCategory(): Record<string, ActionWithFullId[]> {
-  ensurePluginsLoaded();
   const categories: Record<string, ActionWithFullId[]> = {};
 
   for (const plugin of integrationRegistry.values()) {
@@ -428,7 +397,6 @@ export function getActionsByCategory(): Record<string, ActionWithFullId[]> {
 export function findActionById(
   actionId: string | undefined | null
 ): ActionWithFullId | undefined {
-  ensurePluginsLoaded();
   if (!actionId) {
     return undefined;
   }
@@ -475,7 +443,6 @@ export function findActionById(
  * Get integration labels map
  */
 export function getIntegrationLabels(): Record<IntegrationType, string> {
-  ensurePluginsLoaded();
   const labels: Record<string, string> = {};
   for (const plugin of integrationRegistry.values()) {
     labels[plugin.type] = plugin.label;
@@ -487,7 +454,6 @@ export function getIntegrationLabels(): Record<IntegrationType, string> {
  * Get integration descriptions map
  */
 export function getIntegrationDescriptions(): Record<IntegrationType, string> {
-  ensurePluginsLoaded();
   const descriptions: Record<string, string> = {};
   for (const plugin of integrationRegistry.values()) {
     descriptions[plugin.type] = plugin.description;
@@ -499,7 +465,6 @@ export function getIntegrationDescriptions(): Record<IntegrationType, string> {
  * Get sorted integration types for dropdowns
  */
 export function getSortedIntegrationTypes(): IntegrationType[] {
-  ensurePluginsLoaded();
   return Array.from(integrationRegistry.keys()).sort();
 }
 
@@ -507,7 +472,6 @@ export function getSortedIntegrationTypes(): IntegrationType[] {
  * Get all NPM dependencies across all integrations
  */
 export function getAllDependencies(): Record<string, string> {
-  ensurePluginsLoaded();
   const deps: Record<string, string> = {};
 
   for (const plugin of integrationRegistry.values()) {
@@ -571,7 +535,6 @@ export function flattenConfigFields(
  * This dynamically builds the action types documentation for the AI
  */
 export function generateAIActionPrompts(): string {
-  ensurePluginsLoaded();
   const lines: string[] = [];
 
   for (const plugin of integrationRegistry.values()) {

--- a/plugins/sendgrid/index.ts
+++ b/plugins/sendgrid/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { SendGridIcon } from "./icon";
 
 const sendgridPlugin: IntegrationPlugin = {

--- a/plugins/slack/index.ts
+++ b/plugins/slack/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "../registry";
-import { registerIntegration } from "../registry";
+import { registerIntegration } from "../registry-core";
 import { SlackIcon } from "./icon";
 
 const slackPlugin: IntegrationPlugin = {

--- a/plugins/telegram/index.ts
+++ b/plugins/telegram/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { TelegramIcon } from "./icon";
 
 const telegramPlugin: IntegrationPlugin = {

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { Web3Icon } from "./icon";
 
 const web3Plugin: IntegrationPlugin = {

--- a/plugins/webflow/index.ts
+++ b/plugins/webflow/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "../registry";
-import { registerIntegration } from "../registry";
+import { registerIntegration } from "../registry-core";
 import { WebflowIcon } from "./icon";
 
 const webflowPlugin: IntegrationPlugin = {

--- a/plugins/webhook/index.ts
+++ b/plugins/webhook/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationPlugin } from "@/plugins/registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 import { WebhookIcon } from "./icon";
 
 const webhookPlugin: IntegrationPlugin = {

--- a/protocols/index.ts
+++ b/protocols/index.ts
@@ -12,7 +12,7 @@
  */
 
 import { protocolToPlugin, registerProtocol } from "@/lib/protocol-registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 
 import aaveV3Def from "./aave-v3";
 import aaveV4Def from "./aave-v4";

--- a/scripts/discover-plugins.ts
+++ b/scripts/discover-plugins.ts
@@ -152,7 +152,7 @@ async function loadProtocolDefinitions(): Promise<ProtocolEntry[]> {
  */
 async function registerProtocolPlugins(): Promise<string[]> {
   const { protocolToPlugin, registerProtocol } = await import("@/lib/protocol-registry");
-  const { registerIntegration } = await import("../plugins/registry");
+  const { registerIntegration } = await import("../plugins/registry-core");
 
   const definitions = await loadProtocolDefinitions();
   const slugs: string[] = [];
@@ -230,7 +230,7 @@ function generateProtocolsIndexFile(): void {
  */
 
 import { protocolToPlugin, registerProtocol } from "@/lib/protocol-registry";
-import { registerIntegration } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
 
 ${imports.join("\n")}
 
@@ -1042,8 +1042,7 @@ async function generateCredentialMap(): Promise<void> {
  * Used by lib/credential-fetcher.ts so that the credential keys exposed to
  * step files (e.g. credentials.TELEGRAM_BOT_TOKEN) can be resolved even when
  * the runtime plugin registry is unavailable - notably inside Workflow DevKit
- * step bundles, where the dynamic require("@/plugins") in ensurePluginsLoaded()
- * silently fails because the bundler cannot statically analyze it.
+ * step bundles, where the plugin registry import chain is not pulled in.
  *
  * Generated entries: ${integrations.length} plugin(s), ${totalFields} field(s)
  */


### PR DESCRIPTION
## Summary

- Extract `integrationRegistry` and `registerIntegration` into `plugins/registry-core.ts` so `plugins/registry.ts` can statically `import "@/plugins"` at module top without a TDZ on the Map. Plugin index files import `registerIntegration` from `registry-core` to keep the load graph linear and avoid the registry/plugins cycle.
- Drop `ensurePluginsLoaded` and its 11 call sites.
- Revert the temporary static `import "@/plugins"` workarounds added to `action-grid.tsx` and `action-config.tsx` now that the registry self-loads.
- Update `scripts/discover-plugins.ts` codegen so regenerated `protocols/index.ts` and the `lib/credential-map.ts` comment reference the new core module.

## Why

KEEP-1559 stripped the re-exporter pattern from `plugins/index.ts` and switched consumers to `@/plugins/registry`. Nothing in the client tree imported `@/plugins` anymore, so the side-effect imports that register every plugin stopped running. The follow-up workaround added a lazy `ensurePluginsLoaded()` that called `require("@/plugins")`. Node CJS resolves that fine on the server, but webpack treats a dynamic `require()` of an aliased path as unanalysable and silently drops it from the client bundle, so the registry stayed empty in the browser.

The earlier hotfix in #1038 plastered `import "@/plugins"` onto `action-grid.tsx`. That fixed the action grid but only the action grid: every other client consumer of the registry (Service dropdown, connection overlays, integration icons, action node, toolbar) still hit the empty registry whenever it rendered before action-grid was loaded.

The proper fix is to make the registry module itself responsible for loading every plugin. Splitting the Map and `registerIntegration` into `registry-core` removes the TDZ that originally forced the dynamic require, so `registry.ts` can statically import the barrel and every consumer gets a populated registry on the first read.

## Error found

On `https://localhost:3000/workflows/<id>` the Service dropdown rendered only the 20 protocol-derived integrations (Aave, Curve, Uniswap, etc.) plus System. Discord, Telegram, Slack, SendGrid, Webhook, Web3, Code, Math, and Safe were all missing. The DeFi protocols slipped through because `node-config-panel.tsx -> code-generators.ts -> protocol-synthesiser.ts -> protocol-metadata.ts` has a top-level `import "@/protocols"` that webpack does pull into the client bundle. The individual plugins had no equivalent static path, so webpack never emitted them and `getAllIntegrations()` returned a partial set in the browser. The server-side registry was unaffected: `/api/mcp/schemas` returned all 33 types.
