### PR TITLE
fix: KEEP-379 show enable toggle for webhook workflows

### DIFF
--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -198,6 +198,7 @@ export async function POST(request: Request) {
         isAnonymous,
         projectId: body.projectId || null,
         tagId: body.tagId || null,
+        ...(typeof body.enabled === "boolean" ? { enabled: body.enabled } : {}),
       })
       .returning();
 

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1349,7 +1349,7 @@ function ToolbarActions({
   };
 
   const triggerType = state.nodes.find((node) => node?.data?.type === "trigger")
-    ?.data?.config?.triggerType;
+    ?.data?.config?.triggerType as WorkflowTriggerEnum;
 
   const shouldDisplayEnableWorkflowSwitch = shouldShowEnableSwitch(triggerType);
 

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -78,6 +78,7 @@ import {
   selectedEdgeAtom,
   selectedExecutionIdAtom,
   selectedNodeAtom,
+  shouldShowEnableSwitch,
   triggerExecuteAtom,
   undoAtom,
   updateNodeDataAtom,
@@ -1350,10 +1351,7 @@ function ToolbarActions({
   const triggerType = state.nodes.find((node) => node?.data?.type === "trigger")
     ?.data?.config?.triggerType;
 
-  const shouldDisplayEnableWorkflowSwitch =
-    triggerType === WorkflowTriggerEnum.EVENT ||
-    triggerType === WorkflowTriggerEnum.SCHEDULE ||
-    triggerType === WorkflowTriggerEnum.BLOCK;
+  const shouldDisplayEnableWorkflowSwitch = shouldShowEnableSwitch(triggerType);
 
   return (
     <>

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -98,7 +98,7 @@ Each server entry has its own tool namespace, so the AI agent can distinguish wh
 | `list_workflows` | List all workflows in the organization. Accepts `limit` and `offset` for pagination. |
 | `get_workflow` | Get full workflow configuration by ID including nodes and edges. |
 | `create_workflow` | Create a workflow with explicit nodes and edges. Call `list_action_schemas` first to get valid action types. |
-| `update_workflow` | Update a workflow's name, description, nodes, or edges. |
+| `update_workflow` | Update a workflow's name, description, nodes, edges, or enabled state. Pass `enabled: false` to halt schedule, event, block, or webhook triggers without deleting the workflow. |
 | `delete_workflow` | Permanently delete a workflow and stop all its executions. Use `force: true` to delete workflows with execution history (cascades to all runs and logs). |
 
 ### Execution

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -140,7 +140,7 @@ export function registerTools(
 
   server.tool(
     "create_workflow",
-    "Create a new workflow with nodes and edges. Nodes define the trigger and actions; edges define the execution flow.",
+    "Create a new workflow with nodes and edges. Nodes define the trigger and actions; edges define the execution flow. Workflows are created disabled by default; pass enabled=true to make schedule/event/block/webhook triggers fire immediately.",
     {
       name: z.string().describe("Workflow name"),
       description: z
@@ -153,6 +153,12 @@ export function registerTools(
       edges: z
         .array(z.record(z.string(), z.unknown()))
         .describe("Workflow edges connecting nodes"),
+      enabled: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the workflow is active on creation. Defaults to false; non-manual triggers stay dormant until enabled."
+        ),
       projectId: z
         .string()
         .optional()
@@ -175,6 +181,7 @@ export function registerTools(
             description: args.description,
             nodes: args.nodes,
             edges: args.edges,
+            enabled: args.enabled,
             projectId: args.projectId,
             tagId: args.tagId,
           }
@@ -188,7 +195,7 @@ export function registerTools(
 
   server.tool(
     "update_workflow",
-    "Update an existing workflow's name, description, nodes, edges, or project/tag assignment.",
+    "Update an existing workflow's name, description, nodes, edges, project/tag assignment, or enabled state. Set enabled=false to stop scheduled/event/block/webhook triggers from firing without deleting the workflow.",
     {
       workflowId: z.string().describe("The workflow ID to update"),
       name: z.string().optional().describe("New workflow name"),
@@ -201,6 +208,12 @@ export function registerTools(
         .array(z.record(z.string(), z.unknown()))
         .optional()
         .describe("Updated workflow edges"),
+      enabled: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the workflow is active. Disabled workflows are skipped by schedule/event/block triggers and webhook calls return 410 Gone."
+        ),
       projectId: z
         .string()
         .nullable()

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -18,6 +18,21 @@ export enum WorkflowTriggerEnum {
 
 export type WorkflowTriggerType = `${WorkflowTriggerEnum}`;
 
+// Trigger types that need a UI toggle to flip `workflows.enabled`.
+// Server-side gates (schedule/event/block/webhook) all check this column,
+// so a disabled workflow keeps the trigger registered but rejects executions.
+// Manual triggers don't fire on their own, so the switch isn't needed there.
+export function shouldShowEnableSwitch(
+  triggerType: WorkflowTriggerType | undefined
+): boolean {
+  return (
+    triggerType === WorkflowTriggerEnum.EVENT ||
+    triggerType === WorkflowTriggerEnum.SCHEDULE ||
+    triggerType === WorkflowTriggerEnum.BLOCK ||
+    triggerType === WorkflowTriggerEnum.WEBHOOK
+  );
+}
+
 export type WorkflowNodeData = {
   label: string;
   description?: string;

--- a/tests/e2e/playwright/webhook-enable-toggle.test.ts
+++ b/tests/e2e/playwright/webhook-enable-toggle.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "./fixtures";
+import { waitForCanvas } from "./utils/workflow";
+
+const ENABLE_BUTTON_REGEX = /^(Enable|Disable) workflow$/;
+
+async function selectTriggerType(
+  page: import("@playwright/test").Page,
+  optionLabel: string
+): Promise<void> {
+  const triggerNode = page.locator(".react-flow__node-trigger").first();
+  await expect(triggerNode).toBeVisible({ timeout: 10_000 });
+  await triggerNode.click();
+
+  const triggerTypeSelect = page.locator("#triggerType");
+  await expect(triggerTypeSelect).toBeVisible({ timeout: 5000 });
+  await triggerTypeSelect.click();
+
+  const option = page.getByRole("option", { name: optionLabel });
+  await expect(option).toBeVisible({ timeout: 3000 });
+  await option.click();
+}
+
+test.describe("Workflow enable/disable toggle visibility by trigger type", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForCanvas(page);
+  });
+
+  test("toggle is visible for Webhook trigger", async ({ page }) => {
+    await selectTriggerType(page, "Webhook");
+    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("toggle is visible for Schedule trigger", async ({ page }) => {
+    await selectTriggerType(page, "Schedule");
+    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("toggle is visible for Event trigger", async ({ page }) => {
+    await selectTriggerType(page, "Event");
+    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("toggle is visible for Block trigger", async ({ page }) => {
+    await selectTriggerType(page, "Block");
+    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("toggle is hidden for Manual trigger", async ({ page }) => {
+    await selectTriggerType(page, "Manual");
+    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toHaveCount(0);
+  });
+});

--- a/tests/e2e/playwright/webhook-enable-toggle.test.ts
+++ b/tests/e2e/playwright/webhook-enable-toggle.test.ts
@@ -1,61 +1,48 @@
 import { expect, test } from "./fixtures";
+import {
+  createTestWorkflow,
+  deleteTestWorkflow,
+  PERSISTENT_TEST_USER_EMAIL,
+  type WorkflowTriggerType,
+} from "./utils/db";
 import { waitForCanvas } from "./utils/workflow";
 
 const ENABLE_BUTTON_REGEX = /^(Enable|Disable) workflow$/;
 
-async function selectTriggerType(
+async function loadWorkflowWithTrigger(
   page: import("@playwright/test").Page,
-  optionLabel: string
-): Promise<void> {
-  const triggerNode = page.locator(".react-flow__node-trigger").first();
-  await expect(triggerNode).toBeVisible({ timeout: 10_000 });
-  await triggerNode.click();
-
-  const triggerTypeSelect = page.locator("#triggerType");
-  await expect(triggerTypeSelect).toBeVisible({ timeout: 5000 });
-  await triggerTypeSelect.click();
-
-  const option = page.getByRole("option", { name: optionLabel });
-  await expect(option).toBeVisible({ timeout: 3000 });
-  await option.click();
+  triggerType: WorkflowTriggerType
+): Promise<string> {
+  const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+    name: `enable-toggle-${triggerType}-${Date.now()}`,
+    triggerType,
+    enabled: false,
+  });
+  await page.goto(`/workflows/${workflow.id}`, { waitUntil: "domcontentloaded" });
+  await waitForCanvas(page);
+  return workflow.id;
 }
 
 test.describe("Workflow enable/disable toggle visibility by trigger type", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/", { waitUntil: "domcontentloaded" });
-    await waitForCanvas(page);
-  });
-
   test("toggle is visible for Webhook trigger", async ({ page }) => {
-    await selectTriggerType(page, "Webhook");
+    const id = await loadWorkflowWithTrigger(page, "webhook");
     await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
-      timeout: 5000,
+      timeout: 10_000,
     });
+    await deleteTestWorkflow(id);
   });
 
   test("toggle is visible for Schedule trigger", async ({ page }) => {
-    await selectTriggerType(page, "Schedule");
+    const id = await loadWorkflowWithTrigger(page, "schedule");
     await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
-      timeout: 5000,
+      timeout: 10_000,
     });
-  });
-
-  test("toggle is visible for Event trigger", async ({ page }) => {
-    await selectTriggerType(page, "Event");
-    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
-      timeout: 5000,
-    });
-  });
-
-  test("toggle is visible for Block trigger", async ({ page }) => {
-    await selectTriggerType(page, "Block");
-    await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toBeVisible({
-      timeout: 5000,
-    });
+    await deleteTestWorkflow(id);
   });
 
   test("toggle is hidden for Manual trigger", async ({ page }) => {
-    await selectTriggerType(page, "Manual");
+    const id = await loadWorkflowWithTrigger(page, "manual");
     await expect(page.getByTitle(ENABLE_BUTTON_REGEX)).toHaveCount(0);
+    await deleteTestWorkflow(id);
   });
 });

--- a/tests/unit/mcp-workflow-enabled.test.ts
+++ b/tests/unit/mcp-workflow-enabled.test.ts
@@ -69,12 +69,15 @@ describe("MCP workflow tools accept enabled flag", () => {
   });
 
   it("update_workflow handler forwards enabled to the workflow PATCH endpoint", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ id: "wf-1", enabled: true }),
-      text: async () => "",
-    }));
+    const fetchMock = vi.fn(
+      async (_url: string, _init: RequestInit) =>
+        ({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ id: "wf-1", enabled: true }),
+          text: async () => "",
+        }) as unknown as Response
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const tool = await findTool("update_workflow");
@@ -89,12 +92,15 @@ describe("MCP workflow tools accept enabled flag", () => {
   });
 
   it("create_workflow handler forwards enabled to the workflow create endpoint", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ id: "wf-2", enabled: true }),
-      text: async () => "",
-    }));
+    const fetchMock = vi.fn(
+      async (_url: string, _init: RequestInit) =>
+        ({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ id: "wf-2", enabled: true }),
+          text: async () => "",
+        }) as unknown as Response
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const tool = await findTool("create_workflow");

