### PR TITLE
fix: KEEP-240 set Origin on session-authed test API mutations

### DIFF
--- a/tests/e2e/playwright/credential-bundle.test.ts
+++ b/tests/e2e/playwright/credential-bundle.test.ts
@@ -295,7 +295,7 @@ async function safeCleanup(handle: CleanupHandle | null): Promise<void> {
 test.describe("Credential resolution in workflow step bundles", () => {
   for (const commsCase of COMMS_CASES) {
     test(`${commsCase.integrationType} step receives credentials via PLUGIN_CREDENTIAL_MAP, not the lossy fallback`, async ({
-      page,
+      apiRequest,
     }) => {
       const { userId, organizationId } = await lookupUserAndOrg(
         PERSISTENT_TEST_USER_EMAIL
@@ -325,7 +325,7 @@ test.describe("Credential resolution in workflow step bundles", () => {
       const cleanup: CleanupHandle = { workflowId, integrationId };
 
       try {
-        const response = await page.request.post(
+        const response = await apiRequest.post(
           `/api/workflow/${workflowId}/execute`,
           { data: {} }
         );

--- a/tests/e2e/playwright/fixtures.ts
+++ b/tests/e2e/playwright/fixtures.ts
@@ -1,10 +1,33 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ConsoleMessage, Page, TestInfo } from "@playwright/test";
+import type {
+  APIRequestContext,
+  ConsoleMessage,
+  Page,
+  TestInfo,
+} from "@playwright/test";
 import { test as base } from "@playwright/test";
 import { probe } from "./utils/discover";
 
 export { expect } from "@playwright/test";
+
+/**
+ * Wrapper around `page.request` for state-changing API calls. Defaults the
+ * Origin header to baseURL so the proxy.ts CSRF guard (KEEP-240) accepts the
+ * request. Playwright's APIRequestContext is server-side fetch and does not
+ * auto-attach Origin like a browser would.
+ *
+ * Use raw `page.request` when you specifically want to exercise the guard's
+ * negative path (e.g. assert that origin-less or wrong-origin requests 403).
+ */
+export type AuthenticatedApiRequest = {
+  post: APIRequestContext["post"];
+  put: APIRequestContext["put"];
+  patch: APIRequestContext["patch"];
+  delete: APIRequestContext["delete"];
+};
+
+type StateChangingOptions = Parameters<APIRequestContext["post"]>[1];
 
 const MAX_CONSOLE_ENTRIES = 200;
 const MAX_CONSOLE_ENTRY_LENGTH = 500;
@@ -32,7 +55,23 @@ interface NetworkFailure {
  */
 export const test = base.extend<{
   _autoFailureDiagnostics: undefined;
+  apiRequest: AuthenticatedApiRequest;
 }>({
+  apiRequest: async ({ page, baseURL }, use) => {
+    const origin = baseURL ?? "http://localhost:3000";
+    const withOrigin = (
+      options: StateChangingOptions
+    ): StateChangingOptions => ({
+      ...options,
+      headers: { Origin: origin, ...options?.headers },
+    });
+    await use({
+      post: (url, options) => page.request.post(url, withOrigin(options)),
+      put: (url, options) => page.request.put(url, withOrigin(options)),
+      patch: (url, options) => page.request.patch(url, withOrigin(options)),
+      delete: (url, options) => page.request.delete(url, withOrigin(options)),
+    });
+  },
   _autoFailureDiagnostics: [
     async ({ page }, use, testInfo) => {
       const consoleLogs: ConsoleEntry[] = [];


### PR DESCRIPTION
## Summary

- Fixes the `e2e-playwright-ephemeral` failure on staging where `credential-bundle.test.ts` returned `403 {"error":"Invalid origin"}` from the workflow execute endpoint.
- Root cause: KEEP-240's CSRF origin guard (`proxy.ts`) rejects state-changing `/api/**` requests that carry a better-auth session cookie but no Origin header. Playwright's `APIRequestContext` (`page.request`) is server-side fetch and does not auto-attach Origin like a browser would.
- Adds an `apiRequest` test fixture that wraps `page.request.{post,put,patch,delete}` with `Origin: baseURL` so future authenticated mutations don't re-hit the same wall. Raw `page.request` is left untouched so tests can still exercise the guard's negative path.
- Migrates `credential-bundle.test.ts` (the sole test using `page.request.post`) to the new fixture.

## Test plan

- [x] CI `e2e-tests / e2e-playwright-ephemeral` passes on this PR (was failing on the same commit on staging).
- [x] All three credential-bundle cases (telegram, slack, discord) reach the upstream API, not the local credential gate.
- [x] No regression on other e2e tests (only `credential-bundle.test.ts` and `fixtures.ts` are touched).

## Notes

- Did not touch the pre-existing line-83 biome formatter complaint in `credential-bundle.test.ts` — present on staging, out of scope.
- Did not add `Origin` globally via `playwright.config.ts.extraHTTPHeaders` (option D1 from the design discussion) so the CSRF guard can still be exercised from E2E by calling raw `page.request` if needed.