### PR TITLE
refactor(agentic-wallet): rename c to challengeFields in deriveApprovalBinding

### DIFF
--- a/lib/agentic-wallet/approval.ts
+++ b/lib/agentic-wallet/approval.ts
@@ -76,17 +76,17 @@ export function deriveApprovalBinding(
   if (!challenge || typeof challenge !== "object" || Array.isArray(challenge)) {
     return null;
   }
-  const c = challenge as Record<string, unknown>;
+  const challengeFields = challenge as Record<string, unknown>;
 
   const recipient =
     chain === "base"
-      ? String(c.payTo ?? "")
-      : String(c.payTo ?? c.recipient ?? "");
+      ? String(challengeFields.payTo ?? "")
+      : String(challengeFields.payTo ?? challengeFields.recipient ?? "");
   if (!recipient) {
     return null;
   }
 
-  const rawAmount = c.amount;
+  const rawAmount = challengeFields.amount;
   if (rawAmount === undefined || rawAmount === null) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Rename the single-letter `c` alias to `challengeFields` inside `deriveApprovalBinding` so the recipient/amount field reads (`challengeFields.payTo`, `challengeFields.amount`, `challengeFields.recipient`) are self-documenting.
- Pure local rename. No behavior change. Callers (`/api/agentic-wallet/sign`, `/api/agentic-wallet/approval-request`, `checkApprovalForResolve`) and existing tests untouched.

## Test plan
- [ ] CI lint + type-check pass
- [ ] Existing agentic-wallet approval tests still green