### PR TITLE
hotfix(prod): raise V8 heap limit to stop keeperhub-common OOM

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -125,7 +125,7 @@ serviceMonitors:
 
 resources:
   limits:
-    memory: 2Gi
+    memory: 3Gi
   requests:
     cpu: 100m
     memory: 512Mi
@@ -146,7 +146,7 @@ env:
     value: "5000"
   NODE_OPTIONS:
     type: kv
-    value: "--enable-source-maps"
+    value: "--enable-source-maps --max-old-space-size=2048"
   HOSTNAME:
     type: kv
     value: "0.0.0.0"


### PR DESCRIPTION
## Summary
- Set `--max-old-space-size=2048` on the `keeperhub-common` prod deployment so V8 stops crashing at its default heap floor.
- Raise the prod container memory limit from `2Gi` to `3Gi` so the 2 GB heap plus non-heap RSS has cgroup headroom.
- Prod-only; staging unchanged.

## Why
Both `keeperhub-common` prod replicas crashed today with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` (exit 139), each restarting twice. V8 was dying around 1018 MB while the container limit was 2 Gi, so the heap floor was the bottleneck, not the cgroup.

`keeperhub-common` runs the in-process Workflow Executor alongside the MCP tool surface. When it OOMs mid-execution, runs are marked as started in the DB but never produce log lines, which matches the user-visible "runs without logs" reports.