### PR TITLE
docs: document programmatic workflow API specifications

### DIFF
--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -370,6 +370,6 @@ Returns the complete registry of available workflow actions, triggers, and templ
 
 > **Note on Action Types:** The keys in the `actions` object are the values to use in `config.actionType` when creating workflow nodes.
 > - **Plugin actions** use a `{pluginType}/{slug}` format (e.g., `"web3/check-balance"`, `"aave-v3/supply"`).
-> - **System actions** use Pascal Case with spaces (e.g., `"Condition"`, `"For Each"`, `"HTTP Request"`). System actions do not have a `requiresCredentials` field.
+> - **System actions** use Pascal-case with spaces between words (e.g., `"Condition"`, `"For Each"`, `"HTTP Request"`). System actions do not have a `requiresCredentials` field.
 > - **Triggers** are listed under the `triggers` key (not `actions`) and their values map to `config.triggerType` on trigger nodes.
 > - The endpoint self-documents the correct node and edge shapes under the `workflowStructure` and `edgeStructure` keys — use these as the source of truth for programmatic workflow generation.

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -90,9 +90,42 @@ POST /api/workflows/create
 {
   "name": "New Workflow",
   "description": "Optional description",
-  "projectId": "proj_123"
+  "projectId": "proj_123",
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger",
+      "data": {
+        "type": "trigger",
+        "label": "Schedule Trigger",
+        "config": { "triggerType": "Schedule", "scheduleCron": "*/30 * * * *" },
+        "status": "idle"
+      },
+      "position": { "x": 120, "y": 80 }
+    },
+    {
+      "id": "supply-aave",
+      "type": "action",
+      "data": {
+        "type": "web3/supply-aave-v3",
+        "label": "Supply Aave",
+        "config": { "network": "8453", "asset": "USDC", "amount": "100" },
+        "status": "idle"
+      },
+      "position": { "x": 120, "y": 240 }
+    }
+  ],
+  "edges": [
+    {
+      "id": "trigger->supply-aave",
+      "source": "trigger",
+      "target": "supply-aave"
+    }
+  ]
 }
 ```
+
+> **Note on Node Format:** When creating workflows programmatically, each node must have its payload wrapped in a `data` object containing `type`, `label`, `config`, and `status: "idle"`. The outer `type` determines the node category (e.g. `trigger`, `action`), while `data.type` determines the specific action plugin slug. The `position` object is required for visual rendering.
 
 The `projectId` field is optional. If provided, the workflow is assigned to the specified [project](/api/projects).
 
@@ -139,6 +172,8 @@ DELETE /api/workflows/{workflowId}?force=true
 ```http
 POST /api/workflow/{workflowId}/execute
 ```
+
+> **Note:** This endpoint uses singular `/workflow/` in the path, unlike other endpoints which use plural `/workflows/`.
 
 Manually trigger a workflow execution.
 
@@ -276,3 +311,45 @@ POST /api/hub/featured
 ```
 
 Mark a workflow as featured in the hub. Requires internal service authentication (`hub` service). Accepts optional `category`, `protocol`, and `featuredOrder` fields alongside the `workflowId`.
