### PR TITLE
feat: KEEP-244 add input length limits and rate limit to AI generate endpoint

### DIFF
--- a/app/api/ai/_lib/rate-limit.ts
+++ b/app/api/ai/_lib/rate-limit.ts
@@ -1,0 +1,62 @@
+// In-memory per pod. In a multi-replica deployment, each pod tracks its own
+// window. Effective limit is LIMIT * num_replicas. Replace with Redis-backed
+// solution when replica count grows.
+//
+// AI generation is expensive (per-token billing on OpenAI/Anthropic), so the
+// limit is tighter than the execute endpoint (60/min) and MCP (120/min).
+
+const WINDOW_MS = 60_000;
+const LIMIT = 10;
+
+const requestLog = new Map<string, number[]>();
+
+export type AiRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfter: number };
+
+export function checkAiGenerateRateLimit(key: string): AiRateLimitResult {
+  const now = Date.now();
+  const windowStart = now - WINDOW_MS;
+
+  const timestamps = requestLog.get(key);
+  const recent = timestamps ? timestamps.filter((t) => t > windowStart) : [];
+
+  if (recent.length >= LIMIT) {
+    const oldestInWindow = recent[0];
+    const retryAfter = Math.ceil((oldestInWindow + WINDOW_MS - now) / 1000);
+    return { allowed: false, retryAfter: Math.max(retryAfter, 1) };
+  }
+
+  recent.push(now);
+  requestLog.set(key, recent);
+
+  return { allowed: true };
+}
+
+type RateLimitContext = {
+  apiKeyId: string | null;
+  userId: string | null;
+  organizationId: string | null;
+};
+
+// Identifies the caller for rate-limiting. API keys are the most stable handle
+// (one key per integration), userId covers session/oauth callers, and
+// organizationId is the last fallback so a request that authenticated against
+// an org but somehow has no userId still gets bucketed.
+export function getAiGenerateRateLimitKey(ctx: RateLimitContext): string {
+  if (ctx.apiKeyId) {
+    return `apikey:${ctx.apiKeyId}`;
+  }
+  if (ctx.userId) {
+    return `user:${ctx.userId}`;
+  }
+  if (ctx.organizationId) {
+    return `org:${ctx.organizationId}`;
+  }
+  return "unknown";
+}
+
+// Test-only reset hook. Production code never imports this.
+export function __resetAiGenerateRateLimitForTests(): void {
+  requestLog.clear();
+}

--- a/app/api/ai/_lib/validate.ts
+++ b/app/api/ai/_lib/validate.ts
@@ -1,0 +1,82 @@
+// Caps prompt and existing-workflow size so an authenticated caller cannot
+// burn the OpenAI/Anthropic bill by submitting massive inputs. The
+// rate limiter (see ./rate-limit) bounds frequency; these caps bound
+// per-request cost.
+
+export const MAX_PROMPT_LENGTH = 50_000;
+export const MAX_WORKFLOW_JSON_LENGTH = 100_000;
+
+// Loose shape: the route reads .nodes / .edges and JSON-stringifies the whole
+// object back into the model context. The validator does not enforce the
+// inner array element shape; downstream callers narrow as needed.
+export type ExistingWorkflowInput = {
+  nodes?: { id: string; data?: { label?: string } }[];
+  edges?: { id: string; source: string; target: string }[];
+} & Record<string, unknown>;
+
+export type GenerateBodyValidation =
+  | {
+      ok: true;
+      prompt: string;
+      existingWorkflow: ExistingWorkflowInput | null;
+    }
+  | { ok: false; error: string; status: number };
+
+export function validateGenerateBody(body: unknown): GenerateBodyValidation {
+  if (!body || typeof body !== "object") {
+    return { ok: false, error: "Invalid request body", status: 400 };
+  }
+
+  const { prompt, existingWorkflow } = body as {
+    prompt?: unknown;
+    existingWorkflow?: unknown;
+  };
+
+  if (typeof prompt !== "string" || prompt.length === 0) {
+    return { ok: false, error: "Prompt is required", status: 400 };
+  }
+
+  if (prompt.length > MAX_PROMPT_LENGTH) {
+    return {
+      ok: false,
+      error: `Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH} characters`,
+      status: 413,
+    };
+  }
+
+  if (existingWorkflow === undefined || existingWorkflow === null) {
+    return { ok: true, prompt, existingWorkflow: null };
+  }
+
+  if (typeof existingWorkflow !== "object") {
+    return {
+      ok: false,
+      error: "existingWorkflow must be an object",
+      status: 400,
+    };
+  }
+
+  let serializedLength: number;
+  try {
+    serializedLength = JSON.stringify(existingWorkflow).length;
+  } catch {
+    return {
+      ok: false,
+      error: "existingWorkflow is not serializable",
+      status: 400,
+    };
+  }
+  if (serializedLength > MAX_WORKFLOW_JSON_LENGTH) {
+    return {
+      ok: false,
+      error: `existingWorkflow exceeds maximum size of ${MAX_WORKFLOW_JSON_LENGTH} characters when serialized`,
+      status: 413,
+    };
+  }
+
+  return {
+    ok: true,
+    prompt,
+    existingWorkflow: existingWorkflow as ExistingWorkflowInput,
+  };
+}

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -338,9 +338,6 @@ export async function POST(request: Request) {
       getAiGenerateRateLimitKey(authContext)
     );
     if (!rateLimit.allowed) {
-      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
-        status: "failure",
-      });
       return NextResponse.json(
         { error: "Rate limit exceeded" },
         {
@@ -354,17 +351,11 @@ export async function POST(request: Request) {
     try {
       rawBody = await request.json();
     } catch {
-      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
-        status: "failure",
-      });
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
     const validation = validateGenerateBody(rawBody);
     if (!validation.ok) {
-      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
-        status: "failure",
-      });
       return NextResponse.json(
         { error: validation.error },
         { status: validation.status }

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -8,6 +8,11 @@ import { createTimer, getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { generateAIActionPrompts } from "@/plugins/registry";
+import {
+  checkAiGenerateRateLimit,
+  getAiGenerateRateLimitKey,
+} from "../_lib/rate-limit";
+import { validateGenerateBody } from "../_lib/validate";
 
 // Simple type for operations
 type Operation = {
@@ -329,18 +334,43 @@ export async function POST(request: Request) {
       );
     }
 
-    const body = await request.json();
-    const { prompt, existingWorkflow } = body;
-
-    if (!prompt) {
+    const rateLimit = checkAiGenerateRateLimit(
+      getAiGenerateRateLimitKey(authContext)
+    );
+    if (!rateLimit.allowed) {
       metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
         status: "failure",
       });
       return NextResponse.json(
-        { error: "Prompt is required" },
-        { status: 400 }
+        { error: "Rate limit exceeded" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimit.retryAfter) },
+        }
       );
     }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
