### PR TITLE
fix(ethena): embed inline sUSDe ABI to fix mainnet vault actions

### DIFF
--- a/protocols/abis/ethena-susde.json
+++ b/protocols/abis/ethena-susde.json
@@ -1,0 +1,242 @@
+[
+  {
+    "type": "function",
+    "name": "asset",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "totalAssets",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "stateMutability": "view",
+    "inputs": [{ "name": "account", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint8" }]
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }]
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }]
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "owner", "type": "address" },
+      { "name": "spender", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "spender", "type": "address" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "to", "type": "address" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "type": "function",
+    "name": "convertToShares",
+    "stateMutability": "view",
+    "inputs": [{ "name": "assets", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "convertToAssets",
+    "stateMutability": "view",
+    "inputs": [{ "name": "shares", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "maxDeposit",
+    "stateMutability": "view",
+    "inputs": [{ "name": "receiver", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "previewDeposit",
+    "stateMutability": "view",
+    "inputs": [{ "name": "assets", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "assets", "type": "uint256" },
+      { "name": "receiver", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "maxMint",
+    "stateMutability": "view",
+    "inputs": [{ "name": "receiver", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "previewMint",
+    "stateMutability": "view",
+    "inputs": [{ "name": "shares", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "shares", "type": "uint256" },
+      { "name": "receiver", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "maxWithdraw",
+    "stateMutability": "view",
+    "inputs": [{ "name": "owner", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "previewWithdraw",
+    "stateMutability": "view",
+    "inputs": [{ "name": "assets", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "assets", "type": "uint256" },
+      { "name": "receiver", "type": "address" },
+      { "name": "owner", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "maxRedeem",
+    "stateMutability": "view",
+    "inputs": [{ "name": "owner", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "previewRedeem",
+    "stateMutability": "view",
+    "inputs": [{ "name": "shares", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "redeem",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "shares", "type": "uint256" },
+      { "name": "receiver", "type": "address" },
+      { "name": "owner", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "cooldownAssets",
+    "stateMutability": "nonpayable",
+    "inputs": [{ "name": "assets", "type": "uint256" }],
+    "outputs": [{ "name": "shares", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "cooldownShares",
+    "stateMutability": "nonpayable",
+    "inputs": [{ "name": "shares", "type": "uint256" }],
+    "outputs": [{ "name": "assets", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "cooldownDuration",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint24" }]
+  },
+  {
+    "type": "function",
+    "name": "cooldowns",
+    "stateMutability": "view",
+    "inputs": [{ "name": "", "type": "address" }],
+    "outputs": [
+      { "name": "cooldownEnd", "type": "uint104" },
+      { "name": "underlyingAmount", "type": "uint152" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "unstake",
+    "stateMutability": "nonpayable",
+    "inputs": [{ "name": "receiver", "type": "address" }],
+    "outputs": []
+  }
+]

--- a/protocols/ethena.ts
+++ b/protocols/ethena.ts
@@ -1,5 +1,8 @@
 import { defineProtocol } from "@/lib/protocol-registry";
 import { erc4626VaultActions } from "@/lib/web3/standards/erc4626";
+import sUsdeAbi from "./abis/ethena-susde.json";
+
+const SUSDE_ABI = JSON.stringify(sUsdeAbi);
 
 const ERC20_ABI = JSON.stringify([
   {
@@ -39,6 +42,7 @@ export default defineProtocol({
   contracts: {
     sUsde: {
       label: "sUSDe (Staked USDe)",
+      abi: SUSDE_ABI,
       addresses: {
         // Ethereum Mainnet
         "1": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",


### PR DESCRIPTION
## Summary

`ethena/vault-balance` and `ethena/vault-preview-redeem` (and related auto-generated ERC-4626 actions) failed on Ethereum mainnet with `"Failed to resolve ABI for contract 'sUsde' in protocol 'ethena': ... Contract may not be verified."` — but the contract IS verified.

Root cause: `lib/abi/cache.ts` collapses every Etherscan failure mode (missing/invalid API key, rate limit, network error, genuinely unverified) into the single misleading `"Contract may not be verified."` message. The most likely real cause for sUSDe is a missing/invalid `ETHERSCAN_API_KEY` for chain 1 in some runtime contexts. sUSDe is NOT a proxy — confirmed StakedUSDeV2 singleton at `0x9D39A5DE30e57443BfF2A8307A4256c8797A3497`.

Fix (hot-fix only): embed the verified sUSDe ABI in `protocols/abis/ethena-susde.json` (full ERC-4626 surface + cooldown extensions: `cooldownAssets`, `cooldownShares`, `cooldownDuration`, `cooldowns`, `unstake`). Routes through `lib/abi/cache.ts` `source: "definition"` path, bypasses the explorer.

The `lib/abi/cache.ts` UX fix (surface real Etherscan errors) is queued as a follow-up — reviewers strongly recommend prioritizing it before more inline-ABI hot-fixes accumulate.

Closes KEEP-397.

## Test plan

- [x] `tests/unit/protocol-ethena.test.ts` 20/20 pass
- [x] All 18 `erc4626VaultActions` resolve to functions present in inline ABI
- [x] All 5 cooldown actions in `protocols/ethena.ts` resolve to functions present in inline ABI
- [x] ABI cross-verified against Sourcify full_match metadata for `0x9D39A5DE30e57443BfF2A8307A4256c8797A3497`
- [x] Lint/type-check clean on touched files
- [ ] Live verify against `localhost:3000`: call `ethena/vault-balance` on chain `1` with any wallet address