### PR TITLE
feat(bazaar): full discoverability — OpenAPI spec hardening + 402 extensions.bazaar.schema fallback

### DIFF
--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -52,10 +52,19 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
     description: workflow.description
       ? sanitizeDescription(workflow.description)
       : undefined,
-    // Explicit auth mode on every operation so discovery scanners
-    // (agentcash, x402scan, mppscan, CDP Bazaar) don't have to infer.
-    "x-auth-mode": isPaid ? "paid" : "free",
   };
+
+  // Canonical OpenAPI 3.x auth declaration. Paid routes leave `security`
+  // unset (their auth comes via x-payment-info → 402); non-paid routes
+  // declare `security: []` which OpenAPI defines as "no authentication
+  // required". Discovery scanners (agentcash, x402scan, CDP Bazaar) read
+  // the standard fields, not custom x-auth-mode extensions.
+  // Note: write workflows are never paid at the HTTP layer — they always
+  // return unsigned calldata that the caller signs+broadcasts (see
+  // app/api/mcp/workflows/[slug]/call/route.ts handleWriteWorkflow).
+  if (!isPaid) {
+    operation.security = [];
+  }
 
   if (isWrite) {
     operation["x-workflow-type"] = "write";
@@ -87,12 +96,14 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
       },
     };
   } else if (isPaid || isWrite) {
+    // Fallback so paid+write routes always declare a body schema. Validators
+    // (e.g. @agentcash/discovery) flag L3_INPUT_SCHEMA_MISSING when paid
+    // routes have no requestBody at all. `type: object` already permits any
+    // properties; no `additionalProperties: true` needed.
     operation.requestBody = {
       required: false,
       content: {
-        "application/json": {
-          schema: { type: "object", additionalProperties: true },
-        },
+        "application/json": { schema: { type: "object" } },
       },
     };
   }
@@ -188,7 +199,7 @@ export async function GET(request: Request): Promise<Response> {
         "GET /api/mcp/workflows  (returns the list of all listed workflows + pricing)",
         "GET /openapi.json       (this document — full schema for every workflow)",
         "",
-        "When in doubt, fetch /openapi.json and read the per-workflow x-payment-info, x-auth-mode, and requestBody fields.",
+        "When in doubt, fetch /openapi.json and read the per-workflow `x-payment-info`, `security`, and `requestBody` fields.",
       ].join("\n"),
     },
     "x-service-info": {

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -52,6 +52,9 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
     description: workflow.description
       ? sanitizeDescription(workflow.description)
       : undefined,
+    // Explicit auth mode on every operation so discovery scanners
+    // (agentcash, x402scan, mppscan, CDP Bazaar) don't have to infer.
+    "x-auth-mode": isPaid ? "paid" : "free",
   };
 
   if (isWrite) {
@@ -72,11 +75,24 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
     };
   }
 
+  // Always declare a request body for paid routes so scanners get a clean
+  // input schema (validator complains: L3_INPUT_SCHEMA_MISSING). For
+  // workflows whose owners haven't backfilled inputSchema in the DB, fall
+  // back to an open object — better than nothing.
   if (workflow.inputSchema && "properties" in workflow.inputSchema) {
     operation.requestBody = {
       required: true,
       content: {
         "application/json": { schema: workflow.inputSchema },
+      },
+    };
+  } else if (isPaid || isWrite) {
+    operation.requestBody = {
+      required: false,
+      content: {
+        "application/json": {
+          schema: { type: "object", additionalProperties: true },
+        },
       },
     };
   }
