### PR TITLE
fix: KEEP-393 drop stale ethValue when target function is non-payable

### DIFF
--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -7,6 +7,7 @@ import {
   writeContractCore,
 } from "@/plugins/web3/steps/write-contract-core";
 import { resolveAbi } from "@/lib/abi/cache";
+import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
 import { getProtocol } from "@/lib/protocol-registry";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { applyEncodeTransformsNamed } from "@/lib/protocol-encode-transforms";
@@ -26,6 +27,39 @@ type ProtocolWriteInput = StepInput & {
   _actionType?: string;
   [key: string]: unknown;
 };
+
+function resolveEthValue(
+  rawEthValue: unknown,
+  abi: string,
+  functionName: string
+): string | undefined {
+  if (typeof rawEthValue !== "string" || rawEthValue.trim() === "") {
+    return undefined;
+  }
+  const trimmed = rawEthValue.trim();
+
+  let parsedAbi: unknown;
+  try {
+    parsedAbi = JSON.parse(abi);
+  } catch {
+    return trimmed;
+  }
+  if (!Array.isArray(parsedAbi)) {
+    return trimmed;
+  }
+
+  // Drop ethValue when the resolved function is positively non-payable. Form
+  // state can retain stale ethValue from a previous configuration (e.g. a
+  // WETH.deposit action reconfigured into a Uniswap swap), and the value
+  // cannot reach the contract anyway. If the function is missing from the
+  // ABI or its mutability is unknown, pass the value through and let
+  // writeContractCore surface the existing payable/not-found errors.
+  const fn = findAbiFunction(parsedAbi as AbiItem[], functionName);
+  if (fn && fn.stateMutability && fn.stateMutability !== "payable") {
+    return undefined;
+  }
+  return trimmed;
+}
 
 function buildFunctionArgs(
   input: ProtocolWriteInput,
@@ -130,10 +164,11 @@ export async function protocolWriteStep(
     const functionArgs = buildFunctionArgs(input, meta);
 
     // 6. Delegate to writeContractCore
-    const ethValue =
-      typeof input.ethValue === "string" && input.ethValue.trim() !== ""
-        ? input.ethValue.trim()
-        : undefined;
+    const ethValue = resolveEthValue(
+      input.ethValue,
+      resolvedAbi,
+      meta.functionName
+    );
 
     const coreInput: WriteContractCoreInput = {
       contractAddress,

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -8,6 +8,7 @@ import {
 } from "@/plugins/web3/steps/write-contract-core";
 import { resolveAbi } from "@/lib/abi/cache";
 import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getProtocol } from "@/lib/protocol-registry";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { applyEncodeTransformsNamed } from "@/lib/protocol-encode-transforms";
@@ -31,7 +32,8 @@ type ProtocolWriteInput = StepInput & {
 function resolveEthValue(
   rawEthValue: unknown,
   abi: string,
-  functionName: string
+  functionName: string,
+  protocolSlug: string
 ): string | undefined {
   if (typeof rawEthValue !== "string" || rawEthValue.trim() === "") {
     return undefined;
@@ -55,7 +57,19 @@ function resolveEthValue(
   // ABI or its mutability is unknown, pass the value through and let
   // writeContractCore surface the existing payable/not-found errors.
   const fn = findAbiFunction(parsedAbi as AbiItem[], functionName);
-  if (fn && fn.stateMutability && fn.stateMutability !== "payable") {
+  if (fn?.stateMutability && fn.stateMutability !== "payable") {
+    logUserError(
+      ErrorCategory.CONFIGURATION,
+      `[Protocol Write] Dropped ethValue for non-payable function '${functionName}' (was '${trimmed}')`,
+      undefined,
+      {
+        plugin_name: "protocol",
+        action_name: "protocol-write",
+        protocol_slug: protocolSlug,
+        function_name: functionName,
+        state_mutability: fn.stateMutability,
+      }
+    );
     return undefined;
   }
   return trimmed;
@@ -167,7 +181,8 @@ export async function protocolWriteStep(
     const ethValue = resolveEthValue(
       input.ethValue,
       resolvedAbi,
-      meta.functionName
+      meta.functionName,
+      meta.protocolSlug
     );
 
     const coreInput: WriteContractCoreInput = {

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -5,6 +5,12 @@ import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 vi.mock("@/protocols", () => ({}));
 
+const mockLogUserError = vi.fn();
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { CONFIGURATION: "configuration" },
+  logUserError: (...args: unknown[]) => mockLogUserError(...args),
+}));
+
 const mockWithStepLogging = vi.fn((_input: unknown, fn: () => unknown) => fn());
 
 vi.mock("@/lib/workflow/executor/step-handler", () => ({
@@ -411,7 +417,7 @@ describe("protocolWriteStep", () => {
         },
       ]);
 
-      it("drops ethValue when the resolved function is nonpayable", async () => {
+      it("drops ethValue when the resolved function is nonpayable and logs the drop", async () => {
         mockResolveProtocolMeta.mockReturnValue({
           protocolSlug: "uniswap",
           contractKey: "swapRouter",
@@ -450,6 +456,21 @@ describe("protocolWriteStep", () => {
 
         const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
         expect(coreCall.ethValue).toBeUndefined();
+
+        expect(mockLogUserError).toHaveBeenCalledTimes(1);
+        const [category, message, , labels] = (mockLogUserError as Mock).mock
+          .calls[0];
+        expect(category).toBe("configuration");
+        expect(message).toContain("Dropped ethValue");
+        expect(message).toContain("exactInputSingle");
+        expect(message).toContain("0.04");
+        expect(labels).toMatchObject({
+          plugin_name: "protocol",
+          action_name: "protocol-write",
+          protocol_slug: "uniswap",
+          function_name: "exactInputSingle",
+          state_mutability: "nonpayable",
+        });
       });
 
       it("preserves ethValue when the resolved function is payable", async () => {

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -550,6 +550,87 @@ describe("protocolWriteStep", () => {
         const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
         expect(coreCall.ethValue).toBe("0.25");
       });
+
+      it("passes ethValue through when the ABI is valid JSON but not an array", async () => {
+        // Some auto-fetched ABIs come back wrapped (e.g. `{"abi": [...]}`).
+        // We only know how to inspect array-form ABIs; fall back to passing
+        // the value through and let writeContractCore handle it.
+        mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+        mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+        mockResolveAbi.mockResolvedValue({
+          abi: '{"type":"function","name":"supply"}',
+        });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0x000",
+          transactionLink: "",
+          gasUsed: "21000",
+        });
+
+        await protocolWriteStep(makeInput({ ethValue: "0.5" }));
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBe("0.5");
+        expect(mockLogUserError).not.toHaveBeenCalled();
+      });
+
+      it("preserves ethValue when the function has no stateMutability field", async () => {
+        // Pre-Solidity 0.5 ABIs may omit stateMutability. Without explicit
+        // information we cannot know whether the function is payable, so
+        // err on the side of preserving user input.
+        mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+        mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+        mockResolveAbi.mockResolvedValue({
+          abi: JSON.stringify([
+            { type: "function", name: "supply", inputs: [], outputs: [] },
+          ]),
+        });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0x000",
+          transactionLink: "",
+          gasUsed: "21000",
+        });
+
+        await protocolWriteStep(makeInput({ ethValue: "0.75" }));
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBe("0.75");
+        expect(mockLogUserError).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        ["view", "view"],
+        ["pure", "pure"],
+      ])("drops ethValue when the resolved function is %s", async (_label, mutability) => {
+        mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+        mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+        mockResolveAbi.mockResolvedValue({
+          abi: JSON.stringify([
+            {
+              type: "function",
+              name: "supply",
+              stateMutability: mutability,
+              inputs: [],
+              outputs: [],
+            },
+          ]),
+        });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0x000",
+          transactionLink: "",
+          gasUsed: "21000",
+        });
+
+        await protocolWriteStep(makeInput({ ethValue: "0.1" }));
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBeUndefined();
+        expect(mockLogUserError).toHaveBeenCalledTimes(1);
+        const labels = (mockLogUserError as Mock).mock.calls[0][3];
+        expect(labels.state_mutability).toBe(mutability);
+      });
     });
 
     it("omits _context when input has no _context", async () => {

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -386,6 +386,151 @@ describe("protocolWriteStep", () => {
       expect(coreCall.ethValue).toBeUndefined();
     });
 
+    // KEEP-393: form state can carry a stale ethValue from a previous action
+    // configuration (e.g. WETH.deposit) into a non-payable action (e.g. a
+    // Uniswap swap). Drop the value rather than let writeContractCore surface
+    // the opaque "function is not payable" error.
+    describe("KEEP-393 stale ethValue guard", () => {
+      const NONPAYABLE_ABI = JSON.stringify([
+        {
+          type: "function",
+          name: "exactInputSingle",
+          stateMutability: "nonpayable",
+          inputs: [],
+          outputs: [],
+        },
+      ]);
+
+      const PAYABLE_ABI = JSON.stringify([
+        {
+          type: "function",
+          name: "deposit",
+          stateMutability: "payable",
+          inputs: [],
+          outputs: [],
+        },
+      ]);
+
+      it("drops ethValue when the resolved function is nonpayable", async () => {
+        mockResolveProtocolMeta.mockReturnValue({
+          protocolSlug: "uniswap",
+          contractKey: "swapRouter",
+          functionName: "exactInputSingle",
+          actionType: "write",
+        });
+        mockGetProtocol.mockReturnValue({
+          name: "Uniswap V3",
+          slug: "uniswap",
+          contracts: {
+            swapRouter: {
+              label: "SwapRouter02",
+              userSpecifiedAddress: false,
+              addresses: {
+                "11155111": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E",
+              },
+            },
+          },
+          actions: [],
+        });
+        mockResolveAbi.mockResolvedValue({ abi: NONPAYABLE_ABI });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0xswap",
+          transactionLink: "",
+          gasUsed: "150000",
+        });
+
+        await protocolWriteStep(
+          makeInput({
+            network: "11155111",
+            ethValue: "0.04",
+            _actionType: "uniswap/swap-exact-input",
+          })
+        );
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBeUndefined();
+      });
+
+      it("preserves ethValue when the resolved function is payable", async () => {
+        mockResolveProtocolMeta.mockReturnValue({
+          protocolSlug: "wrapped",
+          contractKey: "weth",
+          functionName: "deposit",
+          actionType: "write",
+        });
+        mockGetProtocol.mockReturnValue({
+          name: "WETH",
+          slug: "wrapped",
+          contracts: {
+            weth: {
+              label: "WETH",
+              userSpecifiedAddress: false,
+              addresses: {
+                "11155111": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
+              },
+            },
+          },
+          actions: [],
+        });
+        mockResolveAbi.mockResolvedValue({ abi: PAYABLE_ABI });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0xdep",
+          transactionLink: "",
+          gasUsed: "50000",
+        });
+
+        await protocolWriteStep(
+          makeInput({
+            network: "11155111",
+            ethValue: "0.04",
+            _actionType: "wrapped/deposit",
+          })
+        );
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBe("0.04");
+      });
+
+      it("passes ethValue through when the function is missing from the ABI", async () => {
+        // ABI does not contain the resolved function name. Pass through and
+        // let writeContractCore produce its existing "function not found" error
+        // instead of silently mutating user input.
+        mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+        mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+        mockResolveAbi.mockResolvedValue({ abi: "[]" });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0x000",
+          transactionLink: "",
+          gasUsed: "21000",
+        });
+
+        await protocolWriteStep(makeInput({ ethValue: "1.5" }));
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBe("1.5");
+      });
+
+      it("passes ethValue through when the ABI fails to parse", async () => {
+        mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+        mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+        mockResolveAbi.mockResolvedValue({ abi: "not-json" });
+        mockWriteContractCore.mockResolvedValue({
+          success: true,
+          transactionHash: "0x000",
+          transactionLink: "",
+          gasUsed: "21000",
+        });
+
+        await protocolWriteStep(makeInput({ ethValue: "0.25" }));
+
+        const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+        expect(coreCall.ethValue).toBe("0.25");
+      });
+    });
+
     it("omits _context when input has no _context", async () => {
       mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
       mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);


### PR DESCRIPTION
## Summary

When an action node is reconfigured (e.g. from a Wrap WETH `deposit` to a Uniswap V3 swap), the form retains stale `ethValue` and `abiFunction` fields from the previous configuration. The stale `ethValue` reaches `writeContractCore`, which rejects the call against the (correctly) non-payable `exactInputSingle` ABI:

```
Function 'exactInputSingle' is not payable - cannot send a non-zero value with this call
```

`protocol-write` now drops `ethValue` when the resolved function ABI declares a non-payable mutability. When the function is missing from the ABI or its mutability cannot be determined, the value passes through unchanged so `writeContractCore`'s existing errors are preserved.

This is the server-side defense in depth. The companion UI fix (clear `ethValue` / `abiFunction` / contract overrides on action-type change) is tracked separately in KEEP-393.

## Linear

[KEEP-393](https://linear.app/keeperhubapp/issue/KEEP-393)

## Test plan

- [x] `pnpm vitest run tests/unit/protocol-write-step.test.ts` - 23/23 pass (4 new cases for KEEP-393)
- [x] `pnpm check` - clean on changed files
- [x] `pnpm type-check` - clean
- [ ] Manual verification on staging: reconfigure a node from Wrap WETH to Uniswap V3 Swap Exact Input, confirm swap succeeds without "function not payable" error
- [ ] Manual regression: confirm Wrap WETH (`payable`) still receives `ethValue`