### PR TITLE
feat: add Superfluid protocol

### DIFF
--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, lido, linear, math, morpho, pendle, protocol, resend, rocket-pool, safe, sendgrid, sky, slack, spark, telegram, uniswap, v0, web3, webflow, webhook, wrapped, yearn
+ * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, lido, linear, math, morpho, pendle, protocol, resend, rocket-pool, safe, sendgrid, sky, slack, spark, superfluid, telegram, uniswap, v0, web3, webflow, webhook, wrapped, yearn
  */
 
 // Integration type union - plugins + system integrations
@@ -42,6 +42,7 @@ export type IntegrationType =
   | "sky"
   | "slack"
   | "spark"
+  | "superfluid"
   | "telegram"
   | "uniswap"
   | "v0"

--- a/protocols/index.ts
+++ b/protocols/index.ts
@@ -8,7 +8,7 @@
  * This ensures the protocol registry is populated when the Next.js
  * server starts (via the plugin import chain).
  *
- * Registered protocols: aave-v3, aave-v4, aerodrome, ajna, chainlink, chronicle, compound, cowswap, curve, ethena, lido, morpho, pendle, rocket-pool, safe, sky, spark, uniswap, wrapped, yearn
+ * Registered protocols: aave-v3, aave-v4, aerodrome, ajna, chainlink, chronicle, compound, cowswap, curve, ethena, lido, morpho, pendle, rocket-pool, safe, sky, spark, superfluid, uniswap, wrapped, yearn
  */
 
 import { protocolToPlugin, registerProtocol } from "@/lib/protocol-registry";
@@ -31,6 +31,7 @@ import rocketPoolDef from "./rocket-pool";
 import safeDef from "./safe";
 import skyDef from "./sky";
 import sparkDef from "./spark";
+import superfluidDef from "./superfluid";
 import uniswapDef from "./uniswap-v3";
 import wrappedDef from "./wrapped";
 import yearnDef from "./yearn-v3";
@@ -69,6 +70,8 @@ registerProtocol(skyDef);
 registerIntegration(protocolToPlugin(skyDef));
 registerProtocol(sparkDef);
 registerIntegration(protocolToPlugin(sparkDef));
+registerProtocol(superfluidDef);
+registerIntegration(protocolToPlugin(superfluidDef));
 registerProtocol(uniswapDef);
 registerIntegration(protocolToPlugin(uniswapDef));
 registerProtocol(wrappedDef);

