### PR TITLE
chore(prod): enable NEXT_PUBLIC_BILLING_ENABLED

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -312,7 +312,7 @@ env:
   # Billing (Stripe)
   NEXT_PUBLIC_BILLING_ENABLED:
     type: kv
-    value: "false"
+    value: "true"
   NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED:
     type: kv
     value: "false"


### PR DESCRIPTION
## Summary
- Flip `NEXT_PUBLIC_BILLING_ENABLED` from `"false"` to `"true"` in `deploy/keeperhub/prod/values.yaml` to match staging.

## Test plan
- [ ] Verify prod deployment picks up the new env value
- [ ] Confirm billing UI is enabled in prod after rollout