### PR TITLE
fix: KEEP-418 stop event-tracker pod crashes from unhandled eth_subscribe rejection

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -65,6 +65,14 @@ export interface ChainHealth {
   reconnecting: boolean;
   lastBlockAt: number | null;
   subscriberCount: number;
+  /**
+   * If the most recent `createProvider` attempt rejected, the error
+   * message captured at rejection time. Cleared on the next successful
+   * provider creation. Surfaces probe failures and other setup errors
+   * through `/healthz` so an operator can see *why* a chain is
+   * disconnected, not just that it is.
+   */
+  lastCreateError: string | null;
 }
 
 export interface SubscribeOptions {
@@ -104,6 +112,12 @@ interface ChainEntry {
   heartbeatTimer: ReturnType<typeof setInterval> | null;
   isReconnecting: boolean;
   lastBlockAt: number | null;
+  /**
+   * Populated when `createProvider` rejects (most often the
+   * subscription probe). Cleared on the next successful creation.
+   * Surfaced through `getAllHealth` for `/healthz` consumers.
+   */
+  lastCreateError: string | null;
   disconnectHandlers: Set<DisconnectHandler>;
 }
 
@@ -165,7 +179,22 @@ export class ChainProviderManager {
     // Two concurrent callers must receive the same provider instance, not
     // race to create separate ones.
     if (!entry.readyPromise) {
-      entry.readyPromise = this.createProvider(entry);
+      const created = this.createProvider(entry);
+      entry.readyPromise = created;
+      // Clear the cached promise on rejection so the next caller (the
+      // reconciler runs every 30s in main.ts:70) retries from scratch.
+      // Without this a transient probe failure or RPC hiccup permanently
+      // disables the chain until pod restart - the same rejected promise
+      // would be returned to every subsequent getOrCreateProvider call.
+      // The check guards against clobbering a fresh attempt that another
+      // caller may have already kicked off.
+      created.catch((err: unknown) => {
+        entry.lastCreateError =
+          err instanceof Error ? err.message : String(err);
+        if (entry.readyPromise === created) {
+          entry.readyPromise = null;
+        }
+      });
     }
     return entry.readyPromise;
   }
@@ -268,6 +297,7 @@ export class ChainProviderManager {
       reconnecting: entry.isReconnecting,
       lastBlockAt: entry.lastBlockAt,
       subscriberCount: entry.subscribers.size,
+      lastCreateError: entry.lastCreateError,
     };
   }
 
@@ -281,6 +311,7 @@ export class ChainProviderManager {
         reconnecting: entry.isReconnecting,
         lastBlockAt: entry.lastBlockAt,
         subscriberCount: entry.subscribers.size,
+        lastCreateError: entry.lastCreateError,
       });
     }
     return out;
@@ -349,6 +380,7 @@ export class ChainProviderManager {
       heartbeatTimer: null,
       isReconnecting: false,
       lastBlockAt: null,
+      lastCreateError: null,
       disconnectHandlers: new Set(),
     };
     this.chains.set(chainId, entry);
@@ -362,6 +394,10 @@ export class ChainProviderManager {
     await provider.ready;
     await this.probeSubscriptionSupport(provider, entry);
     entry.provider = provider;
+    // Clear the prior failure marker now that we have a working provider.
+    // Without this, a chain that recovered after a probe failure would
+    // still report `lastCreateError` indefinitely.
+    entry.lastCreateError = null;
     this.attachErrorListener(entry);
     // Heartbeat is subscriber-scoped (started on first subscribe, stopped
     // on last unsubscribe) to avoid wasted pings on an idle chain.
@@ -578,6 +614,11 @@ export class ChainProviderManager {
           logger.warn(
             `[ChainProviderManager] chain=${entry.chainId} reconnect attempt ${attempt} failed: ${String(err)}`,
           );
+          // Surface the most recent attempt error through /healthz so an
+          // operator can see *why* the chain is stuck reconnecting, not
+          // just that it is. Cleared on the next successful reconnect.
+          entry.lastCreateError =
+            err instanceof Error ? err.message : String(err);
           delay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
         }
       }
