### PR TITLE
chore: KEEP-328 enable in-process listeners in prod

### DIFF
--- a/deploy/event-tracker/prod/values.yaml
+++ b/deploy/event-tracker/prod/values.yaml
@@ -78,6 +78,12 @@ env:
   AWS_REGION:
     type: kv
     value: "us-east-2"
+  # KEEP-295 Phase 6 cutover: run listeners in-process instead of forking
+  # a child per workflow. See TechOps/docs/keeperhub/KEEP-214/KEEP-295/plan.md.
+  # Keep flag enabled for at least one deploy cycle as kill-switch (KEEP-328).
+  ENABLE_INPROC_LISTENERS:
+    type: kv
+    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-prod


### PR DESCRIPTION
## Summary

Phase 6 cutover for KEEP-295. Sets `ENABLE_INPROC_LISTENERS=true` in `deploy/event-tracker/prod/values.yaml` so the event-tracker runs listeners in-process instead of forking a child per workflow.

This is Step 2 of three in KEEP-328:
- Step 1 (staging soak) - done. Flag has been on in staging since 2026-04-23 (fdc77cfe), well past the 48-72h gate.
- **Step 2 (this PR)** - flip flag in prod. Keep flag in place for at least one deploy cycle so rollback is still a config flip + pod restart.
- Step 3 (separate PR, later) - delete the fork machinery. Gated on Phase 5 (Postgres dedup) being live in prod and Step 2 holding for a deploy cycle.

## Verification gates before merge

The 9-day staging soak only proves the pods did not crashloop. Confirm the metrics the ticket specifies have actually held vs the pre-flip baseline:

- [ ] Pod RSS dropped from 1 GB+ (capped-at-OOM) to ~100 MB
- [ ] SQS message throughput matches pre-flip baseline (any delta is a missed-event signal)
- [ ] Spot-check a handful of known-active workflows on a block explorer for missed events
- [ ] `/healthz` has stayed 200 throughout the staging soak

## Rollback

Revert is a config flip back to `value: "false"` plus a rolling restart. No revert commit needed while the flag is still in the codebase.

## Test plan

- [ ] Helm template renders with the new env var on prod values
- [ ] After deploy, confirm pod env shows `ENABLE_INPROC_LISTENERS=true`
- [ ] Watch the four metrics above for at least a deploy cycle before considering Step 3