### PR TITLE
fix(billing): enforce execution-limit guard on all trigger types

### DIFF
--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
@@ -150,6 +151,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   let body: Record<string, unknown>;

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
 import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
@@ -155,6 +156,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   let body: Record<string, unknown>;

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { db } from "@/lib/db";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { integrations } from "@/lib/db/schema";
@@ -379,6 +380,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   let body: unknown;

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
 import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
@@ -33,6 +34,12 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  // 2.5 Plan execution-limit guard
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   // 3. Parse body

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -1,0 +1,143 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import {
+  getPlanLimits,
+  PLANS,
+  type PlanName,
+  parsePlanName,
+  parseTierKey,
+} from "../lib/billing/plans";
+import {
+  executionDebt,
+  organizationSubscriptions,
+  workflowExecutions,
+  workflows,
+} from "../lib/db/schema";
+
+const MINIMUM_EXECUTION_FLOOR = 100;
+
+export type BillingGuardResult =
+  | {
+      allowed: true;
+      reason:
+        | "billing_disabled"
+        | "no_org"
+        | "unlimited"
+        | "within_limit"
+        | "overage_billed";
+    }
+  | {
+      allowed: false;
+      reason: "free_limit_exceeded" | "inactive_subscription" | "active_debt";
+      plan: PlanName;
+      used: number;
+      limit: number;
+      debtExecutions: number;
+      effectiveLimit: number;
+    };
+
+function isBillingEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_BILLING_ENABLED === "true";
+}
+
+/**
+ * Mirrors lib/billing/plans-server.ts#checkExecutionLimit but without the
+ * `import "server-only"` constraint so it can run in the standalone executor
+ * process. The result determines whether a workflow execution row should be
+ * created for an SQS-triggered run (schedule, block, event).
+ */
+export async function checkExecutionLimitForExecutor(
+  db: PostgresJsDatabase<Record<string, unknown>>,
+  organizationId: string | null | undefined
+): Promise<BillingGuardResult> {
+  if (!isBillingEnabled()) {
+    return { allowed: true, reason: "billing_disabled" };
+  }
+
+  if (!organizationId) {
+    return { allowed: true, reason: "no_org" };
+  }
+
+  const [sub] = await db
+    .select({
+      plan: organizationSubscriptions.plan,
+      tier: organizationSubscriptions.tier,
+      status: organizationSubscriptions.status,
+      planOverrides: organizationSubscriptions.planOverrides,
+    })
+    .from(organizationSubscriptions)
+    .where(eq(organizationSubscriptions.organizationId, organizationId))
+    .limit(1);
+
+  const plan = parsePlanName(sub?.plan);
+  const tier = parseTierKey(sub?.tier);
+  const limits = getPlanLimits(plan, tier, sub?.planOverrides);
+  const planDef = PLANS[plan];
+
+  if (limits.maxExecutionsPerMonth === -1) {
+    return { allowed: true, reason: "unlimited" };
+  }
+
+  const debtRows = await db
+    .select({ debt: executionDebt.debtExecutions })
+    .from(executionDebt)
+    .where(
+      and(
+        eq(executionDebt.organizationId, organizationId),
+        eq(executionDebt.status, "active")
+      )
+    );
+  const debtExecutions = debtRows.reduce((sum, r) => sum + (r.debt ?? 0), 0);
+  const effectiveLimit = Math.max(
+    MINIMUM_EXECUTION_FLOOR,
+    limits.maxExecutionsPerMonth - debtExecutions
+  );
+
+  if (debtExecutions > 0 && planDef.overage.enabled) {
+    return {
+      allowed: false,
+      reason: "active_debt",
+      plan,
+      used: 0,
+      limit: limits.maxExecutionsPerMonth,
+      debtExecutions,
+      effectiveLimit,
+    };
+  }
+
+  const now = new Date();
+  const startOfMonth = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+  );
+
+  const [{ count }] = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(workflowExecutions)
+    .innerJoin(workflows, eq(workflows.id, workflowExecutions.workflowId))
+    .where(
+      and(
+        eq(workflows.organizationId, organizationId),
+        sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`
+      )
+    );
+
+  const used = count ?? 0;
+
+  if (used < limits.maxExecutionsPerMonth) {
+    return { allowed: true, reason: "within_limit" };
+  }
+
+  if (planDef.overage.enabled && sub?.status === "active") {
+    return { allowed: true, reason: "overage_billed" };
+  }
+
+  return {
+    allowed: false,
+    reason: "free_limit_exceeded",
+    plan,
+    used,
+    limit: limits.maxExecutionsPerMonth,
+    debtExecutions,
+    effectiveLimit,
+  };
+}

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -39,6 +39,7 @@ import {
 import { generateId } from "../lib/utils/id";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { executeViaApi } from "./api-execute";
+import { checkExecutionLimitForExecutor } from "./billing-guard";
 import { CONFIG } from "./config";
 import { resolveDispatchTarget } from "./execution-mode";
 import { executeInProcess } from "./in-process";
@@ -234,6 +235,17 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     if (!valid) {
       return;
     }
+  }
+
+  const billingResult = await checkExecutionLimitForExecutor(
+    db,
+    workflow.organizationId
+  );
+  if (!billingResult.allowed) {
+    console.warn(
+      `[Executor] Billing guard blocked ${triggerType} trigger for workflow ${workflowId}: org=${workflow.organizationId} plan=${billingResult.plan} used=${billingResult.used} limit=${billingResult.limit} effectiveLimit=${billingResult.effectiveLimit} debt=${billingResult.debtExecutions} reason=${billingResult.reason}`
+    );
+    return;
   }
 
   const executionId = generateId();


### PR DESCRIPTION
## Summary

The monthly plan-based execution-limit guard (`enforceExecutionLimit` / `checkExecutionLimit`) was only applied to **HTTP-triggered** workflow runs. Schedule, block, and event triggers (and the Direct Execution API endpoints) bypassed it entirely — so a free-tier org with a cron workflow could rack up 60k+ executions/month with no enforcement.

This PR closes those gaps so **every** path that creates an execution row goes through the guard before any DB write.

## What was unguarded

| Trigger / Endpoint | Insert site | Status before |
|---|---|---|
| Schedule (cron) → SQS | `keeperhub-executor/index.ts:243` | unguarded |
| Block trigger → SQS | same handler | unguarded |
| Event trigger → SQS | same handler | unguarded |
| `POST /api/execute/transfer` | `_lib/spending-cap.ts` insert | spend-cap only, no monthly count |
| `POST /api/execute/contract-call` | `_lib/spending-cap.ts` insert | spend-cap only |
| `POST /api/execute/check-and-execute` | `_lib/spending-cap.ts` insert | spend-cap only |
| `POST /api/execute/node` | `_lib/execution-service.ts` insert | spend-cap only |

## Changes

### `keeperhub-executor/billing-guard.ts` (new)
A runtime-agnostic mirror of `lib/billing/plans-server.ts#checkExecutionLimit`. The original cannot be imported into the standalone executor process because it has `import "server-only"`. The new helper:

- Honors `NEXT_PUBLIC_BILLING_ENABLED` (parity with `enforceExecutionLimit`)
- Reads `organization_subscriptions`, applies plan + tier + overrides via `getPlanLimits`
- Skips when plan is unlimited (`-1`)
- Sums active `execution_debt` and computes `effectiveLimit = max(MINIMUM_EXECUTION_FLOOR=100, limit - debt)` for parity with the canonical result shape
- Returns `{ allowed, reason, plan?, used?, limit?, debtExecutions?, effectiveLimit? }`

### `keeperhub-executor/index.ts`
Calls the new guard inside `processExecutorMessage` after workflow validation and **before** the `workflow_executions` insert (which previously made the row count against the monthly limit no matter what). When blocked: `console.warn` (user-error severity, not system) and `return` so the SQS message is deleted — no retry, since the limit won't reset on the SQS visibility timer.

### `app/api/execute/{transfer,contract-call,check-and-execute,node}/route.ts`
Adds `enforceExecutionLimit(apiKeyCtx.organizationId)` right after the rate-limit check and before any DB writes. Blocked path returns the canonical 429 from `enforceExecutionLimit` (already the same shape as the rest of the API).

`app/api/execute/swap/route.ts` is skipped — currently returns 501 "Coming soon".

## Coverage check

All 9 execution-row insert sites are now gated:

| File | Guarded by |
|---|---|
| `keeperhub-executor/index.ts:255` | `checkExecutionLimitForExecutor` (this PR) |
| `app/api/internal/executions/route.ts:43` | `enforceExecutionLimit` (existing, L37) |
| `app/api/workflows/[workflowId]/webhook/route.ts:271` | existing, L233 |
| `app/api/mcp/workflows/[slug]/call/route.ts:110` | existing, L84 |
| `app/api/workflow/[workflowId]/execute/route.ts:194,206` | existing, L158 |
| `app/api/execute/_lib/spending-cap.ts:59,95` | this PR (callers in 3 routes) |
| `app/api/execute/_lib/execution-service.ts:30` | this PR (caller in node route) |

## Error classification

All blocked paths use **user-error severity** — none route through `logSystemError`:

- HTTP routes: return 429 directly via early-return; outer `try/catch`s with `logSystemError` are not reached.
- Executor: `console.warn` (matches `logUserError`'s console behavior); the wrapping `processMessage` catch only fires on thrown errors.

So billing-blocked executions will not page DevOps.

## Test plan

- [ ] Locally trigger a workflow execution via webhook for an org over its plan limit; expect 429
- [ ] Locally trigger a scheduled run for an org over its plan limit; expect no `workflow_executions` row inserted, `[Executor] Billing guard blocked schedule trigger ...` log entry, SQS message deleted
- [ ] Hit `/api/execute/transfer` for an over-limit org; expect 429
- [ ] Hit `/api/execute/contract-call`, `/api/execute/check-and-execute`, `/api/execute/node` for an over-limit org; expect 429
- [ ] Confirm under-limit calls on each endpoint still succeed
- [ ] Verify enterprise-plan org (unlimited) is unaffected
- [ ] After deploy, watch prod metrics: free-tier orgs should stop crossing 5,000 executions/month on schedule triggers

## Related

- KEEP-433 (separate PR/SQL): backfill default `free`/`active` rows for the 368 prod orgs missing a subscription row, with enterprise upserts for Sky and Ajna. SQL written at `../sql/billing-backfill/backfill-free-subscriptions.sql` (out-of-tree); not run yet.