### PR TITLE
hotfix: drop dead ai-gateway/config import from lib/auth.ts

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -16,7 +16,6 @@ import { nanoid } from "nanoid";
 import { rateLimitBypassRule } from "@/lib/admin-auth";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
 import { TRUSTED_ORIGINS } from "@/lib/trusted-origins";
-import { isAiGatewayManagedKeysEnabled } from "./ai-gateway/config";
 import { wrapWithSessionTokenHash } from "./auth-session-token-hash";
 import { db } from "./db";
 import {


### PR DESCRIPTION
## Summary

Fixes the `staging` build failure introduced by [run 25268333761](https://github.com/KeeperHub/keeperhub/actions/runs/25268333761/job/74086395383).

## Root cause

A semantic merge conflict between two PRs that both touched `lib/auth.ts`'s import block:

- **PR #1049** (`chore: remove Vercel fork relics`, commit `627716bf`) deleted `lib/ai-gateway/` AND removed the `import { isAiGatewayManagedKeysEnabled } from "./ai-gateway/config"` line from `lib/auth.ts`.
- **PR #1048** (`fix: KEEP-240 csrf origin check`) added `import { TRUSTED_ORIGINS } from "@/lib/trusted-origins"` to the same import block.

When PR #1049's branch merged staging in via `815081a0`, git's three-way merge saw a deletion on one side and an unrelated addition on the other (different lines, no textual conflict) and silently kept both — including the line that PR #1049 was supposed to delete. The `lib/ai-gateway/config.ts` file deletion went through cleanly (no conflict on a deleted file), so post-merge `lib/auth.ts:19` imported from a non-existent path:

` ` `
./lib/auth.ts:19
Type error: Cannot find module './ai-gateway/config' or its corresponding type declarations.
` ` `

The `isAiGatewayManagedKeysEnabled` symbol is referenced nowhere else in `lib/auth.ts` — pure dead-import residue.

## Fix

Delete the orphaned import line. One-line change, identical to what PR #1049 had on its source branch.

## Followup worth filing separately

Per-PR CI passes against the PR's pre-merge commit, so semantic conflicts of this shape (deletion in branch A vs unrelated addition in branch B touching the same file but different lines) are invisible to it. They're only caught by post-merge CI on `staging`. Worth considering branch-protection or a merge-queue setup that re-runs CI on the post-merge SHA.

## Test plan

- [x] `pnpm type-check` passes locally
- [x] CI `build-images / build` passes on this branch