### PR TITLE
fix: stop leaking Infura/Alchemy keys via /api/chains

### DIFF
--- a/app/api/chains/route.ts
+++ b/app/api/chains/route.ts
@@ -10,8 +10,6 @@ export type ChainResponse = {
   name: string;
   symbol: string;
   chainType: string;
-  defaultPrimaryRpc: string;
-  defaultFallbackRpc: string | null;
   explorerUrl: string | null;
   explorerAddressPath: string | null;
   explorerApiUrl: string | null;
@@ -49,14 +47,16 @@ export async function GET(request: Request) {
       ? await query
       : await query.where(eq(chains.isEnabled, true));
 
+    // SECURITY: defaultPrimaryRpc / defaultFallbackRpc are intentionally NOT
+    // returned. Some entries embed provider API keys (Infura, Alchemy) and the
+    // response is publicly cacheable. Server-side callers read these fields
+    // directly from the `chains` table.
     const response: GetChainsResponse = results.map(({ chain, explorer }) => ({
       id: chain.id,
       chainId: chain.chainId,
       name: chain.name,
       symbol: chain.symbol,
       chainType: chain.chainType,
-      defaultPrimaryRpc: chain.defaultPrimaryRpc,
-      defaultFallbackRpc: chain.defaultFallbackRpc,
       explorerUrl: explorer?.explorerUrl ?? null,
       explorerAddressPath: explorer?.explorerAddressPath ?? null,
       explorerApiUrl: explorer?.explorerApiUrl ?? null,

--- a/tests/integration/chains-route.test.ts
+++ b/tests/integration/chains-route.test.ts
@@ -208,14 +208,10 @@ describe("/api/chains route", () => {
       expect(chain).toHaveProperty("name", "Ethereum Mainnet");
       expect(chain).toHaveProperty("symbol", "ETH");
       expect(chain).toHaveProperty("chainType", "evm");
-      expect(chain).toHaveProperty(
-        "defaultPrimaryRpc",
-        "https://eth.example.com"
-      );
-      expect(chain).toHaveProperty(
-        "defaultFallbackRpc",
-        "https://eth-backup.example.com"
-      );
+      // SECURITY: defaultPrimaryRpc / defaultFallbackRpc must NOT be returned
+      // by the public endpoint (some entries embed provider API keys).
+      expect(chain).not.toHaveProperty("defaultPrimaryRpc");
+      expect(chain).not.toHaveProperty("defaultFallbackRpc");
       expect(chain).toHaveProperty("explorerUrl", "https://etherscan.io");
       expect(chain).toHaveProperty(
         "explorerApiUrl",


### PR DESCRIPTION
Linear: [KEEP-383](https://linear.app/keeperhubapp/issue/KEEP-383/security-rotate-leaked-infuraalchemy-rpc-keys-retire-urls-from-chain)

## Summary

`/api/chains` was returning `defaultPrimaryRpc` and `defaultFallbackRpc` for every chain to any unauthenticated browser caller. For several chains those URLs embed provider API keys (Infura, Alchemy), so the keys were leaking in the response body. A user reported it after seeing this in DevTools network/console:

```
base-sepolia.infura.io/v3/e362e96030ee43cc9fb69434135a4ae3 -> 429
```

That URL came straight from `/api/chains` -> downstream wallet/web3 plumbing made the request from the browser.

## What this PR does

- Drops `defaultPrimaryRpc` / `defaultFallbackRpc` from the public `ChainResponse` shape returned by `app/api/chains/route.ts`.
- Server-side callers (`app/api/workflows/events/route.ts`, `app/api/user/wallet/withdraw/route.ts`, `lib/rpc/config-service.ts`, `lib/wallet/*`, `lib/metrics/*`) read those columns directly from the `chains` table, so they are unaffected.
- Verified no client component destructures `defaultPrimaryRpc` / `defaultFallbackRpc` from the API response (the type is imported in `components/workflow/config/abi-with-auto-fetch-field.tsx` but the fields are not read).

## Keys exposed (via chain-config repo + DB seeds)

From `chain-config/staging.json` and `production.json`:

- Infura `e362e96030ee43cc9fb69434135a4ae3` -- base-mainnet, base-testnet (HTTP + WSS)
- Alchemy `pPmfbqbZH_6_hR6t1_JRk` -- eth-mainnet, eth-sepolia, base-mainnet, base-sepolia, solana-mainnet, solana-testnet (fallback URLs)
- Alchemy `s_8VpY02izssHI4yW2uyC1XWkrMCdS7a` -- tempo-testnet

## Follow-up (NOT in this PR -- tracked in KEEP-383, assigned to Joel)

This PR plugs the leak surface. It does **not** rotate the keys, and the URLs are still in the DB / chain-config repo. Joel owns the follow-up:

1. Rotate all three keys at Infura / Alchemy.
2. Update `chain-config/{staging,production}.json` to route base-* (and any other key-bearing entries) through the existing `chain.techops.services/...` proxy used by eth-mainnet / eth-sepolia.
3. Audit the `chain-config` repo git history; treat the rotated keys as compromised regardless of when they were added.

## Test plan

- [x] `pnpm type-check` clean.
- [ ] Hit `/api/chains` on a deployed preview and confirm response no longer contains `defaultPrimaryRpc` / `defaultFallbackRpc`.
- [ ] Smoke test: wallet overlay opens, chain selector populates, ABI auto-fetch still works (these consume `/api/chains` but only for `chainId` / `name` / explorer fields).
- [ ] Verify ETH / Base / Solana balance fetches still work end-to-end (server-side codepath, should be unaffected).

Note: `pnpm check` (Ultracite/Biome) currently fails locally for an unrelated reason -- pnpm `minimumReleaseAge` rejects `@biomejs/cli-*@2.4.13` because it was published 6 days ago. CI may or may not hit the same; if it does, that is pre-existing.