--- a/tests/unit/mcp-workflow-enabled.test.ts
+++ b/tests/unit/mcp-workflow-enabled.test.ts
@@ -1,0 +1,115 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { z } from "zod";
+
+type ToolRegistration = {
+  name: string;
+  schema: Record<string, z.ZodTypeAny>;
+  handler: (...args: unknown[]) => unknown;
+};
+
+function makeMockServer(): {
+  server: McpServer;
+  registeredTools: ToolRegistration[];
+} {
+  const registeredTools: ToolRegistration[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        _description: string,
+        schema: Record<string, z.ZodTypeAny>,
+        _annotations: unknown,
+        handler: (...args: unknown[]) => unknown
+      ) => {
+        registeredTools.push({ name, schema, handler });
+      }
+    ),
+  } as unknown as McpServer;
+  return { server, registeredTools };
+}
+
+async function findTool(name: string): Promise<ToolRegistration> {
+  const { server, registeredTools } = makeMockServer();
+  const { registerTools } = await import("@/lib/mcp/tools");
+  registerTools(server, "http://localhost:3000", "Bearer test-token");
+  const tool = registeredTools.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`tool ${name} was not registered`);
+  }
+  return tool;
+}
+
+describe("MCP workflow tools accept enabled flag", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("update_workflow schema accepts an optional enabled boolean", async () => {
+    const tool = await findTool("update_workflow");
+    expect(tool.schema.enabled).toBeDefined();
+
+    const enabledField = tool.schema.enabled;
+    expect(enabledField.safeParse(true).success).toBe(true);
+    expect(enabledField.safeParse(false).success).toBe(true);
+    expect(enabledField.safeParse(undefined).success).toBe(true);
+    expect(enabledField.safeParse("true").success).toBe(false);
+  });
+
+  it("create_workflow schema accepts an optional enabled boolean", async () => {
+    const tool = await findTool("create_workflow");
+    expect(tool.schema.enabled).toBeDefined();
+
+    const enabledField = tool.schema.enabled;
+    expect(enabledField.safeParse(true).success).toBe(true);
+    expect(enabledField.safeParse(false).success).toBe(true);
+    expect(enabledField.safeParse(undefined).success).toBe(true);
+    expect(enabledField.safeParse(0).success).toBe(false);
+  });
+
+  it("update_workflow handler forwards enabled to the workflow PATCH endpoint", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ id: "wf-1", enabled: true }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = await findTool("update_workflow");
+    await tool.handler({ workflowId: "wf-1", enabled: true });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/api/workflows/wf-1");
+    expect(init.method).toBe("PATCH");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.enabled).toBe(true);
+  });
+
+  it("create_workflow handler forwards enabled to the workflow create endpoint", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ id: "wf-2", enabled: true }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = await findTool("create_workflow");
+    await tool.handler({
+      name: "Test",
+      nodes: [],
+      edges: [],
+      enabled: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/api/workflows/create");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.enabled).toBe(true);
+  });
+});