+
+## List Action Schemas
+
+```http
+GET /api/mcp/schemas
+```
+
+Returns the complete registry of available workflow actions, triggers, and templates. Essential for programmatic workflow generation to discover valid action configurations.
+
+### Response Structure
+
+```json
+{
+  "version": "1.0.0",
+  "actions": {
+    "web3/check-balance": {
+      "actionType": "web3/check-balance",
+      "label": "Check Balance",
+      "requiredFields": { "network": "string (chain ID)", "address": "string" },
+      "optionalFields": {},
+      "outputFields": { "balance": "..." },
+      "requiresCredentials": false
+    },
+    "Condition": {
+      "actionType": "Condition",
+      "label": "Condition",
+      "requiredFields": { "rules": "array" }
+    }
+  },
+  "triggers": {
+    "Schedule": { "triggerType": "Schedule", "configSchema": { "scheduleCron": "string" } },
+    "Manual": { "triggerType": "Manual" }
+  },
+  "chains": [...],
+  "templateSyntax": { "pattern": "{{@nodeId:Label.field}}" }
+}
+```
+
+> **Note on Action Types:** The keys in the `actions` object determine the `data.type` value used when creating workflow nodes. 
+> - **Plugin actions** use a `{pluginType}/{slug}` format (e.g., `"web3/check-balance"`, `"aave-v3/supply"`).
+> - **System actions** use Pascal Case with spaces (e.g., `"Condition"`, `"For Each"`, `"HTTP Request"`).
+> - **Triggers** are found under the `triggers` object and correspond to the `triggerType` config value.

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -104,12 +104,13 @@ POST /api/workflows/create
       "id": "supply-aave",
       "type": "action",
       "data": {
-        "label": "Supply Aave",
+        "label": "Supply USDC to Aave",
         "config": {
-          "actionType": "web3/supply-aave-v3",
+          "actionType": "aave-v3/supply",
           "network": "8453",
-          "asset": "USDC",
-          "amount": "100"
+          "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "amount": "100000000",
+          "onBehalfOf": "0x0000000000000000000000000000000000000000"
         }
       }
     }
@@ -126,7 +127,7 @@ POST /api/workflows/create
 
 > **Note on Node Format:** For action nodes, set the outer `type` to `"action"` and place the plugin slug in `config.actionType`. The `data` object contains `label` and `config`; `status` and `position` are optional and auto-assigned by the API if omitted. Trigger nodes use outer `type: "trigger"` with `config.triggerType` set to the Pascal-case trigger name.
 >
-> The server normalizes the request before persisting it, so the saved node will also include an inner `data.type` field set to the kind discriminator (`"trigger"` or `"action"`). You do not need to send `data.type` yourself; if you do, it must match the outer `type`. As a convenience, sending the plugin slug at the outer `type` (for example `"type": "web3/supply-aave-v3"`) is also accepted, and the server rewrites it into `config.actionType` during normalization.
+> The server normalizes the request before persisting it, so the saved node will also include an inner `data.type` field set to the kind discriminator (`"trigger"` or `"action"`). You do not need to send `data.type` yourself; if you do, it must match the outer `type`. As a convenience, sending the plugin slug at the outer `type` (for example `"type": "aave-v3/supply"`) is also accepted, and the server rewrites it into `config.actionType` during normalization.
 
 The `projectId` field is optional. If provided, the workflow is assigned to the specified [project](/api/projects).
 

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -129,7 +129,7 @@ POST /api/workflows/create
 >
 > The server normalizes the request before persisting it, so the saved node will also include an inner `data.type` field set to the kind discriminator (`"trigger"` or `"action"`). You do not need to send `data.type` yourself; if you do, it must match the outer `type`. As a convenience, sending the plugin slug at the outer `type` (for example `"type": "aave-v3/supply"`) is also accepted, and the server rewrites it into `config.actionType` during normalization.
 
-The `projectId` field is optional. If provided, the workflow is assigned to the specified [project](/api/projects).
+`name`, `nodes`, and `edges` are required. `description`, `projectId`, `tagId`, and `enabled` are optional. `projectId` assigns the workflow to a [project](/api/projects); `tagId` assigns it to an organization tag for categorization; `enabled` (boolean) controls whether the workflow is active on creation.
 
 ### Response
 

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -330,6 +330,8 @@ Returns the complete registry of available workflow actions, triggers, and templ
     "web3/check-balance": {
       "actionType": "web3/check-balance",
       "label": "Check Balance",
+      "category": "web3",
+      "integration": "web3",
       "requiredFields": { "network": "string (chain ID)", "address": "string" },
       "optionalFields": {},
       "outputFields": { "balance": "..." },
@@ -338,16 +340,31 @@ Returns the complete registry of available workflow actions, triggers, and templ
     "Condition": {
       "actionType": "Condition",
       "label": "Condition",
+      "category": "System",
       "requiredFields": { "condition": "string (JS expression)" },
-      "optionalFields": { "conditionConfig": "object (visual builder state)" }
+      "optionalFields": { "conditionConfig": "object (visual builder state)" },
+      "sourceHandles": ["true", "false"]
     }
   },
   "triggers": {
-    "Schedule": { "triggerType": "Schedule", "configSchema": { "scheduleCron": "string" } },
-    "Manual": { "triggerType": "Manual" }
+    "Schedule": {
+      "triggerType": "Schedule",
+      "label": "Schedule",
+      "requiredFields": { "scheduleCron": "string" },
+      "optionalFields": { "scheduleTimezone": "string" }
+    },
+    "Manual": { "triggerType": "Manual", "label": "Manual", "requiredFields": {} }
   },
   "chains": [...],
