### PR TITLE
fix: KEEP-420 auto-detach analytics SSE abort listener

### DIFF
--- a/app/api/analytics/stream/route.ts
+++ b/app/api/analytics/stream/route.ts
@@ -4,43 +4,10 @@ import {
   getAnalyticsChecksum,
   getAnalyticsSummary,
 } from "@/lib/analytics/queries";
+import { createAnalyticsStreamStart } from "@/lib/analytics/stream-start";
 import { parseTimeRange } from "@/lib/analytics/time-range";
-import type { AnalyticsStreamEvent } from "@/lib/analytics/types";
 import { apiError } from "@/lib/api-error";
 import { requireOrganization } from "@/lib/middleware/require-org";
-
-const POLL_INTERVAL_MS = 2000;
-const HEARTBEAT_INTERVAL_MS = 30_000;
-const MAX_LIFETIME_MS = 5 * 60 * 1000;
-const MIN_EVENT_INTERVAL_MS = 1000;
-
-function formatSSE(event: AnalyticsStreamEvent): string {
-  return `data: ${JSON.stringify(event)}\n\n`;
-}
-
-async function fetchSummaryEvent(
-  encoder: TextEncoder,
-  organizationId: string,
-  range: ReturnType<typeof parseTimeRange>,
-  customStart: string | undefined,
-  customEnd: string | undefined,
-  projectId: string | undefined
-): Promise<Uint8Array> {
-  const summary = await getAnalyticsSummary(
-    organizationId,
-    range,
-    customStart,
-    customEnd,
-    projectId
-  );
-
-  const event: AnalyticsStreamEvent = {
-    type: "summary",
-    data: summary,
-  };
-
-  return encoder.encode(formatSSE(event));
-}
 
 export const GET = requireOrganization(
   async (req: NextRequest, context): Promise<Response> => {
@@ -59,107 +26,20 @@ export const GET = requireOrganization(
       const customEnd = params.get("customEnd") ?? undefined;
       const projectId = params.get("projectId") ?? undefined;
 
-      let lastChecksum = "";
-      let lastEventTime = 0;
-      let closed = false;
-
-      const stream = new ReadableStream({
-        start(controller): void {
-          const encoder = new TextEncoder();
-          const startTime = Date.now();
-
-          const safeClose = (): void => {
-            if (closed) {
-              return;
-            }
-            closed = true;
-            clearInterval(pollTimer);
-            clearInterval(heartbeatTimer);
-            try {
-              controller.close();
-            } catch {
-              // controller may already be closed by the platform
-            }
-          };
-
-          const safeEnqueue = (chunk: Uint8Array): boolean => {
-            if (closed) {
-              return false;
-            }
-            try {
-              controller.enqueue(chunk);
-              return true;
-            } catch {
-              safeClose();
-              return false;
-            }
-          };
-
-          const pollTimer = setInterval(async (): Promise<void> => {
-            if (closed) {
-              return;
-            }
-
-            if (Date.now() - startTime > MAX_LIFETIME_MS) {
-              safeClose();
-              return;
-            }
-
-            try {
-              const checksum = await getAnalyticsChecksum(organizationId);
-
-              if (closed) {
-                return;
-              }
-
-              if (checksum === lastChecksum) {
-                return;
-              }
-
-              lastChecksum = checksum;
-
-              const now = Date.now();
-              if (now - lastEventTime < MIN_EVENT_INTERVAL_MS) {
-                return;
-              }
-              lastEventTime = now;
-
-              const chunk = await fetchSummaryEvent(
-                encoder,
-                organizationId,
-                range,
-                customStart,
-                customEnd,
-                projectId
-              );
-
-              if (closed) {
-                return;
-              }
-
-              safeEnqueue(chunk);
-            } catch {
-              safeClose();
-            }
-          }, POLL_INTERVAL_MS);
-
-          const heartbeatTimer = setInterval((): void => {
-            if (closed) {
-              return;
-            }
-
-            const event: AnalyticsStreamEvent = {
-              type: "heartbeat",
-              data: { timestamp: new Date().toISOString() },
-            };
-            safeEnqueue(encoder.encode(formatSSE(event)));
-          }, HEARTBEAT_INTERVAL_MS);
-
-          req.signal.addEventListener("abort", () => {
-            safeClose();
-          });
+      const start = createAnalyticsStreamStart({
+        signal: req.signal,
+        organizationId,
+        range,
+        customStart,
+        customEnd,
+        projectId,
+        deps: {
+          getChecksum: getAnalyticsChecksum,
+          getSummary: getAnalyticsSummary,
         },
       });
+
+      const stream = new ReadableStream<Uint8Array>({ start });
 
       return await Promise.resolve(
         new Response(stream, {

--- a/lib/analytics/stream-start.ts
+++ b/lib/analytics/stream-start.ts
@@ -1,0 +1,176 @@
+import type {
+  AnalyticsStreamEvent,
+  AnalyticsSummary,
+  TimeRange,
+} from "@/lib/analytics/types";
+
+export const POLL_INTERVAL_MS = 2000;
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+export const MAX_LIFETIME_MS = 5 * 60 * 1000;
+export const MIN_EVENT_INTERVAL_MS = 1000;
+
+function formatSSE(event: AnalyticsStreamEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+export type AnalyticsStreamDeps = {
+  getChecksum: (organizationId: string) => Promise<string>;
+  getSummary: (
+    organizationId: string,
+    range: TimeRange,
+    customStart?: string,
+    customEnd?: string,
+    projectId?: string
+  ) => Promise<AnalyticsSummary>;
+};
+
+export type AnalyticsStreamConfig = {
+  pollIntervalMs?: number;
+  heartbeatIntervalMs?: number;
+  maxLifetimeMs?: number;
+  minEventIntervalMs?: number;
+};
+
+export type AnalyticsStreamOpts = {
+  signal: AbortSignal;
+  organizationId: string;
+  range: TimeRange;
+  customStart?: string;
+  customEnd?: string;
+  projectId?: string;
+  deps: AnalyticsStreamDeps;
+  config?: AnalyticsStreamConfig;
+};
+
+export function createAnalyticsStreamStart(
+  opts: AnalyticsStreamOpts
+): (controller: ReadableStreamDefaultController<Uint8Array>) => void {
+  const {
+    signal,
+    organizationId,
+    range,
+    customStart,
+    customEnd,
+    projectId,
+    deps,
+    config,
+  } = opts;
+  const pollIntervalMs = config?.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const heartbeatIntervalMs =
+    config?.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+  const maxLifetimeMs = config?.maxLifetimeMs ?? MAX_LIFETIME_MS;
+  const minEventIntervalMs =
+    config?.minEventIntervalMs ?? MIN_EVENT_INTERVAL_MS;
+
+  return (controller): void => {
+    const encoder = new TextEncoder();
+    const startTime = Date.now();
+
+    let lastChecksum = "";
+    let lastEventTime = 0;
+    let closed = false;
+
+    const safeClose = (): void => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      clearInterval(pollTimer);
+      clearInterval(heartbeatTimer);
+      signal.removeEventListener("abort", onAbort);
+      try {
+        controller.close();
+      } catch {
+        // controller may already be closed by the platform
+      }
+    };
+
+    const safeEnqueue = (chunk: Uint8Array): boolean => {
+      if (closed) {
+        return false;
+      }
+      try {
+        controller.enqueue(chunk);
+        return true;
+      } catch {
+        safeClose();
+        return false;
+      }
+    };
+
+    const fetchSummaryEvent = async (): Promise<Uint8Array> => {
+      const summary = await deps.getSummary(
+        organizationId,
+        range,
+        customStart,
+        customEnd,
+        projectId
+      );
+
+      const event: AnalyticsStreamEvent = {
+        type: "summary",
+        data: summary,
+      };
+
+      return encoder.encode(formatSSE(event));
+    };
+
+    const pollTimer = setInterval(async (): Promise<void> => {
+      if (closed) {
+        return;
+      }
+
+      if (Date.now() - startTime > maxLifetimeMs) {
+        safeClose();
+        return;
+      }
+
+      try {
+        const checksum = await deps.getChecksum(organizationId);
+
+        if (closed) {
+          return;
+        }
+
+        if (checksum === lastChecksum) {
+          return;
+        }
+
+        lastChecksum = checksum;
+
+        const now = Date.now();
+        if (now - lastEventTime < minEventIntervalMs) {
+          return;
+        }
+        lastEventTime = now;
+
+        const chunk = await fetchSummaryEvent();
+
+        if (closed) {
+          return;
+        }
+
+        safeEnqueue(chunk);
+      } catch {
+        safeClose();
+      }
+    }, pollIntervalMs);
+
+    const heartbeatTimer = setInterval((): void => {
+      if (closed) {
+        return;
+      }
+
+      const event: AnalyticsStreamEvent = {
+        type: "heartbeat",
+        data: { timestamp: new Date().toISOString() },
+      };
+      safeEnqueue(encoder.encode(formatSSE(event)));
+    }, heartbeatIntervalMs);
+
+    const onAbort = (): void => {
+      safeClose();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  };
+}

--- a/tests/unit/analytics-stream-start.test.ts
+++ b/tests/unit/analytics-stream-start.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AnalyticsStreamDeps,
+  type AnalyticsStreamOpts,
+  createAnalyticsStreamStart,
+} from "@/lib/analytics/stream-start";
+import type { AnalyticsSummary } from "@/lib/analytics/types";
+
+const EMPTY_SUMMARY: AnalyticsSummary = {
+  totalRuns: 0,
+  successCount: 0,
+  errorCount: 0,
+  cancelledCount: 0,
+  successRate: 0,
+  avgDurationMs: null,
+  totalGasWei: "0",
+  activeRuns: 0,
+  previousPeriod: null,
+};
+
+function makeDeps(): AnalyticsStreamDeps {
+  return {
+    getChecksum: vi.fn(async () => "stable-checksum"),
+    getSummary: vi.fn(async () => EMPTY_SUMMARY),
+  };
+}
+
+function makeController(): ReadableStreamDefaultController<Uint8Array> {
+  return {
+    enqueue: vi.fn(),
+    close: vi.fn(),
+    error: vi.fn(),
+    desiredSize: 1,
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+}
+
+function makeOpts(overrides: Partial<AnalyticsStreamOpts> = {}): {
+  opts: AnalyticsStreamOpts;
+  abortController: AbortController;
+} {
+  const abortController = new AbortController();
+  const opts: AnalyticsStreamOpts = {
+    signal: abortController.signal,
+    organizationId: "org-1",
+    range: "7d",
+    deps: makeDeps(),
+    config: {
+      pollIntervalMs: 100,
+      heartbeatIntervalMs: 10_000,
+      maxLifetimeMs: 500,
+      minEventIntervalMs: 50,
+    },
+    ...overrides,
+  };
+  return { opts, abortController };
+}
+
+describe("createAnalyticsStreamStart", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("registers the abort listener with { once: true }", () => {
+    const { opts, abortController } = makeOpts();
+    const addSpy = vi.spyOn(abortController.signal, "addEventListener");
+
+    const start = createAnalyticsStreamStart(opts);
+    start(makeController());
+
+    expect(addSpy).toHaveBeenCalledWith("abort", expect.any(Function), {
+      once: true,
+    });
+  });
+
+  it("removes the listener and closes the controller when abort fires", async () => {
+    const { opts, abortController } = makeOpts();
+    const removeSpy = vi.spyOn(abortController.signal, "removeEventListener");
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    abortController.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the listener and closes the controller on natural lifetime expiry", async () => {
+    const { opts, abortController } = makeOpts();
+    const removeSpy = vi.spyOn(abortController.signal, "removeEventListener");
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    // pollIntervalMs=100, maxLifetimeMs=500. Tick past the threshold so the
+    // poll handler observes Date.now() - startTime > maxLifetime and triggers safeClose.
+    await vi.advanceTimersByTimeAsync(700);
+
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("safeClose is idempotent when both abort and timeout occur", async () => {
+    const { opts, abortController } = makeOpts();
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    abortController.abort();
+    await vi.advanceTimersByTimeAsync(700);
+
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Detaches the `abort` listener on `req.signal` in the analytics SSE stream route so it does not outlive the request. Refactors the stream lifecycle into a testable factory and adds a unit test pinning the listener-removal contract.

## Change

**`lib/analytics/stream-start.ts`** (new) -- `createAnalyticsStreamStart(opts)` factory that returns a `ReadableStream` start callback. Takes the AbortSignal, params, and analytics deps as arguments so it can be tested without route plumbing. Constants and intervals are also configurable for tests.

**`app/api/analytics/stream/route.ts`** -- now a thin wrapper: parse params, build deps from `@/lib/analytics/queries`, call the factory, return the `Response`. The previous inline lifecycle moved into `stream-start.ts`.

**Listener fix proper** (the original purpose of the PR):

- Abort handler extracted to a named `onAbort` const so it has a stable reference.
- Registered with `{ once: true }` so it auto-detaches when the abort event fires.
- `signal.removeEventListener("abort", onAbort)` added inside `safeClose` so it also detaches when the stream completes naturally (timer hits `MAX_LIFETIME_MS`, controller errors, etc.).

Both close paths now release the listener; the only remaining retention is bounded by signal GC.

## Tests

**`tests/unit/analytics-stream-start.test.ts`** (new) -- 4 tests:

1. Listener is registered with `{ once: true }`.
2. Listener is removed and controller closed when abort fires.
3. Listener is removed and controller closed on natural lifetime expiry (fake-timer advance past `maxLifetimeMs`).
4. `safeClose` is idempotent when both abort and timeout occur (controller closed exactly once).

Run: `pnpm exec vitest run tests/unit/analytics-stream-start.test.ts` -- 4 pass in <1s.

## Caveats

- This is hygiene cleanup, not a measured leak fix. There is no benchmark or heap snapshot demonstrating accumulated retention -- the change is consistent with the leak hypothesis but does not by itself prove one existed. The new tests verify the listener-removal *behavior* in isolation; they do not prove there was a leak.
- A separate pre-existing bug is not addressed here: if `req.signal.aborted` is already true when `start()` runs, the listener is never invoked (per the AbortSignal spec), so `safeClose` is never triggered via the abort path. The intervals still register and run until `MAX_LIFETIME_MS`. Worth a follow-up ticket.

## Linear

KEEP-420 -- https://linear.app/keeperhubapp/issue/KEEP-420