### PR TITLE
fix(executor): resolve convergence/template race + bounded downstream drain

### DIFF
--- a/lib/workflow/executor/convergence-tracker-merge.ts
+++ b/lib/workflow/executor/convergence-tracker-merge.ts
@@ -1,0 +1,87 @@
+/**
+ * KEEP-395: Convergence template race -- the closure-captured outputs map can
+ * be stale at template-render time for the LAST predecessor of a fan-in
+ * convergence node when the workflow is replayed/rehydrated under
+ * "use workflow" durability. The mutation of `outputs[<id>] = ...` happens
+ * after the awaited step return, so the SDK's checkpoint resume can see a
+ * snapshot where one predecessor's output is still null even though the
+ * step completed successfully and recordStepSuccess was called.
+ *
+ * The in-process step-success-tracker is authoritative for completed steps.
+ * Before rendering templates on a convergence-target node's config, merge any
+ * tracker-recorded outputs over the closure outputs map -- the tracker
+ * always wins because it is populated synchronously inside withStepLogging
+ * after a successful step return.
+ *
+ * This helper is split into a separate module so it can be unit-tested in
+ * isolation without spinning up the full workflow executor.
+ */
+
+import type { WorkflowNode } from "@/lib/workflow/store";
+
+export type NodeOutputs = Record<string, { label: string; data: unknown }>;
+
+type TrackerLookup = (executionId: string) => Map<string, unknown> | undefined;
+type NodeNameLookup = (node: WorkflowNode) => string;
+
+/**
+ * Merge tracker-recorded outputs over the closure outputs map for the
+ * predecessors of a convergence node.
+ *
+ * Returns the original outputs map unchanged when:
+ *   - no executionId is provided
+ *   - the tracker has no entries for this execution
+ *   - none of the predecessors have tracker entries
+ *
+ * Otherwise returns a fresh shallow-copied outputs map with the tracker
+ * entries merged in. The tracker value wins -- if the closure already has a
+ * value for a predecessor, the tracker entry overrides it.
+ */
+export function mergeFromTracker(params: {
+  outputs: NodeOutputs;
+  executionId: string | undefined;
+  predecessorIds: readonly string[];
+  nodeMap: ReadonlyMap<string, WorkflowNode>;
+  getTracker: TrackerLookup;
+  getNodeName: NodeNameLookup;
+}): NodeOutputs {
+  const {
+    outputs,
+    executionId,
+    predecessorIds,
+    nodeMap,
+    getTracker,
+    getNodeName,
+  } = params;
+
+  if (!executionId || predecessorIds.length === 0) {
+    return outputs;
+  }
+
+  const recorded = getTracker(executionId);
+  if (recorded === undefined || recorded.size === 0) {
+    return outputs;
+  }
+
+  let merged: NodeOutputs | null = null;
+
+  for (const predId of predecessorIds) {
+    if (!recorded.has(predId)) {
+      continue;
+    }
+    const node = nodeMap.get(predId);
+    if (!node) {
+      continue;
+    }
+    if (merged === null) {
+      merged = { ...outputs };
+    }
+    const sanitized = predId.replace(/[^a-zA-Z0-9]/g, "_");
+    merged[sanitized] = {
+      label: getNodeName(node),
+      data: recorded.get(predId),
+    };
+  }
+
+  return merged ?? outputs;
+}

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -106,6 +106,27 @@ type ExecutionResult = {
 
 type NodeOutputs = Record<string, { label: string; data: unknown }>;
 
+/**
+ * Branch-aware finalSuccess computation: a workflow succeeds iff every node
+ * in `results` succeeded OR was on a not-taken condition branch (skipped).
+ *
+ * Extracted so callers can re-evaluate after `pendingTasks.drain()` (KEEP-395
+ * Bug 2 hardening): drained orphan-node failures land in `results` while
+ * drain awaits them, but the original computation ran before drain and
+ * missed them. Calling this once after drain is the authoritative answer.
+ */
+export function computeFinalSuccess(
+  results: Record<string, ExecutionResult>,
+  skippedTargets: ReadonlySet<string>
+): boolean {
+  for (const [nodeId, r] of Object.entries(results)) {
+    if (!(r.success || skippedTargets.has(nodeId))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /** Matches path segment like "carts[0]" for array index access (same as template.ts) */
 const ARRAY_ACCESS_PATTERN = /^([^[]+)\[(\d+)\]$/;
 
@@ -1134,6 +1155,15 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   // end ensures we never finalise before downstream nodes have run.
   const pendingTasks = createPendingTracker();
 
+  // KEEP-395 observability: in a multi-process / multi-pod world the
+  // step-success-tracker is in-process only. If a convergence node executes
+  // on a pod that did not run its predecessors, getSuccessfulSteps returns
+  // undefined and the merge-from-tracker silently degrades to closure
+  // outputs (which may carry the staleness this fix exists to prevent).
+  // Emit a one-time per-execution warning when that happens so prod logs
+  // surface the degradation. Set membership prevents log spam.
+  const warnedDegradationConvergenceIds = new Set<string>();
+
   // Build node and edge maps
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const edgesBySource = buildEdgesBySource(edges);
@@ -1786,7 +1816,27 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 executionId,
                 predecessorIds,
                 nodeMap,
-                getTracker: getSuccessfulSteps,
+                getTracker: (execId: string) => {
+                  const tracker = getSuccessfulSteps(execId);
+                  if (
+                    tracker === undefined &&
+                    !warnedDegradationConvergenceIds.has(nodeId)
+                  ) {
+                    warnedDegradationConvergenceIds.add(nodeId);
+                    logSystemError(
+                      ErrorCategory.WORKFLOW_ENGINE,
+                      "[Workflow Executor] convergence-tracker degraded -- in-process tracker has no entries for this execution (likely cross-pod replay); merge-from-tracker fix is silently inert here",
+                      new Error(
+                        `tracker_degraded execution_id=${execId} convergence_node_id=${nodeId}`
+                      ),
+                      {
+                        ...baseLogLabels,
+                        node_id: nodeId,
+                      }
+                    );
+                  }
+                  return tracker;
+                },
                 getNodeName,
               })
             : outputs;
@@ -2052,13 +2102,59 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     // workflow layer and can be truncated by SDK checkpoint resume, leaving
     // an orphaned promise in pendingTasks. Drain catches those so the
     // workflow does not finalise before all scheduled nodes complete.
-    await pendingTasks.drain();
+    //
+    // Drain is bounded by a timeout (default 5min, override via
+    // KH_EXECUTOR_DRAIN_TIMEOUT_MS) to prevent a hung step (most plugin
+    // steps lack AbortSignal) from stalling the workflow indefinitely.
+    if (process.env.DEBUG_DRAIN === "1") {
+      console.log(
+        `[Workflow Executor] drain starting with ${pendingTasks.size()} pending`
+      );
+    }
+    // Snapshot result keys BEFORE drain so we can identify drained-node
+    // failures and re-evaluate finalSuccess after drain (KEEP-395 Bug 2
+    // hardening: orphan failures must flow into finalSuccess, not be silently
+    // accepted as success).
+    const resultKeysBeforeDrain = new Set(Object.keys(results));
+    await pendingTasks.drain({
+      onTimeout: (pendingCount) => {
+        logSystemError(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[Workflow Executor] drain timed out with pending promises -- workflow may finalise with incomplete state",
+          new Error(
+            `drain_timeout pending=${pendingCount} workflow_id=${workflowId ?? "unknown"} execution_id=${executionId ?? "unknown"}`
+          ),
+          {
+            ...baseLogLabels,
+            pending_count: String(pendingCount),
+          }
+        );
+      },
+    });
 
-    // Branch-aware finalSuccess: exclude nodes on dead (not-taken) condition branches
+    // Branch-aware finalSuccess: exclude nodes on dead (not-taken) condition branches.
+    // KEEP-395 Bug 2 hardening: re-evaluated AFTER drain so any failures from
+    // drained orphan nodes are reflected here. The pre-drain computation (now
+    // unused) only ever saw nodes whose call-stack reached processSettledResults;
+    // drained orphans land in `results` while drain awaits them.
     const allSkippedTargets = collectAllSkippedTargets(conditionDecisions);
-    const finalSuccess = Object.entries(results).every(
-      ([nodeId, r]) => r.success || allSkippedTargets.has(nodeId)
+    const finalSuccess = computeFinalSuccess(results, allSkippedTargets);
+
+    // Surface drained-orphan failures explicitly so prod logs make the
+    // SDK-checkpoint-truncation case visible (otherwise the failure looks
+    // identical to a normal sync-path failure).
+    const drainedNodeIds = Object.keys(results).filter(
+      (id) => !resultKeysBeforeDrain.has(id)
     );
+    const drainedFailures = drainedNodeIds.filter(
+      (id) => !(results[id]?.success || allSkippedTargets.has(id))
+    );
+    if (drainedFailures.length > 0) {
+      console.log(
+        "[Workflow Executor] drained orphan node failures captured:",
+        drainedFailures
+      );
+    }
     const duration = Date.now() - workflowStartTime;
 
     // Diagnostic logging for branching workflow failures

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -40,10 +40,15 @@ import {
   propagateConvergenceSkips,
   signalConvergenceArrival,
 } from "@/lib/workflow/executor/convergence-barrier";
+import { mergeFromTracker } from "@/lib/workflow/executor/convergence-tracker-merge";
 import { enterWorkflowErrorContext } from "@/lib/workflow/executor/error-context";
 import { runBodyNode } from "@/lib/workflow/executor/for-each-body-runner";
+import { createPendingTracker } from "@/lib/workflow/executor/pending-tasks";
 import type { StepContext } from "@/lib/workflow/executor/step-handler";
-import { clearExecution } from "@/lib/workflow/executor/step-success-tracker";
+import {
+  clearExecution,
+  getSuccessfulSteps,
+} from "@/lib/workflow/executor/step-success-tracker";
 import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
 import {
   type ConditionDecision,
@@ -1121,6 +1126,14 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   const outputs: NodeOutputs = {};
   const results: Record<string, ExecutionResult> = {};
 
+  // KEEP-395 (Bug 2): track every in-flight Promise.allSettled that
+  // schedules executeNode calls, so we can drain orphaned downstream
+  // branches before finalisation. The SDK's checkpoint resume can truncate
+  // the call-stack-await chain inside executeReadyDownstream recursion;
+  // wrapping every settle in `pendingTasks.track(...)` and draining at the
+  // end ensures we never finalise before downstream nodes have run.
+  const pendingTasks = createPendingTracker();
+
   // Build node and edge maps
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const edgesBySource = buildEdgesBySource(edges);
@@ -1289,7 +1302,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         ownerId,
         workflowId,
       },
-      runStep: async ({ actionType, processedConfig, scopedOutputs: outputs, stepContext }) =>
+      runStep: async ({
+        actionType,
+        processedConfig,
+        scopedOutputs: outputs,
+        stepContext,
+      }) =>
         await executeActionStep({
           actionType,
           config: processedConfig,
@@ -1584,8 +1602,8 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     );
 
     if (readyIds.length > 0) {
-      const settled = await Promise.allSettled(
-        readyIds.map((id) => executeNode(id, visited))
+      const settled = await pendingTasks.track(
+        Promise.allSettled(readyIds.map((id) => executeNode(id, visited)))
       );
       processSettledResults(settled, readyIds);
     }
@@ -1754,10 +1772,29 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           return;
         }
 
+        // KEEP-395 (Bug 1): for convergence-target nodes (multiple incoming
+        // edges) the closure-captured `outputs` map can carry a stale snapshot
+        // for the LAST predecessor when the SDK replays/rehydrates this
+        // workflow. Merge tracker-recorded outputs over the closure before
+        // template rendering -- the in-process step-success-tracker is
+        // authoritative for completed steps.
+        const predecessorIds = edgesByTarget.get(nodeId) ?? [];
+        const liveOutputs =
+          predecessorIds.length > 1
+            ? mergeFromTracker({
+                outputs,
+                executionId,
+                predecessorIds,
+                nodeMap,
+                getTracker: getSuccessfulSteps,
+                getNodeName,
+              })
+            : outputs;
+
         const processedConfig = processActionConfig(
           config,
           actionType,
-          outputs
+          liveOutputs
         );
 
         // Build step context for logging (stepHandler will handle the logging)
@@ -1780,7 +1817,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         const stepResult = await executeActionStep({
           actionType,
           config: processedConfig,
-          outputs,
+          outputs: liveOutputs,
           context: stepContext,
           nodeMap,
           executionResults: results,
@@ -1920,8 +1957,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 ...new Set([...preSeedUnblocked, ...unblockedIds]),
               ];
               if (allUnblocked.length > 0) {
-                const settled = await Promise.allSettled(
-                  allUnblocked.map((id) => executeNode(id, visited))
+                const settled = await pendingTasks.track(
+                  Promise.allSettled(
+                    allUnblocked.map((id) => executeNode(id, visited))
+                  )
                 );
                 processSettledResults(settled, allUnblocked);
               }
@@ -2003,10 +2042,17 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     incrementConcurrentExecutions();
 
     const triggerNodeIds = triggerNodes.map((trigger) => trigger.id);
-    const triggerSettled = await Promise.allSettled(
-      triggerNodeIds.map((id) => executeNode(id))
+    const triggerSettled = await pendingTasks.track(
+      Promise.allSettled(triggerNodeIds.map((id) => executeNode(id)))
     );
     processSettledResults(triggerSettled, triggerNodeIds);
+
+    // KEEP-395 (Bug 2): drain any in-flight downstream branches before
+    // finalisation. The recursive executeReadyDownstream chain runs in the
+    // workflow layer and can be truncated by SDK checkpoint resume, leaving
+    // an orphaned promise in pendingTasks. Drain catches those so the
+    // workflow does not finalise before all scheduled nodes complete.
+    await pendingTasks.drain();
 
     // Branch-aware finalSuccess: exclude nodes on dead (not-taken) condition branches
     const allSkippedTargets = collectAllSkippedTargets(conditionDecisions);

--- a/lib/workflow/executor/pending-tasks.ts
+++ b/lib/workflow/executor/pending-tasks.ts
@@ -1,0 +1,71 @@
+/**
+ * KEEP-395 (Bug 2): Drain-loop tracker for pending workflow tasks.
+ *
+ * Under "use workflow" durability, the SDK can checkpoint and resume
+ * `executeWorkflow` partway through. The recursive `executeReadyDownstream`
+ * call chain runs in the workflow layer (NOT inside a "use step"), so when
+ * the SDK truncates the call-stack-await chain at a checkpoint resume the
+ * scheduling of a downstream node is sometimes lost -- finalisation occurs
+ * before that downstream node has even been queued.
+ *
+ * Wrap every `Promise.allSettled(...)` whose elements call `executeNode`
+ * with `trackPending` so the executor holds a strong reference to every
+ * in-flight branch. After the trigger settle, drain until the set is empty.
+ * This catches any orphaned promise that was scheduled but not awaited via
+ * the call-stack chain.
+ *
+ * Behavioural-equivalent: when no checkpoint resume happens, every awaited
+ * `Promise.allSettled` resolves naturally and the drain loop sees an empty
+ * set immediately. The new behaviour only kicks in when an orphaned promise
+ * exists -- previously they were silently dropped, now they are awaited.
+ */
+
+export type PendingTracker = {
+  /**
+   * Wrap a promise so it is held in the pending set until it settles.
+   * Returns the same promise (settled or rejected) so callers can `await`
+   * it normally.
+   */
+  track<T>(p: Promise<T>): Promise<T>;
+  /**
+   * Drain the pending set: await every currently-tracked promise. New
+   * promises added by the awaited promises are also drained. Returns once
+   * the set is empty.
+   */
+  drain(): Promise<void>;
+  /** Current count of in-flight promises (used in tests / diagnostics). */
+  size(): number;
+};
+
+export function createPendingTracker(): PendingTracker {
+  const pending = new Set<Promise<unknown>>();
+
+  function track<T>(p: Promise<T>): Promise<T> {
+    pending.add(p);
+    // `.finally` returns a NEW promise that rejects with the same reason if
+    // `p` rejects. Attach a noop `.catch` so an internal rejection here is
+    // never reported as unhandled. Callers that care about rejection should
+    // await the original promise (returned below) where their own handlers
+    // apply.
+    p.finally(() => {
+      pending.delete(p);
+    }).catch(() => undefined);
+    return p;
+  }
+
+  async function drain(): Promise<void> {
+    // New promises may be added while we await existing ones (e.g. an
+    // awaited branch schedules another downstream node). Loop until the
+    // set is fully drained.
+    while (pending.size > 0) {
+      const snapshot = [...pending];
+      await Promise.allSettled(snapshot);
+    }
+  }
+
+  function size(): number {
+    return pending.size;
+  }
+
+  return { track, drain, size };
+}

--- a/lib/workflow/executor/pending-tasks.ts
+++ b/lib/workflow/executor/pending-tasks.ts
@@ -18,7 +18,40 @@
  * `Promise.allSettled` resolves naturally and the drain loop sees an empty
  * set immediately. The new behaviour only kicks in when an orphaned promise
  * exists -- previously they were silently dropped, now they are awaited.
+ *
+ * KEEP-395 (Bug 2 hardening): drain is bounded by a timeout so a hung step
+ * (no AbortSignal in most plugin implementations) cannot stall the workflow
+ * indefinitely. Default 5 minutes, override via `KH_EXECUTOR_DRAIN_TIMEOUT_MS`.
+ * When the timeout fires, drain returns and the caller is informed via the
+ * `onTimeout` callback (if supplied) so it can log the leak with workflow
+ * context. The leaked promises are NOT cancelled (no AbortController plumbing
+ * here) -- they continue running in the background and the platform-level
+ * workflow timeout will eventually clean them up.
  */
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+function readDrainTimeoutMs(): number {
+  const raw = process.env.KH_EXECUTOR_DRAIN_TIMEOUT_MS;
+  if (!raw) {
+    return DEFAULT_DRAIN_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_DRAIN_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+export type DrainOptions = {
+  /** Override the timeout in ms. Defaults to env or 5 minutes. */
+  timeoutMs?: number;
+  /**
+   * Called once if the drain hits its timeout with promises still pending.
+   * `pendingCount` is the snapshot size at the moment the timeout fired.
+   */
+  onTimeout?: (pendingCount: number) => void;
+};
 
 export type PendingTracker = {
   /**
@@ -30,9 +63,9 @@ export type PendingTracker = {
   /**
    * Drain the pending set: await every currently-tracked promise. New
    * promises added by the awaited promises are also drained. Returns once
-   * the set is empty.
+   * the set is empty OR the timeout fires (whichever first).
    */
-  drain(): Promise<void>;
+  drain(opts?: DrainOptions): Promise<void>;
   /** Current count of in-flight promises (used in tests / diagnostics). */
   size(): number;
 };
@@ -53,13 +86,41 @@ export function createPendingTracker(): PendingTracker {
     return p;
   }
 
-  async function drain(): Promise<void> {
+  async function drainLoop(): Promise<void> {
     // New promises may be added while we await existing ones (e.g. an
     // awaited branch schedules another downstream node). Loop until the
     // set is fully drained.
     while (pending.size > 0) {
       const snapshot = [...pending];
       await Promise.allSettled(snapshot);
+    }
+  }
+
+  async function drain(opts?: DrainOptions): Promise<void> {
+    if (pending.size === 0) {
+      return;
+    }
+
+    const timeoutMs = opts?.timeoutMs ?? readDrainTimeoutMs();
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+      // Don't keep the event loop alive for this watchdog.
+      timeoutHandle.unref?.();
+    });
+
+    const result = await Promise.race([
+      drainLoop().then(() => "drained" as const),
+      timeoutPromise,
+    ]);
+
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+
+    if (result === "timeout") {
+      opts?.onTimeout?.(pending.size);
     }
   }
 

--- a/tests/unit/executor-convergence-race.test.ts
+++ b/tests/unit/executor-convergence-race.test.ts
@@ -1,0 +1,196 @@
+/**
+ * KEEP-395 (Bug 1): convergence template renders chain-dep predecessor as null.
+ *
+ * Tests the `mergeFromTracker` helper used at the convergence-target
+ * template-render call site. The closure-captured `outputs` map can carry a
+ * stale snapshot for the LAST predecessor under "use workflow" SDK replay;
+ * the in-process step-success-tracker is the authoritative source for
+ * completed steps.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { mergeFromTracker } from "@/lib/workflow/executor/convergence-tracker-merge";
+import type { WorkflowNode } from "@/lib/workflow/store";
+
+type FakeNodeOpts = {
+  id: string;
+  label?: string;
+};
+
+function makeNode({ id, label }: FakeNodeOpts): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 0 },
+    data: {
+      type: "action",
+      label: label ?? id,
+      config: {},
+    },
+  } as unknown as WorkflowNode;
+}
+
+const getNodeName = (n: WorkflowNode): string =>
+  (n.data.label as string) ?? n.id;
+
+describe("mergeFromTracker (KEEP-395 Bug 1)", () => {
+  it("returns the original outputs when executionId is undefined", () => {
+    const outputs = { a: { label: "A", data: 1 } };
+    const result = mergeFromTracker({
+      outputs,
+      executionId: undefined,
+      predecessorIds: ["a"],
+      nodeMap: new Map([["a", makeNode({ id: "a" })]]),
+      getTracker: () => new Map([["a", 999]]),
+      getNodeName,
+    });
+    expect(result).toBe(outputs);
+  });
+
+  it("returns the original outputs when predecessorIds is empty", () => {
+    const outputs = { a: { label: "A", data: 1 } };
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-1",
+      predecessorIds: [],
+      nodeMap: new Map([["a", makeNode({ id: "a" })]]),
+      getTracker: () => new Map([["a", 999]]),
+      getNodeName,
+    });
+    expect(result).toBe(outputs);
+  });
+
+  it("returns the original outputs when tracker has no entries for execution", () => {
+    const outputs = { a: { label: "A", data: 1 } };
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-1",
+      predecessorIds: ["a"],
+      nodeMap: new Map([["a", makeNode({ id: "a" })]]),
+      getTracker: () => undefined,
+      getNodeName,
+    });
+    expect(result).toBe(outputs);
+  });
+
+  it("returns the original outputs when tracker has no entry for any predecessor", () => {
+    const outputs = { a: { label: "A", data: 1 } };
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-1",
+      predecessorIds: ["a", "b"],
+      nodeMap: new Map([
+        ["a", makeNode({ id: "a" })],
+        ["b", makeNode({ id: "b" })],
+      ]),
+      getTracker: () => new Map([["c", 42]]),
+      getNodeName,
+    });
+    expect(result).toBe(outputs);
+  });
+
+  it("overrides closure entry with tracker entry when both exist", () => {
+    // The closure has a STALE null for `cmpRate` (the bug: SDK replay sees
+    // the snapshot before the post-await mutation lands). The tracker has
+    // the real recorded output. Tracker must win.
+    const stale = { label: "cmpRate", data: null };
+    const outputs = {
+      cmpRate: stale,
+      otherPred: { label: "OP", data: { x: 1 } },
+    };
+    const fresh = { rate: 4.5, source: "compound" };
+
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-1",
+      predecessorIds: ["cmpRate", "otherPred"],
+      nodeMap: new Map([
+        ["cmpRate", makeNode({ id: "cmpRate", label: "cmpRate" })],
+        ["otherPred", makeNode({ id: "otherPred", label: "OP" })],
+      ]),
+      getTracker: () => new Map<string, unknown>([["cmpRate", fresh]]),
+      getNodeName,
+    });
+
+    expect(result).not.toBe(outputs);
+    expect(result.cmpRate).toEqual({ label: "cmpRate", data: fresh });
+    // Predecessors with no tracker entry are left untouched.
+    expect(result.otherPred).toBe(outputs.otherPred);
+    // Original outputs map is NOT mutated.
+    expect(outputs.cmpRate).toBe(stale);
+    expect(outputs.cmpRate.data).toBeNull();
+  });
+
+  it("sanitises non-alphanumeric chars in node IDs the same way the executor does", () => {
+    // Executor stores outputs under sanitized keys (id.replace(/[^a-zA-Z0-9]/g, "_")).
+    // The tracker keys are the raw node IDs. Merge MUST produce a sanitized key.
+    const rawId = "node-with-dashes.and.dots";
+    const sanitized = "node_with_dashes_and_dots";
+    const outputs = {
+      [sanitized]: { label: "raw", data: null },
+    };
+    const fresh = { ok: true };
+
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-1",
+      predecessorIds: [rawId],
+      nodeMap: new Map([[rawId, makeNode({ id: rawId, label: "raw" })]]),
+      getTracker: () => new Map<string, unknown>([[rawId, fresh]]),
+      getNodeName,
+    });
+
+    expect(result[sanitized]).toEqual({ label: "raw", data: fresh });
+  });
+
+  it("merges last-arriving predecessor in a 4-fan-in convergence (regression)", () => {
+    // Repro of the original bug shape: 4 predecessors -> combine. D is the
+    // slowest and is the LAST to arrive. The closure captured the snapshot
+    // when D was still null. Tracker has D's real result.
+    const outputs = {
+      A: { label: "A", data: 0.05 },
+      B: { label: "B", data: 0.06 },
+      C: { label: "C", data: 0.04 },
+      D: { label: "D", data: null },
+    };
+    const dFresh = 0.075;
+
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-fanin",
+      predecessorIds: ["A", "B", "C", "D"],
+      nodeMap: new Map([
+        ["A", makeNode({ id: "A" })],
+        ["B", makeNode({ id: "B" })],
+        ["C", makeNode({ id: "C" })],
+        ["D", makeNode({ id: "D" })],
+      ]),
+      getTracker: () => new Map<string, unknown>([["D", dFresh]]),
+      getNodeName,
+    });
+
+    expect(result.D.data).toBe(dFresh);
+    // The other predecessors are not touched (no tracker entry).
+    expect(result.A).toBe(outputs.A);
+    expect(result.B).toBe(outputs.B);
+    expect(result.C).toBe(outputs.C);
+  });
+
+  it("skips predecessors that are not in nodeMap (defensive)", () => {
+    // If a node has been removed from nodeMap mid-flight (defensive guard),
+    // the tracker entry is ignored rather than throwing.
+    const outputs = { a: { label: "A", data: null } };
+    const result = mergeFromTracker({
+      outputs,
+      executionId: "exec-1",
+      predecessorIds: ["a"],
+      nodeMap: new Map(),
+      getTracker: () => new Map<string, unknown>([["a", 1]]),
+      getNodeName,
+    });
+    expect(result).toBe(outputs);
+  });
+});

--- a/tests/unit/executor-drain-loop.test.ts
+++ b/tests/unit/executor-drain-loop.test.ts
@@ -139,6 +139,63 @@ describe("createPendingTracker (KEEP-395 Bug 2)", () => {
     expect(tracker.size()).toBe(0);
   });
 
+  it("drain returns and invokes onTimeout when timeout fires before pending settles", async () => {
+    // KEEP-395 Bug 2 hardening (R2 BLOCKER 1): drain must be bounded so a
+    // hung step (most plugin steps lack AbortSignal) cannot stall the
+    // workflow indefinitely. Timeout fires -> drain resolves -> onTimeout
+    // is called once with the remaining pending count.
+    const tracker = createPendingTracker();
+    const d1 = deferred<number>();
+    const d2 = deferred<number>();
+    // Suppress unhandled-rejection noise on never-resolved promises.
+    d1.promise.catch(() => undefined);
+    d2.promise.catch(() => undefined);
+    tracker.track(d1.promise);
+    tracker.track(d2.promise);
+
+    const onTimeout = vi.fn();
+    const start = Date.now();
+    await tracker.drain({ timeoutMs: 25, onTimeout });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(20);
+    expect(elapsed).toBeLessThan(500); // generous CI margin
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledWith(2);
+    // The two never-settled promises remain in the set; tracker is leaked
+    // but that's the documented behaviour (no AbortController plumbing).
+    expect(tracker.size()).toBe(2);
+
+    // Cleanup: settle them so vitest doesn't report leaks.
+    d1.resolve(1);
+    d2.resolve(2);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it("drain does NOT invoke onTimeout when pending settles before timeout", async () => {
+    const tracker = createPendingTracker();
+    const d = deferred<string>();
+    tracker.track(d.promise);
+
+    const onTimeout = vi.fn();
+    const drainPromise = tracker.drain({ timeoutMs: 5000, onTimeout });
+    d.resolve("done");
+    await drainPromise;
+
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(tracker.size()).toBe(0);
+  });
+
+  it("drain returns immediately (no timer) when pending is already empty", async () => {
+    const tracker = createPendingTracker();
+    const onTimeout = vi.fn();
+    // Zero timeout would normally fire instantly; the empty-set short-circuit
+    // must skip the timer entirely so onTimeout is never called.
+    await tracker.drain({ timeoutMs: 0, onTimeout });
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
   it("simulates the executor pattern: trigger settle + recursive downstream + drain", async () => {
     // Fake a workflow shape: trigger -> A -> B. Trigger settle awaits
     // executeNode(trigger), which schedules A inside its promise chain. A

--- a/tests/unit/executor-drain-loop.test.ts
+++ b/tests/unit/executor-drain-loop.test.ts
@@ -1,0 +1,192 @@
+/**
+ * KEEP-395 (Bug 2): single-edge chain through chained node not fully awaited.
+ *
+ * Tests the `createPendingTracker` drain-loop helper used by the workflow
+ * executor. Under "use workflow" SDK durability, the call-stack-await chain
+ * inside `executeReadyDownstream` recursion can be truncated by checkpoint
+ * resume, leaving an orphaned promise that nothing is awaiting. The pending
+ * tracker holds a strong reference to every wrapped promise and lets the
+ * executor drain them all before finalisation.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { createPendingTracker } from "@/lib/workflow/executor/pending-tasks";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createPendingTracker (KEEP-395 Bug 2)", () => {
+  it("track returns the original promise", async () => {
+    const tracker = createPendingTracker();
+    const p = Promise.resolve(42);
+    const wrapped = tracker.track(p);
+    expect(wrapped).toBe(p);
+    expect(await wrapped).toBe(42);
+  });
+
+  it("size reflects in-flight promises and decrements on settle", async () => {
+    const tracker = createPendingTracker();
+    const d1 = deferred<number>();
+    const d2 = deferred<number>();
+
+    tracker.track(d1.promise);
+    tracker.track(d2.promise);
+    expect(tracker.size()).toBe(2);
+
+    d1.resolve(1);
+    // Allow the .finally microtask to run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(tracker.size()).toBe(1);
+
+    d2.resolve(2);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(tracker.size()).toBe(0);
+  });
+
+  it("drain resolves immediately when the set is empty", async () => {
+    const tracker = createPendingTracker();
+    await expect(tracker.drain()).resolves.toBeUndefined();
+  });
+
+  it("drain awaits a single in-flight promise", async () => {
+    const tracker = createPendingTracker();
+    const d = deferred<string>();
+    tracker.track(d.promise);
+
+    let drained = false;
+    const drainPromise = tracker.drain().then(() => {
+      drained = true;
+    });
+
+    // Drain has not resolved yet (promise still pending).
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    d.resolve("done");
+    await drainPromise;
+    expect(drained).toBe(true);
+    expect(tracker.size()).toBe(0);
+  });
+
+  it("drain awaits NEW promises added while existing ones are settling (recursive scheduling)", async () => {
+    // This is the core Bug 2 scenario: when an awaited branch schedules a
+    // downstream node mid-drain (executeReadyDownstream recursion), the
+    // newly-added promise must also be awaited before drain returns.
+    const tracker = createPendingTracker();
+
+    const dA = deferred<string>();
+    const dB = deferred<string>();
+
+    tracker.track(dA.promise);
+    // When A settles it will (synchronously, in its .then) schedule B.
+    dA.promise
+      .then(() => {
+        tracker.track(dB.promise);
+      })
+      .catch(() => undefined);
+
+    let drained = false;
+    const drainPromise = tracker.drain().then(() => {
+      drained = true;
+    });
+
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    expect(tracker.size()).toBe(1);
+
+    dA.resolve("a-done");
+    // After A settles, drain should re-iterate and find B is now pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    expect(tracker.size()).toBe(1);
+
+    dB.resolve("b-done");
+    await drainPromise;
+    expect(drained).toBe(true);
+    expect(tracker.size()).toBe(0);
+  });
+
+  it("drain handles a rejected promise without throwing (allSettled semantics)", async () => {
+    const tracker = createPendingTracker();
+    const d = deferred<number>();
+    // The caller's branch is responsible for handling its own rejection
+    // (the executor uses Promise.allSettled at every call site). track()
+    // must NOT cause an unhandled-rejection in its internal `.finally`.
+    d.promise.catch(() => undefined);
+    tracker.track(d.promise);
+
+    const drainPromise = tracker.drain();
+    d.reject(new Error("kaboom"));
+
+    await expect(drainPromise).resolves.toBeUndefined();
+    expect(tracker.size()).toBe(0);
+  });
+
+  it("simulates the executor pattern: trigger settle + recursive downstream + drain", async () => {
+    // Fake a workflow shape: trigger -> A -> B. Trigger settle awaits
+    // executeNode(trigger), which schedules A inside its promise chain. A
+    // schedules B. The outermost trigger settle resolves before A finishes
+    // (simulating SDK truncation). Without drain, B would be lost.
+    const tracker = createPendingTracker();
+
+    const aResolver = deferred<void>();
+    const bResolver = deferred<void>();
+    const completed: string[] = [];
+
+    const executeNode = (id: string): Promise<void> => {
+      if (id === "trigger") {
+        // Schedule A but RETURN BEFORE A settles -- simulates SDK truncation
+        // where the trigger's await chain is cut off.
+        const aPromise = (async () => {
+          await aResolver.promise;
+          completed.push("A");
+          // A schedules B
+          const bPromise = (async () => {
+            await bResolver.promise;
+            completed.push("B");
+          })();
+          tracker.track(bPromise);
+        })();
+        tracker.track(aPromise);
+        completed.push("trigger");
+        return Promise.resolve();
+      }
+      return Promise.resolve();
+    };
+
+    const triggerSettled = await tracker.track(
+      Promise.allSettled([executeNode("trigger")])
+    );
+    expect(triggerSettled).toHaveLength(1);
+    expect(completed).toEqual(["trigger"]);
+
+    // Without drain: A and B never run before finalisation. With drain:
+    // both must complete before drain returns.
+    const drainPromise = tracker.drain();
+
+    aResolver.resolve();
+    await Promise.resolve();
+    bResolver.resolve();
+
+    await drainPromise;
+    expect(completed).toEqual(["trigger", "A", "B"]);
+    expect(tracker.size()).toBe(0);
+  });
+});

--- a/tests/unit/executor-final-success.test.ts
+++ b/tests/unit/executor-final-success.test.ts
@@ -1,0 +1,77 @@
+/**
+ * KEEP-395 (Bug 2 hardening, R2 BLOCKER 2): finalSuccess must be re-evaluated
+ * AFTER pendingTasks.drain() so failures from drained orphan nodes are
+ * reflected in the workflow outcome. Pre-fix, the computation ran before
+ * drain; an orphan node's failure landed in `results` post-computation, and
+ * the workflow reported `success: true` despite a logged failure.
+ *
+ * `computeFinalSuccess` is the extracted helper called once after drain.
+ * This test exercises the pure logic (the integration "called twice with
+ * different inputs" semantics is enforced by the call-site shape in
+ * executor.workflow.ts -- see the call site at the drain block).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { computeFinalSuccess } from "@/lib/workflow/executor/executor.workflow";
+
+describe("computeFinalSuccess (KEEP-395 Bug 2 finalSuccess race)", () => {
+  it("returns true when results is empty", () => {
+    expect(computeFinalSuccess({}, new Set())).toBe(true);
+  });
+
+  it("returns true when every node succeeded", () => {
+    const results = {
+      a: { success: true, data: 1 },
+      b: { success: true, data: 2 },
+    };
+    expect(computeFinalSuccess(results, new Set())).toBe(true);
+  });
+
+  it("returns false when any node failed (no skipped targets)", () => {
+    const results = {
+      a: { success: true, data: 1 },
+      b: { success: false, error: "boom" },
+    };
+    expect(computeFinalSuccess(results, new Set())).toBe(false);
+  });
+
+  it("treats not-taken condition branches as skipped (not failed)", () => {
+    const results = {
+      cond: { success: true, data: { condition: true } },
+      taken: { success: true, data: 1 },
+      notTaken: { success: false, error: "should not have run" },
+    };
+    // notTaken was on the dead branch -- it must not flip finalSuccess.
+    expect(computeFinalSuccess(results, new Set(["notTaken"]))).toBe(true);
+  });
+
+  it("BLOCKER 2 repro: drained orphan failure flips finalSuccess from true to false", () => {
+    // Pre-drain snapshot: only the trigger had landed when the (now removed)
+    // pre-drain finalSuccess computation would have run -> success=true.
+    const preDrainResults = {
+      trigger: { success: true, data: { triggered: true } },
+    };
+    expect(computeFinalSuccess(preDrainResults, new Set())).toBe(true);
+
+    // Post-drain: an orphan downstream node landed with success=false.
+    const postDrainResults = {
+      ...preDrainResults,
+      orphanNode: { success: false, error: "rpc timeout" },
+    };
+    // BLOCKER 2 fix: post-drain re-evaluation must catch this.
+    expect(computeFinalSuccess(postDrainResults, new Set())).toBe(false);
+  });
+
+  it("does not skip a failed node that is also in skippedTargets only by coincidence", () => {
+    // Edge case: a node id appears in skipped targets but it actually ran
+    // (e.g. via a different path). The OR semantics are intentional --
+    // skipped wins. This locks the existing behaviour.
+    const results = {
+      a: { success: false, error: "ran but failed" },
+    };
+    expect(computeFinalSuccess(results, new Set(["a"]))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two related races in the workflow executor caused fan-in convergence workflows to silently drop data or skip downstream nodes.

**Bug 1 — Convergence template renders chain-dep predecessor as null.** When node X is the LAST predecessor to signal arrival at fan-in convergence node Y, X's \`outputs[<id>].data\` reads as \`null\` inside Y's \`processCodeTemplates\` even though X completed successfully. Root cause: \`executeWorkflow\` carries the \`"use workflow"\` directive; SDK replays at every step boundary; the closure-captured \`outputs\` mutation happens AFTER the awaited step return, so SDK replay sees a stale snapshot.

**Bug 2 — Single-edge chain through chained node not fully awaited.** When combine has 1 incoming edge from a chained node, executor sometimes finalizes BEFORE scheduling combine. Root cause: \`executeReadyDownstream\` recursion is workflow-layer code; SDK checkpoint resume can truncate the await chain.

**Fix:**
- Bug 1: extract \`mergeFromTracker\` helper. At template-render time for any convergence node (\`predecessorIds.length > 1\`), merge \`step-success-tracker\` recorded outputs OVER the closure outputs. Tracker is authoritative for completed steps.
- Bug 2: extract \`createPendingTracker\` helper. Wrap every \`Promise.allSettled\` site (3 of 4 — catch-block site is intentionally KEEP-398's). Drain loop at end of \`executeWorkflow\` re-checks until pending set is empty so promises added mid-drain are awaited too.

Coexists with KEEP-398 — catch block (lines ~1986-2028) byte-identical to staging.

Closes KEEP-395.

## Changes addressed from review

- **Drain-hang risk fixed:** drain now bounded by \`KH_EXECUTOR_DRAIN_TIMEOUT_MS\` (default 300000ms / 5min). On timeout: \`logSystemError\` with workflow_id, execution_id, pending_count. Prevents a hung step from stalling workflow finalization indefinitely.
- **finalSuccess race fixed:** extracted \`computeFinalSuccess\` helper. Now called ONCE after drain completes, so drained orphan failures count toward final success.
- **Multi-process degradation observability:** when \`getSuccessfulSteps()\` returns undefined for a convergence node mid-execution, emits \`logSystemError\` once per execution per node. Makes the silent-no-op case visible in prod.
- **Drain debug log:** \`DEBUG_DRAIN=1\` env var enables \`drain starting with N pending\` log for live verification.

## Test plan

- [x] New unit tests: \`executor-drain-loop\` (timeout firing covered), \`executor-convergence-race\`, \`executor-final-success\` — 24/24 pass
- [x] Regression: \`condition-executor\` + \`for-each-executor\` + \`convergence-barrier\` 133/133 pass
- [x] Type-check clean
- [ ] Live verify against \`localhost:3000\` with \`DEBUG_DRAIN=1\` and the repro workflows:
  - Run \`stablecoin-yield-compare-base\` 10x — confirm convergence node config shows both predecessors non-null every run
  - Run \`defi-position-aggregator-ethereum\` 10x — confirm chained downstream node appears in \`results\` every run
  - Confirm drain debug log fires (proves drain catches orphans, not a no-op)