### PR TITLE
fix(x402): include domain extra fields in PAYMENT-REQUIRED challenge

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -14,6 +14,54 @@
 
 ---
 
-## Next Milestone
+## Current Milestone: v1.10 Agentic Wallet & Marketplace Plumbing
 
-Run `/gsd-new-milestone` to define v1.10 goals, research the domain, write requirements, and create the roadmap.
+**Goal:** Close two gaps blocking agent-to-marketplace flows: fix the broken x402 signing path in `@keeperhub/wallet`, give agents per-call protocol selection (x402 vs MPP), and expose the full curator lifecycle for workflow listings via MCP so agents can manage their marketplace presence without UI clicks.
+
+## Phases
+
+- [ ] **Phase 40: Agentic Wallet — x402 Fix + Payment Hint** - Diagnose and fix `verification-failed` for fresh sub-orgs; add `paymentHint` override to `signer.fetch`/`pay`; one npm version bump, one PR (agentic-wallet repo)
+- [ ] **Phase 41: Marketplace MCP Curator Tools** - Add four MCP curator tools (`list_workflow`, `unlist_workflow`, `update_workflow_listing`, `get_workflow_listing`) backed by new listing routes; one PR to staging (keeperhub repo)
+
+---
+
+## Phase Details
+
+### Phase 40: Agentic Wallet — x402 Fix + Payment Hint
+**Goal**: Any provisioned agentic-wallet sub-org can complete an x402 payment end-to-end, and agents can select x402 or MPP per call with a typed `paymentHint` field
+**Depends on**: Nothing (first phase of v1.10; Phase 41 can run concurrently — no code dependency)
+**Requirements**: WX402-01, WX402-02, WX402-03, WX402-04, WX402-05, WX402-06, WHINT-01, WHINT-02, WHINT-03, WHINT-04, WHINT-05, WHINT-06, TEST-01 (Phase A portion)
+**Success Criteria** (what must be TRUE):
+  1. A fresh agentic-wallet sub-org provisioned same-day, never previously used for x402, completes `paymentSigner.fetch(...)` against a KeeperHub x402-gated workflow and receives 200 — not a 402 with `verification-failed`
+  2. An agent calling `signer.fetch(url, { paymentHint: "mpp" })` on a resource that offers only MPP pays via MPP; calling with `paymentHint: "x402"` on a resource that offers only x402 pays via x402; requesting a protocol not in the 402 challenge throws a typed `KeeperHubError` with the appropriate code (`X402_NOT_OFFERED` or `MPP_NOT_OFFERED`)
+  3. All 9 cases in the hint x challenge-availability matrix (3 hints: auto/x402/mpp, times 3 availability states: x402-only/mpp-only/both) pass unit tests and produce no regressions on the `auto` (default) path
+  4. Seven named test files pass with no skips: `payment-signer-x402-payload.test.ts`, `sign-x402-challenge.test.ts`, `x402-domain-version.test.ts`, `mpp-attribution-memo.test.ts`, `payment-signer-hint.test.ts`, `payment-hint.test.ts`, `x402-repro.test.ts`
+  5. Work is fully verified on local dev server (pnpm dev + pnpm link or npm pack) before the PR is opened; trace logging added during diagnostics is removed before merge
+**Plans**: 4 plans
+Plans:
+- [ ] 40-01-PLAN.md — 4-step EIP-712 diagnostic: log grep, trace patch, x402-repro.test.ts harness, fresh-wallet CDP smoke test
+- [ ] 40-02-PLAN.md — KEEP-364 fix (conditional on confirmed suspect) + four named regression-guard tests (WX402-03..06)
+- [ ] 40-03-PLAN.md — KEEP-361 paymentHint: PaymentHint type, FetchInit, selectProtocol pure function, 9-case test matrix
+- [ ] 40-04-PLAN.md — Trace logging removal, npm version bump to 0.2.0, build, local link, end-to-end smoke test, hand-off summary
+
+### Phase 41: Marketplace MCP Curator Tools
+**Goal**: Agents can list, unlist, update, and inspect workflow listings programmatically via MCP without any UI interaction
+**Depends on**: Phase 40 is a logical predecessor (x402 fix unblocks paid testing of listed workflows) but there is no code dependency — Phase 41 can be coded concurrently in the keeperhub repo
+**Requirements**: MLIST-01, MLIST-02, MLIST-03, MLIST-04, MLIST-05, MLIST-06, MLIST-07, MLIST-08, MLIST-09, MLIST-10, TEST-01 (Phase B portion)
+**Success Criteria** (what must be TRUE):
+  1. An MCP agent can call `list_workflow(workflowId, metadata)` and the workflow immediately appears in the public `GET /api/mcp/workflows` catalog with `isListed=true` and an assigned `listedSlug` — no UI clicks required
+  2. An MCP agent can call `unlist_workflow(workflowId)` and the workflow is removed from the catalog (`isListed=false`), then call `list_workflow` again and the original `listedSlug` is preserved and `listedAt` is refreshed — confirmed by the list/unlist/relist integration test
+  3. Calling `update_workflow_listing` to change `priceUsdcPerCall` while the workflow is listed returns 409 `PRICE_CHANGE_WHILE_LISTED`; a slug collision returns 409 `SLUG_CONFLICT`; accessing another org's workflow ID returns 404
+  4. `get_workflow_listing(slug)` is publicly accessible, IP-rate-limited, and returns `Cache-Control: public, max-age=60` — no auth required for reads
+  5. Four named test files pass with no skips: `mcp-curator-tools.test.ts`, `workflow-listing-lifecycle.test.ts`, `mcp-curator-slug.test.ts`, `mcp-curator-price-change.test.ts`
+**Plans**: TBD
+**UI hint**: yes
+
+---
+
+## Progress Table
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 40. Agentic Wallet — x402 Fix + Payment Hint | 0/4 | Planned | - |
+| 41. Marketplace MCP Curator Tools | 0/? | Not started | - |

