### PR TITLE
fix: KEEP-377 correct Arbitrum Sepolia USDC token address

### DIFF
--- a/drizzle/0063_keep_377_arbitrum_sepolia_usdc_address.sql
+++ b/drizzle/0063_keep_377_arbitrum_sepolia_usdc_address.sql
@@ -1,0 +1,66 @@
+-- Correct the USDC token address seeded for Arbitrum Sepolia (chainId 421614).
+-- The seed introduced in fd5265ae used 0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1,
+-- which is a deployed USDC-named ERC20 on Arbitrum Sepolia but is NOT Circle's
+-- official testnet USDC. Circle's documented Arbitrum Sepolia USDC is
+-- 0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d (see
+-- https://developers.circle.com/stablecoins/usdc-on-test-networks). Wallets
+-- holding the official Circle USDC therefore show a zero USDC balance because
+-- the balances API queries balanceOf at the wrong contract.
+--
+-- Affected tables:
+--   - supported_tokens: system-wide stablecoin list. Has unique constraint
+--     supported_tokens_chain_address on (chain_id, token_address). Update in
+--     place; bail out if a row with the new address already coexists.
+--   - organization_tokens: per-org tracked tokens. No unique constraint on
+--     (chain_id, token_address). If an org has BOTH the wrong and correct
+--     rows (e.g. they manually added the right address), drop the wrong one
+--     to avoid duplicates; otherwise update in place.
+--
+-- This migration deliberately contains no statement breakpoint markers so
+-- drizzle-kit runs the whole file as a single query inside its implicit
+-- per-migration transaction. Matches the precedent set by 0061.
+--
+-- IMPORTANT: do NOT write the drizzle breakpoint marker phrase verbatim
+-- anywhere in this file -- not even inside comments or quoted strings.
+-- drizzle-orm's readMigrationFiles does a context-free string split for
+-- that phrase across the whole file, regardless of where it appears.
+
+-- Precondition: refuse to run if both wrong and correct USDC rows already
+-- coexist in supported_tokens. The unique constraint would block the UPDATE
+-- in that case; a human should reconcile manually.
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM "supported_tokens"
+        WHERE "chain_id" = 421614
+          AND "token_address" = '0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1') > 0
+     AND (SELECT count(*) FROM "supported_tokens"
+        WHERE "chain_id" = 421614
+          AND "token_address" = '0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d') > 0 THEN
+    RAISE EXCEPTION 'supported_tokens has rows for both wrong and correct Arbitrum Sepolia USDC; reconcile manually before running 0063.';
+  END IF;
+END$$;
+
+-- Repoint the system-wide row at Circle's official Arbitrum Sepolia USDC.
+UPDATE "supported_tokens"
+   SET "token_address" = '0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d'
+ WHERE "chain_id" = 421614
+   AND "token_address" = '0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1';
+
+-- Drop any per-org wrong-address rows for orgs that already track the correct
+-- address, so the subsequent UPDATE cannot produce duplicate (org, chain,
+-- address) tuples. There is no unique constraint here so the UPDATE alone
+-- would not fail, but we want one canonical row per org.
+DELETE FROM "organization_tokens" AS ot
+ WHERE ot."chain_id" = 421614
+   AND ot."token_address" = '0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1'
+   AND EXISTS (
+     SELECT 1 FROM "organization_tokens" AS other
+      WHERE other."organization_id" = ot."organization_id"
+        AND other."chain_id" = 421614
+        AND other."token_address" = '0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d'
+   );
+
+UPDATE "organization_tokens"
+   SET "token_address" = '0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d'
+ WHERE "chain_id" = 421614
+   AND "token_address" = '0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1777267669472,
       "tag": "0062_plan_overrides",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1777423425214,
+      "tag": "0063_keep_377_arbitrum_sepolia_usdc_address",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed/seed-tokens.ts
+++ b/scripts/seed/seed-tokens.ts
@@ -217,7 +217,7 @@ const TOKEN_CONFIGS: TokenConfig[] = [
   // ==========================================================================
   {
     chainId: 421_614,
-    tokenAddress: "0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1", // USDC (Circle testnet)
+    tokenAddress: "0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d", // USDC (Circle testnet)
     logoUrl: LOGOS.USDC,
     isStablecoin: true,
     sortOrder: 1,


### PR DESCRIPTION
## Summary

Arbitrum Sepolia (chainId 421614) was seeded with USDC at `0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1` -- a deployed USDC-named ERC20, but not Circle's official testnet USDC. Wallets holding Circle's official USDC at `0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d` therefore showed a zero USDC balance because `/api/user/wallet/balances` queries `balanceOf` at the seeded contract address.

The wrong address was introduced in commit fd5265ae (KEEP-40, "add supported tokens for new chains"). The other testnets in that commit (Sepolia, Base Sepolia, Polygon Amoy) all match Circle's documented addresses. Arbitrum Sepolia was the lone outlier.

## Changes

- `scripts/seed/seed-tokens.ts:220` -- repoint Arbitrum Sepolia USDC to `0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d` per [Circle's testnet USDC list](https://developers.circle.com/stablecoins/usdc-on-test-networks).
- `drizzle/0063_keep_377_arbitrum_sepolia_usdc_address.sql` -- new migration that:
  - Aborts up front if both wrong and correct rows already coexist in `supported_tokens` (unique constraint on `chain_id+token_address` would otherwise block the UPDATE).
  - Updates the `supported_tokens` row for chain 421614 to the correct address.
  - For `organization_tokens` (no unique constraint), deletes wrong-address rows for any org already tracking the correct address, then updates the remaining rows in place.

## Test plan

- [x] `pnpm db:migrate` against a local KEEP-377 dev DB applies cleanly; entry recorded in `drizzle.__drizzle_migrations` with `created_at` matching the journal `when`.
- [x] Synthetic test: inserted a wrong-address row into `supported_tokens`, ran the migration body manually -- precondition passes, `UPDATE 1` rewrites the address as expected.
- [x] Synthetic test: inserted both wrong and correct rows, precondition `RAISE EXCEPTION` fires with the documented message and no UPDATE runs.
- [x] On-chain verification: queried `eth_getBalance` on Arbitrum Sepolia (chainId 421614) for a reporting user's wallet and confirmed they hold 20 USDC at the correct contract `0x75faf114...` and 0 at the seeded `0xf3c3351d...`.
- [ ] Post-deploy: confirm the user's USDC balance now renders correctly in the wallet UI on staging.