### PR TITLE
fix(executor): bound DB-authority queries with 2s statement_timeout (KEEP-410)

### DIFF
--- a/lib/workflow/executor/get-completed-step-output.step.ts
+++ b/lib/workflow/executor/get-completed-step-output.step.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs } from "@/lib/db/schema";
 
@@ -10,17 +10,20 @@ export async function fetchCompletedStepOutputStep(
 ): Promise<{ outputRaw: unknown } | null> {
   "use step";
 
-  const row = await db.query.workflowExecutionLogs.findFirst({
-    where: and(
-      eq(workflowExecutionLogs.executionId, executionId),
-      eq(workflowExecutionLogs.nodeId, nodeId),
-      eq(workflowExecutionLogs.status, "success"),
-      isNull(workflowExecutionLogs.iterationIndex),
-      isNull(workflowExecutionLogs.forEachNodeId),
-      isNotNull(workflowExecutionLogs.outputRaw)
-    ),
-    orderBy: desc(workflowExecutionLogs.completedAt),
-    columns: { outputRaw: true },
+  const row = await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL statement_timeout = '2s'`);
+    return tx.query.workflowExecutionLogs.findFirst({
+      where: and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        eq(workflowExecutionLogs.nodeId, nodeId),
+        eq(workflowExecutionLogs.status, "success"),
+        isNull(workflowExecutionLogs.iterationIndex),
+        isNull(workflowExecutionLogs.forEachNodeId),
+        isNotNull(workflowExecutionLogs.outputRaw)
+      ),
+      orderBy: desc(workflowExecutionLogs.completedAt),
+      columns: { outputRaw: true },
+    });
   });
 
   if (!row) {
@@ -38,17 +41,20 @@ export async function fetchCompletedStepOutputsBatchStep(
 ): Promise<Array<{ nodeId: string; outputRaw: unknown }>> {
   "use step";
 
-  const rows = await db.query.workflowExecutionLogs.findMany({
-    where: and(
-      eq(workflowExecutionLogs.executionId, executionId),
-      inArray(workflowExecutionLogs.nodeId, nodeIds),
-      eq(workflowExecutionLogs.status, "success"),
-      isNull(workflowExecutionLogs.iterationIndex),
-      isNull(workflowExecutionLogs.forEachNodeId),
-      isNotNull(workflowExecutionLogs.outputRaw)
-    ),
-    orderBy: desc(workflowExecutionLogs.completedAt),
-    columns: { nodeId: true, outputRaw: true },
+  const rows = await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL statement_timeout = '2s'`);
+    return tx.query.workflowExecutionLogs.findMany({
+      where: and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        inArray(workflowExecutionLogs.nodeId, nodeIds),
+        eq(workflowExecutionLogs.status, "success"),
+        isNull(workflowExecutionLogs.iterationIndex),
+        isNull(workflowExecutionLogs.forEachNodeId),
+        isNotNull(workflowExecutionLogs.outputRaw)
+      ),
+      orderBy: desc(workflowExecutionLogs.completedAt),
+      columns: { nodeId: true, outputRaw: true },
+    });
   });
 
   return rows.map((row) => ({

--- a/lib/workflow/executor/get-completed-step-output.ts
+++ b/lib/workflow/executor/get-completed-step-output.ts
@@ -1,5 +1,13 @@
 import "server-only";
 
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { getMetricsCollector } from "@/lib/metrics";
+import {
+  fetchCompletedStepOutputStep,
+  fetchCompletedStepOutputsBatchStep,
+} from "@/lib/workflow/executor/get-completed-step-output.step";
+import { getSuccessfulSteps } from "@/lib/workflow/executor/step-success-tracker";
+
 /**
  * Kill-switch: set KH_EXECUTOR_AUTHORITY_DB_FALLBACK=false to disable DB-backed
  * step authority and revert to tracker-only behaviour. Use as an ops emergency
@@ -10,13 +18,20 @@ import "server-only";
 const DB_FALLBACK_ENABLED =
   process.env.KH_EXECUTOR_AUTHORITY_DB_FALLBACK !== "false";
 
-import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { getMetricsCollector } from "@/lib/metrics";
-import {
-  fetchCompletedStepOutputStep,
-  fetchCompletedStepOutputsBatchStep,
-} from "@/lib/workflow/executor/get-completed-step-output.step";
-import { getSuccessfulSteps } from "@/lib/workflow/executor/step-success-tracker";
+/**
+ * Returns true when the error is a PostgreSQL statement timeout (SQLSTATE 57014).
+ * Drizzle wraps the driver error in DrizzleQueryError with the original on
+ * error.cause, so we check both levels.
+ */
+function isStatementTimeout(err: unknown): boolean {
+  const candidates = [err, (err as { cause?: unknown })?.cause];
+  return candidates.some(
+    (e) =>
+      e !== null &&
+      typeof e === "object" &&
+      (e as { code?: unknown }).code === "57014"
+  );
+}
 
 export type CompletedStepOutput = {
   output: unknown;
@@ -123,6 +138,7 @@ export function getCompletedStepOutput(
     },
     (err: unknown) => {
       inflightQueries.delete(cacheKey);
+      const outcome = isStatementTimeout(err) ? "timeout" : "error";
       logSystemError(
         ErrorCategory.WORKFLOW_ENGINE,
         "[getCompletedStepOutput] DB fallback query failed; returning null",
@@ -136,7 +152,7 @@ export function getCompletedStepOutput(
       );
       getMetricsCollector().incrementCounter(
         "workflow.executor.tracker_db_fallback.total",
-        { source: "single", outcome: "error" }
+        { source: "single", outcome }
       );
       return null;
     }
@@ -223,9 +239,10 @@ export async function getCompletedStepOutputs(
       );
     }
   } catch (err: unknown) {
+    const outcome = isStatementTimeout(err) ? "timeout" : "error";
     getMetricsCollector().incrementCounter(
       "workflow.executor.tracker_db_fallback.total",
-      { source: "convergence", outcome: "error" }
+      { source: "convergence", outcome }
     );
     logSystemError(
       ErrorCategory.WORKFLOW_ENGINE,

--- a/tests/unit/get-completed-step-output.test.ts
+++ b/tests/unit/get-completed-step-output.test.ts
@@ -242,6 +242,82 @@ describe("getCompletedStepOutput", () => {
     });
   });
 
+  describe("statement timeout (SQLSTATE 57014)", () => {
+    function makeTimeoutError(): Error {
+      const e = new Error("canceling statement due to statement timeout");
+      (e as { code?: string }).code = "57014";
+      (e as { severity?: string }).severity = "ERROR";
+      return e;
+    }
+
+    it("returns null on timeout", async () => {
+      mockFetchSingle.mockRejectedValueOnce(makeTimeoutError());
+
+      const result = await getCompletedStepOutput(executionId, nodeId);
+
+      expect(result).toBeNull();
+    });
+
+    it("increments outcome=timeout counter on timeout, not outcome=error", async () => {
+      mockFetchSingle.mockRejectedValueOnce(makeTimeoutError());
+
+      await getCompletedStepOutput(executionId, nodeId);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+    });
+
+    it("evicts cache on timeout so subsequent call retries the DB", async () => {
+      mockFetchSingle
+        .mockRejectedValueOnce(makeTimeoutError())
+        .mockResolvedValueOnce({ outputRaw: { retried: true } });
+
+      const r1 = await getCompletedStepOutput(executionId, nodeId);
+      expect(r1).toBeNull();
+
+      const r2 = await getCompletedStepOutput(executionId, nodeId);
+      expect(r2?.output).toEqual({ retried: true });
+      expect(mockFetchSingle).toHaveBeenCalledTimes(2);
+    });
+
+    it("wrapping in cause also detected as timeout (DrizzleQueryError pattern)", async () => {
+      const cause = new Error("canceling statement due to statement timeout");
+      (cause as { code?: string }).code = "57014";
+      (cause as { severity?: string }).severity = "ERROR";
+      const wrapper = new Error("DrizzleQueryError");
+      (wrapper as { cause?: unknown }).cause = cause;
+      mockFetchSingle.mockRejectedValueOnce(wrapper);
+
+      await getCompletedStepOutput(executionId, nodeId);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+    });
+
+    it("generic error still increments outcome=error, not outcome=timeout", async () => {
+      mockFetchSingle.mockRejectedValueOnce(new Error("generic DB failure"));
+
+      await getCompletedStepOutput(executionId, nodeId);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+    });
+  });
+
   describe("kill-switch: KH_EXECUTOR_AUTHORITY_DB_FALLBACK=false skips DB entirely", () => {
     // The kill-switch constant is read at module load time. Runtime env mutation
     // cannot affect it. We use vi.stubEnv + vi.resetModules + dynamic import to
@@ -395,6 +471,53 @@ describe("getCompletedStepOutputs (batch helper)", () => {
       "workflow.executor.tracker_db_fallback.total",
       expect.objectContaining({ outcome: "error" })
     );
+  });
+
+  describe("statement timeout (SQLSTATE 57014) in batch path", () => {
+    function makeTimeoutError(): Error {
+      const e = new Error("canceling statement due to statement timeout");
+      (e as { code?: string }).code = "57014";
+      (e as { severity?: string }).severity = "ERROR";
+      return e;
+    }
+
+    it("returns empty map on batch timeout", async () => {
+      mockFetchBatch.mockRejectedValueOnce(makeTimeoutError());
+
+      const result = await getCompletedStepOutputs(executionId, ["p1", "p2"]);
+
+      expect(result.size).toBe(0);
+    });
+
+    it("increments outcome=timeout counter on batch timeout, not outcome=error", async () => {
+      mockFetchBatch.mockRejectedValueOnce(makeTimeoutError());
+
+      await getCompletedStepOutputs(executionId, ["p1", "p2"]);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+    });
+
+    it("generic batch error still increments outcome=error, not outcome=timeout", async () => {
+      mockFetchBatch.mockRejectedValueOnce(new Error("generic batch failure"));
+
+      await getCompletedStepOutputs(executionId, ["p1", "p2"]);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+    });
   });
 
   it("iteration rows are excluded: only non-loop canonical rows are returned", async () => {


### PR DESCRIPTION
## Summary

- The DB-backed step-success authority added in PR #1110 issues Postgres reads from inside the workflow body. Without a `statement_timeout`, a single slow query holds a pool slot indefinitely; under RDS hiccup or planner regression, all 10 pool slots can stall, cascading into workflow failures across every concurrent execution on the pod. The kill-switch (`KH_EXECUTOR_AUTHORITY_DB_FALLBACK=false`) is the only relief and requires a pod restart cycle.
- This PR bounds both helpers (`fetchCompletedStepOutputStep` and `fetchCompletedStepOutputsBatchStep`) by wrapping each in a Drizzle transaction with `SET LOCAL statement_timeout = '2s'` as the first statement. Pattern mirrors existing precedent at `keeperhub-executor/workflow-runner.ts:99`.
- On Postgres SQLSTATE `57014` (canceling statement due to statement timeout), the helper returns null and increments `tracker_db_fallback.total{outcome='timeout'}` (new label distinct from `error`). Same containment shape as existing error path; just adds a hard upper bound.
- Detection mirrors `lib/db/connection-utils.ts:113-119` and checks both `error.code` and `error.cause.code` for postgres-js' wrapped error shape.

## Notes for review

- 9 new unit tests cover timeout detection (single + batch), counter labeling, cache eviction on timeout, and regression-canary that non-timeout errors still land on `outcome='error'`.
- Manual local-pg verification recommended before merge — unit tests mock at the step boundary, so the actual `db.transaction` + `SET LOCAL` SQL path isn't exercised by mocks. Suggested smoke test: run a workflow against `pnpm dev` with `EXPLAIN`-traceable query.
- Latency cost: BEGIN + SET LOCAL + SELECT + COMMIT triples round-trip count for the cross-pod tracker-miss case. Estimated 2-5ms intra-region overhead, well within the 50ms p99 convergence-merge budget. Tracker-hit fast path is unaffected.
- Kill-switch short-circuit confirmed: `KH_EXECUTOR_AUTHORITY_DB_FALLBACK=false` returns null before `db.transaction()` is opened. No DB connection acquired in the off state.

## Open follow-up

- KEEP-413: app-level circuit breaker. `statement_timeout` bounds each query but NOT the connection-pool queue-wait — the 11th caller still waits up to 30s on a saturated pool. The kill-switch is the only escape and requires pod restart. A circuit breaker would give sub-second relief. Filed as a follow-up; out of scope for this PR.

## Test plan

- [ ] CI: 33/33 unit tests pass (24 pre-existing + 9 new)
- [ ] `pnpm dev` builds cleanly (Workflow DevKit bundler accepts the changes — verified locally)
- [ ] Manual smoke against `pnpm dev`: run a fan-out workflow, verify `tracker_db_fallback.total{outcome='hit'|'miss'|'error'|'timeout'}` is wired and increments per call
- [ ] Staging UAT after merge: confirm zero `outcome='timeout'` increments under steady state; if any fire, investigate before prod
- [ ] Prod monitoring: alert on `tracker_db_fallback.total{outcome='timeout'}` rate exceeding zero

Closes KEEP-410.