### PR TITLE
fix: KEEP-394 clamp Pimlico fees to EIP-1559 invariant

### DIFF
--- a/lib/web3/sponsored-client.ts
+++ b/lib/web3/sponsored-client.ts
@@ -15,6 +15,7 @@ import {
   getPimlicoUrl,
   isSponsorshipSupported,
 } from "@/lib/web3/pimlico-config";
+import { clampSponsoredFees } from "@/lib/web3/sponsored-fee-clamp";
 
 const LOG_PREFIX = "[Sponsorship]";
 
@@ -92,6 +93,7 @@ export async function createSponsoredClient(
     });
 
     const gasPrices = await pimlicoClient.getUserOperationGasPrice();
+    const sponsoredFees = clampSponsoredFees(gasPrices.fast);
 
     const smartAccountClient = createSmartAccountClient({
       chain,
@@ -100,7 +102,7 @@ export async function createSponsoredClient(
       bundlerTransport: http(pimlicoUrl),
       paymaster: pimlicoClient,
       userOperation: {
-        estimateFeesPerGas: async () => gasPrices.fast,
+        estimateFeesPerGas: async () => sponsoredFees,
       },
     });
 

--- a/lib/web3/sponsored-fee-clamp.ts
+++ b/lib/web3/sponsored-fee-clamp.ts
@@ -1,0 +1,21 @@
+/**
+ * Enforce the EIP-1559 invariant maxFeePerGas >= maxPriorityFeePerGas
+ * on a fee pair before handing it to a userOperation.
+ *
+ * Pimlico's getUserOperationGasPrice().fast has been observed on Sepolia
+ * returning maxPriorityFeePerGas > maxFeePerGas. Defensive clamp: lift
+ * maxFeePerGas to the priority value when violated. The on-chain cost
+ * paid is still baseFee + tip, only the cap moves.
+ */
+export function clampSponsoredFees(fees: {
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+}): { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } {
+  if (fees.maxFeePerGas < fees.maxPriorityFeePerGas) {
+    return {
+      maxFeePerGas: fees.maxPriorityFeePerGas,
+      maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+    };
+  }
+  return fees;
+}

--- a/tests/unit/sponsored-client.test.ts
+++ b/tests/unit/sponsored-client.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+// ── Mocks (before imports) ───────────────────────────────────────────
+
+vi.mock("server-only", () => ({}));
+
+// Capture what createSmartAccountClient is called with so we can pull the
+// estimateFeesPerGas callback back out and exercise it directly. Returns
+// an opaque client - not exercised in these tests.
+const mockCreateSmartAccountClient: Mock = vi.fn((_args: unknown) => ({}));
+vi.mock("permissionless", () => ({
+  createSmartAccountClient: (...args: unknown[]) =>
+    mockCreateSmartAccountClient(...args),
+}));
+
+// Pimlico client returns whatever the test has currently set on the spy.
+const mockGetUserOperationGasPrice = vi.fn();
+vi.mock("permissionless/clients/pimlico", () => ({
+  createPimlicoClient: () => ({
+    getUserOperationGasPrice: (...args: unknown[]) =>
+      mockGetUserOperationGasPrice(...args),
+  }),
+}));
+
+// Stubs for everything else createSponsoredClient touches before reaching
+// the createSmartAccountClient call.
+vi.mock("permissionless/accounts", () => ({
+  to7702SimpleSmartAccount: vi.fn().mockResolvedValue({
+    isDeployed: vi.fn().mockResolvedValue(true),
+  }),
+}));
+vi.mock("viem", () => ({
+  createPublicClient: vi.fn().mockReturnValue({}),
+  defineChain: vi.fn().mockReturnValue({}),
+  http: vi.fn().mockReturnValue({}),
+}));
+vi.mock("viem/account-abstraction", () => ({ entryPoint08Address: "0x0" }));
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      chains: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValue({ name: "Sepolia", symbol: "ETH" }),
+      },
+    },
+  },
+}));
+vi.mock("@/lib/db/schema", () => ({ chains: { chainId: "chainId" } }));
+vi.mock("drizzle-orm", () => ({ eq: vi.fn() }));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { TRANSACTION: "transaction" },
+  logSystemError: vi.fn(),
+}));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    recordError: vi.fn(),
+    incrementCounter: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/metrics/types", () => ({
+  LabelKeys: {},
+  MetricNames: {},
+}));
+vi.mock("@/lib/para/viem-account-adapter", () => ({
+  createParaViemAccount: vi.fn().mockResolvedValue({
+    account: { address: "0xabc" },
+    walletRecord: { walletAddress: "0xabc" },
+  }),
+}));
+vi.mock("@/lib/web3/eip7702-delegation", () => ({
+  recordDelegationIfNeeded: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/web3/pimlico-config", () => ({
+  getPimlicoUrl: vi.fn().mockReturnValue("https://pimlico.test"),
+  isSponsorshipSupported: vi.fn().mockReturnValue(true),
+}));
+
+// ── Import under test ────────────────────────────────────────────────
+
+import { createSponsoredClient } from "@/lib/web3/sponsored-client";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+type EstimateFeesPerGas = () => Promise<{
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+}>;
+
+type CapturedClientArgs = {
+  userOperation?: { estimateFeesPerGas?: EstimateFeesPerGas };
+};
+
+async function buildSponsoredClient(): Promise<{
+  result: unknown;
+  args: CapturedClientArgs | undefined;
+}> {
+  const result = await createSponsoredClient(
+    "org-id",
+    11_155_111,
+    "https://sepolia.test"
+  );
+  const args = (mockCreateSmartAccountClient as Mock).mock.calls[0]?.[0] as
+    | CapturedClientArgs
+    | undefined;
+  return { result, args };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createSponsoredClient estimateFeesPerGas wiring", () => {
+  // KEEP-394: this test guarantees the clamp helper is actually invoked
+  // before the fee pair reaches the smart account client. If someone
+  // removes the clampSponsoredFees() call and passes gasPrices.fast
+  // through directly, this fails.
+  it("clamps Pimlico's invalid fee pair before returning to the bundler", async () => {
+    mockGetUserOperationGasPrice.mockResolvedValue({
+      fast: {
+        maxFeePerGas: BigInt(2_463_760),
+        maxPriorityFeePerGas: BigInt(100_000_000),
+      },
+    });
+
+    const { result, args } = await buildSponsoredClient();
+    expect(result).not.toBeNull();
+    const estimateFeesPerGas = args?.userOperation?.estimateFeesPerGas;
+    expect(estimateFeesPerGas).toBeTypeOf("function");
+
+    const fees = await (estimateFeesPerGas as EstimateFeesPerGas)();
+
+    expect(fees.maxFeePerGas).toBeGreaterThanOrEqual(fees.maxPriorityFeePerGas);
+    expect(fees.maxFeePerGas).toBe(BigInt(100_000_000));
+    expect(fees.maxPriorityFeePerGas).toBe(BigInt(100_000_000));
+  });
+
+  it("passes a valid Pimlico fee pair through unchanged", async () => {
+    const validPair = {
+      maxFeePerGas: BigInt(50_000_000_000),
+      maxPriorityFeePerGas: BigInt(2_000_000_000),
+    };
+    mockGetUserOperationGasPrice.mockResolvedValue({ fast: validPair });
+
+    const { result, args } = await buildSponsoredClient();
+    expect(result).not.toBeNull();
+    const estimateFeesPerGas = args?.userOperation?.estimateFeesPerGas;
+    expect(estimateFeesPerGas).toBeTypeOf("function");
+
+    const fees = await (estimateFeesPerGas as EstimateFeesPerGas)();
+
+    expect(fees.maxFeePerGas).toBe(BigInt(50_000_000_000));
+    expect(fees.maxPriorityFeePerGas).toBe(BigInt(2_000_000_000));
+  });
+});

