### PR TITLE
fix: drop browser wallet extension errors at Sentry ingest

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,6 +5,7 @@
 import { captureRouterTransitionStart, init } from "@sentry/nextjs";
 import {
   hasNoInAppFrames,
+  isBrowserExtensionError,
   isEip1193ProviderRejection,
   isMonacoCancellation,
 } from "@/lib/sentry-filters";
@@ -33,6 +34,9 @@ if (SENTRY_DSN) {
         return null;
       }
       if (hasNoInAppFrames(event)) {
+        return null;
+      }
+      if (isBrowserExtensionError(event)) {
         return null;
       }
       if (isMonacoCancellation(event)) {

--- a/lib/sentry-filters.ts
+++ b/lib/sentry-filters.ts
@@ -36,6 +36,34 @@ export function hasNoInAppFrames(event: ErrorEvent): boolean {
   return !frames.some((frame) => frame.in_app === true);
 }
 
+// Browser wallet extensions (MetaMask and forks) bundle a service worker that
+// throws "Attempting to use a disconnected port object" when their
+// `chrome.runtime.Port` to the page detaches mid-message. Sentry's
+// `browserApiErrors` integration wraps `addEventListener` and surfaces these
+// as in-app errors because Sentry's frame normalizer rewrites the original
+// `chrome-extension://<id>/...` URL to `app:///...`, defeating
+// `hasNoInAppFrames`. Match on the rewritten filename or the original
+// extension-protocol abs_path so we drop them at ingest.
+const EXTENSION_FILENAME_PATTERN = /extensionServiceWorker\.js$/;
+const EXTENSION_PROTOCOL_PATTERN =
+  /^(?:chrome|moz|safari|safari-web)-extension:\/\//;
+
+export function isBrowserExtensionError(event: ErrorEvent): boolean {
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+  if (!frames || frames.length === 0) {
+    return false;
+  }
+  return frames.some((frame) => {
+    const filename = frame.filename;
+    const absPath = (frame as { abs_path?: string }).abs_path;
+    return (
+      (typeof filename === "string" &&
+        EXTENSION_FILENAME_PATTERN.test(filename)) ||
+      (typeof absPath === "string" && EXTENSION_PROTOCOL_PATTERN.test(absPath))
+    );
+  });
+}
+
 // `@monaco-editor/react` rejects with a `CancellationError` ("Canceled") when
 // its loader/dispose chain unwinds before the editor finishes mounting — for
 // example when the user navigates away from `/workflows/:workflowId` quickly.

--- a/tests/unit/sentry-filters.test.ts
+++ b/tests/unit/sentry-filters.test.ts
@@ -2,6 +2,7 @@ import type { ErrorEvent } from "@sentry/nextjs";
 import { describe, expect, it } from "vitest";
 import {
   hasNoInAppFrames,
+  isBrowserExtensionError,
   isEip1193ProviderRejection,
   isMonacoCancellation,
 } from "@/lib/sentry-filters";
@@ -14,7 +15,13 @@ type TestEvent = {
       type?: string;
       value?: string;
       mechanism?: { type?: string; handled?: boolean };
-      stacktrace?: { frames?: Array<{ in_app?: boolean; filename?: string }> };
+      stacktrace?: {
+        frames?: Array<{
+          in_app?: boolean;
+          filename?: string;
+          abs_path?: string;
+        }>;
+      };
     }>;
   };
   extra?: Record<string, unknown>;
@@ -118,6 +125,101 @@ describe("hasNoInAppFrames", () => {
   it("returns false when there are no frames", () => {
     const event = makeEvent({ exception: { values: [{}] } });
     expect(hasNoInAppFrames(event)).toBe(false);
+  });
+});
+
+describe("isBrowserExtensionError", () => {
+  it("matches when a frame's filename is the wallet extension service worker", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            mechanism: {
+              type: "auto.browser.browserapierrors.addEventListener",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  in_app: true,
+                  filename: "app:///extensionServiceWorker.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(isBrowserExtensionError(event)).toBe(true);
+  });
+
+  it("matches when a frame's abs_path uses the chrome-extension protocol", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  in_app: true,
+                  filename: "app:///inpage.js",
+                  abs_path:
+                    "chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/inpage.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(isBrowserExtensionError(event)).toBe(true);
+  });
+
+  it("matches firefox moz-extension abs_paths", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  in_app: true,
+                  filename: "app:///inpage.js",
+                  abs_path: "moz-extension://abc/inpage.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(isBrowserExtensionError(event)).toBe(true);
+  });
+
+  it("does not match plain app frames", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  in_app: true,
+                  filename: "app:///app/workflows/[workflowId]/page.tsx",
+                  abs_path: "https://app.keeperhub.com/workflows/x",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(isBrowserExtensionError(event)).toBe(false);
+  });
+
+  it("does not match when there are no frames", () => {
+    const event = makeEvent({ exception: { values: [{}] } });
+    expect(isBrowserExtensionError(event)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `isBrowserExtensionError` predicate to `lib/sentry-filters.ts` and wires it into the `beforeSend` chain in `instrumentation-client.ts`.
- Drops events whose stacktrace originates from a wallet extension service worker (matches either the rewritten `extensionServiceWorker.js` filename or an `chrome|moz|safari|safari-web-extension://` `abs_path`).

## Why

MetaMask and forks throw "Attempting to use a disconnected port object" when their `chrome.runtime.Port` to the page detaches mid-message. Sentry's `browserApiErrors` integration wraps `addEventListener` and surfaces these as in-app errors because its frame normalizer rewrites `chrome-extension://<id>/...` to `app:///...`, so the existing `hasNoInAppFrames` filter does not catch them. Production issue: KEEPERHUB-PRODUCTION-15.