@@ -645,6 +686,9 @@ export class ChainProviderManager {
     await this.probeSubscriptionSupport(provider, entry);
 
     entry.provider = provider;
+    // Successful reconnect clears any prior failure marker so /healthz
+    // stops reporting a stale error on a now-healthy chain.
+    entry.lastCreateError = null;
 
     this.attachErrorListener(entry);
     // Block listener and heartbeat only if this chain has subscribers.

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -360,11 +360,61 @@ export class ChainProviderManager {
   ): Promise<ethers.WebSocketProvider> {
     const provider = this.factory(entry.wssUrl);
     await provider.ready;
+    await this.probeSubscriptionSupport(provider, entry);
     entry.provider = provider;
     this.attachErrorListener(entry);
     // Heartbeat is subscriber-scoped (started on first subscribe, stopped
     // on last unsubscribe) to avoid wasted pings on an idle chain.
     return provider;
+  }
+
+  /**
+   * Confirm the connected RPC accepts `eth_subscribe`. Once the manager
+   * calls `provider.on("block", ...)`, ethers' SocketSubscriber.start()
+   * fires `eth_subscribe(["newHeads"])` and stores the resulting promise
+   * on a private field with no `.catch`. An RPC that rejects subscriptions
+   * (-32601 method not available, common on lightweight or HTTP-only RPCs
+   * accidentally pasted into the WSS column) lets the rejection escape to
+   * `process.unhandledRejection`, which crashes the pod.
+   *
+   * Probing here moves the failure into an awaited path: the rejection
+   * propagates out of `createProvider`, gets caught by `registry.add`,
+   * and the listener is logged-and-skipped instead of taking down every
+   * other listener in the pod.
+   *
+   * On success we immediately `eth_unsubscribe` so the upcoming
+   * `provider.on("block", ...)` opens a fresh subscription that ethers
+   * actually routes messages through. An unsubscribe failure is
+   * non-fatal: the orphaned subscription is cleaned up when the provider
+   * is destroyed (next reconnect or shutdown).
+   */
+  private async probeSubscriptionSupport(
+    provider: ethers.WebSocketProvider,
+    entry: ChainEntry,
+  ): Promise<void> {
+    let filterId: unknown;
+    try {
+      filterId = await provider.send("eth_subscribe", ["newHeads"]);
+    } catch (err) {
+      try {
+        await provider.destroy();
+      } catch {
+        // Best-effort: the failed provider is already unusable; if
+        // destroy throws (e.g. socket already closed) there is nothing
+        // to do but proceed to the throw below.
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `chain ${entry.chainId} (${entry.wssUrl}): RPC does not support eth_subscribe: ${message}`,
+      );
+    }
+    try {
+      await provider.send("eth_unsubscribe", [filterId]);
+    } catch (err) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} probe eth_unsubscribe failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private attachBlockListener(entry: ChainEntry): void {
@@ -586,6 +636,13 @@ export class ChainProviderManager {
       }
       return;
     }
+
+    // Same probe as createProvider: confirm the rebuilt connection still
+    // accepts eth_subscribe before any .on("block") call exposes us to
+    // ethers' uncaught-rejection path. A failure here propagates out and
+    // the reconnect loop counts it as a failed attempt, falling back on
+    // exponential backoff.
+    await this.probeSubscriptionSupport(provider, entry);
 
     entry.provider = provider;
 

--- a/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
+++ b/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
@@ -59,6 +59,27 @@ export function buildRegistration(
     return null;
   }
 
+  // The DB column `chains.default_primary_wss` is nullable, but
+  // `NetworkConfig.defaultPrimaryWss` is typed `string`. Treat it as
+  // `string | null | undefined` at runtime: an HTTP URL or empty string
+  // pasted into this column would otherwise reach
+  // `new ethers.WebSocketProvider(...)` and trigger an `eth_subscribe`
+  // rejection that ethers' SocketSubscriber.start() leaves uncaught,
+  // crashing the pod.
+  const wssUrl: unknown = network.defaultPrimaryWss;
+  if (typeof wssUrl !== "string" || wssUrl.length === 0) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} chain ${chainId} has no defaultPrimaryWss; skipping`,
+    );
+    return null;
+  }
+  if (!(wssUrl.startsWith("wss://") || wssUrl.startsWith("ws://"))) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} chain ${chainId} defaultPrimaryWss is not a WebSocket URL ("${wssUrl}"); skipping`,
+    );
+    return null;
+  }
+
   const contractAddress =
     typeof config.contractAddress === "string" ? config.contractAddress : null;
   if (!contractAddress) {

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -20,6 +20,14 @@ class MockProvider {
   public sendCalls: SendCall[] = [];
   public sendResponses: unknown[] = [];
   public blockNumberResponses: Array<number | Error> = [];
+  // When set, eth_subscribe rejects with this error - simulates an RPC
+  // that does not implement subscriptions (the real-world ethers crash
+  // path: -32601 "method not available").
+  public subscribeFailure: Error | null = null;
+  // When set, eth_unsubscribe rejects with this error - lets tests
+  // exercise the non-fatal probe-cleanup path without affecting the
+  // probe's success.
+  public unsubscribeFailure: Error | null = null;
   public destroyed = false;
   private blockHandler: BlockHandler | null = null;
   private errorHandler: ErrorHandler | null = null;
@@ -42,6 +50,20 @@ class MockProvider {
 
   async send(method: string, params: unknown[]): Promise<unknown> {
     this.sendCalls.push({ method, params });
+    if (method === "eth_subscribe") {
+      if (this.subscribeFailure) {
+        throw this.subscribeFailure;
+      }
+      // Synthetic filterId; the manager round-trips it through
+      // eth_unsubscribe but does not otherwise inspect it.
+      return "0xprobe";
+    }
+    if (method === "eth_unsubscribe") {
+      if (this.unsubscribeFailure) {
+        throw this.unsubscribeFailure;
+      }
+      return true;
+    }
     if (method === "eth_blockNumber") {
       if (this.blockNumberResponses.length === 0) {
         return 0x1234;
@@ -92,22 +114,33 @@ function makeFactory(): {
   factory: ProviderFactory;
   created: MockProvider[];
   setPersistentFailure: (err: Error | null) => void;
+  setNextSubscribeFailure: (err: Error | null) => void;
 } {
   const created: MockProvider[] = [];
   let persistentFailure: Error | null = null;
+  let nextSubscribeFailure: Error | null = null;
   const factory: ProviderFactory = (_wssUrl: string) => {
     if (persistentFailure) {
       throw persistentFailure;
     }
     const mock = new MockProvider();
+    if (nextSubscribeFailure) {
+      // One-shot: failure must be re-armed for each provider that should
+      // fail, otherwise reconnect's fresh provider would inherit it.
+      mock.subscribeFailure = nextSubscribeFailure;
+      nextSubscribeFailure = null;
+    }
     created.push(mock);
     return mock as unknown as ethers.WebSocketProvider;
   };
   return {
     factory,
     created,
-    setPersistentFailure: (err) => {
+    setPersistentFailure: (err: Error | null) => {
       persistentFailure = err;
+    },
+    setNextSubscribeFailure: (err: Error | null) => {
+      nextSubscribeFailure = err;
     },
   };
 }
@@ -173,6 +206,63 @@ describe("ChainProviderManager", () => {
       await expect(
         manager.getOrCreateProvider(CHAIN_A, "ws://different"),
       ).rejects.toThrow(/already registered/);
+    });
+
+    // Probe is the gate that prevents ethers' uncaught eth_subscribe
+    // rejection from reaching process.unhandledRejection and crashing
+    // the pod. These tests lock in the contract.
+    describe("eth_subscribe probe", () => {
+      it("sends eth_subscribe([newHeads]) and unsubscribes immediately", async () => {
+        await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+        const provider = factoryBundle.created[0];
+        const subscribe = provider.sendCalls.find(
+          (c) => c.method === "eth_subscribe",
+        );
+        const unsubscribe = provider.sendCalls.find(
+          (c) => c.method === "eth_unsubscribe",
+        );
+        expect(subscribe?.params).toEqual(["newHeads"]);
+        expect(unsubscribe?.params).toEqual(["0xprobe"]);
+      });
+
+      it("throws when eth_subscribe is not supported", async () => {
+        const err = new Error(
+          'unsupported operation (operation="eth_subscribe", code=-32601)',
+        );
+        factoryBundle.setNextSubscribeFailure(err);
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        ).rejects.toThrow(/RPC does not support eth_subscribe/);
+      });
+
+      it("destroys the provider when the probe fails", async () => {
+        factoryBundle.setNextSubscribeFailure(new Error("boom"));
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        ).rejects.toThrow();
+        expect(factoryBundle.created[0].destroyed).toBe(true);
+      });
+
+      it("survives an eth_unsubscribe failure (probe succeeded)", async () => {
+        // Plant the unsubscribe failure synchronously after the factory
+        // returns the mock but before createProvider awaits the probe.
+        // The factory exposes a hook for subscribe failures only, so we
+        // wrap the factory to set unsubscribeFailure on the new mock.
+        const inner = factoryBundle.factory;
+        const wrapped: ProviderFactory = (wssUrl: string) => {
+          const p = inner(wssUrl) as unknown as MockProvider;
+          p.unsubscribeFailure = new Error("rpc unstable");
+          return p as unknown as ethers.WebSocketProvider;
+        };
+        const localManager = new ChainProviderManager({
+          factory: wrapped,
+          onPermanentFailure,
+        });
+        await expect(
+          localManager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        ).resolves.toBeDefined();
+        await localManager.destroy();
+      });
     });
   });
 
@@ -250,9 +340,13 @@ describe("ChainProviderManager", () => {
       provider.sendResponses = [[]];
       await provider.emitBlock(100);
 
-      expect(provider.sendCalls).toHaveLength(1);
-      expect(provider.sendCalls[0].method).toBe("eth_getLogs");
-      const filter = provider.sendCalls[0].params[0] as {
+      // createProvider runs an eth_subscribe / eth_unsubscribe probe
+      // before any block dispatch; filter to the demux path under test.
+      const getLogsCalls = provider.sendCalls.filter(
+        (c) => c.method === "eth_getLogs",
+      );
+      expect(getLogsCalls).toHaveLength(1);
+      const filter = getLogsCalls[0].params[0] as {
         address: string[];
         topics: string[][];
         fromBlock: string;
@@ -913,6 +1007,38 @@ describe("ChainProviderManager", () => {
       expect(factoryBundle.created).toHaveLength(3);
       expect(manager.isHealthy(CHAIN_A)).toBe(true);
       expect(manager.subscriberCount(CHAIN_A)).toBe(1);
+    });
+
+    it("treats a probe failure on reconnect as a failed attempt and retries", async () => {
+      // The probe runs on every fresh provider, including those built
+      // by reconnect. If the new provider's RPC stops supporting
+      // eth_subscribe (transient or persistent), the probe failure
+      // must surface to reconnectLoop so backoff and the
+      // permanent-failure guardrail still fire.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      // Drop the connection. The next factory call returns a new
+      // mock whose probe fails - reconnect should treat that as a
+      // failed attempt rather than installing a half-working provider.
+      factoryBundle.setNextSubscribeFailure(
+        new Error('unsupported operation (operation="eth_subscribe")'),
+      );
+      factoryBundle.created[0].emitError(new Error("drop"));
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(factoryBundle.created).toHaveLength(2);
+      // Probe failed, so the new provider was not installed.
+      expect(manager.isHealthy(CHAIN_A)).toBe(false);
+      // Subsequent reconnect attempt (probe re-armed false by default,
+      // so factory returns a healthy mock) recovers.
+      await vi.advanceTimersByTimeAsync(2_500);
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
     });
   });
 

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -243,6 +243,45 @@ describe("ChainProviderManager", () => {
         expect(factoryBundle.created[0].destroyed).toBe(true);
       });
 
+      it("retries createProvider on the next call after a probe failure", async () => {
+        // The reconciler runs synchronizeData every 30s. A transient
+        // probe failure must NOT permanently disable the chain - the
+        // next call to getOrCreateProvider must kick off a fresh
+        // factory call rather than re-returning the cached rejected
+        // promise.
+        factoryBundle.setNextSubscribeFailure(new Error("transient"));
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        ).rejects.toThrow();
+        expect(factoryBundle.created).toHaveLength(1);
+
+        // Second attempt: probe failure no longer armed; the call
+        // should produce a fresh factory invocation and succeed.
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        ).resolves.toBeDefined();
+        expect(factoryBundle.created).toHaveLength(2);
+        expect(manager.isHealthy(CHAIN_A)).toBe(true);
+      });
+
+      it("records lastCreateError after a probe failure and clears it on success", async () => {
+        factoryBundle.setNextSubscribeFailure(
+          new Error('unsupported operation (operation="eth_subscribe")'),
+        );
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://a"),
+        ).rejects.toThrow();
+        // Failure is observable through health surface so /healthz can
+        // report *why* a chain is degraded.
+        expect(manager.getHealth(CHAIN_A)?.lastCreateError).toMatch(
+          /eth_subscribe/,
+        );
+
+        // Subsequent successful retry clears the marker.
+        await manager.getOrCreateProvider(CHAIN_A, "ws://a");
+        expect(manager.getHealth(CHAIN_A)?.lastCreateError).toBeNull();
+      });
+
       it("survives an eth_unsubscribe failure (probe succeeded)", async () => {
         // Plant the unsubscribe failure synchronously after the factory
         // returns the mock but before createProvider awaits the probe.
@@ -648,6 +687,7 @@ describe("ChainProviderManager", () => {
         reconnecting: false,
         lastBlockAt: null,
         subscriberCount: 1,
+        lastCreateError: null,
       });
     });
 

--- a/keeperhub-events/event-tracker/tests/unit/workflow-mapper.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/workflow-mapper.test.ts
@@ -195,6 +195,47 @@ describe("buildRegistration", () => {
     ).toBeNull();
   });
 
+  // The DB column for defaultPrimaryWss is nullable. If it slips through
+  // to provider creation, ethers' SocketSubscriber.start() leaves the
+  // eth_subscribe rejection uncaught and crashes the pod - so reject here.
+  it("returns null when defaultPrimaryWss is null", () => {
+    const networks: NetworksMap = {
+      [CHAIN_ID]: {
+        ...NETWORK,
+        defaultPrimaryWss: null as unknown as string,
+      },
+    };
+    expect(buildRegistration(makeWorkflow(), networks)).toBeNull();
+  });
+
+  it("returns null when defaultPrimaryWss is empty", () => {
+    const networks: NetworksMap = {
+      [CHAIN_ID]: { ...NETWORK, defaultPrimaryWss: "" },
+    };
+    expect(buildRegistration(makeWorkflow(), networks)).toBeNull();
+  });
+
+  it("returns null when defaultPrimaryWss is an HTTP URL", () => {
+    const networks: NetworksMap = {
+      [CHAIN_ID]: {
+        ...NETWORK,
+        defaultPrimaryWss: "https://eth-mainnet.example.com",
+      },
+    };
+    expect(buildRegistration(makeWorkflow(), networks)).toBeNull();
+  });
+
+  it("accepts a wss:// URL", () => {
+    const networks: NetworksMap = {
+      [CHAIN_ID]: {
+        ...NETWORK,
+        defaultPrimaryWss: "wss://eth-mainnet.example.com",
+      },
+    };
+    const reg = buildRegistration(makeWorkflow(), networks);
+    expect(reg?.wssUrl).toBe("wss://eth-mainnet.example.com");
+  });
+
   it("returns null when contractAddress is missing", () => {
     expect(
       buildRegistration(


### PR DESCRIPTION
## Summary

- `workflow-mapper.buildRegistration` rejects workflows whose chain has a null, empty, or non-WSS `defaultPrimaryWss` so they never reach `new ethers.WebSocketProvider(...)`.
- `ChainProviderManager.createProvider` and `reconnect` now pre-flight `eth_subscribe(["newHeads"])` (then `eth_unsubscribe`) so subscription support is verified on an awaited path before `provider.on("block", ...)` exposes ethers' uncaught-rejection bug.

## Why

`keeperhub-event-common` was crash-looping every ~63 minutes with `[Fatal] unhandledRejection: unsupported operation (operation="eth_subscribe", code=-32601)`. Memory was 41 MiB / 1 Gi - it was not a memory issue.

ethers v6 `SocketSubscriber.start()` (`provider-socket.js:42-48`) fires `eth_subscribe` and stores the resulting promise on a private field with no `.catch`. When the connected RPC rejects subscriptions, the rejection escapes to `process.unhandledRejection`, which the event-tracker's fatal handler turns into `process.exit(1)`. Two paths bring us there:

1. The DB column `chains.default_primary_wss` is nullable, but the event-tracker's `NetworkConfig` types it `string`; an HTTP URL or empty value pasted into that column would silently propagate.
2. A real `wss://` URL whose endpoint accepts WebSocket connections but does not implement subscriptions (some lightweight or proxy RPCs).

(A) handles the first case at the data boundary; (B) catches the second by surfacing the failure on an awaited path so `registry.add` (`registry.ts:88-95`) logs and skips the listener instead of taking down the pod.

See KEEP-418 for the full root-cause writeup.

## Test plan

- [x] `pnpm test:unit` (event-tracker) - 116 passed (5 new probe tests, 4 new mapper tests)
- [x] `pnpm lint` (event-tracker) - clean
- [x] `pnpm typecheck` (event-tracker) - clean
- [ ] Staging soak: confirm `keeperhub-event-common` restart count stops climbing
- [ ] Confirm misconfigured chain (still TBD - SQL noted in KEEP-418) is correctly skipped with a `[workflow-mapper]` warn log

## Out of scope

- Identifying which chain row has the bad `defaultPrimaryWss` (open question on KEEP-418).
- Whether persistent probe failure should mark a chain globally unusable, vs just skipping each listener (currently the latter; KEEP-418 question 2).