### PR TITLE
hotfix: KEEP-407 deduplicate builder stage to fix .next/cache race

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,10 @@ ENV INCLUDE_TEST_ENDPOINTS=$INCLUDE_TEST_ENDPOINTS
 
 # Build the application with Turbopack (source maps generated but not uploaded).
 # Cache mount persists .next/cache across builds on the same BuildKit instance,
-# enabling Turbopack's incremental compilation.
-RUN --mount=type=cache,target=/app/.next/cache pnpm build
+# enabling Turbopack's incremental compilation. sharing=locked serialises
+# concurrent builders to prevent racing on Next.js cache writes when bake runs
+# multiple targets that share this stage.
+RUN --mount=type=cache,target=/app/.next/cache,sharing=locked pnpm build
 
 # Stage 2.5b: Sentry source map upload (side-effect only, not consumed by other stages)
 FROM builder AS sentry-upload

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -110,6 +110,18 @@ target "workflow-runner" {
   context    = "."
   dockerfile = "Dockerfile"
   target     = "workflow-runner"
+  # Args mirror "app" so BuildKit deduplicates the shared "builder" stage
+  # across targets and runs `pnpm build` once. Divergent args here cause
+  # parallel builder invocations that race on the .next/cache mount.
+  args = {
+    NEXT_PUBLIC_AUTH_PROVIDERS    = NEXT_PUBLIC_AUTH_PROVIDERS
+    NEXT_PUBLIC_GITHUB_CLIENT_ID = NEXT_PUBLIC_GITHUB_CLIENT_ID
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID = NEXT_PUBLIC_GOOGLE_CLIENT_ID
+    NEXT_PUBLIC_BILLING_ENABLED  = NEXT_PUBLIC_BILLING_ENABLED
+    NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED = NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED
+    NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    INCLUDE_TEST_ENDPOINTS       = INCLUDE_TEST_ENDPOINTS
+  }
   tags = compact([
     "${ECR_REGISTRY}/${ECR_REPO}:workflow-runner-${IMAGE_TAG}",
     "${ECR_REGISTRY}/${ECR_REPO}:workflow-runner-latest",


### PR DESCRIPTION
## Summary

Unblocks `staging` CI. The `build-images / build` job has been failing on every merge since 2026-05-03 02:56 UTC ([first failure](https://github.com/KeeperHub/keeperhub/actions/runs/25268235928), [latest](https://github.com/KeeperHub/keeperhub/actions/runs/25269034085)) with:

```
Error: ENOENT: no such file or directory,
rename '/app/.next/cache/config.json.<n>' -> '/app/.next/cache/config.json'
```

## Root cause

`docker-bake.hcl` declares `app` and `workflow-runner` as separate targets, both depending on the shared `builder` Dockerfile stage. The targets passed divergent inputs:

| Target | `args` |
|---|---|
| `app` | 7 `NEXT_PUBLIC_*` + `INCLUDE_TEST_ENDPOINTS` |
| `workflow-runner` | none |

Different ARG values => BuildKit could not deduplicate the stage. Both invocations of `pnpm build` ran in parallel, sharing `--mount=type=cache,target=/app/.next/cache` (default `sharing=shared`). Next.js writes `.next/cache/config.json` via temp file + rename; concurrent writes raced, one process's temp file vanished before the rename, ENOENT.

The race was latent since `workflow-runner` was added in `444916b2` (KEEP-1587, 2026-03-25). It became deterministic ~6 weeks later, almost certainly because of cache state on the runner.

## Fix

Two single-line changes:

**A. Mirror `app`'s args onto `workflow-runner`** (`docker-bake.hcl`). With identical ARGs, BuildKit deduplicates the `builder` stage and runs `pnpm build` exactly once.

**B. Add `sharing=locked` to the `.next/cache` mount** (`Dockerfile:84`). Safety net: if anyone later differentiates the targets again, concurrent builders will serialise on the cache instead of racing.

Both layers together. A is the unblock, B prevents recurrence.

## Verification

`docker buildx bake app workflow-runner` locally:

- Single `[app builder 2/2] RUN ... pnpm build` invocation (was 2)
- Zero `rename`/`ENOENT` errors
- `workflow-runner` consumes builder output via `COPY --link --from=builder` for the 7 generated TS files
- Build exits 0

## Out of scope

Refactoring `workflow-runner` to skip `next build` entirely. Tracked as KEEP-406.

## Test plan

- [ ] `build-images / build` job is green on this PR
- [ ] No `rename` / `ENOENT` errors in the build log
- [ ] CI logs show a single `[<target> builder 2/2] RUN ... pnpm build` invocation, not two
- [ ] After merge, next staging build is also green