### PR TITLE
docs: fix Direct Execution auth header

### DIFF
--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -9,13 +9,13 @@ The Direct Execution API allows you to execute blockchain transactions directly 
 
 ## Authentication
 
-All direct execution endpoints require an API key passed in the `X-API-Key` header:
+All direct execution endpoints require an organization API key (`kh_`) passed in the `Authorization` header as a bearer token:
 
 ```http
-X-API-Key: keeper_...
+Authorization: Bearer kh_your_api_key
 ```
 
-See [API Keys](/api/api-keys) for details on creating and managing API keys.
+See [Authentication](/api/authentication) for the full auth model and [API Keys](/api/api-keys) for details on creating and managing API keys.
 
 ## Rate Limits
 


### PR DESCRIPTION
## Summary

- An integrator hit reproducible 401s following the Direct Execution docs literally: the page instructed them to send `X-API-Key: keeper_...`, but every `/api/execute/*` route reads `Authorization: Bearer kh_...` via `lib/api-key-auth.ts` and `X-API-Key` is never an inbound auth header anywhere in the codebase. `keeper_` is also not a valid key prefix. This aligns the Direct Execution page with the Authentication page so the documented call works first try.
- Doc-only change, no code touched.

## Test Plan

- [ ] Render the docs site and confirm the Authentication block now shows `Authorization: Bearer kh_your_api_key`
- [ ] Confirm the cross-link to `/api/authentication` resolves
- [ ] Sanity-check: `curl -H "Authorization: Bearer kh_..." https://app.keeperhub.com/api/execute/contract-call` returns 200 on a read-only call (per the integrator's repro)