### PR TITLE
feat: KEEP-OOC add per-workflow context to reconcile failures

### DIFF
--- a/keeperhub-events/event-tracker/src/main.ts
+++ b/keeperhub-events/event-tracker/src/main.ts
@@ -40,34 +40,67 @@ async function reconcile(
       .filter((id): id is string => typeof id === "string"),
   );
 
+  let removed = 0;
+  let addAttempted = 0;
+  let skippedInvalid = 0;
+  let failed = 0;
+
   // Remove listeners for workflows that are no longer active.
   for (const id of reg.ids()) {
     if (!activeIds.has(id)) {
       logger.log(`[Reconciler] removing listener ${id} (no longer active)`);
       reg.remove(id);
+      removed++;
     }
   }
 
   // Add listeners for active workflows that are not yet registered, and
   // restart listeners whose config has changed since last reconcile.
   for (const workflow of workflows) {
-    const registration = buildRegistration(workflow, networks);
-    if (!registration) {
-      continue;
-    }
-    const existingHash = reg.getConfigHash(registration.workflowId);
-    if (existingHash === registration.configHash) {
-      // Listener already running with the same config; nothing to do.
-      continue;
-    }
-    if (existingHash !== undefined) {
-      logger.log(
-        `[Reconciler] config changed for ${registration.workflowId}; restarting listener`,
+    const workflowId =
+      typeof workflow.id === "string" ? workflow.id : "<unknown>";
+    try {
+      const registration = buildRegistration(workflow, networks);
+      if (!registration) {
+        // Operator-visible signal that a workflow was dropped from the
+        // active set due to invalid config (bad chain, missing fields,
+        // unsupported trigger). Without this log, operators see the
+        // workflow in the source-of-truth but no listener and no hint why.
+        logger.warn(
+          `[Reconciler] skipping workflow ${workflowId}: buildRegistration returned null (invalid config)`,
+        );
+        skippedInvalid++;
+        continue;
+      }
+      const existingHash = reg.getConfigHash(registration.workflowId);
+      if (existingHash === registration.configHash) {
+        // Listener already running with the same config; nothing to do.
+        continue;
+      }
+      if (existingHash !== undefined) {
+        logger.log(
+          `[Reconciler] config changed for ${registration.workflowId}; restarting listener`,
+        );
+        reg.remove(registration.workflowId);
+      }
+      await reg.add(registration);
+      addAttempted++;
+    } catch (err) {
+      // Per-workflow isolation: one poisoned workflow's exception must
+      // not abort the whole reconcile pass. The synchronizeData catch
+      // sees a generic message; this catch records which workflow
+      // tripped so the next log line points at the culprit.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        `[Reconciler] workflow ${workflowId} failed during reconcile: ${message}`,
       );
-      reg.remove(registration.workflowId);
+      failed++;
     }
-    await reg.add(registration);
   }
+
+  logger.log(
+    `[Reconciler] pass complete: ${workflows.length} active, +${addAttempted} add-attempted, -${removed} removed, !${skippedInvalid} invalid, !!${failed} failed`,
+  );
 }
 
 async function synchronizeData(): Promise<void> {


### PR DESCRIPTION
## Summary
Three small observability improvements in `keeperhub-events/event-tracker/src/main.ts` `reconcile()`:

1. **Per-workflow try/catch.** A single poisoned workflow's exception used to abort the whole reconcile pass; `synchronizeData`'s outer catch only saw a generic message and the in-flight workflow was anonymous. Now each workflow is isolated and the failure log carries its id.
2. **Log when `buildRegistration` returns null.** A workflow that's active in the source-of-truth but invalid (bad chain, missing fields, unsupported trigger) used to be silently dropped from the active set. Operators saw the workflow upstream but no listener and no hint why. Now it logs at warn with the workflow id.
3. **Pass-level summary log.** One line per reconcile cycle: `+N add-attempted, -N removed, !N invalid, !!N failed`. Lets operators monitor reconcile health without scrolling through per-workflow logs.

## Why "add-attempted" not "added"
Registry's own `add()` swallows listener-start failures internally (logs warn, returns). That's outside reconcile's visibility, so this counter reports what reconcile pushed in, not what's actually running. Don't paper over the gap.

## Scope
Single function in one file, ~33 lines added net. No behavior change for the happy path; new logs only fire on previously-silent or previously-anonymous failure modes. Existing logs (config-changed, removing-listener) are unchanged.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] CI events workflow runs; existing integration tests still pass (they exercise reconcile via the in-process listener tests).