-  "templateSyntax": { "pattern": "{{@nodeId:Label.field}}" }
+  "platform": { "wallet": {...}, "proxyContracts": {...}, "abiHandling": {...} },
+  "templateSyntax": { "pattern": "{{@nodeId:Label.field}}" },
+  "builtinVariables": {
+    "nodeId": "__system",
+    "nodeLabel": "System",
+    "variables": { "unixTimestamp": {...}, "unixTimestampMs": {...}, "isoTimestamp": {...} }
+  },
+  "workflowStructure": { "nodeStructure": {...}, "edgeStructure": {...} },
+  "tips": ["actionType must match exactly", "..."]
 }
 ```
 

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -96,23 +96,22 @@ POST /api/workflows/create
       "id": "trigger",
       "type": "trigger",
       "data": {
-        "type": "trigger",
         "label": "Schedule Trigger",
-        "config": { "triggerType": "Schedule", "scheduleCron": "*/30 * * * *" },
-        "status": "idle"
-      },
-      "position": { "x": 120, "y": 80 }
+        "config": { "triggerType": "Schedule", "scheduleCron": "*/30 * * * *" }
+      }
     },
     {
       "id": "supply-aave",
       "type": "action",
       "data": {
-        "type": "web3/supply-aave-v3",
         "label": "Supply Aave",
-        "config": { "network": "8453", "asset": "USDC", "amount": "100" },
-        "status": "idle"
-      },
-      "position": { "x": 120, "y": 240 }
+        "config": {
+          "actionType": "web3/supply-aave-v3",
+          "network": "8453",
+          "asset": "USDC",
+          "amount": "100"
+        }
+      }
     }
   ],
   "edges": [
@@ -125,7 +124,7 @@ POST /api/workflows/create
 }
 ```
 
-> **Note on Node Format:** When creating workflows programmatically, each node must have its payload wrapped in a `data` object containing `type`, `label`, `config`, and `status: "idle"`. The outer `type` determines the node category (e.g. `trigger`, `action`), while `data.type` determines the specific action plugin slug. The `position` object is required for visual rendering.
+> **Note on Node Format:** For action nodes, set the outer `type` to `"action"` and place the plugin slug in `config.actionType`. The `data` object contains `label` and `config`; `status` and `position` are optional and auto-assigned by the API if omitted. Trigger nodes use outer `type: "trigger"` with `config.triggerType` set to the Pascal_Case trigger name.
 
 The `projectId` field is optional. If provided, the workflow is assigned to the specified [project](/api/projects).
 
@@ -337,7 +336,8 @@ Returns the complete registry of available workflow actions, triggers, and templ
     "Condition": {
       "actionType": "Condition",
       "label": "Condition",
-      "requiredFields": { "rules": "array" }
+      "requiredFields": { "condition": "string (JS expression)" },
+      "optionalFields": { "conditionConfig": "object (visual builder state)" }
     }
   },
   "triggers": {
@@ -349,7 +349,8 @@ Returns the complete registry of available workflow actions, triggers, and templ
 }
 ```
 
-> **Note on Action Types:** The keys in the `actions` object determine the `data.type` value used when creating workflow nodes. 
+> **Note on Action Types:** The keys in the `actions` object are the values to use in `config.actionType` when creating workflow nodes.
 > - **Plugin actions** use a `{pluginType}/{slug}` format (e.g., `"web3/check-balance"`, `"aave-v3/supply"`).
-> - **System actions** use Pascal Case with spaces (e.g., `"Condition"`, `"For Each"`, `"HTTP Request"`).
-> - **Triggers** are found under the `triggers` object and correspond to the `triggerType` config value.
+> - **System actions** use Pascal Case with spaces (e.g., `"Condition"`, `"For Each"`, `"HTTP Request"`). System actions do not have a `requiresCredentials` field.
+> - **Triggers** are listed under the `triggers` key (not `actions`) and their values map to `config.triggerType` on trigger nodes.
+> - The endpoint self-documents the correct node and edge shapes under the `workflowStructure` and `edgeStructure` keys — use these as the source of truth for programmatic workflow generation.

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -124,7 +124,9 @@ POST /api/workflows/create
 }
 ```
 
