### PR TITLE
refactor(mcp): KEEP-419 review follow-ups for rate-limit map leak fix

### DIFF
--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -83,16 +83,12 @@ export function getClientIp(request: Request): string {
 // org/IP makes requests once and never returns.
 export function cleanupExpiredRateLimitEntries(): void {
   const cutoff = Date.now() - maxWindowMs * STALE_THRESHOLD_MULTIPLIER;
-  for (const [key, timestamps] of requestLog) {
-    const newest = timestamps.at(-1);
-    if (newest === undefined || newest <= cutoff) {
-      requestLog.delete(key);
-    }
-  }
-  for (const [key, timestamps] of ipRequestLog) {
-    const newest = timestamps.at(-1);
-    if (newest === undefined || newest <= cutoff) {
-      ipRequestLog.delete(key);
+  for (const map of [requestLog, ipRequestLog]) {
+    for (const [key, timestamps] of map) {
+      const newest = timestamps.at(-1);
+      if (newest === undefined || newest <= cutoff) {
+        map.delete(key);
+      }
     }
   }
 }

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -5,16 +5,18 @@
 const WINDOW_MS = 60_000; // 1 minute
 const LIMIT = 120; // requests per window (higher than execute endpoint; MCP sessions are chatty)
 
-// Stale-entry sweep: callers (org and IP) use windows up to 60s, so anything
-// whose newest timestamp is older than this threshold can never affect a
-// rate-limit decision and exists only as map-key overhead. The threshold is
-// generous to avoid racing against in-flight callers near a window boundary.
-const STALE_AFTER_MS = 5 * 60 * 1000;
+// Stale-entry sweep: anything whose newest timestamp is older than
+// (STALE_THRESHOLD_MULTIPLIER * maxWindowMs) can never affect a rate-limit
+// decision and exists only as map-key overhead. The largest window is
+// tracked dynamically so future callers with longer windows are safe by
+// construction -- no caller can introduce a window that races the sweep.
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+const STALE_THRESHOLD_MULTIPLIER = 5;
 
 const requestLog = new Map<string, number[]>();
 const ipRequestLog = new Map<string, number[]>();
 
+let maxWindowMs = WINDOW_MS;
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 export type RateLimitResult =
@@ -46,6 +48,9 @@ export function checkIpRateLimit(
   limit: number,
   windowMs: number
 ): RateLimitResult {
+  if (windowMs > maxWindowMs) {
+    maxWindowMs = windowMs;
+  }
   const now = Date.now();
   const windowStart = now - windowMs;
 
@@ -77,7 +82,7 @@ export function getClientIp(request: Request): string {
 // because it only fires when the same key comes back; entries leak when an
 // org/IP makes requests once and never returns.
 export function cleanupStaleRateLimitEntries(): void {
-  const cutoff = Date.now() - STALE_AFTER_MS;
+  const cutoff = Date.now() - maxWindowMs * STALE_THRESHOLD_MULTIPLIER;
   for (const [key, timestamps] of requestLog) {
     const newest = timestamps.at(-1);
     if (newest === undefined || newest <= cutoff) {
@@ -125,4 +130,13 @@ export function getRateLimitStats(): {
     organizationCount: requestLog.size,
     ipCount: ipRequestLog.size,
   };
+}
+
+// Test-only: clears all in-process state (maps + tracked window). Tests need
+// this because `maxWindowMs` is module-scoped and can otherwise leak between
+// cases that exercise different window sizes.
+export function resetRateLimitState(): void {
+  requestLog.clear();
+  ipRequestLog.clear();
+  maxWindowMs = WINDOW_MS;
 }

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -101,6 +101,11 @@ export function startRateLimitCleanupInterval(): void {
   if (cleanupTimer !== null) {
     clearInterval(cleanupTimer);
   }
+  // Run a sweep immediately so a re-init (HMR, error-recovery path, etc.)
+  // doesn't have to wait CLEANUP_INTERVAL_MS to clean entries left over
+  // from before the restart. At server boot the maps are empty so this is
+  // a cheap no-op.
+  cleanupExpiredRateLimitEntries();
   cleanupTimer = setInterval(
     cleanupExpiredRateLimitEntries,
     CLEANUP_INTERVAL_MS

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -2,8 +2,8 @@
 // Effective limit is LIMIT * num_replicas. Replace with Redis-backed solution
 // when replica count grows.
 
-const WINDOW_MS = 60_000; // 1 minute
-const LIMIT = 120; // requests per window (higher than execute endpoint; MCP sessions are chatty)
+export const WINDOW_MS = 60_000; // 1 minute
+export const LIMIT = 120; // requests per window (higher than execute endpoint; MCP sessions are chatty)
 
 // Stale-entry sweep: anything whose newest timestamp is older than
 // (STALE_THRESHOLD_MULTIPLIER * maxWindowMs) can never affect a rate-limit

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -81,7 +81,7 @@ export function getClientIp(request: Request): string {
 // stale threshold. Inline cleanup on the request path can't fix this leak
 // because it only fires when the same key comes back; entries leak when an
 // org/IP makes requests once and never returns.
-export function cleanupStaleRateLimitEntries(): void {
+export function cleanupExpiredRateLimitEntries(): void {
   const cutoff = Date.now() - maxWindowMs * STALE_THRESHOLD_MULTIPLIER;
   for (const [key, timestamps] of requestLog) {
     const newest = timestamps.at(-1);
@@ -102,7 +102,7 @@ export function startRateLimitCleanupInterval(): void {
     clearInterval(cleanupTimer);
   }
   cleanupTimer = setInterval(
-    cleanupStaleRateLimitEntries,
+    cleanupExpiredRateLimitEntries,
     CLEANUP_INTERVAL_MS
   );
   if (

--- a/tests/unit/mcp-rate-limit.test.ts
+++ b/tests/unit/mcp-rate-limit.test.ts
@@ -96,7 +96,7 @@ describe("mcp/rate-limit", () => {
       expect(getRateLimitStats().ipCount).toBe(0);
     });
 
-    it("reproduces the leak case: idle keys accumulate without cleanup, are released after cleanup (KEEP-419)", () => {
+    it("reproduces the leak case: idle keys accumulate without cleanup, are released after cleanup", () => {
       checkMcpRateLimit("org-a");
       vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
 

--- a/tests/unit/mcp-rate-limit.test.ts
+++ b/tests/unit/mcp-rate-limit.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkIpRateLimit,
   checkMcpRateLimit,
-  cleanupStaleRateLimitEntries,
+  cleanupExpiredRateLimitEntries,
   getRateLimitStats,
   LIMIT,
   resetRateLimitState,
@@ -25,13 +25,13 @@ describe("mcp/rate-limit", () => {
     vi.useRealTimers();
   });
 
-  describe("cleanupStaleRateLimitEntries", () => {
+  describe("cleanupExpiredRateLimitEntries", () => {
     it("removes organisation entries whose newest timestamp is past the stale threshold", () => {
       checkMcpRateLimit("org-a");
       expect(getRateLimitStats().organizationCount).toBe(1);
 
       vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
 
       expect(getRateLimitStats().organizationCount).toBe(0);
     });
@@ -41,7 +41,7 @@ describe("mcp/rate-limit", () => {
       expect(getRateLimitStats().ipCount).toBe(1);
 
       vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
 
       expect(getRateLimitStats().ipCount).toBe(0);
     });
@@ -52,7 +52,7 @@ describe("mcp/rate-limit", () => {
 
       // Half-way through the stale window
       vi.setSystemTime(Date.now() + STALE_AFTER_MS / 2);
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
 
       const stats = getRateLimitStats();
       expect(stats.organizationCount).toBe(1);
@@ -69,7 +69,7 @@ describe("mcp/rate-limit", () => {
       expect(blocked.allowed).toBe(false);
 
       // Cleanup must NOT drop an entry whose newest timestamp is `now`.
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
       expect(getRateLimitStats().organizationCount).toBe(1);
 
       // And the block must persist.
@@ -87,12 +87,12 @@ describe("mcp/rate-limit", () => {
       // caller's window -- entries must NOT be dropped or the next request
       // would see an empty array and forget the prior burst.
       vi.setSystemTime(Date.now() + 6 * WINDOW_MS);
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
       expect(getRateLimitStats().ipCount).toBe(1);
 
       // Past 5x the largest window (10min * 5 = 50min) -- now safe to drop.
       vi.setSystemTime(Date.now() + 60 * WINDOW_MS);
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
       expect(getRateLimitStats().ipCount).toBe(0);
     });
 
@@ -105,7 +105,7 @@ describe("mcp/rate-limit", () => {
       expect(getRateLimitStats().organizationCount).toBe(2);
 
       // With cleanup: only the recently-active key remains.
-      cleanupStaleRateLimitEntries();
+      cleanupExpiredRateLimitEntries();
       expect(getRateLimitStats().organizationCount).toBe(1);
     });
   });

--- a/tests/unit/mcp-rate-limit.test.ts
+++ b/tests/unit/mcp-rate-limit.test.ts
@@ -4,13 +4,13 @@ import {
   checkMcpRateLimit,
   cleanupStaleRateLimitEntries,
   getRateLimitStats,
+  LIMIT,
   resetRateLimitState,
   stopRateLimitCleanupInterval,
+  WINDOW_MS,
 } from "@/lib/mcp/rate-limit";
 
-const MINUTE_MS = 60_000;
-const STALE_AFTER_MS = 5 * MINUTE_MS;
-const MCP_LIMIT = 120;
+const STALE_AFTER_MS = 5 * WINDOW_MS;
 
 describe("mcp/rate-limit", () => {
   beforeEach(() => {
@@ -37,7 +37,7 @@ describe("mcp/rate-limit", () => {
     });
 
     it("removes IP entries whose newest timestamp is past the stale threshold", () => {
-      checkIpRateLimit("1.2.3.4", 10, MINUTE_MS);
+      checkIpRateLimit("1.2.3.4", 10, WINDOW_MS);
       expect(getRateLimitStats().ipCount).toBe(1);
 
       vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
@@ -48,7 +48,7 @@ describe("mcp/rate-limit", () => {
 
     it("preserves entries with activity inside the stale threshold", () => {
       checkMcpRateLimit("org-active");
-      checkIpRateLimit("9.9.9.9", 10, MINUTE_MS);
+      checkIpRateLimit("9.9.9.9", 10, WINDOW_MS);
 
       // Half-way through the stale window
       vi.setSystemTime(Date.now() + STALE_AFTER_MS / 2);
@@ -60,7 +60,7 @@ describe("mcp/rate-limit", () => {
     });
 
     it("does not break rate-limit decisions when called against an at-limit entry", () => {
-      const allowed = Array.from({ length: MCP_LIMIT }, () =>
+      const allowed = Array.from({ length: LIMIT }, () =>
         checkMcpRateLimit("org-busy")
       );
       expect(allowed.every((r) => r.allowed)).toBe(true);
@@ -78,7 +78,7 @@ describe("mcp/rate-limit", () => {
     });
 
     it("self-tunes the stale threshold to the largest IP window seen across callers", () => {
-      const TEN_MINUTE_WINDOW_MS = 10 * MINUTE_MS;
+      const TEN_MINUTE_WINDOW_MS = 10 * WINDOW_MS;
 
       checkIpRateLimit("ip-long-window", 5, TEN_MINUTE_WINDOW_MS);
       expect(getRateLimitStats().ipCount).toBe(1);
@@ -86,12 +86,12 @@ describe("mcp/rate-limit", () => {
       // Past the default 5x60s threshold, but well inside the 10-minute
       // caller's window -- entries must NOT be dropped or the next request
       // would see an empty array and forget the prior burst.
-      vi.setSystemTime(Date.now() + 6 * MINUTE_MS);
+      vi.setSystemTime(Date.now() + 6 * WINDOW_MS);
       cleanupStaleRateLimitEntries();
       expect(getRateLimitStats().ipCount).toBe(1);
 
       // Past 5x the largest window (10min * 5 = 50min) -- now safe to drop.
-      vi.setSystemTime(Date.now() + 60 * MINUTE_MS);
+      vi.setSystemTime(Date.now() + 60 * WINDOW_MS);
       cleanupStaleRateLimitEntries();
       expect(getRateLimitStats().ipCount).toBe(0);
     });

--- a/tests/unit/mcp-rate-limit.test.ts
+++ b/tests/unit/mcp-rate-limit.test.ts
@@ -4,26 +4,24 @@ import {
   checkMcpRateLimit,
   cleanupStaleRateLimitEntries,
   getRateLimitStats,
+  resetRateLimitState,
   stopRateLimitCleanupInterval,
 } from "@/lib/mcp/rate-limit";
 
 const MINUTE_MS = 60_000;
 const STALE_AFTER_MS = 5 * MINUTE_MS;
-const ONE_DAY_MS = 24 * 60 * MINUTE_MS;
 const MCP_LIMIT = 120;
 
 describe("mcp/rate-limit", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    resetRateLimitState();
   });
 
   afterEach(() => {
     stopRateLimitCleanupInterval();
-    // Module-scoped maps persist between tests; advance well past the stale
-    // window and run cleanup so the next test starts from an empty slate.
-    vi.setSystemTime(Date.now() + ONE_DAY_MS);
-    cleanupStaleRateLimitEntries();
+    resetRateLimitState();
     vi.useRealTimers();
   });
 
@@ -77,6 +75,25 @@ describe("mcp/rate-limit", () => {
       // And the block must persist.
       const stillBlocked = checkMcpRateLimit("org-busy");
       expect(stillBlocked.allowed).toBe(false);
+    });
+
+    it("self-tunes the stale threshold to the largest IP window seen across callers", () => {
+      const TEN_MINUTE_WINDOW_MS = 10 * MINUTE_MS;
+
+      checkIpRateLimit("ip-long-window", 5, TEN_MINUTE_WINDOW_MS);
+      expect(getRateLimitStats().ipCount).toBe(1);
+
+      // Past the default 5x60s threshold, but well inside the 10-minute
+      // caller's window -- entries must NOT be dropped or the next request
+      // would see an empty array and forget the prior burst.
+      vi.setSystemTime(Date.now() + 6 * MINUTE_MS);
+      cleanupStaleRateLimitEntries();
+      expect(getRateLimitStats().ipCount).toBe(1);
+
+      // Past 5x the largest window (10min * 5 = 50min) -- now safe to drop.
+      vi.setSystemTime(Date.now() + 60 * MINUTE_MS);
+      cleanupStaleRateLimitEntries();
+      expect(getRateLimitStats().ipCount).toBe(0);
     });
 
     it("reproduces the leak case: idle keys accumulate without cleanup, are released after cleanup (KEEP-419)", () => {


### PR DESCRIPTION
Follow-ups to PR #1124 (already merged via `cff4290e`) addressing review feedback. Linear: [KEEP-419](https://linear.app/keeperhubapp/issue/KEEP-419/fixmcp-rate-limit-maps-in-libmcprate-limitts-never-delete-keys).

The original PR was merged before review nits could be addressed in-place; this PR stacks the 6 follow-up commits on top. Branch already contains all 7 commits but GitHub displays only the 6 not in the base.

## Commits

| Type | Subject |
|---|---|
| fix | KEEP-419 self-tune rate-limit stale threshold to largest window seen |
| test | KEEP-419 import LIMIT and WINDOW_MS in rate-limit tests |
| refactor | KEEP-419 rename `cleanupStaleRateLimitEntries` → `cleanupExpiredRateLimitEntries` |
| fix | KEEP-419 run rate-limit sweep immediately on `startRateLimitCleanupInterval` |
| refactor | KEEP-419 collapse parallel cleanup loops in rate-limit sweep |
| test | KEEP-419 drop trailing ticket id from leak-repro test name |

## Substantive change (the only behaviour-affecting one)

`STALE_AFTER_MS` was a hardcoded `5 * 60_000` rooted in the implicit assumption that no caller passes `windowMs > 60s` to `checkIpRateLimit`. True for current callers (`app/api/oauth/{register,token}/route.ts`, `app/api/mcp/workflows/route.ts`) but fragile — a future caller passing 600_000 (10 min) would have entries silently dropped while still inside their rate-limit window.

Replaced with `maxWindowMs` tracked dynamically (initialised to `WINDOW_MS`, bumped in `checkIpRateLimit` if a larger window is supplied) and `STALE_THRESHOLD_MULTIPLIER = 5`. New regression test (`self-tunes the stale threshold to the largest IP window seen across callers`) demonstrates that a 10-minute window is preserved past the original 5-minute cutoff.

Other commits are naming consistency (`cleanupExpired*` matches `lib/mcp/sessions.ts`), DRY of the parallel for-loops, immediate sweep on (re-)start (relevant for HMR / error-recovery re-init paths — at boot the maps are empty so the call is a no-op), and a one-line test name cleanup.

## Test plan

- [x] `pnpm vitest run tests/unit/mcp-rate-limit.test.ts` — 6 / 6 passing (was 5; added self-tune regression test)
- [x] `pnpm biome lint lib/mcp/rate-limit.ts tests/unit/mcp-rate-limit.test.ts instrumentation.ts` — clean
- [x] `pnpm type-check` — clean (with `NODE_OPTIONS=--max-old-space-size=8192`; tsc OOMs on the default heap, separate concern)
- [x] No public API removed; `cleanupStaleRateLimitEntries` → `cleanupExpiredRateLimitEntries` is renamed and there are no external callers (only the test file imports it)