### PR TITLE
release: to prod

### DIFF
--- a/lib/workflow/executor/get-completed-step-output.step.ts
+++ b/lib/workflow/executor/get-completed-step-output.step.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs } from "@/lib/db/schema";
 
@@ -10,17 +10,20 @@ export async function fetchCompletedStepOutputStep(
 ): Promise<{ outputRaw: unknown } | null> {
   "use step";
 
-  const row = await db.query.workflowExecutionLogs.findFirst({
-    where: and(
-      eq(workflowExecutionLogs.executionId, executionId),
-      eq(workflowExecutionLogs.nodeId, nodeId),
-      eq(workflowExecutionLogs.status, "success"),
-      isNull(workflowExecutionLogs.iterationIndex),
-      isNull(workflowExecutionLogs.forEachNodeId),
-      isNotNull(workflowExecutionLogs.outputRaw)
-    ),
-    orderBy: desc(workflowExecutionLogs.completedAt),
-    columns: { outputRaw: true },
+  const row = await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL statement_timeout = '2s'`);
+    return tx.query.workflowExecutionLogs.findFirst({
+      where: and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        eq(workflowExecutionLogs.nodeId, nodeId),
+        eq(workflowExecutionLogs.status, "success"),
+        isNull(workflowExecutionLogs.iterationIndex),
+        isNull(workflowExecutionLogs.forEachNodeId),
+        isNotNull(workflowExecutionLogs.outputRaw)
+      ),
+      orderBy: desc(workflowExecutionLogs.completedAt),
+      columns: { outputRaw: true },
+    });
   });
 
   if (!row) {
@@ -38,17 +41,20 @@ export async function fetchCompletedStepOutputsBatchStep(
 ): Promise<Array<{ nodeId: string; outputRaw: unknown }>> {
   "use step";
 
-  const rows = await db.query.workflowExecutionLogs.findMany({
-    where: and(
-      eq(workflowExecutionLogs.executionId, executionId),
-      inArray(workflowExecutionLogs.nodeId, nodeIds),
-      eq(workflowExecutionLogs.status, "success"),
-      isNull(workflowExecutionLogs.iterationIndex),
-      isNull(workflowExecutionLogs.forEachNodeId),
-      isNotNull(workflowExecutionLogs.outputRaw)
-    ),
-    orderBy: desc(workflowExecutionLogs.completedAt),
-    columns: { nodeId: true, outputRaw: true },
+  const rows = await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL statement_timeout = '2s'`);
+    return tx.query.workflowExecutionLogs.findMany({
+      where: and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        inArray(workflowExecutionLogs.nodeId, nodeIds),
+        eq(workflowExecutionLogs.status, "success"),
+        isNull(workflowExecutionLogs.iterationIndex),
+        isNull(workflowExecutionLogs.forEachNodeId),
+        isNotNull(workflowExecutionLogs.outputRaw)
+      ),
+      orderBy: desc(workflowExecutionLogs.completedAt),
+      columns: { nodeId: true, outputRaw: true },
+    });
   });
 
   return rows.map((row) => ({

--- a/lib/workflow/executor/get-completed-step-output.ts
+++ b/lib/workflow/executor/get-completed-step-output.ts
@@ -1,5 +1,13 @@
 import "server-only";
 
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { getMetricsCollector } from "@/lib/metrics";
+import {
+  fetchCompletedStepOutputStep,
+  fetchCompletedStepOutputsBatchStep,
+} from "@/lib/workflow/executor/get-completed-step-output.step";
+import { getSuccessfulSteps } from "@/lib/workflow/executor/step-success-tracker";
+
 /**
  * Kill-switch: set KH_EXECUTOR_AUTHORITY_DB_FALLBACK=false to disable DB-backed
  * step authority and revert to tracker-only behaviour. Use as an ops emergency
@@ -10,13 +18,20 @@ import "server-only";
 const DB_FALLBACK_ENABLED =
   process.env.KH_EXECUTOR_AUTHORITY_DB_FALLBACK !== "false";
 
-import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { getMetricsCollector } from "@/lib/metrics";
-import {
-  fetchCompletedStepOutputStep,
-  fetchCompletedStepOutputsBatchStep,
-} from "@/lib/workflow/executor/get-completed-step-output.step";
-import { getSuccessfulSteps } from "@/lib/workflow/executor/step-success-tracker";
+/**
+ * Returns true when the error is a PostgreSQL statement timeout (SQLSTATE 57014).
+ * Drizzle wraps the driver error in DrizzleQueryError with the original on
+ * error.cause, so we check both levels.
+ */
+function isStatementTimeout(err: unknown): boolean {
+  const candidates = [err, (err as { cause?: unknown })?.cause];
+  return candidates.some(
+    (e) =>
+      e !== null &&
+      typeof e === "object" &&
+      (e as { code?: unknown }).code === "57014"
+  );
+}
 
 export type CompletedStepOutput = {
   output: unknown;
@@ -123,6 +138,7 @@ export function getCompletedStepOutput(
     },
     (err: unknown) => {
       inflightQueries.delete(cacheKey);
+      const outcome = isStatementTimeout(err) ? "timeout" : "error";
       logSystemError(
         ErrorCategory.WORKFLOW_ENGINE,
         "[getCompletedStepOutput] DB fallback query failed; returning null",
@@ -136,7 +152,7 @@ export function getCompletedStepOutput(
       );
       getMetricsCollector().incrementCounter(
         "workflow.executor.tracker_db_fallback.total",
-        { source: "single", outcome: "error" }
+        { source: "single", outcome }
       );
       return null;
     }
@@ -223,9 +239,10 @@ export async function getCompletedStepOutputs(
       );
     }
   } catch (err: unknown) {
+    const outcome = isStatementTimeout(err) ? "timeout" : "error";
     getMetricsCollector().incrementCounter(
       "workflow.executor.tracker_db_fallback.total",
-      { source: "convergence", outcome: "error" }
+      { source: "convergence", outcome }
     );
     logSystemError(
       ErrorCategory.WORKFLOW_ENGINE,

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -4,7 +4,7 @@
  */
 import "server-only";
 
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -309,38 +309,27 @@ export type IncrementCompletedStepsParams = {
 };
 
 /**
- * Increment the completed steps counter and update execution trace.
+ * Increment the completed steps counter and append to the execution trace.
  * Called when a step completes (success or error).
+ *
+ * Uses a single atomic UPDATE so concurrent fan-out steps (for-each, parallel
+ * branches) cannot overwrite each other's trace entries or counter increments.
+ * The WHERE clause replaces the pre-read terminal-status guard, eliminating
+ * the TOCTOU race against cancellation.
+ *
+ * Follow-up: audit other jsonb/array updates under lib/workflow/executor/ for
+ * atomicity — see KEEP-411 commit message for known open spots.
  */
 export async function incrementCompletedSteps(
   params: IncrementCompletedStepsParams
 ): Promise<void> {
-  // Fetch current execution to get current values
-  const execution = await db.query.workflowExecutions.findFirst({
-    where: eq(workflowExecutions.id, params.executionId),
-  });
-
-  if (!execution) {
-    return;
-  }
-
-  // Guard: skip if execution was cancelled (runtime continues after cancel)
-  if (TERMINAL_STATUSES.has(execution.status)) {
-    return;
-  }
-
-  const completedSteps =
-    Number.parseInt(execution.completedSteps || "0", 10) + 1;
-  const trace = (execution.executionTrace as string[] | null) || [];
-
   await db
     .update(workflowExecutions)
     .set({
-      completedSteps: completedSteps.toString(),
-      executionTrace: [...trace, params.nodeId],
+      completedSteps: sql`(COALESCE(${workflowExecutions.completedSteps}, '0')::int + 1)::text`,
+      executionTrace: sql`COALESCE(${workflowExecutions.executionTrace}, '[]'::jsonb) || ${JSON.stringify([params.nodeId])}::jsonb`,
       currentNodeId: null,
       currentNodeName: null,
-      // Only update last successful if this step succeeded
       ...(params.success
         ? {
             lastSuccessfulNodeId: params.nodeId,
@@ -348,5 +337,10 @@ export async function incrementCompletedSteps(
           }
         : {}),
     })
-    .where(eq(workflowExecutions.id, params.executionId));
+    .where(
+      and(
+        eq(workflowExecutions.id, params.executionId),
+        ne(workflowExecutions.status, "cancelled")
+      )
+    );
 }

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -317,8 +317,9 @@ export type IncrementCompletedStepsParams = {
  * The WHERE clause replaces the pre-read terminal-status guard, eliminating
  * the TOCTOU race against cancellation.
  *
- * Follow-up: audit other jsonb/array updates under lib/workflow/executor/ for
- * atomicity — see KEEP-411 commit message for known open spots.
+ * Returns void; the UPDATE silently affects 0 rows when the execution is
+ * cancelled (or has been deleted). Callers should not depend on the trace
+ * being incremented for late-arriving step completions on cancelled runs.
  */
 export async function incrementCompletedSteps(
   params: IncrementCompletedStepsParams

--- a/tests/e2e/vitest/execution-trace-race.test.ts
+++ b/tests/e2e/vitest/execution-trace-race.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Integration tests for incrementCompletedSteps atomicity.
+ *
+ * These tests exercise real Postgres row-level behavior.  Mock harnesses
+ * cannot reproduce the concurrent-write race; only a real DB can.
+ *
+ * Prerequisites:
+ *   - Local Postgres running (DATABASE_URL set, or default localhost:5433)
+ *   - Schema migrated: pnpm db:push
+ *
+ * Run with:
+ *   pnpm test tests/e2e/vitest/execution-trace-race.test.ts
+ */
+
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ---- module mocks --------------------------------------------------------
+// server-only is a Next.js guard that throws outside SSR context.
+// Bypass it so we can import the logging module in a Node test.
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
+  logSystemError: vi.fn(),
+}));
+
+// Build a real postgres connection at hoist time so it is available when
+// vi.mock("@/lib/db") runs.  vi.hoisted executes before ESM imports are
+// resolved, so we must use require() instead of the imported bindings.
+const { realDb } = vi.hoisted(() => {
+  const connectionString =
+    process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5433/keeperhub";
+  // CJS interop: require() is needed here because ESM imports are not yet
+  // resolved when vi.hoisted runs.  The default export varies by bundler.
+  // pgClient is typed as Sql<{}> at runtime; we cast through unknown to satisfy
+  // drizzle's overloaded signature without pulling in postgres types at hoist time.
+  const pgClientRaw: unknown = (
+    require("postgres") as (url: string, opts: { max: number }) => unknown
+  )(connectionString, { max: 20 });
+  const { drizzle: drizzleFn } = require("drizzle-orm/postgres-js") as {
+    drizzle: typeof drizzle;
+  };
+  const realDb = drizzleFn(pgClientRaw as any) as ReturnType<typeof drizzle>;
+  return { realDb };
+});
+
+// Override the global @/lib/db mock (from tests/setup.ts) with a real DB
+// so that incrementCompletedSteps issues SQL against the local Postgres.
+vi.mock("@/lib/db", () => ({ db: realDb }));
+
+// ---- schema + function under test ----------------------------------------
+// These imports run after the mocks above are established.
+import { users, workflowExecutions, workflows } from "@/lib/db/schema";
+import { incrementCompletedSteps } from "@/lib/workflow/executor/logging";
+
+// ---- skip guard ----------------------------------------------------------
+const shouldSkip =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+
+function generateId(): string {
+  return crypto.randomBytes(11).toString("base64url");
+}
+
+describe.skipIf(shouldSkip)("incrementCompletedSteps atomicity", () => {
+  let testDb: ReturnType<typeof drizzle>;
+  let pgClientOwned: ReturnType<typeof postgres>;
+  let testUserId: string;
+  let testWorkflowId: string;
+
+  beforeAll(async () => {
+    const connectionString =
+      process.env.DATABASE_URL ??
+      "postgresql://postgres:postgres@localhost:5433/keeperhub";
+
+    // A separate client for test assertions and setup.
+    pgClientOwned = postgres(connectionString, { max: 5 });
+    testDb = drizzle(pgClientOwned, {
+      schema: { users, workflowExecutions, workflows },
+    });
+
+    // Create a transient test user owned by this suite.
+    testUserId = generateId();
+    const now = new Date();
+    await testDb.insert(users).values({
+      id: testUserId,
+      name: "Trace Race Test User",
+      email: `trace-race-${testUserId}@test.local`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    testWorkflowId = generateId();
+    await testDb.insert(workflows).values({
+      id: testWorkflowId,
+      name: "Trace Race Test Workflow",
+      userId: testUserId,
+      nodes: [],
+      edges: [],
+    });
+  });
+
+  afterAll(async () => {
+    if (testWorkflowId) {
+      await testDb
+        .delete(workflowExecutions)
+        .where(eq(workflowExecutions.workflowId, testWorkflowId));
+      await testDb.delete(workflows).where(eq(workflows.id, testWorkflowId));
+    }
+    if (testUserId) {
+      await testDb.delete(users).where(eq(users.id, testUserId));
+    }
+    await pgClientOwned.end();
+  });
+
+  beforeEach(async () => {
+    await testDb
+      .delete(workflowExecutions)
+      .where(eq(workflowExecutions.workflowId, testWorkflowId));
+  });
+
+  async function createRunningExecution(): Promise<string> {
+    const executionId = generateId();
+    await testDb.insert(workflowExecutions).values({
+      id: executionId,
+      workflowId: testWorkflowId,
+      userId: testUserId,
+      status: "running",
+      input: {},
+      completedSteps: "0",
+      executionTrace: [],
+    });
+    return executionId;
+  }
+
+  async function readExecution(executionId: string): Promise<{
+    completedSteps: string | null;
+    executionTrace: string[] | null;
+  }> {
+    const rows = await testDb
+      .select({
+        completedSteps: workflowExecutions.completedSteps,
+        executionTrace: workflowExecutions.executionTrace,
+      })
+      .from(workflowExecutions)
+      .where(eq(workflowExecutions.id, executionId));
+
+    if (rows.length === 0) {
+      throw new Error(`execution ${executionId} not found`);
+    }
+    return rows[0] as {
+      completedSteps: string | null;
+      executionTrace: string[] | null;
+    };
+  }
+
+  it("appends 10 concurrent distinct nodeIds without loss", async () => {
+    const executionId = await createRunningExecution();
+    const nodeIds = Array.from(
+      { length: 10 },
+      (_, i) => `node-concurrent-${i}`
+    );
+
+    await Promise.all(
+      nodeIds.map((nodeId) =>
+        incrementCompletedSteps({
+          executionId,
+          nodeId,
+          nodeName: nodeId,
+          success: true,
+        })
+      )
+    );
+
+    const { completedSteps, executionTrace } = await readExecution(executionId);
+    const trace = executionTrace ?? [];
+
+    expect(trace).toHaveLength(10);
+    expect(new Set(trace)).toEqual(new Set(nodeIds));
+    expect(completedSteps).toBe("10");
+  });
+
+  it("sequential calls preserve order and count", async () => {
+    const executionId = await createRunningExecution();
+    const nodeIds = Array.from({ length: 5 }, (_, i) => `node-seq-${i}`);
+
+    for (const nodeId of nodeIds) {
+      await incrementCompletedSteps({
+        executionId,
+        nodeId,
+        nodeName: nodeId,
+        success: true,
+      });
+    }
+
+    const { completedSteps, executionTrace } = await readExecution(executionId);
+    const trace = executionTrace ?? [];
+
+    expect(trace).toEqual(nodeIds);
+    expect(completedSteps).toBe("5");
+  });
+
+  it("duplicate nodeId yields two trace entries (preserves for-each semantics)", async () => {
+    const executionId = await createRunningExecution();
+
+    await incrementCompletedSteps({
+      executionId,
+      nodeId: "foreach-body-node",
+      nodeName: "foreach-body-node",
+      success: true,
+    });
+    await incrementCompletedSteps({
+      executionId,
+      nodeId: "foreach-body-node",
+      nodeName: "foreach-body-node",
+      success: true,
+    });
+
+    const { completedSteps, executionTrace } = await readExecution(executionId);
+    const trace = executionTrace ?? [];
+
+    expect(trace).toHaveLength(2);
+    expect(trace).toEqual(["foreach-body-node", "foreach-body-node"]);
+    expect(completedSteps).toBe("2");
+  });
+
+  it("cancelled execution drops the write", async () => {
+    const executionId = await createRunningExecution();
+
+    await testDb
+      .update(workflowExecutions)
+      .set({ status: "cancelled" })
+      .where(eq(workflowExecutions.id, executionId));
+
+    await incrementCompletedSteps({
+      executionId,
+      nodeId: "node-after-cancel",
+      nodeName: "node-after-cancel",
+      success: true,
+    });
+
+    const { completedSteps, executionTrace } = await readExecution(executionId);
+    const trace = executionTrace ?? [];
+
+    expect(trace).toHaveLength(0);
+    expect(completedSteps).toBe("0");
+  });
+
+  it("100 concurrent calls produce exactly 100 trace entries (stress)", async () => {
+    const executionId = await createRunningExecution();
+    const count = 100;
+    const nodeIds = Array.from({ length: count }, (_, i) => `node-stress-${i}`);
+
+    await Promise.all(
+      nodeIds.map(async (nodeId) => {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, Math.floor(Math.random() * 5))
+        );
+        return incrementCompletedSteps({
+          executionId,
+          nodeId,
+          nodeName: nodeId,
+          success: true,
+        });
+      })
+    );
+
+    const { completedSteps, executionTrace } = await readExecution(executionId);
+    const trace = executionTrace ?? [];
+
+    expect(trace).toHaveLength(count);
+    expect(new Set(trace)).toEqual(new Set(nodeIds));
+    expect(completedSteps).toBe(count.toString());
+  }, 60_000);
+});

--- a/tests/unit/get-completed-step-output.test.ts
+++ b/tests/unit/get-completed-step-output.test.ts
@@ -242,6 +242,82 @@ describe("getCompletedStepOutput", () => {
     });
   });
 
+  describe("statement timeout (SQLSTATE 57014)", () => {
+    function makeTimeoutError(): Error {
+      const e = new Error("canceling statement due to statement timeout");
+      (e as { code?: string }).code = "57014";
+      (e as { severity?: string }).severity = "ERROR";
+      return e;
+    }
+
+    it("returns null on timeout", async () => {
+      mockFetchSingle.mockRejectedValueOnce(makeTimeoutError());
+
+      const result = await getCompletedStepOutput(executionId, nodeId);
+
+      expect(result).toBeNull();
+    });
+
+    it("increments outcome=timeout counter on timeout, not outcome=error", async () => {
+      mockFetchSingle.mockRejectedValueOnce(makeTimeoutError());
+
+      await getCompletedStepOutput(executionId, nodeId);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+    });
+
+    it("evicts cache on timeout so subsequent call retries the DB", async () => {
+      mockFetchSingle
+        .mockRejectedValueOnce(makeTimeoutError())
+        .mockResolvedValueOnce({ outputRaw: { retried: true } });
+
+      const r1 = await getCompletedStepOutput(executionId, nodeId);
+      expect(r1).toBeNull();
+
+      const r2 = await getCompletedStepOutput(executionId, nodeId);
+      expect(r2?.output).toEqual({ retried: true });
+      expect(mockFetchSingle).toHaveBeenCalledTimes(2);
+    });
+
+    it("wrapping in cause also detected as timeout (DrizzleQueryError pattern)", async () => {
+      const cause = new Error("canceling statement due to statement timeout");
+      (cause as { code?: string }).code = "57014";
+      (cause as { severity?: string }).severity = "ERROR";
+      const wrapper = new Error("DrizzleQueryError");
+      (wrapper as { cause?: unknown }).cause = cause;
+      mockFetchSingle.mockRejectedValueOnce(wrapper);
+
+      await getCompletedStepOutput(executionId, nodeId);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+    });
+
+    it("generic error still increments outcome=error, not outcome=timeout", async () => {
+      mockFetchSingle.mockRejectedValueOnce(new Error("generic DB failure"));
+
+      await getCompletedStepOutput(executionId, nodeId);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+    });
+  });
+
   describe("kill-switch: KH_EXECUTOR_AUTHORITY_DB_FALLBACK=false skips DB entirely", () => {
     // The kill-switch constant is read at module load time. Runtime env mutation
     // cannot affect it. We use vi.stubEnv + vi.resetModules + dynamic import to
@@ -395,6 +471,53 @@ describe("getCompletedStepOutputs (batch helper)", () => {
       "workflow.executor.tracker_db_fallback.total",
       expect.objectContaining({ outcome: "error" })
     );
+  });
+
+  describe("statement timeout (SQLSTATE 57014) in batch path", () => {
+    function makeTimeoutError(): Error {
+      const e = new Error("canceling statement due to statement timeout");
+      (e as { code?: string }).code = "57014";
+      (e as { severity?: string }).severity = "ERROR";
+      return e;
+    }
+
+    it("returns empty map on batch timeout", async () => {
+      mockFetchBatch.mockRejectedValueOnce(makeTimeoutError());
+
+      const result = await getCompletedStepOutputs(executionId, ["p1", "p2"]);
+
+      expect(result.size).toBe(0);
+    });
+
+    it("increments outcome=timeout counter on batch timeout, not outcome=error", async () => {
+      mockFetchBatch.mockRejectedValueOnce(makeTimeoutError());
+
+      await getCompletedStepOutputs(executionId, ["p1", "p2"]);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+    });
+
+    it("generic batch error still increments outcome=error, not outcome=timeout", async () => {
+      mockFetchBatch.mockRejectedValueOnce(new Error("generic batch failure"));
+
+      await getCompletedStepOutputs(executionId, ["p1", "p2"]);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "error" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        "workflow.executor.tracker_db_fallback.total",
+        expect.objectContaining({ outcome: "timeout" })
+      );
+    });
   });
 
   it("iteration rows are excluded: only non-loop canonical rows are returned", async () => {


### PR DESCRIPTION
## Summary

Promote the following merged PRs from staging to prod:

- #1111 fix(executor): bound DB-authority queries with 2s statement_timeout (KEEP-410)
- #1112 fix(executor): atomic append for executionTrace and completedSteps (KEEP-411)

## Post-deploy verification

- [ ] `deploy-keeperhub` workflow finishes green
- [ ] `curl -fsS https://app.keeperhub.com/api/health` returns 200
- [ ] Smoke-test the surfaces affected by the merged PRs above
- [ ] Watch Sentry / logs for ~10 minutes after the rollout
