### PR TITLE
refactor(web3): remove dead triggerType plumbing from transaction context (KEEP-387)

### DIFF
--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -234,7 +234,6 @@ export async function POST(request: Request) {
       executionId,
       chainId,
       rpcUrl,
-      triggerType: "manual",
     };
 
     // Execute transaction with nonce management

--- a/lib/web3/chain-adapter/types.ts
+++ b/lib/web3/chain-adapter/types.ts
@@ -1,7 +1,6 @@
 import type { ethers } from "ethers";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import type { NonceSession } from "../nonce-manager";
-import type { TriggerType } from "../transaction-manager";
 
 export type TransactionReceipt = {
   hash: string;
@@ -82,7 +81,6 @@ export interface ChainAdapter {
 }
 
 export type TransactionOptions = {
-  triggerType: TriggerType;
   gasOverrides: GasOverrides;
   workflowId?: string;
   rpcManager?: RpcProviderManager;

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -34,15 +34,12 @@ import {
 import { getGasStrategy } from "./gas-strategy";
 import { getNonceManager, type NonceSession } from "./nonce-manager";
 
-export type TriggerType = "event" | "webhook" | "scheduled" | "manual";
-
 export type TransactionContext = {
   organizationId: string;
   executionId: string;
   workflowId?: string;
   chainId: number;
   rpcUrl: string;
-  triggerType?: TriggerType;
   rpcManager?: RpcProviderManager;
 };
 

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -148,7 +148,6 @@ export async function protocolWriteStep(
       _context: input._context
         ? {
             executionId: input._context.executionId,
-            triggerType: input._context.triggerType,
           }
         : undefined,
     };

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -50,7 +50,6 @@ export type ApproveTokenCoreInput = {
   strict?: boolean;
   _context?: {
     executionId?: string;
-    triggerType?: string;
     organizationId?: string;
   };
 };
@@ -210,7 +209,6 @@ export async function approveTokenCore(
     workflowId,
     chainId,
     rpcUrl,
-    triggerType: _context.triggerType as TransactionContext["triggerType"],
     rpcManager,
   };
 
@@ -356,7 +354,6 @@ export async function approveTokenCore(
         functionKey: "approve",
         args: [spenderAddress, amountRaw],
       }, session, {
-        triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
         rpcManager,

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -45,7 +45,6 @@ export type TransferFundsCoreInput = {
   strict?: boolean;
   _context?: {
     executionId?: string;
-    triggerType?: string;
     organizationId?: string;
   };
 };
@@ -178,7 +177,6 @@ export async function transferFundsCore(
     workflowId,
     chainId,
     rpcUrl,
-    triggerType: _context.triggerType as TransactionContext["triggerType"],
     rpcManager,
   };
 
@@ -258,7 +256,6 @@ export async function transferFundsCore(
         to: recipientAddress,
         value: amountInWei,
       }, session, {
-        triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
         rpcManager,

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -53,7 +53,6 @@ export type TransferTokenCoreInput = {
   strict?: boolean;
   _context?: {
     executionId?: string;
-    triggerType?: string;
     organizationId?: string;
   };
 };
@@ -318,7 +317,6 @@ export async function transferTokenCore(
     workflowId,
     chainId,
     rpcUrl,
-    triggerType: _context.triggerType as TransactionContext["triggerType"],
     rpcManager,
   };
 
@@ -459,7 +457,6 @@ export async function transferTokenCore(
         functionKey: "transfer",
         args: [recipientAddress, amountRaw],
       }, session, {
-        triggerType: txContext.triggerType ?? "manual",
         gasOverrides: { multiplierOverride, gasLimitOverride },
         workflowId,
         rpcManager,

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -60,7 +60,6 @@ export type WriteContractCoreInput = {
   strict?: boolean;
   _context?: {
     executionId?: string;
-    triggerType?: string;
     organizationId?: string;
   };
 };
@@ -283,7 +282,6 @@ export async function writeContractCore(
     workflowId,
     chainId,
     rpcUrl,
-    triggerType: _context?.triggerType as TransactionContext["triggerType"],
     rpcManager,
   };
 
@@ -379,7 +377,6 @@ export async function writeContractCore(
         args,
         value: parsedEthValue,
       }, session, {
-        triggerType: txContext.triggerType ?? "manual",
         gasOverrides: {
           multiplierOverride,
           gasLimitOverride,

--- a/tests/unit/evm-chain-adapter-preflight.test.ts
+++ b/tests/unit/evm-chain-adapter-preflight.test.ts
@@ -103,7 +103,7 @@ describe("EvmChainAdapter preflight signer address", () => {
         },
         // biome-ignore lint/suspicious/noExplicitAny: test mock
         { currentNonce: 5 } as any,
-        { triggerType: "manual", gasOverrides: {} }
+        { gasOverrides: {} }
       );
     } catch (err) {
       // confirmTransaction fails with mocks - expected
@@ -144,7 +144,7 @@ describe("EvmChainAdapter preflight signer address", () => {
         },
         // biome-ignore lint/suspicious/noExplicitAny: test mock
         { currentNonce: 5 } as any,
-        { triggerType: "manual", gasOverrides: {} }
+        { gasOverrides: {} }
       );
     } catch {
       // confirmTransaction fails with mocks - expected

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -331,7 +331,7 @@ describe("protocolWriteStep", () => {
           "1000000",
         ]),
         ethValue: undefined,
-        _context: { executionId: "exec-456", triggerType: "manual" },
+        _context: { executionId: "exec-456" },
       });
     });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1071. That PR removed trigger-type branching from gas strategy entirely — gas is now purely a function of chain state. As a result, `triggerType` is still **set** on `TransactionContext` and `TransactionOptions` and threaded through every web3 step, but nothing reads it. This rips out the dead plumbing.

## What changes

**Type definitions** (drop the field):
- `lib/web3/transaction-manager.ts` — `TransactionContext.triggerType` removed; `TriggerType` alias deleted (no remaining consumers in this module).
- `lib/web3/chain-adapter/types.ts` — `TransactionOptions.triggerType` removed; unused `TriggerType` import removed.

**Step files** (drop the assignment):
- `plugins/web3/steps/write-contract-core.ts` (input `_context.triggerType`, `txContext` set, `TransactionOptions` set)
- `plugins/web3/steps/transfer-funds-core.ts` (same shape)
- `plugins/web3/steps/transfer-token-core.ts` (same shape)
- `plugins/web3/steps/approve-token-core.ts` (same shape)
- `plugins/protocol/steps/protocol-write.ts` — stop threading `triggerType` into `writeContractCore` input.

**Tests** (drop the now-invalid arg):
- `tests/unit/evm-chain-adapter-preflight.test.ts` — `executeContractCall` opts no longer take `triggerType`.
- `tests/unit/protocol-write-step.test.ts` — assertion on threaded `_context` drops `triggerType`.

## Out of scope

The broader `TriggerType` concept — workflow execution dispatch, metrics labels (`lib/metrics/types.ts`), template helpers, schedule-dispatcher, sanitize-nodes — is load-bearing elsewhere and untouched. This PR only deletes the dead branch in the web3 transaction path.

## Verification

- `pnpm type-check` — exit 0
- `pnpm vitest run` — exit 0 (full suite)
- `pnpm check` — at parity with baseline (no new lint findings introduced)
- `pnpm discover-plugins` — no diff in regenerated codegen
- Final grep: `grep -r "triggerType" plugins/web3/steps/ plugins/protocol/steps/ lib/web3/` returns nothing.

## Test plan

- [x] Unit suite green
- [x] Type-check clean
- [ ] Smoke: webhook-triggered Write Contract on staging after deploy (already exercised by KEEP-384 / PR #1071 verification)

## Diff

9 files changed, +3 / -21