### PR TITLE
fix(executor): KEEP-431 cross-pod step-success authority for x402 path

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -47,7 +47,10 @@ import {
   type ExecutionResult,
 } from "@/lib/workflow/executor/final-success";
 import { runBodyNode } from "@/lib/workflow/executor/for-each-body-runner";
-import { clearOutputCache } from "@/lib/workflow/executor/get-completed-step-output";
+import {
+  clearOutputCache,
+  getCompletedStepOutput,
+} from "@/lib/workflow/executor/get-completed-step-output";
 import { createPendingTracker } from "@/lib/workflow/executor/pending-tasks";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
@@ -2044,21 +2047,31 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       const errorMessage = await getErrorMessageAsync(error);
 
       // KEEP-398: Reconcile spurious max-retries / step-completion errors using
-      // the in-process step-success-tracker. The Workflow DevKit framework's
-      // post-step "step_completed" event is occasionally lost under heavy
-      // fan-in (e.g. many parallel reads converging into a code/run-code
-      // combine). When that happens, useStep re-fires the step on resume and
-      // -- with runCodeStep.maxRetries=0 -- the framework throws
+      // the step-success authority (in-process tracker fast-path with DB
+      // fallback). The Workflow DevKit framework's post-step "step_completed"
+      // event is occasionally lost under heavy fan-in (e.g. many parallel
+      // reads converging into a code/run-code combine). When that happens,
+      // useStep re-fires the step on resume and -- with
+      // runCodeStep.maxRetries=0 -- the framework throws
       // "Step ... exceeded max retries" / "Step ... failed after N retries"
       // even though the step body returned successfully and recorded its
       // output via recordStepSuccess.
+      //
+      // KEEP-431: Use getCompletedStepOutput (tracker + DB) instead of
+      // getSuccessfulSteps (tracker only) so cross-pod recovery works in
+      // catch as well as post-drain. The tracker is process-local; on the
+      // x402 / call_workflow path the SDK frequently resumes on a fresh pod
+      // whose tracker is empty, leaving the in-catch branch unable to
+      // recover and forcing reliance on post-drain. Reading the DB-backed
+      // authority here makes the recovery uniform across both paths.
       const isSpuriousMaxRetries =
         EXCEEDED_MAX_RETRIES_REGEX.test(errorMessage) ||
         FAILED_AFTER_RETRIES_REGEX.test(errorMessage) ||
         NO_STEP_COMPLETION_REGEX.test(errorMessage);
