### PR TITLE
feat: KEEP-239 hash session tokens in database

### DIFF
--- a/app/api/organizations/[organizationId]/leave/route.ts
+++ b/app/api/organizations/[organizationId]/leave/route.ts
@@ -50,6 +50,9 @@ export async function POST(
         ? body.newOwnerMemberId.trim()
         : "";
 
+    // Post-KEEP-239 this is the sha256 hash stored in sessions.token, not the
+    // raw bearer. Safe to use as a row key against sessions.token (both sides
+    // hashed); never expose to clients or use as an Authorization header.
     const sessionToken = session.session?.token;
     if (!sessionToken) {
       return NextResponse.json(

--- a/drizzle/0064_keep_239_hash_session_tokens.sql
+++ b/drizzle/0064_keep_239_hash_session_tokens.sql
@@ -1,0 +1,15 @@
+-- KEEP-239: replace plaintext sessions.token with sha256 hash.
+-- Cookies / bearer headers held by clients still contain the raw token; this
+-- migration hashes the column so that a DB exfiltration no longer yields live
+-- bearers. The wrapWithSessionTokenHash adapter (lib/auth-session-token-hash.ts)
+-- transparently hashes inbound tokens at lookup time, so existing sessions
+-- keep working without forcing users to re-authenticate.
+--
+-- Idempotency: a second run would double-hash. Guarded by a length check --
+-- generateId(32) produces 32-char tokens; sha256 hex is 64 chars. Skip rows
+-- that already look hashed.
+
+UPDATE sessions
+SET token = encode(sha256(token::bytea), 'hex')
+WHERE length(token) <> 64
+   OR token !~ '^[0-9a-f]{64}$';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1777423425214,
       "tag": "0063_keep_377_arbitrum_sepolia_usdc_address",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1777429262207,
+      "tag": "0064_keep_239_hash_session_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/auth-session-token-hash.ts
+++ b/lib/auth-session-token-hash.ts
@@ -97,6 +97,14 @@ export function wrapWithSessionTokenHash<F extends AdapterFactory>(
 function wrapAdapter(inner: DBAdapter): DBAdapter {
   return {
     ...inner,
+    // The cast on `create` is intentional and worth preserving. DBAdapter.create
+    // is `<T, R = T>(data: { model; data: Omit<T, "id">; ... }) => Promise<R>`,
+    // so writing the body as a generic function loses the `T` binding when we
+    // spread `data` into a fresh object: TS widens to `Record<string, any>`
+    // which then doesn't satisfy `Omit<T, "id">` on the recursive inner.create
+    // call. Casting the implementation to `DBAdapter["create"]` keeps the
+    // public type intact at the cost of unchecked types inside the function;
+    // we get the type-checking back at the call sites where it matters.
     create: ((data: CreateArgs) => {
       const incoming = data.data as Record<string, unknown>;
       if (

--- a/lib/auth-session-token-hash.ts
+++ b/lib/auth-session-token-hash.ts
@@ -51,6 +51,11 @@ function hashTokenWhere(where: Where[] | undefined): Where[] | undefined {
           `Session token where with operator "${op}" must have an array value`
         );
       }
+      if (!clause.value.every((v) => typeof v === "string")) {
+        throw new Error(
+          `Session token where with operator "${op}" must contain only string values`
+        );
+      }
       return { ...clause, value: clause.value.map(hashSessionToken) };
     }
     if (op !== "eq" && op !== "ne") {

--- a/lib/auth-session-token-hash.ts
+++ b/lib/auth-session-token-hash.ts
@@ -1,0 +1,158 @@
+import { createHash } from "node:crypto";
+import type { DBAdapter, Where } from "better-auth";
+
+// KEEP-239: better-auth 1.5.6 stores `sessions.token` plaintext, which gives
+// any attacker who reads the DB live bearer tokens. Until upstream supports
+// `session: { hashToken: true }` we wrap the adapter so the column holds
+// sha256(token) while the token returned from `create` (and therefore the
+// cookie / bearer payload) remains the raw value the client must present.
+//
+// Coupled to two undocumented call shapes in better-auth:
+//   - createSession passes `data.token` as the raw token on `create`.
+//   - findSession / findSessions / updateSession / deleteSession all locate
+//     rows via `where: [{ field: "token", value }]` (eq) or `operator: "in"`.
+// If either changes upstream, the unit tests in
+// tests/unit/auth-session-token-hash.test.ts will fail before the bug ships.
+
+const SESSION_MODEL = "session";
+const TOKEN_FIELD = "token";
+
+type CreateArgs = Parameters<DBAdapter["create"]>[0];
+type FindOneArgs = Parameters<DBAdapter["findOne"]>[0];
+type FindManyArgs = Parameters<DBAdapter["findMany"]>[0];
+type CountArgs = Parameters<DBAdapter["count"]>[0];
+type UpdateArgs = Parameters<DBAdapter["update"]>[0];
+type UpdateManyArgs = Parameters<DBAdapter["updateMany"]>[0];
+type DeleteArgs = Parameters<DBAdapter["delete"]>[0];
+type DeleteManyArgs = Parameters<DBAdapter["deleteMany"]>[0];
+
+export function hashSessionToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function hashTokenWhere(where: Where[] | undefined): Where[] | undefined {
+  if (!where) {
+    return where;
+  }
+  return where.map((clause) => {
+    if (clause.field !== TOKEN_FIELD) {
+      return clause;
+    }
+    const op = clause.operator ?? "eq";
+    if (op === "in" || op === "not_in") {
+      const values = clause.value as string[];
+      return { ...clause, value: values.map(hashSessionToken) };
+    }
+    if (typeof clause.value !== "string") {
+      return clause;
+    }
+    return { ...clause, value: hashSessionToken(clause.value) };
+  });
+}
+
+function hashTokenInUpdate(
+  update: Record<string, unknown>
+): Record<string, unknown> {
+  if (typeof update[TOKEN_FIELD] !== "string") {
+    return update;
+  }
+  return {
+    ...update,
+    [TOKEN_FIELD]: hashSessionToken(update[TOKEN_FIELD] as string),
+  };
+}
+
+type AdapterFactory = (...args: never[]) => DBAdapter;
+
+export function wrapWithSessionTokenHash<F extends AdapterFactory>(
+  factory: F
+): F {
+  const wrapped = ((...args: Parameters<F>) => {
+    const inner = factory(...args);
+    return wrapAdapter(inner);
+  }) as F;
+  return wrapped;
+}
+
+function wrapAdapter(inner: DBAdapter): DBAdapter {
+  return {
+    ...inner,
+    create: ((data: CreateArgs) => {
+      const incoming = data.data as Record<string, unknown>;
+      if (
+        data.model !== SESSION_MODEL ||
+        typeof incoming[TOKEN_FIELD] !== "string"
+      ) {
+        return inner.create(data);
+      }
+      const rawToken = incoming[TOKEN_FIELD] as string;
+      const hashed = {
+        ...data,
+        data: { ...incoming, [TOKEN_FIELD]: hashSessionToken(rawToken) },
+      } as CreateArgs;
+      return inner.create(hashed).then((stored) => ({
+        ...(stored as Record<string, unknown>),
+        [TOKEN_FIELD]: rawToken,
+      }));
+    }) as DBAdapter["create"],
+    findOne: <T>(data: FindOneArgs): Promise<T | null> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.findOne<T>(data);
+      }
+      return inner.findOne<T>({
+        ...data,
+        where: hashTokenWhere(data.where) ?? [],
+      });
+    },
+    findMany: <T>(data: FindManyArgs): Promise<T[]> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.findMany<T>(data);
+      }
+      return inner.findMany<T>({ ...data, where: hashTokenWhere(data.where) });
+    },
+    count: (data: CountArgs): Promise<number> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.count(data);
+      }
+      return inner.count({ ...data, where: hashTokenWhere(data.where) });
+    },
+    update: <T>(data: UpdateArgs): Promise<T | null> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.update<T>(data);
+      }
+      return inner.update<T>({
+        ...data,
+        where: hashTokenWhere(data.where) ?? [],
+        update: hashTokenInUpdate(data.update),
+      });
+    },
+    updateMany: (data: UpdateManyArgs): Promise<number> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.updateMany(data);
+      }
+      return inner.updateMany({
+        ...data,
+        where: hashTokenWhere(data.where) ?? [],
+        update: hashTokenInUpdate(data.update),
+      });
+    },
+    delete: <T>(data: DeleteArgs): Promise<void> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.delete<T>(data);
+      }
+      return inner.delete<T>({
+        ...data,
+        where: hashTokenWhere(data.where) ?? [],
+      });
+    },
+    deleteMany: (data: DeleteManyArgs): Promise<number> => {
+      if (data.model !== SESSION_MODEL) {
+        return inner.deleteMany(data);
+      }
+      return inner.deleteMany({
+        ...data,
+        where: hashTokenWhere(data.where) ?? [],
+      });
+    },
+  };
+}

