### PR TITLE
feat: KEEP-408 enable native ETH input on Uniswap V3 swaps

### DIFF
--- a/lib/protocol-registry.ts
+++ b/lib/protocol-registry.ts
@@ -308,16 +308,19 @@ function buildConfigFieldsFromAction(
   }
 
   if (action.payable) {
-    // Native value is opt-in: most payable functions are payable only to support
-    // multicall composition (e.g. Uniswap swaps where the dominant case is
-    // ERC20-to-ERC20 with no msg.value). Required: true would break that path
-    // by forcing users to type "0" on every config.
+    // ETH Value is required only when it is the action's sole meaningful input
+    // (e.g. WETH.deposit() takes no args - the native value IS the action).
+    // For payable functions that also take arguments, the native value is
+    // opt-in (most are payable purely for multicall composition - Uniswap
+    // swaps default to ERC20-to-ERC20 with no msg.value, NFT position
+    // mint/burn/collect rarely send ETH, etc.).
+    const isOnlyInput = action.inputs.length === 0;
     fields.push({
       key: "ethValue",
       label: "ETH Value",
       type: "protocol-eth-value",
       placeholder: "0.0",
-      required: false,
+      required: isOnlyInput,
     });
   }
 

--- a/lib/protocol-registry.ts
+++ b/lib/protocol-registry.ts
@@ -308,12 +308,16 @@ function buildConfigFieldsFromAction(
   }
 
   if (action.payable) {
+    // Native value is opt-in: most payable functions are payable only to support
+    // multicall composition (e.g. Uniswap swaps where the dominant case is
+    // ERC20-to-ERC20 with no msg.value). Required: true would break that path
+    // by forcing users to type "0" on every config.
     fields.push({
       key: "ethValue",
       label: "ETH Value",
       type: "protocol-eth-value",
       placeholder: "0.0",
-      required: true,
+      required: false,
     });
   }
 

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -29,6 +29,17 @@ type ProtocolWriteInput = StepInput & {
   [key: string]: unknown;
 };
 