--- a/tests/unit/workflow-enable-switch.test.ts
+++ b/tests/unit/workflow-enable-switch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldShowEnableSwitch,
+  WorkflowTriggerEnum,
+} from "@/lib/workflow/store";
+
+describe("shouldShowEnableSwitch", () => {
+  it.each([
+    WorkflowTriggerEnum.EVENT,
+    WorkflowTriggerEnum.SCHEDULE,
+    WorkflowTriggerEnum.BLOCK,
+    WorkflowTriggerEnum.WEBHOOK,
+  ])("returns true for %s triggers (server gates on workflows.enabled)", (trigger) => {
+    expect(shouldShowEnableSwitch(trigger)).toBe(true);
+  });
+
+  it("returns false for Manual triggers (no scheduled invocation to disable)", () => {
+    expect(shouldShowEnableSwitch(WorkflowTriggerEnum.MANUAL)).toBe(false);
+  });
+
+  it("returns false when no trigger is configured yet", () => {
+    expect(shouldShowEnableSwitch(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The workflow toolbar gated the Enable/Disable switch on Schedule, Event, and Block trigger types only. Webhook-triggered workflows hit the same server-side `enabled` gate (the route at `app/api/workflows/[workflowId]/webhook/route.ts` returns 410 Gone when `workflows.enabled` is false), but the editor exposed no UI control to flip the flag back on, leaving users stuck after a workflow had been disabled. MCP clients had the same gap on the API side: neither `create_workflow` nor `update_workflow` exposed `enabled`, so an agent could author a workflow but not activate (or pause) it.

## Changes

- Toolbar: extract the gating predicate into `shouldShowEnableSwitch` next to `WorkflowTriggerEnum` and include `WEBHOOK`; wire the toolbar through the new helper.
- MCP tools: add an optional `enabled?: boolean` to `update_workflow` and `create_workflow` and forward it in the underlying API call.
- Workflow create endpoint: thread `enabled` from the request body into the insert so `create_workflow` can author and activate in a single call.
- Docs: update `docs/ai-tools/mcp-server.md` to mention the new `enabled` argument on `update_workflow`.
- Tests: unit coverage for `shouldShowEnableSwitch`, unit coverage for the `enabled` passthrough on both MCP tools, and a Playwright test that injects workflows by trigger type and asserts toggle visibility in the toolbar.

Linear: https://linear.app/keeperhubapp/issue/KEEP-379