--- a/lib/auth-session-token-hash.ts
+++ b/lib/auth-session-token-hash.ts
@@ -13,6 +13,12 @@ import type { DBAdapter, Where } from "better-auth";
 //     rows via `where: [{ field: "token", value }]` (eq) or `operator: "in"`.
 // If either changes upstream, the unit tests in
 // tests/unit/auth-session-token-hash.test.ts will fail before the bug ships.
+//
+// IMPORTANT: this wrapper is bypassed when `betterAuth({ secondaryStorage })`
+// is configured. better-auth's createSession writes directly to the cache via
+// `secondaryStorage.set(data.token, ...)` without calling the DB adapter, so
+// plaintext tokens would land in the cache. If the project ever enables
+// secondaryStorage, this protection must be re-implemented at that layer too.
 
 const SESSION_MODEL = "session";
 const TOKEN_FIELD = "token";

--- a/lib/auth-session-token-hash.ts
+++ b/lib/auth-session-token-hash.ts
@@ -46,11 +46,25 @@ function hashTokenWhere(where: Where[] | undefined): Where[] | undefined {
     }
     const op = clause.operator ?? "eq";
     if (op === "in" || op === "not_in") {
-      const values = clause.value as string[];
-      return { ...clause, value: values.map(hashSessionToken) };
+      if (!Array.isArray(clause.value)) {
+        throw new Error(
+          `Session token where with operator "${op}" must have an array value`
+        );
+      }
+      return { ...clause, value: clause.value.map(hashSessionToken) };
+    }
+    if (op !== "eq" && op !== "ne") {
+      // Substring/range operators on a hashed column never match meaningfully.
+      // Throw loudly rather than silently returning the wrong rows if a future
+      // caller tries to query sessions by partial token.
+      throw new Error(
+        `Session token where with operator "${op}" is not supported by the session-token-hash wrapper`
+      );
     }
     if (typeof clause.value !== "string") {
-      return clause;
+      throw new Error(
+        `Session token where with operator "${op}" must have a string value, got ${typeof clause.value}`
+      );
     }
     return { ...clause, value: hashSessionToken(clause.value) };
   });