-> **Note on Node Format:** For action nodes, set the outer `type` to `"action"` and place the plugin slug in `config.actionType`. The `data` object contains `label` and `config`; `status` and `position` are optional and auto-assigned by the API if omitted. Trigger nodes use outer `type: "trigger"` with `config.triggerType` set to the Pascal_Case trigger name.
+> **Note on Node Format:** For action nodes, set the outer `type` to `"action"` and place the plugin slug in `config.actionType`. The `data` object contains `label` and `config`; `status` and `position` are optional and auto-assigned by the API if omitted. Trigger nodes use outer `type: "trigger"` with `config.triggerType` set to the Pascal-case trigger name.
+>
+> The server normalizes the request before persisting it, so the saved node will also include an inner `data.type` field set to the kind discriminator (`"trigger"` or `"action"`). You do not need to send `data.type` yourself; if you do, it must match the outer `type`. As a convenience, sending the plugin slug at the outer `type` (for example `"type": "web3/supply-aave-v3"`) is also accepted, and the server rewrites it into `config.actionType` during normalization.
 
 The `projectId` field is optional. If provided, the workflow is assigned to the specified [project](/api/projects).
 

--- a/docs/workflows/creating.md
+++ b/docs/workflows/creating.md
@@ -90,8 +90,8 @@ For trigger nodes, you'll also configure specific settings based on the trigger 
 | Schedule | `"Schedule"` | `scheduleCron` |
 | Manual | `"Manual"` | (none) |
 | Webhook | `"Webhook"` | optional `webhookSchema` |
-| Contract Event| `"Event"` | `network`, `contractAddress`, `contractABI`, `eventName` |
-| New Block | `"Block"` | `network`, `blockInterval` |
+| Event | `"Event"` | `network`, `contractAddress`, `contractABI`, `eventName` |
+| Block | `"Block"` | `network`, `blockInterval` |
 
 > **Note for API users:** The `triggerType` must match the Pascal_Case string exactly (e.g., `"Schedule"`, not `"cron"`).
 
@@ -166,7 +166,7 @@ When creating edges via the API that originate from branching nodes, you **must*
 | Node type | `sourceHandle` values | When to use |
 |-----------|---------------------|-------------|
 | **Condition** | `"true"`, `"false"` | Required on all outgoing edges |
-| **For Each** | `"loop"`, `"done"` | Required on all outgoing edges |
+| **For Each** | `"loop"`, `"done"` | Required on all outgoing edges. `"done"` must target a Collect node; `"loop"` may not. |
 | All others | (none) | Omit entirely |
 
 ## Template Syntax Reference
@@ -176,7 +176,7 @@ KeeperHub uses a powerful template syntax to reference outputs from upstream nod
 **Features:**
 - **Dot notation** for nested fields: `{{@http-1:Fetch Data.data.price}}`
 - **Array indexing**: `{{@query-1:Get Users.items[0].id}}`
-- **Built-in variables**: Access system state like `{{@__builtin__:Builtin.unixTimestamp}}` or `{{@__builtin__:Builtin.workflowId}}`
+- **Built-in variables**: Access system state with `{{@__system:System.unixTimestamp}}`, `{{@__system:System.unixTimestampMs}}`, or `{{@__system:System.isoTimestamp}}`
 
 **Example usage in a Condition node:**
 To check if a balance from a previous "Check Balance" node (ID: `check-balance`) is greater than 1000:

--- a/docs/workflows/creating.md
+++ b/docs/workflows/creating.md
@@ -166,8 +166,10 @@ When creating edges via the API that originate from branching nodes, you **must*
 | Node type | `sourceHandle` values | When to use |
 |-----------|---------------------|-------------|
 | **Condition** | `"true"`, `"false"` | Required on all outgoing edges |
-| **For Each** | `"loop"`, `"done"` | Required on all outgoing edges. `"done"` must target a Collect node; `"loop"` may not. |
+| **For Each** | `"loop"`, `"done"` | Required on all outgoing edges |
 | All others | (none) | Omit entirely |
+
+The visual canvas additionally enforces two For Each connection conventions: the `"done"` handle is intended to terminate at a **Collect** node that aggregates iteration results, and the `"loop"` handle is intended to enter the loop body (not a Collect node). The API does not currently reject edges that violate these conventions, but workflows that follow them produce predictable executor behavior.
 
 ## Template Syntax Reference
 

--- a/docs/workflows/creating.md
+++ b/docs/workflows/creating.md
@@ -85,15 +85,15 @@ Click any node to open the configuration panel on the right side of the screen.
 
 For trigger nodes, you'll also configure specific settings based on the trigger type. When creating workflows programmatically via the API, use the exact `triggerType` and config keys shown below:
 
-| Trigger Label | `triggerType` value | Required config key |
-|---------------|-------------------|-------------------|
-| Schedule | `"Schedule"` | `scheduleCron` |
-| Manual | `"Manual"` | (none) |
-| Webhook | `"Webhook"` | optional `webhookSchema` |
-| Event | `"Event"` | `network`, `contractAddress`, `contractABI`, `eventName` |
-| Block | `"Block"` | `network`, `blockInterval` |
+| Trigger Label | `triggerType` value | Required config keys | Optional config keys |
+|---------------|---------------------|----------------------|----------------------|
+| Manual   | `"Manual"`   | (none) | (none) |
+| Schedule | `"Schedule"` | `scheduleCron` | `scheduleTimezone` |
+| Webhook  | `"Webhook"`  | (none) | `webhookSchema`, `webhookMockRequest` |
+| Event    | `"Event"`    | `network`, `contractAddress`, `contractABI`, `eventName` | (none) |
+| Block    | `"Block"`    | `network`, `blockInterval` | (none) |
 
