### PR TITLE
feat: KEEP-374 add 0G chain support

### DIFF
--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -53,6 +53,10 @@ export const PUBLIC_RPCS = {
   PLASMA_MAINNET_FALLBACK: "https://plasma.drpc.org",
   PLASMA_TESTNET: "https://testnet-rpc.plasma.to",
   PLASMA_TESTNET_FALLBACK: "https://9746.rpc.thirdweb.com",
+  ZERO_G_MAINNET: "https://evmrpc.0g.ai",
+  ZERO_G_MAINNET_FALLBACK: "https://0g.drpc.org",
+  ZERO_G_GALILEO: "https://evmrpc-testnet.0g.ai",
+  ZERO_G_GALILEO_FALLBACK: "https://16602.rpc.thirdweb.com",
   SOLANA_MAINNET: "https://api.mainnet-beta.solana.com",
   SOLANA_DEVNET: "https://api.devnet.solana.com",
 } as const;
@@ -191,6 +195,22 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     fallbackEnvKey: "CHAIN_PLASMA_TESTNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.PLASMA_TESTNET,
     publicFallback: PUBLIC_RPCS.PLASMA_TESTNET_FALLBACK,
+  },
+  // 0G Mainnet (Aristotle)
+  16661: {
+    jsonKey: "0g-mainnet",
+    envKey: "CHAIN_ZERO_G_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_ZERO_G_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.ZERO_G_MAINNET,
+    publicFallback: PUBLIC_RPCS.ZERO_G_MAINNET_FALLBACK,
+  },
+  // 0G Galileo Testnet
+  16602: {
+    jsonKey: "0g-galileo",
+    envKey: "CHAIN_ZERO_G_GALILEO_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_ZERO_G_GALILEO_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.ZERO_G_GALILEO,
+    publicFallback: PUBLIC_RPCS.ZERO_G_GALILEO_FALLBACK,
   },
   // Solana Mainnet
   101: {

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -414,6 +414,51 @@ const DEFAULT_CHAINS: NewChain[] = [
     usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "plasma-testnet" }),
     defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "plasma-testnet" }),
   },
+  // 0G chains
+  {
+    chainId: getChainConfigValue("0g-mainnet", "chainId", 16_661),
+    name: "0G",
+    symbol: getChainConfigValue("0g-mainnet", "symbol", "0G"),
+    chainType: "evm",
+    defaultPrimaryRpc: getRpcUrlByChainId(16_661, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(16_661, "fallback"),
+    defaultPrimaryWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[16_661].jsonKey,
+      type: "primary",
+    }),
+    defaultFallbackWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[16_661].jsonKey,
+      type: "fallback",
+    }),
+    isTestnet: getChainConfigValue("0g-mainnet", "isTestnet", false),
+    isEnabled: getChainConfigValue("0g-mainnet", "isEnabled", true),
+    usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "0g-mainnet" }),
+    defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "0g-mainnet" }),
+  },
+  {
+    chainId: getChainConfigValue("0g-galileo", "chainId", 16_602),
+    name: "0G Galileo",
+    symbol: getChainConfigValue("0g-galileo", "symbol", "0G"),
+    chainType: "evm",
+    defaultPrimaryRpc: getRpcUrlByChainId(16_602, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(16_602, "fallback"),
+    defaultPrimaryWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[16_602].jsonKey,
+      type: "primary",
+    }),
+    defaultFallbackWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[16_602].jsonKey,
+      type: "fallback",
+    }),
+    isTestnet: getChainConfigValue("0g-galileo", "isTestnet", true),
+    isEnabled: getChainConfigValue("0g-galileo", "isEnabled", false),
+    usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "0g-galileo" }),
+    defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "0g-galileo" }),
+  },
   // Solana chains (non-EVM - uses SolanaProviderManager)
   {
     chainId: getChainConfigValue("solana-mainnet", "chainId", 101),
@@ -629,6 +674,26 @@ const EXPLORER_CONFIG_TEMPLATES: Record<
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}#code",
   },
