### PR TITLE
fix: point 0G chainscan explorer config at Etherscan-compat API

### DIFF
--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -674,25 +674,25 @@ const EXPLORER_CONFIG_TEMPLATES: Record<
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}#code",
   },
-  // 0G Mainnet - Blockscout (0G ChainScan)
+  // 0G Mainnet - ConfluxScan-derived explorer with Etherscan-compat API at /open/api
   16661: {
     chainType: "evm",
     explorerUrl: "https://chainscan.0g.ai",
-    explorerApiType: "blockscout",
-    explorerApiUrl: "https://chainscan.0g.ai/api",
+    explorerApiType: "etherscan",
+    explorerApiUrl: "https://chainscan.0g.ai/open/api",
     explorerTxPath: "/tx/{hash}",
     explorerAddressPath: "/address/{address}",
-    explorerContractPath: "/address/{address}?tab=contract",
+    explorerContractPath: "/address/{address}?tab=contract-viewer",
   },
-  // 0G Galileo Testnet - Blockscout (0G ChainScan)
+  // 0G Galileo Testnet - ConfluxScan-derived explorer with Etherscan-compat API at /open/api
   16602: {
     chainType: "evm",
     explorerUrl: "https://chainscan-galileo.0g.ai",
-    explorerApiType: "blockscout",
-    explorerApiUrl: "https://chainscan-galileo.0g.ai/api",
+    explorerApiType: "etherscan",
+    explorerApiUrl: "https://chainscan-galileo.0g.ai/open/api",
     explorerTxPath: "/tx/{hash}",
     explorerAddressPath: "/address/{address}",
-    explorerContractPath: "/address/{address}?tab=contract",
+    explorerContractPath: "/address/{address}?tab=contract-viewer",
   },
   // Solana Mainnet - Solscan
   101: {


### PR DESCRIPTION
## Summary
- `chainscan.0g.ai` is a ConfluxScan-derived SPA, not Blockscout. Every path under `/api` returns the HTML index, so `/api/web3/fetch-abi` blows up with `Unexpected token '<', "<!doctype "...` when fetching ABIs on 0G.
- The actual Etherscan-compatible API is hosted at `/open/api` (verified against both `getabi` and `getsourcecode`).
- Updates the explorer configs for 0G mainnet (16661) and 0G Galileo testnet (16602) in `scripts/seed/seed-chains.ts`:
  - `explorerApiType`: `blockscout` -> `etherscan` (also unlocks proxy detection in `app/api/web3/fetch-abi/route.ts`)
  - `explorerApiUrl`: `.../api` -> `.../open/api`
  - `explorerContractPath`: `?tab=contract` -> `?tab=contract-viewer` to match the explorer's actual tab.

## Follow-up
- Re-run `pnpm tsx scripts/seed/seed-chains.ts` against staging/prod to upsert the corrected `explorer_configs` rows.