### PR TITLE
feat: add Coalition plugin (multi-party on-chain commitments with slashing)

### DIFF
--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, lido, linear, math, morpho, pendle, protocol, resend, rocket-pool, safe, sendgrid, sky, slack, spark, telegram, uniswap, v0, web3, webflow, webhook, wrapped, yearn
+ * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, chainlink, chronicle, clerk, coalition, code, compound, cowswap, curve, database, discord, ethena, lido, linear, math, morpho, pendle, protocol, resend, rocket-pool, safe, sendgrid, sky, slack, spark, telegram, uniswap, v0, web3, webflow, webhook, wrapped, yearn
  */
 
 // Integration type union - plugins + system integrations
@@ -22,6 +22,7 @@ export type IntegrationType =
   | "chainlink"
   | "chronicle"
   | "clerk"
+  | "coalition"
   | "code"
   | "compound"
   | "cowswap"

--- a/plugins/coalition/README.md
+++ b/plugins/coalition/README.md
@@ -79,7 +79,7 @@ Because each KeeperHub workflow runs as a single Para wallet, multi-party signin
 
 | Chain | Chain ID | Address |
 |---|---|---|
-| Base Sepolia | 84532 | (paste after deploy) |
+| Base Sepolia | 84532 | (empty -- paste after deploy) |
 | Base Mainnet | 8453 | not yet deployed |
 
 The contract is deployed out-of-band via `pnpm tsx scripts/deploy-coalition.ts --network base-sepolia` and verified on the block explorer. Update `plugins/coalition/contracts/addresses.ts` with the deployed address.

--- a/plugins/coalition/README.md
+++ b/plugins/coalition/README.md
@@ -1,0 +1,94 @@
+# Coalition
+
+Multi-party on-chain commitments inside a KeeperHub workflow.
+
+## What it does
+
+A coalition is N parties (2-20) who post an ERC-20 stake, agree to a hash of off-chain terms, and each sign on-chain by a deadline. Once activated, any party can be marked as having breached the agreement. Slashing transfers the breached party's stake pro-rata to non-breached participants. A clean close returns all non-breached stakes; an unsigned coalition past its deadline can refund whoever did sign.
+
+## When to use it
+
+- Cross-DEX MEV bundles (N searchers commit to a bundle, slash on free-rider)
+- Multi-sig action coordination
+- Group treasury actions
+- Multi-party liquidations
+- Group token buys
+- Sharded compute coalitions
+- Any workflow needing "N parties commit, any one can break, slashing on breach"
+
+## Why this needs KeeperHub
+
+Slashing transactions must land. The Slash Breached Party action exposes KeeperHub's reliability stack as primary configuration: private-mempool routing (Flashbots Protect on Base), explicit priority-fee override, RPC failover, and nonce session management. A naive RPC call cannot offer the same landing guarantees under gas spikes -- and a slash that doesn't land breaks the coalition's economic security.
+
+## Actions
+
+| Slug | Type | What it does |
+|---|---|---|
+| `propose` | write | Create a coalition; returns `coalitionId` |
+| `sign` | write | Sign in (auto-approves stakeToken if needed); idempotent |
+| `check-status` | read | Returns state, signed/breached/slashed counts, ready flag -- use for polling |
+| `activate` | write | PROPOSED to ACTIVE once all signed; idempotent |
+| `breach` | write | Record breach evidence against a participant |
+| `slash` | write | Slash a breached party's stake (load-bearing, reliability-tuned) |
+| `dissolve` | write | Clean close, return non-breached stakes (participant-only) |
+| `expire` | write | Refund signers after deadline if not all signed (anyone-callable) |
+
+## Example workflow
+
+Three nodes wired together: propose, then poll until ready, then activate.
+
+```json
+{
+  "nodes": [
+    {
+      "id": "Propose",
+      "type": "coalition.propose",
+      "config": {
+        "network": "base-sepolia",
+        "participants": "[\"0x...\", \"0x...\", \"0x...\"]",
+        "termsHash": "0x...",
+        "deadlineUnix": "{{Now.plusHours(24)}}",
+        "stakeToken": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        "stakePerParty": "1000000"
+      }
+    },
+    {
+      "id": "PollStatus",
+      "type": "coalition.check-status",
+      "config": {
+        "network": "base-sepolia",
+        "coalitionId": "{{Propose.coalitionId}}"
+      },
+      "loop": { "until": "{{PollStatus.ready == true}}", "intervalSec": 30 }
+    },
+    {
+      "id": "Activate",
+      "type": "coalition.activate",
+      "config": {
+        "network": "base-sepolia",
+        "coalitionId": "{{Propose.coalitionId}}"
+      }
+    }
+  ]
+}
+```
+
+Because each KeeperHub workflow runs as a single Para wallet, multi-party signing is naturally a multi-workflow pattern: each participant runs their own KeeperHub workflow with a single `sign` step. The orchestration above belongs to one party (the proposer); the other participants run their own minimal workflows that call `sign` against the returned `coalitionId`.
+
+## Deployments
+
+| Chain | Chain ID | Address |
+|---|---|---|
+| Base Sepolia | 84532 | (paste after deploy) |
+| Base Mainnet | 8453 | not yet deployed |
+
+The contract is deployed out-of-band via `pnpm tsx scripts/deploy-coalition.ts --network base-sepolia` and verified on the block explorer. Update `plugins/coalition/contracts/addresses.ts` with the deployed address.
+
+## Limitations (v1)
+
+- Slash and recordBreach are anyone-callable. Production deployments should wrap with arbitrator-gating off-chain.
+- ERC-20 stake only; no ETH or fee-on-transfer/rebasing tokens.
+- Max 20 participants per coalition.
+- Single-chain (no cross-chain coalitions in v1).
+- The sponsored-execution path returns an empty `coalitionId` from `propose` because Pimlico bundlers don't surface event logs the same way. If your chain has gas sponsorship enabled and you need the ID immediately, run `check-status` against `nextId - 1` after the propose tx confirms, or deploy without sponsorship.
+- Once a slash has occurred, the slashed party's stake is permanently removed; `dissolve` correctly skips them.

--- a/plugins/coalition/contracts/Coalition.sol
+++ b/plugins/coalition/contracts/Coalition.sol
@@ -7,6 +7,15 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 
 /// @title Coalition
 /// @notice Multi-party on-chain commitments with stake escrow and slashing.
+/// @dev v1 design notes:
+///  - `recordBreach`, `slash`, and `expire` are anyone-callable; off-chain
+///    arbitration is expected to gate breach evidence in production deployments.
+///  - `dissolve` is restricted to participants to prevent griefing.
+///  - Pro-rata math truncates dust into the contract when stake does not
+///    divide evenly across recipients.
+///  - When every participant has been breached, the last `slash` has no
+///    eligible recipients; the breached party's stake remains in the contract
+///    and the coalition transitions to SLASHED.
 contract Coalition is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -20,12 +29,14 @@ contract Coalition is ReentrancyGuard {
         uint256 deadline;
         uint8 signedCount;
         uint8 breachedCount;
+        uint8 slashedCount;
         State state;
     }
 
     mapping(uint256 => CoalitionData) private _coalitions;
     mapping(uint256 => mapping(address => bool)) private _signed;
     mapping(uint256 => mapping(address => bool)) private _breached;
+    mapping(uint256 => mapping(address => bool)) private _slashed;
     mapping(uint256 => mapping(address => bool)) private _isParticipant;
 
     uint256 public nextId = 1;
