### PR TITLE
fix: KEEP-351 guard analytics SSE controller against close/enqueue races

### DIFF
--- a/app/api/analytics/stream/route.ts
+++ b/app/api/analytics/stream/route.ts
@@ -18,15 +18,14 @@ function formatSSE(event: AnalyticsStreamEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
 
-async function fetchAndEmit(
-  controller: ReadableStreamDefaultController,
+async function fetchSummaryEvent(
   encoder: TextEncoder,
   organizationId: string,
   range: ReturnType<typeof parseTimeRange>,
   customStart: string | undefined,
   customEnd: string | undefined,
   projectId: string | undefined
-): Promise<void> {
+): Promise<Uint8Array> {
   const summary = await getAnalyticsSummary(
     organizationId,
     range,
@@ -40,7 +39,7 @@ async function fetchAndEmit(
     data: summary,
   };
 
-  controller.enqueue(encoder.encode(formatSSE(event)));
+  return encoder.encode(formatSSE(event));
 }
 
 export const GET = requireOrganization(
@@ -69,25 +68,49 @@ export const GET = requireOrganization(
           const encoder = new TextEncoder();
           const startTime = Date.now();
 
-          const cleanup = (): void => {
+          const safeClose = (): void => {
+            if (closed) {
+              return;
+            }
             closed = true;
             clearInterval(pollTimer);
             clearInterval(heartbeatTimer);
+            try {
+              controller.close();
+            } catch {
+              // controller may already be closed by the platform
+            }
           };
 
-          const pollTimer = setInterval(async () => {
+          const safeEnqueue = (chunk: Uint8Array): boolean => {
+            if (closed) {
+              return false;
+            }
+            try {
+              controller.enqueue(chunk);
+              return true;
+            } catch {
+              safeClose();
+              return false;
+            }
+          };
+
+          const pollTimer = setInterval(async (): Promise<void> => {
             if (closed) {
               return;
             }
 
             if (Date.now() - startTime > MAX_LIFETIME_MS) {
-              cleanup();
-              controller.close();
+              safeClose();
               return;
             }
 
             try {
               const checksum = await getAnalyticsChecksum(organizationId);
+
+              if (closed) {
+                return;
+              }
 
               if (checksum === lastChecksum) {
                 return;
@@ -101,8 +124,7 @@ export const GET = requireOrganization(
               }
               lastEventTime = now;
 
-              await fetchAndEmit(
-                controller,
+              const chunk = await fetchSummaryEvent(
                 encoder,
                 organizationId,
                 range,
@@ -110,31 +132,31 @@ export const GET = requireOrganization(
                 customEnd,
                 projectId
               );
+
+              if (closed) {
+                return;
+              }
+
+              safeEnqueue(chunk);
             } catch {
-              cleanup();
-              controller.close();
+              safeClose();
             }
           }, POLL_INTERVAL_MS);
 
-          const heartbeatTimer = setInterval(() => {
+          const heartbeatTimer = setInterval((): void => {
             if (closed) {
               return;
             }
 
-            try {
-              const event: AnalyticsStreamEvent = {
-                type: "heartbeat",
-                data: { timestamp: new Date().toISOString() },
-              };
-              controller.enqueue(encoder.encode(formatSSE(event)));
-            } catch {
-              cleanup();
-            }
+            const event: AnalyticsStreamEvent = {
+              type: "heartbeat",
+              data: { timestamp: new Date().toISOString() },
+            };
+            safeEnqueue(encoder.encode(formatSSE(event)));
           }, HEARTBEAT_INTERVAL_MS);
 
           req.signal.addEventListener("abort", () => {
-            cleanup();
-            controller.close();
+            safeClose();
           });
         },
       });


### PR DESCRIPTION
## Summary

`app/api/analytics/stream/route.ts` was emitting `TypeError: Invalid state: Controller is already closed` (`ERR_INVALID_STATE`) as unhandled rejections in production whenever a client disconnected mid-poll.

Root cause: the `pollTimer` callback is `async` and only checks the `closed` flag at the top. If `req.signal` aborts during the `await getAnalyticsChecksum(...)` or `await fetchAndEmit(...)`, the controller is already closed when execution resumes, so the next `controller.enqueue` throws — and the `catch` then calls `controller.close()` a second time, which is itself an `ERR_INVALID_STATE`.

## Changes

- Add `safeClose()`: idempotent, clears both timers, try/catches `controller.close()`.
- Add `safeEnqueue()`: short-circuits when `closed`, falls through to `safeClose()` if enqueue throws.
- Refactor `fetchAndEmit` → `fetchSummaryEvent` so it returns the encoded bytes; the caller re-checks `closed` post-await before enqueuing.
- Re-check `closed` after every `await` in the poll callback.
- Replace all bare `controller.close()` / `controller.enqueue()` calls with the safe helpers (poll error path, lifetime expiry, heartbeat, abort handler).

Closes [KEEP-351](https://linear.app/keeperhubapp/issue/KEEP-351).