### PR TITLE
release: to prod

### DIFF
--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import { createIntegration, getIntegrations } from "@/lib/db/integrations";
+import {
+  createIntegration,
+  ensureWalletIntegration,
+  getIntegrations,
+} from "@/lib/db/integrations";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import type {
@@ -54,6 +58,31 @@ export async function GET(request: Request) {
     // Get optional type filter from query params
     const { searchParams } = new URL(request.url);
     const typeFilter = searchParams.get("type") as IntegrationType | null;
+
+    // Repair wallet/integration data drift before listing: orgs whose
+    // wallet pre-dates the auto-create code (or whose web3 integration
+    // row was deleted) would otherwise see "Add Web3 connection" in the
+    // workflow builder despite having a working wallet. This makes the
+    // first read after deploy heal silently and is a no-op for everyone
+    // already in the consistent state.
+    if (userId && organizationId) {
+      try {
+        await ensureWalletIntegration(userId, organizationId);
+      } catch (error) {
+        // Non-fatal: log and continue. Worst case is the user briefly
+        // sees the orange warning until the next read; the wallet
+        // itself still works.
+        logSystemError(
+          ErrorCategory.DATABASE,
+          "[Integrations] Failed to ensure wallet integration",
+          error,
+          {
+            endpoint: "/api/integrations",
+            operation: "ensureWalletIntegration",
+          }
+        );
+      }
+    }
 
     const integrations = await getIntegrations(
       userId ?? "",

--- a/components/ui/integration-selector.tsx
+++ b/components/ui/integration-selector.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { truncateAddress } from "@/lib/address-utils";
 import { useWalletInfo } from "@/lib/wallet/use-wallet-info";
 import { ConfigureConnectionOverlay } from "@/components/overlays/add-connection-overlay";
 import { AiGatewayConsentOverlay } from "@/components/overlays/ai-gateway-consent-overlay";
@@ -453,22 +454,27 @@ type Web3WalletAwareEmptyStateProps = {
 
 /**
  * Empty state for the Web3 IntegrationSelector. Web3 actions sign with the
- * org's KeeperHub wallet, not with a "web3 integration" credential -- the
- * loud orange "Add Web3 connection" warning was misleading users into
- * thinking the action was misconfigured. Show a quieter wallet-aware state
- * instead, with a discreet "+" for users who actually want to attach a
- * custom RPC.
+ * org's KeeperHub wallet, so when wallet exists but the auto-created
+ * integration row is missing (legacy data, member ownership mismatch, etc.)
+ * render the same single-integration shape used in the integrations.length
+ * === 1 branch -- truncated wallet address with a green check -- so the
+ * panel reads consistently regardless of whether an integration row backs
+ * the wallet. The "+" affordance opens ConfigureConnectionOverlay for users
+ * who want to attach a custom RPC.
  */
 function Web3WalletAwareEmptyState({
   disabled,
   onAddConnection,
 }: Web3WalletAwareEmptyStateProps): React.JSX.Element {
-  const { hasWallet, isLoading } = useWalletInfo();
+  const { hasWallet, walletAddress, isLoading } = useWalletInfo();
 
   // While wallet status is still loading, prefer the wallet-aware copy --
   // most signed-in orgs have a wallet, so flashing the orange warning
   // before the fetch resolves causes a visible jump.
-  if (isLoading || hasWallet) {
+  if (isLoading || (hasWallet && walletAddress)) {
+    const displayName = walletAddress
+      ? truncateAddress(walletAddress)
+      : "Loading wallet...";
     return (
       <div
         className={cn(
@@ -477,9 +483,7 @@ function Web3WalletAwareEmptyState({
         )}
       >
         <Check className="size-4 shrink-0 text-green-600" />
-        <span className="flex-1 truncate text-muted-foreground">
-          Uses your KeeperHub wallet
-        </span>
+        <span className="flex-1 truncate">{displayName}</span>
         <Button
           aria-label="Add custom RPC connection"
           className="size-6 shrink-0"

--- a/components/ui/integration-selector.tsx
+++ b/components/ui/integration-selector.tsx
@@ -9,7 +9,9 @@ import {
   Plus,
   Settings,
 } from "lucide-react";
+import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useWalletInfo } from "@/lib/wallet/use-wallet-info";
 import { ConfigureConnectionOverlay } from "@/components/overlays/add-connection-overlay";
 import { AiGatewayConsentOverlay } from "@/components/overlays/ai-gateway-consent-overlay";
 import { EditConnectionOverlay } from "@/components/overlays/edit-connection-overlay";
@@ -274,8 +276,24 @@ export function IntegrationSelector({
   const managedIntegrations = integrations.filter((i) => i.isManaged);
   const manualIntegrations = integrations.filter((i) => !i.isManaged);
 
-  // No integrations - show add button
+  // No integrations - show add button.
+  //
+  // Special case for the web3 integration type: KeeperHub provisions an org
+  // wallet automatically, and write/transfer/approve actions sign with that
+  // wallet -- not with a "web3 integration" credential. Showing the loud
+  // orange "Add Web3 connection" warning is misleading for those actions
+  // (the action will run fine without any web3 integration). Render a
+  // wallet-aware empty state instead, with a discreet add button so users
+  // who do want a custom RPC can still attach one.
   if (integrations.length === 0) {
+    if (integrationType === "web3") {
+      return (
+        <Web3WalletAwareEmptyState
+          disabled={disabled}
+          onAddConnection={handleAddConnection}
+        />
+      );
+    }
     return (
       <>
         <Button
@@ -425,5 +443,71 @@ export function IntegrationSelector({
         )}
       </div>
     </>
+  );
+}
+
+type Web3WalletAwareEmptyStateProps = {
+  disabled?: boolean;
+  onAddConnection: () => void;
+};
+
+/**
+ * Empty state for the Web3 IntegrationSelector. Web3 actions sign with the
+ * org's KeeperHub wallet, not with a "web3 integration" credential -- the
+ * loud orange "Add Web3 connection" warning was misleading users into
+ * thinking the action was misconfigured. Show a quieter wallet-aware state
+ * instead, with a discreet "+" for users who actually want to attach a
+ * custom RPC.
+ */
+function Web3WalletAwareEmptyState({
+  disabled,
+  onAddConnection,
+}: Web3WalletAwareEmptyStateProps): React.JSX.Element {
+  const { hasWallet, isLoading } = useWalletInfo();
+
+  // While wallet status is still loading, prefer the wallet-aware copy --
+  // most signed-in orgs have a wallet, so flashing the orange warning
+  // before the fetch resolves causes a visible jump.
+  if (isLoading || hasWallet) {
+    return (
+      <div
+        className={cn(
+          "flex h-9 w-full items-center gap-2 rounded-md border px-3 text-sm",
+          disabled && "cursor-not-allowed opacity-50"
+        )}
+      >
+        <Check className="size-4 shrink-0 text-green-600" />
+        <span className="flex-1 truncate text-muted-foreground">
+          Uses your KeeperHub wallet
+        </span>
+        <Button
+          aria-label="Add custom RPC connection"
+          className="size-6 shrink-0"
+          disabled={disabled}
+          onClick={onAddConnection}
+          size="icon"
+          title="Add custom RPC"
+          variant="ghost"
+        >
+          <Plus className="size-3" />
+        </Button>
+      </div>
+    );
+  }
+
+  // No wallet yet -- keep the original prompt so the user knows action is
+  // needed (the wallet onboarding flow lives elsewhere; the integration
+  // overlay still lets them attach a custom RPC).
+  return (
+    <Button
+      className="w-full justify-start gap-2 border-orange-500/50 bg-orange-500/10 text-orange-600 hover:bg-orange-500/20 dark:text-orange-400"
+      disabled={disabled}
+      onClick={onAddConnection}
+      variant="outline"
+    >
+      <AlertTriangle className="size-4" />
+      <span className="flex-1 text-left">Add Web3 connection</span>
+      <Plus className="size-4" />
+    </Button>
   );
 }

--- a/components/ui/integration-selector.tsx
+++ b/components/ui/integration-selector.tsx
@@ -9,10 +9,7 @@ import {
   Plus,
   Settings,
 } from "lucide-react";
-import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { truncateAddress } from "@/lib/address-utils";
-import { useWalletInfo } from "@/lib/wallet/use-wallet-info";
 import { ConfigureConnectionOverlay } from "@/components/overlays/add-connection-overlay";
 import { AiGatewayConsentOverlay } from "@/components/overlays/ai-gateway-consent-overlay";
 import { EditConnectionOverlay } from "@/components/overlays/edit-connection-overlay";
@@ -277,24 +274,8 @@ export function IntegrationSelector({
   const managedIntegrations = integrations.filter((i) => i.isManaged);
   const manualIntegrations = integrations.filter((i) => !i.isManaged);
 
-  // No integrations - show add button.
-  //
-  // Special case for the web3 integration type: KeeperHub provisions an org
-  // wallet automatically, and write/transfer/approve actions sign with that
-  // wallet -- not with a "web3 integration" credential. Showing the loud
-  // orange "Add Web3 connection" warning is misleading for those actions
-  // (the action will run fine without any web3 integration). Render a
-  // wallet-aware empty state instead, with a discreet add button so users
-  // who do want a custom RPC can still attach one.
+  // No integrations - show add button
   if (integrations.length === 0) {
-    if (integrationType === "web3") {
-      return (
-        <Web3WalletAwareEmptyState
-          disabled={disabled}
-          onAddConnection={handleAddConnection}
-        />
-      );
-    }
     return (
       <>
         <Button
@@ -444,74 +425,5 @@ export function IntegrationSelector({
         )}
       </div>
     </>
-  );
-}
-
-type Web3WalletAwareEmptyStateProps = {
-  disabled?: boolean;
-  onAddConnection: () => void;
-};
-
-/**
- * Empty state for the Web3 IntegrationSelector. Web3 actions sign with the
- * org's KeeperHub wallet, so when wallet exists but the auto-created
- * integration row is missing (legacy data, member ownership mismatch, etc.)
- * render the same single-integration shape used in the integrations.length
- * === 1 branch -- truncated wallet address with a green check -- so the
- * panel reads consistently regardless of whether an integration row backs
- * the wallet. The "+" affordance opens ConfigureConnectionOverlay for users
- * who want to attach a custom RPC.
- */
-function Web3WalletAwareEmptyState({
-  disabled,
-  onAddConnection,
-}: Web3WalletAwareEmptyStateProps): React.JSX.Element {
-  const { hasWallet, walletAddress, isLoading } = useWalletInfo();
-
-  // While wallet status is still loading, prefer the wallet-aware copy --
-  // most signed-in orgs have a wallet, so flashing the orange warning
-  // before the fetch resolves causes a visible jump.
-  if (isLoading || (hasWallet && walletAddress)) {
-    const displayName = walletAddress
-      ? truncateAddress(walletAddress)
-      : "Loading wallet...";
-    return (
-      <div
-        className={cn(
-          "flex h-9 w-full items-center gap-2 rounded-md border px-3 text-sm",
-          disabled && "cursor-not-allowed opacity-50"
-        )}
-      >
-        <Check className="size-4 shrink-0 text-green-600" />
-        <span className="flex-1 truncate">{displayName}</span>
-        <Button
-          aria-label="Add custom RPC connection"
-          className="size-6 shrink-0"
-          disabled={disabled}
-          onClick={onAddConnection}
-          size="icon"
-          title="Add custom RPC"
-          variant="ghost"
-        >
-          <Plus className="size-3" />
-        </Button>
-      </div>
-    );
-  }
-
-  // No wallet yet -- keep the original prompt so the user knows action is
-  // needed (the wallet onboarding flow lives elsewhere; the integration
-  // overlay still lets them attach a custom RPC).
-  return (
-    <Button
-      className="w-full justify-start gap-2 border-orange-500/50 bg-orange-500/10 text-orange-600 hover:bg-orange-500/20 dark:text-orange-400"
-      disabled={disabled}
-      onClick={onAddConnection}
-      variant="outline"
-    >
-      <AlertTriangle className="size-4" />
-      <span className="flex-1 text-left">Add Web3 connection</span>
-      <Plus className="size-4" />
-    </Button>
   );
 }

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -2,6 +2,11 @@ import "server-only";
 
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 import { and, eq, inArray } from "drizzle-orm";
+import { truncateAddress } from "@/lib/address-utils";
+import {
+  getOrganizationWallet,
+  organizationHasWallet,
+} from "@/lib/para/wallet-helpers";
 import {
   findActionById,
   getIntegration as getPluginDefinition,
@@ -269,6 +274,61 @@ export async function createIntegration(
     ...result,
     config,
   };
+}
+
+/**
+ * Ensure the org's KeeperHub wallet has a backing web3 integration row.
+ *
+ * Wallet provisioning at app/api/user/wallet/route.ts:195 auto-creates a
+ * cosmetic web3 integration alongside the wallet. For orgs whose wallet
+ * pre-dates that auto-create code, or whose integration was deleted /
+ * migrated, the row can be missing -- which made the Workflow Builder
+ * render a misleading "Add Web3 connection" warning even though the
+ * wallet itself was working fine.
+ *
+ * Heals that drift idempotently: if the org has an active wallet but no
+ * web3 integration row, create one with the same payload the
+ * provisioning route would have written. Safe to call from any read path
+ * that lists integrations -- after the first call for a given org the
+ * row exists and subsequent calls early-return.
+ *
+ * Two concurrent callers can race and both pass the existence check,
+ * resulting in two web3 rows for the same wallet. We accept that rare
+ * edge case rather than introducing a unique constraint or transaction
+ * lock; the multi-integration list still renders, and the user can
+ * delete the extra row.
+ */
+export async function ensureWalletIntegration(
+  userId: string,
+  organizationId: string
+): Promise<void> {
+  const hasWallet = await organizationHasWallet(organizationId);
+  if (!hasWallet) {
+    return;
+  }
+
+  const existing = await db
+    .select({ id: integrations.id })
+    .from(integrations)
+    .where(
+      and(
+        eq(integrations.organizationId, organizationId),
+        eq(integrations.type, "web3")
+      )
+    )
+    .limit(1);
+  if (existing.length > 0) {
+    return;
+  }
+
+  const wallet = await getOrganizationWallet(organizationId);
+  await createIntegration({
+    userId,
+    organizationId,
+    name: truncateAddress(wallet.walletAddress),
+    type: "web3",
+    config: {},
+  });
 }
 
 /**

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -760,13 +760,28 @@ const errorLabelAllowlist: Record<string, string[]> = {
 };
 
 /**
- * Filter labels to only include allowed ones for a specific metric
+ * Filter labels to only include allowed ones for a specific metric.
+ *
+ * Precedence: a metric in `errorLabelAllowlist` uses that legacy allowlist;
+ * otherwise the counter's own declared `labelNames` are used as the allowlist.
+ * Either way, unknown labels are silently dropped before reaching prom-client.
+ *
+ * This prevents callers from accidentally exploding the labelset with
+ * high-cardinality fields (contract addresses, transaction hashes, raw error
+ * messages, etc.) and -- critically -- prevents prom-client from throwing
+ * "Added label X is not included in initial labelset" out of metric code,
+ * which would otherwise bubble up through `logUserError` and break the
+ * user-facing API call that emitted the log.
  */
 function filterLabelsForMetric(
   metricName: string,
+  counter: Counter,
   labels: Record<string, string>
 ): Record<string, string> {
-  const allowed = errorLabelAllowlist[metricName];
+  const allowed =
+    errorLabelAllowlist[metricName] ??
+    (counter as Counter & { labelNames?: string[] }).labelNames;
+
   if (!allowed) {
     return labels;
   }
@@ -933,8 +948,15 @@ function recordErrorCounter(
   } else {
     sanitized.error_type = "UnknownError";
   }
-  const errorLabels = filterLabelsForMetric(name, sanitized);
-  counter.inc(errorLabels);
+  const errorLabels = filterLabelsForMetric(name, counter, sanitized);
+  try {
+    counter.inc(errorLabels);
+  } catch (err) {
+    // Defense-in-depth: if filtering missed something or prom-client rejects
+    // the label set for any other reason, never let metrics break the
+    // user-facing operation that called us.
+    console.warn(`[Prometheus] Failed to record error counter ${name}:`, err);
+  }
 }
 
 /**

--- a/tests/unit/prometheus-collector.test.ts
+++ b/tests/unit/prometheus-collector.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the Prometheus collector's defensive error-counter handling.
+ *
+ * Regression context: an Etherscan ABI auto-fetch failure surfaced a
+ * prom-client error to the user-facing UI ("Added label \"contract_address\"
+ * is not included in initial labelset...") because:
+ *   1. The fetch-abi route enriched logUserError with `contract_address`
+ *      (and other unbounded fields) for console + Sentry context.
+ *   2. The error counters declare a bounded ERROR_LABELS set.
+ *   3. prom-client throws on unknown labels.
+ *   4. The throw bubbled through logUserError -> the route's try/catch ->
+ *      back to the UI as a 500 with the prom-client message in the body.
+ *
+ * The fix: filter labels to the counter's declared labelNames before
+ * counter.inc(), and wrap inc() in a defensive try/catch so a future
+ * label mismatch can never break the user-facing operation that emitted
+ * the log.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  getPrometheusMetrics,
+  prometheusMetricsCollector,
+} from "@/lib/metrics/collectors/prometheus";
+
+describe("prometheusMetricsCollector.recordError -- defensive label filtering", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // suppress
+    });
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("does not throw when caller passes a label outside the counter's labelset", () => {
+    expect(() => {
+      prometheusMetricsCollector.recordError(
+        "errors.external.service.total",
+        new Error("Etherscan rate limit"),
+        {
+          // contract_address is intentionally passed for console/Sentry context
+          // but is NOT in ERROR_LABELS -- prom-client would have thrown before
+          // the fix.
+          contract_address: "0xD7c8809c37a510a31CE066468bbFd81b778d7Ca6",
+          service: "etherscan",
+        }
+      );
+    }).not.toThrow();
+  });
+
+  it("still increments the counter using only the labels the counter declares", async () => {
+    prometheusMetricsCollector.recordError(
+      "errors.external.service.total",
+      new Error("Etherscan rate limit"),
+      {
+        contract_address: "0xD7c8809c37a510a31CE066468bbFd81b778d7Ca6",
+        network: "ethereum-sepolia",
+        status: "0",
+        service: "etherscan",
+      }
+    );
+
+    const output = await getPrometheusMetrics();
+
+    // Counter must increment with the allowed label set.
+    expect(output).toContain("keeperhub_errors_external_service_total");
+    expect(output).toMatch(/service="etherscan"/);
+
+    // Unknown labels must be dropped before reaching prom-client.
+    expect(output).not.toMatch(/contract_address=/);
+    expect(output).not.toMatch(/network="ethereum-sepolia"/);
+  });
+
+  it("does not throw when caller passes labels outside the legacy allowlist for workflow.execution.errors", () => {
+    // workflow.execution.errors uses the legacy allowlist (workflow_id,
+    // trigger_type, error_type, org_slug, plan). plugin_name is NOT allowed
+    // for this metric -- ensure the legacy filter still strips it cleanly.
+    expect(() => {
+      prometheusMetricsCollector.recordError(
+        "workflow.execution.errors",
+        new Error("test"),
+        {
+          workflow_id: "wf_test_123",
+          trigger_type: "webhook",
+          plugin_name: "web3",
+          contract_address: "0xabc",
+        }
+      );
+    }).not.toThrow();
+  });
+
+  it("logs a warning instead of throwing if the counter name is unknown", () => {
+    prometheusMetricsCollector.recordError(
+      "errors.unknown.metric.does.not.exist",
+      new Error("test"),
+      { service: "etherscan" }
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Unknown error metric: errors.unknown.metric.does.not.exist"
+      )
+    );
+  });
+
+  it("survives multiple recordings with rotating mixes of valid and invalid labels", () => {
+    const labelMixes: Array<Record<string, string>> = [
+      { contract_address: "0x1", service: "etherscan" },
+      { unknown_label: "x", endpoint: "/api/web3/fetch-abi" },
+      { workflow_id: "wf_1", random_field: "y" },
+      { service: "discord", chain_id: "1" },
+    ];
+
+    for (const labels of labelMixes) {
+      expect(() => {
+        prometheusMetricsCollector.recordError(
+          "errors.external.service.total",
+          new Error("test"),
+          labels
+        );
+      }).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Promote the following merged PRs from staging to prod:

- #1068 fix(metrics): drop unknown labels in error counters instead of throwing
- #1069 fix(integrations): heal missing web3 integration row server-side

## Post-deploy verification

- [ ] `deploy-keeperhub` workflow finishes green
- [ ] `curl -fsS https://app.keeperhub.com/api/health` returns 200
- [ ] Smoke-test the surfaces affected by the merged PRs above
- [ ] Watch Sentry / logs for ~10 minutes after the rollout
- [ ] Eyeball `GET /api/integrations` query volume — #1069 adds a self-healing write on the read path (idempotent, but worth a glance)