-> **Note for API users:** The `triggerType` must match the Pascal_Case string exactly (e.g., `"Schedule"`, not `"cron"`).
+> **Note for API users:** The `triggerType` must match the Pascal-case string exactly (e.g., `"Schedule"`, not `"cron"`). The canonical list, including any future additions, is returned under the `triggers` map of [`GET /api/mcp/schemas`](/api/workflows#list-action-schemas).
 
 ### Condition Configuration
 

--- a/docs/workflows/creating.md
+++ b/docs/workflows/creating.md
@@ -83,11 +83,17 @@ Click any node to open the configuration panel on the right side of the screen.
 
 ### Trigger Configuration
 
-For trigger nodes, you'll also configure:
-- **Schedule**: Interval for scheduled triggers (every 5 minutes, hourly, etc.)
-- **Webhook URL**: Provided URL for webhook triggers
-- **Event Filter**: Event signature for event triggers
-- **Block Interval**: Network and block interval for block triggers (e.g., every 10 blocks on Ethereum)
+For trigger nodes, you'll also configure specific settings based on the trigger type. When creating workflows programmatically via the API, use the exact `triggerType` and config keys shown below:
+
+| Trigger Label | `triggerType` value | Required config key |
+|---------------|-------------------|-------------------|
+| Schedule | `"Schedule"` | `scheduleCron` |
+| Manual | `"Manual"` | (none) |
+| Webhook | `"Webhook"` | optional `webhookSchema` |
+| Contract Event| `"Event"` | `network`, `contractAddress`, `contractABI`, `eventName` |
+| New Block | `"Block"` | `network`, `blockInterval` |
+
+> **Note for API users:** The `triggerType` must match the Pascal_Case string exactly (e.g., `"Schedule"`, not `"cron"`).
 
 ### Condition Configuration
 
@@ -148,10 +154,33 @@ Expression mode also supports JavaScript methods, array indexing, and property a
 
 Condition nodes have two output handles:
 
-- **true**: downstream nodes connected here execute when the condition passes
-- **false**: downstream nodes connected here execute when the condition fails
+- **true**: downstream nodes connected here execute when the condition passes (API `sourceHandle: "true"`)
+- **false**: downstream nodes connected here execute when the condition fails (API `sourceHandle: "false"`)
 
 Connect different branches to each handle to create if/else logic in a single node.
+
+### Programmatic Edge Creation (sourceHandle)
+
+When creating edges via the API that originate from branching nodes, you **must** specify the `sourceHandle` to indicate which path the edge follows:
+
+| Node type | `sourceHandle` values | When to use |
+|-----------|---------------------|-------------|
+| **Condition** | `"true"`, `"false"` | Required on all outgoing edges |
+| **For Each** | `"loop"`, `"done"` | Required on all outgoing edges |
+| All others | (none) | Omit entirely |
+
+## Template Syntax Reference
+
+KeeperHub uses a powerful template syntax to reference outputs from upstream nodes dynamically. The pattern is `{{@nodeId:Label.field}}`.
+
+**Features:**
+- **Dot notation** for nested fields: `{{@http-1:Fetch Data.data.price}}`
+- **Array indexing**: `{{@query-1:Get Users.items[0].id}}`
+- **Built-in variables**: Access system state like `{{@__builtin__:Builtin.unixTimestamp}}` or `{{@__builtin__:Builtin.workflowId}}`
+
+**Example usage in a Condition node:**
+To check if a balance from a previous "Check Balance" node (ID: `check-balance`) is greater than 1000:
+`{{@check-balance:Check Balance.balance}} > 1000`
 
 ## Managing Connections
 


### PR DESCRIPTION
# Address major programmatic workflow creation documentation gaps

This PR addresses several critical documentation gaps that block developers from successfully creating and executing workflows programmatically via the REST API or SDK. The changes reflect reverse-engineered findings from the `StrategyForge` team while building an AI workflow compiler for the hackathon.

## What's changed:

**1. Fixed `POST /api/workflows/create` JSON Schema**
- **The problem:** The previous docs showed a simplified conceptual model (`type: "action"`, `action: {...}`) that results in a 400 Bad Request.
- **The fix:** Updated the JSON payload example to show the actual required structure: nested `data` wrappers, `status: "idle"`, required `position` coordinates, and the distinction between outer `type` and inner `data.type`.

**2. Documented the `GET /api/mcp/schemas` endpoint**
- **The problem:** `list_action_schemas` was documented for the MCP server, but completely missing from the REST API docs. This is a hard blocker for programmatic workflow creation because developers have no way to discover the exact `data.type` strings or config schemas.
- **The fix:** Added a "List Action Schemas" section to `api/workflows.md` detailing the response shape, and clarified the naming conventions between Plugin actions (`plugin/slug`) and System actions (`Pascal Case`).

**3. Added explicit Trigger Configuration Reference**
- **The problem:** The docs previously gave `"type": "cron"` as an example, but the API expects `triggerType: "Schedule"`. 
- **The fix:** Added a lookup table in `workflows/creating.md` mapping all trigger labels to their exact `Pascal_Case` API values and required configuration keys.

**4. Documented Branching Node `sourceHandle` Requirements**
- **The problem:** Edges originating from a `Condition` or `For Each` node fail silently or behave unpredictably if `sourceHandle` is omitted in the API payload.
- **The fix:** Added a "Programmatic Edge Creation" section explicitly documenting the required `sourceHandle` values (`"true"`/`"false"` and `"loop"`/`"done"`).

**5. Added Template Syntax Reference**
- **The problem:** Cross-node data referencing `{{@nodeId:Label.field}}` is the only way to build multi-step conditional workflows, but the exact syntax was undocumented outside of UI tooltips.
- **The fix:** Added a dedicated "Template Syntax Reference" with concrete examples of dot notation, array indexing, and `__builtin__` variables.

## Impact
These updates will save future API integrators and SDK developers hours of trial-and-error by documenting the actual shape of the production REST API.
