### PR TITLE
feat: KEEP-OOB include available event names in listener start error

### DIFF
--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -64,8 +64,18 @@ export class EventListener {
     const iface = getInterface(this.opts.eventsAbiStrings);
     const eventFragment = iface.getEvent(this.opts.eventName);
     if (!eventFragment) {
+      // Enumerate the events the ABI does contain so the operator can
+      // see the mismatch in one log line. A blank list means the ABI
+      // has no event fragments at all — typically a wrong-ABI config
+      // rather than a typo'd event name.
+      const availableEvents: string[] = [];
+      iface.forEachEvent((fragment) => {
+        availableEvents.push(fragment.name);
+      });
+      const available =
+        availableEvents.length > 0 ? availableEvents.join(", ") : "(none)";
       throw new Error(
-        `EventListener(${this.opts.workflowId}): event "${this.opts.eventName}" not found in ABI`,
+        `EventListener(${this.opts.workflowId}): event "${this.opts.eventName}" not found in ABI. Available events: ${available}`,
       );
     }
 


### PR DESCRIPTION
## Summary
When `EventListener.start()` throws because the workflow's `eventName` isn't present in the ABI, the error now appends the list of event names that ARE in the ABI. `ListenerRegistry.add()`'s catch logs `formatError(err)` verbatim, so the richer diagnostic surfaces in one log line.

## Why
Before: operator sees `event "Transfer" not found in ABI`. They have to fetch the ABI separately to find out it's actually called `transfer`, or that the wrong ABI was attached to the workflow.

After: same line includes `Available events: Approval, Mint, Burn, transfer` (or `(none)` when the ABI has no event fragments at all -- usually a wrong-ABI config rather than a typo).

## Scope
Single file, single throw site. No control flow change. `ListenerRegistry` was deliberately left alone -- the existing `formatError(err)` already does the right thing now that the message itself carries the diagnostic.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] CI runs (events workflow). Existing integration tests exercise the happy path; the error path triggers naturally on any miswired workflow during integration runs.