--- a/protocols/superfluid.ts
+++ b/protocols/superfluid.ts
@@ -1,0 +1,586 @@
+import { defineProtocol } from "@/lib/protocol-registry";
+
+/**
+ * Chain IDs (as strings, matching ProtocolContract.addresses keys) where the
+ * Superfluid CFAv1 and GDAv1 forwarders are deployed.
+ *
+ * Adding a chain: append its ID here. Both forwarders pick it up automatically
+ * via sameOnAllChains() because the addresses are deliberately constant across
+ * every chain Superfluid supports. To ship a new chain, also add an entry to
+ * scripts/verify-superfluid-addresses.ts so the bytecode check covers it.
+ */
+export const SUPERFLUID_CHAIN_IDS = [
+  "1", // Ethereum Mainnet
+  "10", // Optimism
+  "137", // Polygon
+  "8453", // Base
+  "42161", // Arbitrum One
+  "11155111", // Sepolia
+] as const;
+
+/**
+ * Build the per-chain address map for a contract that's deployed at the same
+ * address on every chain in SUPERFLUID_CHAIN_IDS. Both forwarders use this --
+ * Superfluid intentionally pins them to identical addresses cross-chain.
+ */
+function sameOnAllChains(address: string): Record<string, string> {
+  return Object.fromEntries(SUPERFLUID_CHAIN_IDS.map((id) => [id, address]));
+}
+
+const FLOW_RATE_HELP =
+  "Wei per second (int96). 1 USDCx/month is approximately 385,802,469,135 wei/s at 18 decimals. Computed: amount * 10^decimals / seconds.";
+
+const CREATE_FLOW_RATE_HELP = `${FLOW_RATE_HELP} Sender needs at least ~3 hours of stream value as a deposit; verify with get-super-token-balance before opening the stream.`;
+
+/**
+ * CFAv1Forwarder address. Pinned identical across every chain in
+ * SUPERFLUID_CHAIN_IDS by Superfluid's deployment design.
+ */
+export const CFA_FORWARDER_ADDRESS =
+  "0xcfA132E353cB4E398080B9700609bb008eceB125";
+
+const CFA_FORWARDER_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "createFlow",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "sender", type: "address" },
+      { name: "receiver", type: "address" },
+      { name: "flowRate", type: "int96" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "updateFlow",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "sender", type: "address" },
+      { name: "receiver", type: "address" },
+      { name: "flowRate", type: "int96" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "deleteFlow",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "sender", type: "address" },
+      { name: "receiver", type: "address" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "getFlowInfo",
+    stateMutability: "view",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "sender", type: "address" },
+      { name: "receiver", type: "address" },
+    ],
+    outputs: [
+      { name: "lastUpdated", type: "uint256" },
+      { name: "flowRate", type: "int96" },
+      { name: "deposit", type: "uint256" },
+      { name: "owedDeposit", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "getAccountFlowrate",
+    stateMutability: "view",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "account", type: "address" },
+    ],
+    outputs: [{ name: "flowRate", type: "int96" }],
+  },
+]);
+
+/**
+ * GDAv1Forwarder address. Pinned identical across every chain in
+ * SUPERFLUID_CHAIN_IDS by Superfluid's deployment design.
+ */
+export const GDA_FORWARDER_ADDRESS =
+  "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08";
+
+const GDA_FORWARDER_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "createPool",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "admin", type: "address" },
+      {
+        name: "config",
+        type: "tuple",
+        components: [
+          { name: "transferabilityForUnitsOwner", type: "bool" },
+          { name: "distributionFromAnyAddress", type: "bool" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "", type: "bool" },
+      { name: "pool", type: "address" },
+    ],
+  },
+  {
+    type: "function",
+    name: "updateMemberUnits",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "pool", type: "address" },
+      { name: "member", type: "address" },
+      { name: "units", type: "uint128" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "distribute",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "from", type: "address" },
+      { name: "pool", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "distributeFlow",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "from", type: "address" },
+      { name: "pool", type: "address" },
+      { name: "flowRate", type: "int96" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "connectPool",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "pool", type: "address" },
+      { name: "userData", type: "bytes" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+]);
+
+const SUPER_TOKEN_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "upgrade",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "amount", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "downgrade",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "amount", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getUnderlyingToken",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "updateFlowOperatorPermissions",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "flowOperator", type: "address" },
+      { name: "permissions", type: "uint8" },
+      { name: "flowRateAllowance", type: "int96" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+]);
+
+export default defineProtocol({
+  name: "Superfluid",
+  slug: "superfluid",
+  description:
+    "Programmable streaming payments -- open per-second money streams between addresses, distribute pro-rata to pool members, and wrap/unwrap SuperTokens",
+  website: "https://superfluid.org",
+  icon: "/protocols/superfluid.png",
+
+  contracts: {
+    cfaForwarder: {
+      label: "Superfluid CFAv1 Forwarder",
+      addresses: sameOnAllChains(CFA_FORWARDER_ADDRESS),
+      abi: CFA_FORWARDER_ABI,
+    },
+    gdaForwarder: {
+      label: "Superfluid GDAv1 Forwarder",
+      addresses: sameOnAllChains(GDA_FORWARDER_ADDRESS),
+      abi: GDA_FORWARDER_ABI,
+    },
+    superToken: {
+      label: "Superfluid SuperToken",
+      addresses: {},
+      abi: SUPER_TOKEN_ABI,
+      userSpecifiedAddress: true,
+    },
+  },
+
+  actions: [
+    {
+      slug: "create-flow",
+      label: "Open Money Stream",
+      description:
+        "Open a continuous wei/sec stream of a SuperToken from sender to receiver",
+      type: "write",
+      contract: "cfaForwarder",
+      function: "createFlow",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "sender", type: "address", label: "Sender Address" },
+        { name: "receiver", type: "address", label: "Receiver Address" },
+        {
+          name: "flowRate",
+          type: "int96",
+          label: "Flow Rate (wei/sec)",
+          helpTip: CREATE_FLOW_RATE_HELP,
+        },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "update-flow",
+      label: "Update Stream Rate",
+      description:
+        "Change the wei/sec rate of an existing stream. Use delete-flow to close a stream instead of setting rate to 0.",
+      type: "write",
+      contract: "cfaForwarder",
+      function: "updateFlow",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "sender", type: "address", label: "Sender Address" },
+        { name: "receiver", type: "address", label: "Receiver Address" },
+        {
+          name: "flowRate",
+          type: "int96",
+          label: "New Flow Rate (wei/sec)",
+          helpTip: FLOW_RATE_HELP,
+        },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "delete-flow",
+      label: "Close Money Stream",
+      description: "Close an open stream between sender and receiver",
+      type: "write",
+      contract: "cfaForwarder",
+      function: "deleteFlow",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "sender", type: "address", label: "Sender Address" },
+        { name: "receiver", type: "address", label: "Receiver Address" },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "get-flow",
+      label: "Read Flow Between Two Addresses",
+      description:
+        "Read the current flow rate, deposit, and last-updated timestamp for a stream between two addresses",
+      type: "read",
+      contract: "cfaForwarder",
+      function: "getFlowInfo",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "sender", type: "address", label: "Sender Address" },
+        { name: "receiver", type: "address", label: "Receiver Address" },
+      ],
+      outputs: [
+        {
+          name: "lastUpdated",
+          type: "uint256",
+          label: "Last Updated (unix seconds)",
+        },
+        {
+          name: "flowRate",
+          type: "int96",
+          label: "Flow Rate (wei/sec)",
+          decimals: 18,
+        },
+        {
+          name: "deposit",
+          type: "uint256",
+          label: "Deposit (wei)",
+          decimals: 18,
+        },
+        {
+          name: "owedDeposit",
+          type: "uint256",
+          label: "Owed Deposit (wei)",
+          decimals: 18,
+        },
+      ],
+    },
+    {
+      slug: "get-net-flow",
+      label: "Read Net Flow Rate of an Address",
+      description:
+        "Read an address's net flow rate for a SuperToken (positive = net receiver, negative = net sender)",
+      type: "read",
+      contract: "cfaForwarder",
+      function: "getAccountFlowrate",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "account", type: "address", label: "Account Address" },
+      ],
+      outputs: [
+        {
+          name: "flowRate",
+          type: "int96",
+          label: "Net Flow Rate (wei/sec, signed)",
+          decimals: 18,
+        },
+      ],
+    },
+    {
+      slug: "create-pool",
+      label: "Create Distribution Pool",
+      description:
+        "Create a GDA distribution pool with the supplied address as administrator. The new pool address is emitted in the PoolCreated event -- chain a web3.query-events call after this action filtered by the returned tx hash to capture it.",
+      type: "write",
+      contract: "gdaForwarder",
+      function: "createPool",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "admin", type: "address", label: "Pool Admin Address" },
+        {
+          name: "config",
+          type: "tuple",
+          label: "Pool Config",
+          components: [
+            { name: "transferabilityForUnitsOwner", type: "bool" },
+            { name: "distributionFromAnyAddress", type: "bool" },
+          ],
+        },
+      ],
+    },
+    {
+      slug: "update-member-units",
+      label: "Set Member Units in a Pool",
+      description:
+        "Set a recipient's pro-rata share in a distribution pool. New members must call connect-pool from their own wallet before they receive distributions.",
+      type: "write",
+      contract: "gdaForwarder",
+      function: "updateMemberUnits",
+      inputs: [
+        { name: "pool", type: "address", label: "Pool Address" },
+        { name: "member", type: "address", label: "Member Address" },
+        { name: "units", type: "uint128", label: "Units" },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "distribute",
+      label: "Instant Distribution to a Pool",
+      description:
+        "Push a one-shot distribution into a pool. Amount divides pro-rata across members by their unit share.",
+      type: "write",
+      contract: "gdaForwarder",
+      function: "distribute",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "from", type: "address", label: "Sender Address" },
+        { name: "pool", type: "address", label: "Pool Address" },
+        { name: "amount", type: "uint256", label: "Amount (wei)" },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "distribute-flow",
+      label: "Stream Into a Pool",
+      description:
+        "Open a continuous stream into a pool. Members receive their pro-rata share by the second; updating member units changes the split in real time.",
+      type: "write",
+      contract: "gdaForwarder",
+      function: "distributeFlow",
+      inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
+        { name: "from", type: "address", label: "Sender Address" },
+        { name: "pool", type: "address", label: "Pool Address" },
+        {
+          name: "flowRate",
+          type: "int96",
+          label: "Flow Rate (wei/sec)",
+          helpTip: FLOW_RATE_HELP,
+        },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "connect-pool",
+      label: "Connect to a Pool (Member Opt-In)",
+      description:
+        "Members must call this from their own wallet to start receiving distributions. Without this, units exist but no money flows.",
+      type: "write",
+      contract: "gdaForwarder",
+      function: "connectPool",
+      inputs: [
+        { name: "pool", type: "address", label: "Pool Address" },
+        {
+          name: "userData",
+          type: "bytes",
+          label: "User Data",
+          default: "0x",
+          advanced: true,
+        },
+      ],
+    },
+    {
+      slug: "wrap",
+      label: "Wrap to SuperToken",
+      description:
+        "Wrap an underlying ERC-20 amount into its SuperToken. Requires a prior web3.approve-token call against the SuperToken address.",
+      type: "write",
+      contract: "superToken",
+      function: "upgrade",
+      inputs: [{ name: "amount", type: "uint256", label: "Amount (wei)" }],
+    },
+    {
+      slug: "unwrap",
+      label: "Unwrap from SuperToken",
+      description: "Unwrap a SuperToken amount back to its underlying ERC-20",
+      type: "write",
+      contract: "superToken",
+      function: "downgrade",
+      inputs: [{ name: "amount", type: "uint256", label: "Amount (wei)" }],
+    },
+    {
+      slug: "grant-flow-operator",
+      label: "Grant Flow-Operator Permissions",
+      description:
+        "Authorize another address to manage your flows of this SuperToken up to a wei/sec allowance",
+      type: "write",
+      contract: "superToken",
+      function: "updateFlowOperatorPermissions",
+      inputs: [
+        {
+          name: "flowOperator",
+          type: "address",
+          label: "Flow Operator Address",
+        },
+        {
+          name: "permissions",
+          type: "uint8",
+          label: "Permissions Bitmap",
+          helpTip:
+            "Bitmask: 1 = create, 2 = update, 4 = delete, 7 = all three. Combine via bitwise OR.",
+        },
+        {
+          name: "flowRateAllowance",
+          type: "int96",
+          label: "Flow Rate Allowance (wei/sec)",
+          helpTip: FLOW_RATE_HELP,
+        },
+      ],
+    },
+    {
+      slug: "get-super-token-balance",
+      label: "Get SuperToken Balance",
+      description: "Read an address's current SuperToken balance",
+      type: "read",
+      contract: "superToken",
+      function: "balanceOf",
+      inputs: [{ name: "account", type: "address", label: "Account Address" }],
+      outputs: [
+        {
+          name: "balance",
+          type: "uint256",
+          label: "Balance (wei)",
+          decimals: 18,
+        },
+      ],
+    },
+    {
+      slug: "get-underlying-token",
+      label: "Get Underlying ERC-20 Address",
+      description:
+        "Read the underlying ERC-20 address for this SuperToken (the token that gets escrowed when you wrap)",
+      type: "read",
+      contract: "superToken",
+      function: "getUnderlyingToken",
+      inputs: [],
+      outputs: [
+        {
+          name: "underlying",
+          type: "address",
+          label: "Underlying ERC-20 Address",
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/e2e-superfluid-sepolia.ts
+++ b/scripts/e2e-superfluid-sepolia.ts
@@ -1,0 +1,459 @@
+/**
+ * Live Sepolia end-to-end script for the Superfluid protocol.
+ *
+ * Walks the full streaming + pool lifecycle against real Superfluid contracts:
+ * approve -> wrap -> create-flow -> update-flow -> get-net-flow -> delete-flow
+ * -> create-pool -> update-member-units -> connect-pool -> distribute-flow
+ * -> read net flow -> cleanup
+ *
+ * Usage:
+ *   export SUPERFLUID_E2E_SENDER_KEY=0x...
+ *   pnpm tsx scripts/e2e-superfluid-sepolia.ts
+ *
+ * Contract addresses are pinned to Superfluid's canonical Sepolia deployments.
+ * If Superfluid migrates a contract, override via env vars:
+ *   SUPERFLUID_E2E_CFA_FORWARDER   (default: 0xcfA132E353cB4E398080B9700609bb008eceB125)
+ *   SUPERFLUID_E2E_GDA_FORWARDER   (default: 0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08)
+ *   SUPERFLUID_E2E_SUPER_TOKEN     (default: 0xb598E6C621618a9f63788816ffb50Ee2862D443B, fUSDCx)
+ *   SUPERFLUID_E2E_UNDERLYING      (default: 0xe72f289584eDA2bE69Cfe487f4638F09bAc920Db, fUSDC -- "fUSDC Fake Token"; mint(address,uint256) is permissive on Sepolia)
+ *
+ * Required env vars:
+ *   SUPERFLUID_E2E_SENDER_KEY      hex private key, 0x-prefixed
+ *
+ * Optional env vars:
+ *   SUPERFLUID_E2E_RECEIVER_KEY    second wallet key; connect-pool step is SKIPPED if absent
+ *   SUPERFLUID_E2E_RPC_URL         default: https://ethereum-sepolia-rpc.publicnode.com
+ *   SUPERFLUID_E2E_WRAP_AMOUNT     wei to wrap (default: 100000000)
+ *   SUPERFLUID_E2E_FLOW_RATE       wei/sec flow rate (default: 1000000)
+ *
+ * Pre-flight: fund the sender wallet with Sepolia ETH (gas) and fUSDC.
+ * Faucet: https://app.superfluid.finance/faucet (select Sepolia, claim fUSDC).
+ * The script does NOT automate faucet interaction.
+ */
+
+import { Contract, ethers, JsonRpcProvider, Wallet } from "ethers";
+import {
+  CFA_FORWARDER_ADDRESS,
+  GDA_FORWARDER_ADDRESS,
+} from "@/protocols/superfluid";
+
+const SEPOLIA_CHAIN_ID = 11155111;
+
+const DEFAULT_RPC = "https://ethereum-sepolia-rpc.publicnode.com";
+const DEFAULT_CFA_FORWARDER = CFA_FORWARDER_ADDRESS;
+const DEFAULT_GDA_FORWARDER = GDA_FORWARDER_ADDRESS;
+const DEFAULT_SUPER_TOKEN = "0xb598E6C621618a9f63788816ffb50Ee2862D443B";
+const DEFAULT_UNDERLYING = "0xe72f289584eDA2bE69Cfe487f4638F09bAc920Db";
+const DEFAULT_WRAP_AMOUNT = "100000000";
+const DEFAULT_FLOW_RATE = "1000000";
+
+// Override gas limit on every write tx. Ethers v6's default eth_estimateGas
+// buffer is too tight for CFA/GDA writes -- the actual gas usage can exceed
+// the estimate due to SLOAD warming differences between simulation and
+// execution, causing OOG reverts (e.g. updateFlow uses ~315k vs estimated
+// ~285k). 1.5M gas covers the heaviest call (createPool) with margin.
+const TX_OVERRIDES = { gasLimit: 1_500_000 };
+
+// Stable receiver address used when SUPERFLUID_E2E_RECEIVER_KEY is not set.
+// This is a deterministic dead-drop address; it will receive flows but nobody
+// controls the key, so connect-pool cannot be signed for it.
+const FALLBACK_RECEIVER = "0x000000000000000000000000000000000000dEaD";
+
+const ERC20_ABI = [
+  "function approve(address spender, uint256 amount) returns (bool)",
+  "function balanceOf(address account) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+  "function allowance(address owner, address spender) view returns (uint256)",
+];
+
+const SUPER_TOKEN_ABI = [
+  "function upgrade(uint256 amount)",
+  "function downgrade(uint256 amount)",
+  "function balanceOf(address account) view returns (uint256)",
+];
+
+const CFA_FORWARDER_ABI = [
+  "function createFlow(address token, address sender, address receiver, int96 flowRate, bytes userData) returns (bool)",
+  "function updateFlow(address token, address sender, address receiver, int96 flowRate, bytes userData) returns (bool)",
+  "function deleteFlow(address token, address sender, address receiver, bytes userData) returns (bool)",
+  "function getFlowInfo(address token, address sender, address receiver) view returns (uint256 lastUpdated, int96 flowRate, uint256 deposit, uint256 owedDeposit)",
+  "function getAccountFlowrate(address token, address account) view returns (int96 flowRate)",
+];
+
+const GDA_FORWARDER_ABI = [
+  "function createPool(address token, address admin, tuple(bool transferabilityForUnitsOwner, bool distributionFromAnyAddress) config) returns (bool success, address pool)",
+  "function updateMemberUnits(address pool, address member, uint128 units, bytes userData) returns (bool)",
+  "function getNetFlow(address token, address account) view returns (int96)",
+  "function connectPool(address pool, bytes userData) returns (bool)",
+  "function distributeFlow(address token, address from, address pool, int96 flowRate, bytes userData) returns (bool)",
+  "event PoolCreated(address indexed token, address indexed admin, address pool)",
+];
+
+type StepStatus = "PASS" | "SKIPPED" | "FAILED";
+
+interface StepResult {
+  name: string;
+  status: StepStatus;
+  detail: string;
+}
+
+const results: StepResult[] = [];
+
+function record(name: string, status: StepStatus, detail: string): void {
+  results.push({ name, status, detail });
+  const prefix = status === "PASS" ? "OK" : status === "SKIPPED" ? "SKIPPED" : "FAILED";
+  console.log(`[${prefix}] ${name}: ${detail}`);
+}
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return val;
+}
+
+function getEnv(name: string, fallback: string): string {
+  return process.env[name] ?? fallback;
+}
+
+async function sendAndWait(
+  label: string,
+  // biome-ignore lint/suspicious/noExplicitAny: ethers contract calls return ContractTransactionResponse which needs any
+  txPromise: Promise<any>
+): Promise<ethers.TransactionReceipt> {
+  // biome-ignore lint/suspicious/noExplicitAny: ethers v6 contract method return type
+  const tx: any = await txPromise;
+  console.log(`  [${label}] tx ${tx.hash}`);
+  const receipt: ethers.TransactionReceipt | null = await tx.wait();
+  if (!receipt || receipt.status !== 1) {
+    throw new Error(`Transaction reverted: ${tx.hash}`);
+  }
+  return receipt;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function main(): Promise<void> {
+  // --- env setup ---
+  const senderKey = requireEnv("SUPERFLUID_E2E_SENDER_KEY");
+  const receiverKey = process.env.SUPERFLUID_E2E_RECEIVER_KEY;
+  const rpcUrl = getEnv("SUPERFLUID_E2E_RPC_URL", DEFAULT_RPC);
+  const cfaAddress = getEnv("SUPERFLUID_E2E_CFA_FORWARDER", DEFAULT_CFA_FORWARDER);
+  const gdaAddress = getEnv("SUPERFLUID_E2E_GDA_FORWARDER", DEFAULT_GDA_FORWARDER);
+  const superTokenAddress = getEnv("SUPERFLUID_E2E_SUPER_TOKEN", DEFAULT_SUPER_TOKEN);
+  const underlyingAddress = getEnv("SUPERFLUID_E2E_UNDERLYING", DEFAULT_UNDERLYING);
+  const wrapAmount = BigInt(getEnv("SUPERFLUID_E2E_WRAP_AMOUNT", DEFAULT_WRAP_AMOUNT));
+  const flowRate = BigInt(getEnv("SUPERFLUID_E2E_FLOW_RATE", DEFAULT_FLOW_RATE));
+
+  const provider = new JsonRpcProvider(rpcUrl, SEPOLIA_CHAIN_ID);
+  const senderWallet = new Wallet(senderKey, provider);
+  const senderAddress = senderWallet.address;
+
+  let receiverAddress: string;
+  let receiverWallet: Wallet | null = null;
+  if (receiverKey) {
+    receiverWallet = new Wallet(receiverKey, provider);
+    receiverAddress = receiverWallet.address;
+  } else {
+    receiverAddress = FALLBACK_RECEIVER;
+    console.log(`SUPERFLUID_E2E_RECEIVER_KEY not set -- using fallback receiver ${FALLBACK_RECEIVER}`);
+    console.log("Steps requiring receiver signature will be SKIPPED.");
+  }
+
+  console.log(`Sender:   ${senderAddress}`);
+  console.log(`Receiver: ${receiverAddress}`);
+  console.log(`RPC:      ${rpcUrl}`);
+  console.log(`Chain ID: ${SEPOLIA_CHAIN_ID}`);
+  console.log("");
+
+  const erc20 = new Contract(underlyingAddress, ERC20_ABI, senderWallet);
+  const superToken = new Contract(superTokenAddress, SUPER_TOKEN_ABI, senderWallet);
+  const cfa = new Contract(cfaAddress, CFA_FORWARDER_ABI, senderWallet);
+  const gda = new Contract(gdaAddress, GDA_FORWARDER_ABI, senderWallet);
+
+  // --- step 1: pre-flight ---
+  console.log("[step 1 / pre-flight]");
+  const ethBalance: bigint = await provider.getBalance(senderAddress);
+  const minEth = ethers.parseEther("0.01");
+  if (ethBalance < minEth) {
+    console.error(
+      `Insufficient ETH for gas: ${ethers.formatEther(ethBalance)} ETH (need >= 0.01). Fund the sender wallet on Sepolia.`
+    );
+    process.exit(1);
+  }
+  const underlyingBalance: bigint = await erc20.balanceOf(senderAddress);
+  if (underlyingBalance < wrapAmount) {
+    console.error(
+      `Insufficient fUSDC balance: ${underlyingBalance} wei (need >= ${wrapAmount}). Claim from https://app.superfluid.finance/faucet (Sepolia).`
+    );
+    process.exit(1);
+  }
+  record(
+    "step 1 / pre-flight",
+    "PASS",
+    `ETH ${ethers.formatEther(ethBalance)} | fUSDC balance ${underlyingBalance} wei`
+  );
+
+  // --- idempotency: close any pre-existing flow before the lifecycle ---
+  console.log("\n[idempotency check]");
+  const [, existingRate]: [bigint, bigint, bigint, bigint] = await cfa.getFlowInfo(
+    superTokenAddress,
+    senderAddress,
+    receiverAddress
+  );
+  if (existingRate > BigInt(0)) {
+    console.log(`  Pre-existing flow found (${existingRate} wei/s). Deleting before lifecycle.`);
+    await sendAndWait("pre-cleanup delete-flow", cfa.deleteFlow(superTokenAddress, senderAddress, receiverAddress, "0x", TX_OVERRIDES));
+    console.log("  Pre-existing flow deleted.");
+  } else {
+    console.log("  No pre-existing flow. Proceeding.");
+  }
+
+  // --- step 2: approve underlying ---
+  console.log("\n[step 2 / approve]");
+  const receipt2 = await sendAndWait(
+    "approve",
+    erc20.approve(superTokenAddress, wrapAmount, TX_OVERRIDES)
+  );
+  record(
+    "step 2 / approve",
+    "PASS",
+    `tx ${receipt2.hash} | amount ${wrapAmount} wei`
+  );
+
+  // --- step 3: wrap ---
+  console.log("\n[step 3 / wrap]");
+  const balBefore: bigint = await superToken.balanceOf(senderAddress);
+  const receipt3 = await sendAndWait("wrap", superToken.upgrade(wrapAmount, TX_OVERRIDES));
+  const balAfter: bigint = await superToken.balanceOf(senderAddress);
+  if (balAfter <= balBefore) {
+    throw new Error(`Wrap did not increase SuperToken balance: before=${balBefore} after=${balAfter}`);
+  }
+  record(
+    "step 3 / wrap",
+    "PASS",
+    `tx ${receipt3.hash} | superToken balance before=${balBefore} after=${balAfter}`
+  );
+
+  // --- step 4: create-flow ---
+  console.log("\n[step 4 / create-flow]");
+  const receipt4 = await sendAndWait(
+    "create-flow",
+    cfa.createFlow(superTokenAddress, senderAddress, receiverAddress, flowRate, "0x", TX_OVERRIDES)
+  );
+  const [, flowRateAfterCreate]: [bigint, bigint, bigint, bigint] = await cfa.getFlowInfo(
+    superTokenAddress,
+    senderAddress,
+    receiverAddress
+  );
+  if (flowRateAfterCreate !== flowRate) {
+    throw new Error(`Flow rate mismatch after create: expected ${flowRate}, got ${flowRateAfterCreate}`);
+  }
+  record(
+    "step 4 / create-flow",
+    "PASS",
+    `tx ${receipt4.hash} | flowRate ${flowRate} wei/s`
+  );
+
+  // --- step 5: update-flow ---
+  console.log("\n[step 5 / update-flow]");
+  const newFlowRate = flowRate * BigInt(2);
+  const receipt5 = await sendAndWait(
+    "update-flow",
+    cfa.updateFlow(superTokenAddress, senderAddress, receiverAddress, newFlowRate, "0x", TX_OVERRIDES)
+  );
+  const [, flowRateAfterUpdate]: [bigint, bigint, bigint, bigint] = await cfa.getFlowInfo(
+    superTokenAddress,
+    senderAddress,
+    receiverAddress
+  );
+  if (flowRateAfterUpdate !== newFlowRate) {
+    throw new Error(`Flow rate mismatch after update: expected ${newFlowRate}, got ${flowRateAfterUpdate}`);
+  }
+  record(
+    "step 5 / update-flow",
+    "PASS",
+    `tx ${receipt5.hash} | flowRate ${newFlowRate} wei/s`
+  );
+
+  // --- step 6: get-net-flow ---
+  console.log("\n[step 6 / get-net-flow]");
+  const netFlow: bigint = await cfa.getAccountFlowrate(superTokenAddress, receiverAddress);
+  // netFlow may be negative for the sender side; for receiver it should be >= newFlowRate
+  // (could be higher if receiver has other inbound flows)
+  record(
+    "step 6 / get-net-flow",
+    "PASS",
+    `receiver net flow ${netFlow} wei/s`
+  );
+
+  // --- step 7: delete-flow ---
+  console.log("\n[step 7 / delete-flow]");
+  const receipt7 = await sendAndWait(
+    "delete-flow",
+    cfa.deleteFlow(superTokenAddress, senderAddress, receiverAddress, "0x", TX_OVERRIDES)
+  );
+  const [, flowRateAfterDelete]: [bigint, bigint, bigint, bigint] = await cfa.getFlowInfo(
+    superTokenAddress,
+    senderAddress,
+    receiverAddress
+  );
+  if (flowRateAfterDelete !== BigInt(0)) {
+    throw new Error(`Flow still active after delete: rate=${flowRateAfterDelete}`);
+  }
+  record(
+    "step 7 / delete-flow",
+    "PASS",
+    `tx ${receipt7.hash} | flowRate now 0`
+  );
+
+  // --- step 8: create-pool ---
+  console.log("\n[step 8 / create-pool]");
+  const receipt8 = await sendAndWait(
+    "create-pool",
+    gda.createPool(superTokenAddress, senderAddress, [false, false], TX_OVERRIDES)
+  );
+
+  // Parse PoolCreated event from receipt logs
+  const gdaInterface = new ethers.Interface(GDA_FORWARDER_ABI);
+  const poolCreatedTopic = gdaInterface.getEvent("PoolCreated")?.topicHash;
+  let poolAddress = "";
+  for (const log of receipt8.logs) {
+    if (log.topics[0] === poolCreatedTopic) {
+      const parsed = gdaInterface.parseLog({ topics: [...log.topics], data: log.data });
+      if (parsed?.args.pool) {
+        poolAddress = parsed.args.pool as string;
+        break;
+      }
+    }
+  }
+  if (!poolAddress) {
+    throw new Error("PoolCreated event not found in create-pool receipt");
+  }
+  record(
+    "step 8 / create-pool",
+    "PASS",
+    `tx ${receipt8.hash} | pool ${poolAddress}`
+  );
+
+  // --- step 9: update-member-units ---
+  console.log("\n[step 9 / update-member-units]");
+  const receipt9 = await sendAndWait(
+    "update-member-units",
+    gda.updateMemberUnits(poolAddress, receiverAddress, BigInt(100), "0x", TX_OVERRIDES)
+  );
+  record(
+    "step 9 / update-member-units",
+    "PASS",
+    `tx ${receipt9.hash} | member ${receiverAddress} | units 100`
+  );
+
+  // --- step 10: connect-pool (receiver must sign) ---
+  console.log("\n[step 10 / connect-pool]");
+  if (receiverWallet !== null) {
+    const gdaAsReceiver = new Contract(gdaAddress, GDA_FORWARDER_ABI, receiverWallet);
+    const receipt10 = await sendAndWait(
+      "connect-pool",
+      gdaAsReceiver.connectPool(poolAddress, "0x", TX_OVERRIDES)
+    );
+    record(
+      "step 10 / connect-pool",
+      "PASS",
+      `tx ${receipt10.hash} | receiver ${receiverAddress} connected`
+    );
+  } else {
+    record(
+      "step 10 / connect-pool",
+      "SKIPPED",
+      "SUPERFLUID_E2E_RECEIVER_KEY not set; receiver cannot sign connect-pool"
+    );
+  }
+
+  // --- step 11: distribute-flow ---
+  console.log("\n[step 11 / distribute-flow]");
+  const receipt11 = await sendAndWait(
+    "distribute-flow",
+    gda.distributeFlow(superTokenAddress, senderAddress, poolAddress, flowRate, "0x", TX_OVERRIDES)
+  );
+  record(
+    "step 11 / distribute-flow",
+    "PASS",
+    `tx ${receipt11.hash} | flowRate ${flowRate} wei/s`
+  );
+
+  // --- step 12: read net flow twice, 5 seconds apart ---
+  // CFA's getAccountFlowrate aggregates only CFA flows. To observe the
+  // receiver's incoming pool stream we have to query the GDA forwarder's
+  // getNetFlow, which combines CFA and GDA flows.
+  console.log("\n[step 12 / read-net-flow x2]");
+  const netFlowBefore: bigint = await gda.getNetFlow(superTokenAddress, receiverAddress);
+  console.log(`  net flow (t=0): ${netFlowBefore} wei/s`);
+  await sleep(5000);
+  const netFlowAfter: bigint = await gda.getNetFlow(superTokenAddress, receiverAddress);
+  console.log(`  net flow (t=5s): ${netFlowAfter} wei/s`);
+
+  if (receiverWallet !== null) {
+    if (netFlowAfter <= BigInt(0)) {
+      throw new Error(`Expected receiver net flow to be > 0 after connect-pool + distribute-flow, got ${netFlowAfter}`);
+    }
+    record(
+      "step 12 / read-net-flow",
+      "PASS",
+      `t=0: ${netFlowBefore} wei/s | t=5s: ${netFlowAfter} wei/s`
+    );
+  } else {
+    record(
+      "step 12 / read-net-flow",
+      "PASS",
+      `t=0: ${netFlowBefore} wei/s | t=5s: ${netFlowAfter} wei/s (receiver not connected; flow accumulation not verified)`
+    );
+  }
+
+  // --- step 13: cleanup ---
+  console.log("\n[step 13 / cleanup]");
+  const receipt13 = await sendAndWait(
+    "cleanup distribute-flow",
+    gda.distributeFlow(superTokenAddress, senderAddress, poolAddress, BigInt(0), "0x", TX_OVERRIDES)
+  );
+  record(
+    "step 13 / cleanup",
+    "PASS",
+    `tx ${receipt13.hash} | pool stream closed`
+  );
+
+  // --- summary ---
+  console.log("\n--- SUMMARY ---");
+  console.log(
+    `${"Step".padEnd(40)} ${"Status".padEnd(10)} Detail`
+  );
+  console.log("-".repeat(100));
+  for (const r of results) {
+    console.log(`${r.name.padEnd(40)} ${r.status.padEnd(10)} ${r.detail}`);
+  }
+
+  const failed = results.filter((r) => r.status === "FAILED");
+  const skipped = results.filter((r) => r.status === "SKIPPED");
+  console.log(
+    `\n${results.length} steps total | ${results.length - failed.length - skipped.length} PASS | ${skipped.length} SKIPPED | ${failed.length} FAILED`
+  );
+
+  if (failed.length > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error: unknown) => {
+  const failed = results.filter((r) => r.status === "FAILED");
+  const msg = error instanceof Error ? error.message : String(error);
+  if (failed.length === 0) {
+    // Unrecorded failure
+    console.error(`\nFATAL: ${msg}`);
+  }
+  process.exit(1);
+});

--- a/scripts/verify-superfluid-addresses.ts
+++ b/scripts/verify-superfluid-addresses.ts
@@ -1,0 +1,134 @@
+/**
+ * Superfluid forwarder address verification.
+ *
+ * One-shot CLI: confirms CFAv1Forwarder and GDAv1Forwarder are deployed
+ * (have non-empty bytecode) at their pinned addresses on every chain
+ * Superfluid is shipped on. Run before opening the PR; paste the table
+ * output into the PR description.
+ *
+ * Interpreting failures: a row with a network error (HTTP 401/429/5xx,
+ * DNS, timeout) means the public RPC is unreachable -- retry or swap the
+ * URL in the CHAINS array below. A row showing FAIL with no error message
+ * means the address actually has empty bytecode on that chain (a real
+ * deployment miss to investigate).
+ *
+ * Usage: pnpm tsx scripts/verify-superfluid-addresses.ts
+ */
+
+import { JsonRpcProvider } from "ethers";
+import {
+  CFA_FORWARDER_ADDRESS,
+  GDA_FORWARDER_ADDRESS,
+  SUPERFLUID_CHAIN_IDS,
+} from "@/protocols/superfluid";
+
+type ForwarderName = "CFAv1Forwarder" | "GDAv1Forwarder";
+
+const FORWARDERS: Record<ForwarderName, string> = {
+  CFAv1Forwarder: CFA_FORWARDER_ADDRESS,
+  GDAv1Forwarder: GDA_FORWARDER_ADDRESS,
+};
+
+// RPC + display metadata per chain. The chain set itself is sourced from the
+// protocol module so adding/removing a chain happens in exactly one place;
+// any chain ID present in SUPERFLUID_CHAIN_IDS but missing here will surface
+// as an "unknown chain" entry below.
+const CHAIN_RPC: Record<string, { name: string; rpc: string }> = {
+  "1": { name: "Ethereum Mainnet", rpc: "https://rpc.ankr.com/eth" },
+  "10": { name: "Optimism", rpc: "https://mainnet.optimism.io" },
+  "137": { name: "Polygon", rpc: "https://rpc.ankr.com/polygon" },
+  "8453": { name: "Base", rpc: "https://mainnet.base.org" },
+  "42161": { name: "Arbitrum One", rpc: "https://arb1.arbitrum.io/rpc" },
+  "11155111": {
+    name: "Sepolia",
+    rpc: "https://ethereum-sepolia-rpc.publicnode.com",
+  },
+};
+
+const CHAINS: Array<{ id: number; name: string; rpc: string }> =
+  SUPERFLUID_CHAIN_IDS.map((id) => {
+    const meta = CHAIN_RPC[id];
+    return {
+      id: Number(id),
+      name: meta?.name ?? `Unknown chain ${id}`,
+      rpc: meta?.rpc ?? "",
+    };
+  });
+
+type CheckResult = {
+  chainName: string;
+  chainId: number;
+  forwarder: ForwarderName;
+  address: string;
+  deployed: boolean;
+  error?: string;
+};
+
+async function checkOne(
+  chain: { id: number; name: string; rpc: string },
+  forwarder: ForwarderName
+): Promise<CheckResult> {
+  const address = FORWARDERS[forwarder];
+  try {
+    const provider = new JsonRpcProvider(chain.rpc, chain.id);
+    const code = await provider.getCode(address);
+    return {
+      chainName: chain.name,
+      chainId: chain.id,
+      forwarder,
+      address,
+      deployed: code !== "0x",
+    };
+  } catch (error) {
+    return {
+      chainName: chain.name,
+      chainId: chain.id,
+      forwarder,
+      address,
+      deployed: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function printMarkdownTable(results: CheckResult[]): void {
+  console.log("");
+  console.log("| Chain | Chain ID | Contract | Address | Status |");
+  console.log("|---|---|---|---|---|");
+  for (const r of results) {
+    const status = r.deployed ? "OK" : `FAIL${r.error ? ` (${r.error})` : ""}`;
+    console.log(
+      `| ${r.chainName} | ${r.chainId} | ${r.forwarder} | \`${r.address}\` | ${status} |`
+    );
+  }
+  console.log("");
+}
+
+async function main(): Promise<void> {
+  console.error("Verifying Superfluid forwarder deployments...");
+
+  const tasks: Array<Promise<CheckResult>> = [];
+  for (const chain of CHAINS) {
+    for (const fwd of Object.keys(FORWARDERS) as ForwarderName[]) {
+      tasks.push(checkOne(chain, fwd));
+    }
+  }
+
+  const results = await Promise.all(tasks);
+  printMarkdownTable(results);
+
+  const failed = results.filter((r) => !r.deployed);
+  if (failed.length > 0) {
+    console.error(
+      `FAILED: ${failed.length} of ${results.length} checks did not find deployed bytecode.`
+    );
+    process.exit(1);
+  }
+
+  console.error(`All ${results.length} forwarder deployments verified.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/superfluid-protocol.test.ts
+++ b/tests/unit/superfluid-protocol.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, it } from "vitest";
+import superfluidProtocol, {
+  CFA_FORWARDER_ADDRESS,
+  GDA_FORWARDER_ADDRESS,
+  SUPERFLUID_CHAIN_IDS,
+} from "@/protocols/superfluid";
+
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+const KEBAB_CASE_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const EXPECTED_CHAINS: string[] = [...SUPERFLUID_CHAIN_IDS];
+
+const CFA_FORWARDER = CFA_FORWARDER_ADDRESS;
+
+type SuperfluidAction = (typeof superfluidProtocol.actions)[number];
+
+const findAction = (slug: string): SuperfluidAction | undefined =>
+  superfluidProtocol.actions.find((a) => a.slug === slug);
+
+describe("Superfluid protocol", () => {
+  describe("metadata", () => {
+    it("declares the expected name, slug, and description", () => {
+      expect(superfluidProtocol.name).toBe("Superfluid");
+      expect(superfluidProtocol.slug).toBe("superfluid");
+      expect(superfluidProtocol.description).toBeTruthy();
+      expect(superfluidProtocol.website).toBe("https://superfluid.org");
+    });
+  });
+
+  describe("cfaForwarder contract", () => {
+    it("declares cfaForwarder with the same address on all six chains", () => {
+      const contract = superfluidProtocol.contracts.cfaForwarder;
+      expect(contract).toBeDefined();
+      expect(Object.keys(contract.addresses).sort()).toEqual(
+        [...EXPECTED_CHAINS].sort()
+      );
+      const unique = new Set(Object.values(contract.addresses));
+      expect(unique.size).toBe(1);
+      expect([...unique][0]).toBe(CFA_FORWARDER);
+      for (const addr of Object.values(contract.addresses)) {
+        expect(addr).toMatch(ADDRESS_REGEX);
+      }
+    });
+
+    it("ships an inline ABI containing the 5 expected functions", () => {
+      const contract = superfluidProtocol.contracts.cfaForwarder;
+      expect(contract.abi).toBeTruthy();
+      const abi = JSON.parse(contract.abi as string) as Array<{
+        type: string;
+        name?: string;
+      }>;
+      const fnNames = abi
+        .filter((f) => f.type === "function")
+        .map((f) => f.name)
+        .sort();
+      expect(fnNames).toEqual(
+        [
+          "createFlow",
+          "deleteFlow",
+          "getAccountFlowrate",
+          "getFlowInfo",
+          "updateFlow",
+        ].sort()
+      );
+    });
+  });
+
+  describe("create-flow action", () => {
+    it("is declared as a write action against cfaForwarder.createFlow", () => {
+      const action = findAction("create-flow");
+      expect(action).toBeDefined();
+      expect(action?.type).toBe("write");
+      expect(action?.contract).toBe("cfaForwarder");
+      expect(action?.function).toBe("createFlow");
+      expect(action?.slug).toMatch(KEBAB_CASE_REGEX);
+    });
+
+    it("has the five expected inputs in order", () => {
+      const action = findAction("create-flow");
+      const names = action?.inputs.map((i) => i.name);
+      expect(names).toEqual([
+        "token",
+        "sender",
+        "receiver",
+        "flowRate",
+        "userData",
+      ]);
+    });
+
+    it("marks userData as advanced with default 0x", () => {
+      const action = findAction("create-flow");
+      const userData = action?.inputs.find((i) => i.name === "userData");
+      expect(userData?.advanced).toBe(true);
+      expect(userData?.default).toBe("0x");
+    });
+
+    it("includes the int96 helpTip on flowRate", () => {
+      const action = findAction("create-flow");
+      const flowRate = action?.inputs.find((i) => i.name === "flowRate");
+      expect(flowRate?.helpTip).toContain("Wei per second");
+      expect(flowRate?.helpTip).toContain("int96");
+    });
+  });
+
+  describe("update-flow action", () => {
+    it("is declared as a write action against cfaForwarder.updateFlow", () => {
+      const action = findAction("update-flow");
+      expect(action).toBeDefined();
+      expect(action?.type).toBe("write");
+      expect(action?.contract).toBe("cfaForwarder");
+      expect(action?.function).toBe("updateFlow");
+    });
+
+    it("has the same input shape as create-flow", () => {
+      const action = findAction("update-flow");
+      const names = action?.inputs.map((i) => i.name);
+      expect(names).toEqual([
+        "token",
+        "sender",
+        "receiver",
+        "flowRate",
+        "userData",
+      ]);
+    });
+  });
+
+  describe("delete-flow action", () => {
+    it("is declared as a write action against cfaForwarder.deleteFlow", () => {
+      const action = findAction("delete-flow");
+      expect(action).toBeDefined();
+      expect(action?.type).toBe("write");
+      expect(action?.contract).toBe("cfaForwarder");
+      expect(action?.function).toBe("deleteFlow");
+    });
+
+    it("has token/sender/receiver/userData inputs", () => {
+      const action = findAction("delete-flow");
+      const names = action?.inputs.map((i) => i.name);
+      expect(names).toEqual(["token", "sender", "receiver", "userData"]);
+    });
+  });
+
+  describe("get-flow action", () => {
+    it("is declared as a read action against cfaForwarder.getFlowInfo", () => {
+      const action = findAction("get-flow");
+      expect(action).toBeDefined();
+      expect(action?.type).toBe("read");
+      expect(action?.contract).toBe("cfaForwarder");
+      expect(action?.function).toBe("getFlowInfo");
+    });
+
+    it("declares the four expected outputs with decimals on rate/deposit", () => {
+      const action = findAction("get-flow");
+      const outputs = action?.outputs ?? [];
+      expect(outputs.map((o) => o.name)).toEqual([
+        "lastUpdated",
+        "flowRate",
+        "deposit",
+        "owedDeposit",
+      ]);
+      expect(outputs.find((o) => o.name === "flowRate")?.decimals).toBe(18);
+      expect(outputs.find((o) => o.name === "deposit")?.decimals).toBe(18);
+    });
+  });
+
+  describe("get-net-flow action", () => {
+    it("is declared as a read action against cfaForwarder.getAccountFlowrate", () => {
+      const action = findAction("get-net-flow");
+      expect(action).toBeDefined();
+      expect(action?.type).toBe("read");
+      expect(action?.contract).toBe("cfaForwarder");
+      expect(action?.function).toBe("getAccountFlowrate");
+    });
+
+    it("returns flowRate as int96 with decimals: 18", () => {
+      const action = findAction("get-net-flow");
+      const out = action?.outputs?.[0];
+      expect(out?.name).toBe("flowRate");
+      expect(out?.type).toBe("int96");
+      expect(out?.decimals).toBe(18);
+    });
+  });
+
+  describe("gdaForwarder contract", () => {
+    const GDA_FORWARDER = GDA_FORWARDER_ADDRESS;
+
+    it("declares gdaForwarder with the same address on all six chains", () => {
+      const contract = superfluidProtocol.contracts.gdaForwarder;
+      expect(contract).toBeDefined();
+      expect(Object.keys(contract.addresses).sort()).toEqual(
+        [...EXPECTED_CHAINS].sort()
+      );
+      const unique = new Set(Object.values(contract.addresses));
+      expect(unique.size).toBe(1);
+      expect([...unique][0]).toBe(GDA_FORWARDER);
+    });
+
+    it("ships an inline ABI with the 5 expected functions", () => {
+      const contract = superfluidProtocol.contracts.gdaForwarder;
+      const abi = JSON.parse(contract.abi as string) as Array<{
+        type: string;
+        name?: string;
+      }>;
+      const fnNames = abi
+        .filter((f) => f.type === "function")
+        .map((f) => f.name)
+        .sort();
+      expect(fnNames).toEqual(
+        [
+          "connectPool",
+          "createPool",
+          "distribute",
+          "distributeFlow",
+          "updateMemberUnits",
+        ].sort()
+      );
+    });
+
+    it("createPool ABI declares the (bool,bool) PoolConfig tuple", () => {
+      const contract = superfluidProtocol.contracts.gdaForwarder;
+      const abi = JSON.parse(contract.abi as string) as Array<{
+        type: string;
+        name?: string;
+        inputs?: Array<{
+          name: string;
+          type: string;
+          components?: Array<{ name: string; type: string }>;
+        }>;
+      }>;
+      const createPool = abi.find(
+        (f) => f.type === "function" && f.name === "createPool"
+      );
+      const config = createPool?.inputs?.find((i) => i.name === "config");
+      expect(config?.type).toBe("tuple");
+      expect(config?.components?.map((c) => c.name)).toEqual([
+        "transferabilityForUnitsOwner",
+        "distributionFromAnyAddress",
+      ]);
+    });
+  });
+
+  describe("GDA actions", () => {
+    it("declares the five expected GDA action slugs", () => {
+      const slugs = superfluidProtocol.actions
+        .filter((a) => a.contract === "gdaForwarder")
+        .map((a) => a.slug)
+        .sort();
+      expect(slugs).toEqual(
+        [
+          "connect-pool",
+          "create-pool",
+          "distribute",
+          "distribute-flow",
+          "update-member-units",
+        ].sort()
+      );
+    });
+
+    it("create-pool declares the config tuple input via components", () => {
+      const action = findAction("create-pool");
+      const config = action?.inputs.find((i) => i.name === "config");
+      expect(config?.type).toBe("tuple");
+      expect(config?.components?.map((c) => c.name)).toEqual([
+        "transferabilityForUnitsOwner",
+        "distributionFromAnyAddress",
+      ]);
+    });
+
+    it("distribute-flow uses int96 flowRate with the shared helpTip", () => {
+      const action = findAction("distribute-flow");
+      const flowRate = action?.inputs.find((i) => i.name === "flowRate");
+      expect(flowRate?.type).toBe("int96");
+      expect(flowRate?.helpTip).toContain("Wei per second");
+    });
+
+    it("connect-pool documents that members must call from their own wallet", () => {
+      const action = findAction("connect-pool");
+      expect(action?.description.toLowerCase()).toContain("own wallet");
+    });
+  });
+
+  describe("superToken contract", () => {
+    it("declares superToken with userSpecifiedAddress: true", () => {
+      const contract = superfluidProtocol.contracts.superToken;
+      expect(contract).toBeDefined();
+      expect(contract.userSpecifiedAddress).toBe(true);
+    });
+
+    it("ships an inline ABI with the 5 expected functions", () => {
+      const contract = superfluidProtocol.contracts.superToken;
+      const abi = JSON.parse(contract.abi as string) as Array<{
+        type: string;
+        name?: string;
+      }>;
+      const fnNames = abi
+        .filter((f) => f.type === "function")
+        .map((f) => f.name)
+        .sort();
+      expect(fnNames).toEqual(
+        [
+          "balanceOf",
+          "downgrade",
+          "getUnderlyingToken",
+          "updateFlowOperatorPermissions",
+          "upgrade",
+        ].sort()
+      );
+    });
+  });
+
+  describe("SuperToken actions", () => {
+    it("declares the five expected SuperToken action slugs", () => {
+      const slugs = superfluidProtocol.actions
+        .filter((a) => a.contract === "superToken")
+        .map((a) => a.slug)
+        .sort();
+      expect(slugs).toEqual(
+        [
+          "get-super-token-balance",
+          "get-underlying-token",
+          "grant-flow-operator",
+          "unwrap",
+          "wrap",
+        ].sort()
+      );
+    });
+
+    it("wrap is a write action against superToken.upgrade", () => {
+      const action = findAction("wrap");
+      expect(action?.type).toBe("write");
+      expect(action?.contract).toBe("superToken");
+      expect(action?.function).toBe("upgrade");
+    });
+
+    it("unwrap is a write action against superToken.downgrade", () => {
+      const action = findAction("unwrap");
+      expect(action?.type).toBe("write");
+      expect(action?.function).toBe("downgrade");
+    });
+
+    it("grant-flow-operator includes the bitmap helpTip on permissions", () => {
+      const action = findAction("grant-flow-operator");
+      const perms = action?.inputs.find((i) => i.name === "permissions");
+      expect(perms?.type).toBe("uint8");
+      expect(perms?.helpTip).toContain("1");
+      expect(perms?.helpTip).toContain("2");
+      expect(perms?.helpTip).toContain("4");
+      expect(perms?.helpTip).toContain("7");
+    });
+
+    it("get-super-token-balance returns balance with decimals: 18", () => {
+      const action = findAction("get-super-token-balance");
+      expect(action?.type).toBe("read");
+      expect(action?.outputs?.[0]?.decimals).toBe(18);
+    });
+
+    it("get-underlying-token returns an address output and takes no inputs", () => {
+      const action = findAction("get-underlying-token");
+      expect(action?.type).toBe("read");
+      expect(action?.inputs).toEqual([]);
+      expect(action?.outputs?.[0]?.type).toBe("address");
+    });
+  });
+
+  describe("overall integrity", () => {
+    it("declares 15 actions in total", () => {
+      expect(superfluidProtocol.actions).toHaveLength(15);
+    });
+
+    it("every action slug is unique kebab-case", () => {
+      const slugs = superfluidProtocol.actions.map((a) => a.slug);
+      expect(new Set(slugs).size).toBe(slugs.length);
+      for (const slug of slugs) {
+        expect(slug).toMatch(KEBAB_CASE_REGEX);
+      }
+    });
+
+    it("every action references a defined contract", () => {
+      const contractKeys = new Set(Object.keys(superfluidProtocol.contracts));
+      for (const action of superfluidProtocol.actions) {
+        expect(contractKeys.has(action.contract)).toBe(true);
+      }
+    });
+
+    it("every action's function exists in its contract's ABI", () => {
+      for (const action of superfluidProtocol.actions) {
+        const contract =
+          superfluidProtocol.contracts[
+            action.contract as keyof typeof superfluidProtocol.contracts
+          ];
+        const abi = contract.abi
+          ? (JSON.parse(contract.abi) as Array<{
+              type: string;
+              name?: string;
+            }>)
+          : [];
+        const fnNames = abi
+          .filter((f) => f.type === "function")
+          .map((f) => f.name);
+        expect(fnNames).toContain(action.function);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Superfluid as a first-class KeeperHub protocol via the existing `defineProtocol()` DSL. One declarative file at `protocols/superfluid.ts` exposes **15 workflow actions** (11 writes + 4 reads) covering streaming payments (CFA), pool-based distributions (GDA), and SuperToken wrap/unwrap. No new plugin folder, no per-action step files, no SDK dependency, no contracts deployed.

| Surface | Actions |
|---|---|
| **Constant-Flow Agreement (1:1 streams)** | `create-flow`, `update-flow`, `delete-flow`, `get-flow`, `get-net-flow` |
| **General Distribution Agreement (1:many pools)** | `create-pool`, `update-member-units`, `distribute`, `distribute-flow`, `connect-pool` |
| **SuperToken (wrap/unwrap/ACL)** | `wrap`, `unwrap`, `grant-flow-operator`, `get-super-token-balance`, `get-underlying-token` |

## Why this is critical for KeeperHub

KeeperHub's existing protocol library (Aave, Lido, Sky, Uniswap, Curve, Morpho, Pendle, Yearn, etc.) is entirely **discrete state-change primitives** -- one tx, one accounting update, done. A huge category of high-value automation is fundamentally **time-based** instead: payroll, vesting, royalty splits, usage-based subscriptions, compute-coalition payments, insurance premiums, DAO contributor pay. Today these become workflows that wake up every N hours to fire transfers; every wake-up is a chance for failure (gas spikes, RPC outages, missed cron, balance drift) and pushes time accounting off-chain into the workflow runtime.

Superfluid moves time accounting on-chain. Set a rate once -- value flows continuously without further workflow invocations. The workflow's job becomes **deciding when to change the rate**, which is exactly KeeperHub's wheelhouse:

- **One-shot trigger -> infinite-period payment.** Workflow fires on \"PR merged\" -> opens a stream to the contributor. Workflow ends. Recipient is paid for the next month/year/four years on that single tx.
- **Event-driven rate changes are atomic.** \"Validator uptime falls below 99%\" -> `update-flow` halves the rate. One tx, applied instantly.
- **Pool distributions replace per-recipient batching.** A 50-person payroll workflow becomes one stream into a pool + one tx per share change, not 50 transfers per cycle.
- **Conditional cessation in one call.** \"Slashing event detected\" -> `delete-flow`. Stops within a single tx of detection.
- **Multi-stream composition.** `get-net-flow` is a first-class workflow read; workflows can branch on a recipient's incoming rate before opening another stream.

These are patterns no existing KeeperHub protocol can express. Lending has no \"rate.\" Swapping has no recipient list. Staking has no member units. Superfluid fills a unique architectural gap, and KeeperHub's strengths (triggered execution, retry, gas optimization, multi-step composition, per-org Para wallets, audit trails) are exactly what production streaming-payment workflows need.

Market signal: Superfluid reports 1.23M+ users and over \$1.5B streamed across mainnets. Every chain KeeperHub already supports has Superfluid deployed. Audited, live for 4+ years, two stable agreement standards.

## Live deployment / dogfooding

**Tested on `https://computepool.vercel.app`** -- this plugin is the streaming-payments backbone of a live compute coalition product where GPU providers receive continuous fUSDCx-equivalent payments while inference workloads run, and member units adjust in real time as worker capacity changes. The 13-step lifecycle in this PR maps 1:1 to the demo's pay-as-you-compute flow.

## Implementation approach

Uses KeeperHub's existing `defineProtocol()` DSL (the F-048 mechanism that powers Lido, Aave V3, Sky, Uniswap V3, Curve, Morpho, and 14 other protocols). Three contracts declared:

- `cfaForwarder` (`0xcfA132E353cB4E398080B9700609bb008eceB125`) -- constant address across all 6 supported chains
- `gdaForwarder` (`0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08`) -- constant address across all 6 supported chains
- `superToken` -- `userSpecifiedAddress: true` (each SuperToken is a distinct deployment chosen by the workflow author)

Inline ABI fragments (15 total: 5 per contract). All wallet/RPC/gas/sponsorship/nonce/error-decoding/explorer-link plumbing is inherited from `plugins/protocol/steps/protocol-{read,write}.ts`. **Zero step files added.**

Marginal cost per action: ~10 LOC of declarative config vs. 200-400 LOC per action in the imperative `plugins/` path. The 15 actions cost ~150 LOC instead of ~3,500 LOC of step files plus matching unit tests.

## Chains shipped in v1

| Chain ID | Name |
|---|---|
| 1 | Ethereum Mainnet |
| 10 | Optimism |
| 137 | Polygon |
| 8453 | Base |
| 42161 | Arbitrum One |
| 11155111 | Sepolia |

Mirrors Aave V3's footprint plus Sepolia for testing. Base Sepolia (`84532`) deferred as a follow-up.

## What's in the diff

```
protocols/superfluid.ts                    NEW   ~580 LOC   declarative protocol definition
tests/unit/superfluid-protocol.test.ts     NEW   ~440 LOC   schema/integrity assertions (34 tests)
scripts/verify-superfluid-addresses.ts     NEW   ~115 LOC   one-shot CLI: eth_getCode per (chain, forwarder)
scripts/e2e-superfluid-sepolia.ts          NEW   ~470 LOC   live Sepolia lifecycle test (no mocks)
specs/superfluid-protocol-plugin.md        NEW              internal spec
specs/superfluid-protocol-plugin-plan.md   NEW              internal implementation plan
protocols/index.ts                         MOD   +5         auto-regenerated by pnpm discover-plugins
lib/types/integration.ts                   MOD   +1         auto-regenerated
```

No new contracts, no `abis/` folder, no per-action step files, no plugin-level README, no new npm dependencies, no migrations.

## Testing

### Unit (schema integrity)

\`\`\`
Test Files  1 passed (1)
Tests       34 passed (34)
Duration    1.21s
\`\`\`

34 assertions across 12 describe blocks: top-level metadata, all 3 contracts on all 6 chains (valid hex format + ABI parses), each of the 15 actions (correct slug, contract reference, ABI function existence, input order, decimals on outputs, helpTip text), integrity sweep (15 actions total, slugs unique, all references resolve).

### Full unit suite

\`\`\`
Test Files  185 passed (185)
Tests       3454 passed (3454)
Duration    174.82s
\`\`\`

Zero regressions introduced.

### Forwarder address verification

`pnpm tsx scripts/verify-superfluid-addresses.ts`

| Chain | Chain ID | CFAv1Forwarder | GDAv1Forwarder |
|---|---|---|---|
| Ethereum Mainnet | 1 | requires keyed RPC; verified manually on Etherscan | requires keyed RPC; verified manually |
| Optimism | 10 | OK | OK |
| Polygon | 137 | requires keyed RPC; verified manually on Polygonscan | requires keyed RPC; verified manually |
| Base | 8453 | OK | OK |
| Arbitrum One | 42161 | OK | OK |
| Sepolia | 11155111 | OK | OK |

8/12 (chain x contract) pairs directly verified via `eth_getCode`. The 4 \"requires keyed RPC\" entries are because public keyless RPCs for Ethereum mainnet and Polygon now require API keys; the constant address claim is supported by the 8 verified pairs and Superfluid's official deployment registry.

### Live Sepolia E2E (no mocks)

`scripts/e2e-superfluid-sepolia.ts` walks all 13 lifecycle steps against the actual deployed CFA + GDA forwarders. **13/13 PASS, 0 SKIPPED, 0 FAILED.**

| # | Step | Tx hash |
|---|---|---|
| 1 | pre-flight (balance check) | (read-only) |
| 2 | approve underlying ERC-20 | `0xba369838395ee789ff1c43a792be722345695d9d35d3c3c6ddd2ff036e0161e5` |
| 3 | wrap (fUSDC -> fUSDCx) | `0x1aeec87b082139c8020c9502c2b67e7d26274a0b1e25b9bec45a3ccb510e6c88` |
| 4 | create-flow @ 1e6 wei/s | `0x2bf2352ba9d540cce7f0488fa7c4c8be94a3ce53a0e2cdc84b941497ea681c12` |
| 5 | update-flow -> 2e6 wei/s | `0x9e6d22edd5989def33ac930a0734be0707423b054e4fa16d60cf872d1f34eb0d` |
| 6 | get-net-flow (receiver = +2e6) | (read-only) |
| 7 | delete-flow | `0x7f1f05d3dc1b56a4e116d63cab3cd5b7e93abf0c23303433e158313d4ef40d45` |
| 8 | create-pool -> `0x899C2a8feB3E123DBD56281D282C74D5f22Fc8F2` | `0x5f547bb73da808caef84ef19fb86c4e7e264cd4717a90e0a1a337d44cc508fc3` |
| 9 | update-member-units (100 units) | `0x65e6dfc6b2af254942d80b437db9613dbe1fb8385ba6571404efb82805cf02e2` |
| 10 | connect-pool (signed by receiver) | `0x69ebde941412b2d354fd5ad74ed21fcb741459cbec1925e22f4037071f814bd4` |
| 11 | distribute-flow @ 1e6 wei/s | `0xd5cbd55120c982e1f51bfd1e78402ff6ccda7b679f51f035e9dd8030b0d3b456` |
| 12 | gdaForwarder.getNetFlow (receiver = 1e6 wei/s) | (read-only) |
| 13 | cleanup distribute-flow -> 0 | `0x7540529df8d472a5f8daffd67e3e99edb4a80862eac402821cf2f0605d17ab05` |

## Code review

Two-stage review completed before final commits:

- **Spec compliance review**: APPROVED. All 15 actions present, ABIs match Superfluid's signatures, no scope creep.
- **Code quality review**: APPROVE WITH MINOR FIXES. No Critical or Important issues. Minor polish items either fixed in `20259122` or deliberately deferred to match the `protocols/` family convention.
- **Simplify pass**: extracted a `findAction(slug)` helper in the test file (-33 LOC, identical assertions).

## Out of scope (deliberate)

- `wrap-token.autoApprove` flag -- approval is a separate workflow node via `web3.approve-token` (matches Lido's pattern).
- `requiredDeposit` precomputation in `create-flow` output -- workflows chain `get-net-flow` / `get-super-token-balance` for pre-flight checks.
- Per-protocol README -- `protocols/` ships none (Lido has none); action descriptions and helpTips carry the load.
- `events[]` declaration -- deferred until per-chain emitter addresses are verified (CFA/GDA emit from host contracts, not the forwarders we declare).
- Subgraph queries, batched calls, ETH->WETHx convenience, flow-end-time, Super-App callbacks -- out of scope per the original PRD.
- Base Sepolia (`84532`) -- single testnet is enough for this PR; trivial follow-up.

## Risk assessment

| Risk | Mitigation |
|---|---|
| Forwarder address moves on a chain | Pre-merge verification script run; constant addresses across all 6 chains; documented override path via env vars in the E2E script |
| `int96` flow-rate quantization | Shared helpTip on every flow-rate input with the wei/sec formula |
| Insufficient SuperToken deposit for `create-flow` | helpTip recommending a `get-super-token-balance` pre-check |
| Pool member opt-in friction | helpTip on `update-member-units` and `create-pool` description prominently feature `connect-pool` |
| New protocol breaks existing protocols | Additive only; no shared module touched; full unit suite (3454 tests) green |
| Gas estimation issues at workflow runtime | Inherited from `protocol-write-core`'s existing gas-multiplier override path (battle-tested by Aave/Lido/etc.) |

## Migration / backwards compatibility

Purely additive. No existing workflow, protocol, plugin, or stored data is modified. Workflow UI gains a new \"Superfluid\" category with 15 actions; no existing categories or actions change. No DB migration. No env-var changes. No new build-time secrets. No new runtime dependencies.

## Test plan checklist

- [x] `pnpm test:unit tests/unit/superfluid-protocol.test.ts` (34/34)
- [x] `pnpm test:unit` full suite (3454 tests, 0 regressions)
- [x] `pnpm type-check` clean
- [x] `pnpm check` (biome) clean on touched files
- [x] `pnpm discover-plugins` regenerates `protocols/index.ts` with Superfluid registered
- [x] `pnpm tsx scripts/verify-superfluid-addresses.ts` -- 8/12 verified live; addresses match Superfluid's published registry
- [x] `pnpm tsx scripts/e2e-superfluid-sepolia.ts` -- 13/13 lifecycle steps PASS on real Sepolia
- [x] Dogfooded on https://computepool.vercel.app for streaming compute-coalition payments
- [ ] (optional) `pnpm dev`, drag the new \"Superfluid\" category onto a workflow canvas, dry-run against Sepolia using a funded org wallet

## References

- Superfluid Protocol docs: https://docs.superfluid.org
- CFAv1Forwarder source: https://github.com/superfluid-finance/protocol-monorepo
- Internal spec: `specs/superfluid-protocol-plugin.md`
- Internal plan: `specs/superfluid-protocol-plugin-plan.md`
- Reference protocol (closest analog): `protocols/lido.ts`
- Reference protocol (multi-contract analog): `protocols/aave-v3.ts`
- Live demo: https://computepool.vercel.app