--- a/tests/unit/sponsored-fee-clamp.test.ts
+++ b/tests/unit/sponsored-fee-clamp.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { clampSponsoredFees } from "@/lib/web3/sponsored-fee-clamp";
+
+describe("clampSponsoredFees", () => {
+  // KEEP-394: Pimlico's getUserOperationGasPrice has been observed
+  // returning an invalid pair on Sepolia. Mirror the KEEP-384 regression
+  // test for the direct-signing path.
+  it("lifts maxFeePerGas to maxPriorityFeePerGas when given an invalid pair", () => {
+    // Wei values from a reported Sepolia incident (chainId 11155111).
+    const fees = {
+      maxFeePerGas: BigInt(2_463_760),
+      maxPriorityFeePerGas: BigInt(100_000_000),
+    };
+
+    const clamped = clampSponsoredFees(fees);
+
+    expect(clamped.maxFeePerGas).toBeGreaterThanOrEqual(
+      clamped.maxPriorityFeePerGas
+    );
+    expect(clamped.maxPriorityFeePerGas).toBe(BigInt(100_000_000));
+    expect(clamped.maxFeePerGas).toBe(BigInt(100_000_000));
+  });
+
+  it("preserves a valid pair unchanged", () => {
+    const fees = {
+      maxFeePerGas: BigInt(50_000_000_000),
+      maxPriorityFeePerGas: BigInt(2_000_000_000),
+    };
+
+    const clamped = clampSponsoredFees(fees);
+
+    expect(clamped).toBe(fees);
+  });
+
+  it("preserves an exactly equal pair unchanged", () => {
+    const fees = {
+      maxFeePerGas: BigInt(1_000_000_000),
+      maxPriorityFeePerGas: BigInt(1_000_000_000),
+    };
+
+    const clamped = clampSponsoredFees(fees);
+
+    expect(clamped.maxFeePerGas).toBe(clamped.maxPriorityFeePerGas);
+    expect(clamped).toBe(fees);
+  });
+
+  it("returns a valid pair when both values are zero", () => {
+    const fees = {
+      maxFeePerGas: BigInt(0),
+      maxPriorityFeePerGas: BigInt(0),
+    };
+
+    const clamped = clampSponsoredFees(fees);
+
+    expect(clamped.maxFeePerGas).toBe(BigInt(0));
+    expect(clamped.maxPriorityFeePerGas).toBe(BigInt(0));
+  });
+
+  it("handles the boundary case where maxFee is one wei below priority", () => {
+    const fees = {
+      maxFeePerGas: BigInt(99_999_999),
+      maxPriorityFeePerGas: BigInt(100_000_000),
+    };
+
+    const clamped = clampSponsoredFees(fees);
+
+    expect(clamped.maxFeePerGas).toBe(BigInt(100_000_000));
+    expect(clamped.maxPriorityFeePerGas).toBe(BigInt(100_000_000));
+  });
+
+  it("preserves the boundary case where maxFee is one wei above priority", () => {
+    const fees = {
+      maxFeePerGas: BigInt(100_000_001),
+      maxPriorityFeePerGas: BigInt(100_000_000),
+    };
+
+    const clamped = clampSponsoredFees(fees);
+
+    expect(clamped).toBe(fees);
+  });
+});


