### PR TITLE
fix(integrations): close ensureWalletIntegration race with unique partial index

### DIFF
--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -170,6 +170,18 @@ export async function POST(request: Request) {
 
     return NextResponse.json(response);
   } catch (error) {
+    // KEEP-384: idx_integrations_org_web3 enforces at most one web3
+    // integration per org. Surface that as a 409 with a meaningful
+    // message instead of letting it fall through to a generic 500.
+    if (isWeb3UniqueViolation(error)) {
+      return NextResponse.json(
+        {
+          error:
+            "This organization already has a web3 integration for the KeeperHub wallet.",
+        },
+        { status: 409 }
+      );
+    }
     logSystemError(
       ErrorCategory.DATABASE,
       "Failed to create integration",
@@ -187,4 +199,12 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
+}
+
+function isWeb3UniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const e = err as { code?: string; cause?: { code?: string } };
+  return (e.cause?.code ?? e.code) === "23505";
 }

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -171,13 +171,12 @@ export async function POST(request: Request) {
     return NextResponse.json(response);
   } catch (error) {
     // KEEP-384: idx_integrations_org_web3 enforces at most one web3
-    // integration per org. Surface that as a 409 with a meaningful
-    // message instead of letting it fall through to a generic 500.
-    if (isWeb3UniqueViolation(error)) {
+    // integration per org. Surface that as a 409 instead of falling
+    // through to the generic 500.
+    if (isUniqueViolation(error)) {
       return NextResponse.json(
         {
-          error:
-            "This organization already has a web3 integration for the KeeperHub wallet.",
+          error: "This organization already has a web3 integration.",
         },
         { status: 409 }
       );
@@ -201,7 +200,7 @@ export async function POST(request: Request) {
   }
 }
 
-function isWeb3UniqueViolation(err: unknown): boolean {
+function isUniqueViolation(err: unknown): boolean {
   if (!err || typeof err !== "object") {
     return false;
   }

--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -1,14 +1,14 @@
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
-import {
-  normalizeAddressForStorage,
-  truncateAddress,
-} from "@/lib/address-utils";
+import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { apiError } from "@/lib/api-error";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { createIntegration } from "@/lib/db/integrations";
+import {
+  buildWalletIntegrationPayload,
+  createIntegration,
+} from "@/lib/db/integrations";
 import { integrations, organizationWallets } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
@@ -191,14 +191,9 @@ async function storeTurnkeyWalletAndIntegration(options: {
     turnkeyPrivateKeyId,
   });
 
-  const truncatedAddress = truncateAddress(normalizedWalletAddress);
-  await createIntegration({
-    userId,
-    organizationId,
-    name: truncatedAddress,
-    type: "web3",
-    config: {},
-  });
+  await createIntegration(
+    buildWalletIntegrationPayload(userId, organizationId, normalizedWalletAddress)
+  );
 
   return { walletAddress: normalizedWalletAddress, walletId: turnkeyWalletId };
 }

--- a/drizzle/0065_keep_384_web3_integration_unique.sql
+++ b/drizzle/0065_keep_384_web3_integration_unique.sql
@@ -7,13 +7,17 @@
 -- a duplicate radio entry plus loss of single-integration auto-select.
 --
 -- Step 1: dedupe any existing duplicates, keeping the oldest row per org so
--- user-supplied names / edits on the original survive.
+-- user-supplied names / edits on the original survive. The (created_at, id)
+-- tuple comparison gives a deterministic total order even when two rows tie
+-- on microsecond-resolution created_at -- which is exactly what the race we
+-- are closing produces. Without the id tiebreaker, ties survive on both
+-- rows and the CREATE UNIQUE INDEX below would abort the migration.
 DELETE FROM integrations a USING integrations b
 WHERE a.organization_id = b.organization_id
   AND a.type = 'web3'
   AND b.type = 'web3'
   AND a.organization_id IS NOT NULL
-  AND a.created_at > b.created_at;
+  AND (a.created_at, a.id) > (b.created_at, b.id);
 
 -- Step 2: prevent the race from ever producing a duplicate again. Partial
 -- index keyed on organization_id, scoped to web3 rows with a non-null org.

--- a/drizzle/0065_keep_384_web3_integration_unique.sql
+++ b/drizzle/0065_keep_384_web3_integration_unique.sql
@@ -1,0 +1,22 @@
+-- KEEP-384 follow-up: enforce at most one cosmetic web3 integration per org.
+--
+-- Surfaced from PR #1070 review. ensureWalletIntegration in lib/db/integrations.ts
+-- does a check-then-insert with no locking; two concurrent /api/integrations GETs
+-- for the same org can both pass the existence check and both insert, producing
+-- two web3 rows pointing at the same wallet. Visible in the workflow builder as
+-- a duplicate radio entry plus loss of single-integration auto-select.
+--
+-- Step 1: dedupe any existing duplicates, keeping the oldest row per org so
+-- user-supplied names / edits on the original survive.
+DELETE FROM integrations a USING integrations b
+WHERE a.organization_id = b.organization_id
+  AND a.type = 'web3'
+  AND b.type = 'web3'
+  AND a.organization_id IS NOT NULL
+  AND a.created_at > b.created_at;
+
+-- Step 2: prevent the race from ever producing a duplicate again. Partial
+-- index keyed on organization_id, scoped to web3 rows with a non-null org.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_integrations_org_web3"
+  ON "integrations" ("organization_id")
+  WHERE "type" = 'web3' AND "organization_id" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1777429262207,
       "tag": "0064_keep_239_hash_session_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0065_keep_384_web3_integration_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -277,26 +277,40 @@ export async function createIntegration(
 }
 
 /**
+ * Build the canonical payload used to create the cosmetic web3 integration
+ * row that backs an org's KeeperHub wallet. Shared between the provisioning
+ * route (`app/api/user/wallet/route.ts`) and the read-path heal below so the
+ * shape can't drift if one site adds a field.
+ */
+export function buildWalletIntegrationPayload(
+  userId: string,
+  organizationId: string,
+  walletAddress: string
+): CreateIntegrationOptions {
+  return {
+    userId,
+    organizationId,
+    name: truncateAddress(walletAddress),
+    type: "web3",
+    config: {},
+  };
+}
+
+/**
  * Ensure the org's KeeperHub wallet has a backing web3 integration row.
  *
- * Wallet provisioning at app/api/user/wallet/route.ts:195 auto-creates a
- * cosmetic web3 integration alongside the wallet. For orgs whose wallet
- * pre-dates that auto-create code, or whose integration was deleted /
- * migrated, the row can be missing -- which made the Workflow Builder
- * render a misleading "Add Web3 connection" warning even though the
- * wallet itself was working fine.
+ * Wallet provisioning auto-creates a cosmetic web3 integration alongside the
+ * wallet. For orgs whose wallet pre-dates that auto-create code, or whose
+ * integration was deleted / migrated, the row can be missing -- which made
+ * the Workflow Builder render a misleading "Add Web3 connection" warning
+ * even though the wallet itself was working fine.
  *
  * Heals that drift idempotently: if the org has an active wallet but no
- * web3 integration row, create one with the same payload the
- * provisioning route would have written. Safe to call from any read path
- * that lists integrations -- after the first call for a given org the
- * row exists and subsequent calls early-return.
- *
- * Two concurrent callers can race and both pass the existence check,
- * resulting in two web3 rows for the same wallet. We accept that rare
- * edge case rather than introducing a unique constraint or transaction
- * lock; the multi-integration list still renders, and the user can
- * delete the extra row.
+ * web3 integration row, create one with the canonical payload. Safe to call
+ * from any read path that lists integrations -- after the first call for a
+ * given org the row exists and subsequent calls early-return. The userId on
+ * a healed row is just the first member to GET after deploy; reads are
+ * org-scoped so this is benign.
  */
 export async function ensureWalletIntegration(
   userId: string,
@@ -322,13 +336,21 @@ export async function ensureWalletIntegration(
   }
 
   const wallet = await getOrganizationWallet(organizationId);
-  await createIntegration({
-    userId,
-    organizationId,
-    name: truncateAddress(wallet.walletAddress),
-    type: "web3",
-    config: {},
-  });
+  // The existence check above is racy: two concurrent /api/integrations GETs
+  // for the same org can both pass it and both insert. The
+  // `idx_integrations_org_web3` partial unique index makes the second insert
+  // fail with Postgres unique_violation (23505); swallow it and treat as
+  // success since the other caller already created the row.
+  try {
+    await createIntegration(
+      buildWalletIntegrationPayload(userId, organizationId, wallet.walletAddress)
+    );
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "23505") {
+      throw err;
+    }
+  }
 }
 
 /**

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -340,17 +340,27 @@ export async function ensureWalletIntegration(
   // for the same org can both pass it and both insert. The
   // `idx_integrations_org_web3` partial unique index makes the second insert
   // fail with Postgres unique_violation (23505); swallow it and treat as
-  // success since the other caller already created the row.
+  // success since the other caller already created the row. drizzle-orm wraps
+  // driver errors in DrizzleQueryError with the original PostgresError on
+  // `.cause` -- match the repo's established pattern (lib/mcp/listing.ts,
+  // app/api/user/wallet/route.ts).
   try {
     await createIntegration(
       buildWalletIntegrationPayload(userId, organizationId, wallet.walletAddress)
     );
   } catch (err) {
-    const code = (err as { code?: string } | null)?.code;
-    if (code !== "23505") {
+    if (!isUniqueViolation(err)) {
       throw err;
     }
   }
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const e = err as { code?: string; cause?: { code?: string } };
+  return (e.cause?.code ?? e.code) === "23505";
 }
 
 /**

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -271,9 +271,11 @@ export const integrations = pgTable(
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    // At most one cosmetic web3 integration row per org. Closes the race
-    // in ensureWalletIntegration where two concurrent /api/integrations GETs
-    // could both pass the existence check and both insert.
+    // At most one web3 integration row per org. Today the only web3 row is
+    // the cosmetic KeeperHub-wallet entry; the broader rule is enforced
+    // here so any future web3 write hits the same guard. Closes the race
+    // in ensureWalletIntegration where two concurrent /api/integrations
+    // GETs could both pass the existence check and both insert.
     uniqueIndex("idx_integrations_org_web3")
       .on(table.organizationId)
       .where(

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { isNotNull, relations } from "drizzle-orm";
+import { isNotNull, relations, sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -249,25 +249,38 @@ export const workflows = pgTable(
 );
 
 // Integrations table for storing user credentials
-export const integrations = pgTable("integrations", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => generateId()),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  organizationId: text("organization_id").references(() => organization.id, {
-    onDelete: "cascade",
-  }),
-  name: text("name").notNull(),
-  type: text("type").notNull().$type<IntegrationType>(),
-  // biome-ignore lint/suspicious/noExplicitAny: JSONB type - encrypted credentials stored as JSON
-  config: jsonb("config").notNull().$type<any>(),
-  // Whether this integration was created via OAuth (managed by app) vs manual entry
-  isManaged: boolean("is_managed").default(false),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at").notNull().defaultNow(),
-});
+export const integrations = pgTable(
+  "integrations",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    organizationId: text("organization_id").references(() => organization.id, {
+      onDelete: "cascade",
+    }),
+    name: text("name").notNull(),
+    type: text("type").notNull().$type<IntegrationType>(),
+    // biome-ignore lint/suspicious/noExplicitAny: JSONB type - encrypted credentials stored as JSON
+    config: jsonb("config").notNull().$type<any>(),
+    // Whether this integration was created via OAuth (managed by app) vs manual entry
+    isManaged: boolean("is_managed").default(false),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    // At most one cosmetic web3 integration row per org. Closes the race
+    // in ensureWalletIntegration where two concurrent /api/integrations GETs
+    // could both pass the existence check and both insert.
+    uniqueIndex("idx_integrations_org_web3")
+      .on(table.organizationId)
+      .where(
+        sql`${table.type} = 'web3' AND ${table.organizationId} IS NOT NULL`
+      ),
+  ]
+);
 
 // Workflow executions table to track workflow runs
 export const workflowExecutions = pgTable(

--- a/tests/unit/ensure-wallet-integration.test.ts
+++ b/tests/unit/ensure-wallet-integration.test.ts
@@ -137,6 +137,11 @@ describe("ensureWalletIntegration", () => {
     expect(mockInsertReturning).toHaveBeenCalledTimes(1);
   });
 
+  // Drizzle wraps every driver error in DrizzleQueryError today, so the
+  // top-level `err.code` path is unreachable in production. Kept as a
+  // defense-in-depth regression guard against the `?? e.code` fallback
+  // being deleted as "dead" -- if a future driver path surfaces
+  // PostgresError directly, the guard still fires. Do not strip.
   it("also swallows 23505 surfaced as a top-level code (defense-in-depth)", async () => {
     mockOrganizationHasWallet.mockResolvedValue(true);
     mockSelectLimit.mockResolvedValue([]);

--- a/tests/unit/ensure-wallet-integration.test.ts
+++ b/tests/unit/ensure-wallet-integration.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockOrganizationHasWallet = vi.fn();
+const mockGetOrganizationWallet = vi.fn();
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  organizationHasWallet: (...args: unknown[]) =>
+    mockOrganizationHasWallet(...args),
+  getOrganizationWallet: (...args: unknown[]) =>
+    mockGetOrganizationWallet(...args),
+}));
+
+const mockSelectLimit = vi.fn();
+const mockInsertReturning = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: (...args: unknown[]) => mockSelectLimit(...args),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: (...args: unknown[]) => mockInsertReturning(...args),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  integrations: { id: "id", organizationId: "organization_id", type: "type" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock("@/plugins/registry", () => ({
+  findActionById: vi.fn(),
+  getIntegration: vi.fn(),
+}));
+
+vi.mock("@/lib/address-utils", () => ({
+  truncateAddress: (addr: string) => `${addr.slice(0, 6)}...${addr.slice(-4)}`,
+}));
+
+const ORIGINAL_ENCRYPTION_KEY = process.env.INTEGRATION_ENCRYPTION_KEY;
+process.env.INTEGRATION_ENCRYPTION_KEY = "0".repeat(64);
+
+const { ensureWalletIntegration, buildWalletIntegrationPayload } = await import(
+  "@/lib/db/integrations"
+);
+
+const USER_ID = "user-1";
+const ORG_ID = "org-1";
+const WALLET_ADDRESS = "0xA3CD0000000000000000000000000000000007Eb3";
+
+describe("ensureWalletIntegration", () => {
+  beforeEach(() => {
+    mockOrganizationHasWallet.mockReset();
+    mockGetOrganizationWallet.mockReset();
+    mockSelectLimit.mockReset();
+    mockInsertReturning.mockReset();
+  });
+
+  it("no-ops when the org has no wallet", async () => {
+    mockOrganizationHasWallet.mockResolvedValue(false);
+
+    await ensureWalletIntegration(USER_ID, ORG_ID);
+
+    expect(mockOrganizationHasWallet).toHaveBeenCalledWith(ORG_ID);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when a web3 row already exists", async () => {
+    mockOrganizationHasWallet.mockResolvedValue(true);
+    mockSelectLimit.mockResolvedValue([{ id: "existing-row" }]);
+
+    await ensureWalletIntegration(USER_ID, ORG_ID);
+
+    expect(mockGetOrganizationWallet).not.toHaveBeenCalled();
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it("inserts when no row exists and returns cleanly", async () => {
+    mockOrganizationHasWallet.mockResolvedValue(true);
+    mockSelectLimit.mockResolvedValue([]);
+    mockGetOrganizationWallet.mockResolvedValue({
+      walletAddress: WALLET_ADDRESS,
+    });
+    mockInsertReturning.mockResolvedValue([
+      {
+        id: "new-row",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        name: "0xA3CD...7Eb3",
+        type: "web3",
+        config: "encrypted",
+        isManaged: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    await expect(
+      ensureWalletIntegration(USER_ID, ORG_ID)
+    ).resolves.toBeUndefined();
+    expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows 23505 unique_violation when a concurrent caller wins the race", async () => {
+    mockOrganizationHasWallet.mockResolvedValue(true);
+    mockSelectLimit.mockResolvedValue([]);
+    mockGetOrganizationWallet.mockResolvedValue({
+      walletAddress: WALLET_ADDRESS,
+    });
+    const uniqueViolation = Object.assign(new Error("duplicate key"), {
+      code: "23505",
+    });
+    mockInsertReturning.mockRejectedValueOnce(uniqueViolation);
+
+    await expect(
+      ensureWalletIntegration(USER_ID, ORG_ID)
+    ).resolves.toBeUndefined();
+    expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws non-23505 errors from createIntegration", async () => {
+    mockOrganizationHasWallet.mockResolvedValue(true);
+    mockSelectLimit.mockResolvedValue([]);
+    mockGetOrganizationWallet.mockResolvedValue({
+      walletAddress: WALLET_ADDRESS,
+    });
+    const otherError = Object.assign(new Error("connection refused"), {
+      code: "08006",
+    });
+    mockInsertReturning.mockRejectedValueOnce(otherError);
+
+    await expect(ensureWalletIntegration(USER_ID, ORG_ID)).rejects.toThrow(
+      "connection refused"
+    );
+  });
+});
+
+describe("buildWalletIntegrationPayload", () => {
+  it("produces the canonical web3 integration shape", () => {
+    const payload = buildWalletIntegrationPayload(
+      USER_ID,
+      ORG_ID,
+      WALLET_ADDRESS
+    );
+
+    expect(payload).toEqual({
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      name: "0xA3CD...7Eb3",
+      type: "web3",
+      config: {},
+    });
+  });
+});
+
+if (ORIGINAL_ENCRYPTION_KEY === undefined) {
+  process.env.INTEGRATION_ENCRYPTION_KEY = undefined;
+} else {
+  process.env.INTEGRATION_ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
+}

--- a/tests/unit/ensure-wallet-integration.test.ts
+++ b/tests/unit/ensure-wallet-integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -115,16 +115,21 @@ describe("ensureWalletIntegration", () => {
     expect(mockInsertReturning).toHaveBeenCalledTimes(1);
   });
 
-  it("swallows 23505 unique_violation when a concurrent caller wins the race", async () => {
+  it("swallows 23505 wrapped by DrizzleQueryError on .cause when the race fires", async () => {
     mockOrganizationHasWallet.mockResolvedValue(true);
     mockSelectLimit.mockResolvedValue([]);
     mockGetOrganizationWallet.mockResolvedValue({
       walletAddress: WALLET_ADDRESS,
     });
-    const uniqueViolation = Object.assign(new Error("duplicate key"), {
+    // drizzle-orm wraps driver errors: outer DrizzleQueryError, original
+    // PostgresError on .cause carrying the SQLSTATE code.
+    const pgError = Object.assign(new Error("duplicate key value"), {
       code: "23505",
     });
-    mockInsertReturning.mockRejectedValueOnce(uniqueViolation);
+    const drizzleWrapped = Object.assign(new Error("Failed query"), {
+      cause: pgError,
+    });
+    mockInsertReturning.mockRejectedValueOnce(drizzleWrapped);
 
     await expect(
       ensureWalletIntegration(USER_ID, ORG_ID)
@@ -132,19 +137,38 @@ describe("ensureWalletIntegration", () => {
     expect(mockInsertReturning).toHaveBeenCalledTimes(1);
   });
 
-  it("re-throws non-23505 errors from createIntegration", async () => {
+  it("also swallows 23505 surfaced as a top-level code (defense-in-depth)", async () => {
     mockOrganizationHasWallet.mockResolvedValue(true);
     mockSelectLimit.mockResolvedValue([]);
     mockGetOrganizationWallet.mockResolvedValue({
       walletAddress: WALLET_ADDRESS,
     });
-    const otherError = Object.assign(new Error("connection refused"), {
+    const directError = Object.assign(new Error("duplicate key value"), {
+      code: "23505",
+    });
+    mockInsertReturning.mockRejectedValueOnce(directError);
+
+    await expect(
+      ensureWalletIntegration(USER_ID, ORG_ID)
+    ).resolves.toBeUndefined();
+  });
+
+  it("re-throws non-23505 errors (e.g. wrapped 08006 connection refused)", async () => {
+    mockOrganizationHasWallet.mockResolvedValue(true);
+    mockSelectLimit.mockResolvedValue([]);
+    mockGetOrganizationWallet.mockResolvedValue({
+      walletAddress: WALLET_ADDRESS,
+    });
+    const pgError = Object.assign(new Error("connection refused"), {
       code: "08006",
     });
-    mockInsertReturning.mockRejectedValueOnce(otherError);
+    const wrapped = Object.assign(new Error("Failed query"), {
+      cause: pgError,
+    });
+    mockInsertReturning.mockRejectedValueOnce(wrapped);
 
     await expect(ensureWalletIntegration(USER_ID, ORG_ID)).rejects.toThrow(
-      "connection refused"
+      "Failed query"
     );
   });
 });
@@ -167,8 +191,10 @@ describe("buildWalletIntegrationPayload", () => {
   });
 });
 
-if (ORIGINAL_ENCRYPTION_KEY === undefined) {
-  process.env.INTEGRATION_ENCRYPTION_KEY = undefined;
-} else {
-  process.env.INTEGRATION_ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
-}
+afterAll(() => {
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) {
+    delete process.env.INTEGRATION_ENCRYPTION_KEY;
+  } else {
+    process.env.INTEGRATION_ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
+  }
+});


### PR DESCRIPTION
## Summary

Surfaced from the PR #1070 review of #1069 (KEEP-384 follow-up). `ensureWalletIntegration` in `lib/db/integrations.ts` did a racy check-then-insert with no locking — two concurrent `/api/integrations` GETs for the same org could both pass the existence check and both insert, producing two web3 integration rows pointing at the same wallet.

UI consequence: `IntegrationSelector` only renders the single-integration "checkmark + pencil" branch when `length === 1` (`components/ui/integration-selector.tsx:298-323`); duplicate rows force the multi-radio list with two indistinguishable entries. `node-config-panel.tsx:533` also loses auto-select.

## What changes

**1. Schema (`lib/db/schema.ts`)** — partial unique index on `integrations(organization_id) WHERE type = 'web3' AND organization_id IS NOT NULL`. Converts the `integrations` `pgTable` to the second-arg-array form to attach the index. Adds `sql` to the drizzle-orm import.

**2. Migration (`drizzle/0065_keep_384_web3_integration_unique.sql` + journal entry)** — hand-written because `drizzle-kit generate` currently fails on an unrelated BigInt serialization. Two steps:
- Dedupe existing duplicates with `(created_at, id) > (created_at, id)` tuple comparison so `id` breaks ties on equal microseconds (without the tiebreaker, race-created rows could survive on both sides and the next step would abort).
- `CREATE UNIQUE INDEX IF NOT EXISTS idx_integrations_org_web3 ...`.

Journal `when` is `1777680000000`, monotonically increasing on top of idx 64.

**3. Race-safe insert (`lib/db/integrations.ts`)** — wrap `createIntegration` inside `ensureWalletIntegration` in try/catch that swallows Postgres `unique_violation` (23505); other errors re-throw. Reads from `err.cause?.code ?? err.code` because drizzle-orm wraps driver errors in `DrizzleQueryError` with the original `PostgresError` on `.cause` — matching the established repo pattern (`lib/mcp/listing.ts:71-74`, `app/api/user/wallet/route.ts:108-129`).

**4. POST `/api/integrations` 23505 handling (`app/api/integrations/route.ts`)** — the unique index applies to all web3 rows for an org, not just the cosmetic wallet row. POST falls through to a 409 with a meaningful message instead of a generic 500 if a user tries to create a second web3 integration.

**5. Helper extraction (`lib/db/integrations.ts`, `app/api/user/wallet/route.ts`)** — `buildWalletIntegrationPayload(userId, orgId, walletAddress)` is the single source of truth for the cosmetic web3 integration row shape, used by both the read-path heal and the canonical wallet provisioning write. Eliminates a real shape-drift class of bug.

## Out of scope

- Moving the heal off the read path (steady-state cost: 2 indexed lookups per `/api/integrations` GET). The right end state is a one-shot backfill in this migration plus deleting the read-path heal — but doing it here would expand the diff. Worth a follow-up ticket once we confirm drift is empty.
- The broader "web3 integration" concept cleanup — KEEP-386 covers that.

## Test plan

- [x] `pnpm type-check` exit 0
- [x] `pnpm vitest run` full suite exit 0; `tests/unit/ensure-wallet-integration.test.ts` 7/7 (no-wallet no-op, existing-row no-op, fresh insert, 23505 swallowed via `DrizzleQueryError.cause`, 23505 swallowed via top-level code (defense-in-depth), non-23505 re-throw, helper shape)
- [x] `pnpm db:migrate` applies 0065 cleanly on local Postgres
- [x] `pnpm check` parity with `origin/staging` baseline (no new lint diagnostics on changed files)
- [x] `pnpm build` exit 0
- [ ] Two-session psql concurrency test — open two `BEGIN; INSERT INTO integrations(... type='web3' ...); COMMIT;` sessions for the same org; second one gets 23505 against `idx_integrations_org_web3` (manual, not automated)

## Reviewed by

Three-agent review pass on the original commit (`79e01314`) caught:
- **BL-01**: 23505 catch was reading `err.code` directly, but drizzle-orm wraps in `DrizzleQueryError` with the SQLSTATE on `.cause`. The original catch would have never matched in production — heal would have re-thrown and 500'd the GET, strictly worse than the duplicate-row symptom. Fixed.
- **BL-02**: Migration DELETE used strict `created_at > created_at`. Microsecond-tied duplicates would survive on both sides → `CREATE UNIQUE INDEX` aborts → deploy breaks. Fixed with `(created_at, id)` tuple comparison.
- **HI-01**: Public POST `/api/integrations` would 500 if a user tried to create a second web3 integration after the index landed. Fixed with explicit 409.
- **HI-02**: Unit test mocked the same wrong shape the production code used (top-level `code`), giving false confidence. Rewritten to assert against the actual `DrizzleQueryError.cause` shape, plus a defense-in-depth case for the top-level fallback.

All addressed in the followup commit `41491d21`.