### PR TITLE
fix: KEEP-392 coerce non-string ABI config values before .trim()

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -439,9 +439,11 @@ function renderAbiFunctionSelect(
   disabled?: boolean
 ) {
   const abiField = field.abiField || "abi";
-  const abiValue = (config[abiField] as string | undefined) || "";
+  const rawAbi = config[abiField];
+  const abiValue = typeof rawAbi === "string" ? rawAbi : "";
+  const rawValue = config[field.key];
   const value =
-    (config[field.key] as string | undefined) || field.defaultValue || "";
+    (typeof rawValue === "string" ? rawValue : "") || field.defaultValue || "";
 
   return (
     <div className="space-y-2" key={field.key}>
@@ -472,10 +474,13 @@ function renderAbiFunctionArgs(
 ) {
   const abiField = field.abiField || "abi";
   const functionField = field.abiFunctionField || "abiFunction";
-  const abiValue = (config[abiField] as string | undefined) || "";
-  const functionValue = (config[functionField] as string | undefined) || "";
+  const rawAbi = config[abiField];
+  const abiValue = typeof rawAbi === "string" ? rawAbi : "";
+  const rawFunction = config[functionField];
+  const functionValue = typeof rawFunction === "string" ? rawFunction : "";
+  const rawValue = config[field.key];
   const value =
-    (config[field.key] as string | undefined) || field.defaultValue || "";
+    (typeof rawValue === "string" ? rawValue : "") || field.defaultValue || "";
 
   return (
     <div className="space-y-2" key={field.key}>


### PR DESCRIPTION
## Summary

Fixes `TypeError: i.trim is not a function` thrown on `/workflows/:workflowId` (Sentry [KEEPERHUB-PRODUCTION-24](https://techops-services.sentry.io/issues/KEEPERHUB-PRODUCTION-24)).

## Root cause

In `components/workflow/config/action-config-renderer.tsx`, `renderAbiFunctionSelect` and `renderAbiFunctionArgs` resolved config values with a TypeScript-only cast:

```ts
const abiValue = (config[abiField] as string | undefined) || "";
```

The cast is a runtime no-op. When `config[abiField]` is a non-string (e.g., a parsed ABI array), `[]` is truthy so the `|| ""` fallback is skipped, and the non-string flows into `AbiFunctionSelectField` where `abiValue.trim()` crashes.

## Fix

Replace the unsafe cast with a runtime `typeof` check at both helper boundaries:

```ts
const rawAbi = config[abiField];
const abiValue = typeof rawAbi === "string" ? rawAbi : "";
```

Closes KEEP-392.