-      const recordedOutput = executionId
-        ? getSuccessfulSteps(executionId)?.get(nodeId)
-        : undefined;
+      const recordedOutput =
+        isSpuriousMaxRetries && executionId
+          ? (await getCompletedStepOutput(executionId, nodeId))?.output
+          : undefined;
       if (isSpuriousMaxRetries && recordedOutput !== undefined) {
         // Recovered execution: the step body succeeded, only the SDK's
         // bookkeeping tripped. Emit a structured warn (no Sentry) and a

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -4,7 +4,7 @@
  */
 import "server-only";
 
-import { and, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -166,6 +166,18 @@ export async function logWorkflowCompleteDb(
   // spurious SDK error - the workflow really is incomplete. Keep 'error'
   // and close the orphaned rows below so the UI doesn't show stuck
   // spinners.
+  //
+  // KEEP-431: Aggregate by nodeId rather than counting raw rows. Under
+  // cross-pod SDK checkpoint resume, a step that already succeeded on pod A
+  // can be re-fired on pod B, leaving an orphan 'running' or 'error' row
+  // from the interrupted retry while the original success row is intact.
+  // Treat a node as succeeded if it has at least one success row -- only
+  // flag the workflow as failed when a node has no success row at all.
+  // This is the difference between "step really is incomplete" (no success
+  // row anywhere) and "framework retry was interrupted after the body
+  // already recorded success" (success row exists, orphan running/error
+  // row from the retry). Critical for x402/call_workflow paid callers who
+  // hit large fan-in workflows where the cross-pod resume is the norm.
   let resolvedStatus: "success" | "error" = params.status;
   let resolvedError: string | undefined = params.error;
 
@@ -179,18 +191,29 @@ export async function logWorkflowCompleteDb(
     );
 
     try {
-      const unresolvedLogs = await db.query.workflowExecutionLogs.findMany({
-        where: and(
-          eq(workflowExecutionLogs.executionId, params.executionId),
-          inArray(workflowExecutionLogs.status, ["error", "running"])
-        ),
-        columns: { id: true, status: true },
+      const allLogs = await db.query.workflowExecutionLogs.findMany({
+        where: eq(workflowExecutionLogs.executionId, params.executionId),
+        columns: { nodeId: true, status: true },
       });
 
-      const hasErrorLog = unresolvedLogs.some((l) => l.status === "error");
-      const hasRunningLog = unresolvedLogs.some((l) => l.status === "running");
+      // Per-nodeId aggregate: a node "succeeded" if any of its rows is success.
+      const nodeSucceeded = new Map<string, boolean>();
+      for (const log of allLogs) {
+        if (log.status === "success") {
+          nodeSucceeded.set(log.nodeId, true);
+        } else if (!nodeSucceeded.has(log.nodeId)) {
+          nodeSucceeded.set(log.nodeId, false);
+        }
+      }
 
-      if (!(hasErrorLog || hasRunningLog)) {
+      const trulyFailedNodes: string[] = [];
+      for (const [nodeId, succeeded] of nodeSucceeded) {
+        if (!succeeded) {
+          trulyFailedNodes.push(nodeId);
+        }
+      }
+
+      if (trulyFailedNodes.length === 0) {
         logSystemError(
           ErrorCategory.WORKFLOW_ENGINE,
           "[Workflow Logging] No node-level errors found, overriding spurious SDK error to success",

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -26,6 +26,7 @@ const { workflowExecutionsMock, workflowExecutionLogsMock } = vi.hoisted(
     workflowExecutionLogsMock: {
       id: "id",
       executionId: "execution_id",
+      nodeId: "node_id",
       status: "status",
       error: "error",
       completedAt: "completed_at",
@@ -43,7 +44,8 @@ type UpdateCall = {
   target: unknown;
   set: Record<string, unknown>;
 };
-let unresolvedLogs: { id: string; status: string }[] = [];
+type LogRow = { id?: string; nodeId: string; status: string };
+let allLogs: LogRow[] = [];
 let updateCalls: UpdateCall[] = [];
 let updateShouldThrow = false;
 
@@ -71,7 +73,7 @@ vi.mock("@/lib/db", () => ({
   db: {
     query: {
       workflowExecutionLogs: {
-        findMany: vi.fn(() => Promise.resolve(unresolvedLogs)),
+        findMany: vi.fn(() => Promise.resolve(allLogs)),
       },
     },
     update: vi.fn((target: unknown) => buildUpdate(target)),
@@ -90,7 +92,7 @@ function getLogUpdate(): UpdateCall | undefined {
 
 describe("logWorkflowCompleteDb", () => {
   beforeEach(() => {
-    unresolvedLogs = [];
+    allLogs = [];
     updateCalls = [];
     updateShouldThrow = false;
     vi.clearAllMocks();
@@ -112,8 +114,8 @@ describe("logWorkflowCompleteDb", () => {
     );
   });
 
-  it("keeps error status when a node log recorded an error", async () => {
-    unresolvedLogs = [{ id: "log_1", status: "error" }];
+  it("keeps error status when a node log recorded an error and never succeeded", async () => {
+    allLogs = [{ id: "log_1", nodeId: "node_a", status: "error" }];
 
     await logWorkflowCompleteDb({
       executionId: "exec_1",
@@ -131,7 +133,10 @@ describe("logWorkflowCompleteDb", () => {
   });
 
   it("overrides spurious SDK error to success when no logs are error or running", async () => {
-    unresolvedLogs = [];
+    allLogs = [
+      { id: "log_a", nodeId: "node_a", status: "success" },
+      { id: "log_b", nodeId: "node_b", status: "success" },
+    ];
 
     await logWorkflowCompleteDb({
       executionId: "exec_1",
@@ -150,8 +155,8 @@ describe("logWorkflowCompleteDb", () => {
 
   // KEEP-333: If a step started but never recorded completion, the workflow
   // really is incomplete. Don't lie to the user by overriding to success.
-  it("keeps error status when any log is stuck in running", async () => {
-    unresolvedLogs = [{ id: "log_running", status: "running" }];
+  it("keeps error status when a node has only a running log (no success row)", async () => {
+    allLogs = [{ id: "log_running", nodeId: "node_a", status: "running" }];
 
     await logWorkflowCompleteDb({
       executionId: "exec_1",
@@ -168,8 +173,83 @@ describe("logWorkflowCompleteDb", () => {
     );
   });
 
+  // KEEP-431: cross-pod SDK checkpoint resume. The original step body
+  // succeeded on pod A and recorded a success row. The framework re-fired
+  // the step on pod B; that retry's logStepStartDb inserted a 'running'
+  // row, but the SDK threw "exceeded max retries" before logStepCompleteDb
+  // ran for the retry. The success row from pod A is the truth.
+  it("overrides spurious error when node has both success and running rows (cross-pod retry)", async () => {
+    allLogs = [
+      // First read row succeeded normally on pod A
+      { id: "log_read1", nodeId: "read1", status: "success" },
+      // Combine succeeded on pod A then framework re-fired on pod B
+      { id: "log_combine_success", nodeId: "combine", status: "success" },
+      { id: "log_combine_orphan", nodeId: "combine", status: "running" },
+    ];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_x402_cross_pod",
+      status: "error",
+      error: 'Step "runCodeStep" exceeded max retries (1 retry)',
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "success",
+        error: undefined,
+      })
+    );
+  });
+
+  it("overrides spurious error when node has both success and error rows from retry", async () => {
+    allLogs = [
+      { id: "log_combine_success", nodeId: "combine", status: "success" },
+      // Retry attempt rejected by SDK and logStepComplete recorded error.
+      { id: "log_combine_retry", nodeId: "combine", status: "error" },
+    ];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_retry_error",
+      status: "error",
+      error: "Step did not record completion",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "success",
+        error: undefined,
+      })
+    );
+  });
+
+  it("keeps error status when one node truly failed even if others have retries", async () => {
+    allLogs = [
+      // node_a: cross-pod retry pattern, would otherwise succeed.
+      { id: "log_a_success", nodeId: "node_a", status: "success" },
+      { id: "log_a_orphan", nodeId: "node_a", status: "running" },
+      // node_b: real failure, no success row anywhere.
+      { id: "log_b_error", nodeId: "node_b", status: "error" },
+    ];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_mixed",
+      status: "error",
+      error: "node_b failed",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "error",
+        error: "node_b failed",
+      })
+    );
+  });
+
   it("closes orphaned running logs on completion (error path)", async () => {
-    unresolvedLogs = [{ id: "log_running", status: "running" }];
+    allLogs = [{ id: "log_running", nodeId: "node_a", status: "running" }];
 
     await logWorkflowCompleteDb({
       executionId: "exec_1",
@@ -192,7 +272,7 @@ describe("logWorkflowCompleteDb", () => {
   it("closes orphaned running logs as success when workflow succeeded", async () => {
     // Spurious SDK error reconciled to success; any running rows should
     // match the reconciled status so the UI is consistent.
-    unresolvedLogs = [];
+    allLogs = [];
 
     await logWorkflowCompleteDb({
       executionId: "exec_1",
@@ -214,16 +294,18 @@ describe("logWorkflowCompleteDb", () => {
   it("still updates execution status when log cleanup throws", async () => {
     // Simulate a transient DB failure during the log cleanup UPDATE;
     // the execution status update must still run.
-    unresolvedLogs = [];
+    allLogs = [];
     let callIndex = 0;
     updateShouldThrow = false;
 
     // Patch buildUpdate behavior per-call: first UPDATE (logs) throws,
     // second UPDATE (executions) succeeds.
     const { db } = await import("@/lib/db");
-    (db.update as unknown as {
-      mockImplementation: (fn: (t: unknown) => UpdateChain) => void;
-    }).mockImplementation((target: unknown) => ({
+    (
+      db.update as unknown as {
+        mockImplementation: (fn: (t: unknown) => UpdateChain) => void;
+      }
+    ).mockImplementation((target: unknown) => ({
       set: (values: Record<string, unknown>): SetChain => {
         updateCalls.push({ target, set: values });
         const shouldThrow =

--- a/tests/unit/executor-in-catch-db-fallback.test.ts
+++ b/tests/unit/executor-in-catch-db-fallback.test.ts
@@ -1,0 +1,225 @@
+/**
+ * KEEP-431: In-catch DB fallback for spurious max-retries recovery.
+ *
+ * The executor.workflow.ts catch block previously consulted only the in-process
+ * step-success-tracker, which is empty on a fresh pod that did not run the
+ * predecessor step. Under cross-pod SDK checkpoint resume (the dominant mode
+ * on the x402/call_workflow path), this left the in-catch unable to recover
+ * and forced reliance on the post-drain reconciler.
+ *
+ * The fix: in-catch now uses getCompletedStepOutput, which checks the tracker
+ * first (fast path) and falls back to workflow_execution_logs.outputRaw. This
+ * makes recovery uniform across same-process (direct execute_workflow) and
+ * cross-process (x402 call_workflow) paths.
+ *
+ * These tests exercise the in-catch decision predicate via getCompletedStepOutput
+ * directly. Doing this against the live executor would require ~200 lines of
+ * plugin-registry / metrics / logging mocking; the predicate-level test verifies
+ * the actual code path (getCompletedStepOutput) the in-catch now calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockFetchSingle } = vi.hoisted(() => ({
+  mockFetchSingle: vi.fn(),
+}));
+
+vi.mock("@/lib/workflow/executor/get-completed-step-output.step", () => ({
+  fetchCompletedStepOutputStep: mockFetchSingle,
+  fetchCompletedStepOutputsBatchStep: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
+  logSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter: vi.fn(),
+    recordLatency: vi.fn(),
+  }),
+}));
+
+import {
+  clearOutputCache,
+  getCompletedStepOutput,
+} from "@/lib/workflow/executor/get-completed-step-output";
+import {
+  EXCEEDED_MAX_RETRIES_REGEX,
+  FAILED_AFTER_RETRIES_REGEX,
+  NO_STEP_COMPLETION_REGEX,
+} from "@/lib/workflow/executor/runner-error-patterns";
+import {
+  clearExecution,
+  recordStepSuccess,
+} from "@/lib/workflow/executor/step-success-tracker";
+
+function isSpuriousMaxRetriesError(message: string): boolean {
+  return (
+    EXCEEDED_MAX_RETRIES_REGEX.test(message) ||
+    FAILED_AFTER_RETRIES_REGEX.test(message) ||
+    NO_STEP_COMPLETION_REGEX.test(message)
+  );
+}
+
+/**
+ * Mirror of the executor.workflow.ts catch-block decision after KEEP-431.
+ * Returns the recovered output, or undefined if no recovery should happen.
+ */
+async function inCatchRecover(
+  executionId: string | undefined,
+  nodeId: string,
+  errorMessage: string
+): Promise<unknown | undefined> {
+  if (!isSpuriousMaxRetriesError(errorMessage)) {
+    return;
+  }
+  if (!executionId) {
+    return;
+  }
+  const completed = await getCompletedStepOutput(executionId, nodeId);
+  return completed?.output;
+}
+
+describe("KEEP-431: in-catch DB fallback recovery", () => {
+  const executionId = "exec-keep-431-in-catch";
+  const nodeId = "combine-cross-pod";
+
+  beforeEach(() => {
+    clearOutputCache(executionId);
+    clearExecution(executionId);
+    mockFetchSingle.mockReset();
+  });
+
+  afterEach(() => {
+    clearOutputCache(executionId);
+    clearExecution(executionId);
+  });
+
+  describe("fast path: tracker populated (same-process direct execute_workflow)", () => {
+    it("recovers from tracker without hitting DB", async () => {
+      recordStepSuccess(executionId, nodeId, { merged: 42 });
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        'Step "runCodeStep" exceeded max retries (1 retry)'
+      );
+
+      expect(recovered).toEqual({ merged: 42 });
+      expect(mockFetchSingle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cross-pod path: tracker empty, DB has the row (x402 prod scenario)", () => {
+    it("recovers from DB when tracker is empty", async () => {
+      mockFetchSingle.mockResolvedValue({
+        outputRaw: { aave_v3: { shares_1e18: "12345" } },
+      });
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        'Step "runCodeStep" exceeded max retries (1 retry)'
+      );
+
+      expect(recovered).toEqual({ aave_v3: { shares_1e18: "12345" } });
+      expect(mockFetchSingle).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers from DB for 'failed after N retries' error shape", async () => {
+      mockFetchSingle.mockResolvedValue({ outputRaw: { ok: true } });
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        'Step "combine" failed after 0 retries: state replay mismatch'
+      );
+
+      expect(recovered).toEqual({ ok: true });
+    });
+
+    it("recovers from DB for 'did not record completion' error shape", async () => {
+      mockFetchSingle.mockResolvedValue({ outputRaw: { result: 99 } });
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        "Step did not record completion within timeout window"
+      );
+
+      expect(recovered).toEqual({ result: 99 });
+    });
+  });
+
+  describe("negative cases: do not recover", () => {
+    it("returns undefined when DB has no row and tracker is empty", async () => {
+      mockFetchSingle.mockResolvedValue(null);
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        'Step "runCodeStep" exceeded max retries (1 retry)'
+      );
+
+      expect(recovered).toBeUndefined();
+    });
+
+    it("does not recover unrelated step errors even when DB has a success row", async () => {
+      mockFetchSingle.mockResolvedValue({ outputRaw: { ok: true } });
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        "Contract reverted: insufficient balance"
+      );
+
+      expect(recovered).toBeUndefined();
+      // Predicate fails before DB is consulted, so no DB query is issued.
+      expect(mockFetchSingle).not.toHaveBeenCalled();
+    });
+
+    it("does not recover when executionId is missing", async () => {
+      const recovered = await inCatchRecover(
+        undefined,
+        nodeId,
+        'Step "runCodeStep" exceeded max retries (1 retry)'
+      );
+
+      expect(recovered).toBeUndefined();
+      expect(mockFetchSingle).not.toHaveBeenCalled();
+    });
+
+    it("does not swallow DB rejection (returns undefined and logs internally)", async () => {
+      mockFetchSingle.mockRejectedValue(new Error("Pool exhausted"));
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        'Step "runCodeStep" exceeded max retries (1 retry)'
+      );
+
+      // getCompletedStepOutput catches DB errors internally and returns null.
+      expect(recovered).toBeUndefined();
+    });
+  });
+
+  describe("preserves falsy outputs (regression guard against `recordedOutput !== undefined` checks)", () => {
+    it("recovers a recorded null output", async () => {
+      mockFetchSingle.mockResolvedValue({ outputRaw: null });
+
+      const recovered = await inCatchRecover(
+        executionId,
+        nodeId,
+        'Step "x" exceeded max retries (1 retry)'
+      );
+
+      // null is a valid recovered value; the executor's
+      // `recordedOutput !== undefined` guard should still pass it through.
+      expect(recovered).toBeNull();
+    });
+  });
+});

--- a/tests/unit/executor-spurious-max-retries.test.ts
+++ b/tests/unit/executor-spurious-max-retries.test.ts
@@ -14,8 +14,8 @@ import {
 } from "@/lib/workflow/executor/step-success-tracker";
 
 /**
- * KEEP-398: Reconcile spurious max-retries / step-completion-tracker errors
- * via the in-process step-success-tracker.
+ * KEEP-398 / KEEP-431: Reconcile spurious max-retries / step-completion-tracker
+ * errors via the step-success authority.
  *
  * Background:
  *   The Workflow DevKit's post-step "step_completed" event is occasionally
@@ -25,18 +25,18 @@ import {
  *   even though the step body returned successfully and recorded its output
  *   via recordStepSuccess (called from step-handler.ts).
  *
- *   The executor.workflow.ts catch block now consults getSuccessfulSteps:
- *   when the error message matches the spurious shape AND a recorded output
- *   exists for the failing node, the executor treats it as success and
- *   continues downstream.
+ *   The executor.workflow.ts catch block now consults getCompletedStepOutput
+ *   (tracker fast-path with DB fallback): when the error message matches the
+ *   spurious shape AND a recorded success exists for the failing node, the
+ *   executor treats it as success and continues downstream.
  *
- * These tests cover the predicate logic (regex shape) and the tracker
- * round-trip used by the recovery path. A full executeWorkflow integration
- * test is intentionally out of scope: the executor module imports plugin
- * registries, metrics, logging, AsyncLocalStorage error contexts, and a
- * dynamically generated step-registry, all of which would require
- * >200 lines of mocking. The pure-logic and tracker behaviour fully
- * exercise the new branch in the catch block.
+ * These tests cover the predicate logic (regex shape) and the tracker fast
+ * path round-trip used by the recovery decision. The DB-fallback path is
+ * covered by cross-process-tracker-simulation.test.ts. A full executeWorkflow
+ * integration test is intentionally out of scope: the executor module imports
+ * plugin registries, metrics, logging, AsyncLocalStorage error contexts, and
+ * a dynamically generated step-registry, all of which would require >200
+ * lines of mocking.
  *
  * The regex constants are imported from the production module (not redefined
  * here) so any rename or pattern change in executor.workflow.ts breaks this


### PR DESCRIPTION
## Summary

Fixes [KEEP-431](https://linear.app/keeperhubapp/issue/KEEP-431/fix-keep-398-step-completion-tracker-fix-didnt-reach-the-x402-call). PRs #1103/#1110 added DB-backed cross-process step-success authority via `output_raw` and a post-drain reconciler, but two gaps left the x402/`call_workflow` path failing on large fan-in workflows where direct `execute_workflow` succeeded:

- `logWorkflowCompleteDb` reconciliation counted raw error/running rows. Under cross-pod SDK checkpoint resume, a step that already succeeded on pod A can be re-fired on pod B, leaving an orphan `running` row from the interrupted retry. The original success row is intact, but the orphan running row blocked the spurious-error-to-success override. Switch to per-nodeId aggregation: a node truly failed only if it has no success row anywhere.
- `executor.workflow.ts` in-catch spurious recovery used only the in-process tracker via `getSuccessfulSteps`. The tracker is empty on a fresh pod, leaving cross-pod recovery dependent on the post-drain pass. Switch to `getCompletedStepOutput` so the in-catch fast path matches the post-drain reconciler: tracker hit when same-process, DB fallback when cross-pod.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm vitest run` 4214 passed, 0 failed
- [x] New `tests/unit/executor-in-catch-db-fallback.test.ts` exercises the tracker fast path, x402 cross-pod recovery, and negative/falsy edge cases
- [x] Updated `tests/integration/workflow-logging.test.ts` covers per-nodeId aggregation: success+running orphan, success+error from retry, mixed real-failure-plus-retry, KEEP-333 still preserved (running-only nodes flagged as real failure)
- [ ] Manual verification on staging once PR environment is up: re-run `defi-position-aggregator-ethereum` with 13 parallel reads via x402 `call_workflow` (failing repro: `6nq7kf1az9ku49hmjcrnc`); expect `status: success` with full output payload
- [ ] Confirm direct `execute_workflow` path still succeeds (no regression to working path)

Linear: KEEP-431