### PR TITLE
fix: reaper also reaps stuck pending executions

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, inArray, lt, notInArray, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, lt, notInArray, or, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
@@ -7,6 +7,11 @@ import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 const DEFAULT_THRESHOLD_MINUTES = 30;
+
+// Pending rows that have produced no step logs are unambiguously stuck:
+// the executor inserted but the runtime never started. A few minutes is
+// generous for image pulls and k8s scheduling; beyond that, it's dead.
+const PENDING_THRESHOLD_MINUTES = 5;
 
 function getThresholdMinutes(): number {
   const envValue = process.env.STALE_EXECUTION_THRESHOLD_MINUTES;
@@ -36,7 +41,10 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   try {
     const thresholdMinutes = getThresholdMinutes();
-    const cutoff = new Date(Date.now() - thresholdMinutes * 60 * 1000);
+    const runningCutoff = new Date(Date.now() - thresholdMinutes * 60 * 1000);
+    const pendingCutoff = new Date(
+      Date.now() - PENDING_THRESHOLD_MINUTES * 60 * 1000
+    );
 
     // Find execution IDs that have recent step activity (should NOT be reaped)
     const activeExecutionIds = await db
@@ -44,25 +52,46 @@ export async function GET(request: Request): Promise<NextResponse> {
         executionId: workflowExecutionLogs.executionId,
       })
       .from(workflowExecutionLogs)
-      .where(gt(workflowExecutionLogs.completedAt, cutoff))
+      .where(gt(workflowExecutionLogs.completedAt, runningCutoff))
       .groupBy(workflowExecutionLogs.executionId);
 
     const excludeIds = activeExecutionIds.map((row) => row.executionId);
 
-    // Bulk update all stale executions in a single query, excluding those with recent activity
-    const staleConditions = and(
-      eq(workflowExecutions.status, "running"),
-      lt(workflowExecutions.startedAt, cutoff),
-      excludeIds.length > 0
-        ? notInArray(workflowExecutions.id, excludeIds)
-        : undefined
+    // Bulk update all stale executions in a single query.
+    //
+    // Two independent stuck-state predicates combined with OR:
+    //   - status='running' rows that haven't recorded recent step activity
+    //     within the running threshold (default 30 min). The runtime claimed
+    //     the execution but stopped progressing.
+    //   - status='pending' rows older than the pending threshold (5 min) with
+    //     no step logs at all. The SQS executor inserted the row but the
+    //     runtime never started (dispatch failed, pod crash before first
+    //     step, etc). Guarded by NOT EXISTS rather than a NOT IN list because
+    //     every successful execution has step logs and a NOT IN would load
+    //     that entire set into the predicate.
+    const staleConditions = or(
+      and(
+        eq(workflowExecutions.status, "running"),
+        lt(workflowExecutions.startedAt, runningCutoff),
+        excludeIds.length > 0
+          ? notInArray(workflowExecutions.id, excludeIds)
+          : undefined
+      ),
+      and(
+        eq(workflowExecutions.status, "pending"),
+        lt(workflowExecutions.startedAt, pendingCutoff),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${workflowExecutionLogs}
+          WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+        )`
+      )
     );
 
     const reaped = await db
       .update(workflowExecutions)
       .set({
         status: "error",
-        error: `Execution timed out: no activity for ${thresholdMinutes} minutes`,
+        error: `Execution timed out: no progress for ${thresholdMinutes} minutes`,
         completedAt: new Date(),
         duration: sql`ROUND(EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000)`,
       })

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -28,7 +28,7 @@ import {
   ReceiveMessageCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import {
@@ -256,14 +256,39 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     `[Executor] Dispatch target: ${target} (mode: ${CONFIG.executionMode})`
   );
 
-  await dispatchExecution({
-    target,
-    workflowId,
-    executionId,
-    input,
-    triggerType,
-    scheduleId: getScheduleId(message),
-  });
+  try {
+    await dispatchExecution({
+      target,
+      workflowId,
+      executionId,
+      input,
+      triggerType,
+      scheduleId: getScheduleId(message),
+    });
+  } catch (error) {
+    // Don't leak the inserted row as 'pending' if dispatch fails. The
+    // k8s-job target updates the row internally; this outer guard covers
+    // api / in-process / future targets uniformly. The status='pending'
+    // filter prevents overwriting a status the runtime already set if
+    // the failure happened after the workflow started running.
+    await db
+      .update(workflowExecutions)
+      .set({
+        status: "error",
+        error:
+          error instanceof Error
+            ? `Dispatch failed: ${error.message}`
+            : "Dispatch failed",
+        completedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(workflowExecutions.id, executionId),
+          eq(workflowExecutions.status, "pending")
+        )
+      );
+    throw error;
+  }
 }
 
 async function processMessage(message: Message): Promise<void> {

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -215,6 +215,19 @@ describe("/api/internal/reaper", () => {
     );
   });
 
+  // The reaper now covers both 'running' rows (stale activity) and 'pending'
+  // rows (runtime never started, no step logs at all). The unified error
+  // message describes both states accurately.
+  it("uses 'no progress' wording in the timeout error message", async () => {
+    mockReapedRows = [{ id: "exec_1" }];
+
+    await GET(createRequest());
+
+    expect(getExecUpdate()?.set.error).toEqual(
+      expect.stringContaining("no progress")
+    );
+  });
+
   it("calls authenticateInternalService with the request", async () => {
     const request = createRequest();
     await GET(request);


### PR DESCRIPTION
## Summary

The reaper at \`app/api/internal/reaper/route.ts\` only reaped \`workflow_executions\` rows in \`status='running'\`. Rows inserted as \`pending\` by the SQS executor that never transition (dispatch failure, pod crash before first step, SQS redelivery) leaked into a permanent \`pending\` state and inflated \`keeperhub_workflow_queue_depth\` over time. Prod has 314 stale pending rows accumulated over the past two weeks, 89% from an Apr 23-24 incident, all with zero step logs.

## Change

Extend the WHERE predicate to also match \`pending\` rows older than 5 minutes that have zero rows in \`workflow_execution_logs\`:

- Stuck \`running\`: started >30 min ago, no recent step completion (existing behavior).
- Stuck \`pending\`: started >5 min ago, \`NOT EXISTS\` in \`workflow_execution_logs\` (new).

The \`NOT EXISTS\` guard protects actively-running workflows, since the SDK keeps \`parent.status='pending'\` while step logs accumulate. The 5-minute threshold reflects the unambiguous nature of "stuck pending with no logs": once the runtime starts, step logs appear within seconds.

Existing follow-up cleanup (KEEP-333 orphaned 'running' step log closure, KEEP-344 nonce lock release) operates on the combined reaped set unchanged.

## Expected effect post-deploy

- First reaper tick (10 min after deploy): the 314 stale rows transition to \`error\` in a single UPDATE.
- \`keeperhub_workflow_queue_depth\` panel drops sharply from ~314 to the real in-flight count (single digits).
- Future leaks self-heal within 5 min instead of accumulating.