### PR TITLE
fix(metrics): group workflow error breakdown by org column reference

### DIFF
--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -111,17 +111,22 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
 
     // Per-org error breakdown: JOIN workflows + organization, LEFT JOIN so
     // anonymous workflows still contribute (under ANONYMOUS_ORG_SLUG).
-    const orgSlugExpr = sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`;
+    // GROUP BY uses the column reference (not the COALESCE expression):
+    // Drizzle would otherwise bind ANONYMOUS_ORG_SLUG as separate parameters
+    // in SELECT and GROUP BY clauses, and Postgres rejects the query because
+    // the two COALESCE expressions are not textually identical. Postgres
+    // groups all NULL slugs into one group (NULLs are equal in GROUP BY),
+    // and the SELECT-side COALESCE renders that group as ANONYMOUS_ORG_SLUG.
     const errorByOrg = await db
       .select({
-        orgSlug: orgSlugExpr,
+        orgSlug: sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`,
         count: count(),
       })
       .from(workflowExecutions)
       .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
       .leftJoin(organization, eq(workflows.organizationId, organization.id))
       .where(eq(workflowExecutions.status, "error"))
-      .groupBy(orgSlugExpr);
+      .groupBy(organization.slug);
 
     for (const row of errorByOrg) {
       stats.errorByOrgSlug[row.orgSlug] = Number(row.count) || 0;


### PR DESCRIPTION
Postgres rejects the per-org error query in production:

  column "organization.slug" must appear in the GROUP BY clause
  or be used in an aggregate function

Drizzle bound the ANONYMOUS_ORG_SLUG constant as separate parameters in the SELECT and GROUP BY clauses (params show "_anonymous" appearing twice), so the two COALESCE expressions weren't textually identical to Postgres -- it could only see COALESCE(slug, $1) vs COALESCE(slug, $3) and demanded that organization.slug itself be in the GROUP BY.

Group by the column reference directly instead. NULLs are equal in GROUP BY so all anonymous workflows still collapse into one row, and the SELECT-side COALESCE renders that row's slug as ANONYMOUS_ORG_SLUG.

Without this fix, the catch block at db-metrics.ts:144 swallowed the error and zeroed all workflow stats, which made
keeperhub_workflow_execution_errors_total disappear from /api/metrics entirely after deploy.