### PR TITLE
feat(metrics): add billing-aware observability for orgs, plans, and MRR

### DIFF
--- a/lib/billing/handle-billing-event.ts
+++ b/lib/billing/handle-billing-event.ts
@@ -4,13 +4,36 @@ import {
   organizationSubscriptions,
   overageBillingRecords,
 } from "@/lib/db/schema";
+import { getMetricsCollector } from "@/lib/metrics";
+import { MetricNames } from "@/lib/metrics/types";
 import { BILLING_ALERTS } from "./constants";
 import { clearAllDebtForOrg, clearDebtForInvoice } from "./execution-debt";
 import { billOverageForOrg } from "./overage";
+import { type PlanName, parsePlanName } from "./plans";
 import { resolveSubscriptionPlan } from "./plans-server";
 import type { BillingProvider, BillingWebhookEvent } from "./provider";
 
 const LOG_PREFIX = "[Billing Handler]";
+
+// Numeric ranking used to label plan changes as upgrade/downgrade. Same-plan
+// tier changes (e.g. Pro 25k -> Pro 50k) are labeled "tier_change" since the
+// dashboard tracks them separately from plan-level moves.
+const PLAN_RANK: Record<PlanName, number> = {
+  free: 0,
+  pro: 1,
+  business: 2,
+  enterprise: 3,
+};
+
+function planChangeDirection(
+  from: PlanName,
+  to: PlanName
+): "upgrade" | "downgrade" | "tier_change" {
+  if (from === to) {
+    return "tier_change";
+  }
+  return PLAN_RANK[to] > PLAN_RANK[from] ? "upgrade" : "downgrade";
+}
 
 type SubscriptionRow = typeof organizationSubscriptions.$inferSelect;
 
@@ -167,6 +190,14 @@ async function handleCheckoutCompleted(
     });
 
   console.info(LOG_PREFIX, "Upserted subscription for org:", organizationId);
+
+  getMetricsCollector().incrementCounter(
+    MetricNames.BILLING_SUBSCRIPTION_CREATED,
+    {
+      plan,
+      tier: tier ?? "none",
+    }
+  );
 }
 
 // Build the DB update payload for a subscription.updated event.
@@ -289,6 +320,27 @@ async function handleSubscriptionUpdated(
         providerSubscriptionId
       )
     );
+
+  const metrics = getMetricsCollector();
+  const newPlanRaw = update.plan;
+  const newPlan: PlanName =
+    typeof newPlanRaw === "string"
+      ? parsePlanName(newPlanRaw, parsePlanName(current.plan))
+      : parsePlanName(current.plan);
+  metrics.incrementCounter(MetricNames.BILLING_SUBSCRIPTION_UPDATED, {
+    plan: newPlan,
+  });
+
+  // Plan change is signaled by priceChanged in buildSubscriptionUpdate
+  // (only present in the update payload when the price differs).
+  if (update.providerPriceId !== undefined) {
+    const fromPlan = parsePlanName(current.plan);
+    metrics.incrementCounter(MetricNames.BILLING_SUBSCRIPTION_PLAN_CHANGED, {
+      from_plan: fromPlan,
+      to_plan: newPlan,
+      direction: planChangeDirection(fromPlan, newPlan),
+    });
+  }
 }
 
 async function handleSubscriptionDeleted(
@@ -337,6 +389,14 @@ async function handleSubscriptionDeleted(
     if (current) {
       await clearAllDebtForOrg(current.organizationId);
     }
+
+    getMetricsCollector().incrementCounter(
+      MetricNames.BILLING_SUBSCRIPTION_CANCELED,
+      {
+        plan: parsePlanName(current?.plan, "free"),
+        tier: current?.tier ?? "none",
+      }
+    );
     return;
   }
 
@@ -370,6 +430,14 @@ async function handleSubscriptionDeleted(
   if (current) {
     await clearAllDebtForOrg(current.organizationId);
   }
+
+  getMetricsCollector().incrementCounter(
+    MetricNames.BILLING_SUBSCRIPTION_CANCELED,
+    {
+      plan: parsePlanName(current?.plan, "free"),
+      tier: current?.tier ?? "none",
+    }
+  );
 }
 
 async function markOverageRecordsPaid(
@@ -421,6 +489,10 @@ async function handleInvoicePaid(
     if (sub && invoiceId) {
       await markOverageRecordsPaid(sub.organizationId, invoiceId);
     }
+
+    getMetricsCollector().incrementCounter(MetricNames.BILLING_INVOICE_PAID, {
+      plan: parsePlanName(sub?.plan, "free"),
+    });
     return;
   }
 
@@ -450,6 +522,10 @@ async function handleInvoicePaid(
       if (invoiceId) {
         await markOverageRecordsPaid(sub.organizationId, invoiceId);
       }
+
+      getMetricsCollector().incrementCounter(MetricNames.BILLING_INVOICE_PAID, {
+        plan: parsePlanName(sub.plan, "free"),
+      });
     }
   }
 }
