### PR TITLE
fix(aave-v3): embed inline Pool ABI to fix mainnet proxy auto-fetch

### DIFF
--- a/protocols/aave-v3.ts
+++ b/protocols/aave-v3.ts
@@ -1,4 +1,5 @@
 import { defineProtocol } from "@/lib/protocol-registry";
+import aaveV3PoolAbi from "./abis/aave-v3-pool.json";
 
 export default defineProtocol({
   name: "Aave V3",
@@ -23,7 +24,14 @@ export default defineProtocol({
         // Sepolia Testnet
         "11155111": "0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951",
       },
-      // Proxy contract -- ABI auto-resolved via abi-cache
+      // Aave V3 Pool is a custom upgradeable proxy
+      // (InitializableImmutableAdminUpgradeabilityProxy). Etherscan's
+      // getsourcecode does not flag it as a proxy and getabi returns the
+      // proxy's own ABI (admin/implementation/upgradeTo), so the
+      // auto-resolver fails to find pool functions on mainnet.
+      // Embed the implementation ABI inline so resolveAbi short-circuits
+      // via the "definition" source. KEEP-396.
+      abi: JSON.stringify(aaveV3PoolAbi),
     },
     poolDataProvider: {
       label: "Aave V3 Pool Data Provider",

--- a/protocols/abis/aave-v3-pool.json
+++ b/protocols/abis/aave-v3-pool.json
@@ -1,0 +1,74 @@
+[
+  {
+    "type": "function",
+    "name": "supply",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "asset", "type": "address" },
+      { "name": "amount", "type": "uint256" },
+      { "name": "onBehalfOf", "type": "address" },
+      { "name": "referralCode", "type": "uint16" }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "asset", "type": "address" },
+      { "name": "amount", "type": "uint256" },
+      { "name": "to", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "borrow",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "asset", "type": "address" },
+      { "name": "amount", "type": "uint256" },
+      { "name": "interestRateMode", "type": "uint256" },
+      { "name": "referralCode", "type": "uint16" },
+      { "name": "onBehalfOf", "type": "address" }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "repay",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "asset", "type": "address" },
+      { "name": "amount", "type": "uint256" },
+      { "name": "interestRateMode", "type": "uint256" },
+      { "name": "onBehalfOf", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "setUserUseReserveAsCollateral",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "asset", "type": "address" },
+      { "name": "useAsCollateral", "type": "bool" }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "getUserAccountData",
+    "stateMutability": "view",
+    "inputs": [{ "name": "user", "type": "address" }],
+    "outputs": [
+      { "name": "totalCollateralBase", "type": "uint256" },
+      { "name": "totalDebtBase", "type": "uint256" },
+      { "name": "availableBorrowsBase", "type": "uint256" },
+      { "name": "currentLiquidationThreshold", "type": "uint256" },
+      { "name": "ltv", "type": "uint256" },
+      { "name": "healthFactor", "type": "uint256" }
+    ]
+  }
+]

--- a/tests/unit/protocol-synthesiser.test.ts
+++ b/tests/unit/protocol-synthesiser.test.ts
@@ -126,8 +126,8 @@ describe("synthesiseProtocolTemplate", () => {
     });
   });
 
-  describe("proxy contract ABI fallback (no inline abi)", () => {
-    it("synthesises an ABI fragment from action metadata for aave-v3/supply", () => {
+  describe("inline ABI present (KEEP-396)", () => {
+    it("uses the inline Pool ABI for aave-v3/supply (no synthesis fallback)", () => {
       const out = synthesiseProtocolTemplate("aave-v3/supply", {
         network: "1",
       });
@@ -135,16 +135,10 @@ describe("synthesiseProtocolTemplate", () => {
       expect(out).not.toBeNull();
       const code = out as string;
 
-      // Header comment marks the synthesised origin so a reader knows the
-      // shape came from action metadata, not a real ABI lookup.
-      expect(code).toContain(
-        "// ABI fragment synthesised from protocol action metadata"
-      );
-
       // Real Aave V3 pool address on mainnet, resolved per chain.
       expect(code).toContain('"0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"');
 
-      // Action.inputs become positional contract args with the right casts.
+      // Function name + positional arg casts come from the resolved ABI fragment.
       expect(code).toContain('functionName: "supply"');
       expect(code).toContain(
         "args: [input.asset, BigInt(input.amount), input.onBehalfOf, BigInt(input.referralCode)]"
@@ -153,6 +147,12 @@ describe("synthesiseProtocolTemplate", () => {
       // Write-shaped output template.
       expect(code).toContain("export async function supplyStep");
       expect(code).toContain("publicClient.simulateContract");
+
+      // Inline ABI is now present on the pool contract, so the synthesis
+      // fallback comment must NOT appear.
+      expect(code).not.toContain(
+        "// ABI fragment synthesised from protocol action metadata"
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

`aave-v3/get-user-account-data` failed on Ethereum mainnet (chain `1`) with `"Function 'getUserAccountData' not found in ABI"`. Worked on Base.

Root cause: Aave V3 mainnet Pool at `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` is a custom upgradeable proxy (`InitializableImmutableAdminUpgradeabilityProxy`). Etherscan's `getsourcecode` does NOT auto-flag it as a proxy, so `lib/abi/cache.ts`'s `hasFunctions` check accepted the proxy's own ABI (`admin`/`implementation`/`upgradeTo`) without consulting the EIP-1967 slot. Base worked because BaseScan correctly flagged its proxy.

Fix (hot-fix only): embed the canonical Aave V3 Pool ABI (6 methods used by current actions) in `protocols/abis/aave-v3-pool.json`. Routes through `lib/abi/cache.ts` `source: "definition"` path, bypasses the explorer entirely. Applies to all 5 chains the pool is registered on.

Structural fix to `lib/abi/cache.ts` (always-on EIP-1967 detection + proxy-aware `hasFunctions`) is deferred to a follow-up. Reviewers also flagged Spark mainnet pool as a likely-affected sibling — should be filed separately.

Closes KEEP-396.

## Test plan

- [x] `tests/unit/protocol-aave-v3.test.ts` 16/16 pass
- [x] `abi-utils` + `abi-function-args` 30/30 pass
- [x] Lint/type-check clean on touched files
- [ ] Live verify against `localhost:3000`: call `aave-v3/get-user-account-data` on chain `1` with any wallet address
- [ ] Live verify regression on chain `8453` (Base) — should still work