### PR DESCRIPTION
## Summary

Pimlico's `getUserOperationGasPrice().fast` was observed on Sepolia returning a pair where `maxPriorityFeePerGas > maxFeePerGas`, violating the EIP-1559 invariant required by ERC-4337 bundlers.

`lib/web3/sponsored-client.ts` was passing the result of `getUserOperationGasPrice().fast` directly into `estimateFeesPerGas` without enforcing the invariant. This PR adds `clampSponsoredFees` (pure helper, exported for unit testing) that lifts `maxFeePerGas` to `maxPriorityFeePerGas` when violated, and wires it through sponsored-client construction.

The on-chain cost paid is still `baseFee + tip`, so the only effect of the clamp is that the cap moves up; spend is unchanged in normal conditions.

Mirrors the KEEP-384 fix in `lib/web3/gas-strategy.ts` that addressed the same class of bug for the direct-signing path.

## Linear

[KEEP-394](https://linear.app/keeperhubapp/issue/KEEP-394)

## Environments

- **staging**: `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=true` - was affected, this PR fixes
- **prod**: `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=false` - sponsored path is gated off, no behavioral change

## Test plan

- [x] `pnpm vitest run tests/unit/sponsored-fee-clamp.test.ts` - 6/6 pass (invalid pair lifted, valid preserved, equal preserved, zero pair valid, both wei boundary cases)
- [x] `pnpm vitest run tests/unit/sponsored-client.test.ts` - 2/2 pass (clamp is wired through `createSponsoredClient.estimateFeesPerGas`; valid pair passes through)
- [x] `pnpm check` - clean on changed files
- [x] `pnpm type-check` - clean
- [ ] Manual verification on staging: run an approve + Uniswap V3 swap workflow on Sepolia, confirm no invariant-violation failure
- [ ] Confirm no regression on chains where Pimlico returns valid pairs (Base, Optimism)

## Investigation notes

- Pimlico Alto ([source](https://github.com/pimlicolabs/alto)) exposes a `floor-max-priority-fee-per-gas` CLI option (`src/cli/config/options.ts`) that uses `maxBigInt(floor, priority)` to enforce a priority minimum (`src/handlers/gasPriceManager.ts:138-148`). The 100,000,000 wei value observed in production matches `0.1 gwei` exactly, consistent with such a floor being configured on Pimlico's hosted bundler, though we have not confirmed the deployed config.
- Current Alto source enforces the EIP-1559 invariant at the end of `bumpTheGasPrice` (`gasPriceManager.ts:153`: `maxFeePerGas: maxBigInt(maxFeePerGas, maxPriorityFeePerGas)`). The production observation either pre-dates that line or hits a path that bypasses it. Either way, defensive clamping on our side is required because we do not control Pimlico's deployed version.
- Sampled 512 recent Sepolia blocks (~100 minutes of history) via public RPC: base fees sat in the 10-40 wei range, p50 = 22 wei. The `2,463,760 wei` `maxFeePerGas` figure that has appeared in incident logs is Pimlico's buffered value, not the chain's raw base fee.
