### PR TITLE
fix(mcp): KEEP-419 sweep stale entries from in-process rate-limit maps

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -90,6 +90,15 @@ export async function register() {
       console.log("[Metrics] Prometheus dual-write collector initialized");
     }
 
+    // Periodic sweep of stale entries in the in-process MCP/IP rate-limit
+    // maps. Inline cleanup on the request path can't reach keys that never
+    // come back, so without this the maps grow unbounded with one-shot
+    // organisations or IPs. See KEEP-419.
+    const { startRateLimitCleanupInterval } = await import(
+      "@/lib/mcp/rate-limit"
+    );
+    startRateLimitCleanupInterval();
+
     // Initialize Workflow Postgres World (pg-boss queue polling)
     if (process.env.WORKFLOW_TARGET_WORLD === "@workflow/world-postgres") {
       const rawUrl =

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -5,8 +5,17 @@
 const WINDOW_MS = 60_000; // 1 minute
 const LIMIT = 120; // requests per window (higher than execute endpoint; MCP sessions are chatty)
 
+// Stale-entry sweep: callers (org and IP) use windows up to 60s, so anything
+// whose newest timestamp is older than this threshold can never affect a
+// rate-limit decision and exists only as map-key overhead. The threshold is
+// generous to avoid racing against in-flight callers near a window boundary.
+const STALE_AFTER_MS = 5 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
 const requestLog = new Map<string, number[]>();
 const ipRequestLog = new Map<string, number[]>();
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 export type RateLimitResult =
   | { allowed: true }
@@ -61,4 +70,59 @@ export function getClientIp(request: Request): string {
     request.headers.get("x-real-ip") ??
     "unknown"
   );
+}
+
+// Walk both maps and drop entries whose newest timestamp is older than the
+// stale threshold. Inline cleanup on the request path can't fix this leak
+// because it only fires when the same key comes back; entries leak when an
+// org/IP makes requests once and never returns.
+export function cleanupStaleRateLimitEntries(): void {
+  const cutoff = Date.now() - STALE_AFTER_MS;
+  for (const [key, timestamps] of requestLog) {
+    const newest = timestamps.at(-1);
+    if (newest === undefined || newest <= cutoff) {
+      requestLog.delete(key);
+    }
+  }
+  for (const [key, timestamps] of ipRequestLog) {
+    const newest = timestamps.at(-1);
+    if (newest === undefined || newest <= cutoff) {
+      ipRequestLog.delete(key);
+    }
+  }
+}
+
+export function startRateLimitCleanupInterval(): void {
+  if (cleanupTimer !== null) {
+    clearInterval(cleanupTimer);
+  }
+  cleanupTimer = setInterval(
+    cleanupStaleRateLimitEntries,
+    CLEANUP_INTERVAL_MS
+  );
+  if (
+    cleanupTimer !== null &&
+    typeof cleanupTimer === "object" &&
+    "unref" in cleanupTimer
+  ) {
+    cleanupTimer.unref();
+  }
+}
+
+export function stopRateLimitCleanupInterval(): void {
+  if (cleanupTimer !== null) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
+  }
+}
+
+// Tracked-entry counts. Useful for /healthz or memory observability.
+export function getRateLimitStats(): {
+  organizationCount: number;
+  ipCount: number;
+} {
+  return {
+    organizationCount: requestLog.size,
+    ipCount: ipRequestLog.size,
+  };
 }