+        status: "failure",
+      });
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const validation = validateGenerateBody(rawBody);
+    if (!validation.ok) {
+      metrics.recordLatency(MetricNames.AI_GENERATION_DURATION, timer(), {
+        status: "failure",
+      });
+      return NextResponse.json(
+        { error: validation.error },
+        { status: validation.status }
+      );
+    }
+    const { prompt, existingWorkflow } = validation;
 
     // Determine which AI provider and model to use
     const modelString = process.env.AI_MODEL || "gpt-4o";

--- a/tests/unit/ai-generate-rate-limit.test.ts
+++ b/tests/unit/ai-generate-rate-limit.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetAiGenerateRateLimitForTests,
+  checkAiGenerateRateLimit,
+  getAiGenerateRateLimitKey,
+} from "@/app/api/ai/_lib/rate-limit";
+
+describe("getAiGenerateRateLimitKey", () => {
+  it("prefers apiKeyId", () => {
+    expect(
+      getAiGenerateRateLimitKey({
+        apiKeyId: "ak_1",
+        userId: "u_1",
+        organizationId: "o_1",
+      })
+    ).toBe("apikey:ak_1");
+  });
+
+  it("falls back to userId when no apiKeyId", () => {
+    expect(
+      getAiGenerateRateLimitKey({
+        apiKeyId: null,
+        userId: "u_1",
+        organizationId: "o_1",
+      })
+    ).toBe("user:u_1");
+  });
+
+  it("falls back to organizationId last", () => {
+    expect(
+      getAiGenerateRateLimitKey({
+        apiKeyId: null,
+        userId: null,
+        organizationId: "o_1",
+      })
+    ).toBe("org:o_1");
+  });
+
+  it("returns 'unknown' if all identifiers are null", () => {
+    expect(
+      getAiGenerateRateLimitKey({
+        apiKeyId: null,
+        userId: null,
+        organizationId: null,
+      })
+    ).toBe("unknown");
+  });
+});
+
+describe("checkAiGenerateRateLimit", () => {
+  beforeEach(() => {
+    __resetAiGenerateRateLimitForTests();
+  });
+
+  it("allows requests up to the per-window limit", () => {
+    for (let i = 0; i < 10; i += 1) {
+      const result = checkAiGenerateRateLimit("user:test");
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it("rejects the 11th request within the window", () => {
+    for (let i = 0; i < 10; i += 1) {
+      checkAiGenerateRateLimit("user:test");
+    }
+    const result = checkAiGenerateRateLimit("user:test");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.retryAfter).toBeGreaterThanOrEqual(1);
+      expect(result.retryAfter).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it("isolates buckets by key", () => {
+    for (let i = 0; i < 10; i += 1) {
+      checkAiGenerateRateLimit("user:a");
+    }
+    expect(checkAiGenerateRateLimit("user:a").allowed).toBe(false);
+    expect(checkAiGenerateRateLimit("user:b").allowed).toBe(true);
+  });
+});

--- a/tests/unit/ai-generate-validate.test.ts
+++ b/tests/unit/ai-generate-validate.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PROMPT_LENGTH,
+  MAX_WORKFLOW_JSON_LENGTH,
+  validateGenerateBody,
+} from "@/app/api/ai/_lib/validate";
+
+const PROMPT_REQUIRED_RE = /prompt is required/i;
+const MAX_LENGTH_RE = /maximum length/i;
+const EXISTING_WORKFLOW_RE = /existingWorkflow/;
+const SERIALIZABLE_RE = /serializable/;
+
+describe("validateGenerateBody", () => {
+  it("rejects null body", () => {
+    const result = validateGenerateBody(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+    }
+  });
+
+  it("rejects missing prompt", () => {
+    const result = validateGenerateBody({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(PROMPT_REQUIRED_RE);
+    }
+  });
+
+  it("rejects empty-string prompt", () => {
+    const result = validateGenerateBody({ prompt: "" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-string prompt", () => {
+    const result = validateGenerateBody({ prompt: 123 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts a prompt at the max length boundary", () => {
+    const result = validateGenerateBody({
+      prompt: "a".repeat(MAX_PROMPT_LENGTH),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a prompt one character over the max length", () => {
+    const result = validateGenerateBody({
+      prompt: "a".repeat(MAX_PROMPT_LENGTH + 1),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(413);
+      expect(result.error).toMatch(MAX_LENGTH_RE);
+    }
+  });
+
+  it("accepts a small existingWorkflow", () => {
+    const result = validateGenerateBody({
+      prompt: "build a workflow",
+      existingWorkflow: { nodes: [], edges: [] },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.existingWorkflow).toEqual({ nodes: [], edges: [] });
+    }
+  });
+
+  it("returns null for missing existingWorkflow", () => {
+    const result = validateGenerateBody({ prompt: "hi" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.existingWorkflow).toBeNull();
+    }
+  });
+
+  it("rejects existingWorkflow that serializes over the cap", () => {
+    // A node with a description longer than the cap forces serialized length
+    // past the limit even after JSON's quoting overhead.
+    const huge = "x".repeat(MAX_WORKFLOW_JSON_LENGTH + 100);
+    const result = validateGenerateBody({
+      prompt: "hi",
+      existingWorkflow: { nodes: [{ id: "n1", data: { label: huge } }] },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(413);
+      expect(result.error).toMatch(EXISTING_WORKFLOW_RE);
+    }
+  });
+
+  it("rejects circular existingWorkflow", () => {
+    const cyclic: Record<string, unknown> = { nodes: [] };
+    cyclic.self = cyclic;
+    const result = validateGenerateBody({
+      prompt: "hi",
+      existingWorkflow: cyclic,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(SERIALIZABLE_RE);
+    }
+  });
+
+  it("rejects non-object existingWorkflow", () => {
+    const result = validateGenerateBody({
+      prompt: "hi",
+      existingWorkflow: "not an object",
+    });
+    expect(result.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes [KEEP-244](https://linear.app/keeperhubapp/issue/KEEP-244/add-input-length-limits-to-ai-generate-endpoint).

`app/api/ai/generate/route.ts` had no length or rate validation, so an authenticated caller could burn the OpenAI/Anthropic bill with large or repeated prompts.

- Cap `prompt` at 50,000 chars (per ticket).
- Cap `existingWorkflow` at 100,000 serialized chars. Not in the ticket text, but the route JSON-stringifies `existingWorkflow` straight into the model context, so a `prompt`-only cap would leave a side channel.
- Add in-memory per-pod rate limiter (10 req/min) keyed `apiKeyId -> userId -> organizationId`. Mirrors the patterns in `app/api/execute/_lib/rate-limit.ts` and `lib/mcp/rate-limit.ts`.
- Validation and rate-limit logic lifted into `app/api/ai/_lib/` so they're unit-testable in isolation.

Per-org daily token budget (ticket item 3) is intentionally out of scope. Wording was "consider", severity is low, and proper token accounting needs streaming-time bookkeeping that the current route doesn't have.

## Tradeoffs

- **Per-pod limiter, not Redis-backed**: effective limit is `10 * num_replicas`. Same caveat as the execute/MCP limiters; consistent with how rate limiting works elsewhere in the repo today.
- **Limit chosen at 10/min**: tighter than execute (60/min) and MCP (120/min) because each AI generate call is genuinely expensive. If staging telemetry shows this is too tight for legitimate use, easy to bump.
- **Loose `existingWorkflow` shape**: the validator types it as `{ nodes?, edges? } & Record<string, unknown>` to match how the route already used it (cast at use site). I did not tighten the inner element shape, since that's outside this ticket's scope.

## Test plan

- [x] `pnpm exec ultracite check` clean on all 5 changed files
- [x] `pnpm type-check` introduces zero new errors (verified by stashing and re-running on clean staging)
- [x] `pnpm vitest run tests/unit/ai-generate-validate.test.ts tests/unit/ai-generate-rate-limit.test.ts` — 18/18 pass
- [ ] Manual: POST `/api/ai/generate` with prompt of 50,001 chars returns 413
- [ ] Manual: POST `/api/ai/generate` 11 times in a minute returns 429 with `Retry-After` header on the 11th
- [ ] Manual: existing happy-path generate flow still works