@@ -101,61 +115,73 @@ function wrapAdapter(inner: DBAdapter): DBAdapter {
         [TOKEN_FIELD]: rawToken,
       }));
     }) as DBAdapter["create"],
-    findOne: <T>(data: FindOneArgs): Promise<T | null> => {
+    // Each method below is async so that a synchronous throw from
+    // hashTokenWhere / hashTokenInUpdate becomes a rejected promise rather
+    // than crashing the caller's call site. better-auth always awaits, so a
+    // rejected promise surfaces as a normal error.
+    // Each method below is async so that a synchronous throw from
+    // hashTokenWhere / hashTokenInUpdate becomes a rejected promise rather
+    // than crashing the caller's call site. better-auth always awaits, so a
+    // rejected promise surfaces as a normal error.
+    findOne: async <T>(data: FindOneArgs): Promise<T | null> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.findOne<T>(data);
+        return await inner.findOne<T>(data);
       }
-      return inner.findOne<T>({
+      return await inner.findOne<T>({
         ...data,
         where: hashTokenWhere(data.where) ?? [],
       });
     },
-    findMany: <T>(data: FindManyArgs): Promise<T[]> => {
+    findMany: async <T>(data: FindManyArgs): Promise<T[]> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.findMany<T>(data);
+        return await inner.findMany<T>(data);
       }
-      return inner.findMany<T>({ ...data, where: hashTokenWhere(data.where) });
+      return await inner.findMany<T>({
+        ...data,
+        where: hashTokenWhere(data.where),
+      });
     },
-    count: (data: CountArgs): Promise<number> => {
+    count: async (data: CountArgs): Promise<number> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.count(data);
+        return await inner.count(data);
       }
-      return inner.count({ ...data, where: hashTokenWhere(data.where) });
+      return await inner.count({ ...data, where: hashTokenWhere(data.where) });
     },
-    update: <T>(data: UpdateArgs): Promise<T | null> => {
+    update: async <T>(data: UpdateArgs): Promise<T | null> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.update<T>(data);
+        return await inner.update<T>(data);
       }
