### PR TITLE
fix: KEEP-352 filter Monaco "Canceled" unhandled rejections at ingest

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,46 +2,15 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { captureRouterTransitionStart, init } from "@sentry/nextjs";
 import {
-  captureRouterTransitionStart,
-  type ErrorEvent,
-  init,
-} from "@sentry/nextjs";
+  hasNoInAppFrames,
+  isEip1193ProviderRejection,
+  isMonacoCancellation,
+} from "@/lib/sentry-filters";
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN;
 const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
-
-// Wallet providers (EIP-1193) reject with plain `{ code, message }` objects
-// rather than Error instances, producing unhandled rejections with no stack.
-// These are not actionable, so drop them at ingest.
-function isEip1193ProviderRejection(event: ErrorEvent): boolean {
-  const mechanismType = event.exception?.values?.[0]?.mechanism?.type;
-  if (!mechanismType?.includes("onunhandledrejection")) {
-    return false;
-  }
-  const serialized = (event.extra as { __serialized__?: unknown } | undefined)
-    ?.__serialized__;
-  if (!serialized || typeof serialized !== "object") {
-    return false;
-  }
-  const asRecord = serialized as Record<string, unknown>;
-  return (
-    typeof asRecord.code === "number" && typeof asRecord.message === "string"
-  );
-}
-
-// Browser extensions (wallet shims, ad blockers, etc.) inject scripts into the
-// page and throw errors that surface to window.onerror. They show up in Sentry
-// with stacktraces composed entirely of non-app frames (`injected.js`,
-// `injectedScript.bundle.js`, vendor shims). Drop events where the SDK marked
-// every frame as out-of-app — they're third-party noise we can't fix.
-function hasNoInAppFrames(event: ErrorEvent): boolean {
-  const frames = event.exception?.values?.[0]?.stacktrace?.frames;
-  if (!frames || frames.length === 0) {
-    return false;
-  }
-  return !frames.some((frame) => frame.in_app === true);
-}
 
 if (SENTRY_DSN) {
   init({
@@ -64,6 +33,9 @@ if (SENTRY_DSN) {
         return null;
       }
       if (hasNoInAppFrames(event)) {
+        return null;
+      }
+      if (isMonacoCancellation(event)) {
         return null;
       }
       return event;

--- a/lib/sentry-filters.ts
+++ b/lib/sentry-filters.ts
@@ -1,0 +1,51 @@
+// Predicates used by Sentry's beforeSend hook to drop benign or
+// unactionable events at ingest. Kept in their own module so they can be
+// unit-tested without re-running Sentry's init() side effects.
+
+import type { ErrorEvent } from "@sentry/nextjs";
+
+// Wallet providers (EIP-1193) reject with plain `{ code, message }` objects
+// rather than Error instances, producing unhandled rejections with no stack.
+// These are not actionable, so drop them at ingest.
+export function isEip1193ProviderRejection(event: ErrorEvent): boolean {
+  const mechanismType = event.exception?.values?.[0]?.mechanism?.type;
+  if (!mechanismType?.includes("onunhandledrejection")) {
+    return false;
+  }
+  const serialized = (event.extra as { __serialized__?: unknown } | undefined)
+    ?.__serialized__;
+  if (!serialized || typeof serialized !== "object") {
+    return false;
+  }
+  const asRecord = serialized as Record<string, unknown>;
+  return (
+    typeof asRecord.code === "number" && typeof asRecord.message === "string"
+  );
+}
+
+// Browser extensions (wallet shims, ad blockers, etc.) inject scripts into the
+// page and throw errors that surface to window.onerror. They show up in Sentry
+// with stacktraces composed entirely of non-app frames (`injected.js`,
+// `injectedScript.bundle.js`, vendor shims). Drop events where the SDK marked
+// every frame as out-of-app — they're third-party noise we can't fix.
+export function hasNoInAppFrames(event: ErrorEvent): boolean {
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+  if (!frames || frames.length === 0) {
+    return false;
+  }
+  return !frames.some((frame) => frame.in_app === true);
+}
+
+// `@monaco-editor/react` rejects with a `CancellationError` ("Canceled") when
+// its loader/dispose chain unwinds before the editor finishes mounting — for
+// example when the user navigates away from `/workflows/:workflowId` quickly.
+// The rejection is benign (the editor is already gone) but bubbles to
+// `window.onunhandledrejection` and pollutes Sentry. Filter it out at ingest.
+export function isMonacoCancellation(event: ErrorEvent): boolean {
+  const exception = event.exception?.values?.[0];
+  const mechanismType = exception?.mechanism?.type;
+  if (!mechanismType?.includes("onunhandledrejection")) {
+    return false;
+  }
+  return exception?.value === "Canceled" && exception?.type === "Canceled";
+}

--- a/tests/unit/sentry-filters.test.ts
+++ b/tests/unit/sentry-filters.test.ts
@@ -1,0 +1,192 @@
+import type { ErrorEvent } from "@sentry/nextjs";
+import { describe, expect, it } from "vitest";
+import {
+  hasNoInAppFrames,
+  isEip1193ProviderRejection,
+  isMonacoCancellation,
+} from "@/lib/sentry-filters";
+
+// Minimal shape the filter predicates actually read. Cast to ErrorEvent so we
+// don't have to spell out the dozens of fields the SDK accepts at runtime.
+type TestEvent = {
+  exception?: {
+    values?: Array<{
+      type?: string;
+      value?: string;
+      mechanism?: { type?: string; handled?: boolean };
+      stacktrace?: { frames?: Array<{ in_app?: boolean; filename?: string }> };
+    }>;
+  };
+  extra?: Record<string, unknown>;
+};
+
+function makeEvent(partial: TestEvent): ErrorEvent {
+  return partial as ErrorEvent;
+}
+
+describe("isEip1193ProviderRejection", () => {
+  it("matches a rejection that carries a serialized provider error", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+          },
+        ],
+      },
+      extra: {
+        __serialized__: { code: 4001, message: "User rejected the request" },
+      },
+    });
+    expect(isEip1193ProviderRejection(event)).toBe(true);
+  });
+
+  it("ignores non-unhandledrejection events", () => {
+    const event = makeEvent({
+      exception: {
+        values: [{ mechanism: { type: "onerror", handled: false } }],
+      },
+      extra: { __serialized__: { code: 1, message: "x" } },
+    });
+    expect(isEip1193ProviderRejection(event)).toBe(false);
+  });
+
+  it("ignores events without a serialized record", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          { mechanism: { type: "onunhandledrejection", handled: false } },
+        ],
+      },
+    });
+    expect(isEip1193ProviderRejection(event)).toBe(false);
+  });
+
+  it("ignores events whose serialized record is not the EIP-1193 shape", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          { mechanism: { type: "onunhandledrejection", handled: false } },
+        ],
+      },
+      extra: { __serialized__: { foo: "bar" } },
+    });
+    expect(isEip1193ProviderRejection(event)).toBe(false);
+  });
+});
+
+describe("hasNoInAppFrames", () => {
+  it("returns true when every frame is out-of-app", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                { in_app: false, filename: "injected.js" },
+                { in_app: false, filename: "injectedScript.bundle.js" },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(hasNoInAppFrames(event)).toBe(true);
+  });
+
+  it("returns false when at least one frame is in-app", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                { in_app: false, filename: "injected.js" },
+                { in_app: true, filename: "app/page.tsx" },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(hasNoInAppFrames(event)).toBe(false);
+  });
+
+  it("returns false when there are no frames", () => {
+    const event = makeEvent({ exception: { values: [{}] } });
+    expect(hasNoInAppFrames(event)).toBe(false);
+  });
+});
+
+describe("isMonacoCancellation", () => {
+  it("matches an unhandled rejection with type and value 'Canceled'", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "Canceled",
+            value: "Canceled",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+          },
+        ],
+      },
+    });
+    expect(isMonacoCancellation(event)).toBe(true);
+  });
+
+  it("does not match when the mechanism is not unhandledrejection", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "Canceled",
+            value: "Canceled",
+            mechanism: { type: "onerror", handled: false },
+          },
+        ],
+      },
+    });
+    expect(isMonacoCancellation(event)).toBe(false);
+  });
+
+  it("does not match when only value is 'Canceled' but type is something else", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Canceled",
+            mechanism: { type: "onunhandledrejection", handled: false },
+          },
+        ],
+      },
+    });
+    expect(isMonacoCancellation(event)).toBe(false);
+  });
+
+  it("does not match unrelated cancellation messages", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "AbortError",
+            value: "The user aborted a request.",
+            mechanism: { type: "onunhandledrejection", handled: false },
+          },
+        ],
+      },
+    });
+    expect(isMonacoCancellation(event)).toBe(false);
+  });
+
+  it("does not match an empty exception", () => {
+    const event = makeEvent({});
+    expect(isMonacoCancellation(event)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Sentry was repeatedly receiving unhandled `Canceled: Canceled` promise rejections from `@monaco-editor/react` on `/workflows/:workflowId` (KEEPERHUB-PRODUCTION-R, -12). They fire when the editor unmounts before its loader settles (fast nav away from a workflow page) and are not user-facing failures.
- Extracted the existing `beforeSend` predicates (`isEip1193ProviderRejection`, `hasNoInAppFrames`) into `lib/sentry-filters.ts` so they're unit-testable, then added `isMonacoCancellation` and wired it into the pipeline.
- Predicate matches when the mechanism is `onunhandledrejection` and both `exception.type` and `exception.value` equal `"Canceled"` — narrow enough to avoid suppressing legitimate cancellation errors from app code.

Closes KEEP-352.