+  // 0G Mainnet - Blockscout (0G ChainScan)
+  16661: {
+    chainType: "evm",
+    explorerUrl: "https://chainscan.0g.ai",
+    explorerApiType: "blockscout",
+    explorerApiUrl: "https://chainscan.0g.ai/api",
+    explorerTxPath: "/tx/{hash}",
+    explorerAddressPath: "/address/{address}",
+    explorerContractPath: "/address/{address}?tab=contract",
+  },
+  // 0G Galileo Testnet - Blockscout (0G ChainScan)
+  16602: {
+    chainType: "evm",
+    explorerUrl: "https://chainscan-galileo.0g.ai",
+    explorerApiType: "blockscout",
+    explorerApiUrl: "https://chainscan-galileo.0g.ai/api",
+    explorerTxPath: "/tx/{hash}",
+    explorerAddressPath: "/address/{address}",
+    explorerContractPath: "/address/{address}?tab=contract",
+  },
   // Solana Mainnet - Solscan
   101: {
     chainType: "solana",
@@ -717,6 +782,8 @@ async function seedChains() {
     "Avalanche Fuji": 43_113,
     Plasma: 9745,
     "Plasma Testnet": 9746,
+    "0G": 16_661,
+    "0G Galileo": 16_602,
     Solana: 101,
     "Solana Devnet": 103,
   };

--- a/scripts/seed/seed-tokens.ts
+++ b/scripts/seed/seed-tokens.ts
@@ -278,6 +278,21 @@ const TOKEN_CONFIGS: TokenConfig[] = [
   },
 
   // ==========================================================================
+  // 0G Mainnet (chainId: 16661)
+  // ==========================================================================
+  // Only XSwap-bridged USDC.e is tracked: Circle has not deployed native USDC
+  // on 0G, and no other stablecoin issuer has deployed natively. Bridged via
+  // Chainlink CCIP from Ethereum. Galileo testnet has no canonical bridged
+  // USDC (CCIP is decommissioned on Galileo), so no testnet entry.
+  {
+    chainId: 16_661,
+    tokenAddress: "0x1f3aa82227281ca364bfb3d253b0f1af1da6473e", // USDC.e (XSwap Bridged USDC via Chainlink CCIP)
+    logoUrl: LOGOS.USDC,
+    isStablecoin: true,
+    sortOrder: 1,
+  },
+
+  // ==========================================================================
   // Plasma Mainnet (chainId: 9745)
   // ==========================================================================
   // Only USDT0 is tracked: Circle has not deployed native USDC on Plasma, and


### PR DESCRIPTION
## Summary

Adds 0G Mainnet (chainId 16661) and 0G Galileo Testnet (chainId 16602) to the chain registry, plus the XSwap-bridged USDC.e stablecoin on mainnet.

- `lib/rpc/rpc-config.ts` — register both chains in `PUBLIC_RPCS` and `CHAIN_CONFIG`
- `scripts/seed/seed-chains.ts` — `DEFAULT_CHAINS` rows, Blockscout explorer templates, `chainToDefaultIdMap` entries
- `scripts/seed/seed-tokens.ts` — USDC.e entry (`0x1f3aa82227281ca364bfb3d253b0f1af1da6473e`) for chain 16661

## Stablecoin context

USDC.e on 0G mainnet is **XSwap Bridged USDC**, not Circle-issued native USDC. It is bridged from Ethereum via Chainlink CCIP (live since ~Sept 28, 2025; mainnet TGE was Sept 21, 2025). Circle does not issue native USDC on 0G — chain 16661 / 16602 are not in Circle's supported-chains list.

- Symbol: `USDC.e` (not `USDC`) — frontend must avoid lumping with native USDC
- Decimals: 6 (matches Ethereum USDC)
- On-chain total supply at time of writing: ~$1.79M (thin, expect significant slippage on large swaps)
- Bridge concentration risk: every USD on 0G traces back to the CCIP lock pool on Ethereum

## Galileo testnet decisions

- `isEnabled: false` by default — CCIP is decommissioned on Galileo and no canonical bridged USDC exists, so the chain has no working asset story
- No token row seeded for Galileo
- Native symbol set to `0G` (not `OG`) to match mainnet and what the live RPC reports

## Action items outside this PR

1. **AWS Parameter Store / Helm**: production `CHAIN_RPC_CONFIG` needs `0g-mainnet` and `0g-galileo` keys added before this rolls to staging/prod. Local-only `.env` was updated for this worktree's testing but is git-ignored. Suggested values:
   - `0g-mainnet`: primary `https://evmrpc.0g.ai`, fallback `https://0g.drpc.org`, no WSS, `isEnabled: true`
   - `0g-galileo`: primary `https://evmrpc-testnet.0g.ai`, fallback `https://16602.rpc.thirdweb.com`, no WSS, `isEnabled: false`
2. **techops.services proxy**: every other chain has a `chain.techops.services/<key>` primary; 0G does not yet. Worth adding before mainnet sees real traffic.
3. **WSS**: 0G publishes no WSS endpoints. If subscriptions matter for 0G workflows, ops needs a WSS-capable third-party (dRPC, Ankr, ThirdWeb).

## Verification

- `pnpm discover-plugins` clean
- `pnpm type-check` clean (no TS errors)
- `pnpm exec biome check` on the three changed files: clean (one pre-existing format nit on `getUsePrivateMempoolRpc` in `rpc-config.ts` is unchanged from staging baseline)
- `pnpm tsx scripts/seed/seed-chains.ts` runs end-to-end: 20 chains + 20 explorer configs inserted, including 0G mainnet (Blockscout @ `chainscan.0g.ai`) and 0G Galileo (Blockscout @ `chainscan-galileo.0g.ai`)
- `pnpm tsx scripts/seed/seed-tokens.ts` runs end-to-end: USDC.e fetched from chain 16661, on-chain metadata matches (`USDC.e` / `Bridged USDC` / 6 decimals), inserted into `supported_tokens`

## Test plan

- [ ] On staging deploy: confirm `CHAIN_RPC_CONFIG` in AWS Parameter Store has been updated with the two new keys before merge
- [ ] After merge, run `pnpm db:seed` against staging DB and verify rows in `chains` and `supported_tokens` for chain IDs 16661 and 16602
- [ ] Hit chain 16661 from a workflow: confirm RPC reachability via `chain.techops.services` proxy (once added) or fallback to public RPC
- [ ] UI smoke: confirm the 0G mainnet card renders and USDC.e is selectable; confirm Galileo does not appear in user-facing chain pickers (gated by `isEnabled: false`)
- [ ] Confirm token symbol displays as `USDC.e`, not `USDC`, anywhere the token list is rendered