### PR TITLE
fix(billing): enforce execution-limit guard on all trigger types

### DIFF
--- a/app/api/billing/subscription/route.ts
+++ b/app/api/billing/subscription/route.ts
@@ -15,8 +15,8 @@ import { db } from "@/lib/db";
 import { overageBillingRecords } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
-  type OrganizationAuthContext,
   auditFromAuth,
+  type OrganizationAuthContext,
   resolveOrganizationId,
 } from "@/lib/middleware/auth-helpers";
 
@@ -50,11 +50,21 @@ export async function GET(request: Request): Promise<NextResponse> {
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
     );
     const usageResult = await db.execute<{ count: number }>(
-      sql`SELECT COUNT(*)::int as count
-          FROM workflow_executions we
-          JOIN workflows w ON we.workflow_id = w.id
-          WHERE w.organization_id = ${activeOrgId}
-          AND we.started_at >= ${startOfMonth.toISOString()}`
+      sql`SELECT
+            (
+              SELECT COUNT(*)
+                FROM workflow_executions we
+                JOIN workflows w ON we.workflow_id = w.id
+               WHERE w.organization_id = ${activeOrgId}
+                 AND we.started_at >= ${startOfMonth.toISOString()}
+            )
+            +
+            (
+              SELECT COUNT(*)
+                FROM direct_executions de
+               WHERE de.organization_id = ${activeOrgId}
+                 AND de.created_at >= ${startOfMonth.toISOString()}
+            ) AS count`
     );
     const executionsUsed = usageResult[0]?.count ?? 0;
 

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
@@ -150,6 +151,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   let body: Record<string, unknown>;

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
 import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
@@ -155,6 +156,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   let body: Record<string, unknown>;

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { db } from "@/lib/db";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { integrations } from "@/lib/db/schema";
@@ -379,6 +380,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   let body: unknown;

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
 import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