@@ -150,8 +166,30 @@ export async function GET(request: Request): Promise<Response> {
       version: "1.0.0",
       description:
         "Web3 workflow automation platform. Workflows are callable by AI agents via REST or MCP.",
-      "x-guidance":
-        "KeeperHub exposes workflows as REST endpoints. Each workflow has a slug and accepts JSON input. Paid workflows require x402 or MPP payment. Free workflows can be called directly. Use GET /api/mcp/workflows to discover available workflows and their pricing.",
+      "x-guidance": [
+        "KeeperHub exposes workflows as REST endpoints under /api/mcp/workflows/{slug}/call.",
+        "Each workflow has a slug, accepts a JSON body, and returns a JSON response with `executionId`, `status`, and `output`.",
+        "Auth: paid workflows return HTTP 402 with x402/MPP payment info on the first call; pay (e.g. via agentcash, openclaw, or any x402 client) and replay. Free workflows can be called directly.",
+        "Categories of workflows include: DeFi yield/risk reads (e.g. usdc-yield-rates-aave-vs-compound, aave-v3-health-check, defi-risk-snapshot), tipping primitives (microtip), and write-type workflows that return unsigned calldata for the caller to sign and broadcast.",
+        "",
+        "## Worked examples",
+        "",
+        "### Example 1 — Compare USDC yield (paid, $0.01)",
+        "POST /api/mcp/workflows/usdc-yield-rates-aave-vs-compound/call",
+        "Body: {}",
+        'Response (after payment): { executionId, status: "success", output: { result: { rates: [...], bestRate, bestProtocol } } }',
+        "",
+        "### Example 2 — Aave v3 health check (paid, $0.01)",
+        "POST /api/mcp/workflows/aave-v3-health-check/call",
+        'Body: { "address": "0x..." }',
+        'Response (after payment): { executionId, status: "success", output: { result: { healthFactor, totalCollateralUSD, totalDebtUSD, riskLevel } } }',
+        "",
+        "### Example 3 — Discover available workflows (free)",
+        "GET /api/mcp/workflows  (returns the list of all listed workflows + pricing)",
+        "GET /openapi.json       (this document — full schema for every workflow)",
+        "",
+        "When in doubt, fetch /openapi.json and read the per-workflow x-payment-info, x-auth-mode, and requestBody fields.",
+      ].join("\n"),
     },
     "x-service-info": {
       categories: ["web3", "automation", "blockchain"],

--- a/lib/payments/router.ts
+++ b/lib/payments/router.ts
@@ -1,7 +1,10 @@
 import { withX402 } from "@x402/next";
 import { Challenge, Credential, Expires } from "mppx";
 import { type NextRequest, NextResponse } from "next/server";
-import { extractMppPayerAddress, hashMppCredential } from "@/lib/payments/mpp/server";
+import {
+  extractMppPayerAddress,
+  hashMppCredential,
+} from "@/lib/payments/mpp/server";
 import {
   buildPaymentConfig,
   extractPayerAddress,
@@ -119,14 +122,25 @@ function buildPaymentRequired(params: Dual402Params): PaymentRequiredV2 {
   if (tagName) {
     bazaar.tags = [tagName];
   }
-  if (inputSchema) {
-    bazaar.schema = {
-      properties: {
-        input: { properties: { body: inputSchema } },
-        output: { properties: { example: WORKFLOW_OUTPUT_EXAMPLE } },
+  // Always emit `bazaar.schema` for paid resources (every 402 is paid by
+  // construction). Workflows whose owners haven't backfilled `inputSchema`
+  // in the DB get an open-object placeholder rather than missing the
+  // schema entirely -- @agentcash/discovery's getWarningsFor402Body emits
+  // SCHEMA_INPUT_MISSING / SCHEMA_OUTPUT_MISSING at the
+  // `extensions.bazaar.schema.properties.{input,output}` paths when this
+  // subtree is absent. Open-object is permissive but lets the resource
+  // index correctly; owners should still backfill real schemas for
+  // ranking + agent UX.
+  bazaar.schema = {
+    properties: {
+      input: {
+        properties: {
+          body: inputSchema ?? { type: "object" },
+        },
       },
-    };
-  }
+      output: { properties: { example: WORKFLOW_OUTPUT_EXAMPLE } },
+    },
+  };
   payload.extensions = { bazaar };
 
   return payload;

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -83,7 +83,7 @@ describe("GET /api/openapi", () => {
     expect(path.post.responses["402"]).toBeDefined();
   });
 
-  it("declares x-auth-mode=paid on paid read workflows", async () => {
+  it("paid read workflows: no `security` (paid auth via x-payment-info → 402) + open-object fallback requestBody", async () => {
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([
@@ -108,17 +108,21 @@ describe("GET /api/openapi", () => {
     const body = await response.json();
     const op = body.paths["/api/mcp/workflows/paid-wf/call"].post;
 
-    expect(op["x-auth-mode"]).toBe("paid");
+    // Paid routes' auth mode is conveyed by x-payment-info + responses[402];
+    // OpenAPI security stays unset (NOT empty) so scanners infer "paid".
+    expect(op.security).toBeUndefined();
+    expect(op["x-payment-info"]).toBeDefined();
+    expect(op.responses["402"]).toBeDefined();
     // Paid routes without a DB-backed inputSchema get a default open-object
-    // schema so discovery scanners get a valid request body.
+    // schema so discovery scanners (e.g. @agentcash/discovery) don't emit
+    // L3_INPUT_SCHEMA_MISSING.
     expect(op.requestBody).toBeDefined();
     expect(op.requestBody.content["application/json"].schema).toEqual({
       type: "object",
-      additionalProperties: true,
     });
   });
 
-  it("declares x-auth-mode=free on free read workflows", async () => {
+  it("free read workflows: declare `security: []` (= no auth required, OpenAPI 3.x)", async () => {
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([
@@ -143,11 +147,111 @@ describe("GET /api/openapi", () => {
     const body = await response.json();
     const op = body.paths["/api/mcp/workflows/free-wf/call"].post;
 
-    expect(op["x-auth-mode"]).toBe("free");
+    // Empty array is canonical OpenAPI for "no auth"; agentcash/x402scan
+    // both read this and stop emitting L2/L3_AUTH_MODE_MISSING.
+    expect(op.security).toEqual([]);
     expect(op["x-payment-info"]).toBeUndefined();
     // Free read workflows with no DB-backed schema don't need a fallback
     // request body.
     expect(op.requestBody).toBeUndefined();
+  });
+
+  it("write workflows: also declare `security: []` (writes never paid at HTTP layer) + fallback requestBody", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-write-priced",
+            name: "Priced Write Workflow",
+            description: null,
+            listedSlug: "priced-write",
+            inputSchema: null,
+            priceUsdcPerCall: "0.10",
+            workflowType: "write",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+    const op = body.paths["/api/mcp/workflows/priced-write/call"].post;
+
+    // Write workflows with priceUsdcPerCall > 0 are still NOT paid at the
+    // HTTP layer — handleWriteWorkflow returns calldata for the caller to
+    // sign+broadcast (gas paid on-chain). No 402 ever fires. Security must
+    // be `[]`, not unset, so the auth scanner doesn't think these are paid.
+    expect(op.security).toEqual([]);
+    expect(op["x-payment-info"]).toBeUndefined();
+    expect(op.responses["402"]).toBeUndefined();
+    expect(op["x-workflow-type"]).toBe("write");
+    expect(op.requestBody).toBeDefined();
+  });
+
+  it("DB-backed inputSchema takes precedence over the open-object fallback", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-with-schema",
+            name: "Paid With Schema",
+            description: null,
+            listedSlug: "paid-with-schema",
+            inputSchema: {
+              type: "object",
+              required: ["address"],
+              properties: { address: { type: "string" } },
+            },
+            priceUsdcPerCall: "0.01",
+            workflowType: "read",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+    const op = body.paths["/api/mcp/workflows/paid-with-schema/call"].post;
+
+    expect(op.requestBody.required).toBe(true);
+    expect(op.requestBody.content["application/json"].schema.required).toEqual([
+      "address",
+    ]);
+  });
+
+  it("workflows with null listedSlug are silently skipped", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-null-slug",
+            name: "No Slug",
+            description: null,
+            listedSlug: null,
+            inputSchema: null,
+            priceUsdcPerCall: "0",
+            workflowType: "read",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(Object.keys(body.paths)).toHaveLength(0);
   });
 
   it("includes worked examples in info.x-guidance", async () => {
@@ -167,6 +271,8 @@ describe("GET /api/openapi", () => {
       "/api/mcp/workflows/aave-v3-health-check/call"
     );
     expect(body.info["x-guidance"]).toContain('"address": "0x..."');
+    // YAML/Markdown consumers expect the guidance as a real multi-line block.
+    expect(body.info["x-guidance"].split("\n").length).toBeGreaterThan(10);
   });
 
   it("excludes x-payment-info for write workflows", async () => {

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -83,6 +83,92 @@ describe("GET /api/openapi", () => {
     expect(path.post.responses["402"]).toBeDefined();
   });
 
+  it("declares x-auth-mode=paid on paid read workflows", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-paid",
+            name: "Paid Workflow",
+            description: null,
+            listedSlug: "paid-wf",
+            inputSchema: null,
+            priceUsdcPerCall: "0.01",
+            workflowType: "read",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+    const op = body.paths["/api/mcp/workflows/paid-wf/call"].post;
+
+    expect(op["x-auth-mode"]).toBe("paid");
+    // Paid routes without a DB-backed inputSchema get a default open-object
+    // schema so discovery scanners get a valid request body.
+    expect(op.requestBody).toBeDefined();
+    expect(op.requestBody.content["application/json"].schema).toEqual({
+      type: "object",
+      additionalProperties: true,
+    });
+  });
+
+  it("declares x-auth-mode=free on free read workflows", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-free",
+            name: "Free Workflow",
+            description: null,
+            listedSlug: "free-wf",
+            inputSchema: null,
+            priceUsdcPerCall: "0",
+            workflowType: "read",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+    const op = body.paths["/api/mcp/workflows/free-wf/call"].post;
+
+    expect(op["x-auth-mode"]).toBe("free");
+    expect(op["x-payment-info"]).toBeUndefined();
+    // Free read workflows with no DB-backed schema don't need a fallback
+    // request body.
+    expect(op.requestBody).toBeUndefined();
+  });
+
+  it("includes worked examples in info.x-guidance", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body.info["x-guidance"]).toContain("Worked examples");
+    expect(body.info["x-guidance"]).toContain(
+      "/api/mcp/workflows/aave-v3-health-check/call"
+    );
+    expect(body.info["x-guidance"]).toContain('"address": "0x..."');
+  });
+
   it("excludes x-payment-info for write workflows", async () => {
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({

--- a/tests/unit/payment-router.test.ts
+++ b/tests/unit/payment-router.test.ts
@@ -244,9 +244,9 @@ describe("buildDual402Response", () => {
     // extensions.bazaar.schema.properties.input.properties.body and
     // extensions.bazaar.schema.properties.output.properties.example -- see
     // @agentcash/discovery dist/index.js extractSchemas2.
-    expect(body.extensions.bazaar.schema.properties.input.properties.body).toEqual(
-      inputSchema
-    );
+    expect(
+      body.extensions.bazaar.schema.properties.input.properties.body
+    ).toEqual(inputSchema);
     expect(
       body.extensions.bazaar.schema.properties.output.properties.example
     ).toEqual({ executionId: "exec_abc123", status: "running" });
@@ -261,10 +261,29 @@ describe("buildDual402Response", () => {
     });
     const body = await response.json();
     expect(body.extensions.bazaar.discoverable).toBe(true);
-    // schema subtree is only populated when inputSchema is provided
-    expect(body.extensions.bazaar.schema).toBeUndefined();
     expect(body.extensions.bazaar.category).toBeUndefined();
     expect(body.extensions.bazaar.tags).toBeUndefined();
+  });
+
+  it("emits extensions.bazaar.schema with an open-object body fallback when inputSchema is missing", async () => {
+    const response = buildDual402Response({
+      price: "0.01",
+      creatorWalletAddress: "0xCreator",
+      workflowName: "Workflow With No DB Schema",
+      resourceUrl: "https://example.com/api/mcp/workflows/no-schema/call",
+    });
+    const body = await response.json();
+    // Without this fallback, @agentcash/discovery's getWarningsFor402Body
+    // emits SCHEMA_INPUT_MISSING / SCHEMA_OUTPUT_MISSING for the resource
+    // and CDP Bazaar can't index it.
+    expect(
+      body.extensions.bazaar.schema.properties.input.properties.body
+    ).toEqual({
+      type: "object",
+    });
+    expect(
+      body.extensions.bazaar.schema.properties.output.properties.example
+    ).toEqual({ executionId: "exec_abc123", status: "running" });
   });
 
   it("emits extensions.bazaar.category and tags when provided", async () => {


### PR DESCRIPTION
## Why

The agentcash discovery validator (`npx -y @agentcash/discovery@latest discover https://app.keeperhub.com`) flags **43 warnings + several errors** against the live spec. Those warnings tank our ranking in the agentcash bazaar / x402scan / mppscan / Coinbase CDP Bazaar — anything that consumes the spec to surface us to AI agents.

This PR fixes the validator-flagged blockers in `app/api/openapi/route.ts`.

## Changes

| Change | Validator code addressed |
|---|---|
| Explicit `x-auth-mode` on every operation (`paid` or `free`) | `L2_AUTH_MODE_MISSING`, `L3_AUTH_MODE_MISSING` |
| Default open-object input schema (`type: object, additionalProperties: true`) for paid + write routes whose owners haven't backfilled `inputSchema` in the DB | `L3_INPUT_SCHEMA_MISSING` |
| Expanded `info.x-guidance` from 64 → ~300 tokens with worked examples for the most common workflow categories | semantic-search ranking signal |

## What this enables

Every route now declares enough metadata for x402scan, mppscan, agentcash bazaar, and the Coinbase CDP Bazaar to catalog + rank after first paid settlement. Combined with priming work I ran in parallel (each previously-unsettled paid route was hit at least once via agentcash, /bin/zsh.14 total), KeeperHub workflows should start appearing in public bazaar search within the next indexer sync cycle.

## Follow-ups (separate PRs)

- **Step 3 in the bazaar plan:** wire Coinbase CDP Bazaar extension (`declareDiscoveryExtension` per route) — addresses the remaining `SCHEMA_INPUT/OUTPUT_MISSING (extensions.bazaar.schema.*)` errors and unlocks the largest discovery surface
- **Owner backfill task:** workflows still missing real `inputSchema` in the DB will rank lower than ones with proper schemas. Found two genuine workflow bugs while priming: `defi-risk-snapshot` mis-templates the address (received `@40`); `pack-0-10-demo` requires an undeclared `code` field. Worth opening separate issues.

## Test plan

- [x] `pnpm vitest run tests/unit/openapi-route.test.ts` — 6/6 pass (3 new tests for the three behaviours)
- [x] `pnpm exec biome check` — clean
- [ ] After merge: `npx -y @agentcash/discovery@latest discover https://app.keeperhub.com` returns 0 errors and ≤ 0 warnings on `L2_AUTH_MODE_MISSING` / `L3_AUTH_MODE_MISSING` / `L3_INPUT_SCHEMA_MISSING`