@@ -473,6 +549,8 @@ async function handleInvoicePaymentFailed(
     providerSubscriptionId
   );
 
+  const sub = await findSubscriptionByProviderId(providerSubscriptionId);
+
   await db
     .update(organizationSubscriptions)
     .set({
@@ -487,6 +565,10 @@ async function handleInvoicePaymentFailed(
         providerSubscriptionId
       )
     );
+
+  getMetricsCollector().incrementCounter(MetricNames.BILLING_INVOICE_FAILED, {
+    plan: parsePlanName(sub?.plan, "free"),
+  });
 }
 
 async function handleInvoiceOverdue(

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -6,6 +6,8 @@ import {
   organizationSubscriptions,
   overageBillingRecords,
 } from "@/lib/db/schema";
+import { getMetricsCollector } from "@/lib/metrics";
+import { MetricNames } from "@/lib/metrics/types";
 import { getPlanLimits, PLANS, parsePlanName, parseTierKey } from "./plans";
 import { getBillingProvider } from "./providers";
 
@@ -131,6 +133,11 @@ export async function billOverageForOrg(
         providerInvoiceItemId: invoiceItemId,
       })
       .where(eq(overageBillingRecords.id, record.id));
+
+    getMetricsCollector().incrementCounter(
+      MetricNames.BILLING_OVERAGE_CHARGED,
+      { plan }
+    );
 
     return { billed: true, overageCount, totalChargeCents };
   } catch (error) {

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -124,7 +124,33 @@ Gauge metrics tracking user and organization statistics.
 | `org.members_by_role` | Organization members by role | `role` | DB |
 | `org.invitations.pending` | Pending organization invitations | - | DB |
 | `org.with_workflows` | Organizations with at least one workflow | - | DB |
-| `org.info` | Info gauge with one series per org | `org_name`, `slug` | DB |
+| `org.info` | Info gauge with one series per org | `org_name`, `slug`, `plan`, `billing_status` | DB |
+
+### Billing Metrics
+
+Billing-aware observability layered onto the org model. Plan distribution, per-org execution volume vs plan limits, MRR, and subscription lifecycle counters.
+
+**Cardinality control:** per-org execution gauges (`org.executions.30d`, `org.executions.month`, `org.plan_usage_ratio`) emit one series per *paid* org (pro/business/enterprise). Free-tier orgs are aggregated into a single series with `org_slug="_free"` to keep Prometheus storage bounded.
+
+| Metric Name | Description | Labels | Source |
+|-------------|-------------|--------|--------|
+| `org.total_by_plan` | Org count grouped by plan and billing status | `plan`, `billing_status` | DB |
+| `org.executions.30d` | Workflow executions per org in the last 30 days | `org_slug`, `plan` | DB |
+| `org.executions.month` | Workflow executions per org since start of current calendar month | `org_slug`, `plan` | DB |
+| `org.plan_usage_ratio` | Current-month executions / monthly plan limit (0 when unlimited) | `org_slug`, `plan` | DB |
+| `mrr.usd_cents` | Approximate MRR in USD cents per plan (PLANS table * current tier) | `plan` | DB |
+| `mrr.usd_cents.total` | Approximate total MRR across all plans | - | DB |
+| `billing.subscription.created` | Subscriptions created (paid plan attached after checkout) | `plan`, `tier` | API |
+| `billing.subscription.updated` | Subscription update events from the billing provider | `plan` | API |
+| `billing.subscription.canceled` | Subscriptions canceled (provider-side or downgraded to free) | `plan`, `tier` | API |
+| `billing.subscription.plan_changed` | Plan changes labeled by direction | `from_plan`, `to_plan`, `direction` (`upgrade` / `downgrade` / `tier_change`) | API |
+| `billing.invoice.paid` | Invoices paid via the billing provider | `plan` | API |
+| `billing.invoice.failed` | Invoice payment failures (`past_due` / `payment_failed`) | `plan` | API |
+| `billing.overage.charged` | Overage charges issued for plan limit excess | `plan` | API |
+
+**Billing status values** (`billing_status` label): `active`, `trialing`, `past_due`, `canceled`, `unpaid`, `paused`, `none` (orgs without a subscription row).
+
+**MRR caveat:** `mrr.usd_cents` is computed from `lib/billing/plans.ts` × the org's current `(plan, tier)` tuple, summed across subscriptions in `active`, `trialing`, or `past_due` status. Stripe Dashboard remains the source of truth for accounting; this gauge exists for trend visibility only.
 
 ### Workflow Definition Metrics
 
@@ -187,6 +213,12 @@ Gauge metrics tracking user and organization statistics.
 | `verified` | User email verified status (info gauge) | `true`, `false` |
 | `org_name` | Organization name (info gauge) | `Acme Corp` |
 | `slug` | Organization slug (info gauge) | `acme-corp` |
+| `org_slug` | Organization slug for billing gauges (`_free` aggregates free-tier orgs, `_anonymous` for personal workflows) | `acme-corp`, `_free`, `_anonymous` |
+| `plan` | Subscription plan | `free`, `pro`, `business`, `enterprise` |
+| `tier` | Plan tier (none for free/enterprise) | `25k`, `50k`, `100k`, `250k`, `500k`, `1m`, `none` |
+| `billing_status` | Subscription status | `active`, `trialing`, `past_due`, `canceled`, `unpaid`, `paused`, `none` |
+| `from_plan` / `to_plan` | Plan change source/target | `pro`, `business` |
+| `direction` | Plan change direction | `upgrade`, `downgrade`, `tier_change` |
 
 ---
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -276,11 +276,73 @@ const orgWithWorkflows = getOrCreateGauge(
 );
 
 // Organization info gauge (DB-sourced, one series per org)
+// Includes plan + billing_status so the Organization Directory table panel
+// in Grafana can show those columns directly off this gauge without an
+// extra Prometheus join.
 const orgInfo = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_info",
-  "Organization info with name and slug labels",
-  ["org_name", "slug"]
+  "Organization info with name, slug, plan, and billing_status labels",
+  ["org_name", "slug", "plan", "billing_status"]
+);
+
+// Billing-aware org metrics (DB-sourced)
+//
+// Org count broken down by (plan, billing_status). One series per
+// (plan, billing_status) combination — bounded cardinality (4 plans x
+// ~7 statuses).
+const orgTotalByPlan = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_org_total_by_plan",
+  "Organizations grouped by plan and billing status",
+  ["plan", "billing_status"]
+);
+
+// Per-org execution counts (rolling 30-day window). Cardinality control:
+// paid orgs (pro/business/enterprise) emit individual series; free-tier
+// orgs aggregate into a single series with org_slug="_free".
+const orgExecutions30d = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_org_executions_30d",
+  'Workflow executions per org in the last 30 days (paid orgs individually; free orgs aggregated under org_slug="_free")',
+  ["org_slug", "plan"]
+);
+
+// Per-org execution counts (current calendar month, used for plan limit
+// pressure). Same cardinality rules as orgExecutions30d.
+const orgExecutionsMonth = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_org_executions_month",
+  "Workflow executions per org since start of the current calendar month",
+  ["org_slug", "plan"]
+);
+
+// Plan usage ratio: current-month executions / monthly limit. 0 when the
+// plan is unlimited (enterprise) or when there is no usage. Drives the
+// "approaching plan limit" alert and the dashboard heatmap.
+const orgPlanUsageRatio = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_org_plan_usage_ratio",
+  "Current-month executions divided by the org's plan monthly limit (0 = no pressure or unlimited)",
+  ["org_slug", "plan"]
+);
+
+// Directional MRR per plan in USD cents. Computed from PLANS[plan].tiers
+// monthlyPrice × current (plan, tier) of every active/trialing/past_due
+// subscription. Stripe Dashboard remains the source of truth for actual
+// revenue accounting; this gauge is for trend/observability only.
+const mrrUsdCents = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_mrr_usd_cents",
+  "Approximate MRR in USD cents per plan (PLANS table * current tier)",
+  ["plan"]
+);
+
+const mrrUsdCentsTotal = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_mrr_usd_cents_total",
+  "Approximate total MRR in USD cents across all plans",
+  []
 );
 
 // Workflow definition metrics (DB-sourced)