-      return inner.update<T>({
+      return await inner.update<T>({
         ...data,
         where: hashTokenWhere(data.where) ?? [],
         update: hashTokenInUpdate(data.update),
       });
     },
-    updateMany: (data: UpdateManyArgs): Promise<number> => {
+    updateMany: async (data: UpdateManyArgs): Promise<number> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.updateMany(data);
+        return await inner.updateMany(data);
       }
-      return inner.updateMany({
+      return await inner.updateMany({
         ...data,
         where: hashTokenWhere(data.where) ?? [],
         update: hashTokenInUpdate(data.update),
       });
     },
-    delete: <T>(data: DeleteArgs): Promise<void> => {
+    delete: async <T>(data: DeleteArgs): Promise<void> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.delete<T>(data);
+        await inner.delete<T>(data);
+        return;
       }
-      return inner.delete<T>({
+      await inner.delete<T>({
         ...data,
         where: hashTokenWhere(data.where) ?? [],
       });
     },
-    deleteMany: (data: DeleteManyArgs): Promise<number> => {
+    deleteMany: async (data: DeleteManyArgs): Promise<number> => {
       if (data.model !== SESSION_MODEL) {
-        return inner.deleteMany(data);
+        return await inner.deleteMany(data);
       }
-      return inner.deleteMany({
+      return await inner.deleteMany({
         ...data,
         where: hashTokenWhere(data.where) ?? [],
       });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -17,6 +17,7 @@ import { nanoid } from "nanoid";
 import { rateLimitBypassRule } from "@/lib/admin-auth";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
 import { isAiGatewayManagedKeysEnabled } from "./ai-gateway/config";
+import { wrapWithSessionTokenHash } from "./auth-session-token-hash";
 import { db } from "./db";
 import {
   accounts,
@@ -401,10 +402,12 @@ async function notifyDiscordSignup(user: {
 
 export const auth = betterAuth({
   baseURL: getBaseURL(),
-  database: drizzleAdapter(db, {
-    provider: "pg",
-    schema,
-  }),
+  database: wrapWithSessionTokenHash(
+    drizzleAdapter(db, {
+      provider: "pg",
+      schema,
+    })
+  ),
   logger: {
     level: "debug",
     disabled: false,

--- a/tests/e2e/vitest/auth-session-token-hash-integration.test.ts
+++ b/tests/e2e/vitest/auth-session-token-hash-integration.test.ts
@@ -1,0 +1,187 @@
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.unmock("@/lib/db");
+vi.mock("server-only", () => ({}));
+
+import {
+  hashSessionToken,
+  wrapWithSessionTokenHash,
+} from "@/lib/auth-session-token-hash";
+import { sessions, users } from "@/lib/db/schema";
+import { generateId } from "@/lib/utils/id";
+
+/**
+ * KEEP-239 integration: exercise the session-token-hashing adapter wrapper
+ * against the real drizzleAdapter and a real Postgres database. This catches
+ * the failure mode the unit tests cannot: better-auth's drizzle adapter
+ * silently changing the call shape (e.g. `field: "token"` → `field: "tokenHash"`)
+ * would let unit tests pass while production auth quietly breaks.
+ *
+ * Skipped when no DATABASE_URL is configured.
+ */
+
+const shouldSkip =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+
+describe.skipIf(shouldSkip)("wrapWithSessionTokenHash (integration)", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let testUserId: string;
+  // The wrapped adapter we exercise. better-auth's drizzleAdapter returns
+  // a factory `(options) => DBAdapter`; calling it with a minimal options
+  // object is enough for the operations we use here.
+  let adapter: ReturnType<ReturnType<typeof drizzleAdapter>>;
+
+  const createdSessionTokens: string[] = [];
+
+  beforeAll(async () => {
+    const connectionString =
+      process.env.DATABASE_URL ??
+      "postgresql://postgres:postgres@localhost:5433/keeperhub";
+    client = postgres(connectionString, { max: 2 });
+    db = drizzle(client);
+
+    const factory = wrapWithSessionTokenHash(
+      drizzleAdapter(db, {
+        provider: "pg",
+        schema: { user: users, session: sessions },
+      })
+    );
+    // better-auth options shape is internal; the adapter only needs a
+    // non-null object for the operations we use here.
+    adapter = factory({} as Parameters<typeof factory>[0]);
+
+    testUserId = `test-${generateId()}`;
+    const now = new Date();
+    await db.insert(users).values({
+      id: testUserId,
+      email: `${testUserId}@keep-239-test.local`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+  afterAll(async () => {
+    if (!client) {
+      return;
+    }
+    for (const token of createdSessionTokens) {
+      await db
+        .delete(sessions)
+        .where(eq(sessions.token, hashSessionToken(token)));
+    }
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+    await client.end({ timeout: 2 });
+  });
+
+  it("stores sha256(token) in the DB and round-trips lookups via raw token", async () => {
+    const rawToken = `raw-token-${generateId()}`;
+    createdSessionTokens.push(rawToken);
+    const expiresAt = new Date(Date.now() + 60_000);
+
+    const created = await adapter.create<Record<string, unknown>>({
+      model: "session",
+      data: {
+        id: `sess-${generateId()}`,
+        token: rawToken,
+        userId: testUserId,
+        expiresAt,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    // Wrapper restores the raw token in the create return so better-auth
+    // can sign the cookie / bearer header with it.
+    expect(created.token).toBe(rawToken);
+
+    // The DB column holds the hash, not the raw token.
+    const [row] = await db
+      .select({ token: sessions.token })
+      .from(sessions)
+      .where(eq(sessions.id, created.id as string));
+    expect(row.token).toBe(hashSessionToken(rawToken));
+    expect(row.token).not.toBe(rawToken);
+
+    // findOne via the wrapper, presenting the raw token, finds the row.
+    const found = await adapter.findOne<{ id: string; token: string }>({
+      model: "session",
+      where: [{ field: "token", value: rawToken }],
+    });
+    expect(found?.id).toBe(created.id);
+    // Returned row's token is the stored hash (post-KEEP-239 semantics).
+    expect(found?.token).toBe(hashSessionToken(rawToken));
+
+    // A wrong token finds nothing.
+    const missing = await adapter.findOne({
+      model: "session",
+      where: [{ field: "token", value: "not-the-token" }],
+    });
+    expect(missing).toBeNull();
+  });
+
+  it("findMany with operator: in hashes every value", async () => {
+    const tokenA = `multi-a-${generateId()}`;
+    const tokenB = `multi-b-${generateId()}`;
+    createdSessionTokens.push(tokenA, tokenB);
+    const expiresAt = new Date(Date.now() + 60_000);
+
+    for (const token of [tokenA, tokenB]) {
+      await adapter.create({
+        model: "session",
+        data: {
+          id: `sess-${generateId()}`,
+          token,
+          userId: testUserId,
+          expiresAt,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+    }
+
+    const rows = await adapter.findMany<{ token: string }>({
+      model: "session",
+      where: [{ field: "token", value: [tokenA, tokenB], operator: "in" }],
+    });
+    expect(rows).toHaveLength(2);
+    const storedTokens = rows.map((r) => r.token).sort();
+    expect(storedTokens).toEqual(
+      [hashSessionToken(tokenA), hashSessionToken(tokenB)].sort()
+    );
+  });
+
+  it("delete by raw token removes the row", async () => {
+    const rawToken = `delete-me-${generateId()}`;
+    const expiresAt = new Date(Date.now() + 60_000);
+    const created = await adapter.create<{ id: string }>({
+      model: "session",
+      data: {
+        id: `sess-${generateId()}`,
+        token: rawToken,
+        userId: testUserId,
+        expiresAt,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    await adapter.delete({
+      model: "session",
+      where: [{ field: "token", value: rawToken }],
+    });
+
+    const [row] = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.id, created.id));
+    expect(row).toBeUndefined();
+  });
+});

--- a/tests/e2e/vitest/auth-session-token-hash-integration.test.ts
+++ b/tests/e2e/vitest/auth-session-token-hash-integration.test.ts
@@ -36,8 +36,6 @@ describe.skipIf(shouldSkip)("wrapWithSessionTokenHash (integration)", () => {
   // object is enough for the operations we use here.
   let adapter: ReturnType<ReturnType<typeof drizzleAdapter>>;
 
-  const createdSessionTokens: string[] = [];
-
   beforeAll(async () => {
     const connectionString =
       process.env.DATABASE_URL ??
@@ -70,12 +68,13 @@ describe.skipIf(shouldSkip)("wrapWithSessionTokenHash (integration)", () => {
     if (!client) {
       return;
     }
-    for (const token of createdSessionTokens) {
-      await db
-        .delete(sessions)
-        .where(eq(sessions.token, hashSessionToken(token)));
-    }
+    // Sweep by userId rather than tracking individual tokens. sessions.userId
+    // has no ON DELETE CASCADE, so any session row that leaked past test-level
+    // cleanup would block the user delete with an FK violation. This sweep
+    // catches all rows the test created, even when an assertion fails between
+    // create and per-test cleanup.
     if (testUserId) {
+      await db.delete(sessions).where(eq(sessions.userId, testUserId));
       await db.delete(users).where(eq(users.id, testUserId));
     }
     await client.end({ timeout: 2 });
@@ -83,7 +82,6 @@ describe.skipIf(shouldSkip)("wrapWithSessionTokenHash (integration)", () => {
 
   it("stores sha256(token) in the DB and round-trips lookups via raw token", async () => {
     const rawToken = `raw-token-${generateId()}`;
-    createdSessionTokens.push(rawToken);
     const expiresAt = new Date(Date.now() + 60_000);
 
     const created = await adapter.create<Record<string, unknown>>({
@@ -130,7 +128,6 @@ describe.skipIf(shouldSkip)("wrapWithSessionTokenHash (integration)", () => {
   it("findMany with operator: in hashes every value", async () => {
     const tokenA = `multi-a-${generateId()}`;
     const tokenB = `multi-b-${generateId()}`;
-    createdSessionTokens.push(tokenA, tokenB);
     const expiresAt = new Date(Date.now() + 60_000);
 
     for (const token of [tokenA, tokenB]) {

--- a/tests/unit/auth-session-token-hash.test.ts
+++ b/tests/unit/auth-session-token-hash.test.ts
@@ -194,6 +194,26 @@ describe("wrapWithSessionTokenHash", () => {
     });
   });
 
+  describe("count", () => {
+    it("hashes session token in eq where clause", async () => {
+      await wrapped.count({
+        model: "session",
+        where: [{ field: "token", value: RAW }],
+      });
+      const where = mocks.count.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(HASH);
+    });
+
+    it("passes through count for non-session models", async () => {
+      await wrapped.count({
+        model: "user",
+        where: [{ field: "token", value: RAW }],
+      });
+      const where = mocks.count.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(RAW);
+    });
+  });
+
   describe("update / updateMany", () => {
     it("hashes where token and any new token in the update payload", async () => {
       const newRaw = "rotated-token";

--- a/tests/unit/auth-session-token-hash.test.ts
+++ b/tests/unit/auth-session-token-hash.test.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import type { DBAdapter, Where } from "better-auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  hashSessionToken,
+  wrapWithSessionTokenHash,
+} from "@/lib/auth-session-token-hash";
+
+const RAW = "raw-session-token-abcdef0123456789";
+const HASH = createHash("sha256").update(RAW).digest("hex");
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+type Mock = ReturnType<typeof vi.fn>;
+
+type AdapterMocks = {
+  create: Mock;
+  findOne: Mock;
+  findMany: Mock;
+  count: Mock;
+  update: Mock;
+  updateMany: Mock;
+  delete: Mock;
+  deleteMany: Mock;
+};
+
+function buildInner(): { inner: DBAdapter; mocks: AdapterMocks } {
+  const mocks: AdapterMocks = {
+    create: vi.fn(async (data) => data.data),
+    findOne: vi.fn(async () => null),
+    findMany: vi.fn(async () => []),
+    count: vi.fn(async () => 0),
+    update: vi.fn(async () => null),
+    updateMany: vi.fn(async () => 0),
+    delete: vi.fn(async () => undefined),
+    deleteMany: vi.fn(async () => 0),
+  };
+  const inner: DBAdapter = {
+    id: "mock",
+    create: mocks.create,
+    findOne: mocks.findOne,
+    findMany: mocks.findMany,
+    count: mocks.count,
+    update: mocks.update,
+    updateMany: mocks.updateMany,
+    delete: mocks.delete,
+    deleteMany: mocks.deleteMany,
+    createSchema: undefined,
+    options: undefined,
+  } as unknown as DBAdapter;
+  return { inner, mocks };
+}
+
+function build(): { wrapped: DBAdapter; mocks: AdapterMocks } {
+  const { inner, mocks } = buildInner();
+  const factory = vi.fn(() => inner) as unknown as () => DBAdapter;
+  const wrappedFactory = wrapWithSessionTokenHash(factory);
+  const wrapped = wrappedFactory();
+  return { wrapped, mocks };
+}
+
+describe("hashSessionToken", () => {
+  it("returns hex-encoded sha256", () => {
+    expect(hashSessionToken(RAW)).toBe(HASH);
+    expect(hashSessionToken(RAW)).toMatch(SHA256_HEX_PATTERN);
+  });
+});
+
+describe("wrapWithSessionTokenHash", () => {
+  let wrapped: DBAdapter;
+  let mocks: AdapterMocks;
+
+  beforeEach(() => {
+    ({ wrapped, mocks } = build());
+  });
+
+  describe("create", () => {
+    it("hashes the token before storage and restores raw token in result", async () => {
+      mocks.create.mockImplementationOnce(
+        async (data: { data: Record<string, unknown> }) => ({
+          id: "sess-1",
+          ...data.data,
+        })
+      );
+
+      const result = await wrapped.create({
+        model: "session",
+        data: { token: RAW, userId: "u-1", expiresAt: new Date() },
+      });
+
+      expect(mocks.create).toHaveBeenCalledOnce();
+      const stored = mocks.create.mock.calls[0][0].data;
+      expect(stored.token).toBe(HASH);
+      expect((result as { token: string }).token).toBe(RAW);
+    });
+
+    it("does not touch creates for other models", async () => {
+      await wrapped.create({
+        model: "user",
+        data: { token: RAW, email: "x@y.z" },
+      });
+      expect(mocks.create.mock.calls[0][0].data.token).toBe(RAW);
+    });
+
+    it("passes through session creates that have no token field", async () => {
+      await wrapped.create({
+        model: "session",
+        data: { userId: "u-1", expiresAt: new Date() },
+      });
+      const stored = mocks.create.mock.calls[0][0].data;
+      expect(stored.token).toBeUndefined();
+    });
+  });
+
+  describe("findOne", () => {
+    it("hashes session token in eq where clause", async () => {
+      await wrapped.findOne({
+        model: "session",
+        where: [{ field: "token", value: RAW }],
+      });
+      const where = mocks.findOne.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(HASH);
+    });
+
+    it("hashes session token with explicit operator: eq", async () => {
+      await wrapped.findOne({
+        model: "session",
+        where: [{ field: "token", value: RAW, operator: "eq" }],
+      });
+      const where = mocks.findOne.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(HASH);
+    });
+
+    it("does not hash where clauses on non-token fields", async () => {
+      await wrapped.findOne({
+        model: "session",
+        where: [{ field: "id", value: RAW }],
+      });
+      const where = mocks.findOne.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(RAW);
+    });
+
+    it("ignores findOne for non-session models", async () => {
+      await wrapped.findOne({
+        model: "user",
+        where: [{ field: "token", value: RAW }],
+      });
+      const where = mocks.findOne.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(RAW);
+    });
+  });
+
+  describe("findMany", () => {
+    it("hashes each value in operator: in arrays", async () => {
+      const tokens = [RAW, "another-token"];
+      const expected = tokens.map(hashSessionToken);
+      await wrapped.findMany({
+        model: "session",
+        where: [{ field: "token", value: tokens, operator: "in" }],
+      });
+      const where = mocks.findMany.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toEqual(expected);
+    });
+  });
+
+  describe("update / updateMany", () => {
+    it("hashes where token and any new token in the update payload", async () => {
+      const newRaw = "rotated-token";
+      await wrapped.update({
+        model: "session",
+        where: [{ field: "token", value: RAW }],
+        update: { token: newRaw, expiresAt: new Date() },
+      });
+      const call = mocks.update.mock.calls[0][0];
+      expect((call.where as Where[])[0].value).toBe(HASH);
+      expect(call.update.token).toBe(hashSessionToken(newRaw));
+    });
+
+    it("updateMany hashes where clause", async () => {
+      await wrapped.updateMany({
+        model: "session",
+        where: [{ field: "token", value: RAW }],
+        update: { expiresAt: new Date() },
+      });
+      const where = mocks.updateMany.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(HASH);
+    });
+  });
+
+  describe("delete / deleteMany", () => {
+    it("hashes session token where clauses", async () => {
+      await wrapped.delete({
+        model: "session",
+        where: [{ field: "token", value: RAW }],
+      });
+      const where = mocks.delete.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(HASH);
+    });
+
+    it("deleteMany hashes session token where clauses", async () => {
+      await wrapped.deleteMany({
+        model: "session",
+        where: [{ field: "token", value: RAW }],
+      });
+      const where = mocks.deleteMany.mock.calls[0][0].where as Where[];
+      expect(where[0].value).toBe(HASH);
+    });
+  });
+});

--- a/tests/unit/auth-session-token-hash.test.ts
+++ b/tests/unit/auth-session-token-hash.test.ts
@@ -9,6 +9,9 @@ import {
 const RAW = "raw-session-token-abcdef0123456789";
 const HASH = createHash("sha256").update(RAW).digest("hex");
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+const UNSUPPORTED_OP_PATTERN = /operator "contains" is not supported/;
+const NON_STRING_VALUE_PATTERN = /must have a string value/;
+const NON_ARRAY_VALUE_PATTERN = /must have an array value/;
 
 type Mock = ReturnType<typeof vi.fn>;
 
@@ -147,6 +150,26 @@ describe("wrapWithSessionTokenHash", () => {
       const where = mocks.findOne.mock.calls[0][0].where as Where[];
       expect(where[0].value).toBe(RAW);
     });
+
+    it("throws on substring operators against the token field", async () => {
+      await expect(
+        wrapped.findOne({
+          model: "session",
+          where: [{ field: "token", value: RAW, operator: "contains" }],
+        })
+      ).rejects.toThrow(UNSUPPORTED_OP_PATTERN);
+      expect(mocks.findOne).not.toHaveBeenCalled();
+    });
+
+    it("throws on non-string values for token eq lookups", async () => {
+      await expect(
+        wrapped.findOne({
+          model: "session",
+          where: [{ field: "token", value: 12_345 }],
+        })
+      ).rejects.toThrow(NON_STRING_VALUE_PATTERN);
+      expect(mocks.findOne).not.toHaveBeenCalled();
+    });
   });
 
   describe("findMany", () => {
@@ -159,6 +182,15 @@ describe("wrapWithSessionTokenHash", () => {
       });
       const where = mocks.findMany.mock.calls[0][0].where as Where[];
       expect(where[0].value).toEqual(expected);
+    });
+
+    it("throws when operator: in receives a non-array value", async () => {
+      await expect(
+        wrapped.findMany({
+          model: "session",
+          where: [{ field: "token", value: RAW, operator: "in" }],
+        })
+      ).rejects.toThrow(NON_ARRAY_VALUE_PATTERN);
     });
   });
 


### PR DESCRIPTION
## Summary

Better-auth 1.5.6 stores `sessions.token` plaintext, so a DB leak hands an attacker live bearer tokens for every active user. This wraps the drizzle adapter so the column persists `sha256(token)` while the value returned from `adapter.create` (and therefore the cookie / bearer payload) stays as the raw token the client must present.

- New `wrapWithSessionTokenHash` helper in `lib/auth-session-token-hash.ts`. Hashes inbound `where`-clause values for `findOne` / `findMany` / `update` / `delete` (handles both `eq` and `in` operators) and any `token` field in update payloads. On `create`, hashes before storage and restores the raw token in the returned row so cookie signing keeps working.
- Migration `0064_keep_239_hash_session_tokens.sql` bulk-hashes existing rows in place. Cookies clients already hold remain valid because they still contain the raw token; the next request hashes it via the wrapper and matches the new column value. Idempotent (skips rows that already look like 64-char hex).
- Inline note added to `app/api/organizations/[organizationId]/leave/route.ts` flagging that `session.session?.token` is now the stored hash, not a bearer.

## Why a wrapper

Better-auth 1.5.6 exposes no first-class `hashSessionToken` option. The wrapper is coupled to two undocumented call shapes: `data.token` on `create`, and `where: [{ field: "token", value }]` on lookups. Worth filing upstream so we can drop the wrapper, but ship now.

## Tradeoffs / risks

- **Brief 401 window during rolling deploy**: between when the migration runs and when old pods are replaced, old pods will get `null` from `findSession` because the DB is now hashed. Accepted — users who hit refresh after the rollout are fine.
- **Coupling to better-auth internals**: the unit tests lock in the call-shape contract and the integration test exercises it against the real adapter, so a future better-auth bump that changes the shape trips a test rather than silently breaking auth in production.
- **`session.session.token` semantics changed**: it now contains the stored hash, not a bearer. Only one direct consumer (`leave/route.ts`); both sides of its `eq(sessions.token, sessionToken)` comparison are now hashes, so it works without code change. Comment added.

## Tests

- `tests/unit/auth-session-token-hash.test.ts` -- 13 unit tests covering every wrapper method, both `eq` and `in` operators, model isolation, and the `create`-return rewrite.
- `tests/e2e/vitest/auth-session-token-hash-integration.test.ts` -- 3 integration tests against real Postgres + real `drizzleAdapter`. Confirms hashes land in the DB, raw-token round-trips work, and `delete` by raw token removes the row.
- Migration validated end-to-end: applied via `pnpm db:migrate`, verified hashing of plaintext rows, second run is `UPDATE 0` (idempotent).

## Test plan

- [ ] CI green (lint, type-check, unit, integration)
- [ ] Confirm one existing logged-in session in staging continues to work after the migration applies
- [ ] Spot-check a fresh login: cookie value is opaque, DB column is 64-char hex
- [ ] Confirm bearer-plugin auth still works (CLI / programmatic)
- [ ] Watch staging for 401 spikes during the rollout window


## Follow-up (out of scope for this PR)

`accounts.accessToken`, `accounts.refreshToken`, `accounts.idToken`, and `accounts.password` (`lib/db/schema.ts:70-76`) are also stored plaintext. Same threat model as session tokens: a DB exfiltration yields live OAuth credentials and password hashes. Hashing doesn't apply directly to these (the values are presented to upstream OAuth providers verbatim, and `password` is presumably already bcrypted by better-auth) -- the right fix is at-rest encryption with KMS or pgcrypto. Worth a separate Linear ticket; flagging here so it doesn't drop on the floor.
