### PR TITLE
fix(mcp): allow anonymous /mcp probes and enrich agent-registry metadata

### DIFF
--- a/app/api/agent-registry/route.ts
+++ b/app/api/agent-registry/route.ts
@@ -32,16 +32,28 @@ export async function GET(_request: Request): Promise<NextResponse> {
         "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP.",
       image: "https://app.keeperhub.com/keeperhub_logo.png",
       services: [
-        { name: "mcp", endpoint: "https://app.keeperhub.com/mcp" },
+        {
+          name: "mcp",
+          endpoint: "https://app.keeperhub.com/mcp",
+          version: "2025-06-18",
+        },
         {
           name: "workflows",
           endpoint: "https://app.keeperhub.com/api/mcp/workflows",
         },
         { name: "web", endpoint: "https://app.keeperhub.com" },
         { name: "ens", endpoint: "keeperhub.eth" },
+        {
+          name: "agentWallet",
+          endpoint: "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51",
+        },
       ],
+      supportedTrust: ["reputation"],
       x402Support: true,
       active: true,
+      updatedAt: registration
+        ? Math.floor(registration.registeredAt.getTime() / 1000)
+        : Math.floor(Date.now() / 1000),
       registrations: registration
         ? [
             {

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -61,12 +61,12 @@ function ensureMcpAcceptHeader(request: Request): Request {
 
   const headers = new Headers(request.headers);
   headers.set("accept", parts.join(", "));
+  // Body is not forwarded here. POST callers always supply parsedBody to the
+  // SDK transport separately, and GET has no body. Re-attaching request.body
+  // would fail on POST because the early body parse has already consumed it.
   return new Request(request.url, {
     method: request.method,
     headers,
-    body: request.body,
-    // @ts-expect-error -- duplex is required for streaming bodies in Node
-    duplex: "half",
   });
 }
 
@@ -411,6 +411,15 @@ export async function POST(request: Request): Promise<Response> {
 
   const sessionId = request.headers.get("mcp-session-id");
 
+  // The early body parse above consumed request.body, so every transport
+  // call from here on must hand the parsed value through parsedBody.
+  if (!bodyParsed) {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+  }
+
   if (sessionId) {
     const resolved = await resolveSession(sessionId, organizationId, request);
     if (!resolved.ok) {
@@ -420,18 +429,10 @@ export async function POST(request: Request): Promise<Response> {
       });
     }
     const response = await resolved.transport.handleRequest(
-      ensureMcpAcceptHeader(request)
+      ensureMcpAcceptHeader(request),
+      { parsedBody: body }
     );
     return withRenewedSessionHeader(response, resolved.renewedSessionId);
-  }
-
-  // No session ID: must be an initialize request.
-  // Body was already parsed above; pass parsedBody to the SDK transport.
-  if (!bodyParsed) {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-    });
   }
 
   if (!isInitializeRequestBody(body)) {

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -140,7 +140,7 @@ async function authenticate(request: Request): Promise<ApiKeyAuthResult> {
 
 function isInitializeRequestBody(body: unknown): boolean {
   if (Array.isArray(body)) {
-    return body.some((item) => isInitializeRequest(item));
+    return body.length > 0 && body.every((item) => isInitializeRequest(item));
   }
   return isInitializeRequest(body);
 }
@@ -369,7 +369,14 @@ export async function POST(request: Request): Promise<Response> {
   if (!auth.authenticated && bodyParsed && isInitializeRequestBody(body)) {
     const baseUrl = getBaseUrl(request);
     const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
-    const requestId = (body as Record<string, unknown>).id ?? null;
+    const rawId = Array.isArray(body)
+      ? undefined
+      : (body as Record<string, unknown>).id;
+    // JSON-RPC 2.0 ids are string | number | null. Reflecting any other
+    // shape lets a caller force the server to serialize an arbitrary value
+    // back into the response body.
+    const requestId =
+      typeof rawId === "string" || typeof rawId === "number" ? rawId : null;
     const anonInitResult = {
       jsonrpc: "2.0",
       id: requestId,
@@ -385,7 +392,11 @@ export async function POST(request: Request): Promise<Response> {
     };
     return new Response(JSON.stringify(anonInitResult), {
       status: 200,
-      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        ...CORS_HEADERS,
+      },
     });
   }
 
@@ -508,7 +519,11 @@ export async function GET(request: Request): Promise<Response> {
       }),
       {
         status: 200,
-        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+          ...CORS_HEADERS,
+        },
       }
     );
   }

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -373,10 +373,13 @@ export async function POST(request: Request): Promise<Response> {
       ? undefined
       : (body as Record<string, unknown>).id;
     // JSON-RPC 2.0 ids are string | number | null. Reflecting any other
-    // shape lets a caller force the server to serialize an arbitrary value
-    // back into the response body.
+    // shape — or an unbounded-length string — lets a caller force the
+    // server to serialize an arbitrary value back into the response body.
     const requestId =
-      typeof rawId === "string" || typeof rawId === "number" ? rawId : null;
+      (typeof rawId === "string" && rawId.length <= 256) ||
+      typeof rawId === "number"
+        ? rawId
+        : null;
     const anonInitResult = {
       jsonrpc: "2.0",
       id: requestId,

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -351,7 +351,44 @@ function withRenewedSessionHeader(
 }
 
 export async function POST(request: Request): Promise<Response> {
+  // Parse body early so we can inspect it before the auth check.
+  // A body that won't parse falls through to the existing 401 path.
+  let body: unknown;
+  let bodyParsed = false;
+  try {
+    body = await request.json();
+    bodyParsed = true;
+  } catch {
+    // Leave bodyParsed = false; handled below after auth check.
+  }
+
   const auth = await authenticate(request);
+
+  // Anonymous initialize: let unauthenticated callers learn the server
+  // identity and auth requirements without touching the SDK.
+  if (!auth.authenticated && bodyParsed && isInitializeRequestBody(body)) {
+    const baseUrl = getBaseUrl(request);
+    const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+    const requestId = (body as Record<string, unknown>).id ?? null;
+    const anonInitResult = {
+      jsonrpc: "2.0",
+      id: requestId,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        serverInfo: { name: "keeperhub", version: "1.0.0" },
+        authentication: {
+          required: true,
+          resource_metadata: resourceMetadataUrl,
+        },
+      },
+    };
+    return new Response(JSON.stringify(anonInitResult), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+  }
+
   if (!auth.authenticated) {
     const reason = auth.error ?? "Unauthorized";
     logMcpEvent("mcp.auth.failed", { reason });
@@ -389,12 +426,8 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // No session ID: must be an initialize request.
-  // Pre-parse body because request.json() consumes the stream.
-  // We pass parsedBody to handleRequest so the SDK does not re-read it.
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
+  // Body was already parsed above; pass parsedBody to the SDK transport.
+  if (!bodyParsed) {
     return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
       status: 400,
       headers: { "Content-Type": "application/json", ...CORS_HEADERS },
@@ -454,6 +487,31 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 export async function GET(request: Request): Promise<Response> {
+  // Anonymous health probe: no session header means the caller is just
+  // checking reachability (e.g. ERC-8004 indexer). Return minimal
+  // server-info without touching auth or the SDK.
+  const sessionId = request.headers.get("mcp-session-id");
+  if (!sessionId) {
+    const baseUrl = getBaseUrl(request);
+    const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+    return new Response(
+      JSON.stringify({
+        name: "keeperhub",
+        version: "1.0.0",
+        protocol: "mcp",
+        status: "ok",
+        authentication: {
+          required: true,
+          resource_metadata: resourceMetadataUrl,
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+      }
+    );
+  }
+
   const auth = await authenticate(request);
   if (!auth.authenticated) {
     const reason = auth.error ?? "Unauthorized";
@@ -465,17 +523,6 @@ export async function GET(request: Request): Promise<Response> {
       status: auth.statusCode,
       headers: { "Content-Type": "application/json", ...CORS_HEADERS },
     });
-  }
-
-  const sessionId = request.headers.get("mcp-session-id");
-  if (!sessionId) {
-    return new Response(
-      JSON.stringify({ error: "Missing mcp-session-id header" }),
-      {
-        status: 400,
-        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-      }
-    );
   }
 
   const organizationId = auth.organizationId ?? "";

--- a/tests/unit/agent-registry-route.test.ts
+++ b/tests/unit/agent-registry-route.test.ts
@@ -69,19 +69,20 @@ describe("GET /api/agent-registry", () => {
     expect(json.image).toBe("https://app.keeperhub.com/keeperhub_logo.png");
   });
 
-  it("Test 4: returns services array with mcp, web, and ens entries", async () => {
+  it("Test 4: returns services array with mcp, web, ens, workflows, and agentWallet entries", async () => {
     setupDbMock([]);
     const { GET } = await import("@/app/api/agent-registry/route");
     const request = new Request("http://localhost:3000/api/agent-registry");
     const response = await GET(request);
     const json = await response.json();
     expect(Array.isArray(json.services)).toBe(true);
-    expect(json.services).toHaveLength(4);
+    expect(json.services).toHaveLength(5);
     const serviceNames = json.services.map((s: { name: string }) => s.name);
     expect(serviceNames).toContain("mcp");
     expect(serviceNames).toContain("workflows");
     expect(serviceNames).toContain("web");
     expect(serviceNames).toContain("ens");
+    expect(serviceNames).toContain("agentWallet");
     const mcpService = json.services.find(
       (s: { name: string; endpoint: string }) => s.name === "mcp"
     );
@@ -94,6 +95,66 @@ describe("GET /api/agent-registry", () => {
       (s: { name: string; endpoint: string }) => s.name === "ens"
     );
     expect(ensService?.endpoint).toBe("keeperhub.eth");
+    const agentWalletService = json.services.find(
+      (s: { name: string; endpoint: string }) => s.name === "agentWallet"
+    );
+    expect(agentWalletService?.endpoint).toBe(
+      "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51"
+    );
+  });
+
+  it("Test 4a: mcp service has version 2025-06-18", async () => {
+    setupDbMock([]);
+    const { GET } = await import("@/app/api/agent-registry/route");
+    const request = new Request("http://localhost:3000/api/agent-registry");
+    const response = await GET(request);
+    const json = await response.json();
+    const mcpService = json.services.find(
+      (s: { name: string; version?: string }) => s.name === "mcp"
+    );
+    expect(mcpService?.version).toBe("2025-06-18");
+  });
+
+  it("Test 4b: top-level supportedTrust equals [reputation]", async () => {
+    setupDbMock([]);
+    const { GET } = await import("@/app/api/agent-registry/route");
+    const request = new Request("http://localhost:3000/api/agent-registry");
+    const response = await GET(request);
+    const json = await response.json();
+    expect(json.supportedTrust).toEqual(["reputation"]);
+  });
+
+  it("Test 4c: updatedAt equals registeredAt unix seconds when a registration row exists", async () => {
+    const registeredAt = new Date("2025-03-15T12:00:00Z");
+    setupDbMock([
+      {
+        id: "test-id",
+        agentId: "42",
+        txHash: "0xabc123",
+        registeredAt,
+        chainId: 1,
+        registryAddress: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+      },
+    ]);
+    const { GET } = await import("@/app/api/agent-registry/route");
+    const request = new Request("http://localhost:3000/api/agent-registry");
+    const response = await GET(request);
+    const json = await response.json();
+    expect(json.updatedAt).toBe(Math.floor(registeredAt.getTime() / 1000));
+  });
+
+  it("Test 4d: updatedAt falls back to a recent Date.now()-derived value when no row exists", async () => {
+    setupDbMock([]);
+    const before = Math.floor(Date.now() / 1000);
+    const { GET } = await import("@/app/api/agent-registry/route");
+    const request = new Request("http://localhost:3000/api/agent-registry");
+    const response = await GET(request);
+    const after = Math.floor(Date.now() / 1000);
+    const json = await response.json();
+    expect(typeof json.updatedAt).toBe("number");
+    expect(Number.isFinite(json.updatedAt)).toBe(true);
+    expect(json.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(json.updatedAt).toBeLessThanOrEqual(after);
   });
 
   it("Test 5: returns x402Support: true and active: true", async () => {

--- a/tests/unit/mcp-route-anon.test.ts
+++ b/tests/unit/mcp-route-anon.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before any imports that use them.
+// ---------------------------------------------------------------------------
+
+const { mockAuthenticate } = vi.hoisted(() => ({
+  mockAuthenticate: vi.fn(),
+}));
+
+// Stub server-only so the route module can be imported in a test environment.
+vi.mock("server-only", () => ({}));
+
+// Mock authenticate path: the local `authenticate()` function in the route
+// calls both authenticateApiKey and authenticateOAuthToken.
+vi.mock("@/lib/api-key-auth", () => ({
+  authenticateApiKey: mockAuthenticate,
+}));
+
+vi.mock("@/lib/mcp/oauth-auth", () => ({
+  authenticateOAuthToken: vi.fn().mockResolvedValue({ authenticated: false }),
+}));
+
+vi.mock("@/lib/mcp/logging", () => ({
+  logMcpEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  checkMcpRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+  startCleanupInterval: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/server", () => ({
+  createMcpServer: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/session-token", () => ({
+  createSessionToken: vi.fn(),
+  verifySessionToken: vi.fn(),
+  verifySessionTokenDetailed: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/sessions", () => ({
+  deleteSession: vi.fn(),
+  getSession: vi.fn().mockReturnValue(null),
+  setSession: vi.fn(),
+  startCleanupInterval: vi.fn(),
+  touchSession: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/event-store", () => ({
+  McpEventStore: vi.fn(),
+}));
+
+// The SDK transport is only reached for authed requests, but we mock it to
+// prevent module-load errors in the test environment.
+vi.mock(
+  "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js",
+  () => ({
+    WebStandardStreamableHTTPServerTransport: vi.fn(),
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Import route handlers after all mocks are registered.
+// ---------------------------------------------------------------------------
+
+import { DELETE, GET, POST } from "@/app/mcp/route";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const UNAUTHENTICATED: {
+  authenticated: false;
+  error: string;
+  statusCode: number;
+} = { authenticated: false, error: "Unauthorized", statusCode: 401 };
+
+function makeRequest(
+  method: string,
+  headers: Record<string, string> = {},
+  body?: string
+): Request {
+  return new Request("http://localhost:3000/mcp", {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+    body,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /mcp — anonymous health probe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthenticate.mockResolvedValue(UNAUTHENTICATED);
+  });
+
+  it("returns 200 with server info when no mcp-session-id header is present", async () => {
+    const request = makeRequest("GET");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.name).toBe("keeperhub");
+    expect(json.protocol).toBe("mcp");
+    expect(json.authentication.required).toBe(true);
+  });
+
+  it("returns 401 when mcp-session-id is present but no auth token is provided", async () => {
+    const request = makeRequest("GET", { "mcp-session-id": "some-session-id" });
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /mcp — anonymous initialize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthenticate.mockResolvedValue(UNAUTHENTICATED);
+  });
+
+  it("returns 200 JSON-RPC envelope for initialize with no auth, echoing the request id", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.1" },
+      },
+    });
+    const request = makeRequest("POST", {}, body);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.jsonrpc).toBe("2.0");
+    expect(json.id).toBe(7);
+    expect(json.result.protocolVersion).toBe("2025-06-18");
+    expect(json.result.serverInfo.name).toBe("keeperhub");
+    expect(json.result.authentication.required).toBe(true);
+  });
+
+  it("returns 401 for tools/list with no auth (only initialize is anon-allowed)", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/list",
+    });
+    const request = makeRequest("POST", {}, body);
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 for malformed JSON body with no auth (no 500)", async () => {
+    const request = makeRequest("POST", {}, "{ not valid json");
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("DELETE /mcp — always requires auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthenticate.mockResolvedValue(UNAUTHENTICATED);
+  });
+
+  it("returns 401 when no auth token is provided", async () => {
+    const request = makeRequest("DELETE", {
+      "mcp-session-id": "some-session-id",
+    });
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/unit/mcp-route-anon.test.ts
+++ b/tests/unit/mcp-route-anon.test.ts
@@ -81,6 +81,8 @@ const UNAUTHENTICATED: {
   statusCode: number;
 } = { authenticated: false, error: "Unauthorized", statusCode: 401 };
 
+const RESOURCE_METADATA_PATH = /\/\.well-known\/oauth-protected-resource$/;
+
 function makeRequest(
   method: string,
   headers: Record<string, string> = {},
@@ -126,10 +128,16 @@ describe("GET /mcp — anonymous health probe", () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     const json = await response.json();
     expect(json.name).toBe("keeperhub");
+    expect(json.version).toBe("1.0.0");
     expect(json.protocol).toBe("mcp");
+    expect(json.status).toBe("ok");
     expect(json.authentication.required).toBe(true);
+    expect(json.authentication.resource_metadata).toMatch(
+      RESOURCE_METADATA_PATH
+    );
   });
 
   it("returns the OAuth challenge when mcp-session-id is present but no auth", async () => {
@@ -161,12 +169,18 @@ describe("POST /mcp — anonymous initialize", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     const json = await response.json();
     expect(json.jsonrpc).toBe("2.0");
     expect(json.id).toBe(7);
     expect(json.result.protocolVersion).toBe("2025-06-18");
+    expect(json.result.capabilities).toEqual({});
     expect(json.result.serverInfo.name).toBe("keeperhub");
+    expect(json.result.serverInfo.version).toBe("1.0.0");
     expect(json.result.authentication.required).toBe(true);
+    expect(json.result.authentication.resource_metadata).toMatch(
+      RESOURCE_METADATA_PATH
+    );
   });
 
   it("returns the OAuth challenge for tools/list with no auth", async () => {
@@ -225,6 +239,55 @@ describe("POST /mcp — anonymous initialize", () => {
     const response = await POST(request);
 
     await expectOAuthChallenge(response);
+  });
+
+  it("rejects an empty array body with the OAuth challenge", async () => {
+    const request = makeRequest("POST", {}, JSON.stringify([]));
+    const response = await POST(request);
+
+    await expectOAuthChallenge(response);
+  });
+
+  it("accepts a single-element initialize batch and returns the anon envelope", async () => {
+    const body = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        id: 9,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "0.0.1" },
+        },
+      },
+    ]);
+    const request = makeRequest("POST", {}, body);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.result.serverInfo.name).toBe("keeperhub");
+    // Array bodies have no top-level id, so the response id is null.
+    expect(json.id).toBeNull();
+  });
+
+  it("coerces an over-length string id to null (response amplification guard)", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: "x".repeat(257),
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.1" },
+      },
+    });
+    const request = makeRequest("POST", {}, body);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.id).toBeNull();
   });
 });
 

--- a/tests/unit/mcp-route-anon.test.ts
+++ b/tests/unit/mcp-route-anon.test.ts
@@ -4,9 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Hoisted mocks — must be declared before any imports that use them.
 // ---------------------------------------------------------------------------
 
-const { mockAuthenticate } = vi.hoisted(() => ({
-  mockAuthenticate: vi.fn(),
-}));
+const { mockAuthenticate, mockGetSession, mockTouchSession } = vi.hoisted(
+  () => ({
+    mockAuthenticate: vi.fn(),
+    mockGetSession: vi.fn(),
+    mockTouchSession: vi.fn(),
+  })
+);
 
 // Stub server-only so the route module can be imported in a test environment.
 vi.mock("server-only", () => ({}));
@@ -42,10 +46,10 @@ vi.mock("@/lib/mcp/session-token", () => ({
 
 vi.mock("@/lib/mcp/sessions", () => ({
   deleteSession: vi.fn(),
-  getSession: vi.fn().mockReturnValue(null),
+  getSession: mockGetSession,
   setSession: vi.fn(),
   startCleanupInterval: vi.fn(),
-  touchSession: vi.fn(),
+  touchSession: mockTouchSession,
 }));
 
 vi.mock("@/lib/mcp/event-store", () => ({
@@ -164,6 +168,67 @@ describe("POST /mcp — anonymous initialize", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /mcp — authed session-resume forwards parsedBody", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthenticate.mockResolvedValue({
+      authenticated: true,
+      organizationId: "org-1",
+      apiKeyId: "key-1",
+      scope: undefined,
+    });
+  });
+
+  it("passes the parsed body through to transport.handleRequest, not the consumed stream", async () => {
+    const handleRequest = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    mockGetSession.mockReturnValue({
+      organizationId: "org-1",
+      transport: { handleRequest },
+    });
+
+    const parsed = {
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/list",
+      params: {},
+    };
+    const request = makeRequest(
+      "POST",
+      { "mcp-session-id": "session-abc" },
+      JSON.stringify(parsed)
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(handleRequest).toHaveBeenCalledTimes(1);
+    const [, options] = handleRequest.mock.calls[0] as [
+      Request,
+      { parsedBody: unknown },
+    ];
+    expect(options).toEqual({ parsedBody: parsed });
+  });
+
+  it("returns 400 when an authed POST has a malformed body (cannot reach transport)", async () => {
+    const handleRequest = vi.fn();
+    mockGetSession.mockReturnValue({
+      organizationId: "org-1",
+      transport: { handleRequest },
+    });
+
+    const request = makeRequest(
+      "POST",
+      { "mcp-session-id": "session-abc" },
+      "{ not json"
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(handleRequest).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/mcp-route-anon.test.ts
+++ b/tests/unit/mcp-route-anon.test.ts
@@ -93,6 +93,24 @@ function makeRequest(
   });
 }
 
+async function expectOAuthChallenge(response: Response): Promise<void> {
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(response.status).toBe(401);
+  const challenge = response.headers.get("WWW-Authenticate") ?? "";
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(challenge).toContain('Bearer realm="OAuth"');
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(challenge).toContain("resource_metadata=");
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(challenge).toContain('error="invalid_token"');
+  const json = (await response.json()) as Record<string, unknown>;
+  // biome-ignore lint/suspicious/noMisplacedAssertion: helper called exclusively from inside test() blocks
+  expect(json).toEqual({
+    error: "invalid_token",
+    error_description: "Missing or invalid access token",
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -114,11 +132,11 @@ describe("GET /mcp — anonymous health probe", () => {
     expect(json.authentication.required).toBe(true);
   });
 
-  it("returns 401 when mcp-session-id is present but no auth token is provided", async () => {
+  it("returns the OAuth challenge when mcp-session-id is present but no auth", async () => {
     const request = makeRequest("GET", { "mcp-session-id": "some-session-id" });
     const response = await GET(request);
 
-    expect(response.status).toBe(401);
+    await expectOAuthChallenge(response);
   });
 });
 
@@ -151,7 +169,7 @@ describe("POST /mcp — anonymous initialize", () => {
     expect(json.result.authentication.required).toBe(true);
   });
 
-  it("returns 401 for tools/list with no auth (only initialize is anon-allowed)", async () => {
+  it("returns the OAuth challenge for tools/list with no auth", async () => {
     const body = JSON.stringify({
       jsonrpc: "2.0",
       id: 8,
@@ -160,14 +178,53 @@ describe("POST /mcp — anonymous initialize", () => {
     const request = makeRequest("POST", {}, body);
     const response = await POST(request);
 
-    expect(response.status).toBe(401);
+    await expectOAuthChallenge(response);
   });
 
-  it("returns 401 for malformed JSON body with no auth (no 500)", async () => {
+  it("returns the OAuth challenge for malformed JSON, with no parser leak", async () => {
     const request = makeRequest("POST", {}, "{ not valid json");
     const response = await POST(request);
 
-    expect(response.status).toBe(401);
+    await expectOAuthChallenge(response);
+  });
+
+  it("coerces non-scalar JSON-RPC ids to null", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: { evil: "object" },
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.1" },
+      },
+    });
+    const request = makeRequest("POST", {}, body);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.id).toBeNull();
+  });
+
+  it("rejects a batch with mixed methods (only all-initialize batches are anon-allowed)", async () => {
+    const body = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "0.0.1" },
+        },
+      },
+      { jsonrpc: "2.0", id: 2, method: "tools/call" },
+    ]);
+    const request = makeRequest("POST", {}, body);
+    const response = await POST(request);
+
+    await expectOAuthChallenge(response);
   });
 });
 
@@ -238,12 +295,12 @@ describe("DELETE /mcp — always requires auth", () => {
     mockAuthenticate.mockResolvedValue(UNAUTHENTICATED);
   });
 
-  it("returns 401 when no auth token is provided", async () => {
+  it("returns the OAuth challenge when no auth token is provided", async () => {
     const request = makeRequest("DELETE", {
       "mcp-session-id": "some-session-id",
     });
     const response = await DELETE(request);
 
-    expect(response.status).toBe(401);
+    await expectOAuthChallenge(response);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the "Unhealthy" status for the KeeperHub agent on https://8004scan.io/agents/ethereum/31875. 8004scan's health checker hits `/mcp` anonymously and gets a 401 with an OAuth challenge it doesn't follow, dragging the Services posture to Degraded (50/100) and the Overall Score to ~5/100.

Two narrow changes:

- **`/mcp` anonymous probe surface.** `GET /mcp` without a session header returns a small server-info ping. `POST /mcp` with an `initialize` JSON-RPC method returns a valid initialize envelope with empty capabilities. Both responses include `authentication.required: true` and the resource-metadata URL so spec-compliant clients still know to auth before tool calls. Every other method (`tools/list`, `tools/call`, `resources/*`, etc.) and `DELETE` still return 401 unchanged.
- **`/api/agent-registry` metadata enrichment.** Adds `version` on the MCP service entry, an `agentWallet` service with the CAIP-10 endpoint matching the on-chain registration EOA, top-level `supportedTrust: ["reputation"]`, and `updatedAt` (unix seconds, sourced from the registration row's `registeredAt` or `Date.now()` fallback). Brings the off-chain JSON closer to the v1.3 "complete" shape from `best-practices.8004scan.io`.

## Why

After the 8004scan indexer's next refresh, MCP should flip from Unhealthy → Healthy and the off-chain metadata score should improve. Body parsing in the MCP POST handler is now centralized at the top of the function, so a malformed payload still returns 401 rather than crashing.

## Test plan

- [x] `pnpm vitest run tests/unit/agent-registry-route.test.ts tests/unit/mcp-route-anon.test.ts` — 18/18 pass
- [x] `pnpm check` — clean on the four touched files
- [x] `pnpm type-check` — clean on the four touched files
- [ ] After merge + deploy, hit `curl https://app.keeperhub.com/mcp` anonymously and confirm 200 ping body
- [ ] After merge + deploy, hit `curl -X POST https://app.keeperhub.com/mcp -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'` anonymously and confirm a JSON-RPC 200
- [ ] After merge + deploy, hit `curl -X POST https://app.keeperhub.com/mcp -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'` anonymously and confirm 401 (regression check)
- [ ] After merge + deploy, fetch `/api/agent-registry` and confirm new fields appear
- [ ] Wait for 8004scan to re-run health check; verify MCP flips to Healthy and overall score improves