--- a/tests/unit/mcp-rate-limit.test.ts
+++ b/tests/unit/mcp-rate-limit.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  checkIpRateLimit,
+  checkMcpRateLimit,
+  cleanupStaleRateLimitEntries,
+  getRateLimitStats,
+  stopRateLimitCleanupInterval,
+} from "@/lib/mcp/rate-limit";
+
+const MINUTE_MS = 60_000;
+const STALE_AFTER_MS = 5 * MINUTE_MS;
+const ONE_DAY_MS = 24 * 60 * MINUTE_MS;
+const MCP_LIMIT = 120;
+
+describe("mcp/rate-limit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    stopRateLimitCleanupInterval();
+    // Module-scoped maps persist between tests; advance well past the stale
+    // window and run cleanup so the next test starts from an empty slate.
+    vi.setSystemTime(Date.now() + ONE_DAY_MS);
+    cleanupStaleRateLimitEntries();
+    vi.useRealTimers();
+  });
+
+  describe("cleanupStaleRateLimitEntries", () => {
+    it("removes organisation entries whose newest timestamp is past the stale threshold", () => {
+      checkMcpRateLimit("org-a");
+      expect(getRateLimitStats().organizationCount).toBe(1);
+
+      vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
+      cleanupStaleRateLimitEntries();
+
+      expect(getRateLimitStats().organizationCount).toBe(0);
+    });
+
+    it("removes IP entries whose newest timestamp is past the stale threshold", () => {
+      checkIpRateLimit("1.2.3.4", 10, MINUTE_MS);
+      expect(getRateLimitStats().ipCount).toBe(1);
+
+      vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
+      cleanupStaleRateLimitEntries();
+
+      expect(getRateLimitStats().ipCount).toBe(0);
+    });
+
+    it("preserves entries with activity inside the stale threshold", () => {
+      checkMcpRateLimit("org-active");
+      checkIpRateLimit("9.9.9.9", 10, MINUTE_MS);
+
+      // Half-way through the stale window
+      vi.setSystemTime(Date.now() + STALE_AFTER_MS / 2);
+      cleanupStaleRateLimitEntries();
+
+      const stats = getRateLimitStats();
+      expect(stats.organizationCount).toBe(1);
+      expect(stats.ipCount).toBe(1);
+    });
+
+    it("does not break rate-limit decisions when called against an at-limit entry", () => {
+      const allowed = Array.from({ length: MCP_LIMIT }, () =>
+        checkMcpRateLimit("org-busy")
+      );
+      expect(allowed.every((r) => r.allowed)).toBe(true);
+
+      const blocked = checkMcpRateLimit("org-busy");
+      expect(blocked.allowed).toBe(false);
+
+      // Cleanup must NOT drop an entry whose newest timestamp is `now`.
+      cleanupStaleRateLimitEntries();
+      expect(getRateLimitStats().organizationCount).toBe(1);
+
+      // And the block must persist.
+      const stillBlocked = checkMcpRateLimit("org-busy");
+      expect(stillBlocked.allowed).toBe(false);
+    });
+
+    it("reproduces the leak case: idle keys accumulate without cleanup, are released after cleanup (KEEP-419)", () => {
+      checkMcpRateLimit("org-a");
+      vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
+
+      // Without cleanup: a brand-new key is added and the stale one stays.
+      checkMcpRateLimit("org-b");
+      expect(getRateLimitStats().organizationCount).toBe(2);
+
+      // With cleanup: only the recently-active key remains.
+      cleanupStaleRateLimitEntries();
+      expect(getRateLimitStats().organizationCount).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Fixes [KEEP-419](https://linear.app/keeperhubapp/issue/KEEP-419/fixmcp-rate-limit-maps-in-libmcprate-limitts-never-delete-keys).

## Summary

`lib/mcp/rate-limit.ts` kept two module-level Maps (`requestLog` keyed by organisation, `ipRequestLog` keyed by IP) whose **keys were never deleted**. The timestamp arrays inside each entry were filtered against the rolling window, but keys for orgs/IPs that made one request and never came back stayed forever — unbounded growth.

Inline cleanup on the request path can't address this: by definition the leaked keys are the ones that never come back, so no later request visits them. Mirroring `lib/mcp/sessions.ts`, this PR adds a periodic sweep.

## What changed

- `lib/mcp/rate-limit.ts`
  - `cleanupStaleRateLimitEntries()` — walks both maps, deletes entries whose newest timestamp is older than `STALE_AFTER_MS` (5 min, generous vs. the 60 s windows currently in use).
  - `startRateLimitCleanupInterval()` / `stopRateLimitCleanupInterval()` — schedules the sweep every 5 min via `setInterval(...).unref()` so it never blocks process exit.
  - `getRateLimitStats(): { organizationCount, ipCount }` — observability hook for `/healthz` / memory dashboards.
- `instrumentation.ts` — lazy-import + call `startRateLimitCleanupInterval()` once at Node-runtime boot, alongside the existing startups.

## Why a sweep, not an inline delete

The original draft of KEEP-419 suggested inline cleanup (`if (recent.length === 0) requestLog.delete(...)` after `recent.push(now)`). That branch is dead code (push always makes the array length ≥ 1) and even if it ran it couldn't reach keys that never come back. The Linear ticket has been updated with this correction.

## Test plan

`tests/unit/mcp-rate-limit.test.ts` (new), 5 cases:

- [x] Org entries past stale threshold are removed.
- [x] IP entries past stale threshold are removed.
- [x] Entries inside the threshold are preserved (no false drops).
- [x] At-limit entries are not dropped, and the rate-limit decision still applies after a sweep (no regression).
- [x] Leak repro: two unique orgs, second submitted after stale window, map size goes 2 → 1 after sweep.

Verification:

- [x] `pnpm vitest run tests/unit/mcp-rate-limit.test.ts` — 5 / 5 passing
- [x] `pnpm biome lint lib/mcp/rate-limit.ts tests/unit/mcp-rate-limit.test.ts instrumentation.ts` — clean
- [x] `pnpm type-check` — clean (with `NODE_OPTIONS=--max-old-space-size=8192`; tsc OOMs on default heap, separate concern)