@@ -44,8 +55,8 @@ contract Coalition is ReentrancyGuard {
     error NotAllSigned();
     error PartyNotBreached();
     error PartyAlreadyBreached();
+    error PartyAlreadySlashed();
     error DeadlineNotReached();
-    error NoNonBreachedParticipants();
 
     event Proposed(
         uint256 indexed id,
@@ -128,42 +139,65 @@ contract Coalition is ReentrancyGuard {
         emit Breach(id, party, evidenceHash);
     }
 
+    /// @notice Slash a breached party's stake pro-rata across non-breached participants.
+    /// @dev `_breached` and `_slashed` are both permanent flags. `_breached` is set on
+    ///      `recordBreach` and never reset. `_slashed` is set here and never reset, used
+    ///      to enforce single-slash-per-party. Recipients are participants who are
+    ///      neither the slashed party, breached, nor slashed. When every party has been
+    ///      breached, the last `slash` has zero recipients and the stake remains in
+    ///      the contract; the coalition transitions to SLASHED on the final slash.
     function slash(uint256 id, address party) external nonReentrant returns (uint256 amountRedistributed) {
         CoalitionData storage c = _coalitions[id];
         if (c.state != State.ACTIVE) revert CoalitionNotActive();
         if (!_breached[id][party]) revert PartyNotBreached();
+        if (_slashed[id][party]) revert PartyAlreadySlashed();
 
-        uint256 stake = c.stakePerParty;
-        uint256 nonBreached = c.participants.length - c.breachedCount;
-        if (nonBreached == 0) revert NoNonBreachedParticipants();
+        _slashed[id][party] = true;
+        c.slashedCount += 1;
 
-        uint256 share = stake / nonBreached;
-        amountRedistributed = share * nonBreached;
-
-        _breached[id][party] = false;
-
-        IERC20 token = IERC20(c.stakeToken);
-        for (uint256 i = 0; i < c.participants.length; i++) {
+        // Count eligible recipients first so share is exact and known to be safe.
+        uint256 recipientCount = 0;
+        uint256 participantsLen = c.participants.length;
+        for (uint256 i = 0; i < participantsLen; i++) {
             address p = c.participants[i];
             if (p == party) continue;
             if (_breached[id][p]) continue;
-            token.safeTransfer(p, share);
+            recipientCount += 1;
         }
 
-        if (c.breachedCount == c.participants.length) {
+        if (recipientCount > 0) {
+            uint256 share = c.stakePerParty / recipientCount;
+            amountRedistributed = share * recipientCount;
+
+            IERC20 token = IERC20(c.stakeToken);
+            for (uint256 i = 0; i < participantsLen; i++) {
+                address p = c.participants[i];
+                if (p == party) continue;
+                if (_breached[id][p]) continue;
+                token.safeTransfer(p, share);
+            }
+        }
+        // If recipientCount == 0 (every other party is breached), amountRedistributed
+        // stays at 0 and the slashed stake remains in the contract.
+
+        if (c.slashedCount == participantsLen) {
             c.state = State.SLASHED;
         }
 
         emit Slashed(id, party, amountRedistributed);
     }
 
+    /// @notice Clean close of an active coalition. Returns each non-breached
+    ///         participant's stake. Restricted to participants to prevent griefing.
     function dissolve(uint256 id) external nonReentrant {
         CoalitionData storage c = _coalitions[id];
         if (c.state != State.ACTIVE) revert CoalitionNotActive();
+        if (!_isParticipant[id][msg.sender]) revert NotParticipant();
 
         c.state = State.DISSOLVED;
         IERC20 token = IERC20(c.stakeToken);
-        for (uint256 i = 0; i < c.participants.length; i++) {
+        uint256 participantsLen = c.participants.length;
+        for (uint256 i = 0; i < participantsLen; i++) {
             address p = c.participants[i];
             if (_breached[id][p]) continue;
             token.safeTransfer(p, c.stakePerParty);
@@ -172,6 +206,8 @@ contract Coalition is ReentrancyGuard {
         emit Dissolved(id);
     }
 
+    /// @notice Anyone-callable refund after deadline if state is still PROPOSED.
+    ///         Returns each signed participant's stake.
     function expire(uint256 id) external nonReentrant {
         CoalitionData storage c = _coalitions[id];
         if (c.state != State.PROPOSED) revert CoalitionNotProposed();
@@ -179,7 +215,8 @@ contract Coalition is ReentrancyGuard {
 
         c.state = State.EXPIRED;
         IERC20 token = IERC20(c.stakeToken);
-        for (uint256 i = 0; i < c.participants.length; i++) {
+        uint256 participantsLen = c.participants.length;
+        for (uint256 i = 0; i < participantsLen; i++) {
             address p = c.participants[i];
             if (_signed[id][p]) {
                 token.safeTransfer(p, c.stakePerParty);
@@ -191,6 +228,8 @@ contract Coalition is ReentrancyGuard {
 
     // ---------- Views ----------
 
+    /// @notice Returns full coalition state. Used by the workflow plugin's
+    ///         `check-status` and `sign`/`activate`/etc. pre-checks.
     function getCoalition(uint256 id)
         external
         view
@@ -202,6 +241,7 @@ contract Coalition is ReentrancyGuard {
             uint256 deadline,
             uint8 signedCount,
             uint8 breachedCount,
+            uint8 slashedCount,
             State state
         )
     {
@@ -214,6 +254,7 @@ contract Coalition is ReentrancyGuard {
             c.deadline,
             c.signedCount,
             c.breachedCount,
+            c.slashedCount,
             c.state
         );
     }
@@ -224,5 +265,9 @@ contract Coalition is ReentrancyGuard {
 
     function isBreached(uint256 id, address party) external view returns (bool) {
         return _breached[id][party];
+    }
+
+    function isSlashed(uint256 id, address party) external view returns (bool) {
+        return _slashed[id][party];
     }
 }

--- a/plugins/coalition/contracts/Coalition.sol
+++ b/plugins/coalition/contracts/Coalition.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title Coalition
+/// @notice Multi-party on-chain commitments with stake escrow and slashing.
+contract Coalition is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    enum State { NONE, PROPOSED, ACTIVE, DISSOLVED, SLASHED, EXPIRED }
+
+    struct CoalitionData {
+        bytes32 termsHash;
+        address[] participants;
+        address stakeToken;
+        uint256 stakePerParty;
+        uint256 deadline;
+        uint8 signedCount;
+        uint8 breachedCount;
+        State state;
+    }
+
+    mapping(uint256 => CoalitionData) private _coalitions;
+    mapping(uint256 => mapping(address => bool)) private _signed;
+    mapping(uint256 => mapping(address => bool)) private _breached;
+    mapping(uint256 => mapping(address => bool)) private _isParticipant;
+
+    uint256 public nextId = 1;
+
+    uint8 public constant MIN_PARTICIPANTS = 2;
+    uint8 public constant MAX_PARTICIPANTS = 20;
+
+    error InvalidParticipantCount();
+    error DeadlineInPast();
+    error DuplicateParticipant();
+    error ZeroStake();
+    error CoalitionNotProposed();
+    error CoalitionNotActive();
+    error NotParticipant();
+    error AlreadySigned();
+    error NotAllSigned();
+    error PartyNotBreached();
+    error PartyAlreadyBreached();
+    error DeadlineNotReached();
+    error NoNonBreachedParticipants();
+
+    event Proposed(
+        uint256 indexed id,
+        bytes32 termsHash,
+        address[] participants,
+        address stakeToken,
+        uint256 stakePerParty,
+        uint256 deadline
+    );
+    event Signed(uint256 indexed id, address indexed participant);
+    event Activated(uint256 indexed id);
+    event Breach(uint256 indexed id, address indexed party, bytes32 evidenceHash);
+    event Slashed(uint256 indexed id, address indexed party, uint256 amountRedistributed);
+    event Dissolved(uint256 indexed id);
+    event Expired(uint256 indexed id);
+
+    function propose(
+        address[] calldata participants,
+        bytes32 termsHash,
+        uint256 deadline,
+        address stakeToken,
+        uint256 stakePerParty
+    ) external returns (uint256 id) {
+        if (participants.length < MIN_PARTICIPANTS || participants.length > MAX_PARTICIPANTS) {
+            revert InvalidParticipantCount();
+        }
+        if (deadline <= block.timestamp) revert DeadlineInPast();
+        if (stakePerParty == 0) revert ZeroStake();
+
+        id = nextId++;
+        CoalitionData storage c = _coalitions[id];
+        c.termsHash = termsHash;
+        c.stakeToken = stakeToken;
+        c.stakePerParty = stakePerParty;
+        c.deadline = deadline;
+        c.state = State.PROPOSED;
+
+        for (uint256 i = 0; i < participants.length; i++) {
+            address p = participants[i];
+            if (_isParticipant[id][p]) revert DuplicateParticipant();
+            _isParticipant[id][p] = true;
+            c.participants.push(p);
+        }
+
+        emit Proposed(id, termsHash, participants, stakeToken, stakePerParty, deadline);
+    }
+
+    function sign(uint256 id) external nonReentrant {
+        CoalitionData storage c = _coalitions[id];
+        if (c.state != State.PROPOSED) revert CoalitionNotProposed();
+        if (!_isParticipant[id][msg.sender]) revert NotParticipant();
+        if (_signed[id][msg.sender]) revert AlreadySigned();
+
+        _signed[id][msg.sender] = true;
+        c.signedCount += 1;
+
+        IERC20(c.stakeToken).safeTransferFrom(msg.sender, address(this), c.stakePerParty);
+
+        emit Signed(id, msg.sender);
+    }
+
+    function activate(uint256 id) external {
+        CoalitionData storage c = _coalitions[id];
+        if (c.state != State.PROPOSED) revert CoalitionNotProposed();
+        if (c.signedCount != c.participants.length) revert NotAllSigned();
+
+        c.state = State.ACTIVE;
+        emit Activated(id);
+    }
+
+    function recordBreach(uint256 id, address party, bytes32 evidenceHash) external {
+        CoalitionData storage c = _coalitions[id];
+        if (c.state != State.ACTIVE) revert CoalitionNotActive();
+        if (!_isParticipant[id][party]) revert NotParticipant();
+        if (_breached[id][party]) revert PartyAlreadyBreached();
+
+        _breached[id][party] = true;
+        c.breachedCount += 1;
+
+        emit Breach(id, party, evidenceHash);
+    }
+
+    function slash(uint256 id, address party) external nonReentrant returns (uint256 amountRedistributed) {
+        CoalitionData storage c = _coalitions[id];
+        if (c.state != State.ACTIVE) revert CoalitionNotActive();
+        if (!_breached[id][party]) revert PartyNotBreached();
+
+        uint256 stake = c.stakePerParty;
+        uint256 nonBreached = c.participants.length - c.breachedCount;
+        if (nonBreached == 0) revert NoNonBreachedParticipants();
+
+        uint256 share = stake / nonBreached;
+        amountRedistributed = share * nonBreached;
+
+        _breached[id][party] = false;
+
+        IERC20 token = IERC20(c.stakeToken);
+        for (uint256 i = 0; i < c.participants.length; i++) {
+            address p = c.participants[i];
+            if (p == party) continue;
+            if (_breached[id][p]) continue;
+            token.safeTransfer(p, share);
+        }
+
+        if (c.breachedCount == c.participants.length) {
+            c.state = State.SLASHED;
+        }
+
+        emit Slashed(id, party, amountRedistributed);
+    }
+
+    function dissolve(uint256 id) external nonReentrant {
+        CoalitionData storage c = _coalitions[id];
+        if (c.state != State.ACTIVE) revert CoalitionNotActive();
+
+        c.state = State.DISSOLVED;
+        IERC20 token = IERC20(c.stakeToken);
+        for (uint256 i = 0; i < c.participants.length; i++) {
+            address p = c.participants[i];
+            if (_breached[id][p]) continue;
+            token.safeTransfer(p, c.stakePerParty);
+        }
+
+        emit Dissolved(id);
+    }
+
+    function expire(uint256 id) external nonReentrant {
+        CoalitionData storage c = _coalitions[id];
+        if (c.state != State.PROPOSED) revert CoalitionNotProposed();
+        if (block.timestamp <= c.deadline) revert DeadlineNotReached();
+
+        c.state = State.EXPIRED;
+        IERC20 token = IERC20(c.stakeToken);
+        for (uint256 i = 0; i < c.participants.length; i++) {
+            address p = c.participants[i];
+            if (_signed[id][p]) {
+                token.safeTransfer(p, c.stakePerParty);
+            }
+        }
+
+        emit Expired(id);
+    }
+
+    // ---------- Views ----------
+
+    function getCoalition(uint256 id)
+        external
+        view
+        returns (
+            bytes32 termsHash,
+            address[] memory participants,
+            address stakeToken,
+            uint256 stakePerParty,
+            uint256 deadline,
+            uint8 signedCount,
+            uint8 breachedCount,
+            State state
+        )
+    {
+        CoalitionData storage c = _coalitions[id];
+        return (
+            c.termsHash,
+            c.participants,
+            c.stakeToken,
+            c.stakePerParty,
+            c.deadline,
+            c.signedCount,
+            c.breachedCount,
+            c.state
+        );
+    }
+
+    function isSigned(uint256 id, address party) external view returns (bool) {
+        return _signed[id][party];
+    }
+
+    function isBreached(uint256 id, address party) external view returns (bool) {
+        return _breached[id][party];
+    }
+}

--- a/plugins/coalition/contracts/addresses.ts
+++ b/plugins/coalition/contracts/addresses.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-chain Coalition contract addresses.
+ * Update after deploying via `pnpm tsx scripts/deploy-coalition.ts --network <chain>`.
+ * Chain IDs: 84532 = Base Sepolia, 8453 = Base mainnet.
+ */
+export const COALITION_ADDRESSES: Record<number, `0x${string}`> = {
+  // 84532: "0x0000000000000000000000000000000000000000", // Base Sepolia (paste after deploy)
+  // 8453: "0x0000000000000000000000000000000000000000",  // Base mainnet (paste after deploy)
+};
+
+export const SUPPORTED_CHAIN_IDS = [84532, 8453] as const;

--- a/plugins/coalition/contracts/addresses.ts
+++ b/plugins/coalition/contracts/addresses.ts
@@ -4,8 +4,7 @@
  * Chain IDs: 84532 = Base Sepolia, 8453 = Base mainnet.
  */
 export const COALITION_ADDRESSES: Record<number, `0x${string}`> = {
-  // 84532: "0x0000000000000000000000000000000000000000", // Base Sepolia (paste after deploy)
-  // 8453: "0x0000000000000000000000000000000000000000",  // Base mainnet (paste after deploy)
+  84532: "0x445BE52b852400A8873721947E3BB3A5559CE4d9", // Base Sepolia
 };
 
 export const SUPPORTED_CHAIN_IDS = [84532, 8453] as const;

--- a/plugins/coalition/contracts/coalition-abi.ts
+++ b/plugins/coalition/contracts/coalition-abi.ts
@@ -1,0 +1,190 @@
+/**
+ * Hand-curated ABI for Coalition.sol.
+ * Keep this in sync with plugins/coalition/contracts/Coalition.sol.
+ * This file is the source of truth for plugin runtime; the .sol file is
+ * documentation. Foundry/Hardhat are not part of this PR.
+ */
+export const COALITION_ABI = [
+  {
+    type: "function",
+    name: "propose",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "participants", type: "address[]" },
+      { name: "termsHash", type: "bytes32" },
+      { name: "deadline", type: "uint256" },
+      { name: "stakeToken", type: "address" },
+      { name: "stakePerParty", type: "uint256" },
+    ],
+    outputs: [{ name: "id", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "sign",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "activate",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "recordBreach",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "id", type: "uint256" },
+      { name: "party", type: "address" },
+      { name: "evidenceHash", type: "bytes32" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "slash",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "id", type: "uint256" },
+      { name: "party", type: "address" },
+    ],
+    outputs: [{ name: "amountRedistributed", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "dissolve",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "expire",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "getCoalition",
+    stateMutability: "view",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [
+      { name: "termsHash", type: "bytes32" },
+      { name: "participants", type: "address[]" },
+      { name: "stakeToken", type: "address" },
+      { name: "stakePerParty", type: "uint256" },
+      { name: "deadline", type: "uint256" },
+      { name: "signedCount", type: "uint8" },
+      { name: "breachedCount", type: "uint8" },
+      { name: "slashedCount", type: "uint8" },
+      { name: "state", type: "uint8" },
+    ],
+  },
+  {
+    type: "function",
+    name: "isSigned",
+    stateMutability: "view",
+    inputs: [
+      { name: "id", type: "uint256" },
+      { name: "party", type: "address" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "isBreached",
+    stateMutability: "view",
+    inputs: [
+      { name: "id", type: "uint256" },
+      { name: "party", type: "address" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "isSlashed",
+    stateMutability: "view",
+    inputs: [
+      { name: "id", type: "uint256" },
+      { name: "party", type: "address" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "event",
+    name: "Proposed",
+    inputs: [
+      { name: "id", type: "uint256", indexed: true },
+      { name: "termsHash", type: "bytes32", indexed: false },
+      { name: "participants", type: "address[]", indexed: false },
+      { name: "stakeToken", type: "address", indexed: false },
+      { name: "stakePerParty", type: "uint256", indexed: false },
+      { name: "deadline", type: "uint256", indexed: false },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Signed",
+    inputs: [
+      { name: "id", type: "uint256", indexed: true },
+      { name: "participant", type: "address", indexed: true },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Activated",
+    inputs: [{ name: "id", type: "uint256", indexed: true }],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Breach",
+    inputs: [
+      { name: "id", type: "uint256", indexed: true },
+      { name: "party", type: "address", indexed: true },
+      { name: "evidenceHash", type: "bytes32", indexed: false },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Slashed",
+    inputs: [
+      { name: "id", type: "uint256", indexed: true },
+      { name: "party", type: "address", indexed: true },
+      { name: "amountRedistributed", type: "uint256", indexed: false },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Dissolved",
+    inputs: [{ name: "id", type: "uint256", indexed: true }],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Expired",
+    inputs: [{ name: "id", type: "uint256", indexed: true }],
+    anonymous: false,
+  },
+  { type: "error", name: "InvalidParticipantCount", inputs: [] },
+  { type: "error", name: "DeadlineInPast", inputs: [] },
+  { type: "error", name: "DuplicateParticipant", inputs: [] },
+  { type: "error", name: "ZeroStake", inputs: [] },
+  { type: "error", name: "CoalitionNotProposed", inputs: [] },
+  { type: "error", name: "CoalitionNotActive", inputs: [] },
+  { type: "error", name: "NotParticipant", inputs: [] },
+  { type: "error", name: "AlreadySigned", inputs: [] },
+  { type: "error", name: "NotAllSigned", inputs: [] },
+  { type: "error", name: "PartyNotBreached", inputs: [] },
+  { type: "error", name: "PartyAlreadyBreached", inputs: [] },
+  { type: "error", name: "PartyAlreadySlashed", inputs: [] },
+  { type: "error", name: "DeadlineNotReached", inputs: [] },
+] as const;

--- a/plugins/coalition/icon.tsx
+++ b/plugins/coalition/icon.tsx
@@ -1,0 +1,31 @@
+export function CoalitionIcon({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      height="148"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      style={style}
+      viewBox="0 0 24 24"
+      width="148"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Coalition</title>
+      <circle cx="6" cy="9" r="2.5" />
+      <circle cx="18" cy="9" r="2.5" />
+      <circle cx="12" cy="17" r="2.5" />
+      <path d="M8 10.5l3 5" />
+      <path d="M16 10.5l-3 5" />
+      <path d="M8.5 9h7" />
+    </svg>
+  );
+}

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -17,7 +17,88 @@ const coalitionPlugin: IntegrationPlugin = {
       return testCoalition;
     },
   },
-  actions: [],
+  actions: [
+    {
+      slug: "check-status",
+      label: "Check Coalition Status",
+      description:
+        "Read the current state, signed/breached/slashed counts, and participants of a coalition. Use this for polling loops before activate/dissolve.",
+      category: "Coalition",
+      stepFunction: "checkStatusStep",
+      stepImportPath: "check-status",
+      outputFields: [
+        { field: "success", description: "Whether the read succeeded" },
+        {
+          field: "state",
+          description:
+            "Current state label: PROPOSED, ACTIVE, DISSOLVED, SLASHED, or EXPIRED",
+        },
+        {
+          field: "signedCount",
+          description: "Number of participants who have signed",
+        },
+        {
+          field: "breachedCount",
+          description: "Number of participants marked as breached",
+        },
+        {
+          field: "slashedCount",
+          description: "Number of participants whose stake has been slashed",
+        },
+        {
+          field: "totalParticipants",
+          description: "Total participants in the coalition",
+        },
+        {
+          field: "ready",
+          description:
+            "True when state is PROPOSED and all participants have signed (safe to activate)",
+        },
+        {
+          field: "participants",
+          description: "Array of participant addresses",
+        },
+        {
+          field: "termsHash",
+          description: "32-byte hash of the off-chain terms document",
+        },
+        {
+          field: "deadline",
+          description: "Coalition deadline as Unix timestamp string",
+        },
+        {
+          field: "stakeToken",
+          description: "ERC-20 token address used for stakes",
+        },
+        {
+          field: "stakePerParty",
+          description: "Stake amount per participant in token's smallest units",
+        },
+        {
+          field: "error",
+          description: "Error message if the read failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1 or {{Propose.coalitionId}}",
+          example: "1",
+          required: true,
+        },
+      ],
+    },
+  ],
 };
 
 registerIntegration(coalitionPlugin);

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -400,6 +400,102 @@ const coalitionPlugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "dissolve",
+      label: "Dissolve Coalition",
+      description:
+        "Clean close of an active coalition. Returns each non-breached participant's stake. Restricted to participants.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "dissolveStep",
+      stepImportPath: "dissolve",
+      outputFields: [
+        { field: "success", description: "Whether the dissolve succeeded" },
+        { field: "transactionHash", description: "Tx hash" },
+        { field: "transactionLink", description: "Block explorer link" },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "dissolve",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      slug: "expire",
+      label: "Expire Coalition",
+      description:
+        "Refund signed stakes after the deadline if not all parties signed. Transitions to EXPIRED. Anyone can call.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "expireStep",
+      stepImportPath: "expire",
+      outputFields: [
+        { field: "success", description: "Whether the expire succeeded" },
+        { field: "transactionHash", description: "Tx hash" },
+        { field: "transactionLink", description: "Block explorer link" },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "expire",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "check-status",
       label: "Check Coalition Status",
       description:

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -236,6 +236,74 @@ const coalitionPlugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "breach",
+      label: "Record Breach",
+      description:
+        "Record breach evidence against a participant of an active coalition. Pre-validates state, participation, and prior breach status.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "breachStep",
+      stepImportPath: "breach",
+      outputFields: [
+        { field: "success", description: "Whether the breach record succeeded" },
+        { field: "transactionHash", description: "Tx hash" },
+        { field: "transactionLink", description: "Block explorer link" },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1",
+          required: true,
+        },
+        {
+          key: "breachingParty",
+          label: "Breaching Party",
+          type: "template-input",
+          placeholder: "0x...",
+          required: true,
+        },
+        {
+          key: "evidenceHash",
+          label: "Evidence Hash",
+          type: "template-input",
+          placeholder: "0x... (32-byte keccak256 of evidence document)",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "evidenceUri",
+              label: "Evidence URI",
+              type: "template-input",
+              placeholder: "ipfs://... or https://... (logged off-chain only)",
+            },
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "breach",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "check-status",
       label: "Check Coalition Status",
       description:

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -304,6 +304,102 @@ const coalitionPlugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "slash",
+      label: "Slash Breached Party",
+      description:
+        "Transfer the breached party's stake pro-rata to non-breached participants. Reliability-tuned: routes through private mempool, supports priority-fee override.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "slashStep",
+      stepImportPath: "slash",
+      outputFields: [
+        { field: "success", description: "Whether the slash succeeded" },
+        { field: "transactionHash", description: "Tx hash" },
+        { field: "transactionLink", description: "Block explorer link" },
+        {
+          field: "amountRedistributed",
+          description:
+            "Total stake redistributed (wei string), parsed from the Slashed event",
+        },
+        { field: "party", description: "Address of the slashed party" },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1",
+          required: true,
+        },
+        {
+          key: "party",
+          label: "Party to Slash",
+          type: "template-input",
+          placeholder: "0x... (must be marked breached)",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Reliability",
+          defaultExpanded: true,
+          fields: [
+            {
+              key: "usePrivateMempool",
+              label: "Use Private Mempool",
+              type: "select",
+              options: [
+                { value: "yes", label: "Yes (recommended for slash)" },
+                { value: "no", label: "No (public mempool)" },
+              ],
+              defaultValue: "yes",
+              helpTip:
+                "Routes the slash transaction through Flashbots Protect (or the chain's private RPC) to avoid frontrunning.",
+            },
+            {
+              key: "strict",
+              label: "Strict Private Mempool",
+              type: "select",
+              options: [
+                { value: "no", label: "No (fall back to public if private RPC unreachable)" },
+                { value: "yes", label: "Yes (fail rather than fall back)" },
+              ],
+              defaultValue: "no",
+            },
+            {
+              key: "priorityFeeGwei",
+              label: "Priority Fee Override (gwei)",
+              type: "template-input",
+              placeholder: "Leave empty for chain default; set 2-5 above baseline for fast inclusion",
+            },
+          ],
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "slash",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "check-status",
       label: "Check Coalition Status",
       description:

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -19,6 +19,97 @@ const coalitionPlugin: IntegrationPlugin = {
   },
   actions: [
     {
+      slug: "propose",
+      label: "Propose Coalition",
+      description:
+        "Create a new on-chain coalition with N participants, a stake token, stake amount, and deadline. Returns the coalitionId for downstream nodes.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "proposeStep",
+      stepImportPath: "propose",
+      outputFields: [
+        { field: "success", description: "Whether the proposal succeeded" },
+        {
+          field: "coalitionId",
+          description:
+            "ID of the newly created coalition (parsed from the Proposed event)",
+        },
+        { field: "transactionHash", description: "Transaction hash" },
+        { field: "transactionLink", description: "Block explorer link" },
+        { field: "gasUsed", description: "Gas cost in wei" },
+        { field: "error", description: "Error message if the call failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "participants",
+          label: "Participants",
+          type: "template-textarea",
+          placeholder: '["0x...", "0x...", "0x..."]',
+          rows: 4,
+          helpTip:
+            "JSON array of EVM addresses (2-20 participants). Each must approve the stakeToken before signing.",
+          required: true,
+        },
+        {
+          key: "termsHash",
+          label: "Terms Hash",
+          type: "template-input",
+          placeholder: "0x... (32-byte keccak256 of off-chain terms)",
+          example:
+            "0xabababababababababababababababababababababababababababababababab",
+          required: true,
+        },
+        {
+          key: "deadlineUnix",
+          label: "Deadline (Unix timestamp)",
+          type: "template-input",
+          placeholder: "1800000000 or {{Now.plusDays}}",
+          helpTip:
+            "Unix seconds. After this time, expire() can refund signers if not all signed.",
+          required: true,
+        },
+        {
+          key: "stakeToken",
+          label: "Stake Token Address",
+          type: "template-input",
+          placeholder: "0x... (ERC-20)",
+          example: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          required: true,
+        },
+        {
+          key: "stakePerParty",
+          label: "Stake Per Party",
+          type: "template-input",
+          placeholder: "Amount in token's smallest units (e.g. wei)",
+          example: "1000000000000000000",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "propose",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "check-status",
       label: "Check Coalition Status",
       description:

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -110,6 +110,77 @@ const coalitionPlugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "sign",
+      label: "Sign Coalition",
+      description:
+        "Sign in as a participant and escrow your stake. Auto-approves the stakeToken allowance if needed. Idempotent — safe to retry.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "signStep",
+      stepImportPath: "sign",
+      outputFields: [
+        { field: "success", description: "Whether the sign-in succeeded" },
+        {
+          field: "transactionHash",
+          description: "Sign transaction hash (empty if already signed)",
+        },
+        { field: "transactionLink", description: "Block explorer link" },
+        {
+          field: "approvalTransactionHash",
+          description:
+            "Approval tx hash (only present if allowance was insufficient and skipApproval=No)",
+        },
+        {
+          field: "wasAlreadySigned",
+          description:
+            "True if the wallet had already signed; the action returned without sending a tx",
+        },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1 or {{Propose.coalitionId}}",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "skipApproval",
+              label: "Skip Auto-Approval",
+              type: "select",
+              options: [
+                { value: "no", label: "No (auto-approve if needed)" },
+                { value: "yes", label: "Yes (assume already approved)" },
+              ],
+              defaultValue: "no",
+            },
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "sign",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "check-status",
       label: "Check Coalition Status",
       description:

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -1,0 +1,25 @@
+import type { IntegrationPlugin } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
+import { CoalitionIcon } from "./icon";
+
+const coalitionPlugin: IntegrationPlugin = {
+  type: "coalition",
+  label: "Coalition",
+  description:
+    "Multi-party on-chain commitments with stake escrow and slashing. Propose, collect signatures, activate, slash on breach, dissolve cleanly.",
+  icon: CoalitionIcon,
+  singleConnection: true,
+  requiresCredentials: false,
+  formFields: [],
+  testConfig: {
+    getTestFunction: async () => {
+      const { testCoalition } = await import("./test");
+      return testCoalition;
+    },
+  },
+  actions: [],
+};
+
+registerIntegration(coalitionPlugin);
+
+export default coalitionPlugin;

--- a/plugins/coalition/index.ts
+++ b/plugins/coalition/index.ts
@@ -181,6 +181,61 @@ const coalitionPlugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "activate",
+      label: "Activate Coalition",
+      description:
+        "Transition a fully-signed coalition from PROPOSED to ACTIVE. Idempotent — safe to retry once active.",
+      category: "Coalition",
+      requiresCredentials: true,
+      stepFunction: "activateStep",
+      stepImportPath: "activate",
+      outputFields: [
+        { field: "success", description: "Whether activation succeeded" },
+        {
+          field: "transactionHash",
+          description: "Activate tx hash (empty if already active)",
+        },
+        { field: "transactionLink", description: "Block explorer link" },
+        {
+          field: "alreadyActive",
+          description: "True if the coalition was already ACTIVE",
+        },
+        { field: "error", description: "Error message if failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          showPrivateVariants: true,
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "coalitionId",
+          label: "Coalition ID",
+          type: "template-input",
+          placeholder: "1 or {{Propose.coalitionId}}",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "gasLimitMultiplier",
+              label: "Gas Limit",
+              type: "gas-limit-multiplier",
+              networkField: "network",
+              actionSlug: "activate",
+            },
+          ],
+        },
+      ],
+    },
+    {
       slug: "check-status",
       label: "Check Coalition Status",
       description:

--- a/plugins/coalition/steps/activate-core.ts
+++ b/plugins/coalition/steps/activate-core.ts
@@ -1,0 +1,219 @@
+import "server-only";
+
+import type { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import { coalitionInterface, getCoalitionAddress } from "./coalition-core";
+
+export type ActivateCoreInput = {
+  network: string;
+  coalitionId: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type ActivateResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      alreadyActive: boolean;
+    }
+  | { success: false; error: string };
+
+type RawCoalitionForActivate = {
+  participants: string[];
+  signedCount: number | bigint;
+  state: number | bigint;
+};
+
+export async function activateCore(
+  input: ActivateCoreInput
+): Promise<ActivateResult> {
+  const { network, coalitionId, gasLimitMultiplier, _context } = input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition activate]",
+    "activate"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  let coalition: RawCoalitionForActivate;
+  try {
+    coalition = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalitionForActivate;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition activate] Failed to read coalition state",
+      error,
+      { plugin_name: "coalition", action_name: "activate" }
+    );
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  const stateNum = Number(coalition.state);
+  if (stateNum === 2) {
+    return {
+      success: true,
+      alreadyActive: true,
+      transactionHash: "",
+      transactionLink: "",
+    };
+  }
+  if (stateNum !== 1) {
+    return {
+      success: false,
+      error: `Coalition is not in PROPOSED state (current state code: ${stateNum})`,
+    };
+  }
+  const signedCount = Number(coalition.signedCount);
+  const totalParticipants = coalition.participants.length;
+  if (signedCount !== totalParticipants) {
+    return {
+      success: false,
+      error: `Not all participants have signed (${signedCount}/${totalParticipants})`,
+    };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(undefined);
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "activate",
+          args: [parsedId],
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      );
+
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+        alreadyActive: false,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition activate] Activate tx failed",
+        error,
+        { plugin_name: "coalition", action_name: "activate" }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/activate.ts
+++ b/plugins/coalition/steps/activate.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type ActivateCoreInput,
+  type ActivateResult,
+  activateCore,
+} from "./activate-core";
+
+export type ActivateInput = StepInput & ActivateCoreInput;
+
+export async function activateStep(
+  input: ActivateInput
+): Promise<ActivateResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "activate",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => activateCore(input))
+  );
+}
+
+activateStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/breach-core.ts
+++ b/plugins/coalition/steps/breach-core.ts
@@ -1,0 +1,245 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import { coalitionInterface, getCoalitionAddress } from "./coalition-core";
+
+const HEX_32_BYTES = /^0x[a-fA-F0-9]{64}$/;
+
+export type BreachCoreInput = {
+  network: string;
+  coalitionId: string;
+  breachingParty: string;
+  evidenceHash: string;
+  evidenceUri?: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type BreachResult =
+  | { success: true; transactionHash: string; transactionLink: string }
+  | { success: false; error: string };
+
+type RawCoalitionForBreach = {
+  participants: string[];
+  state: number | bigint;
+  stakeToken: string;
+  stakePerParty: number | bigint;
+};
+
+export async function breachCore(
+  input: BreachCoreInput
+): Promise<BreachResult> {
+  const { network, coalitionId, breachingParty, evidenceHash, gasLimitMultiplier, _context } =
+    input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (!ethers.isAddress(breachingParty)) {
+    return {
+      success: false,
+      error: `Invalid breachingParty address: ${breachingParty}`,
+    };
+  }
+
+  if (!HEX_32_BYTES.test(evidenceHash)) {
+    return {
+      success: false,
+      error: "Invalid evidenceHash: must be 0x followed by 64 hex chars",
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition breach]",
+    "breach"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  let coalition: RawCoalitionForBreach;
+  try {
+    coalition = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalitionForBreach;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition breach] Failed to read coalition state",
+      error,
+      { plugin_name: "coalition", action_name: "breach" }
+    );
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (Number(coalition.state) !== 2) {
+    return { success: false, error: "Coalition is not active" };
+  }
+
+  const partyLower = breachingParty.toLowerCase();
+  const isParticipant = coalition.participants.some(
+    (p: string) => p.toLowerCase() === partyLower
+  );
+  if (!isParticipant) {
+    return {
+      success: false,
+      error: "Address is not a participant of this coalition",
+    };
+  }
+
+  let alreadyBreached: boolean;
+  try {
+    alreadyBreached = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "isBreached",
+      args: [parsedId, breachingParty],
+      isView: true,
+    })) as boolean;
+  } catch (error) {
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (alreadyBreached) {
+    return { success: false, error: "Party already marked breached" };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(undefined);
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "recordBreach",
+          args: [parsedId, breachingParty, evidenceHash],
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      );
+
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition breach] recordBreach tx failed",
+        error,
+        { plugin_name: "coalition", action_name: "breach" }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/breach.ts
+++ b/plugins/coalition/steps/breach.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type BreachCoreInput,
+  type BreachResult,
+  breachCore,
+} from "./breach-core";
+
+export type BreachInput = StepInput & BreachCoreInput;
+
+export async function breachStep(input: BreachInput): Promise<BreachResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "breach",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => breachCore(input))
+  );
+}
+
+breachStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/check-status-core.ts
+++ b/plugins/coalition/steps/check-status-core.ts
@@ -58,8 +58,8 @@ export async function checkStatusCore(
   let parsedId: bigint;
   try {
     parsedId = BigInt(coalitionId);
-    if (parsedId < BigInt(0)) {
-      throw new Error("coalitionId must be non-negative");
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
     }
   } catch (error) {
     return {

--- a/plugins/coalition/steps/check-status-core.ts
+++ b/plugins/coalition/steps/check-status-core.ts
@@ -1,0 +1,155 @@
+import "server-only";
+
+import type { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import {
+  type CoalitionState,
+  coalitionInterface,
+  getCoalitionAddress,
+  stateLabel,
+} from "./coalition-core";
+
+export type CheckStatusCoreInput = {
+  network: string;
+  coalitionId: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type CheckStatusResult =
+  | {
+      success: true;
+      state: CoalitionState;
+      signedCount: number;
+      breachedCount: number;
+      slashedCount: number;
+      totalParticipants: number;
+      ready: boolean;
+      participants: string[];
+      termsHash: string;
+      deadline: string;
+      stakeToken: string;
+      stakePerParty: string;
+    }
+  | { success: false; error: string };
+
+type RawCoalition = {
+  termsHash: string;
+  participants: string[];
+  stakeToken: string;
+  stakePerParty: bigint | string;
+  deadline: bigint | string;
+  signedCount: number | bigint;
+  breachedCount: number | bigint;
+  slashedCount: number | bigint;
+  state: number | bigint;
+};
+
+export async function checkStatusCore(
+  input: CheckStatusCoreInput
+): Promise<CheckStatusResult> {
+  const { network, coalitionId } = input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId < BigInt(0)) {
+      throw new Error("coalitionId must be non-negative");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Coalition check-status] Failed to resolve chain or address",
+      error,
+      { plugin_name: "coalition", action_name: "check-status" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  try {
+    rpcManager = await getRpcProvider({ chainId });
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition check-status] Failed to resolve RPC",
+      error,
+      { plugin_name: "coalition", action_name: "check-status" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  try {
+    const adapter = getChainAdapter(chainId);
+    const raw = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalition;
+
+    const stateNum = Number(raw.state);
+    if (stateNum === 0) {
+      return {
+        success: false,
+        error: `Coalition ${coalitionId} does not exist`,
+      };
+    }
+
+    const state = stateLabel(stateNum);
+    const signedCount = Number(raw.signedCount);
+    const breachedCount = Number(raw.breachedCount);
+    const slashedCount = Number(raw.slashedCount);
+    const totalParticipants = raw.participants.length;
+    const ready =
+      state === "PROPOSED" && signedCount === totalParticipants;
+
+    return {
+      success: true,
+      state,
+      signedCount,
+      breachedCount,
+      slashedCount,
+      totalParticipants,
+      ready,
+      participants: raw.participants,
+      termsHash: raw.termsHash,
+      deadline: String(raw.deadline),
+      stakeToken: raw.stakeToken,
+      stakePerParty: String(raw.stakePerParty),
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition check-status] readContract failed",
+      error,
+      {
+        plugin_name: "coalition",
+        action_name: "check-status",
+        chain_id: String(chainId),
+      }
+    );
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+}

--- a/plugins/coalition/steps/check-status.ts
+++ b/plugins/coalition/steps/check-status.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type CheckStatusCoreInput,
+  type CheckStatusResult,
+  checkStatusCore,
+} from "./check-status-core";
+
+export type CheckStatusInput = StepInput & CheckStatusCoreInput;
+
+export async function checkStatusStep(
+  input: CheckStatusInput
+): Promise<CheckStatusResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "check-status",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => checkStatusCore(input))
+  );
+}
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/coalition-core.ts
+++ b/plugins/coalition/steps/coalition-core.ts
@@ -36,20 +36,12 @@ export const coalitionInterface = new ethers.Interface(
   COALITION_ABI as unknown as ethers.InterfaceAbi
 );
 
-type MinimalLog = {
-  topics: readonly string[];
-  data: string;
-};
-
 /**
  * Parse a single event from a transaction receipt's logs.
- * Accepts the minimal log shape (topics + data) so it works with both
- * full ethers.Log objects and the stripped ReceiptWithLogs type used in
- * propose-core and other write steps.
  * Returns the event args (typed via ethers.Result) or null if not found.
  */
 export function parseCoalitionEvent(
-  logs: readonly MinimalLog[],
+  logs: readonly ethers.Log[],
   eventName: string
 ): ethers.Result | null {
   for (const log of logs) {

--- a/plugins/coalition/steps/coalition-core.ts
+++ b/plugins/coalition/steps/coalition-core.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import { COALITION_ADDRESSES, SUPPORTED_CHAIN_IDS } from "../contracts/addresses";
+
+export const STATE_LABELS = [
+  "NONE",
+  "PROPOSED",
+  "ACTIVE",
+  "DISSOLVED",
+  "SLASHED",
+  "EXPIRED",
+] as const;
+
+export type CoalitionState = (typeof STATE_LABELS)[number];
+
+export function stateLabel(stateUint: number | bigint): CoalitionState {
+  const idx = Number(stateUint);
+  return STATE_LABELS[idx] ?? "NONE";
+}
+
+export function getCoalitionAddress(chainId: number): `0x${string}` {
+  const addr = COALITION_ADDRESSES[chainId];
+  if (!addr) {
+    const supported = SUPPORTED_CHAIN_IDS.join(", ");
+    throw new Error(
+      `Coalition contract is not deployed on chain ${chainId}. Supported chains: ${supported}.`
+    );
+  }
+  return addr;
+}
+
+// One Interface instance for revert decoding across all coalition steps.
+export const coalitionInterface = new ethers.Interface(
+  COALITION_ABI as unknown as ethers.InterfaceAbi
+);
+
+/**
+ * Parse a single event from a transaction receipt's logs.
+ * Returns the event args (typed via ethers.Result) or null if not found.
+ */
+export function parseCoalitionEvent(
+  logs: readonly ethers.Log[],
+  eventName: string
+): ethers.Result | null {
+  for (const log of logs) {
+    try {
+      const parsed = coalitionInterface.parseLog({
+        topics: [...log.topics],
+        data: log.data,
+      });
+      if (parsed?.name === eventName) {
+        return parsed.args;
+      }
+    } catch {
+      // Not a coalition log; skip
+    }
+  }
+  return null;
+}

--- a/plugins/coalition/steps/coalition-core.ts
+++ b/plugins/coalition/steps/coalition-core.ts
@@ -36,12 +36,20 @@ export const coalitionInterface = new ethers.Interface(
   COALITION_ABI as unknown as ethers.InterfaceAbi
 );
 
+type MinimalLog = {
+  topics: readonly string[];
+  data: string;
+};
+
 /**
  * Parse a single event from a transaction receipt's logs.
+ * Accepts the minimal log shape (topics + data) so it works with both
+ * full ethers.Log objects and the stripped ReceiptWithLogs type used in
+ * propose-core and other write steps.
  * Returns the event args (typed via ethers.Result) or null if not found.
  */
 export function parseCoalitionEvent(
-  logs: readonly ethers.Log[],
+  logs: readonly MinimalLog[],
   eventName: string
 ): ethers.Result | null {
   for (const log of logs) {

--- a/plugins/coalition/steps/dissolve-core.ts
+++ b/plugins/coalition/steps/dissolve-core.ts
@@ -1,0 +1,191 @@
+import "server-only";
+
+import type { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import { coalitionInterface, getCoalitionAddress } from "./coalition-core";
+
+export type DissolveCoreInput = {
+  network: string;
+  coalitionId: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type DissolveResult =
+  | { success: true; transactionHash: string; transactionLink: string }
+  | { success: false; error: string };
+
+type RawCoalitionForDissolve = {
+  state: number | bigint;
+};
+
+export async function dissolveCore(
+  input: DissolveCoreInput
+): Promise<DissolveResult> {
+  const { network, coalitionId, gasLimitMultiplier, _context } = input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition dissolve]",
+    "dissolve"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  let coalition: RawCoalitionForDissolve;
+  try {
+    coalition = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalitionForDissolve;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition dissolve] Failed to read coalition state",
+      error,
+      { plugin_name: "coalition", action_name: "dissolve" }
+    );
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (Number(coalition.state) !== 2) {
+    return { success: false, error: "Coalition is not active" };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(undefined);
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "dissolve",
+          args: [parsedId],
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      );
+
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition dissolve] Dissolve tx failed",
+        error,
+        { plugin_name: "coalition", action_name: "dissolve" }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/dissolve-core.ts
+++ b/plugins/coalition/steps/dissolve-core.ts
@@ -37,6 +37,7 @@ export type DissolveResult =
 
 type RawCoalitionForDissolve = {
   state: number | bigint;
+  participants: string[];
 };
 
 export async function dissolveCore(
@@ -121,6 +122,20 @@ export async function dissolveCore(
 
   if (Number(coalition.state) !== 2) {
     return { success: false, error: "Coalition is not active" };
+  }
+
+  // Pre-check participation client-side so the workflow doesn't pay gas for a
+  // tx that would revert with NotParticipant on-chain (dissolve is restricted
+  // to participants in Coalition.sol).
+  const callerLower = walletAddress.toLowerCase();
+  const isCallerParticipant = coalition.participants.some(
+    (p) => p.toLowerCase() === callerLower
+  );
+  if (!isCallerParticipant) {
+    return {
+      success: false,
+      error: "Caller is not a participant of this coalition",
+    };
   }
 
   const { multiplierOverride, gasLimitOverride } =

--- a/plugins/coalition/steps/dissolve.ts
+++ b/plugins/coalition/steps/dissolve.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type DissolveCoreInput,
+  type DissolveResult,
+  dissolveCore,
+} from "./dissolve-core";
+
+export type DissolveInput = StepInput & DissolveCoreInput;
+
+export async function dissolveStep(
+  input: DissolveInput
+): Promise<DissolveResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "dissolve",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => dissolveCore(input))
+  );
+}
+
+dissolveStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/expire-core.ts
+++ b/plugins/coalition/steps/expire-core.ts
@@ -1,0 +1,203 @@
+import "server-only";
+
+import type { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import { coalitionInterface, getCoalitionAddress } from "./coalition-core";
+
+export type ExpireCoreInput = {
+  network: string;
+  coalitionId: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type ExpireResult =
+  | { success: true; transactionHash: string; transactionLink: string }
+  | { success: false; error: string };
+
+type RawCoalitionForExpire = {
+  state: number | bigint;
+  deadline: bigint | string;
+};
+
+export async function expireCore(
+  input: ExpireCoreInput
+): Promise<ExpireResult> {
+  const { network, coalitionId, gasLimitMultiplier, _context } = input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition expire]",
+    "expire"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  let coalition: RawCoalitionForExpire;
+  try {
+    coalition = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalitionForExpire;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition expire] Failed to read coalition state",
+      error,
+      { plugin_name: "coalition", action_name: "expire" }
+    );
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (Number(coalition.state) !== 1) {
+    return {
+      success: false,
+      error: "Coalition is not in PROPOSED state",
+    };
+  }
+  const nowSec = BigInt(Math.floor(Date.now() / 1000));
+  const dl =
+    typeof coalition.deadline === "bigint"
+      ? coalition.deadline
+      : BigInt(coalition.deadline);
+  if (nowSec <= dl) {
+    return { success: false, error: "Deadline has not been reached yet" };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(undefined);
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "expire",
+          args: [parsedId],
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      );
+
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition expire] Expire tx failed",
+        error,
+        { plugin_name: "coalition", action_name: "expire" }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/expire.ts
+++ b/plugins/coalition/steps/expire.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type ExpireCoreInput,
+  type ExpireResult,
+  expireCore,
+} from "./expire-core";
+
+export type ExpireInput = StepInput & ExpireCoreInput;
+
+export async function expireStep(input: ExpireInput): Promise<ExpireResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "expire",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => expireCore(input))
+  );
+}
+
+expireStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/propose-core.ts
+++ b/plugins/coalition/steps/propose-core.ts
@@ -293,7 +293,7 @@ export async function proposeCore(
       try {
         fullReceipt = await rpcManager.executeWithFailover(
           (rpcProvider) => rpcProvider.getTransactionReceipt(receipt.hash),
-          "fetch-receipt-logs"
+          "read"
         );
       } catch (error) {
         logUserError(

--- a/plugins/coalition/steps/propose-core.ts
+++ b/plugins/coalition/steps/propose-core.ts
@@ -32,16 +32,11 @@ import {
 
 const HEX_32_BYTES = /^0x[a-fA-F0-9]{64}$/;
 
-// The platform's TransactionReceipt strips logs, but the EVM adapter's
-// underlying ethers receipt includes them. We extend the type locally so
-// parseCoalitionEvent can read the Proposed event without modifying the
-// shared platform type.
-type ReceiptWithLogs = {
+type StrippedReceipt = {
   hash: string;
   gasUsed: bigint;
   effectiveGasPrice: bigint;
   blockNumber: number;
-  logs: readonly { topics: readonly string[]; data: string }[];
 };
 
 export type ProposeCoreInput = {
@@ -290,9 +285,37 @@ export async function proposeCore(
           workflowId: undefined,
           rpcManager,
         }
-      )) as ReceiptWithLogs;
+      )) as StrippedReceipt;
 
-      const proposedArgs = parseCoalitionEvent(receipt.logs, "Proposed");
+      // The platform's TransactionReceipt strips logs (see lib/web3/chain-adapter/evm.ts).
+      // Refetch via the RPC manager to access the Proposed event.
+      let fullReceipt: ethers.TransactionReceipt | null = null;
+      try {
+        fullReceipt = await rpcManager.executeWithFailover(
+          (rpcProvider) => rpcProvider.getTransactionReceipt(receipt.hash),
+          "fetch-receipt-logs"
+        );
+      } catch (error) {
+        logUserError(
+          ErrorCategory.NETWORK_RPC,
+          "[Coalition propose] Failed to refetch receipt for event parsing",
+          error,
+          { plugin_name: "coalition", action_name: "propose" }
+        );
+        return {
+          success: false,
+          error: `Tx ${receipt.hash} confirmed but receipt could not be refetched: ${getErrorMessage(error)}`,
+        };
+      }
+
+      if (!fullReceipt) {
+        return {
+          success: false,
+          error: `Tx ${receipt.hash} confirmed but provider returned null receipt`,
+        };
+      }
+
+      const proposedArgs = parseCoalitionEvent(fullReceipt.logs, "Proposed");
       if (!proposedArgs) {
         return {
           success: false,

--- a/plugins/coalition/steps/propose-core.ts
+++ b/plugins/coalition/steps/propose-core.ts
@@ -1,0 +1,334 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
+import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import {
+  coalitionInterface,
+  getCoalitionAddress,
+  parseCoalitionEvent,
+} from "./coalition-core";
+
+const HEX_32_BYTES = /^0x[a-fA-F0-9]{64}$/;
+
+// The platform's TransactionReceipt strips logs, but the EVM adapter's
+// underlying ethers receipt includes them. We extend the type locally so
+// parseCoalitionEvent can read the Proposed event without modifying the
+// shared platform type.
+type ReceiptWithLogs = {
+  hash: string;
+  gasUsed: bigint;
+  effectiveGasPrice: bigint;
+  blockNumber: number;
+  logs: readonly { topics: readonly string[]; data: string }[];
+};
+
+export type ProposeCoreInput = {
+  network: string;
+  participants: string;
+  termsHash: string;
+  deadlineUnix: string;
+  stakeToken: string;
+  stakePerParty: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type ProposeResult =
+  | {
+      success: true;
+      coalitionId: string;
+      transactionHash: string;
+      transactionLink: string;
+      gasUsed: string;
+    }
+  | { success: false; error: string };
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: validation + tx flow follows write-contract-core pattern
+export async function proposeCore(
+  input: ProposeCoreInput
+): Promise<ProposeResult> {
+  const {
+    network,
+    participants,
+    termsHash,
+    deadlineUnix,
+    stakeToken,
+    stakePerParty,
+    gasLimitMultiplier,
+    _context,
+  } = input;
+
+  let parsedParticipants: string[];
+  try {
+    const raw = JSON.parse(participants);
+    if (!Array.isArray(raw)) {
+      throw new Error("must be a JSON array");
+    }
+    parsedParticipants = raw.map((p) => String(p));
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid participants list: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (parsedParticipants.length < 2 || parsedParticipants.length > 20) {
+    return {
+      success: false,
+      error: `Invalid participant count: must be between 2 and 20 (got ${parsedParticipants.length})`,
+    };
+  }
+  for (const addr of parsedParticipants) {
+    if (!ethers.isAddress(addr)) {
+      return { success: false, error: `Invalid participant address: ${addr}` };
+    }
+  }
+
+  if (!HEX_32_BYTES.test(termsHash)) {
+    return {
+      success: false,
+      error: "Invalid termsHash: must be 0x followed by 64 hex chars",
+    };
+  }
+
+  let deadlineBig: bigint;
+  try {
+    deadlineBig = BigInt(deadlineUnix);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid deadlineUnix: ${getErrorMessage(error)}`,
+    };
+  }
+  const nowSec = BigInt(Math.floor(Date.now() / 1000));
+  if (deadlineBig <= nowSec) {
+    return { success: false, error: "deadlineUnix must be in the future" };
+  }
+
+  if (!ethers.isAddress(stakeToken)) {
+    return {
+      success: false,
+      error: `Invalid stakeToken address: ${stakeToken}`,
+    };
+  }
+
+  let stakeBig: bigint;
+  try {
+    stakeBig = BigInt(stakePerParty);
+    if (stakeBig <= BigInt(0)) {
+      throw new Error("must be greater than zero");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid stakePerParty: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition propose]",
+    "propose"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Coalition propose] Chain/address resolution failed",
+      error,
+      { plugin_name: "coalition", action_name: "propose" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition propose] RPC resolution failed",
+      error,
+      { plugin_name: "coalition", action_name: "propose" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(undefined);
+
+  const args = [
+    parsedParticipants,
+    termsHash,
+    deadlineBig,
+    stakeToken,
+    stakeBig,
+  ];
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  if (isGasSponsorshipEnabled()) {
+    try {
+      const sponsored = await executeSponsoredContractTransaction({
+        organizationId,
+        executionId: _context?.executionId ?? "direct-execution",
+        chainId,
+        rpcUrl,
+        walletAddress,
+        to: coalitionAddress,
+        // biome-ignore lint/suspicious/noExplicitAny: typed ABI accepted by helper as InterfaceAbi
+        abi: COALITION_ABI as any,
+        functionName: "propose",
+        args,
+        value: undefined,
+      });
+
+      if (sponsored !== null) {
+        const adapter = getChainAdapter(chainId);
+        const transactionLink = await adapter.getTransactionUrl(
+          sponsored.transactionHash
+        );
+        return {
+          success: true,
+          coalitionId: "",
+          transactionHash: sponsored.transactionHash,
+          transactionLink,
+          gasUsed: sponsored.gasUsed,
+        };
+      }
+    } catch (error) {
+      logUserError(
+        ErrorCategory.TRANSACTION,
+        "[Coalition propose] Sponsorship failed, falling back to direct signing",
+        error,
+        { plugin_name: "coalition", action_name: "propose" }
+      );
+    }
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const receipt = (await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "propose",
+          args,
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      )) as ReceiptWithLogs;
+
+      const proposedArgs = parseCoalitionEvent(receipt.logs, "Proposed");
+      if (!proposedArgs) {
+        return {
+          success: false,
+          error:
+            "Coalition.propose tx confirmed but Proposed event was not emitted; investigate via the tx hash",
+        };
+      }
+
+      const coalitionId = String(proposedArgs.id ?? proposedArgs[0]);
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+      const gasCostWei = (
+        receipt.gasUsed * receipt.effectiveGasPrice
+      ).toString();
+
+      return {
+        success: true,
+        coalitionId,
+        transactionHash: receipt.hash,
+        transactionLink,
+        gasUsed: gasCostWei,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition propose] executeContractCall failed",
+        error,
+        {
+          plugin_name: "coalition",
+          action_name: "propose",
+          chain_id: String(chainId),
+        }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/propose.ts
+++ b/plugins/coalition/steps/propose.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type ProposeCoreInput,
+  type ProposeResult,
+  proposeCore,
+} from "./propose-core";
+
+export type ProposeInput = StepInput & ProposeCoreInput;
+
+export async function proposeStep(
+  input: ProposeInput
+): Promise<ProposeResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "propose",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => proposeCore(input))
+  );
+}
+
+proposeStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/sign-core.ts
+++ b/plugins/coalition/steps/sign-core.ts
@@ -1,0 +1,315 @@
+import "server-only";
+
+import type { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import { coalitionInterface, getCoalitionAddress } from "./coalition-core";
+
+const ERC20_ABI = [
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+export type SignCoreInput = {
+  network: string;
+  coalitionId: string;
+  skipApproval?: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type SignResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      approvalTransactionHash?: string;
+      wasAlreadySigned: boolean;
+    }
+  | { success: false; error: string };
+
+type RawCoalitionForSign = {
+  stakeToken: string;
+  stakePerParty: bigint | string;
+  state: number | bigint;
+  participants: string[];
+};
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: state pre-check + conditional approve + sign
+export async function signCore(input: SignCoreInput): Promise<SignResult> {
+  const { network, coalitionId, skipApproval, gasLimitMultiplier, _context } =
+    input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition sign]",
+    "sign"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  let coalition: RawCoalitionForSign;
+  try {
+    coalition = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalitionForSign;
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Coalition sign] Failed to read coalition state",
+      error,
+      { plugin_name: "coalition", action_name: "sign" }
+    );
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (Number(coalition.state) !== 1) {
+    return {
+      success: false,
+      error: `Coalition is not in PROPOSED state (current state code: ${Number(coalition.state)})`,
+    };
+  }
+
+  let alreadySigned: boolean;
+  try {
+    alreadySigned = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "isSigned",
+      args: [parsedId, walletAddress],
+      isView: true,
+    })) as boolean;
+  } catch (error) {
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (alreadySigned) {
+    return {
+      success: true,
+      transactionHash: "",
+      transactionLink: "",
+      wasAlreadySigned: true,
+    };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(undefined);
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  const stakeBig =
+    typeof coalition.stakePerParty === "bigint"
+      ? coalition.stakePerParty
+      : BigInt(coalition.stakePerParty);
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    let approvalHash: string | undefined;
+    if (skipApproval !== "yes") {
+      let allowance: bigint;
+      try {
+        allowance = (await adapter.readContract(rpcManager, {
+          contractAddress: coalition.stakeToken,
+          abi: ERC20_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "allowance",
+          args: [walletAddress, coalitionAddress],
+          isView: true,
+        })) as bigint;
+      } catch (error) {
+        return {
+          success: false,
+          error: `Failed to check allowance: ${getErrorMessage(error)}`,
+        };
+      }
+
+      if (allowance < stakeBig) {
+        try {
+          const approveReceipt = await adapter.executeContractCall(
+            signer,
+            {
+              contractAddress: coalition.stakeToken,
+              abi: ERC20_ABI as unknown as ethers.InterfaceAbi,
+              functionKey: "approve",
+              args: [coalitionAddress, stakeBig],
+              value: undefined,
+            },
+            session,
+            {
+              gasOverrides: {
+                multiplierOverride,
+                gasLimitOverride,
+                priorityFeeOverride,
+              },
+              workflowId: undefined,
+              rpcManager,
+            }
+          );
+          approvalHash = approveReceipt.hash;
+        } catch (error) {
+          logUserError(
+            ErrorCategory.NETWORK_RPC,
+            "[Coalition sign] Approval tx failed",
+            error,
+            { plugin_name: "coalition", action_name: "sign" }
+          );
+          return {
+            success: false,
+            error: `Approval failed: ${formatContractError(error, coalitionInterface)}`,
+          };
+        }
+      }
+    }
+
+    try {
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "sign",
+          args: [parsedId],
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      );
+
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+        approvalTransactionHash: approvalHash,
+        wasAlreadySigned: false,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition sign] Sign tx failed",
+        error,
+        { plugin_name: "coalition", action_name: "sign" }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/sign.ts
+++ b/plugins/coalition/steps/sign.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import { type SignCoreInput, type SignResult, signCore } from "./sign-core";
+
+export type SignInput = StepInput & SignCoreInput;
+
+export async function signStep(input: SignInput): Promise<SignResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "sign",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => signCore(input))
+  );
+}
+
+signStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/steps/slash-core.ts
+++ b/plugins/coalition/steps/slash-core.ts
@@ -1,0 +1,345 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/para/wallet-helpers";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { generateId } from "@/lib/utils/id";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  parsePriorityFeeGwei,
+  resolveGasLimitOverrides,
+} from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
+import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import { COALITION_ABI } from "../contracts/coalition-abi";
+import {
+  coalitionInterface,
+  getCoalitionAddress,
+  parseCoalitionEvent,
+} from "./coalition-core";
+
+export type SlashCoreInput = {
+  network: string;
+  coalitionId: string;
+  party: string;
+  usePrivateMempool?: string;
+  strict?: string;
+  priorityFeeGwei?: string;
+  gasLimitMultiplier?: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type SlashResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      amountRedistributed: string;
+      party: string;
+    }
+  | { success: false; error: string };
+
+type RawCoalitionForSlash = {
+  state: number | bigint;
+  participants: string[];
+};
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: validation + reliability config + sponsorship + direct path + receipt refetch
+export async function slashCore(input: SlashCoreInput): Promise<SlashResult> {
+  const {
+    network,
+    coalitionId,
+    party,
+    usePrivateMempool: usePrivateMempoolStr,
+    strict: strictStr,
+    priorityFeeGwei,
+    gasLimitMultiplier,
+    _context,
+  } = input;
+
+  let parsedId: bigint;
+  try {
+    parsedId = BigInt(coalitionId);
+    if (parsedId <= BigInt(0)) {
+      throw new Error("coalitionId must be positive");
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Invalid coalitionId: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (!ethers.isAddress(party)) {
+    return { success: false, error: `Invalid party address: ${party}` };
+  }
+
+  const usePrivateMempool = usePrivateMempoolStr === "yes";
+  const strictBool = strictStr === "yes";
+
+  const orgCtx = await resolveOrganizationContext(
+    _context ?? {},
+    "[Coalition slash]",
+    "slash"
+  );
+  if (!orgCtx.success) {
+    return { success: false, error: orgCtx.error };
+  }
+  const { organizationId, userId } = orgCtx;
+
+  let chainId: number;
+  let coalitionAddress: `0x${string}`;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    coalitionAddress = getCoalitionAddress(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  let rpcUrl: string;
+  try {
+    rpcManager = await getRpcProvider({
+      chainId,
+      userId,
+      usePrivateMempool,
+      strict: strictBool,
+    });
+    rpcUrl = await rpcManager.resolveActiveRpcUrl();
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get wallet address: ${getErrorMessage(error)}`,
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  let coalition: RawCoalitionForSlash;
+  try {
+    coalition = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "getCoalition",
+      args: [parsedId],
+      isView: true,
+    })) as RawCoalitionForSlash;
+  } catch (error) {
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (Number(coalition.state) !== 2) {
+    return { success: false, error: "Coalition is not active" };
+  }
+
+  let breached: boolean;
+  try {
+    breached = (await adapter.readContract(rpcManager, {
+      contractAddress: coalitionAddress,
+      abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+      functionKey: "isBreached",
+      args: [parsedId, party],
+      isView: true,
+    })) as boolean;
+  } catch (error) {
+    return {
+      success: false,
+      error: formatContractError(error, coalitionInterface),
+    };
+  }
+
+  if (!breached) {
+    return { success: false, error: "Party has not been marked breached" };
+  }
+
+  const { multiplierOverride, gasLimitOverride } =
+    resolveGasLimitOverrides(gasLimitMultiplier);
+  const priorityFeeOverride = parsePriorityFeeGwei(priorityFeeGwei);
+
+  const args = [parsedId, party];
+
+  const txContext: TransactionContext = {
+    organizationId,
+    executionId: _context?.executionId ?? `direct-${generateId()}`,
+    workflowId: undefined,
+    chainId,
+    rpcUrl,
+    rpcManager,
+  };
+
+  if (!usePrivateMempool && isGasSponsorshipEnabled()) {
+    try {
+      const sponsored = await executeSponsoredContractTransaction({
+        organizationId,
+        executionId: _context?.executionId ?? "direct-execution",
+        chainId,
+        rpcUrl,
+        walletAddress,
+        to: coalitionAddress,
+        // biome-ignore lint/suspicious/noExplicitAny: typed ABI accepted by helper as InterfaceAbi
+        abi: COALITION_ABI as any,
+        functionName: "slash",
+        args,
+        value: undefined,
+      });
+
+      if (sponsored !== null) {
+        const transactionLink = await adapter.getTransactionUrl(
+          sponsored.transactionHash
+        );
+
+        let fullReceipt: ethers.TransactionReceipt | null = null;
+        try {
+          fullReceipt = await rpcManager.executeWithFailover(
+            (rpcProvider) =>
+              rpcProvider.getTransactionReceipt(sponsored.transactionHash),
+            "read"
+          );
+        } catch {
+          // Refetch failed; surface tx but with empty amountRedistributed
+        }
+
+        const slashedArgs = fullReceipt
+          ? parseCoalitionEvent(fullReceipt.logs, "Slashed")
+          : null;
+        const amountRedistributed = slashedArgs
+          ? String(slashedArgs.amountRedistributed ?? slashedArgs[2])
+          : "0";
+
+        return {
+          success: true,
+          transactionHash: sponsored.transactionHash,
+          transactionLink,
+          amountRedistributed,
+          party,
+        };
+      }
+    } catch (error) {
+      logUserError(
+        ErrorCategory.TRANSACTION,
+        "[Coalition slash] Sponsorship failed, falling back to direct signing",
+        error,
+        { plugin_name: "coalition", action_name: "slash" }
+      );
+    }
+  }
+
+  return withNonceSession(txContext, walletAddress, async (session) => {
+    let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+    try {
+      signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to initialize wallet: ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: coalitionAddress,
+          abi: COALITION_ABI as unknown as ethers.InterfaceAbi,
+          functionKey: "slash",
+          args,
+          value: undefined,
+        },
+        session,
+        {
+          gasOverrides: {
+            multiplierOverride,
+            gasLimitOverride,
+            priorityFeeOverride,
+          },
+          workflowId: undefined,
+          rpcManager,
+        }
+      );
+
+      let fullReceipt: ethers.TransactionReceipt | null = null;
+      try {
+        fullReceipt = await rpcManager.executeWithFailover(
+          (rpcProvider) => rpcProvider.getTransactionReceipt(receipt.hash),
+          "read"
+        );
+      } catch (error) {
+        logUserError(
+          ErrorCategory.NETWORK_RPC,
+          "[Coalition slash] Failed to refetch receipt for event parsing",
+          error,
+          { plugin_name: "coalition", action_name: "slash" }
+        );
+        return {
+          success: false,
+          error: `Tx ${receipt.hash} confirmed but receipt could not be refetched: ${getErrorMessage(error)}`,
+        };
+      }
+
+      if (!fullReceipt) {
+        return {
+          success: false,
+          error: `Tx ${receipt.hash} confirmed but provider returned null receipt`,
+        };
+      }
+
+      const slashedArgs = parseCoalitionEvent(fullReceipt.logs, "Slashed");
+      if (!slashedArgs) {
+        return {
+          success: false,
+          error: "Slash tx confirmed but Slashed event not emitted",
+        };
+      }
+
+      const amountRedistributed = String(
+        slashedArgs.amountRedistributed ?? slashedArgs[2]
+      );
+      const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+
+      return {
+        success: true,
+        transactionHash: receipt.hash,
+        transactionLink,
+        amountRedistributed,
+        party,
+      };
+    } catch (error) {
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        "[Coalition slash] executeContractCall failed",
+        error,
+        {
+          plugin_name: "coalition",
+          action_name: "slash",
+          chain_id: String(chainId),
+        }
+      );
+      return {
+        success: false,
+        error: formatContractError(error, coalitionInterface),
+      };
+    }
+  });
+}

--- a/plugins/coalition/steps/slash.ts
+++ b/plugins/coalition/steps/slash.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import { type SlashCoreInput, type SlashResult, slashCore } from "./slash-core";
+
+export type SlashInput = StepInput & SlashCoreInput;
+
+export async function slashStep(input: SlashInput): Promise<SlashResult> {
+  "use step";
+  return withPluginMetrics(
+    {
+      pluginName: "coalition",
+      actionName: "slash",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => slashCore(input))
+  );
+}
+
+slashStep.maxRetries = 0;
+
+export const _integrationType = "coalition";

--- a/plugins/coalition/test.ts
+++ b/plugins/coalition/test.ts
@@ -1,0 +1,5 @@
+export function testCoalition(
+  _credentials: Record<string, string>
+): Promise<{ success: boolean; error?: string }> {
+  return Promise.resolve({ success: true });
+}

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -13,9 +13,10 @@
  * 1. Delete the plugin directory
  * 2. Run: pnpm discover-plugins (or it runs automatically on build)
  *
- * Discovered plugins: code, discord, math, protocol, safe, sendgrid, slack, telegram, web3, webhook
+ * Discovered plugins: coalition, code, discord, math, protocol, safe, sendgrid, slack, telegram, web3, webhook
  */
 
+import "./coalition";
 import "./code";
 import "./discord";
 import "./math";

--- a/plugins/plugin-allowlist.json
+++ b/plugins/plugin-allowlist.json
@@ -3,6 +3,7 @@
   "description": "Plugin allowlist - only plugins listed here will be enabled",
   "plugins": [
     "code",
+    "coalition",
     "discord",
     "math",
     "protocol",

--- a/scripts/coalition-e2e.mjs
+++ b/scripts/coalition-e2e.mjs
@@ -1,0 +1,472 @@
+/**
+ * Comprehensive end-to-end test against a live Base Sepolia deployment.
+ *
+ * What it does:
+ *   1. Deploys TestToken (ERC-20 stake) and Coalition.sol from the deployer wallet.
+ *   2. Generates 2 ephemeral participant wallets (in addition to the deployer).
+ *   3. Funds each participant with native gas + 100 STAKE each from the deployer.
+ *   4. Runs the full happy-path lifecycle:
+ *        propose -> sign x3 -> activate -> recordBreach(B) -> slash(B) -> dissolve
+ *   5. Asserts on every transition: events, balances, state.
+ *   6. Runs revert checks: idempotent sign, AlreadySigned replay, non-participant
+ *      breach, slash on non-breached party, dissolve by non-participant.
+ *   7. Persists the deployed Coalition address into
+ *      plugins/coalition/contracts/addresses.ts.
+ *
+ * No mocks. Every call hits Base Sepolia.
+ *
+ * Required env:
+ *   COALITION_DEPLOYER_PK   Hex private key with Base Sepolia ETH
+ *   RPC_URL                 (optional) JSON-RPC URL; defaults to https://sepolia.base.org
+ *
+ * Run:
+ *   node scripts/coalition-e2e.mjs
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { ethers } from "../node_modules/ethers/lib.esm/index.js";
+
+// Default to publicnode (multi-region) which is more consistent than the
+// public sepolia.base.org load balancer.
+const RPC = process.env.RPC_URL || "https://base-sepolia.publicnode.com";
+const PK = process.env.COALITION_DEPLOYER_PK;
+if (!PK) {
+  console.error("Missing COALITION_DEPLOYER_PK env var.");
+  process.exit(1);
+}
+
+const ADDRESSES_PATH =
+  "/home/philix/Documents/GitHub/keeperhub/.worktrees/coalition-plugin/plugins/coalition/contracts/addresses.ts";
+const COALITION_BIN_PATH = "/tmp/coalition-build/Coalition_sol_Coalition.bin";
+const COALITION_ABI_PATH = "/tmp/coalition-build/Coalition_sol_Coalition.abi";
+const TT_BIN_PATH = "/tmp/coalition-build/TestToken_sol_TestToken.bin";
+const TT_ABI_PATH = "/tmp/coalition-build/TestToken_sol_TestToken.abi";
+
+// ---- Load ABI + bytecode (use solc JSON output, not the TS const) ----
+const COALITION_ABI = JSON.parse(readFileSync(COALITION_ABI_PATH, "utf8"));
+
+const COALITION_BYTECODE = `0x${readFileSync(COALITION_BIN_PATH, "utf8").trim()}`;
+const TT_BYTECODE = `0x${readFileSync(TT_BIN_PATH, "utf8").trim()}`;
+const TT_ABI = JSON.parse(readFileSync(TT_ABI_PATH, "utf8"));
+
+const provider = new ethers.JsonRpcProvider(RPC);
+const deployer = new ethers.Wallet(PK, provider);
+
+// ---- Helpers ----
+const log = (msg) => console.log(msg);
+const heading = (msg) =>
+  console.log(`\n\x1b[1m=== ${msg} ===\x1b[0m`);
+const assertEq = (label, actual, expected) => {
+  const a = String(actual);
+  const e = String(expected);
+  if (a !== e) {
+    throw new Error(`ASSERT ${label}: got ${a} expected ${e}`);
+  }
+  log(`  OK  ${label}: ${a}`);
+};
+// Some RPC nodes serve stale reads after a tx. Retry the read a few times
+// before declaring the assertion failed.
+const readWithRetry = async (label, readFn, expected, attempts = 8) => {
+  let last;
+  for (let i = 0; i < attempts; i++) {
+    last = await readFn();
+    if (String(last) === String(expected)) {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, 750));
+  }
+  throw new Error(
+    `ASSERT ${label} after ${attempts} retries: got ${String(last)} expected ${String(expected)}`
+  );
+};
+const assertRevert = async (label, promise, matcher) => {
+  try {
+    await promise;
+    throw new Error(`ASSERT ${label}: expected revert, succeeded instead`);
+  } catch (err) {
+    const msg = err?.shortMessage || err?.reason || err?.message || String(err);
+    if (matcher && !matcher.test(msg)) {
+      throw new Error(`ASSERT ${label}: revert reason mismatch: ${msg}`);
+    }
+    log(`  OK  ${label} reverted (${matcher?.source ?? "any"})`);
+  }
+};
+
+async function main() {
+  const net = await provider.getNetwork();
+  const chainId = Number(net.chainId);
+  if (chainId !== 84532) {
+    throw new Error(`Expected Base Sepolia (84532), got ${chainId}`);
+  }
+  heading(`Connected to Base Sepolia, deployer=${deployer.address}`);
+  const startBal = await provider.getBalance(deployer.address);
+  log(`Deployer balance: ${ethers.formatEther(startBal)} ETH`);
+
+  // ---- 1. Deploy TestToken ----
+  heading("1. Deploy TestToken");
+  const ttFactory = new ethers.ContractFactory(TT_ABI, TT_BYTECODE, deployer);
+  const tt = await ttFactory.deploy();
+  const ttDeployTx = tt.deploymentTransaction();
+  log(`  deploy tx: ${ttDeployTx?.hash}`);
+  await tt.waitForDeployment();
+  const ttAddr = await tt.getAddress();
+  log(`  TestToken: ${ttAddr}`);
+
+  // ---- 2. Deploy Coalition ----
+  heading("2. Deploy Coalition");
+  const coalitionFactory = new ethers.ContractFactory(
+    COALITION_ABI,
+    COALITION_BYTECODE,
+    deployer
+  );
+  const coalition = await coalitionFactory.deploy();
+  const cDeployTx = coalition.deploymentTransaction();
+  log(`  deploy tx: ${cDeployTx?.hash}`);
+  await coalition.waitForDeployment();
+  const coalitionAddr = await coalition.getAddress();
+  log(`  Coalition: ${coalitionAddr}`);
+
+  // Persist address to addresses.ts so the plugin can reference it.
+  const addressesContent = readFileSync(ADDRESSES_PATH, "utf8");
+  const updated = addressesContent.replace(
+    /export const COALITION_ADDRESSES: Record<number, `0x\$\{string\}`> = \{[^}]*\};/,
+    `export const COALITION_ADDRESSES: Record<number, \`0x\${string}\`> = {\n  84532: "${coalitionAddr}", // Base Sepolia\n};`
+  );
+  writeFileSync(ADDRESSES_PATH, updated, "utf8");
+  log(`  Wrote addresses.ts: 84532 -> ${coalitionAddr}`);
+
+  // ---- 3. Generate participants ----
+  heading("3. Generate ephemeral participants B and C");
+  const partyA = deployer; // deployer is also participant A
+  const partyB = ethers.Wallet.createRandom().connect(provider);
+  const partyC = ethers.Wallet.createRandom().connect(provider);
+  log(`  A (deployer): ${partyA.address}`);
+  log(`  B:            ${partyB.address}`);
+  log(`  C:            ${partyC.address}`);
+
+  // ---- 4. Fund participants ----
+  heading("4. Fund participants (gas + 100 stake each)");
+  const STAKE_PER_PARTY = ethers.parseUnits("10", 18); // 10 STAKE per coalition signing
+  const ETH_FOR_GAS = ethers.parseEther("0.01"); // 0.01 ETH each for gas
+  const STAKE_MINT = ethers.parseUnits("100", 18); // 100 STAKE per participant
+
+  const fundB1 = await partyA.sendTransaction({
+    to: partyB.address,
+    value: ETH_FOR_GAS,
+  });
+  log(`  -> B gas tx: ${fundB1.hash}`);
+  await fundB1.wait();
+  const fundC1 = await partyA.sendTransaction({
+    to: partyC.address,
+    value: ETH_FOR_GAS,
+  });
+  log(`  -> C gas tx: ${fundC1.hash}`);
+  await fundC1.wait();
+
+  const ttA = new ethers.Contract(ttAddr, TT_ABI, partyA);
+  const mintATx = await ttA.mint(partyA.address, STAKE_MINT);
+  log(`  -> mint A tx: ${mintATx.hash}`);
+  await mintATx.wait();
+  const mintBTx = await ttA.mint(partyB.address, STAKE_MINT);
+  log(`  -> mint B tx: ${mintBTx.hash}`);
+  await mintBTx.wait();
+  const mintCTx = await ttA.mint(partyC.address, STAKE_MINT);
+  log(`  -> mint C tx: ${mintCTx.hash}`);
+  // Confirm with extra safety: getTransactionReceipt on the same provider.
+  await mintCTx.wait(1);
+  // Belt-and-suspenders: re-poll until the receipt is canonical.
+  for (let i = 0; i < 5; i++) {
+    const r = await provider.getTransactionReceipt(mintCTx.hash);
+    if (r && r.status === 1) {
+      break;
+    }
+    await new Promise((r2) => setTimeout(r2, 1000));
+  }
+  assertEq("A balance after mint", await ttA.balanceOf(partyA.address), STAKE_MINT);
+  assertEq("B balance after mint", await ttA.balanceOf(partyB.address), STAKE_MINT);
+  assertEq("C balance after mint", await ttA.balanceOf(partyC.address), STAKE_MINT);
+
+  // ---- 5. Propose ----
+  heading("5. Propose coalition (deadline = +1 hour)");
+  const cA = new ethers.Contract(coalitionAddr, COALITION_ABI, partyA);
+  const cB = new ethers.Contract(coalitionAddr, COALITION_ABI, partyB);
+  const cC = new ethers.Contract(coalitionAddr, COALITION_ABI, partyC);
+
+  const termsHash = ethers.keccak256(ethers.toUtf8Bytes("E2E Coalition Terms"));
+  const deadline = Math.floor(Date.now() / 1000) + 3600;
+  const proposeTx = await cA.propose(
+    [partyA.address, partyB.address, partyC.address],
+    termsHash,
+    deadline,
+    ttAddr,
+    STAKE_PER_PARTY
+  );
+  log(`  propose tx: ${proposeTx.hash}`);
+  const proposeReceipt = await proposeTx.wait();
+  // Parse the Proposed event to get coalitionId
+  const iface = new ethers.Interface(COALITION_ABI);
+  let coalitionId;
+  for (const log_ of proposeReceipt.logs) {
+    try {
+      const parsed = iface.parseLog({ topics: [...log_.topics], data: log_.data });
+      if (parsed?.name === "Proposed") {
+        coalitionId = parsed.args.id;
+      }
+    } catch {
+      /* not a coalition event */
+    }
+  }
+  if (coalitionId === undefined) {
+    throw new Error("Proposed event not found in receipt");
+  }
+  assertEq("coalitionId", coalitionId, 1n);
+
+  // Read state (retry tolerant — public RPC nodes have eventual consistency)
+  await readWithRetry(
+    "state after propose (PROPOSED=1)",
+    async () => (await cA.getCoalition(coalitionId)).state,
+    1
+  );
+  const stateAfterPropose = await cA.getCoalition(coalitionId);
+  assertEq("participants count", stateAfterPropose.participants.length, 3);
+  assertEq("signedCount", stateAfterPropose.signedCount, 0);
+
+  // ---- 6. Revert checks on propose ----
+  heading("6. Revert checks on propose");
+  await assertRevert(
+    "  propose with 1 participant",
+    cA.propose([partyA.address], termsHash, deadline, ttAddr, STAKE_PER_PARTY),
+    /InvalidParticipantCount|execution reverted/
+  );
+  await assertRevert(
+    "  propose with past deadline",
+    cA.propose(
+      [partyA.address, partyB.address],
+      termsHash,
+      Math.floor(Date.now() / 1000) - 100,
+      ttAddr,
+      STAKE_PER_PARTY
+    ),
+    /DeadlineInPast|execution reverted/
+  );
+  await assertRevert(
+    "  propose with zero stake",
+    cA.propose(
+      [partyA.address, partyB.address],
+      termsHash,
+      deadline,
+      ttAddr,
+      0
+    ),
+    /ZeroStake|execution reverted/
+  );
+
+  // ---- 7. Sign x3 with allowance ----
+  heading("7. Sign x3 (each party approves + signs)");
+  for (const [label, party, c] of [
+    ["A", partyA, cA],
+    ["B", partyB, cB],
+    ["C", partyC, cC],
+  ]) {
+    const tt_ = new ethers.Contract(ttAddr, TT_ABI, party);
+    const apTx = await tt_.approve(coalitionAddr, STAKE_PER_PARTY);
+    await apTx.wait();
+    const signTx = await c.sign(coalitionId);
+    log(`  ${label} sign tx: ${signTx.hash}`);
+    await signTx.wait();
+    await readWithRetry(
+      `  isSigned[${label}]`,
+      async () => await c.isSigned(coalitionId, party.address),
+      true
+    );
+  }
+
+  await readWithRetry(
+    "signedCount after all signs",
+    async () => (await cA.getCoalition(coalitionId)).signedCount,
+    3
+  );
+
+  // Idempotency / replay: signing again must revert
+  await assertRevert(
+    "  sign(A) twice -> AlreadySigned",
+    cA.sign(coalitionId),
+    /AlreadySigned|execution reverted/
+  );
+
+  // Non-participant cannot sign
+  const stranger = ethers.Wallet.createRandom().connect(provider);
+  // Fund stranger with enough gas for the call; sign will revert on NotParticipant first
+  await (
+    await partyA.sendTransaction({ to: stranger.address, value: ethers.parseEther("0.001") })
+  ).wait();
+  await (
+    await new ethers.Contract(ttAddr, TT_ABI, stranger).approve(
+      coalitionAddr,
+      STAKE_PER_PARTY
+    )
+  ).wait();
+  // Note: stranger has no STAKE tokens minted; the contract reverts on NotParticipant before transfer.
+  const cStranger = new ethers.Contract(coalitionAddr, COALITION_ABI, stranger);
+  await assertRevert(
+    "  stranger sign -> NotParticipant",
+    cStranger.sign(coalitionId),
+    /NotParticipant|execution reverted/
+  );
+
+  // ---- 8. Activate ----
+  heading("8. Activate");
+  const activateTx = await cA.activate(coalitionId);
+  log(`  activate tx: ${activateTx.hash}`);
+  await activateTx.wait();
+  await readWithRetry(
+    "state after activate (ACTIVE=2)",
+    async () => (await cA.getCoalition(coalitionId)).state,
+    2
+  );
+
+  await assertRevert(
+    "  activate twice -> CoalitionNotProposed",
+    cA.activate(coalitionId),
+    /CoalitionNotProposed|execution reverted/
+  );
+
+  // ---- 9. Breach pre-checks ----
+  heading("9. Breach pre-check reverts");
+  const evidenceHash = ethers.keccak256(ethers.toUtf8Bytes("E2E breach evidence"));
+  await assertRevert(
+    "  recordBreach for non-participant",
+    cA.recordBreach(coalitionId, stranger.address, evidenceHash),
+    /NotParticipant|execution reverted/
+  );
+
+  // ---- 10. Record breach on B ----
+  heading("10. Record breach on B");
+  const breachTx = await cA.recordBreach(coalitionId, partyB.address, evidenceHash);
+  log(`  breach tx: ${breachTx.hash}`);
+  await breachTx.wait();
+  await readWithRetry(
+    "isBreached[B]",
+    async () => await cA.isBreached(coalitionId, partyB.address),
+    true
+  );
+  await assertRevert(
+    "  recordBreach(B) twice -> PartyAlreadyBreached",
+    cA.recordBreach(coalitionId, partyB.address, evidenceHash),
+    /PartyAlreadyBreached|execution reverted/
+  );
+
+  // ---- 11. Slash pre-checks + execute ----
+  heading("11. Slash B");
+  await assertRevert(
+    "  slash(C) before breach -> PartyNotBreached",
+    cA.slash(coalitionId, partyC.address),
+    /PartyNotBreached|execution reverted/
+  );
+
+  const balsBefore = {
+    A: await tt.balanceOf(partyA.address),
+    B: await tt.balanceOf(partyB.address),
+    C: await tt.balanceOf(partyC.address),
+    contract: await tt.balanceOf(coalitionAddr),
+  };
+  log(
+    `  balances before slash: A=${ethers.formatUnits(balsBefore.A, 18)} B=${ethers.formatUnits(balsBefore.B, 18)} C=${ethers.formatUnits(balsBefore.C, 18)} contract=${ethers.formatUnits(balsBefore.contract, 18)}`
+  );
+
+  const slashTx = await cA.slash(coalitionId, partyB.address);
+  log(`  slash tx: ${slashTx.hash}`);
+  const slashReceipt = await slashTx.wait();
+  // Parse Slashed event for amountRedistributed
+  let amountRedistributed;
+  for (const log_ of slashReceipt.logs) {
+    try {
+      const parsed = iface.parseLog({ topics: [...log_.topics], data: log_.data });
+      if (parsed?.name === "Slashed") {
+        amountRedistributed = parsed.args.amountRedistributed;
+      }
+    } catch {
+      /* not a coalition event */
+    }
+  }
+  // STAKE_PER_PARTY = 10, recipients (A, C) = 2, share = 5, amountRedistributed = 5*2 = 10
+  assertEq("amountRedistributed", amountRedistributed, STAKE_PER_PARTY);
+  await readWithRetry(
+    "isSlashed[B]",
+    async () => await cA.isSlashed(coalitionId, partyB.address),
+    true
+  );
+
+  const balsAfterSlash = {
+    A: await tt.balanceOf(partyA.address),
+    B: await tt.balanceOf(partyB.address),
+    C: await tt.balanceOf(partyC.address),
+    contract: await tt.balanceOf(coalitionAddr),
+  };
+  log(
+    `  balances after slash:  A=${ethers.formatUnits(balsAfterSlash.A, 18)} B=${ethers.formatUnits(balsAfterSlash.B, 18)} C=${ethers.formatUnits(balsAfterSlash.C, 18)} contract=${ethers.formatUnits(balsAfterSlash.contract, 18)}`
+  );
+  // A and C each gain stake/2 = 5
+  const expectedShare = STAKE_PER_PARTY / 2n;
+  assertEq("A delta", balsAfterSlash.A - balsBefore.A, expectedShare);
+  assertEq("C delta", balsAfterSlash.C - balsBefore.C, expectedShare);
+  assertEq("B delta (no change)", balsAfterSlash.B - balsBefore.B, 0n);
+
+  await assertRevert(
+    "  slash(B) twice -> PartyAlreadySlashed",
+    cA.slash(coalitionId, partyB.address),
+    /PartyAlreadySlashed|execution reverted/
+  );
+
+  // ---- 12. Dissolve auth checks + execute ----
+  heading("12. Dissolve");
+  await assertRevert(
+    "  dissolve by stranger -> NotParticipant",
+    cStranger.dissolve(coalitionId),
+    /NotParticipant|execution reverted/
+  );
+
+  const dissolveTx = await cA.dissolve(coalitionId);
+  log(`  dissolve tx: ${dissolveTx.hash}`);
+  await dissolveTx.wait();
+  await readWithRetry(
+    "state after dissolve (DISSOLVED=3)",
+    async () => (await cA.getCoalition(coalitionId)).state,
+    3
+  );
+
+  const balsAfterDissolve = {
+    A: await tt.balanceOf(partyA.address),
+    B: await tt.balanceOf(partyB.address),
+    C: await tt.balanceOf(partyC.address),
+    contract: await tt.balanceOf(coalitionAddr),
+  };
+  log(
+    `  balances after dissolve: A=${ethers.formatUnits(balsAfterDissolve.A, 18)} B=${ethers.formatUnits(balsAfterDissolve.B, 18)} C=${ethers.formatUnits(balsAfterDissolve.C, 18)} contract=${ethers.formatUnits(balsAfterDissolve.contract, 18)}`
+  );
+  // A and C should each receive stakePerParty back
+  assertEq("A refund", balsAfterDissolve.A - balsAfterSlash.A, STAKE_PER_PARTY);
+  assertEq("C refund", balsAfterDissolve.C - balsAfterSlash.C, STAKE_PER_PARTY);
+  // B (slashed/breached) gets nothing
+  assertEq("B refund (none)", balsAfterDissolve.B - balsAfterSlash.B, 0n);
+  // Contract balance is 0 after dissolve (10 originally minted on B's stake fully redistributed in slash)
+  assertEq("Contract empty", balsAfterDissolve.contract, 0n);
+
+  // ---- 13. Final summary ----
+  heading("13. SUCCESS - all 30+ assertions passed");
+  log(`Coalition deployed at:    ${coalitionAddr}`);
+  log(`TestToken deployed at:    ${ttAddr}`);
+  log(`addresses.ts updated for chainId 84532.`);
+  log(`Basescan link:            https://sepolia.basescan.org/address/${coalitionAddr}`);
+  log(`Propose tx:               https://sepolia.basescan.org/tx/${proposeTx.hash}`);
+  log(`Slash tx:                 https://sepolia.basescan.org/tx/${slashTx.hash}`);
+  log(`Dissolve tx:              https://sepolia.basescan.org/tx/${dissolveTx.hash}`);
+
+  const endBal = await provider.getBalance(deployer.address);
+  log(`Deployer ETH spent:       ${ethers.formatEther(startBal - endBal)} ETH`);
+}
+
+main().catch((err) => {
+  console.error("\n\x1b[31mFAILED\x1b[0m");
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/deploy-coalition.ts
+++ b/scripts/deploy-coalition.ts
@@ -1,0 +1,100 @@
+/**
+ * Out-of-band deploy script for plugins/coalition/contracts/Coalition.sol.
+ *
+ * Usage:
+ *   pnpm tsx scripts/deploy-coalition.ts --network <base-sepolia|base>
+ *
+ * Required env:
+ *   COALITION_DEPLOYER_PK  Hex private key of a funded deployer wallet
+ *   RPC_URL                JSON-RPC URL for the target chain
+ *
+ * Workflow:
+ *   1. Compile Coalition.sol locally with solc (one-time):
+ *        npx solc --bin --abi --optimize --base-path . --include-path node_modules \
+ *          -o /tmp/coalition-out plugins/coalition/contracts/Coalition.sol
+ *      Paste the resulting `.bin` content into COALITION_BYTECODE below.
+ *   2. Run this script with the env vars set.
+ *   3. Paste the printed address into plugins/coalition/contracts/addresses.ts.
+ *   4. Verify on Basescan via the printed `forge verify-contract` command.
+ *
+ * This script is intentionally minimal and standalone: no Hardhat, no Foundry,
+ * no deployment manifest. CI does not run it. The contract is documentation-grade
+ * source verified on the block explorer post-deploy.
+ */
+import { ethers } from "ethers";
+
+// Pre-compiled bytecode for Coalition.sol (solc 0.8.24, optimizer 200 runs).
+// Regenerate via the solc command in the header above.
+const COALITION_BYTECODE = "0x";
+
+const COALITION_ABI_FOR_DEPLOY = ["constructor()"];
+
+function parseArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) {
+    return;
+  }
+  return process.argv[idx + 1];
+}
+
+async function main(): Promise<void> {
+  const network = parseArg("network");
+  if (!network) {
+    process.stderr.write(
+      "Usage: pnpm tsx scripts/deploy-coalition.ts --network <base-sepolia|base>\n"
+    );
+    process.exit(1);
+  }
+
+  const pk = process.env.COALITION_DEPLOYER_PK;
+  const rpcUrl = process.env.RPC_URL;
+  if (!(pk && rpcUrl)) {
+    process.stderr.write(
+      "Missing COALITION_DEPLOYER_PK or RPC_URL env vars.\n"
+    );
+    process.exit(1);
+  }
+
+  if (COALITION_BYTECODE === "0x") {
+    process.stderr.write(
+      "COALITION_BYTECODE is empty. Compile Coalition.sol with solc and paste the bin output into this script.\n"
+    );
+    process.exit(1);
+  }
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const deployer = new ethers.Wallet(pk, provider);
+  process.stdout.write(`Deploying from ${deployer.address} on ${network}...\n`);
+
+  const factory = new ethers.ContractFactory(
+    COALITION_ABI_FOR_DEPLOY,
+    COALITION_BYTECODE,
+    deployer
+  );
+  const contract = await factory.deploy();
+  await contract.waitForDeployment();
+  const address = await contract.getAddress();
+
+  const networkInfo = await provider.getNetwork();
+  const chainId = Number(networkInfo.chainId);
+  const deploymentTx = contract.deploymentTransaction()?.hash ?? "(unknown)";
+
+  process.stdout.write("\nDEPLOYED\n");
+  process.stdout.write(`  address:   ${address}\n`);
+  process.stdout.write(`  chainId:   ${chainId}\n`);
+  process.stdout.write(`  deployTx:  ${deploymentTx}\n`);
+  process.stdout.write("\nNext steps:\n");
+  process.stdout.write(
+    `  1. Paste into plugins/coalition/contracts/addresses.ts:\n`
+  );
+  process.stdout.write(`       ${chainId}: "${address}",\n`);
+  process.stdout.write("  2. Verify on the block explorer:\n");
+  process.stdout.write(
+    `       forge verify-contract ${address} plugins/coalition/contracts/Coalition.sol:Coalition --chain ${chainId} --watch\n`
+  );
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/tests/unit/coalition-activate.test.ts
+++ b/tests/unit/coalition-activate.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: {
+        getTransactionReceipt: (h: string) => Promise<unknown>;
+      }) => Promise<unknown>,
+      _label?: string
+    ) =>
+      fn({
+        getTransactionReceipt: async (_h: string) => null,
+      }),
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { activateCore } from "../../plugins/coalition/steps/activate-core";
+
+const SIGN_ERROR_RE = /sign/i;
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+});
+
+describe("coalition activate", () => {
+  it("idempotent: already ACTIVE returns alreadyActive=true without tx", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: 2,
+      participants: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+      ],
+      signedCount: BigInt(2),
+    });
+
+    const result = await activateCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.alreadyActive).toBe(true);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+
+  it("happy path: PROPOSED + all signed -> activates", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: 1,
+      participants: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+      ],
+      signedCount: BigInt(2),
+    });
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xactivate",
+      gasUsed: BigInt(30_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+      logs: [],
+    });
+
+    const result = await activateCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.alreadyActive).toBe(false);
+    expect(result.transactionHash).toBe("0xactivate");
+    expect(executeContractCallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("not yet ready: PROPOSED but signedCount < participants -> error", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: 1,
+      participants: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+      ],
+      signedCount: BigInt(2),
+    });
+
+    const result = await activateCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(SIGN_ERROR_RE);
+  });
+});

--- a/tests/unit/coalition-breach.test.ts
+++ b/tests/unit/coalition-breach.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: {
+        getTransactionReceipt: (h: string) => Promise<unknown>;
+      }) => Promise<unknown>,
+      _label?: string
+    ) =>
+      fn({
+        getTransactionReceipt: async (_h: string) => null,
+      }),
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { breachCore } from "../../plugins/coalition/steps/breach-core";
+
+const ACTIVE_RE = /active/i;
+const PARTICIPANT_RE = /participant/i;
+const ALREADY_BREACHED_RE = /already.*breached/i;
+
+const PARTY_A = "0x0000000000000000000000000000000000000001";
+const PARTY_B = "0x0000000000000000000000000000000000000002";
+const EVIDENCE_HASH =
+  "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+});
+
+describe("coalition breach", () => {
+  it("happy path: ACTIVE + participant + !breached -> records breach", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: BigInt(2),
+      participants: [PARTY_A, PARTY_B],
+      stakeToken: "0x0000000000000000000000000000000000000010",
+      stakePerParty: BigInt(1000),
+    });
+    readContractMock.mockResolvedValueOnce(false);
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xbreach",
+      gasUsed: BigInt(30_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+      logs: [],
+    });
+
+    const result = await breachCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      breachingParty: PARTY_A,
+      evidenceHash: EVIDENCE_HASH,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactionHash).toBe("0xbreach");
+    expect(executeContractCallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fast-fail when not ACTIVE", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: BigInt(1),
+      participants: [PARTY_A, PARTY_B],
+      stakeToken: "0x0000000000000000000000000000000000000010",
+      stakePerParty: BigInt(1000),
+    });
+
+    const result = await breachCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      breachingParty: PARTY_A,
+      evidenceHash: EVIDENCE_HASH,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(ACTIVE_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+
+  it("fast-fail on non-participant", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: BigInt(2),
+      participants: [PARTY_A, PARTY_B],
+      stakeToken: "0x0000000000000000000000000000000000000010",
+      stakePerParty: BigInt(1000),
+    });
+
+    const result = await breachCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      breachingParty: "0x0000000000000000000000000000000000000099",
+      evidenceHash: EVIDENCE_HASH,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(PARTICIPANT_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+
+  it("fast-fail when already breached", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: BigInt(2),
+      participants: [PARTY_A, PARTY_B],
+      stakeToken: "0x0000000000000000000000000000000000000010",
+      stakePerParty: BigInt(1000),
+    });
+    readContractMock.mockResolvedValueOnce(true);
+
+    const result = await breachCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      breachingParty: PARTY_A,
+      evidenceHash: EVIDENCE_HASH,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(ALREADY_BREACHED_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/coalition-check-status.test.ts
+++ b/tests/unit/coalition-check-status.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+  })),
+}));
+
+const readContractMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({ readContract: readContractMock }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+import { checkStatusStep } from "../../plugins/coalition/steps/check-status";
+
+const DOES_NOT_EXIST_RE = /does not exist/i;
+
+beforeEach(() => {
+  readContractMock.mockReset();
+});
+
+describe("coalition check-status", () => {
+  it("returns parsed status for an ACTIVE coalition with all signed", async () => {
+    readContractMock.mockResolvedValue({
+      termsHash: `0x${"ab".repeat(32)}`,
+      participants: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+      ],
+      stakeToken: "0x000000000000000000000000000000000000bbbb",
+      stakePerParty: "1000000000000000000",
+      deadline: "1800000000",
+      signedCount: 3,
+      breachedCount: 0,
+      slashedCount: 0,
+      state: 2,
+    });
+
+    const result = await checkStatusStep({
+      network: "base-sepolia",
+      coalitionId: "1",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.state).toBe("ACTIVE");
+    expect(result.signedCount).toBe(3);
+    expect(result.breachedCount).toBe(0);
+    expect(result.slashedCount).toBe(0);
+    expect(result.totalParticipants).toBe(3);
+    expect(result.ready).toBe(false);
+  });
+
+  it("flags ready=true when state is PROPOSED and all signed", async () => {
+    readContractMock.mockResolvedValue({
+      termsHash: `0x${"00".repeat(32)}`,
+      participants: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+      ],
+      stakeToken: "0x000000000000000000000000000000000000bbbb",
+      stakePerParty: "0",
+      deadline: "1800000000",
+      signedCount: 2,
+      breachedCount: 0,
+      slashedCount: 0,
+      state: 1,
+    });
+
+    const result = await checkStatusStep({
+      network: "base-sepolia",
+      coalitionId: "5",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.state).toBe("PROPOSED");
+    expect(result.ready).toBe(true);
+  });
+
+  it("returns error for missing coalition (state==NONE)", async () => {
+    readContractMock.mockResolvedValue({
+      termsHash: `0x${"00".repeat(32)}`,
+      participants: [],
+      stakeToken: "0x0000000000000000000000000000000000000000",
+      stakePerParty: "0",
+      deadline: "0",
+      signedCount: 0,
+      breachedCount: 0,
+      slashedCount: 0,
+      state: 0,
+    });
+
+    const result = await checkStatusStep({
+      network: "base-sepolia",
+      coalitionId: "999",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(DOES_NOT_EXIST_RE);
+  });
+
+  it("returns error on invalid coalitionId", async () => {
+    const result = await checkStatusStep({
+      network: "base-sepolia",
+      coalitionId: "not-a-number",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("returns error on unsupported chain", async () => {
+    const result = await checkStatusStep({
+      network: "polygon",
+      coalitionId: "1",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/coalition-dissolve.test.ts
+++ b/tests/unit/coalition-dissolve.test.ts
@@ -130,9 +130,17 @@ beforeEach(() => {
   executeContractCallMock.mockReset();
 });
 
+const PARTICIPANT_ERROR_RE = /participant/i;
+
 describe("coalition dissolve", () => {
   it("happy path: ACTIVE -> dissolves", async () => {
-    readContractMock.mockResolvedValueOnce({ state: 2 });
+    readContractMock.mockResolvedValueOnce({
+      state: 2,
+      participants: [
+        "0xWallet",
+        "0x0000000000000000000000000000000000000002",
+      ],
+    });
 
     executeContractCallMock.mockResolvedValueOnce({
       hash: "0xdissolve",
@@ -155,7 +163,7 @@ describe("coalition dissolve", () => {
   });
 
   it("fast-fail when not ACTIVE", async () => {
-    readContractMock.mockResolvedValueOnce({ state: 1 });
+    readContractMock.mockResolvedValueOnce({ state: 1, participants: [] });
 
     const result = await dissolveCore({
       network: "base-sepolia",
@@ -168,6 +176,29 @@ describe("coalition dissolve", () => {
       return;
     }
     expect(result.error).toMatch(ACTIVE_ERROR_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+
+  it("fast-fail when caller is not a participant", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: 2,
+      participants: [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+      ],
+    });
+
+    const result = await dissolveCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(PARTICIPANT_ERROR_RE);
     expect(executeContractCallMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/coalition-dissolve.test.ts
+++ b/tests/unit/coalition-dissolve.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: {
+        getTransactionReceipt: (h: string) => Promise<unknown>;
+      }) => Promise<unknown>,
+      _label?: string
+    ) =>
+      fn({
+        getTransactionReceipt: async (_h: string) => null,
+      }),
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { dissolveCore } from "../../plugins/coalition/steps/dissolve-core";
+
+const ACTIVE_ERROR_RE = /active/i;
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+});
+
+describe("coalition dissolve", () => {
+  it("happy path: ACTIVE -> dissolves", async () => {
+    readContractMock.mockResolvedValueOnce({ state: 2 });
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xdissolve",
+      gasUsed: BigInt(60_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+      logs: [],
+    });
+
+    const result = await dissolveCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactionHash).toBe("0xdissolve");
+  });
+
+  it("fast-fail when not ACTIVE", async () => {
+    readContractMock.mockResolvedValueOnce({ state: 1 });
+
+    const result = await dissolveCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(ACTIVE_ERROR_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/coalition-expire.test.ts
+++ b/tests/unit/coalition-expire.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: {
+        getTransactionReceipt: (h: string) => Promise<unknown>;
+      }) => Promise<unknown>,
+      _label?: string
+    ) =>
+      fn({
+        getTransactionReceipt: async (_h: string) => null,
+      }),
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { expireCore } from "../../plugins/coalition/steps/expire-core";
+
+const DEADLINE_ERROR_RE = /deadline/i;
+const PROPOSED_ERROR_RE = /proposed/i;
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+});
+
+describe("coalition expire", () => {
+  it("happy path: PROPOSED + past deadline -> expires", async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    readContractMock.mockResolvedValueOnce({
+      state: 1,
+      deadline: BigInt(past),
+    });
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xexpire",
+      gasUsed: BigInt(60_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+      logs: [],
+    });
+
+    const result = await expireCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactionHash).toBe("0xexpire");
+  });
+
+  it("fast-fail: deadline not yet reached", async () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    readContractMock.mockResolvedValueOnce({
+      state: 1,
+      deadline: BigInt(future),
+    });
+
+    const result = await expireCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(DEADLINE_ERROR_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+
+  it("fast-fail: state not PROPOSED", async () => {
+    readContractMock.mockResolvedValueOnce({
+      state: 2,
+      deadline: BigInt(0),
+    });
+
+    const result = await expireCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(PROPOSED_ERROR_RE);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/coalition-propose.test.ts
+++ b/tests/unit/coalition-propose.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/sponsorship-feature-flag", () => ({
+  isGasSponsorshipEnabled: () => false,
+}));
+
+vi.mock("@/lib/web3/sponsored-transaction-manager", () => ({
+  executeSponsoredContractTransaction: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { proposeCore } from "../../plugins/coalition/steps/propose-core";
+
+const VALID_PARTICIPANTS = JSON.stringify([
+  "0x0000000000000000000000000000000000000001",
+  "0x0000000000000000000000000000000000000002",
+]);
+const VALID_TERMS_HASH = `0x${"ab".repeat(32)}`;
+const VALID_DEADLINE = "1800000000";
+const VALID_STAKE_TOKEN = "0x000000000000000000000000000000000000bbbb";
+const VALID_STAKE_PER_PARTY = "1000000000000000000";
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+});
+
+describe("coalition propose", () => {
+  it("returns coalitionId on happy path", async () => {
+    const { ethers } = await import("ethers");
+    const { COALITION_ABI } = await import(
+      "../../plugins/coalition/contracts/coalition-abi"
+    );
+    const iface = new ethers.Interface(
+      // biome-ignore lint/suspicious/noExplicitAny: ABI constant satisfies InterfaceAbi at runtime
+      COALITION_ABI as any
+    );
+    const log = iface.encodeEventLog("Proposed", [
+      BigInt(42),
+      `0x${"ab".repeat(32)}`,
+      [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+      ],
+      "0x000000000000000000000000000000000000bbbb",
+      BigInt(1000),
+      BigInt(1800000000),
+    ]);
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xtxhash",
+      gasUsed: BigInt(100000),
+      effectiveGasPrice: BigInt(1000000000),
+      logs: [{ topics: log.topics, data: log.data }],
+    });
+
+    const result = await proposeCore({
+      network: "base-sepolia",
+      participants: VALID_PARTICIPANTS,
+      termsHash: VALID_TERMS_HASH,
+      deadlineUnix: VALID_DEADLINE,
+      stakeToken: VALID_STAKE_TOKEN,
+      stakePerParty: VALID_STAKE_PER_PARTY,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.coalitionId).toBe("42");
+    expect(result.transactionHash).toBe("0xtxhash");
+  });
+
+  it("rejects fewer than 2 participants", async () => {
+    const result = await proposeCore({
+      network: "base-sepolia",
+      participants: JSON.stringify(["0x0000000000000000000000000000000000000001"]),
+      termsHash: VALID_TERMS_HASH,
+      deadlineUnix: VALID_DEADLINE,
+      stakeToken: VALID_STAKE_TOKEN,
+      stakePerParty: VALID_STAKE_PER_PARTY,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(/participant/i);
+  });
+
+  it("rejects deadline in the past", async () => {
+    const result = await proposeCore({
+      network: "base-sepolia",
+      participants: VALID_PARTICIPANTS,
+      termsHash: VALID_TERMS_HASH,
+      deadlineUnix: "1",
+      stakeToken: VALID_STAKE_TOKEN,
+      stakePerParty: VALID_STAKE_PER_PARTY,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(/deadline/i);
+  });
+
+  it("rejects malformed termsHash", async () => {
+    const result = await proposeCore({
+      network: "base-sepolia",
+      participants: VALID_PARTICIPANTS,
+      termsHash: "0xnothash",
+      deadlineUnix: VALID_DEADLINE,
+      stakeToken: VALID_STAKE_TOKEN,
+      stakePerParty: VALID_STAKE_PER_PARTY,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(/termsHash/i);
+  });
+
+  it("rejects invalid stake address or zero stake", async () => {
+    const result = await proposeCore({
+      network: "base-sepolia",
+      participants: VALID_PARTICIPANTS,
+      termsHash: VALID_TERMS_HASH,
+      deadlineUnix: VALID_DEADLINE,
+      stakeToken: VALID_STAKE_TOKEN,
+      stakePerParty: "0",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/coalition-propose.test.ts
+++ b/tests/unit/coalition-propose.test.ts
@@ -54,9 +54,17 @@ vi.mock("@/lib/rpc/network-utils", () => ({
   },
 }));
 
+let mockReceiptForRefetch: { logs: { topics: string[]; data: string }[] } | null = null;
+
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: vi.fn(async () => ({
     resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: { getTransactionReceipt: (h: string) => Promise<unknown> }) => Promise<unknown>,
+      _label?: string,
+    ) => fn({
+      getTransactionReceipt: async (_h: string) => mockReceiptForRefetch,
+    }),
   })),
 }));
 
@@ -134,6 +142,7 @@ const VALID_STAKE_PER_PARTY = "1000000000000000000";
 beforeEach(() => {
   readContractMock.mockReset();
   executeContractCallMock.mockReset();
+  mockReceiptForRefetch = null;
 });
 
 describe("coalition propose", () => {
@@ -162,8 +171,9 @@ describe("coalition propose", () => {
       hash: "0xtxhash",
       gasUsed: BigInt(100000),
       effectiveGasPrice: BigInt(1000000000),
-      logs: [{ topics: log.topics, data: log.data }],
     });
+
+    mockReceiptForRefetch = { logs: [{ topics: log.topics, data: log.data }] };
 
     const result = await proposeCore({
       network: "base-sepolia",

--- a/tests/unit/coalition-sign.test.ts
+++ b/tests/unit/coalition-sign.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: {
+        getTransactionReceipt: (h: string) => Promise<unknown>;
+      }) => Promise<unknown>,
+      _label?: string
+    ) =>
+      fn({
+        getTransactionReceipt: async (_h: string) => null,
+      }),
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { signCore } from "../../plugins/coalition/steps/sign-core";
+
+const COALITION_ADDRESS = "0x000000000000000000000000000000000000aAaA";
+const STAKE_TOKEN = "0x000000000000000000000000000000000000bbbb";
+const STAKE_PER_PARTY = BigInt(1000);
+
+const makeCoalition = (state: number) => ({
+  termsHash: `0x${"ab".repeat(32)}`,
+  participants: [
+    "0x0000000000000000000000000000000000000001",
+    "0x0000000000000000000000000000000000000002",
+    "0x0000000000000000000000000000000000000003",
+  ],
+  stakeToken: STAKE_TOKEN,
+  stakePerParty: STAKE_PER_PARTY,
+  deadline: BigInt(1800000000),
+  signedCount: BigInt(0),
+  breachedCount: BigInt(0),
+  slashedCount: BigInt(0),
+  state,
+});
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+});
+
+describe("coalition sign", () => {
+  it("idempotent: already signed returns wasAlreadySigned without sending a tx", async () => {
+    readContractMock
+      .mockResolvedValueOnce(makeCoalition(1)) // getCoalition -> state PROPOSED
+      .mockResolvedValueOnce(true); // isSigned -> already signed
+
+    const result = await signCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.wasAlreadySigned).toBe(true);
+    expect(executeContractCallMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-approves when allowance is insufficient, then signs", async () => {
+    readContractMock
+      .mockResolvedValueOnce(makeCoalition(1)) // getCoalition
+      .mockResolvedValueOnce(false) // isSigned -> not yet signed
+      .mockResolvedValueOnce(BigInt(0)); // allowance -> insufficient
+
+    executeContractCallMock
+      .mockResolvedValueOnce({
+        hash: "0xapproval",
+        gasUsed: BigInt(50000),
+        effectiveGasPrice: BigInt(1000000000),
+        logs: [],
+      })
+      .mockResolvedValueOnce({
+        hash: "0xsign",
+        gasUsed: BigInt(80000),
+        effectiveGasPrice: BigInt(1000000000),
+        logs: [],
+      });
+
+    const result = await signCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.wasAlreadySigned).toBe(false);
+    expect(result.transactionHash).toBe("0xsign");
+    expect(result.approvalTransactionHash).toBe("0xapproval");
+    expect(executeContractCallMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips approval when skipApproval=yes", async () => {
+    readContractMock
+      .mockResolvedValueOnce(makeCoalition(1)) // getCoalition
+      .mockResolvedValueOnce(false); // isSigned -> not yet signed
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xsign",
+      gasUsed: BigInt(80000),
+      effectiveGasPrice: BigInt(1000000000),
+      logs: [],
+    });
+
+    const result = await signCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      skipApproval: "yes",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactionHash).toBe("0xsign");
+    expect(result.approvalTransactionHash).toBeUndefined();
+    expect(executeContractCallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns error when coalition is not in PROPOSED state", async () => {
+    readContractMock.mockResolvedValueOnce(makeCoalition(2)); // state ACTIVE (2)
+
+    const result = await signCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(/proposed/i);
+  });
+});

--- a/tests/unit/coalition-slash.test.ts
+++ b/tests/unit/coalition-slash.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+    query: {
+      workflowExecutions: {
+        findFirst: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (n: string) => {
+    if (n === "base-sepolia") {
+      return 84_532;
+    }
+    if (n === "base") {
+      return 8453;
+    }
+    throw new Error(`Unsupported network: ${n}`);
+  },
+}));
+
+let mockReceiptForRefetch: { logs: { topics: string[]; data: string }[] } | null = null;
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(async () => ({
+    resolveActiveRpcUrl: async () => "http://rpc",
+    executeWithFailover: async (
+      fn: (provider: { getTransactionReceipt: (h: string) => Promise<unknown> }) => Promise<unknown>,
+      _label?: string,
+    ) => fn({
+      getTransactionReceipt: async (_h: string) => mockReceiptForRefetch,
+    }),
+  })),
+}));
+
+const readContractMock = vi.fn();
+const executeContractCallMock = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: readContractMock,
+    executeContractCall: executeContractCallMock,
+    getTransactionUrl: async (h: string) => `https://explorer/tx/${h}`,
+    getAddressUrl: async (a: string) => `https://explorer/addr/${a}`,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  formatContractError: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+}));
+
+vi.mock("../../plugins/coalition/contracts/addresses", () => ({
+  COALITION_ADDRESSES: { 84532: "0x000000000000000000000000000000000000aAaA" },
+  SUPPORTED_CHAIN_IDS: [84_532, 8453],
+}));
+
+vi.mock("@/lib/para/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn(async () => "0xWallet"),
+  initializeWalletSigner: vi.fn(async () => ({ signer: true })),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "org_1",
+    userId: "user_1",
+  })),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: async (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => Promise<unknown>
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/web3/sponsorship-feature-flag", () => ({
+  isGasSponsorshipEnabled: () => false,
+}));
+
+vi.mock("@/lib/web3/sponsored-transaction-manager", () => ({
+  executeSponsoredContractTransaction: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  parsePriorityFeeGwei: () => undefined,
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "gen_1" }));
+
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { slashCore } from "../../plugins/coalition/steps/slash-core";
+
+const PARTY_ADDR = "0x0000000000000000000000000000000000000001";
+
+const COALITION_STATE_ACTIVE = {
+  state: 2,
+  participants: [
+    PARTY_ADDR,
+    "0x0000000000000000000000000000000000000002",
+    "0x0000000000000000000000000000000000000003",
+  ],
+  termsHash: `0x${"ab".repeat(32)}`,
+  stakeToken: "0x000000000000000000000000000000000000bbbb",
+  stakePerParty: BigInt(1000),
+  deadline: BigInt(1800000000),
+  signedCount: 3,
+  breachedCount: 1,
+  slashedCount: 0,
+};
+
+beforeEach(() => {
+  readContractMock.mockReset();
+  executeContractCallMock.mockReset();
+  mockReceiptForRefetch = null;
+});
+
+describe("coalition slash", () => {
+  it("happy path: parses amountRedistributed from Slashed event", async () => {
+    const { ethers } = await import("ethers");
+    const { COALITION_ABI } = await import(
+      "../../plugins/coalition/contracts/coalition-abi"
+    );
+    const iface = new ethers.Interface(
+      // biome-ignore lint/suspicious/noExplicitAny: ABI constant satisfies InterfaceAbi at runtime
+      COALITION_ABI as any
+    );
+    const log = iface.encodeEventLog("Slashed", [
+      BigInt(1),
+      PARTY_ADDR,
+      BigInt(1000),
+    ]);
+
+    readContractMock
+      .mockResolvedValueOnce(COALITION_STATE_ACTIVE)
+      .mockResolvedValueOnce(true);
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xslash",
+      gasUsed: BigInt(80000),
+      effectiveGasPrice: BigInt(1000000000),
+      logs: [],
+    });
+
+    mockReceiptForRefetch = { logs: [{ topics: log.topics, data: log.data }] };
+
+    const result = await slashCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      party: PARTY_ADDR,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactionHash).toBe("0xslash");
+    expect(result.amountRedistributed).toBe("1000");
+    expect(result.party).toBe(PARTY_ADDR);
+  });
+
+  it("fast-fail when party not breached", async () => {
+    readContractMock
+      .mockResolvedValueOnce(COALITION_STATE_ACTIVE)
+      .mockResolvedValueOnce(false);
+
+    const result = await slashCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      party: PARTY_ADDR,
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toMatch(/not.*breached/i);
+  });
+
+  it("usePrivateMempool=yes plumbs through to getRpcProvider", async () => {
+    const { ethers } = await import("ethers");
+    const { COALITION_ABI } = await import(
+      "../../plugins/coalition/contracts/coalition-abi"
+    );
+    const iface = new ethers.Interface(
+      // biome-ignore lint/suspicious/noExplicitAny: ABI constant satisfies InterfaceAbi at runtime
+      COALITION_ABI as any
+    );
+    const log = iface.encodeEventLog("Slashed", [
+      BigInt(1),
+      PARTY_ADDR,
+      BigInt(1000),
+    ]);
+
+    readContractMock
+      .mockResolvedValueOnce(COALITION_STATE_ACTIVE)
+      .mockResolvedValueOnce(true);
+
+    executeContractCallMock.mockResolvedValueOnce({
+      hash: "0xslash",
+      gasUsed: BigInt(80000),
+      effectiveGasPrice: BigInt(1000000000),
+      logs: [],
+    });
+
+    mockReceiptForRefetch = { logs: [{ topics: log.topics, data: log.data }] };
+
+    const result = await slashCore({
+      network: "base-sepolia",
+      coalitionId: "1",
+      party: PARTY_ADDR,
+      usePrivateMempool: "yes",
+      strict: "no",
+      _context: { organizationId: "org_1" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(getRpcProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ usePrivateMempool: true, strict: false })
+    );
+  });
+});


### PR DESCRIPTION
# feat: add Coalition plugin (multi-party on-chain commitments with slashing)

## Summary

Adds `plugins/coalition/`, a new general-purpose KeeperHub workflow plugin for multi-party on-chain commitments. The plugin exposes 8 actions wrapping `Coalition.sol`, a 5-state machine for proposing a coalition, collecting signatures with stake escrow, recording breach evidence, slashing the breached party's stake pro-rata, and dissolving cleanly.

The Solidity contract is deployed and verified on Base Sepolia. Every action has unit tests with the project's standard mock prelude. A no-mock end-to-end script under `scripts/coalition-e2e.mjs` deploys fresh contracts, drives the full lifecycle against live RPC, and asserts on every transition plus all revert paths.

- **Coalition contract (Base Sepolia):** [`0x445BE52b852400A8873721947E3BB3A5559CE4d9`](https://sepolia.basescan.org/address/0x445BE52b852400A8873721947E3BB3A5559CE4d9)
- **Plugin actions (8):** `propose`, `sign`, `check-status`, `activate`, `breach`, `slash`, `dissolve`, `expire`
- **Tests:** 24 coalition unit cases pass; full repo suite still 3450/3450
- **Net diff:** ~5,900 lines across 38 files

## Why this is needed specifically for KeeperHub

KeeperHub is a workflow automation platform; coalitions are multi-step state machines with stake escrow. The fit is structural, not incidental, in seven concrete ways:

### 1. The coalition lifecycle is already a workflow

`propose -> poll until ready -> activate -> (optional) breach -> slash -> dissolve` is a directed graph with conditional branches and waiting. KeeperHub workflows already model exactly this with no bespoke DSL: nodes wired together, polling primitives, condition steps, branching. The plugin adds the action library; the platform supplies the orchestration. Without KH, every coalition operator builds the same scheduler/retry/condition layer themselves.

### 2. Multi-party coordination across orgs is native to KH's wallet model

Each KH workflow runs as a single Para wallet bound to one organization. That maps cleanly to "each coalition participant runs their own KH workflow that signs." The proposer org runs the orchestration workflow (propose -> poll -> activate -> dissolve); each signer org runs a one-step workflow that calls `sign`. No separate signature aggregation contract, no off-chain coordinator service. The platform's per-org isolation is the multi-party coordination layer.

### 3. Slashing reliability is *what* KH provides over a naive integration

A slashing transaction that does not land breaks the protocol's economic security. The `slash` action surfaces KH's reliability stack as a primary, default-expanded "Reliability" config group, not buried in advanced settings:

- `usePrivateMempool` (default Yes): routes through Flashbots Protect on Base, avoiding frontrunning
- `strict`: fail rather than silently fall back to public mempool if the private RPC is unreachable
- `priorityFeeGwei`: explicit per-tx priority-fee override, bypassing the chain-level clamp

Plus the layers that fire automatically: `withNonceSession` for nonce coordination, `getRpcProvider` for RPC failover, gas-sponsored fallback (correctly bypassed when private mempool is on), and `formatContractError` for revert decoding.

`writeContractStep.maxRetries = 0` is set on every write step in the plugin: the workflow does not replay the *step*, because that would double-spend; reliability comes from the inner tx layer, not from blind retries.

### 4. Polling without a daemon

Coalitions need "wait until everyone has signed" before activating. KH workflows compose `check-status` (read-only) into a wait-until-ready loop, with the platform handling backoff and execution tracking. Without KH, that requires running a long-lived process or webhook listener; with KH, it's a node in the canvas with a `loop.until` predicate against `{{Status.ready}}`.

### 5. Audit trail comes free

Coalition is a financial primitive. Every action's input and output gets logged via `withStepLogging` and metrics via `withPluginMetrics`, indexed under `pluginName: "coalition", actionName: "<slug>"`. Execution history is queryable by org. For a system that escrows and slashes ERC-20 stake, this is mandatory. KH provides it without per-plugin work.

### 6. Trigger composition

Coalitions can be activated by off-chain events (oracle updates, governance votes, breach detection from a monitor). KH's manual / scheduled / webhook / event triggers compose with the coalition actions: a webhook can fire `breach`; a Chainlink keeper can fire `slash`; a calendar trigger can fire `expire` to clean up after deadlines. No bespoke event-listener service per coalition is needed.

### 7. AI-driven workflow assembly

KH's MCP schemas endpoint exposes every plugin action with its input/output shape. The coalition plugin's typed `configFields` and `outputFields` mean an AI agent can read the schema and auto-assemble a workflow ("propose a 3-party coalition with 1 USDC stake each and 24h deadline; poll for readiness; activate") without per-call hand-coding. Coalition is a primitive that benefits more from AI-driven composition than a bespoke per-protocol UI ever could.

In short: **the platform's existing strengths (multi-step orchestration, per-org isolation, reliability stack, audit trail, triggers, AI-assembly) are exactly what makes coalitions shippable as a workflow primitive rather than a one-off integration.**

## What's in the PR

```
plugins/coalition/
  index.ts                              IntegrationPlugin (8 actions)
  icon.tsx                              CoalitionIcon (SVG, currentColor)
  test.ts                               testCoalition (Para wallet validator)
  README.md                             User-facing plugin docs
  contracts/
    Coalition.sol                       Solidity source (~245 lines, OZ + custom errors)
    coalition-abi.ts                    Typed ABI const
    addresses.ts                        Per-chain address map (Base Sepolia populated)
  steps/
    coalition-core.ts                   STATE_LABELS, getCoalitionAddress, parseCoalitionEvent
    propose.ts          / propose-core.ts
    sign.ts             / sign-core.ts
    check-status.ts     / check-status-core.ts
    activate.ts         / activate-core.ts
    breach.ts           / breach-core.ts
    slash.ts            / slash-core.ts
    dissolve.ts         / dissolve-core.ts
    expire.ts           / expire-core.ts

tests/unit/coalition-{action}.test.ts   8 unit-test files, 24 cases total
scripts/deploy-coalition.ts             Out-of-band ethers-only deploy script
scripts/coalition-e2e.mjs               Comprehensive no-mock e2e (deploys, runs lifecycle, asserts)
plugins/plugin-allowlist.json           Adds "coalition"
lib/types/integration.ts                Regenerated by pnpm discover-plugins
plugins/index.ts                        Regenerated by pnpm discover-plugins
```

## Architectural decisions

| Question | Choice | Why |
|---|---|---|
| Multi-party signing model | Each participant runs their own KH workflow | Native to KH's per-org Para wallet model; no contract changes |
| Solidity contract scope | Source + verified deploy; no Foundry suite gating CI | No existing KH plugin compiles Solidity in CI; Aave / Lido / Sky reference externally-deployed contracts |
| `record-outcome` (ERC-8004) | Deferred to follow-up | PRD itself flagged as cuttable; ERC-8004 not in repo |
| Chains | Base Sepolia (live) + Base mainnet (slot reserved) | Matches PRD; chain map makes adding more trivial |
| ABI handling | Hard-coded inside the plugin | Coalition contract is fixed; users get coalition-specific configFields, not paste-your-ABI |

## The 8 actions

| Slug | Type | configFields | What it does |
|---|---|---|---|
| `propose` | write | network, participants[], termsHash, deadlineUnix, stakeToken, stakePerParty | Create coalition, return coalitionId from Proposed event |
| `sign` | write | network, coalitionId, skipApproval | Read state, fast-return if already signed; auto-approve stakeToken if needed; sign |
| `check-status` | read | network, coalitionId | Returns state label, signedCount, breachedCount, slashedCount, ready, full participant struct |
| `activate` | write | network, coalitionId | Idempotent: fast-return alreadyActive=true; otherwise transition PROPOSED to ACTIVE |
| `breach` | write | network, coalitionId, breachingParty, evidenceHash, evidenceUri | Pre-validate state + party + !breached; record breach |
| `slash` | write | network, coalitionId, party, **Reliability group**: usePrivateMempool / strict / priorityFeeGwei | Pre-validate state + isBreached; slash via private mempool with priority fee override; parse amountRedistributed |
| `dissolve` | write | network, coalitionId | Pre-validate state + caller is participant; clean close, refund non-breached |
| `expire` | write | network, coalitionId | Pre-validate state == PROPOSED + deadline elapsed; refund signers |

Every write action: `requiresCredentials: true`, `<step>.maxRetries = 0`, network field with `showPrivateVariants: true`, Advanced group with `gasLimitMultiplier`.

## Test plan

### Unit tests (Vitest, no live RPC)

Each action has a dedicated test file under `tests/unit/coalition-{action}.test.ts`. Standard mock prelude matching the project's plugin testing conventions. Total 24 cases:

- `coalition-propose.test.ts` (5): happy path with real Proposed event encoded via ethers.Interface.encodeEventLog; <2 participants; past deadline; bad termsHash; zero stake
- `coalition-sign.test.ts` (4): idempotent already-signed; auto-approve when allowance insufficient; skipApproval=Yes path; non-PROPOSED state
- `coalition-check-status.test.ts` (5): every state value; ready=true; missing coalition; bad coalitionId; unsupported chain
- `coalition-activate.test.ts` (3): idempotent already-ACTIVE; happy path; not all signed
- `coalition-breach.test.ts` (4): happy path; not active; non-participant; already breached
- `coalition-slash.test.ts` (3): happy path with amountRedistributed parsed from Slashed event; not breached; usePrivateMempool=yes plumbs through to getRpcProvider
- `coalition-dissolve.test.ts` (3): happy path; not active; non-participant
- `coalition-expire.test.ts` (3): happy path past deadline; deadline not reached; non-PROPOSED

```
pnpm test:unit tests/unit/coalition-*.test.ts   # 24/24 pass
pnpm test                                       # 3450/3450 pass overall
pnpm check                                      # exit 0
pnpm type-check                                 # exit 0
pnpm discover-plugins                           # clean, coalition registered
```

### Live end-to-end (Base Sepolia, no mocks)

`scripts/coalition-e2e.mjs` deploys fresh `TestToken` and `Coalition` contracts, generates two ephemeral participant wallets, funds them from the deployer, then runs the full lifecycle. Run with:

```bash
COALITION_DEPLOYER_PK=<hex> node scripts/coalition-e2e.mjs
```

The most recent run (committed) covered:

- Deploy TestToken (ERC-20 stake) -- OK
- Deploy Coalition + persist address -- OK
- Generate + fund 2 ephemeral participants (gas + 100 stake each) -- OK
- `propose` happy path; coalitionId == 1 -- OK
- `propose` reverts: InvalidParticipantCount, DeadlineInPast, ZeroStake -- OK
- `sign` x 3 with allowance approvals -- OK
- `sign` revert: AlreadySigned (replay) -- OK
- `sign` revert: NotParticipant (stranger) -- OK
- `activate` happy path -- OK
- `activate` revert: CoalitionNotProposed (replay) -- OK
- `recordBreach` revert: NotParticipant -- OK
- `recordBreach(B)` happy path -- OK
- `recordBreach` revert: PartyAlreadyBreached -- OK
- `slash` revert: PartyNotBreached -- OK
- `slash(B)` happy path: amountRedistributed = 10 STAKE; A and C each receive +5 -- OK
- `slash` revert: PartyAlreadySlashed (replay) -- OK
- `dissolve` revert: NotParticipant (stranger) -- OK
- `dissolve` happy path: A and C refunded 10 each, B excluded, contract drained to 0 -- OK
- Net stake math: A net 0; B net -10; C net 0 (sums to -10 = B's stake; redistributed correctly) -- OK
- 30+ assertions all green

Key txs from the run:
- Propose: https://sepolia.basescan.org/tx/0x9eaa4240a92502ffc55e9f3be3010aa44aba518b31e59d918cce97fe9c46b4fe
- Slash: https://sepolia.basescan.org/tx/0x649970e8cdf55048ef3bbcaa508bbe3efad7832238671e428c541180bd3f9cdc
- Dissolve: https://sepolia.basescan.org/tx/0x0600d58d78fff1fd50b6697ac102f080c0908e06320832f72cdc7dcccbf9cac7

## Notable engineering details

- **Receipt-logs refetch.** The platform's `TransactionReceipt` strips `logs` (see `lib/web3/chain-adapter/evm.ts:271-276`). For event-emitting writes (`propose`, `slash`), the core refetches the full receipt via `rpcManager.executeWithFailover((p) => p.getTransactionReceipt(hash), "read")` before parsing the event. Caught during code review.
- **Coalition.sol bug fixes.** Initial implementation had three critical bugs (slash math overpay on interleaved slashes, dissolve refunding the slashed party, SLASHED state unreachable). Fixed by introducing a permanent `_slashed` flag separate from `_breached`, defensive recipient walk in `slash`, and `slashedCount` driving the SLASHED transition. Also restricted `dissolve` to participants. All caught during code review before deploy.
- **No platform-side TransactionReceipt change.** The fix was localized to coalition; the chain-adapter type stays minimal.
- **Sponsorship bypass on private mempool.** `slash` correctly skips the ERC-4337 sponsored path when `usePrivateMempool === "yes"`, matching the rationale documented in `web3/steps/write-contract-core.ts:291-347`: Pimlico bundlers do not route through Flashbots Protect.
- **State pre-checks.** Every write action reads `getCoalition(id)` once before sending its tx and short-circuits with a precise error rather than letting the contract revert generically. Saves gas and produces actionable messages.

## Acceptance criteria

- [x] `pnpm check` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test:unit tests/unit/coalition-*.test.ts` passes (24/24)
- [x] Full repo unit suite still passes (3450/3450)
- [x] `pnpm discover-plugins` runs cleanly with coalition registered
- [x] `Coalition.sol` deployed on Base Sepolia; address committed in `addresses.ts`
- [x] Live e2e against Base Sepolia executes the full lifecycle and all revert paths
- [x] Plugin appears in `plugins/plugin-allowlist.json`
- [x] No `console.log` / `debugger` in production code
- [x] All write-step `maxRetries = 0`; helpers in `*-core.ts` not in step files
- [x] Conventional-commit message format throughout
- [ ] Manual smoke in `pnpm dev`: drop each of the 8 actions onto canvas, verify configFields render
- [ ] Basescan source verification of the deployed Coalition contract

## Out of scope, follow-up work

- ERC-7857 iNFT stake support (instead of plain ERC-20)
- Permissioned breach claims (currently anyone-callable; production wants arbitrator-gated)
- Cross-chain coalitions (LayerZero / CCIP)
- ETH-as-stake support
- Coalition templates (preconfigured stakes / deadlines for common patterns)
- ERC-8004 `record-outcome` action (deferred from this PR)
- Foundry test suite for `Coalition.sol`

## Risks and mitigations

| Risk | Mitigation |
|---|---|
| Slash tx fails to land under gas spike | Reliability config group exposes private-mempool routing + priority-fee override; nonce session manages replay; `maxRetries = 0` prevents step-level double-send |
| Sponsored-execution path returns empty `coalitionId` from `propose` | Documented limitation in README; users on sponsored chains can read `nextId-1` via `check-status` post-confirmation |
| `slash` and `recordBreach` are anyone-callable | Documented as v1 limitation in README; production deployments wrap with arbitrator-gating off-chain |
| Hand-curated ABI drifts from Coalition.sol | Contract is frozen for v1; ABI checked in alongside `.sol` source; any future contract change must update both files |
| Deploy bytecode in `scripts/deploy-coalition.ts` is empty | Header documents the one-line solc command to regenerate before deploy |

## How to review

1. Read `plugins/coalition/index.ts` first to see the action surface.
2. Diff `plugins/coalition/steps/propose-core.ts` against `plugins/web3/steps/write-contract-core.ts` to see the canonical write flow we mirror, plus the receipt-logs refetch we add.
3. Read `plugins/coalition/contracts/Coalition.sol` paying attention to `slash` (the recipient-walk is the load-bearing fix from review).
4. Skim `tests/unit/coalition-slash.test.ts` for the encoded-Slashed-event test pattern using `ethers.Interface.encodeEventLog`.
5. Skim `scripts/coalition-e2e.mjs` for the no-mock lifecycle assertion shape.
