### PR TITLE
feat(listing): re-validate edit-while-listed and curator metadata patches

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -408,6 +408,38 @@ export async function PATCH(
           ? updateData.inputSchema
           : existingWorkflow.inputSchema;
 
+      // Gate ordering matches the publish path (lib/mcp/listing.ts::listWorkflow):
+      // write-action -> bare-@ -> input-schema. Same DB state therefore yields
+      // the same error code regardless of which gate-bearing route the caller
+      // hits, which keeps client-side error handling consistent.
+      //
+      // workflowType is curator-only — it's not in `buildUpdateData`'s field
+      // allowlist (lines 156-170 above), so a body's `workflowType` is silently
+      // dropped at the persistence layer. We read it directly from
+      // `existingWorkflow.workflowType` (no fallback chain) so the gate truly
+      // reflects what will be persisted. Type changes flow through
+      // updateWorkflowListing (lib/mcp/listing.ts), which is unconditionally
+      // strict.
+      // `finalNodes` is `unknown` (updateData.nodes is unknown after the
+      // generic Record cast). Both code paths actually hold an array — the
+      // body branch went through `sanitizeWorkflowData`, the existing branch
+      // is `nodes` declared `$type<any[]>` in lib/db/schema.ts. The cast is
+      // honest and matches how lib/mcp/listing.ts:151 calls the same function.
+      if (
+        checkNodes &&
+        existingWorkflow.workflowType === "write" &&
+        findFirstWriteActionNode(finalNodes as unknown[]) === undefined
+      ) {
+        return NextResponse.json(
+          {
+            error: "MISSING_WRITE_ACTION",
+            message:
+              "Workflows listed as workflowType='write' must contain at least one write-contract or protocol-write action node. Add the action back, or unlist the workflow before saving these changes.",
+          },
+          { status: 422 }
+        );
+      }
+
       if (checkNodes) {
         const literals = findBareAtLiterals(finalNodes);
         if (literals.length > 0) {
@@ -428,31 +460,6 @@ export async function PATCH(
             error: "INPUT_SCHEMA_REQUIRED",
             message:
               'Listed workflows must declare an `inputSchema`. Set it to a JSON-schema-shaped object — `{"type": "object"}` is fine for workflows that take no inputs — or unlist the workflow before saving these changes.',
-          },
-          { status: 422 }
-        );
-      }
-
-      // Third publish-time gate from PR #1079: a listed write workflow must
-      // contain at least one write-action node. Same field-touched-only
-      // semantics — only revalidate when nodes are being edited or when
-      // transitioning to listed. workflowType is read from updateData when
-      // the PATCH changes it; otherwise from the existing row.
-      const checkWriteAction =
-        updateData.nodes !== undefined || isTransitioningToListed;
-      const finalWorkflowType =
-        (updateData.workflowType as "read" | "write" | undefined) ??
-        existingWorkflow.workflowType;
-      if (
-        checkWriteAction &&
-        finalWorkflowType === "write" &&
-        findFirstWriteActionNode(finalNodes) === undefined
-      ) {
-        return NextResponse.json(
-          {
-            error: "MISSING_WRITE_ACTION",
-            message:
-              "Listed workflows with workflowType='write' must contain at least one write-contract or protocol-write action node. Add the action back, or unlist the workflow before saving these changes.",
           },
           { status: 422 }
         );

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -5,6 +5,10 @@ import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflows } from "@/lib/db/schema";
+import {
+  findBareAtLiterals,
+  isInputSchemaPresent,
+} from "@/lib/mcp/listing-validators";
 import { syncWorkflowSchedule } from "@/lib/schedule-service";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
@@ -355,6 +359,63 @@ export async function PATCH(
     // Set listedAt server-side on first listing (never from client, never cleared on unlist)
     if (body.isListed === true && existingWorkflow.listedAt === null) {
       updateData.listedAt = new Date();
+    }
+
+    // Re-run the publish-time gates from /listing/route.ts when this PATCH
+    // either (a) edits a workflow that's already listed or (b) is the act of
+    // listing it. This route is a backdoor around the dedicated listing
+    // curator route — without these checks an author could publish a clean
+    // workflow via /listing then PATCH `nodes` here to introduce a bare-@
+    // literal, leaving a broken listing live in the bazaar.
+    //
+    // To stay backwards-compatible with workflows listed before the gates
+    // existed, we only validate the field the PATCH actually touches —
+    // legacy listings with null inputSchema continue to work until the next
+    // edit that touches the schema. The exception is a fresh isListed=true
+    // transition through this route, which validates the full final state.
+    const isTransitioningToListed =
+      body.isListed === true && existingWorkflow.isListed !== true;
+    const willBeListed =
+      isTransitioningToListed || existingWorkflow.isListed === true;
+
+    if (willBeListed) {
+      const checkNodes =
+        updateData.nodes !== undefined || isTransitioningToListed;
+      const finalNodes =
+        updateData.nodes !== undefined
+          ? updateData.nodes
+          : existingWorkflow.nodes;
+      const checkSchema =
+        updateData.inputSchema !== undefined || isTransitioningToListed;
+      const finalSchema =
+        updateData.inputSchema !== undefined
+          ? updateData.inputSchema
+          : existingWorkflow.inputSchema;
+
+      if (checkNodes) {
+        const literals = findBareAtLiterals(finalNodes);
+        if (literals.length > 0) {
+          return NextResponse.json(
+            {
+              error: "INVALID_TEMPLATE_LITERALS",
+              message:
+                "Listed workflow contains a bare `@<word>` literal in a node config field outside a `{{...}}` template wrapper. Replace it with a `{{@nodeId:Label.field}}` reference, or unlist the workflow before saving these changes.",
+              literals,
+            },
+            { status: 422 }
+          );
+        }
+      }
+      if (checkSchema && !isInputSchemaPresent(finalSchema)) {
+        return NextResponse.json(
+          {
+            error: "INPUT_SCHEMA_REQUIRED",
+            message:
+              'Listed workflows must declare an `inputSchema`. Set it to a JSON-schema-shaped object — `{"type": "object"}` is fine for workflows that take no inputs — or unlist the workflow before saving these changes.',
+          },
+          { status: 422 }
+        );
+      }
     }
 
     let updatedWorkflow: typeof workflows.$inferSelect;

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -5,6 +5,7 @@ import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflows } from "@/lib/db/schema";
+import { findFirstWriteActionNode } from "@/lib/mcp/calldata";
 import {
   findBareAtLiterals,
   isInputSchemaPresent,
@@ -368,15 +369,30 @@ export async function PATCH(
     // workflow via /listing then PATCH `nodes` here to introduce a bare-@
     // literal, leaving a broken listing live in the bazaar.
     //
-    // To stay backwards-compatible with workflows listed before the gates
-    // existed, we only validate the field the PATCH actually touches —
-    // legacy listings with null inputSchema continue to work until the next
-    // edit that touches the schema. The exception is a fresh isListed=true
-    // transition through this route, which validates the full final state.
+    // Field-touched-only semantics: stay backwards-compatible with workflows
+    // listed before the gates existed by only validating the field the PATCH
+    // actually changes. Legacy listings with null inputSchema continue to
+    // work until the next edit that touches THAT field. The exception is a
+    // fresh isListed=true transition through this route, which validates the
+    // full final state (effectively a publish event).
+    //
+    // Unlist-and-clean-up bypass: a PATCH that explicitly sets isListed=false
+    // is leaving the listed surface — the bazaar will never see the
+    // post-patch state, so there's no value in blocking the user from fixing
+    // a corrupted workflow on the way out. Skip the gates in that case.
+    //
+    // The 422 messages here intentionally diverge from the listing curator's
+    // (app/api/mcp/workflows/[slug]/listing/route.ts:mapListingError) — they
+    // include "or unlist the workflow before saving these changes" as
+    // context-aware UX guidance. The curator-publish path has no such
+    // option, so its messages don't mention unlisting.
+    const isTransitioningToUnlisted =
+      body.isListed === false && existingWorkflow.isListed === true;
     const isTransitioningToListed =
       body.isListed === true && existingWorkflow.isListed !== true;
     const willBeListed =
-      isTransitioningToListed || existingWorkflow.isListed === true;
+      !isTransitioningToUnlisted &&
+      (isTransitioningToListed || existingWorkflow.isListed === true);
 
     if (willBeListed) {
       const checkNodes =
@@ -412,6 +428,31 @@ export async function PATCH(
             error: "INPUT_SCHEMA_REQUIRED",
             message:
               'Listed workflows must declare an `inputSchema`. Set it to a JSON-schema-shaped object — `{"type": "object"}` is fine for workflows that take no inputs — or unlist the workflow before saving these changes.',
+          },
+          { status: 422 }
+        );
+      }
+
+      // Third publish-time gate from PR #1079: a listed write workflow must
+      // contain at least one write-action node. Same field-touched-only
+      // semantics — only revalidate when nodes are being edited or when
+      // transitioning to listed. workflowType is read from updateData when
+      // the PATCH changes it; otherwise from the existing row.
+      const checkWriteAction =
+        updateData.nodes !== undefined || isTransitioningToListed;
+      const finalWorkflowType =
+        (updateData.workflowType as "read" | "write" | undefined) ??
+        existingWorkflow.workflowType;
+      if (
+        checkWriteAction &&
+        finalWorkflowType === "write" &&
+        findFirstWriteActionNode(finalNodes) === undefined
+      ) {
+        return NextResponse.json(
+          {
+            error: "MISSING_WRITE_ACTION",
+            message:
+              "Listed workflows with workflowType='write' must contain at least one write-contract or protocol-write action node. Add the action back, or unlist the workflow before saving these changes.",
           },
           { status: 422 }
         );

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -288,6 +288,27 @@ export async function updateWorkflowListing(
     return { ok: false, error: "MISSING_WRITE_ACTION" };
   }
 
+  // Defense in depth: if the listed workflow's nodes were corrupted via an
+  // out-of-band path (e.g. a script or an admin tool that bypassed the
+  // /api/workflows/[workflowId] PATCH gate), refuse to apply curator-side
+  // metadata changes that would re-emphasize a broken listing. Same gate as
+  // the publish path. Only runs when the row is (or stays) listed.
+  if (current.isListed === true) {
+    const literals = findBareAtLiterals(current.nodes);
+    if (literals.length > 0) {
+      return {
+        ok: false,
+        error: "INVALID_TEMPLATE_LITERALS",
+        details: { literals },
+      };
+    }
+    const finalInputSchema =
+      patch.inputSchema === undefined ? current.inputSchema : patch.inputSchema;
+    if (!isInputSchemaPresent(finalInputSchema)) {
+      return { ok: false, error: "INPUT_SCHEMA_REQUIRED" };
+    }
+  }
+
   try {
     const [result] = await db
       .update(workflows)

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -293,6 +293,16 @@ export async function updateWorkflowListing(
   // /api/workflows/[workflowId] PATCH gate), refuse to apply curator-side
   // metadata changes that would re-emphasize a broken listing. Same gate as
   // the publish path. Only runs when the row is (or stays) listed.
+  //
+  // Asymmetry note: the workflows-PATCH route uses field-touched-only
+  // semantics (only validates a field when the PATCH actually changes it,
+  // for backwards-compat with legacy listings). This curator path is
+  // intentionally STRICTER — every metadata change re-checks the full state
+  // unconditionally. Rationale: a corrupted listing should not receive
+  // metadata refreshes (category/chain/price etc.) that re-emphasize it on
+  // the bazaar surface. Authors of legacy null-inputSchema or bad-nodes
+  // listings must self-heal via the workflow editor before metadata edits
+  // land here.
   if (current.isListed === true) {
     const literals = findBareAtLiterals(current.nodes);
     if (literals.length > 0) {

--- a/tests/integration/workflow-listing-lifecycle.test.ts
+++ b/tests/integration/workflow-listing-lifecycle.test.ts
@@ -318,6 +318,89 @@ describe("workflow listing lifecycle", () => {
     expect(workflowState.isListed).toBe(false);
   });
 
+  // ──────────────────────────────────────────────────────────────────────
+  // updateWorkflowListing defense-in-depth: refuses to apply curator metadata
+  // changes if the listed workflow's nodes/schema were corrupted out-of-band.
+  // ──────────────────────────────────────────────────────────────────────
+
+  it("updateWorkflowListing: rejects INVALID_TEMPLATE_LITERALS when listed workflow has bare-@ in nodes", async () => {
+    // Out-of-band corruption: a script or admin tool persisted bad nodes
+    // bypassing the workflows-PATCH gate. The curator PATCH must refuse to
+    // re-emphasize the broken listing via metadata changes.
+    workflowState.isListed = true;
+    workflowState.listedSlug = "live-wf";
+    workflowState.listedAt = new Date();
+    workflowState.nodes = [
+      {
+        id: "read-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: { actionType: "web3/read-contract", address: "@40" },
+        },
+      },
+    ];
+
+    const result = await updateWorkflowListing(WORKFLOW_ID, ORG_ID, {
+      category: "defi",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("INVALID_TEMPLATE_LITERALS");
+    expect(result.details?.literals).toContain("@40");
+  });
+
+  it("updateWorkflowListing: rejects INPUT_SCHEMA_REQUIRED when listed workflow has null inputSchema", async () => {
+    workflowState.isListed = true;
+    workflowState.listedSlug = "live-wf";
+    workflowState.listedAt = new Date();
+    workflowState.inputSchema = null;
+
+    const result = await updateWorkflowListing(WORKFLOW_ID, ORG_ID, {
+      category: "defi",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("INPUT_SCHEMA_REQUIRED");
+  });
+
+  it("updateWorkflowListing: accepts schema supplied via patch even when row is null", async () => {
+    workflowState.isListed = true;
+    workflowState.listedSlug = "live-wf";
+    workflowState.listedAt = new Date();
+    workflowState.inputSchema = null;
+
+    const result = await updateWorkflowListing(WORKFLOW_ID, ORG_ID, {
+      inputSchema: { type: "object" },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("updateWorkflowListing: skips defense-in-depth gates on unlisted draft", async () => {
+    // Drafts can be in any state — only listed rows trigger the validators.
+    workflowState.isListed = false;
+    workflowState.inputSchema = null;
+    workflowState.nodes = [
+      {
+        id: "read-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: { actionType: "web3/read-contract", address: "@40" },
+        },
+      },
+    ];
+
+    const result = await updateWorkflowListing(WORKFLOW_ID, ORG_ID, {
+      category: "defi",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("relist: preserves listedSlug, refreshes listedAt, isListed=true", async () => {
     await listWorkflow(WORKFLOW_ID, ORG_ID, { slug: "my-test-workflow" });
     const firstListedAt = workflowState.listedAt as Date;

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -543,6 +543,66 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(response.status).toBe(200);
   });
 
+  it("LIST-VALIDATE transition to listed write workflow with read-only nodes: rejects MISSING_WRITE_ACTION", async () => {
+    // Covers the isTransitioningToListed branch of the write-action gate —
+    // the previous PATCH-route tests only exercised the already-listed branch.
+    // This is also the only realistic way to reach the gate via this route
+    // since workflowType isn't editable here (curator-only).
+    const existing = makeWorkflow({
+      isListed: false,
+      listedAt: null,
+      workflowType: "write",
+      inputSchema: { type: "object" },
+      nodes: [goodNode], // read-only node, no write-action
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(createRequest("PATCH", { isListed: true }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("MISSING_WRITE_ACTION");
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("LIST-VALIDATE legacy write: PATCH only-description on listed write workflow with no write nodes still succeeds", async () => {
+    // Backwards-compat for legacy listings: a workflowType=write row that
+    // somehow exists with only read-only nodes (e.g. predates the publish
+    // gate, or was corrupted out-of-band) should keep accepting metadata
+    // edits via the workflows-PATCH route as long as the patch doesn't
+    // touch nodes. The curator path (updateWorkflowListing) is stricter
+    // and would reject — that's the documented asymmetry.
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "legacy-write",
+      listedAt: new Date(),
+      workflowType: "write",
+      inputSchema: { type: "object" },
+      nodes: [goodNode], // read-only, no write-action
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({
+        isListed: true,
+        listedSlug: "legacy-write",
+        listedAt: new Date(),
+        workflowType: "write",
+        inputSchema: { type: "object" },
+        nodes: [goodNode],
+        description: "updated text",
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { description: "updated text" }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("LIST-VALIDATE legacy: PATCH on listed workflow with null inputSchema, not touching nodes or schema, still succeeds", async () => {
     // Backwards-compat: workflows listed before the gates existed have null
     // inputSchema. They should keep working until the next PATCH that touches

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -388,6 +388,161 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(data.error).toBe("INPUT_SCHEMA_REQUIRED");
   });
 
+  it("LIST-VALIDATE unlist+cleanup: PATCH {isListed: false, nodes: [bad]} on listed workflow succeeds", async () => {
+    // The workflow is leaving the listed surface in this same PATCH — the
+    // bazaar will never see the post-patch state, so blocking the user from
+    // unlisting+cleaning-up in one shot is unnecessary friction. The gate
+    // explicitly skips when body.isListed === false on a currently-listed row.
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-wf",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({
+        isListed: false,
+        listedSlug: "live-wf",
+        listedAt: new Date(),
+        inputSchema: { type: "object" },
+        nodes: [badNode],
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { isListed: false, nodes: [badNode], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("LIST-VALIDATE unlist+null-schema: PATCH {isListed: false, inputSchema: null} on listed workflow succeeds", async () => {
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-wf",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({ isListed: false, inputSchema: null }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { isListed: false, inputSchema: null }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("LIST-VALIDATE write-action removed on listed write workflow: rejects MISSING_WRITE_ACTION", async () => {
+    // Third publish-time gate: an author can publish a write workflow then
+    // PATCH `nodes` here to remove the only write-action node, leaving the
+    // listing live but executing nothing meaningful. Same backdoor class as
+    // bare-@ on listed.
+    const writeNode = {
+      id: "write-1",
+      type: "action",
+      data: {
+        type: "action",
+        config: {
+          actionType: "web3/write-contract",
+          contractAddress: "0xabc",
+          network: "1",
+          abi: "[]",
+          abiFunction: "transfer",
+        },
+      },
+    };
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-write",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      workflowType: "write",
+      nodes: [writeNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [goodNode], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("MISSING_WRITE_ACTION");
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("LIST-VALIDATE inputSchema as array: rejects INPUT_SCHEMA_REQUIRED", async () => {
+    // Edge case: arrays are objects per typeof but not valid JSON-schema
+    // shapes. isInputSchemaPresent rejects them.
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-wf",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(createRequest("PATCH", { inputSchema: [] }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("INPUT_SCHEMA_REQUIRED");
+  });
+
+  it("LIST-VALIDATE messaging-skip on listed: PATCH adding @everyone in discord/* node still succeeds", async () => {
+    // The findBareAtLiterals validator skips action types in the messaging
+    // skip-list (discord/*, slack/*, telegram/*, email/*, ai/*, ai-gateway/*,
+    // code/*). A PATCH that adds a Discord node with @everyone in the message
+    // body must not 422 — same skip semantics as the publish path.
+    const discordNode = {
+      id: "discord-1",
+      type: "action",
+      data: {
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          content: "Alert @here token spiked, @user1 please review",
+        },
+      },
+    };
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-wf",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({
+        isListed: true,
+        listedSlug: "live-wf",
+        listedAt: new Date(),
+        inputSchema: { type: "object" },
+        nodes: [discordNode],
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [discordNode], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("LIST-VALIDATE legacy: PATCH on listed workflow with null inputSchema, not touching nodes or schema, still succeeds", async () => {
     // Backwards-compat: workflows listed before the gates existed have null
     // inputSchema. They should keep working until the next PATCH that touches

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -131,12 +131,21 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
   });
 
   it("LIST-01: PATCH with isListed=true sets listedAt server-side when listedAt is null", async () => {
-    const existing = makeWorkflow({ isListed: false, listedAt: null });
+    // Transitioning to listed via this route triggers the publish-time gates,
+    // so the existing row must already have a valid inputSchema (or the PATCH
+    // body must supply one). Use an existing valid schema here — listing-flow
+    // tests cover the gate failures directly.
+    const existing = makeWorkflow({
+      isListed: false,
+      listedAt: null,
+      inputSchema: { type: "object" },
+    });
     mockWorkflowsFindFirst.mockResolvedValue(existing);
 
     const updated = makeWorkflow({
       isListed: true,
       listedAt: new Date("2026-03-30T00:00:00Z"),
+      inputSchema: { type: "object" },
     });
     mockUpdateReturning.mockResolvedValue([updated]);
 
@@ -256,6 +265,159 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(data.listedSlug).toBe("my-workflow");
     expect(data.listedAt).not.toBeNull();
     expect(data.priceUsdcPerCall).toBe("2.00");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Edit-while-listed re-validation
+  // ──────────────────────────────────────────────────────────────────────
+
+  const badNode = {
+    id: "read-1",
+    type: "action",
+    data: {
+      type: "action",
+      config: { actionType: "web3/read-contract", address: "@40" },
+    },
+  };
+  const goodNode = {
+    id: "read-1",
+    type: "action",
+    data: {
+      type: "action",
+      config: { actionType: "web3/read-contract", address: "0xabc" },
+    },
+  };
+
+  it("LIST-VALIDATE bare-@ on listed: rejects with 422 INVALID_TEMPLATE_LITERALS", async () => {
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-wf",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [badNode], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("INVALID_TEMPLATE_LITERALS");
+    expect(data.literals).toContain("@40");
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("LIST-VALIDATE bare-@ on unlisted: PATCH succeeds (gate only fires when listed)", async () => {
+    const existing = makeWorkflow({
+      isListed: false,
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({ isListed: false, nodes: [badNode] }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [badNode], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("LIST-VALIDATE null inputSchema on listed: rejects with 422 INPUT_SCHEMA_REQUIRED", async () => {
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "live-wf",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(
+      createRequest("PATCH", { inputSchema: null }),
+      {
+        params: mockParams,
+      }
+    );
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("INPUT_SCHEMA_REQUIRED");
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("LIST-VALIDATE transition to listed with bare-@ in existing nodes: rejects", async () => {
+    // Backdoor: workflow was created with bare-@ in a node (out-of-band) and
+    // the user now PATCHes isListed=true here. The transition-to-listed branch
+    // validates the full final state, not just patched fields.
+    const existing = makeWorkflow({
+      isListed: false,
+      inputSchema: { type: "object" },
+      nodes: [badNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(createRequest("PATCH", { isListed: true }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("INVALID_TEMPLATE_LITERALS");
+  });
+
+  it("LIST-VALIDATE transition to listed with null existing inputSchema: rejects", async () => {
+    const existing = makeWorkflow({
+      isListed: false,
+      inputSchema: null,
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+
+    const response = await PATCH(createRequest("PATCH", { isListed: true }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("INPUT_SCHEMA_REQUIRED");
+  });
+
+  it("LIST-VALIDATE legacy: PATCH on listed workflow with null inputSchema, not touching nodes or schema, still succeeds", async () => {
+    // Backwards-compat: workflows listed before the gates existed have null
+    // inputSchema. They should keep working until the next PATCH that touches
+    // nodes or schema. PATCH that only changes other fields (e.g. description)
+    // must not retroactively reject them.
+    const existing = makeWorkflow({
+      isListed: true,
+      listedSlug: "legacy",
+      listedAt: new Date(),
+      inputSchema: null,
+      nodes: [goodNode],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({
+        isListed: true,
+        listedSlug: "legacy",
+        listedAt: new Date(),
+        inputSchema: null,
+        nodes: [goodNode],
+        description: "updated text",
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { description: "updated text" }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #1079 (publish-time validation, merged at ba60f70). Closes two holes that bypass the publish gates:

1. **Workflow PATCH backdoor** — `app/api/workflows/[workflowId]` PATCH accepts \`nodes\`, \`inputSchema\`, and \`isListed\` from the body. Before this PR, an author could publish a clean workflow via the dedicated /listing route, then PATCH \`nodes\` here to introduce a bare-\`@\` literal — workflow stayed listed, bazaar served a broken endpoint. Same backdoor allowed transitioning \`isListed: false -> true\` directly via this route, bypassing the listing-curator's gates.

2. **Curator-metadata defense in depth** — \`updateWorkflowListing\` didn't validate \`current.nodes\` / \`current.inputSchema\`. If the listed workflow's data was corrupted out-of-band (script, admin tool, future code path), a curator-side metadata patch could re-emphasize the broken listing without surfacing the corruption.

## Approach

| Gate | Where | Trigger |
|------|-------|---------|
| Re-validate on workflow PATCH | \`app/api/workflows/[workflowId]/route.ts\` | When \`existingWorkflow.isListed === true\` OR \`body.isListed === true\` |
| Re-validate on curator metadata PATCH | \`lib/mcp/listing.ts::updateWorkflowListing\` | When \`current.isListed === true\` |

**Backwards compatibility:** the workflows-PATCH gate only validates fields the patch actually changes (\`updateData.nodes\`, \`updateData.inputSchema\`). Legacy listings with null \`inputSchema\` (predating #1079) continue to work until the next edit that touches \`nodes\` or schema. The exception is a fresh \`isListed: true\` transition through this route — that's effectively a publish event, so the full final state is validated.

## Test coverage

| File | Added |
|------|-------|
| \`tests/integration/workflow-listing-route.test.ts\` | +6 tests: bare-@ on listed rejects; bare-@ on unlisted succeeds (gate skipped); null inputSchema on listed rejects; transition with bad existing nodes rejects; transition with null existing schema rejects; legacy null-schema PATCH not touching schema still succeeds |
| \`tests/integration/workflow-listing-lifecycle.test.ts\` | +4 tests for \`updateWorkflowListing\`: rejects bare-@, rejects null inputSchema, accepts schema-via-patch, skips on unlisted draft |
| \`tests/integration/workflow-listing-route.test.ts\` LIST-01 | Fixture updated: transition-to-listed now requires a valid inputSchema (correct under new gate) |

**64/64 listing-touching tests pass** (16 listing-route + 14 lifecycle + 28 unit validators + 6 mcp-curator).

## Verification

- \`pnpm exec vitest run tests/integration/workflow-listing-route.test.ts tests/integration/workflow-listing-lifecycle.test.ts\` -> 30/30 pass
- \`pnpm exec biome check\` clean on touched files (the 12 \`useBlockStatements\` violations are the existing project style for \`if (result.ok) return;\` — same pattern used 10 times pre-merge)

## Existing behavior

- Authors of LEGACY listings (created before #1079, with null \`inputSchema\`) can keep editing via this route as long as the edit doesn't touch \`nodes\` or \`inputSchema\` (description, name, tag, project edits all still pass). The next time they edit nodes or schema, the gate fires and they need to fix it.
- Authors transitioning a workflow to listed via this PATCH route (instead of /listing) get the full publish-time gates applied — no more backdoor.

## Not in scope

- **The \`actionType\`-mislabel bypass** documented in #1079 remains. An author can set \`actionType: "code/foo"\` on a non-code node to skip @-detection on that node's config. No cross-tenant impact, accepted tradeoff vs. banning legitimate decorator/AI/messaging content. Closing this requires an allowlist of registered action types, which would also break legitimate plugin-registered ones.