@@ -33,6 +34,12 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  // 2.5 Plan execution-limit guard
+  const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
   }
 
   // 3. Parse body

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -1,0 +1,143 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import {
+  getPlanLimits,
+  PLANS,
+  type PlanName,
+  parsePlanName,
+  parseTierKey,
+} from "../lib/billing/plans";
+import {
+  executionDebt,
+  organizationSubscriptions,
+  workflowExecutions,
+  workflows,
+} from "../lib/db/schema";
+
+const MINIMUM_EXECUTION_FLOOR = 100;
+
+export type BillingGuardResult =
+  | {
+      allowed: true;
+      reason:
+        | "billing_disabled"
+        | "no_org"
+        | "unlimited"
+        | "within_limit"
+        | "overage_billed";
+    }
+  | {
+      allowed: false;
+      reason: "free_limit_exceeded" | "inactive_subscription" | "active_debt";
+      plan: PlanName;
+      used: number;
+      limit: number;
+      debtExecutions: number;
+      effectiveLimit: number;
+    };
+
+function isBillingEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_BILLING_ENABLED === "true";
+}
+
+/**
+ * Mirrors lib/billing/plans-server.ts#checkExecutionLimit but without the
+ * `import "server-only"` constraint so it can run in the standalone executor
+ * process. The result determines whether a workflow execution row should be
+ * created for an SQS-triggered run (schedule, block, event).
+ */
+export async function checkExecutionLimitForExecutor(
+  db: PostgresJsDatabase<Record<string, unknown>>,
+  organizationId: string | null | undefined
+): Promise<BillingGuardResult> {
+  if (!isBillingEnabled()) {
+    return { allowed: true, reason: "billing_disabled" };
+  }
+
+  if (!organizationId) {
+    return { allowed: true, reason: "no_org" };
+  }
+
+  const [sub] = await db
+    .select({
+      plan: organizationSubscriptions.plan,
+      tier: organizationSubscriptions.tier,
+      status: organizationSubscriptions.status,
+      planOverrides: organizationSubscriptions.planOverrides,
+    })
+    .from(organizationSubscriptions)
+    .where(eq(organizationSubscriptions.organizationId, organizationId))
+    .limit(1);
+
+  const plan = parsePlanName(sub?.plan);
+  const tier = parseTierKey(sub?.tier);
+  const limits = getPlanLimits(plan, tier, sub?.planOverrides);
+  const planDef = PLANS[plan];
+
+  if (limits.maxExecutionsPerMonth === -1) {
+    return { allowed: true, reason: "unlimited" };
+  }
+
+  const debtRows = await db
+    .select({ debt: executionDebt.debtExecutions })
+    .from(executionDebt)
+    .where(
+      and(
+        eq(executionDebt.organizationId, organizationId),
+        eq(executionDebt.status, "active")
+      )
+    );
+  const debtExecutions = debtRows.reduce((sum, r) => sum + (r.debt ?? 0), 0);
+  const effectiveLimit = Math.max(
+    MINIMUM_EXECUTION_FLOOR,
+    limits.maxExecutionsPerMonth - debtExecutions
+  );
+
+  if (debtExecutions > 0 && planDef.overage.enabled) {
+    return {
+      allowed: false,
+      reason: "active_debt",
+      plan,
+      used: 0,
+      limit: limits.maxExecutionsPerMonth,
+      debtExecutions,
+      effectiveLimit,
+    };
+  }
+
+  const now = new Date();
+  const startOfMonth = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+  );
+
+  const [{ count }] = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(workflowExecutions)
+    .innerJoin(workflows, eq(workflows.id, workflowExecutions.workflowId))
+    .where(
+      and(
+        eq(workflows.organizationId, organizationId),
+        sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`
+      )
+    );
+
+  const used = count ?? 0;
+
+  if (used < limits.maxExecutionsPerMonth) {
+    return { allowed: true, reason: "within_limit" };
+  }
+
+  if (planDef.overage.enabled && sub?.status === "active") {
+    return { allowed: true, reason: "overage_billed" };
+  }
+
+  return {
+    allowed: false,
+    reason: "free_limit_exceeded",
+    plan,
+    used,
+    limit: limits.maxExecutionsPerMonth,
+    debtExecutions,
+    effectiveLimit,
+  };
+}

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -8,6 +8,7 @@ import {
   parseTierKey,
 } from "../lib/billing/plans";
 import {
+  directExecutions,
   executionDebt,
   organizationSubscriptions,
   workflowExecutions,
@@ -110,7 +111,7 @@ export async function checkExecutionLimitForExecutor(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
   );
 
-  const [{ count }] = await db
+  const [workflowCountRow] = await db
     .select({ count: sql<number>`COUNT(*)::int` })
     .from(workflowExecutions)
     .innerJoin(workflows, eq(workflows.id, workflowExecutions.workflowId))
@@ -121,7 +122,17 @@ export async function checkExecutionLimitForExecutor(
       )
     );
 
-  const used = count ?? 0;
+  const [directCountRow] = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(directExecutions)
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        sql`${directExecutions.createdAt} >= ${startOfMonth.toISOString()}`
+      )
+    );
+
+  const used = (workflowCountRow?.count ?? 0) + (directCountRow?.count ?? 0);
 
   if (used < limits.maxExecutionsPerMonth) {
     return { allowed: true, reason: "within_limit" };

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -39,6 +39,7 @@ import {
 import { generateId } from "../lib/utils/id";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { executeViaApi } from "./api-execute";
+import { checkExecutionLimitForExecutor } from "./billing-guard";
 import { CONFIG } from "./config";
 import { resolveDispatchTarget } from "./execution-mode";
 import { executeInProcess } from "./in-process";
@@ -234,6 +235,17 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     if (!valid) {
       return;
     }
+  }
+
+  const billingResult = await checkExecutionLimitForExecutor(
+    db,
+    workflow.organizationId
+  );
+  if (!billingResult.allowed) {
+    console.warn(
+      `[Executor] Billing guard blocked ${triggerType} trigger for workflow ${workflowId}: org=${workflow.organizationId} plan=${billingResult.plan} used=${billingResult.used} limit=${billingResult.limit} effectiveLimit=${billingResult.effectiveLimit} debt=${billingResult.debtExecutions} reason=${billingResult.reason}`
+    );
+    return;
   }
 
   const executionId = generateId();

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -66,14 +66,26 @@ export async function billOverageForOrg(
     return { billed: false, reason: "already billed for this period" };
   }
 
-  // Count executions for the period
+  // Count executions for the period (workflow + direct executions both count
+  // toward the monthly tier; mirror lib/billing/plans-server.ts#checkExecutionLimit)
   const result = await db.execute<{ count: number }>(
-    sql`SELECT COUNT(*)::int as count
-        FROM workflow_executions we
-        JOIN workflows w ON we.workflow_id = w.id
-        WHERE w.organization_id = ${organizationId}
-        AND we.started_at >= ${periodStart.toISOString()}
-        AND we.started_at < ${periodEnd.toISOString()}`
+    sql`SELECT
+          (
+            SELECT COUNT(*)
+              FROM workflow_executions we
+              JOIN workflows w ON we.workflow_id = w.id
+             WHERE w.organization_id = ${organizationId}
+               AND we.started_at >= ${periodStart.toISOString()}
+               AND we.started_at <  ${periodEnd.toISOString()}
+          )
+          +
+          (
+            SELECT COUNT(*)
+              FROM direct_executions de
+             WHERE de.organization_id = ${organizationId}
+               AND de.created_at >= ${periodStart.toISOString()}
+               AND de.created_at <  ${periodEnd.toISOString()}
+          ) AS count`
   );
 
   const totalExecutions = result[0]?.count ?? 0;

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -253,11 +253,21 @@ export async function checkExecutionLimit(
   );
 
   const result = await db.execute<{ count: number }>(
-    sql`SELECT COUNT(*)::int as count
-        FROM workflow_executions we
-        JOIN workflows w ON we.workflow_id = w.id
-        WHERE w.organization_id = ${organizationId}
-        AND we.started_at >= ${startOfMonth.toISOString()}`
+    sql`SELECT
+          (
+            SELECT COUNT(*)
+              FROM workflow_executions we
+              JOIN workflows w ON we.workflow_id = w.id
+             WHERE w.organization_id = ${organizationId}
+               AND we.started_at >= ${startOfMonth.toISOString()}
+          )
+          +
+          (
+            SELECT COUNT(*)
+              FROM direct_executions de
+             WHERE de.organization_id = ${organizationId}
+               AND de.created_at >= ${startOfMonth.toISOString()}
+          ) AS count`
   );
 
   const used = result[0]?.count ?? 0;

--- a/lib/billing/tier-suggestions.ts
+++ b/lib/billing/tier-suggestions.ts
@@ -52,11 +52,21 @@ export async function getUpgradeSuggestion(
   );
 
   const result = await db.execute<{ count: number }>(
-    sql`SELECT COUNT(*)::int as count
-        FROM workflow_executions we
-        JOIN workflows w ON we.workflow_id = w.id
-        WHERE w.organization_id = ${organizationId}
-        AND we.started_at >= ${startOfMonth.toISOString()}`
+    sql`SELECT
+          (
+            SELECT COUNT(*)
+              FROM workflow_executions we
+              JOIN workflows w ON we.workflow_id = w.id
+             WHERE w.organization_id = ${organizationId}
+               AND we.started_at >= ${startOfMonth.toISOString()}
+          )
+          +
+          (
+            SELECT COUNT(*)
+              FROM direct_executions de
+             WHERE de.organization_id = ${organizationId}
+               AND de.created_at >= ${startOfMonth.toISOString()}
+          ) AS count`
   );
 
   const currentUsage = result[0]?.count ?? 0;

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -65,6 +65,15 @@ vi.mock("@/app/api/execute/_lib/wallet-check", () => ({
   requireWallet: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: vi
+    .fn()
+    .mockResolvedValue({ blocked: false, limitResult: null }),
+  EXECUTION_LIMIT_ERROR: "Monthly execution limit exceeded",
+  EXECUTION_DEBT_ERROR:
+    "Executions suspended due to unpaid overage invoice. Please update your payment method.",
+}));
+
 vi.mock("@/lib/utils", () => ({
   getErrorMessage: (err: unknown) =>
     err instanceof Error ? err.message : String(err),

--- a/tests/unit/check-and-execute-routing.test.ts
+++ b/tests/unit/check-and-execute-routing.test.ts
@@ -66,6 +66,15 @@ vi.mock("@/app/api/execute/_lib/wallet-check", () => ({
   requireWallet: (...args: unknown[]) => mockRequireWallet(...args),
 }));
 
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: vi
+    .fn()
+    .mockResolvedValue({ blocked: false, limitResult: null }),
+  EXECUTION_LIMIT_ERROR: "Monthly execution limit exceeded",
+  EXECUTION_DEBT_ERROR:
+    "Executions suspended due to unpaid overage invoice. Please update your payment method.",
+}));
+
 // Import SUT after all mocks
 import { POST } from "@/app/api/execute/check-and-execute/route";
 


### PR DESCRIPTION
## Summary

Two related fixes that close a billing-enforcement hole and tighten the count semantics:

**1) Enforce the monthly execution-limit guard on every trigger type.** The guard (`enforceExecutionLimit` / `checkExecutionLimit`) was only applied to HTTP-triggered workflow runs. Schedule, block, and event triggers (and the Direct Execution API endpoints) bypassed it entirely — so a free-tier org with a cron workflow could rack up 60k+ executions/month with no enforcement.

**2) Make `direct_executions` count toward the monthly tier.** The Direct Execution API has its own daily gas spend cap, but its calls were never counted against the org's monthly execution tier. So even after the guard above was wired in, a paid org could exhaust its tier on workflows and then keep hammering `/api/execute/*` freely (and the overage billing pipeline would under-charge them).

After this PR, **every** path that creates an execution row goes through the guard before any DB write, and the canonical "used this month" value is `COUNT(workflow_executions) + COUNT(direct_executions)`.

## What was unguarded (closed by this PR)

| Trigger / Endpoint | Insert site | Status before |
|---|---|---|
| Schedule (cron) → SQS | `keeperhub-executor/index.ts:243` | unguarded |
| Block trigger → SQS | same handler | unguarded |
| Event trigger → SQS | same handler | unguarded |
| `POST /api/execute/transfer` | `_lib/spending-cap.ts` insert | spend-cap only, no monthly count |
| `POST /api/execute/contract-call` | `_lib/spending-cap.ts` insert | spend-cap only |
| `POST /api/execute/check-and-execute` | `_lib/spending-cap.ts` insert | spend-cap only |
| `POST /api/execute/node` | `_lib/execution-service.ts` insert | spend-cap only |

## Changes

### Guard wiring

#### `keeperhub-executor/billing-guard.ts` (new)
A runtime-agnostic mirror of `lib/billing/plans-server.ts#checkExecutionLimit`. The original cannot be imported into the standalone executor process because it has `import "server-only"`. The new helper:

- Honors `NEXT_PUBLIC_BILLING_ENABLED` (parity with `enforceExecutionLimit`)
- Reads `organization_subscriptions`, applies plan + tier + overrides via `getPlanLimits`
- Skips when plan is unlimited (`-1`)
- Sums active `execution_debt` and computes `effectiveLimit = max(MINIMUM_EXECUTION_FLOOR=100, limit - debt)` for parity with the canonical result shape
- Returns `{ allowed, reason, plan?, used?, limit?, debtExecutions?, effectiveLimit? }`
- Counts `workflow_executions` AND `direct_executions` for the org this month

#### `keeperhub-executor/index.ts`
Calls the new guard inside `processExecutorMessage` after workflow validation and **before** the `workflow_executions` insert (which previously made the row count against the monthly limit no matter what). When blocked: `console.warn` (user-error severity, not system) and `return` so the SQS message is deleted — no retry, since the limit won't reset on the SQS visibility timer.

#### `app/api/execute/{transfer,contract-call,check-and-execute,node}/route.ts`
Adds `enforceExecutionLimit(apiKeyCtx.organizationId)` right after the rate-limit check and before any DB writes. Blocked path returns the canonical 429 from `enforceExecutionLimit`.

`app/api/execute/swap/route.ts` is skipped — currently returns 501 "Coming soon".

### Direct executions count toward the tier

Five places read the "used this month" value. All updated to do `COUNT(workflow_executions) + COUNT(direct_executions)` for the org in the relevant period:

| File | Role |
|---|---|
| `lib/billing/plans-server.ts` | canonical guard for HTTP routes |
| `keeperhub-executor/billing-guard.ts` | executor mirror (schedule / block / event) |
| `lib/billing/overage.ts` | end-of-period Stripe overage billing — was under-charging mixed-usage orgs |
| `lib/billing/tier-suggestions.ts` | upsell heuristic — was under-projecting usage |
| `app/api/billing/subscription/route.ts` | dashboard "executions used" widget |

Caveat: direct calls now have to **pass** the monthly-tier check, but they're still gated by their own daily spend cap on top. Reads still don't insert a row (so they don't contribute to the count today). If we want reads to count too, that's a follow-up.

## Coverage check

All 9 execution-row insert sites are now gated:

| File | Guarded by |
|---|---|
| `keeperhub-executor/index.ts:255` | `checkExecutionLimitForExecutor` (this PR) |
| `app/api/internal/executions/route.ts:43` | `enforceExecutionLimit` (existing, L37) |
| `app/api/workflows/[workflowId]/webhook/route.ts:271` | existing, L233 |
| `app/api/mcp/workflows/[slug]/call/route.ts:110` | existing, L84 |
| `app/api/workflow/[workflowId]/execute/route.ts:194,206` | existing, L158 |
| `app/api/execute/_lib/spending-cap.ts:59,95` | this PR (callers in 3 routes) |
| `app/api/execute/_lib/execution-service.ts:30` | this PR (caller in node route) |

## Error classification

All blocked paths use **user-error severity** — none route through `logSystemError`:

- HTTP routes: return 429 directly via early-return; outer `try/catch`s with `logSystemError` are not reached.
- Executor: `console.warn` (matches `logUserError`'s console behavior); the wrapping `processMessage` catch only fires on thrown errors.

So billing-blocked executions will not page DevOps.

## Tests

- Existing `tests/unit/check-and-execute-routing.test.ts` and `tests/integration/direct-execution-api.test.ts` updated with `vi.mock("@/lib/billing/execution-guard", ...)` so they don't fall through to the real DB after the new guard call was added to the routes. Same pattern as `tests/unit/x402-call-route.test.ts`.
- Local: 10 impacted test files / 194 tests pass, lint and type-check clean.
- No new test added for the block path itself — tracked as a follow-up.

## Known limitations / follow-ups (not in this PR)

- **TOCTOU race**: the guard is check-then-act, not atomic. Bounded overshoot is small; advisory-lock fix is a one-day follow-up if metrics show real overshoot.
- **No user-side feedback for SQS-triggered blocks**: schedule/block/event drops are silent today (no row, no UI signal). HTTP routes return 429 but the workflow's run history doesn't show the attempt. Addressed in stacked follow-up #1140 which inserts `status='blocked_billing'` rows so blocked attempts are visible in the existing execution-history UI.
- **Direct executions don't count, but reads still don't insert**: only writes hit the spend-cap insert path. If product wants reads to count too, that's a small change (one unconditional insert).

## Test plan

- [ ] Locally trigger a workflow execution via webhook for an org over its plan limit; expect 429
- [ ] Locally trigger a scheduled run for an org over its plan limit; expect no `workflow_executions` row inserted, `[Executor] Billing guard blocked schedule trigger ...` log entry, SQS message deleted
- [ ] Hit `/api/execute/transfer` for an over-limit org; expect 429
- [ ] Hit `/api/execute/contract-call`, `/api/execute/check-and-execute`, `/api/execute/node` for an over-limit org; expect 429
- [ ] Mix workflow + direct calls until the org crosses its monthly limit; confirm subsequent calls (of either type) are blocked
- [ ] Confirm under-limit calls on each endpoint still succeed
- [ ] Verify enterprise-plan org (unlimited) is unaffected
- [ ] After deploy, watch prod metrics: free-tier orgs should stop crossing 5,000 executions/month on schedule triggers
- [ ] After deploy, verify dashboard "executions used" widget reflects workflow + direct totals

## Related

- KEEP-433 (separate PR/SQL): backfill default `free`/`active` rows for the 368 prod orgs missing a subscription row, with enterprise upserts for Sky and Ajna. SQL written at `../sql/billing-backfill/backfill-free-subscriptions.sql` (out-of-tree); not run yet.
- #1140 (stacked on this branch): records blocked attempts as `status='blocked_billing'` rows so users see them in execution history.