--- a/lib/payments/x402/payment-gate.ts
+++ b/lib/payments/x402/payment-gate.ts
@@ -52,6 +52,12 @@ export function buildPaymentConfig(
       network: "eip155:8453",
       payTo: creatorWalletAddress,
       price: `$${price.toFixed(2)}`,
+      // extra.name and extra.version are required by @x402/evm verifyEIP3009 to
+      // reconstruct the EIP-712 domain. Without these fields the CDP facilitator
+      // throws "EIP-712 domain parameters (name, version) are required" and the
+      // payment surfaces as verification-failed for all callers (KEEP-364).
+      // Values must match BASE_USDC_DOMAIN in lib/agentic-wallet/sign.ts exactly.
+      extra: { name: "USD Coin", version: "2" } as const,
     },
     resource: `${publicHost}/api/mcp/workflows/${workflow.listedSlug}/call`,
     description: `Pay to run workflow: ${workflow.name}`,

--- a/tests/unit/build-payment-config-extra-domain.test.ts
+++ b/tests/unit/build-payment-config-extra-domain.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildPaymentConfig } from "@/lib/payments/x402/payment-gate";
+
+const mockWorkflow = {
+  priceUsdcPerCall: "1.00",
+  listedSlug: "my-workflow",
+  name: "My Workflow",
+};
+
+describe("buildPaymentConfig extra domain fields", () => {
+  it("accepts.extra.name is 'USD Coin' (required for CDP facilitator EIP-712 verification)", () => {
+    const config = buildPaymentConfig(
+      mockWorkflow as Parameters<typeof buildPaymentConfig>[0],
+      "0x1234000000000000000000000000000000005678"
+    );
+    const accepts = config.accepts as unknown as Record<string, unknown>;
+    expect((accepts.extra as Record<string, unknown> | undefined)?.name).toBe(
+      "USD Coin"
+    );
+  });
+
+  it("accepts.extra.version is '2' (must match BASE_USDC_DOMAIN.version in sign.ts)", () => {
+    const config = buildPaymentConfig(
+      mockWorkflow as Parameters<typeof buildPaymentConfig>[0],
+      "0x1234000000000000000000000000000000005678"
+    );
+    const accepts = config.accepts as unknown as Record<string, unknown>;
+    expect(
+      (accepts.extra as Record<string, unknown> | undefined)?.version
+    ).toBe("2");
+  });
+});


### PR DESCRIPTION
## Summary

- The CDP x402 facilitator (`@x402/evm@2.9.0`) reads EIP-712 domain `name` and `version` from `requirements.extra.name` / `requirements.extra.version` in the PAYMENT-REQUIRED challenge. Our `buildPaymentConfig` was emitting `extra: {}`, causing the facilitator to throw "EIP-712 domain parameters required" before any signature verification — surfacing as `verification-failed` for every fresh Turnkey sub-org.
- Adds `extra: { name: "USD Coin", version: "2" }` to the x402 `accepts` entry built by `buildPaymentConfig`, plus a unit test pinning the field shape so it cannot regress silently.

## Why now

Reported in KEEP-364 by @luca on 2026-04-27. Reproduces 100% with any fresh sub-org against staging or prod. Blocks the agentic-wallet → x402 path for new wallets while old wallets continue to work (because they were issued challenges before the domain-version check shipped in `@x402/evm@2.9.0`).

## Diagnostic

Confirmed via offline EIP-712 harness in \`@keeperhub/wallet\` (\`src/__tests__/x402-repro.test.ts\`) using \`viem.hashTypedData\` + \`recoverTypedDataAddress\`. Three competing root-cause hypotheses (domain-extra mismatch vs EIP-55 case mismatch vs uint256 string drift) were tested side-by-side. Suspect 1 (this fix) is the only one mechanistically consistent with \`@x402/evm@2.9.0\` source — the other two harness checks pass cleanly today.

## Test plan

- [x] New unit test: \`tests/unit/build-payment-config-extra-domain.test.ts\` asserts \`accepts[0].extra.name === "USD Coin"\` and \`extra.version === "2"\`.
- [x] Local smoke against \`pnpm dev\`: \`curl -X POST http://localhost:3000/api/mcp/workflows/x402-echo-test/call\` → 402 body now contains \`accepts[0].extra = {name: "USD Coin", version: "2"}\`.
- [ ] Live CDP smoke (post-merge): provision a fresh Turnkey sub-org against staging, fund with USDC on Base, run \`paymentSigner.fetch(paid-workflow-url)\` via \`@keeperhub/wallet@>=0.2.0\`, expect 200 instead of \`verification-failed\`.

## Linear

Closes KEEP-364.