### PR TITLE
fix: copy generated credential-map.ts into runner Docker stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,7 @@ COPY --link --from=source /app/tsconfig.json ./tsconfig.json
 
 # Copy auto-generated files from builder stage (step-registry.ts, etc. are in .gitignore)
 COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
+COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts
 COPY --link --from=builder /app/lib/workflow/codegen/registry.ts ./lib/workflow/codegen/registry.ts
 COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
 COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
@@ -228,6 +229,7 @@ COPY --link --from=source /app/tsconfig.json ./tsconfig.json
 
 # Copy auto-generated files from builder stage
 COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
+COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts
 COPY --link --from=builder /app/lib/workflow/codegen/registry.ts ./lib/workflow/codegen/registry.ts
 COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
 COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts


### PR DESCRIPTION
## Summary

- Add `COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts` to both the `workflow-runner` and `executor` Dockerfile stages so the generated credential map is available at runtime in tsx-based pods.

## Why

`lib/credential-map.ts` is auto-generated by `pnpm discover-plugins` (runs inside `pnpm build`) and is gitignored. The Next.js `runner` stage gets it for free via `.next/standalone`, but the `workflow-runner` and `executor` stages run the source tree directly with `tsx` and rely on explicit `COPY --from=builder` lines for every gitignored generated file. The list already covers `step-registry.ts`, `workflow/codegen/registry.ts`, `output-display-configs.ts`, `types/integration.ts`, `plugins/index.ts`, and `protocols/index.ts`. `credential-map.ts` was overlooked.

`lib/credential-fetcher.ts` does `import { PLUGIN_CREDENTIAL_MAP } from "./credential-map"`. With the file missing from the runner image, every step that calls `fetchCredentials()` blew up at module-resolution time -- Database Query, Discord, Telegram, Slack, SendGrid, and the Safe `get-pending-transactions` action. Manual executions ran inside the Next.js app pod (standalone bundle includes the file), so the same workflow looked green when triggered by hand and red when triggered by the scheduler or executor.

## Error found

Pod log from a scheduled execution:

```
[Workflow Executor] Error executing node: [org:iYEtOYl7RjknTr9pTbdnXkWl2zqh3HkL][wf:iu5ymwclazzaeyidwxrlc][exec:g9awjm7y45ap6ny3dduo7]
Error: Cannot find module './credential-map'
Require stack:
- /app/lib/credential-fetcher.ts
- /app/lib/workflow/nodes/database-query/step.ts
    at ...
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app/lib/credential-fetcher.ts',
    '/app/lib/workflow/nodes/database-query/step.ts'
  ]
}
```

The same workflow executed successfully when triggered manually from the UI, since that path goes through the Next.js app pod whose `.next/standalone` output already contains `lib/credential-map.ts`.