+const UNISWAP_PAYABLE_SWAP_FUNCTIONS: ReadonlySet<string> = new Set([
+  "exactInputSingle",
+  "exactOutputSingle",
+]);
+
+const ZERO_ETH_VALUE_PATTERN = /^0(\.0+)?$/;
+
+type PreflightResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
 function resolveEthValue(
   rawEthValue: unknown,
   abi: string,
@@ -73,6 +84,58 @@ function resolveEthValue(
     return undefined;
   }
   return trimmed;
+}
+
+// KEEP-408: Uniswap swap functions are `payable` so SwapRouter02 can wrap
+// msg.value into WETH internally - but only when tokenIn IS the chain's WETH
+// address. Setting ETH Value with any other tokenIn strands the ETH in the
+// router (the contract has no way to refund it without an explicit refundETH
+// in a multicall, which we don't expose). Catch this before the tx is sent.
+function checkUniswapNativeEthPreflight(
+  input: ProtocolWriteInput,
+  meta: ProtocolMeta,
+  ethValue: string | undefined
+): PreflightResult {
+  const isUniswapSwap =
+    meta.protocolSlug === "uniswap" &&
+    UNISWAP_PAYABLE_SWAP_FUNCTIONS.has(meta.functionName);
+  if (!isUniswapSwap) {
+    return { ok: true };
+  }
+  if (!ethValue) {
+    return { ok: true };
+  }
+  const trimmed = ethValue.trim();
+  if (trimmed === "" || ZERO_ETH_VALUE_PATTERN.test(trimmed)) {
+    return { ok: true };
+  }
+
+  const wrapped = getProtocol("wrapped");
+  const wethAddress = wrapped?.contracts.weth?.addresses[input.network];
+  if (!wethAddress) {
+    return {
+      ok: false,
+      error: `ETH Value is set but the WETH address for chain "${input.network}" is not registered. Cannot verify that this swap accepts native ETH; remove ETH Value or add WETH for this chain in protocols/wrapped.ts.`,
+    };
+  }
+
+  const tokenIn = input.tokenIn;
+  if (typeof tokenIn !== "string" || tokenIn.trim() === "") {
+    return {
+      ok: false,
+      error:
+        "ETH Value is set but Input Token Address is missing. To swap native ETH, set Input Token to the WETH address for this chain.",
+    };
+  }
+
+  if (tokenIn.trim().toLowerCase() !== wethAddress.toLowerCase()) {
+    return {
+      ok: false,
+      error: `ETH Value is set but Input Token (${tokenIn}) is not the WETH address for chain "${input.network}" (${wethAddress}). To swap native ETH, set Input Token to the WETH address; otherwise the ETH would be stranded in SwapRouter02.`,
+    };
+  }
+
+  return { ok: true };
 }
 
 function buildFunctionArgs(
@@ -184,6 +247,11 @@ export async function protocolWriteStep(
       meta.functionName,
       meta.protocolSlug
     );
+
+    const preflight = checkUniswapNativeEthPreflight(input, meta, ethValue);
+    if (!preflight.ok) {
+      return { success: false, error: preflight.error };
+    }
 
     const coreInput: WriteContractCoreInput = {
       contractAddress,

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import "@/protocols";
 
+import { ethers } from "ethers";
 import {
   type WriteContractCoreInput,
   type WriteContractResult,
@@ -34,8 +35,6 @@ const UNISWAP_PAYABLE_SWAP_FUNCTIONS: ReadonlySet<string> = new Set([
   "exactOutputSingle",
 ]);
 
-const ZERO_ETH_VALUE_PATTERN = /^0(\.0+)?$/;
-
 type PreflightResult =
   | { ok: true }
   | { ok: false; error: string };
@@ -62,11 +61,14 @@ function resolveEthValue(
   }
 
   // Drop ethValue when the resolved function is positively non-payable. Form
-  // state can retain stale ethValue from a previous configuration (e.g. a
-  // WETH.deposit action reconfigured into a Uniswap swap), and the value
-  // cannot reach the contract anyway. If the function is missing from the
-  // ABI or its mutability is unknown, pass the value through and let
-  // writeContractCore surface the existing payable/not-found errors.
+  // state can retain stale ethValue from a previous payable configuration
+  // when the user reconfigures the action to a non-payable target (e.g. a
+  // WETH.deposit action reconfigured into Compound.supply). Letting the
+  // value through would either revert on-chain with an opaque "function is
+  // not payable" or, worse, get masked by RPC simulation. If the function is
+  // missing from the ABI or its mutability is unknown, pass the value
+  // through and let writeContractCore's existing payable/not-found errors
+  // surface.
   const fn = findAbiFunction(parsedAbi as AbiItem[], functionName);
   if (fn?.stateMutability && fn.stateMutability !== "payable") {
     logUserError(
@@ -91,10 +93,13 @@ function resolveEthValue(
 // address. Setting ETH Value with any other tokenIn strands the ETH in the
 // router (the contract has no way to refund it without an explicit refundETH
 // in a multicall, which we don't expose). Catch this before the tx is sent.
+//
+// Runs before ABI resolution: it only needs `network`, raw `ethValue`, and
+// raw `tokenIn`, so a misconfigured swap fails fast without paying for an
+// Etherscan ABI fetch on the user-specified-address path.
 function checkUniswapNativeEthPreflight(
   input: ProtocolWriteInput,
-  meta: ProtocolMeta,
-  ethValue: string | undefined
+  meta: ProtocolMeta
 ): PreflightResult {
   const isUniswapSwap =
     meta.protocolSlug === "uniswap" &&
@@ -102,11 +107,27 @@ function checkUniswapNativeEthPreflight(
   if (!isUniswapSwap) {
     return { ok: true };
   }
-  if (!ethValue) {
+
+  const rawEthValue = input.ethValue;
+  if (typeof rawEthValue !== "string" || rawEthValue.trim() === "") {
     return { ok: true };
   }
-  const trimmed = ethValue.trim();
-  if (trimmed === "" || ZERO_ETH_VALUE_PATTERN.test(trimmed)) {
+
+  // Use parseEther for the zero check rather than a regex: the regex would
+  // false-positive on inputs like "00", ".0", or "0.0e0" by treating them as
+  // non-zero, even though the downstream parseEther sees them as zero (or
+  // throws). Letting parseEther decide makes the preflight semantics match
+  // what actually reaches the contract.
+  let parsedEthValue: bigint;
+  try {
+    parsedEthValue = ethers.parseEther(rawEthValue.trim());
+  } catch {
+    // Malformed value - let writeContractCore's existing parseEther guard
+    // produce the canonical "Invalid payable value" error rather than
+    // shadowing it with a misleading WETH-address error.
+    return { ok: true };
+  }
+  if (parsedEthValue === BigInt(0)) {
     return { ok: true };
   }
 
@@ -221,6 +242,13 @@ export async function protocolWriteStep(
       };
     }
 
+    // Run cheap protocol-specific preflights before any network I/O so a
+    // misconfigured action fails fast (no Etherscan ABI fetch, no RPC).
+    const preflight = checkUniswapNativeEthPreflight(input, meta);
+    if (!preflight.ok) {
+      return { success: false, error: preflight.error };
+    }
+
     // 4. Resolve ABI (from definition or auto-fetch from explorer)
     let resolvedAbi: string;
     try {
@@ -247,11 +275,6 @@ export async function protocolWriteStep(
       meta.functionName,
       meta.protocolSlug
     );
-
-    const preflight = checkUniswapNativeEthPreflight(input, meta, ethValue);
-    if (!preflight.ok) {
-      return { success: false, error: preflight.error };
-    }
 
     const coreInput: WriteContractCoreInput = {
       contractAddress,

--- a/protocols/abis/uniswap-position-manager.json
+++ b/protocols/abis/uniswap-position-manager.json
@@ -57,7 +57,7 @@
   {
     "type": "function",
     "name": "burn",
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "inputs": [{ "name": "tokenId", "type": "uint256" }],
     "outputs": []
   }

--- a/protocols/abis/uniswap-swap-router.json
+++ b/protocols/abis/uniswap-swap-router.json
@@ -2,7 +2,7 @@
   {
     "type": "function",
     "name": "exactInputSingle",
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "inputs": [
       {
         "name": "params",
@@ -23,7 +23,7 @@
   {
     "type": "function",
     "name": "exactOutputSingle",
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "inputs": [
       {
         "name": "params",

--- a/protocols/uniswap-v3.ts
+++ b/protocols/uniswap-v3.ts
@@ -4,7 +4,8 @@ import positionManagerAbi from "./abis/uniswap-position-manager.json";
 import quoterAbi from "./abis/uniswap-quoter.json";
 import swapRouterAbi from "./abis/uniswap-swap-router.json";
 
-const UNISWAP_DOCS = "https://developers.uniswap.org/docs/protocols/v3/overview";
+const UNISWAP_DOCS =
+  "https://developers.uniswap.org/docs/protocols/v3/overview";
 
 const FEE_TIER_TIP =
   "Pool fee tier in hundredths of a basis point. Common values: 100 (0.01% - stablecoin pairs), 500 (0.05% - correlated pairs), 3000 (0.3% - most pairs), 10000 (1% - exotic pairs).";
@@ -12,20 +13,20 @@ const FEE_TIER_TIP =
 const SQRT_PRICE_LIMIT_TIP =
   "Square-root price limit encoded as a Q64.96 fixed-point number. Constrains how far the pool price can move during the swap. Set to 0 for no limit (most common). Non-zero values act as a slippage guard at the pool level.";
 
+const TOKEN_IN_TIP =
+  "ERC20 contract address of the token you are spending. To swap native ETH directly, set this to the chain's WETH address and provide the swap amount via the 'ETH Value' field below - SwapRouter02 will wrap msg.value internally and no token approval is needed. For ERC20 input, the SwapRouter02 must have an approval for at least the input amount before this action runs.";
+
 const POSITION_TOKEN_ID_TIP =
   "The NFT token ID representing a Uniswap V3 liquidity position. Each position minted via the NonfungiblePositionManager receives a unique uint256 ID. Find it from the Mint event or via the balanceOf + tokenOfOwnerByIndex pattern.";
 
-// QuoterV2 is declared as `view` in the reduced ABI even though the on-chain
-// contract is `nonpayable`. QuoterV2 uses a revert-to-return pattern (calls
-// pool.swap inside a try/catch), so the true mutability is nonpayable, but
-// every client invokes these via eth_call. Declaring `view` keeps the action
-// classified as a read step - no credentials, no gas, no state change.
-//
-// SwapRouter02 and NonfungiblePositionManager have several `payable` functions
-// upstream (exactInputSingle, exactOutputSingle, burn) to support multicall
-// composition. They are marked `nonpayable` in the reduced ABI because we do
-// not expose the ETH-value path through these actions; callers wrap ETH via
-// the WETH protocol first.
+// QuoterV2 is the one deliberate divergence from upstream mutability in this
+// file. Upstream the quote functions are `nonpayable` (they use a revert-as-
+// return idiom: pool.swap is invoked inside try/catch and the simulated
+// amounts are decoded from the revert data), but every client invokes them
+// via eth_call. Marking them `view` here classifies the action as a read
+// step (no credentials, no gas, no transaction). Solidity's mutability model
+// cannot express "off-chain simulation"; this is the cleanest place to bridge
+// that gap until AbiFunctionOverride supports a stateMutability override.
 
 export default defineAbiProtocol({
   name: "Uniswap V3",
@@ -191,7 +192,11 @@ export default defineAbiProtocol({
           description:
             "Swap an exact amount of input tokens for as many output tokens as possible (single-hop)",
           inputs: {
-            tokenIn: { label: "Input Token Address" },
+            tokenIn: {
+              label: "Input Token Address",
+              helpTip: TOKEN_IN_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
             tokenOut: { label: "Output Token Address" },
             fee: {
               label: "Fee Tier (100, 500, 3000, or 10000)",
@@ -223,7 +228,11 @@ export default defineAbiProtocol({
           description:
             "Swap as few input tokens as possible for an exact amount of output tokens (single-hop)",
           inputs: {
-            tokenIn: { label: "Input Token Address" },
+            tokenIn: {
+              label: "Input Token Address",
+              helpTip: TOKEN_IN_TIP,
+              docUrl: UNISWAP_DOCS,
+            },
             tokenOut: { label: "Output Token Address" },
             fee: {
               label: "Fee Tier (100, 500, 3000, or 10000)",

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -397,16 +397,6 @@ describe("protocolWriteStep", () => {
     // Uniswap swap). Drop the value rather than let writeContractCore surface
     // the opaque "function is not payable" error.
     describe("KEEP-393 stale ethValue guard", () => {
-      const NONPAYABLE_ABI = JSON.stringify([
-        {
-          type: "function",
-          name: "exactInputSingle",
-          stateMutability: "nonpayable",
-          inputs: [],
-          outputs: [],
-        },
-      ]);
-
       const PAYABLE_ABI = JSON.stringify([
         {
           type: "function",
@@ -417,40 +407,40 @@ describe("protocolWriteStep", () => {
         },
       ]);
 
+      // Uses compound.supply (nonpayable upstream) rather than a Uniswap swap:
+      // post-KEEP-408 the Uniswap swap functions are correctly typed as
+      // payable, so resolveEthValue would no longer drop the value there
+      // (and the KEEP-408 preflight would reject the stale ethValue with a
+      // user-facing error before this guard runs). The KEEP-393 mechanism
+      // still matters for any payable -> nonpayable action reconfiguration,
+      // which compound.supply demonstrates.
       it("drops ethValue when the resolved function is nonpayable and logs the drop", async () => {
-        mockResolveProtocolMeta.mockReturnValue({
-          protocolSlug: "uniswap",
-          contractKey: "swapRouter",
-          functionName: "exactInputSingle",
-          actionType: "write",
-        });
-        mockGetProtocol.mockReturnValue({
-          name: "Uniswap V3",
-          slug: "uniswap",
-          contracts: {
-            swapRouter: {
-              label: "SwapRouter02",
-              userSpecifiedAddress: false,
-              addresses: {
-                "11155111": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E",
-              },
-            },
+        const COMPOUND_SUPPLY_NONPAYABLE_ABI = JSON.stringify([
+          {
+            type: "function",
+            name: "supply",
+            stateMutability: "nonpayable",
+            inputs: [],
+            outputs: [],
           },
-          actions: [],
+        ]);
+        mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);
+        mockGetProtocol.mockReturnValue(COMPOUND_PROTOCOL);
+        mockResolveAbi.mockResolvedValue({
+          abi: COMPOUND_SUPPLY_NONPAYABLE_ABI,
         });
-        mockResolveAbi.mockResolvedValue({ abi: NONPAYABLE_ABI });
         mockWriteContractCore.mockResolvedValue({
           success: true,
-          transactionHash: "0xswap",
+          transactionHash: "0xsupply",
           transactionLink: "",
           gasUsed: "150000",
         });
 
         await protocolWriteStep(
           makeInput({
-            network: "11155111",
+            network: "8453",
             ethValue: "0.04",
-            _actionType: "uniswap/swap-exact-input",
+            _actionType: "compound/supply",
           })
         );
 
@@ -462,13 +452,13 @@ describe("protocolWriteStep", () => {
           .calls[0];
         expect(category).toBe("configuration");
         expect(message).toContain("Dropped ethValue");
-        expect(message).toContain("exactInputSingle");
+        expect(message).toContain("supply");
         expect(message).toContain("0.04");
         expect(labels).toMatchObject({
           plugin_name: "protocol",
           action_name: "protocol-write",
-          protocol_slug: "uniswap",
-          function_name: "exactInputSingle",
+          protocol_slug: "compound",
+          function_name: "supply",
           state_mutability: "nonpayable",
         });
       });
@@ -799,6 +789,9 @@ describe("protocolWriteStep", () => {
       ["zero", "0"],
       ["zero with decimals", "0.0"],
       ["zero with many decimals", "0.0000"],
+      // Forms a regex would false-positive but parseEther correctly sees as zero:
+      ["leading-zero zero", "00"],
+      ["leading dot zero", ".0"],
     ])("treats ethValue %s as no native value and skips the WETH check", async (_label, ethValue) => {
       setupUniswapSwap();
 

--- a/tests/unit/protocol-write-step.test.ts
+++ b/tests/unit/protocol-write-step.test.ts
@@ -651,6 +651,258 @@ describe("protocolWriteStep", () => {
     });
   });
 
+  // KEEP-408: Uniswap swap functions are payable upstream so SwapRouter02 can
+  // wrap msg.value when tokenIn is the chain's WETH. Sending ETH with any
+  // other tokenIn strands the ETH in the router. Preflight enforces this
+  // before the tx is sent.
+  describe("KEEP-408 Uniswap native-ETH preflight", () => {
+    const WETH_SEPOLIA = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14";
+
+    const PAYABLE_SWAP_ABI = JSON.stringify([
+      {
+        type: "function",
+        name: "exactInputSingle",
+        stateMutability: "payable",
+        inputs: [],
+        outputs: [],
+      },
+    ]);
+
+    const UNISWAP_PROTOCOL = {
+      name: "Uniswap V3",
+      slug: "uniswap",
+      contracts: {
+        swapRouter: {
+          label: "SwapRouter02",
+          userSpecifiedAddress: false,
+          addresses: {
+            "11155111": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E",
+          },
+        },
+      },
+      actions: [],
+    };
+
+    const WRAPPED_PROTOCOL = {
+      name: "Wrapped",
+      slug: "wrapped",
+      contracts: {
+        weth: {
+          label: "WETH",
+          userSpecifiedAddress: false,
+          addresses: {
+            "11155111": WETH_SEPOLIA,
+          },
+        },
+      },
+      actions: [],
+    };
+
+    function setupUniswapSwap(): void {
+      mockResolveProtocolMeta.mockReturnValue({
+        protocolSlug: "uniswap",
+        contractKey: "swapRouter",
+        functionName: "exactInputSingle",
+        actionType: "write",
+      });
+      mockGetProtocol.mockImplementation((slug: string) => {
+        if (slug === "uniswap") {
+          return UNISWAP_PROTOCOL;
+        }
+        if (slug === "wrapped") {
+          return WRAPPED_PROTOCOL;
+        }
+        return undefined;
+      });
+      mockResolveAbi.mockResolvedValue({ abi: PAYABLE_SWAP_ABI });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xswap",
+        transactionLink: "",
+        gasUsed: "150000",
+      });
+    }
+
+    it("rejects when ethValue is set but tokenIn is not WETH", async () => {
+      setupUniswapSwap();
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue: "0.1",
+          tokenIn: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Input Token");
+        expect(result.error).toContain(WETH_SEPOLIA);
+        expect(result.error).toContain("stranded");
+      }
+      expect(mockWriteContractCore).not.toHaveBeenCalled();
+    });
+
+    it("allows native ETH swap when tokenIn matches the chain WETH", async () => {
+      setupUniswapSwap();
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue: "0.1",
+          tokenIn: WETH_SEPOLIA,
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockWriteContractCore).toHaveBeenCalledTimes(1);
+      const coreCall = (mockWriteContractCore as Mock).mock.calls[0][0];
+      expect(coreCall.ethValue).toBe("0.1");
+    });
+
+    it("allows native ETH swap when tokenIn matches WETH with different case", async () => {
+      setupUniswapSwap();
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue: "0.1",
+          tokenIn: WETH_SEPOLIA.toLowerCase(),
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockWriteContractCore).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows ERC20-to-ERC20 swap (no ethValue) regardless of tokenIn", async () => {
+      setupUniswapSwap();
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          tokenIn: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockWriteContractCore).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ["empty string", ""],
+      ["whitespace only", "   "],
+      ["zero", "0"],
+      ["zero with decimals", "0.0"],
+      ["zero with many decimals", "0.0000"],
+    ])("treats ethValue %s as no native value and skips the WETH check", async (_label, ethValue) => {
+      setupUniswapSwap();
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue,
+          tokenIn: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockWriteContractCore).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects when ethValue is set but tokenIn is missing", async () => {
+      setupUniswapSwap();
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue: "0.1",
+          tokenIn: undefined,
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Input Token Address is missing");
+      }
+      expect(mockWriteContractCore).not.toHaveBeenCalled();
+    });
+
+    it("rejects when WETH address for chain is not registered", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        protocolSlug: "uniswap",
+        contractKey: "swapRouter",
+        functionName: "exactInputSingle",
+        actionType: "write",
+      });
+      mockGetProtocol.mockImplementation((slug: string) => {
+        if (slug === "uniswap") {
+          return UNISWAP_PROTOCOL;
+        }
+        return undefined;
+      });
+      mockResolveAbi.mockResolvedValue({ abi: PAYABLE_SWAP_ABI });
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue: "0.1",
+          tokenIn: WETH_SEPOLIA,
+          _actionType: "uniswap/swap-exact-input",
+        })
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("WETH address for chain");
+      }
+      expect(mockWriteContractCore).not.toHaveBeenCalled();
+    });
+
+    it("does not interfere with non-Uniswap payable functions (e.g. WETH.deposit)", async () => {
+      mockResolveProtocolMeta.mockReturnValue({
+        protocolSlug: "wrapped",
+        contractKey: "weth",
+        functionName: "deposit",
+        actionType: "write",
+      });
+      mockGetProtocol.mockReturnValue(WRAPPED_PROTOCOL);
+      mockResolveAbi.mockResolvedValue({
+        abi: JSON.stringify([
+          {
+            type: "function",
+            name: "deposit",
+            stateMutability: "payable",
+            inputs: [],
+            outputs: [],
+          },
+        ]),
+      });
+      mockWriteContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xdep",
+        transactionLink: "",
+        gasUsed: "50000",
+      });
+
+      const result = await protocolWriteStep(
+        makeInput({
+          network: "11155111",
+          ethValue: "0.5",
+          _actionType: "wrapped/deposit",
+        })
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+
   describe("Compound V3 specific scenarios", () => {
     it("handles Compound supply on Base", async () => {
       mockResolveProtocolMeta.mockReturnValue(COMPOUND_SUPPLY_META);


### PR DESCRIPTION
## Summary

- Fixes the Uniswap V3 reduced ABIs to match the deployed mainnet contracts: `SwapRouter02.exactInputSingle`, `exactOutputSingle`, and `NonfungiblePositionManager.burn` are all `payable` upstream. The reduced ABIs previously marked them `nonpayable`, which hid the ETH Value config field and forced users to compose `WETH.deposit` -> `WETH.approve` -> `swap` (3 txs, persistent approval, non-atomic) just to swap native ETH to a token.
- Flips the auto-generated ETH Value field on `payable` actions to `required: false`. ERC20-to-ERC20 swaps - the dominant case - no longer have to type `"0"` explicitly.
- Adds `checkUniswapNativeEthPreflight` in `protocolWriteStep` that rejects the misconfiguration `tokenIn != WETH_for_chain && ethValue > 0` with a clear error before the tx is sent. This is the one footgun the upstream contract does not protect against (stranded ETH in SwapRouter02).
- Adds `TOKEN_IN_TIP` helpTip on both swap actions explaining the WETH-address pattern for native swaps.
- Rewrote the misleading mutability comment in `protocols/uniswap-v3.ts`. The new comment is honest about QuoterV2 being a deliberate `nonpayable` -> `view` divergence (revert-as-return idiom; clients always invoke via `eth_call`) rather than the previous wrong claim that SwapRouter swap functions were not payable upstream.

## Verification

- Upstream payability confirmed against the verified mainnet contracts on Etherscan (SwapRouter02 `0x68b3...Fc45`, NonfungiblePositionManager `0xC364...FE88`).
- 11 new unit tests in `tests/unit/protocol-write-step.test.ts` cover: WETH match (case-insensitive), tokenIn-mismatch rejection, ERC20-to-ERC20 with no ethValue, zero-value variants treated as no-op, missing tokenIn, missing chain WETH, and no interference with non-Uniswap payable functions like `WETH.deposit`.
- 53/53 unit tests in `protocol-write-step.test.ts` + `protocol-uniswap.test.ts` pass.
- Ultracite lint clean on all changed files.

## Out of scope

- Sister ticket KEEP-409 covers the asymmetric output-side problem (token -> native ETH requires multicall + `unwrapWETH9`, not solved by this change).
- Broader refactor to ship full upstream ABIs + explicit `exposedFunctions` allowlist + `simulationOnly` override flag (discussed in design but separate scope).

## Test plan

- [x] Unit tests pass in CI
- [x] On Sepolia, configure `swap-exact-input(tokenIn=WETH_SEPOLIA, tokenOut=USDC, ethValue=0.001)` and confirm a single tx swaps ETH -> USDC successfully without prior wrap/approve.
- [x] On Sepolia, configure `swap-exact-input(tokenIn=USDC, tokenOut=WETH, ethValue=0.001)` and confirm the preflight rejects with the clear error before the tx is sent.
- [x] Existing ERC20-to-ERC20 swaps still execute without an ethValue field set.