@@ -609,6 +671,63 @@ const sponsorshipGasCostUsdMicro = getOrCreateCounter(
   SPONSORSHIP_LABELS
 );
 
+// Billing lifecycle counters (API-process, emitted from the webhook handler
+// in lib/billing/handle-billing-event.ts). These give Grafana time-series
+// for subscription churn, invoice failure rate, and overage events without
+// reading Stripe directly.
+const BILLING_LIFECYCLE_LABELS = ["plan", "tier"];
+const BILLING_INVOICE_LABELS = ["plan"];
+const BILLING_PLAN_CHANGE_LABELS = ["from_plan", "to_plan", "direction"];
+
+const billingSubscriptionCreated = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_subscription_created_total",
+  "Subscriptions created (paid plan attached after checkout)",
+  BILLING_LIFECYCLE_LABELS
+);
+
+const billingSubscriptionUpdated = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_subscription_updated_total",
+  "Subscription update events received from the billing provider",
+  BILLING_INVOICE_LABELS
+);
+
+const billingSubscriptionCanceled = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_subscription_canceled_total",
+  "Subscriptions canceled (provider-side or downgraded to free)",
+  BILLING_LIFECYCLE_LABELS
+);
+
+const billingSubscriptionPlanChanged = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_subscription_plan_changed_total",
+  "Subscription plan changes (upgrade/downgrade), labeled by direction",
+  BILLING_PLAN_CHANGE_LABELS
+);
+
+const billingInvoicePaid = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_invoice_paid_total",
+  "Invoices paid via the billing provider",
+  BILLING_INVOICE_LABELS
+);
+
+const billingInvoiceFailed = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_invoice_failed_total",
+  "Invoice payment failures (past_due / payment_failed)",
+  BILLING_INVOICE_LABELS
+);
+
+const billingOverageCharged = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_billing_overage_charged_total",
+  "Overage charges issued for plan limit excess",
+  BILLING_INVOICE_LABELS
+);
+
 // Traffic counters
 const pluginInvocations = getOrCreateCounter(
   apiRegistry,
@@ -823,6 +942,14 @@ const counterMap: Record<string, Counter> = {
   "sponsorship.transactions.total": sponsorshipTransactions,
   "sponsorship.gas_used.total": sponsorshipGasUsed,
   "sponsorship.gas_cost_usd_micro.total": sponsorshipGasCostUsdMicro,
+  // Billing lifecycle counters
+  "billing.subscription.created": billingSubscriptionCreated,
+  "billing.subscription.updated": billingSubscriptionUpdated,
+  "billing.subscription.canceled": billingSubscriptionCanceled,
+  "billing.subscription.plan_changed": billingSubscriptionPlanChanged,
+  "billing.invoice.paid": billingInvoicePaid,
+  "billing.invoice.failed": billingInvoiceFailed,
+  "billing.overage.charged": billingOverageCharged,
 };
 
 const errorCounterMap: Record<string, Counter> = {
@@ -1017,6 +1144,7 @@ export async function updateDbMetrics(): Promise<void> {
       getUserListFromDb,
       getOrgListFromDb,
       getVoteStatsFromDb,
+      getBillingStatsFromDb,
     } = await import("../db-metrics");
     const [
       workflowStats,
@@ -1031,6 +1159,7 @@ export async function updateDbMetrics(): Promise<void> {
       userList,
       orgList,
       voteStats,
+      billingStats,
     ] = await Promise.all([
       getWorkflowStatsFromDb(),
       getStepStatsFromDb(),
@@ -1044,6 +1173,7 @@ export async function updateDbMetrics(): Promise<void> {
       getUserListFromDb(),
       getOrgListFromDb(),
       getVoteStatsFromDb(),
+      getBillingStatsFromDb(),
     ]);
 
     // Update workflow execution counts by status (gauges - point-in-time snapshots)
@@ -1165,11 +1295,49 @@ export async function updateDbMetrics(): Promise<void> {
     orgInvitationsPending.set(orgStats.invitationsPending);
     orgWithWorkflows.set(orgStats.withWorkflows);
 
-    // Update org info gauge (one series per org)
+    // Update org info gauge (one series per org). plan + billing_status are
+    // populated from the LEFT JOIN on organization_subscriptions in
+    // getOrgListFromDb so the Organization Directory table panel can render
+    // both columns from this single gauge.
     orgInfo.reset();
     for (const org of orgList) {
-      orgInfo.set({ org_name: org.name, slug: org.slug }, 1);
+      orgInfo.set(
+        {
+          org_name: org.name,
+          slug: org.slug,
+          plan: org.plan,
+          billing_status: org.billingStatus,
+        },
+        1
+      );
     }
+
+    // Update billing-aware metrics
+    orgTotalByPlan.reset();
+    for (const [plan, byStatus] of Object.entries(billingStats.orgsByPlan)) {
+      for (const [billingStatus, orgCount] of Object.entries(byStatus)) {
+        orgTotalByPlan.set({ plan, billing_status: billingStatus }, orgCount);
+      }
+    }
+
+    orgExecutions30d.reset();
+    orgExecutionsMonth.reset();
+    orgPlanUsageRatio.reset();
+    for (const row of billingStats.orgsExecutions) {
+      const labels = { org_slug: row.orgSlug, plan: row.plan };
+      orgExecutions30d.set(labels, row.exec30d);
+      orgExecutionsMonth.set(labels, row.execMonth);
+      // Unlimited plan (enterprise) -> ratio 0 to avoid alerting noise.
+      // Limit of 0 is treated the same way to avoid divide-by-zero.
+      const ratio = row.monthlyLimit > 0 ? row.execMonth / row.monthlyLimit : 0;
+      orgPlanUsageRatio.set(labels, ratio);
+    }
+
+    mrrUsdCents.reset();
+    for (const [plan, cents] of Object.entries(billingStats.mrrCentsByPlan)) {
+      mrrUsdCents.set({ plan }, cents);
+    }
+    mrrUsdCentsTotal.set(billingStats.mrrCentsTotal);
 
     // Update workflow definition metrics from DB
     workflowTotal.set(workflowDefStats.total);

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -10,6 +10,13 @@
 import "server-only";
 
 import { and, count, countDistinct, eq, gte, sql } from "drizzle-orm";
+import {
+  PLANS,
+  type PlanName,
+  parsePlanName,
+  parseTierKey,
+  type TierKey,
+} from "@/lib/billing/plans";
 import { db } from "@/lib/db";
 import {
   apiKeys,
@@ -18,6 +25,7 @@ import {
   invitation,
   member,
   organization,
+  organizationSubscriptions,
   paraWallets,
   sessions,
   users,
@@ -27,6 +35,7 @@ import {
   workflowSchedules,
   workflows,
 } from "@/lib/db/schema";
+import type { BillingStatus } from "./types";
 
 // Label value used for workflow executions whose workflow has no organization
 // (personal/anonymous workflows). Keeps the per-org error gauge total equal
@@ -505,7 +514,26 @@ export async function getUserListFromDb(): Promise<UserListEntry[]> {
 export type OrgListEntry = {
   name: string;
   slug: string;
+  plan: PlanName;
+  tier: TierKey | null;
+  billingStatus: BillingStatus;
 };
+
+const VALID_BILLING_STATUSES: ReadonlySet<string> = new Set<BillingStatus>([
+  "active",
+  "trialing",
+  "past_due",
+  "canceled",
+  "unpaid",
+  "paused",
+  "none",
+]);
+
+function parseBillingStatus(value: unknown): BillingStatus {
+  return typeof value === "string" && VALID_BILLING_STATUSES.has(value)
+    ? (value as BillingStatus)
+    : "none";
+}
 
 export async function getOrgListFromDb(): Promise<OrgListEntry[]> {
   try {
@@ -513,12 +541,25 @@ export async function getOrgListFromDb(): Promise<OrgListEntry[]> {
       .select({
         name: organization.name,
         slug: organization.slug,
+        plan: organizationSubscriptions.plan,
+        tier: organizationSubscriptions.tier,
+        billingStatus: organizationSubscriptions.status,
       })
-      .from(organization);
+      .from(organization)
+      .leftJoin(
+        organizationSubscriptions,
+        eq(organizationSubscriptions.organizationId, organization.id)
+      );
 
     return result.map((row) => ({
       name: row.name,
       slug: row.slug,
+      plan: parsePlanName(row.plan, "free"),
+      tier: parseTierKey(row.tier),
+      billingStatus:
+        row.billingStatus === null
+          ? "none"
+          : parseBillingStatus(row.billingStatus),
     }));
   } catch (error) {
     console.error("[Metrics] Failed to query org list from DB:", error);
@@ -858,6 +899,211 @@ export async function getEnabledChainNamesFromDb(): Promise<string[]> {
   } catch (error) {
     console.error("[Metrics] Failed to query enabled chain names:", error);
     return [];
+  }
+}
+
+// Bucket label used for aggregating free-tier orgs in per-org execution
+// gauges. Free-tier orgs share a single series to keep Prometheus
+// cardinality bounded. Paid orgs (pro/business/enterprise) are emitted as
+// individual series so each one is filterable in Grafana.
+export const FREE_ORG_AGGREGATE_SLUG = "_free";
+
+// Subscription statuses that count toward MRR — kept inline in the SQL
+// query (active / trialing / past_due). Canceled / unpaid / paused
+// subscriptions do not contribute.
+
+export type BillingStats = {
+  // Org count per (plan, billing_status). Free orgs without a subscription
+  // row are reported under plan="free", billing_status="none".
+  orgsByPlan: Record<PlanName, Record<BillingStatus, number>>;
+
+  // Per-org execution counts. Paid orgs appear individually with their slug;
+  // all free-tier orgs are aggregated under FREE_ORG_AGGREGATE_SLUG.
+  orgsExecutions: Array<{
+    orgSlug: string;
+    plan: PlanName;
+    exec30d: number;
+    execMonth: number;
+    // Monthly execution allowance for the org's tier, or -1 for unlimited
+    // (enterprise) and 0 when not applicable.
+    monthlyLimit: number;
+  }>;
+
+  // Approximate MRR in USD cents per plan, computed from PLANS[plan].tiers
+  // matched by org's tier. Stripe remains the source of truth for accounting.
+  mrrCentsByPlan: Record<PlanName, number>;
+
+  // Total MRR in USD cents across all plans (sum of mrrCentsByPlan).
+  mrrCentsTotal: number;
+};
+
+function emptyBillingStats(): BillingStats {
+  const orgsByPlan: Record<PlanName, Record<BillingStatus, number>> = {
+    free: {} as Record<BillingStatus, number>,
+    pro: {} as Record<BillingStatus, number>,
+    business: {} as Record<BillingStatus, number>,
+    enterprise: {} as Record<BillingStatus, number>,
+  };
+  const mrrCentsByPlan: Record<PlanName, number> = {
+    free: 0,
+    pro: 0,
+    business: 0,
+    enterprise: 0,
+  };
+  return {
+    orgsByPlan,
+    orgsExecutions: [],
+    mrrCentsByPlan,
+    mrrCentsTotal: 0,
+  };
+}
+
+function tierMonthlyPriceCents(plan: PlanName, tier: TierKey | null): number {
+  if (!tier) {
+    return 0;
+  }
+  const planDef = PLANS[plan];
+  const found = planDef.tiers.find((t) => t.key === tier);
+  return found ? Math.round(found.monthlyPrice * 100) : 0;
+}
+
+/**
+ * Query billing-aware metrics from the database in a single pass.
+ *
+ * Joins workflow_executions -> workflows -> organization -> organization_subscriptions
+ * to produce per-org execution counts (30-day rolling and current-month-to-date),
+ * org distribution by plan/billing status, and a directional MRR figure.
+ *
+ * Free-tier orgs are aggregated into a single FREE_ORG_AGGREGATE_SLUG series
+ * for the per-org executions gauge to bound Prometheus cardinality.
+ */
+export async function getBillingStatsFromDb(): Promise<BillingStats> {
+  try {
+    // Aggregate counts: orgs by (plan, billing_status). LEFT JOIN handles
+    // legacy orgs without a subscription row (mapped to plan="free",
+    // billing_status="none" via fallback in OrgListEntry parsing).
+    const orgsByPlanResult = await db
+      .select({
+        plan: organizationSubscriptions.plan,
+        status: organizationSubscriptions.status,
+        count: count(),
+      })
+      .from(organization)
+      .leftJoin(
+        organizationSubscriptions,
+        eq(organizationSubscriptions.organizationId, organization.id)
+      )
+      .groupBy(
+        organizationSubscriptions.plan,
+        organizationSubscriptions.status
+      );
+
+    // Per-org executions in the last 30 days + current month. We compute
+    // both windows in one query using FILTER clauses, then bucket free orgs
+    // in JS to keep the SQL straightforward. Anonymous workflows (no
+    // organization) are excluded — they're already covered by ANONYMOUS_ORG_SLUG
+    // in the per-org error gauge.
+    const execByOrgResult = await db
+      .select({
+        orgSlug: organization.slug,
+        plan: organizationSubscriptions.plan,
+        tier: organizationSubscriptions.tier,
+        exec30d: count(),
+        execMonth: sql<string>`COUNT(*) FILTER (WHERE ${workflowExecutions.startedAt} >= date_trunc('month', NOW()))`,
+      })
+      .from(workflowExecutions)
+      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+      .innerJoin(organization, eq(workflows.organizationId, organization.id))
+      .leftJoin(
+        organizationSubscriptions,
+        eq(organizationSubscriptions.organizationId, organization.id)
+      )
+      .where(sql`${workflowExecutions.startedAt} >= NOW() - INTERVAL '30 days'`)
+      .groupBy(
+        organization.slug,
+        organizationSubscriptions.plan,
+        organizationSubscriptions.tier
+      );
+
+    // Active-subscription tier list for MRR computation. We include past_due
+    // because those orgs are still on the plan; only canceled/unpaid/paused
+    // are excluded.
+    const mrrSubsResult = await db
+      .select({
+        plan: organizationSubscriptions.plan,
+        tier: organizationSubscriptions.tier,
+      })
+      .from(organizationSubscriptions)
+      .where(
+        sql`${organizationSubscriptions.status} IN ('active', 'trialing', 'past_due')`
+      );
+
+    const stats = emptyBillingStats();
+
+    // Tally orgs by plan + billing_status
+    for (const row of orgsByPlanResult) {
+      const plan = parsePlanName(row.plan, "free");
+      const status: BillingStatus =
+        row.status === null ? "none" : parseBillingStatus(row.status);
+      const planBucket = stats.orgsByPlan[plan];
+      planBucket[status] = (planBucket[status] ?? 0) + Number(row.count);
+    }
+
+    // Tally per-org executions, bucketing free orgs into a single series
+    let freeExec30d = 0;
+    let freeExecMonth = 0;
+    for (const row of execByOrgResult) {
+      const plan = parsePlanName(row.plan, "free");
+      const tier = parseTierKey(row.tier);
+      const exec30d = Number(row.exec30d) || 0;
+      const execMonth = Number(row.execMonth) || 0;
+
+      if (plan === "free") {
+        freeExec30d += exec30d;
+        freeExecMonth += execMonth;
+        continue;
+      }
+
+      const monthlyLimit = PLANS[plan].features.maxExecutionsPerMonth;
+      const tierLimit =
+        tier === null
+          ? monthlyLimit
+          : (PLANS[plan].tiers.find((t) => t.key === tier)?.executions ??
+            monthlyLimit);
+
+      stats.orgsExecutions.push({
+        orgSlug: row.orgSlug,
+        plan,
+        exec30d,
+        execMonth,
+        monthlyLimit: tierLimit,
+      });
+    }
+
+    // Free aggregate row: plan=free, monthlyLimit from free defaults
+    if (freeExec30d > 0 || freeExecMonth > 0) {
+      stats.orgsExecutions.push({
+        orgSlug: FREE_ORG_AGGREGATE_SLUG,
+        plan: "free",
+        exec30d: freeExec30d,
+        execMonth: freeExecMonth,
+        monthlyLimit: PLANS.free.features.maxExecutionsPerMonth,
+      });
+    }
+
+    // Compute MRR per plan from active subscriptions × tier price
+    for (const row of mrrSubsResult) {
+      const plan = parsePlanName(row.plan, "free");
+      const tier = parseTierKey(row.tier);
+      const cents = tierMonthlyPriceCents(plan, tier);
+      stats.mrrCentsByPlan[plan] += cents;
+      stats.mrrCentsTotal += cents;
+    }
+
+    return stats;
+  } catch (error) {
+    console.error("[Metrics] Failed to query billing stats from DB:", error);
+    return emptyBillingStats();
   }
 }
 

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -140,6 +140,15 @@ export const MetricNames = {
   SPONSORSHIP_GAS_USED_TOTAL: "sponsorship.gas_used.total",
   SPONSORSHIP_GAS_COST_USD_MICRO_TOTAL: "sponsorship.gas_cost_usd_micro.total",
 
+  // Billing lifecycle counters (API-process, emitted from webhook handler)
+  BILLING_SUBSCRIPTION_CREATED: "billing.subscription.created",
+  BILLING_SUBSCRIPTION_UPDATED: "billing.subscription.updated",
+  BILLING_SUBSCRIPTION_CANCELED: "billing.subscription.canceled",
+  BILLING_SUBSCRIPTION_PLAN_CHANGED: "billing.subscription.plan_changed",
+  BILLING_INVOICE_PAID: "billing.invoice.paid",
+  BILLING_INVOICE_FAILED: "billing.invoice.failed",
+  BILLING_OVERAGE_CHARGED: "billing.overage.charged",
+
   // Saturation metrics
   DB_POOL_UTILIZATION: "db.pool.utilization",
   DB_QUERY_SLOW_COUNT: "db.query.slow_count",
@@ -171,6 +180,8 @@ export const LabelKeys = {
   ERROR_CATEGORY: "error_category",
   ERROR_CONTEXT: "error_context",
   IS_USER_ERROR: "is_user_error",
+  BILLING_STATUS: "billing_status",
+  TIER: "tier",
 } as const;
 
 /**
@@ -182,3 +193,17 @@ export type TriggerType = "manual" | "webhook" | "scheduled";
  * Execution status values
  */
 export type ExecutionStatus = "success" | "failure" | "timeout" | "cancelled";
+
+/**
+ * Subscription billing status values reported as the `billing_status` label.
+ * Mirrors organization_subscriptions.status, plus "none" for orgs that have
+ * no subscription row (legacy / pre-billing).
+ */
+export type BillingStatus =
+  | "active"
+  | "trialing"
+  | "past_due"
+  | "canceled"
+  | "unpaid"
+  | "paused"
+  | "none";


### PR DESCRIPTION
## Summary

Adds billing-aware Prometheus metrics so Grafana can answer: how many orgs are on each plan, which paid orgs are about to hit their limit, what's the run volume per org, and is subscription churn / invoice failure trending the wrong way.

- Extends \`keeperhub_org_info\` with \`plan\` and \`billing_status\` labels (one series per org, used by the Organization Directory table)
- New DB-sourced gauges: \`org_total_by_plan\`, \`org_executions_30d\`, \`org_executions_month\`, \`org_plan_usage_ratio\`, \`mrr_usd_cents\` per plan + total
- New API-process counters from the Stripe webhook handler: subscription created/updated/canceled, plan_changed (with upgrade/downgrade/tier_change direction), invoice paid/failed, overage charged
- Cardinality control: paid orgs (pro/business/enterprise) emit individual per-org series; free-tier orgs aggregate under \`org_slug=\"_free\"\` to keep Prometheus storage bounded
- \`lib/metrics/METRICS_REFERENCE.md\` gains a Billing section with the full label map and MRR caveat (Stripe Dashboard remains source of truth for accounting)

The companion Grafana dashboard PR (techops-infrastructure) extends the existing Organization Directory panel with Plan / Billing Status / Runs (30d) / Plan Usage % columns and adds a collapsed Billing & Plans row.

Closes [KEEP-417](https://linear.app/keeperhubapp/issue/KEEP-417/add-billing-metrics-and-update-grafana-dashboard).

## Test plan

- [x] \`pnpm type-check\` clean
- [x] \`pnpm exec biome check\` clean on touched files
- [x] All 116 existing unit tests pass (\`tests/unit/billing-*.test.ts\` + \`tests/unit/*-metrics.test.ts\`)
- [ ] After merge: verify new metrics show up at \`/api/metrics/db\` and \`/api/metrics/api\` in staging
- [ ] After Grafana PR merges: verify Organization Directory table shows the new columns and the Billing & Plans row renders without errors