### PR TITLE
feat(listing): validate inputSchema and reject bare-@ literals at publish

### DIFF
--- a/app/api/mcp/workflows/[slug]/listing/route.ts
+++ b/app/api/mcp/workflows/[slug]/listing/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import {
   getWorkflowListing,
+  type ListWorkflowMetadata,
   listWorkflow,
+  type UpdateWorkflowPatch,
   unlistWorkflow,
   updateWorkflowListing,
-  type ListWorkflowMetadata,
-  type UpdateWorkflowPatch,
 } from "@/lib/mcp/listing";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
+import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 
 const LISTING_RATE_LIMIT = 60;
@@ -44,6 +44,26 @@ function mapListingError(error: string): NextResponse {
         error: "MISSING_WRITE_ACTION",
         message:
           "Workflows listed as workflowType='write' must contain at least one write-contract or protocol-write action node. Add the action to the workflow before listing it.",
+      },
+      { status: 422 }
+    );
+  }
+  if (error === "INVALID_TEMPLATE_LITERALS") {
+    return NextResponse.json(
+      {
+        error: "INVALID_TEMPLATE_LITERALS",
+        message:
+          "One or more node config fields contain a bare `@<word>` literal outside a `{{...}}` template wrapper. This usually means the editor's `@` autocomplete was dismissed before the reference was completed. Re-open the workflow, replace the literal with a proper `{{@nodeId:Label.field}}` reference, and try listing again.",
+      },
+      { status: 422 }
+    );
+  }
+  if (error === "INPUT_SCHEMA_REQUIRED") {
+    return NextResponse.json(
+      {
+        error: "INPUT_SCHEMA_REQUIRED",
+        message:
+          'Listed workflows must declare an `inputSchema`. Set it to a JSON-schema-shaped object — `{"type": "object"}` is fine for workflows that take no inputs.',
       },
       { status: 422 }
     );

--- a/app/api/mcp/workflows/[slug]/listing/route.ts
+++ b/app/api/mcp/workflows/[slug]/listing/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   getWorkflowListing,
+  type ListingErrorDetails,
   type ListWorkflowMetadata,
   listWorkflow,
   type UpdateWorkflowPatch,
@@ -16,7 +17,10 @@ const LISTING_RATE_WINDOW_MS = 60_000;
 
 type RouteContext = { params: Promise<{ slug: string }> };
 
-function mapListingError(error: string): NextResponse {
+function mapListingError(
+  error: string,
+  details?: ListingErrorDetails
+): NextResponse {
   if (error === "NOT_FOUND") {
     return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
   }
@@ -54,6 +58,9 @@ function mapListingError(error: string): NextResponse {
         error: "INVALID_TEMPLATE_LITERALS",
         message:
           "One or more node config fields contain a bare `@<word>` literal outside a `{{...}}` template wrapper. This usually means the editor's `@` autocomplete was dismissed before the reference was completed. Re-open the workflow, replace the literal with a proper `{{@nodeId:Label.field}}` reference, and try listing again.",
+        ...(details?.literals && details.literals.length > 0
+          ? { literals: details.literals }
+          : {}),
       },
       { status: 422 }
     );
@@ -179,7 +186,7 @@ export async function POST(
 
   const result = await listWorkflow(workflowId, organizationId, metadata);
   if (!result.ok) {
-    return mapListingError(result.error);
+    return mapListingError(result.error, result.details);
   }
 
   return NextResponse.json(result.listing, { status: 200 });
@@ -240,7 +247,7 @@ export async function PATCH(
 
   const result = await updateWorkflowListing(workflowId, organizationId, patch);
   if (!result.ok) {
-    return mapListingError(result.error);
+    return mapListingError(result.error, result.details);
   }
 
   return NextResponse.json(result.listing, { status: 200 });
@@ -270,7 +277,7 @@ export async function DELETE(
 
   const result = await unlistWorkflow(workflowId, organizationId);
   if (!result.ok) {
-    return mapListingError(result.error);
+    return mapListingError(result.error, result.details);
   }
 
   return NextResponse.json(result.listing, { status: 200 });

--- a/lib/mcp/listing-validators.ts
+++ b/lib/mcp/listing-validators.ts
@@ -11,21 +11,83 @@
  * Kept dependency-free so they're easy to unit-test without DB mocks.
  */
 
-const TEMPLATE_PATTERN = /\{\{[^}]*\}\}/g;
-// Match @<word>(-<word>)* preceded by start-of-string, whitespace, or a
-// delimiter. Excludes intra-token @s (like email addresses).
-const BARE_AT_PATTERN = /(?:^|[\s,;:([])(@\w+(?:-\w+)*)/g;
+// Linear-time strip of wrapped templates. The `[^{}]*` form (vs `[^}]*`) avoids
+// the V8 quadratic-replace pathology when input contains long runs of unmatched
+// `{`s — `current.nodes` is DB-resident, so a malicious workflow row would
+// otherwise pin a worker for tens of seconds at the listing call.
+const TEMPLATE_PATTERN = /\{\{[^{}]*\}\}/g;
+// Match @<word>(-<word>)* preceded by start-of-string or any non-word, non-`@`
+// character. The broad prefix catches quote/equals/bracket-wrapped trapped
+// states (e.g. `condition: "@trigger-1"`, `key=@val`, `("@nested")`) that a
+// narrower delimiter list would miss; emails (`a@b.com`) and intra-token `@`s
+// remain unflagged because the prefix requires the `@` to NOT follow a word
+// character.
+const BARE_AT_PATTERN = /(?:^|[^\w@])(@\w+(?:-\w+)*)/g;
+
+// Bound the walk to keep this gate predictable on adversarial input. The DB
+// row is the attack surface — a malicious workflow planted via an upstream
+// path could otherwise blow the V8 stack (~20k depth) or pin a worker on a
+// multi-MB string field.
+const MAX_DEPTH = 100;
+const MAX_STRING_LEN = 256_000;
+const MAX_FINDINGS = 10;
+
+// Action-type prefixes whose configs legitimately embed `@<word>` content
+// (Discord/Slack/Telegram mentions, AI-prompt natural language, TypeScript
+// decorators in code blocks). Skipped wholesale to avoid false positives on
+// the bazaar's most common authoring shapes.
+const SKIP_ACTION_TYPE_PREFIXES = [
+  "code/",
+  "notify/",
+  "discord/",
+  "slack/",
+  "telegram/",
+  "email/",
+  "ai/",
+  "ai-gateway/",
+];
 
 type NodeLike = {
   id?: unknown;
   type?: unknown;
   data?: {
+    actionType?: unknown;
     config?: { actionType?: unknown } & Record<string, unknown>;
   } & Record<string, unknown>;
 } & Record<string, unknown>;
 
 /**
- * Returns the list of bare-@ literals found in workflow node configs.
+ * Reads the action type from either `data.config.actionType` or the legacy
+ * `data.actionType` fallback (mirroring `findFirstWriteActionNode` in
+ * `lib/mcp/calldata.ts`). Normalizes colon-separated forms (`code:run-code`)
+ * to slash-separated (`code/run-code`) — sanitize-nodes does the same on the
+ * write path, but in-flight or legacy fixtures may still carry the colon form.
+ */
+function getNormalizedActionType(node: NodeLike): string {
+  const fromConfig =
+    typeof node?.data?.config?.actionType === "string"
+      ? (node.data.config.actionType as string)
+      : "";
+  const fromData =
+    typeof node?.data?.actionType === "string"
+      ? (node.data.actionType as string)
+      : "";
+  const raw = fromConfig || fromData;
+  return raw.replace(":", "/");
+}
+
+function shouldSkipForAtDetection(node: NodeLike): boolean {
+  const actionType = getNormalizedActionType(node);
+  if (actionType === "") {
+    return false;
+  }
+  return SKIP_ACTION_TYPE_PREFIXES.some((prefix) =>
+    actionType.startsWith(prefix)
+  );
+}
+
+/**
+ * Returns up to MAX_FINDINGS bare-@ literals found in workflow node configs.
  *
  * A bare-@ literal is an `@<word>` token that appears OUTSIDE a `{{...}}`
  * template wrapper — i.e. the trapped state when a user types `@` in the
@@ -33,9 +95,9 @@ type NodeLike = {
  * reference. These would survive listing and silently break at runtime
  * because the executor only resolves wrapped templates.
  *
- * Nodes whose `data.config.actionType` starts with `code/` are skipped to
- * avoid false positives on TypeScript-style decorators inside user-authored
- * code blocks.
+ * Nodes whose action type matches `SKIP_ACTION_TYPE_PREFIXES` are skipped to
+ * avoid false positives on legitimate `@`-bearing content (Discord/Slack
+ * mentions, AI prompts, TS decorators in code blocks).
  */
 export function findBareAtLiterals(nodes: unknown): string[] {
   if (!Array.isArray(nodes)) {
@@ -45,11 +107,10 @@ export function findBareAtLiterals(nodes: unknown): string[] {
   const findings: string[] = [];
 
   for (const node of nodes as NodeLike[]) {
-    const actionType =
-      typeof node?.data?.config?.actionType === "string"
-        ? (node.data.config.actionType as string)
-        : "";
-    if (actionType.startsWith("code/")) {
+    if (findings.length >= MAX_FINDINGS) {
+      break;
+    }
+    if (shouldSkipForAtDetection(node)) {
       continue;
     }
 
@@ -57,29 +118,44 @@ export function findBareAtLiterals(nodes: unknown): string[] {
     if (config === undefined || config === null) {
       continue;
     }
-    visit(config, findings);
+    visit(config, findings, 0);
   }
 
   return findings;
 }
 
-function visit(value: unknown, findings: string[]): void {
+function visit(value: unknown, findings: string[], depth: number): void {
+  if (depth > MAX_DEPTH || findings.length >= MAX_FINDINGS) {
+    return;
+  }
   if (typeof value === "string") {
+    if (value.length > MAX_STRING_LEN) {
+      return;
+    }
     const stripped = value.replace(TEMPLATE_PATTERN, "");
     for (const m of stripped.matchAll(BARE_AT_PATTERN)) {
       findings.push(m[1]);
+      if (findings.length >= MAX_FINDINGS) {
+        return;
+      }
     }
     return;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      visit(item, findings);
+      visit(item, findings, depth + 1);
+      if (findings.length >= MAX_FINDINGS) {
+        return;
+      }
     }
     return;
   }
   if (typeof value === "object" && value !== null) {
     for (const item of Object.values(value as Record<string, unknown>)) {
-      visit(item, findings);
+      visit(item, findings, depth + 1);
+      if (findings.length >= MAX_FINDINGS) {
+        return;
+      }
     }
   }
 }

--- a/lib/mcp/listing-validators.ts
+++ b/lib/mcp/listing-validators.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure validators for the workflow listing flow.
+ *
+ * These functions inspect the workflow `nodes` payload and the desired
+ * `inputSchema` to catch authoring mistakes that would otherwise reach the
+ * bazaar in a broken state — e.g. an `@40` literal where the editor's `@`
+ * autocomplete was dismissed mid-typing, or a listed workflow with a null
+ * inputSchema (which leaves bazaar consumers unable to render or validate
+ * inputs).
+ *
+ * Kept dependency-free so they're easy to unit-test without DB mocks.
+ */
+
+const TEMPLATE_PATTERN = /\{\{[^}]*\}\}/g;
+// Match @<word>(-<word>)* preceded by start-of-string, whitespace, or a
+// delimiter. Excludes intra-token @s (like email addresses).
+const BARE_AT_PATTERN = /(?:^|[\s,;:([])(@\w+(?:-\w+)*)/g;
+
+type NodeLike = {
+  id?: unknown;
+  type?: unknown;
+  data?: {
+    config?: { actionType?: unknown } & Record<string, unknown>;
+  } & Record<string, unknown>;
+} & Record<string, unknown>;
+
+/**
+ * Returns the list of bare-@ literals found in workflow node configs.
+ *
+ * A bare-@ literal is an `@<word>` token that appears OUTSIDE a `{{...}}`
+ * template wrapper — i.e. the trapped state when a user types `@` in the
+ * editor and dismisses autocomplete before completing a `{{@nodeId:...}}`
+ * reference. These would survive listing and silently break at runtime
+ * because the executor only resolves wrapped templates.
+ *
+ * Nodes whose `data.config.actionType` starts with `code/` are skipped to
+ * avoid false positives on TypeScript-style decorators inside user-authored
+ * code blocks.
+ */
+export function findBareAtLiterals(nodes: unknown): string[] {
+  if (!Array.isArray(nodes)) {
+    return [];
+  }
+
+  const findings: string[] = [];
+
+  for (const node of nodes as NodeLike[]) {
+    const actionType =
+      typeof node?.data?.config?.actionType === "string"
+        ? (node.data.config.actionType as string)
+        : "";
+    if (actionType.startsWith("code/")) {
+      continue;
+    }
+
+    const config = node?.data?.config;
+    if (config === undefined || config === null) {
+      continue;
+    }
+    visit(config, findings);
+  }
+
+  return findings;
+}
+
+function visit(value: unknown, findings: string[]): void {
+  if (typeof value === "string") {
+    const stripped = value.replace(TEMPLATE_PATTERN, "");
+    for (const m of stripped.matchAll(BARE_AT_PATTERN)) {
+      findings.push(m[1]);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visit(item, findings);
+    }
+    return;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      visit(item, findings);
+    }
+  }
+}
+
+/**
+ * Returns true if the given value is a non-null object that can serve as a
+ * JSON-schema-shaped input declaration. Empty objects (e.g. `{type: "object"}`)
+ * are accepted — the goal is to ensure the workflow declares *something* for
+ * bazaar consumers to render, not to enforce schema completeness.
+ */
+export function isInputSchemaPresent(schema: unknown): boolean {
+  return (
+    typeof schema === "object" && schema !== null && !Array.isArray(schema)
+  );
+}

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -16,9 +16,16 @@ export type ListingErrorCode =
   | "INVALID_TEMPLATE_LITERALS"
   | "INPUT_SCHEMA_REQUIRED";
 
+export interface ListingErrorDetails {
+  // Bare-@ literals found in node configs at publish time, surfaced so the
+  // author can locate the offending field without spelunking. Capped at
+  // MAX_FINDINGS by the validator.
+  literals?: string[];
+}
+
 export type ListingResult<T> =
   | { ok: true; listing: T }
-  | { ok: false; error: ListingErrorCode };
+  | { ok: false; error: ListingErrorCode; details?: ListingErrorDetails };
 
 export interface ListWorkflowMetadata {
   slug?: string;
@@ -87,7 +94,9 @@ export async function listWorkflow(
   const existing = await db
     .select()
     .from(workflows)
-    .where(and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId)))
+    .where(
+      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+    )
     .limit(1);
 
   if (existing.length === 0) {
@@ -148,9 +157,15 @@ export async function listWorkflow(
   // editor's `@` autocomplete (user typed `@40` and dismissed the picker before
   // it wrapped the reference into `{{@nodeId:Label.field}}`). The executor only
   // resolves wrapped templates, so an unwrapped `@40` would silently flow
-  // through as a literal at runtime.
-  if (findBareAtLiterals(current.nodes).length > 0) {
-    return { ok: false, error: "INVALID_TEMPLATE_LITERALS" };
+  // through as a literal at runtime. Surface the offending literals so the
+  // author can locate the field without spelunking.
+  const bareLiterals = findBareAtLiterals(current.nodes);
+  if (bareLiterals.length > 0) {
+    return {
+      ok: false,
+      error: "INVALID_TEMPLATE_LITERALS",
+      details: { literals: bareLiterals },
+    };
   }
 
   // Listed workflows must declare an inputSchema. Bazaar consumers (agentcash,
@@ -166,7 +181,9 @@ export async function listWorkflow(
     const [result] = await db
       .update(workflows)
       .set(updateSet)
-      .where(and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId)))
+      .where(
+        and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+      )
       .returning();
     if (!result) {
       return { ok: false, error: "NOT_FOUND" };
@@ -187,7 +204,9 @@ export async function unlistWorkflow(
   const existing = await db
     .select()
     .from(workflows)
-    .where(and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId)))
+    .where(
+      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+    )
     .limit(1);
 
   if (existing.length === 0) {
@@ -197,7 +216,9 @@ export async function unlistWorkflow(
   const [result] = await db
     .update(workflows)
     .set({ isListed: false, updatedAt: new Date() })
-    .where(and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId)))
+    .where(
+      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+    )
     .returning();
 
   if (!result) {
@@ -215,7 +236,9 @@ export async function updateWorkflowListing(
   const existing = await db
     .select()
     .from(workflows)
-    .where(and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId)))
+    .where(
+      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+    )
     .limit(1);
 
   if (existing.length === 0) {
@@ -269,7 +292,9 @@ export async function updateWorkflowListing(
     const [result] = await db
       .update(workflows)
       .set(updateSet)
-      .where(and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId)))
+      .where(
+        and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+      )
       .returning();
 
     if (!result) {
@@ -294,9 +319,7 @@ export async function getWorkflowListing(
   const rows = await db
     .select(LISTING_COLUMNS)
     .from(workflows)
-    .where(
-      and(eq(workflows.listedSlug, slug), eq(workflows.isListed, true))
-    )
+    .where(and(eq(workflows.listedSlug, slug), eq(workflows.isListed, true)))
     .limit(1);
 
   if (rows.length === 0) {

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -2,13 +2,19 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { findFirstWriteActionNode } from "@/lib/mcp/calldata";
+import {
+  findBareAtLiterals,
+  isInputSchemaPresent,
+} from "@/lib/mcp/listing-validators";
 
 export type ListingErrorCode =
   | "NOT_FOUND"
   | "SLUG_CONFLICT"
   | "PRICE_CHANGE_WHILE_LISTED"
   | "INVALID_INPUT"
-  | "MISSING_WRITE_ACTION";
+  | "MISSING_WRITE_ACTION"
+  | "INVALID_TEMPLATE_LITERALS"
+  | "INPUT_SCHEMA_REQUIRED";
 
 export type ListingResult<T> =
   | { ok: true; listing: T }
@@ -136,6 +142,24 @@ export async function listWorkflow(
     findFirstWriteActionNode(current.nodes) === undefined
   ) {
     return { ok: false, error: "MISSING_WRITE_ACTION" };
+  }
+
+  // Reject bare-@ literals in node configs. These are the trapped state of the
+  // editor's `@` autocomplete (user typed `@40` and dismissed the picker before
+  // it wrapped the reference into `{{@nodeId:Label.field}}`). The executor only
+  // resolves wrapped templates, so an unwrapped `@40` would silently flow
+  // through as a literal at runtime.
+  if (findBareAtLiterals(current.nodes).length > 0) {
+    return { ok: false, error: "INVALID_TEMPLATE_LITERALS" };
+  }
+
+  // Listed workflows must declare an inputSchema. Bazaar consumers (agentcash,
+  // x402scan, the OpenAPI spec) need a JSON-schema-shaped object to render and
+  // validate inputs; an empty `{type: "object"}` is fine for zero-input
+  // workflows. Allowing null at publish time leaves the listing unrenderable.
+  const finalInputSchema = updateSet.inputSchema ?? current.inputSchema;
+  if (!isInputSchemaPresent(finalInputSchema)) {
+    return { ok: false, error: "INPUT_SCHEMA_REQUIRED" };
   }
 
   try {

--- a/tests/integration/workflow-listing-lifecycle.test.ts
+++ b/tests/integration/workflow-listing-lifecycle.test.ts
@@ -107,7 +107,9 @@ describe("workflow listing lifecycle", () => {
       priceUsdcPerCall: null,
       name: "Test Workflow",
       description: null,
-      inputSchema: null,
+      // Listed workflows must declare an inputSchema (enforced by listWorkflow).
+      // An empty object is fine for zero-input workflows.
+      inputSchema: { type: "object" },
       outputMapping: null,
       category: null,
       chain: null,
@@ -246,6 +248,59 @@ describe("workflow listing lifecycle", () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+
+  it("list: rejects INPUT_SCHEMA_REQUIRED when neither row nor metadata declares inputSchema", async () => {
+    workflowState.inputSchema = null;
+
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "no-schema",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("INPUT_SCHEMA_REQUIRED");
+    expect(workflowState.isListed).toBe(false);
+  });
+
+  it("list: accepts inputSchema supplied via metadata even when row is null", async () => {
+    workflowState.inputSchema = null;
+
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "schema-via-metadata",
+      inputSchema: { type: "object" },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.listing.isListed).toBe(true);
+    expect(result.listing.inputSchema).toEqual({ type: "object" });
+  });
+
+  it("list: rejects INVALID_TEMPLATE_LITERALS when a node config has a bare @-literal", async () => {
+    workflowState.nodes = [
+      {
+        id: "read-1",
+        type: "action",
+        data: {
+          label: "Trapped autocomplete",
+          type: "action",
+          config: {
+            actionType: "web3/read-contract",
+            address: "@40",
+          },
+        },
+      },
+    ];
+
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "trapped-autocomplete",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("INVALID_TEMPLATE_LITERALS");
+    expect(workflowState.isListed).toBe(false);
   });
 
   it("relist: preserves listedSlug, refreshes listedAt, isListed=true", async () => {

--- a/tests/integration/workflow-listing-lifecycle.test.ts
+++ b/tests/integration/workflow-listing-lifecycle.test.ts
@@ -90,7 +90,12 @@ vi.mock("@/lib/db/schema", () => ({
   },
 }));
 
-const { listWorkflow, unlistWorkflow, getWorkflowListing, updateWorkflowListing } = await import("@/lib/mcp/listing");
+const {
+  listWorkflow,
+  unlistWorkflow,
+  getWorkflowListing,
+  updateWorkflowListing,
+} = await import("@/lib/mcp/listing");
 
 const WORKFLOW_ID = "wf-test-001";
 const ORG_ID = "org-test-001";
@@ -121,7 +126,9 @@ describe("workflow listing lifecycle", () => {
   });
 
   it("list: sets isListed=true, assigns listedSlug, sets listedAt", async () => {
-    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, { slug: "my-test-workflow" });
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "my-test-workflow",
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.listing.isListed).toBe(true);
@@ -138,7 +145,9 @@ describe("workflow listing lifecycle", () => {
     if (!result.ok) return;
     expect(result.listing.isListed).toBe(false);
     expect(result.listing.listedSlug).toBe("my-test-workflow");
-    expect(result.listing.listedAt?.getTime()).toBe(listingTimestamp?.getTime());
+    expect(result.listing.listedAt?.getTime()).toBe(
+      listingTimestamp?.getTime()
+    );
   });
 
   it("getWorkflowListing: returns NOT_FOUND for unlisted workflow even when listedSlug is preserved (sticky-slug)", async () => {
@@ -288,6 +297,7 @@ describe("workflow listing lifecycle", () => {
           config: {
             actionType: "web3/read-contract",
             address: "@40",
+            backup: 'fallback: "@trigger-2"',
           },
         },
       },
@@ -300,6 +310,11 @@ describe("workflow listing lifecycle", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBe("INVALID_TEMPLATE_LITERALS");
+    // details.literals surfaces the offending tokens so the route can return
+    // them in the 422 body for debuggability.
+    expect(result.details?.literals).toEqual(
+      expect.arrayContaining(["@40", "@trigger-2"])
+    );
     expect(workflowState.isListed).toBe(false);
   });
 

--- a/tests/unit/listing-validators.test.ts
+++ b/tests/unit/listing-validators.test.ts
@@ -125,12 +125,212 @@ describe("findBareAtLiterals", () => {
   });
 
   it("does not flag mid-token @ characters", () => {
+    // actionType chosen NOT in the skip list so the regex is actually consulted.
     const nodes = [
       actionNode({
         message: "discord://channel/123#general",
         url: "https://api.example.com/v1/path?token=foo@bar",
-        actionType: "notify/webhook",
+        hex: "0x1234@5678abcd",
+        actionType: "web3/read-contract",
       }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("flags bare-@ when preceded by a quote (JSON-encoded config)", () => {
+    const nodes = [
+      actionNode({
+        condition: 'value: "@trigger-1" must be set',
+        actionType: "web3/read-contract",
+      }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual(["@trigger-1"]);
+  });
+
+  it("flags bare-@ when preceded by =, (, [, or other non-word characters", () => {
+    const nodes = [
+      actionNode({ a: "key=@val", actionType: "web3/read-contract" }),
+      actionNode({ b: "(@nested)", actionType: "web3/read-contract" }),
+      actionNode({ c: "[@listed]", actionType: "web3/read-contract" }),
+      actionNode({ d: "x>@piped", actionType: "web3/read-contract" }),
+    ];
+    expect(findBareAtLiterals(nodes).sort()).toEqual([
+      "@listed",
+      "@nested",
+      "@piped",
+      "@val",
+    ]);
+  });
+
+  it("skips messaging action types so @everyone/@here/@username is not flagged", () => {
+    const nodes = [
+      {
+        id: "discord-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "discord/send-message",
+            content: "Alert @here token spiked, @user1 please review",
+          },
+        },
+      },
+      {
+        id: "slack-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "slack/post-message",
+            text: "@channel daily summary",
+          },
+        },
+      },
+      {
+        id: "telegram-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "telegram/send-message",
+            text: "@everyone read this",
+          },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("skips ai-gateway and ai action types so prompts with @-mentions are not flagged", () => {
+    const nodes = [
+      {
+        id: "ai-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "ai-gateway/chat",
+            prompt: "Tell @user about the latest @trends in defi",
+          },
+        },
+      },
+      {
+        id: "ai-2",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "ai/summarize",
+            input: "Summarize @article-42 highlights",
+          },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("skips email action types so user@domain.com bodies don't trigger", () => {
+    const nodes = [
+      {
+        id: "email-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "email/send",
+            body: "Hello @customer your invoice is ready",
+          },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("normalizes colon-form action types (code:run-code) to apply skip", () => {
+    const nodes = [
+      {
+        id: "code-colon",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "code:run-code",
+            code: "@Component({ selector: 'foo' })\nclass Foo {}",
+          },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("falls back to data.actionType when config.actionType is missing", () => {
+    // Some legacy/in-flight node shapes carry actionType at data top-level.
+    const nodes = [
+      {
+        id: "legacy-code",
+        type: "action",
+        data: {
+          actionType: "code/run-code",
+          config: {
+            code: "@Inject() class Foo {}",
+          },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("still scans nodes with missing or non-string actionType", () => {
+    const nodes = [
+      {
+        id: "no-action-type",
+        type: "action",
+        data: {
+          config: { address: "@40" },
+        },
+      },
+      {
+        id: "non-string",
+        type: "action",
+        data: {
+          actionType: 42,
+          config: { address: "@bad-1" },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes).sort()).toEqual(["@40", "@bad-1"]);
+  });
+
+  it("bounds output at MAX_FINDINGS (10) to keep memory predictable", () => {
+    const config: Record<string, string> = { actionType: "web3/read-contract" };
+    for (let i = 0; i < 50; i++) {
+      config[`field${i}`] = `@bad-${i}`;
+    }
+    const result = findBareAtLiterals([actionNode(config)]);
+    expect(result.length).toBe(10);
+  });
+
+  it("survives deeply-nested node configs without stack overflow", () => {
+    // Build a 10k-deep nested object to confirm MAX_DEPTH guard prevents the
+    // RangeError that would otherwise propagate as a 500 from the route.
+    type Nest = { next?: Nest; leaf?: string };
+    let nested: Nest = { leaf: "@deep" };
+    for (let i = 0; i < 10_000; i++) {
+      nested = { next: nested };
+    }
+    const nodes = [
+      actionNode({ actionType: "web3/read-contract", payload: nested }),
+    ];
+    expect(() => findBareAtLiterals(nodes)).not.toThrow();
+  });
+
+  it("skips strings longer than the size cap to prevent worker-pin", () => {
+    // A 300KB string exceeds MAX_STRING_LEN (256KB). The bare-@ inside is
+    // intentionally not surfaced — the gate trades off this rare large-field
+    // case for predictable performance bounds.
+    const huge = `@bad${"x".repeat(300_000)}`;
+    const nodes = [
+      actionNode({ actionType: "web3/read-contract", blob: huge }),
     ];
     expect(findBareAtLiterals(nodes)).toEqual([]);
   });

--- a/tests/unit/listing-validators.test.ts
+++ b/tests/unit/listing-validators.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findBareAtLiterals,
+  isInputSchemaPresent,
+} from "@/lib/mcp/listing-validators";
+
+const triggerNode = (config: Record<string, unknown>) => ({
+  id: "trigger-1",
+  type: "trigger",
+  data: {
+    label: "Manual Trigger",
+    type: "trigger",
+    config: { triggerType: "Manual", ...config },
+  },
+});
+
+const actionNode = (config: Record<string, unknown>) => ({
+  id: "action-1",
+  type: "action",
+  data: {
+    label: "Some Action",
+    type: "action",
+    config,
+  },
+});
+
+describe("findBareAtLiterals", () => {
+  it("returns empty when nodes is not an array", () => {
+    expect(findBareAtLiterals(null)).toEqual([]);
+    expect(findBareAtLiterals(undefined)).toEqual([]);
+    expect(findBareAtLiterals({})).toEqual([]);
+    expect(findBareAtLiterals("nodes")).toEqual([]);
+  });
+
+  it("returns empty for clean node configs", () => {
+    const nodes = [
+      triggerNode({}),
+      actionNode({ network: "1", actionType: "web3/read" }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("detects @40 trapped from autocomplete", () => {
+    const nodes = [actionNode({ address: "@40", actionType: "web3/read" })];
+    expect(findBareAtLiterals(nodes)).toEqual(["@40"]);
+  });
+
+  it("detects @trigger-1 left orphaned by autocomplete dismissal", () => {
+    const nodes = [
+      actionNode({
+        condition: "@trigger-1 < 100",
+        actionType: "Condition",
+      }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual(["@trigger-1"]);
+  });
+
+  it("ignores wrapped {{@nodeId:Label.field}} references", () => {
+    const nodes = [
+      actionNode({
+        condition:
+          "{{@price-1:Get Token Price.price}} < {{@trigger-1:Manual Trigger.threshold}}",
+        actionType: "Condition",
+      }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("ignores email-like patterns", () => {
+    const nodes = [
+      actionNode({
+        recipient: "support@example.com",
+        actionType: "notify/email",
+      }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("skips code/* action types to avoid TS-decorator false positives", () => {
+    const nodes = [
+      {
+        id: "code-1",
+        type: "action",
+        data: {
+          label: "Custom Code",
+          type: "action",
+          config: {
+            actionType: "code/run-code",
+            code: "@Component({ selector: 'foo' })\nclass Foo {}",
+          },
+        },
+      },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("finds multiple literals across multiple nodes", () => {
+    const nodes = [
+      actionNode({ address: "@40", actionType: "web3/read" }),
+      actionNode({ token: "@bar-2", actionType: "web3/read" }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual(["@40", "@bar-2"]);
+  });
+
+  it("walks nested config objects and arrays", () => {
+    const nodes = [
+      actionNode({
+        actionType: "web3/read",
+        nested: {
+          deeper: { value: "@40" },
+          list: ["clean", "{{@trigger-1:Manual Trigger.foo}}", "@bad"],
+        },
+      }),
+    ];
+    expect(findBareAtLiterals(nodes).sort()).toEqual(["@40", "@bad"]);
+  });
+
+  it("ignores nodes with no config block", () => {
+    const nodes = [
+      { id: "x", type: "action", data: { label: "no config" } },
+      { id: "y", type: "action" },
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+
+  it("does not flag mid-token @ characters", () => {
+    const nodes = [
+      actionNode({
+        message: "discord://channel/123#general",
+        url: "https://api.example.com/v1/path?token=foo@bar",
+        actionType: "notify/webhook",
+      }),
+    ];
+    expect(findBareAtLiterals(nodes)).toEqual([]);
+  });
+});
+
+describe("isInputSchemaPresent", () => {
+  it("accepts a JSON-schema-shaped object", () => {
+    expect(
+      isInputSchemaPresent({
+        type: "object",
+        properties: { address: { type: "string" } },
+        required: ["address"],
+      })
+    ).toBe(true);
+  });
+
+  it("accepts an empty object (zero-input workflows)", () => {
+    expect(isInputSchemaPresent({})).toBe(true);
+    expect(isInputSchemaPresent({ type: "object" })).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(isInputSchemaPresent(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isInputSchemaPresent(undefined)).toBe(false);
+  });
+
+  it("rejects arrays", () => {
+    expect(isInputSchemaPresent([])).toBe(false);
+    expect(isInputSchemaPresent([{ type: "object" }])).toBe(false);
+  });
+
+  it("rejects primitives", () => {
+    expect(isInputSchemaPresent("schema")).toBe(false);
+    expect(isInputSchemaPresent(42)).toBe(false);
+    expect(isInputSchemaPresent(true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes two systemic gaps in the workflow listing flow that surfaced during the [bazaar discoverability work](https://github.com/KeeperHub/keeperhub/pull/1077):

1. **`inputSchema: null` was acceptable.** The bazaar / OpenAPI / x402 consumers (agentcash, x402scan) all expect a JSON-schema object — without it, they can't render or validate inputs. Even `scripts/seed/seed-listing-workflows.ts` ships 2 of 4 reference seeds with `inputSchema: null`.
2. **Node config strings could contain bare `@<word>` literals** outside `{{...}}` wrappers. These are the trapped state of the editor's `@` autocomplete when dismissed before the picker wraps the reference. The executor only resolves wrapped templates, so a bare `@40` flows through as a literal at runtime and breaks the call silently.

Both are publish-time gates in `listWorkflow`, both return **422** with descriptive messages telling the author exactly what to fix.

## Why these are systemic, not test-only

I diagnosed this against the live state. Both bugs would affect any future user-listed workflow:

- The publish flow (`lib/mcp/listing.ts::listWorkflow`) only enforced two things before this PR: a slug must be present, and write workflows must contain a write-action node. It never checked `inputSchema` or scanned node configs for malformed templates.
- The editor produces wrapped `{{@nodeId:Label.field}}` references via autocomplete, but a user who dismisses the picker mid-typing leaves a bare `@<typed-text>` behind. This is a UX-trapped state, not a malicious input. The exact case observed in production was `@40` on `defi-risk-snapshot`'s `address` field.

## Changes

| File | Change |
|------|--------|
| \`lib/mcp/listing-validators.ts\` (NEW) | \`findBareAtLiterals\` (walks node configs, strips \`{{...}}\`, finds bare \`@<word>\`s, skips \`code/*\` actions to avoid TS-decorator FPs) and \`isInputSchemaPresent\` |
| \`lib/mcp/listing.ts\` | Two new gates in \`listWorkflow\` after the existing \`MISSING_WRITE_ACTION\` check; two new error codes in \`ListingErrorCode\` |
| \`app/api/mcp/workflows/[slug]/listing/route.ts\` | \`mapListingError\` cases for the two new codes (422 with descriptive messages) |
| \`tests/unit/listing-validators.test.ts\` (NEW) | 17 pure-function tests |
| \`tests/integration/workflow-listing-lifecycle.test.ts\` | 3 new lifecycle tests for the gates; existing fixture updated to \`inputSchema: {type: "object"}\` |

## Detection details

**Bare-@ regex:** \`(?:^|[\s,;:([])(@\w+(?:-\w+)*)\`
- Matches \`@40\`, \`@trigger-1\`, \`@bar-2\`
- Does NOT match \`support@example.com\` (preceded by word char)
- Does NOT match \`https://api.example.com/?token=foo@bar\` (intra-token)
- Does NOT match anything inside \`{{...}}\` (stripped first via \`\{\{[^}]*\}\}\`)
- \`code/*\` action types skipped entirely (TS decorators like \`@Component\` are valid in those configs)

**inputSchema gate:** \`isInputSchemaPresent(metadata.inputSchema ?? row.inputSchema)\`
- Accepts any non-null object (incl. \`{}\`, \`{type: "object"}\`)
- Rejects null, undefined, arrays, primitives
- Final value is the merged result — caller can supply via metadata even if row is null

## What's not in scope

- **\`updateWorkflowListing\` (PATCH)** doesn't get the same gates yet. The PATCH route already coerces \`inputSchema: null\` from the body to \`undefined\` (so it can't be nulled out via PATCH), and PATCH doesn't change \`nodes\`. Worth a follow-up to also re-run validation on PATCH for defense in depth, but the listing publish path is the primary boundary.
- **Edit-while-listed via \`app/api/workflows/[workflowId]\` PATCH** can still introduce bare-@ literals or null inputSchema on a listed workflow. Closing that requires a re-validation pass on workflow updates when \`isListed=true\`. Follow-up.
- **Cross-check that \`inputSchema.properties\` covers actual input references** in node configs — the most useful next gate, but requires a robust template-extraction pass over nodes to enumerate referenced field names. Separate PR.

## Verification

- \`pnpm exec vitest run tests/unit/listing-validators.test.ts\` -> **17/17 pass**
- \`pnpm exec vitest run tests/integration/workflow-listing-lifecycle.test.ts\` -> **11/11 pass** (8 existing + 3 new)
- \`pnpm exec vitest run tests/unit/mcp-curator-{slug,tools,price-change}.test.ts\` -> **24/24 pass** (no regressions in listing route tests)
- \`pnpm exec biome check\` clean on all touched files (the 5 pre-existing biome violations on \`lib/mcp/listing.ts\` are unrelated)
- \`pnpm exec tsc --noEmit\` -- no new errors in touched files (8 pre-existing errors elsewhere, all about missing generated modules \`step-registry\`, \`credential-map\`, etc.)

## Existing data

This PR only affects FUTURE listing operations. Existing listed workflows with \`inputSchema: null\` or bare-@ literals are unaffected -- they were published under the old (lax) contract. Cleaning them up (notably \`defi-risk-snapshot\` with the \`@40\` literal, plus \`microtip\` / \`usdc-yield-rates-aave-vs-compound\` / \`pack-0-10-demo\` with null \`inputSchema\`) needs a separate DB migration or admin pass.