### PR TITLE
feat(billing): record blocked workflow attempts as visible execution rows

### DIFF
--- a/app/api/billing/subscription/route.ts
+++ b/app/api/billing/subscription/route.ts
@@ -57,6 +57,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                 JOIN workflows w ON we.workflow_id = w.id
                WHERE w.organization_id = ${activeOrgId}
                  AND we.started_at >= ${startOfMonth.toISOString()}
+                 AND we.status <> 'blocked_billing'
             )
             +
             (
@@ -64,6 +65,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                 FROM direct_executions de
                WHERE de.organization_id = ${activeOrgId}
                  AND de.created_at >= ${startOfMonth.toISOString()}
+                 AND de.status <> 'blocked_billing'
             ) AS count`
     );
     const executionsUsed = usageResult[0]?.count ?? 0;

--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
+import { recordBlockedWorkflowExecution } from "@/lib/billing/record-blocked-execution";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
@@ -36,6 +37,13 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const executionGuard = await enforceExecutionLimit(workflow.organizationId);
   if (executionGuard.blocked) {
+    await recordBlockedWorkflowExecution({
+      workflowId,
+      userId,
+      triggerType: "internal",
+      limitResult: executionGuard.limitResult,
+      input: input ?? undefined,
+    });
     return executionGuard.response;
   }
 

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
+import { recordBlockedWorkflowExecution } from "@/lib/billing/record-blocked-execution";
 import { db } from "@/lib/db";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { tags, workflowExecutions, workflows } from "@/lib/db/schema";
@@ -83,6 +84,12 @@ async function prepareExecution(
 ): Promise<{ executionId: string } | { error: NextResponse }> {
   const executionGuard = await enforceExecutionLimit(workflow.organizationId);
   if (executionGuard.blocked) {
+    await recordBlockedWorkflowExecution({
+      workflowId: workflow.id,
+      userId: workflow.userId,
+      triggerType: "mcp",
+      limitResult: executionGuard.limitResult,
+    });
     const guardBody = await executionGuard.response.json();
     return {
       error: NextResponse.json(guardBody, {

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { start } from "workflow/api";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
+import { recordBlockedWorkflowExecution } from "@/lib/billing/record-blocked-execution";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { getMetricsCollector } from "@/lib/metrics";
@@ -157,6 +158,12 @@ export async function POST(
 
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
+      await recordBlockedWorkflowExecution({
+        workflowId,
+        userId,
+        triggerType: isInternalExecution ? "internal" : "manual",
+        limitResult: executionGuard.limitResult,
+      });
       return executionGuard.response;
     }
 

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -11,6 +11,7 @@ import {
   EXECUTION_LIMIT_ERROR,
   enforceExecutionLimit,
 } from "@/lib/billing/execution-guard";
+import { recordBlockedWorkflowExecution } from "@/lib/billing/record-blocked-execution";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
@@ -237,6 +238,12 @@ export async function POST(
         durationMs: timer(),
         statusCode: 429,
         error: EXECUTION_LIMIT_ERROR,
+      });
+      await recordBlockedWorkflowExecution({
+        workflowId,
+        userId: workflow.userId,
+        triggerType: "webhook",
+        limitResult: executionGuard.limitResult,
       });
       const body = await executionGuard.response.json();
       return NextResponse.json(body, {

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -118,7 +118,8 @@ export async function checkExecutionLimitForExecutor(
     .where(
       and(
         eq(workflows.organizationId, organizationId),
-        sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`
+        sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`,
+        sql`${workflowExecutions.status} <> 'blocked_billing'`
       )
     );
 
@@ -128,7 +129,8 @@ export async function checkExecutionLimitForExecutor(
     .where(
       and(
         eq(directExecutions.organizationId, organizationId),
-        sql`${directExecutions.createdAt} >= ${startOfMonth.toISOString()}`
+        sql`${directExecutions.createdAt} >= ${startOfMonth.toISOString()}`,
+        sql`${directExecutions.status} <> 'blocked_billing'`
       )
     );
 
@@ -151,4 +153,38 @@ export async function checkExecutionLimitForExecutor(
     debtExecutions,
     effectiveLimit,
   };
+}
+
+/**
+ * Insert a workflow_executions row marking the SQS-triggered attempt as
+ * blocked by the billing guard so users can see why their schedule, block,
+ * or event trigger did not fire. Mirrors lib/billing/record-blocked-execution.ts
+ * but does not import "server-only" so it runs in the standalone executor.
+ *
+ * Count queries (in plans-server.ts and the four other read sites) exclude
+ * `status = 'blocked_billing'`, so these rows do NOT consume tier quota --
+ * otherwise they would self-multiply.
+ */
+export async function recordBlockedWorkflowExecutionForExecutor(
+  db: PostgresJsDatabase<Record<string, unknown>>,
+  params: {
+    workflowId: string;
+    userId: string;
+    triggerType: "schedule" | "block" | "event";
+    reason: string;
+    plan: string;
+    used: number;
+    limit: number;
+    input?: Record<string, unknown> | null;
+  }
+): Promise<void> {
+  const errorMessage = `Billing limit reached: ${params.reason} (used ${params.used}/${params.limit} on ${params.plan} plan)`;
+  await db.insert(workflowExecutions).values({
+    workflowId: params.workflowId,
+    userId: params.userId,
+    status: "blocked_billing",
+    error: errorMessage,
+    input: params.input ?? undefined,
+    completedAt: new Date(),
+  });
 }

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -39,7 +39,10 @@ import {
 import { generateId } from "../lib/utils/id";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { executeViaApi } from "./api-execute";
-import { checkExecutionLimitForExecutor } from "./billing-guard";
+import {
+  checkExecutionLimitForExecutor,
+  recordBlockedWorkflowExecutionForExecutor,
+} from "./billing-guard";
 import { CONFIG } from "./config";
 import { resolveDispatchTarget } from "./execution-mode";
 import { executeInProcess } from "./in-process";
@@ -245,6 +248,26 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     console.warn(
       `[Executor] Billing guard blocked ${triggerType} trigger for workflow ${workflowId}: org=${workflow.organizationId} plan=${billingResult.plan} used=${billingResult.used} limit=${billingResult.limit} effectiveLimit=${billingResult.effectiveLimit} debt=${billingResult.debtExecutions} reason=${billingResult.reason}`
     );
+    const blockedInput = buildInput(message);
+    const blockedUserId =
+      "userId" in message ? message.userId : workflow.userId;
+    try {
+      await recordBlockedWorkflowExecutionForExecutor(db, {
+        workflowId,
+        userId: blockedUserId,
+        triggerType,
+        reason: billingResult.reason,
+        plan: billingResult.plan,
+        used: billingResult.used,
+        limit: billingResult.limit,
+        input: toJsonSafe(blockedInput) as Record<string, unknown>,
+      });
+    } catch (recordError) {
+      console.error(
+        "[Executor] Failed to record blocked execution:",
+        recordError
+      );
+    }
     return;
   }
 

--- a/lib/billing/execution-guard.ts
+++ b/lib/billing/execution-guard.ts
@@ -12,6 +12,12 @@ type GuardAllowed = {
 type GuardBlocked = {
   blocked: true;
   response: NextResponse;
+  /**
+   * The underlying limit-check result. Surfaced on the blocked variant so
+   * callers can record the attempt as a `blocked_billing` row in the
+   * appropriate execution table for user-facing visibility.
+   */
+  limitResult: Extract<ExecutionLimitResult, { allowed: false }>;
 };
 
 export type ExecutionGuardResult = GuardAllowed | GuardBlocked;
@@ -53,6 +59,7 @@ export async function enforceExecutionLimit(
 
   return {
     blocked: true,
+    limitResult: result,
     response: NextResponse.json(
       {
         error: hasDebt ? EXECUTION_DEBT_ERROR : EXECUTION_LIMIT_ERROR,

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -77,6 +77,7 @@ export async function billOverageForOrg(
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${periodStart.toISOString()}
                AND we.started_at <  ${periodEnd.toISOString()}
+               AND we.status <> 'blocked_billing'
           )
           +
           (
@@ -85,6 +86,7 @@ export async function billOverageForOrg(
              WHERE de.organization_id = ${organizationId}
                AND de.created_at >= ${periodStart.toISOString()}
                AND de.created_at <  ${periodEnd.toISOString()}
+               AND de.status <> 'blocked_billing'
           ) AS count`
   );
 

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -260,6 +260,7 @@ export async function checkExecutionLimit(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
+               AND we.status <> 'blocked_billing'
           )
           +
           (
@@ -267,6 +268,7 @@ export async function checkExecutionLimit(
               FROM direct_executions de
              WHERE de.organization_id = ${organizationId}
                AND de.created_at >= ${startOfMonth.toISOString()}
+               AND de.status <> 'blocked_billing'
           ) AS count`
   );
 

--- a/lib/billing/record-blocked-execution.ts
+++ b/lib/billing/record-blocked-execution.ts
@@ -1,0 +1,152 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+import { directExecutions, workflowExecutions } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
+/**
+ * Trigger types that produce a workflow_executions row when blocked.
+ */
+export type WorkflowBlockedTrigger =
+  | "manual"
+  | "webhook"
+  | "mcp"
+  | "internal"
+  | "schedule"
+  | "block"
+  | "event";
+
+/**
+ * Trigger types that produce a direct_executions row when blocked.
+ */
+export type DirectBlockedTrigger =
+  | "transfer"
+  | "contract-call"
+  | "check-and-execute"
+  | "node";
+
+/**
+ * Subset of fields read off the guard's `limitResult` (when blocked). The
+ * call sites pass `executionGuard.limitResult` directly; we tolerate missing
+ * fields so test mocks that only set `{ blocked: true, response }` do not
+ * throw at runtime.
+ */
+type LimitSummary =
+  | {
+      debtExecutions?: number;
+      plan?: string;
+      used?: number;
+      limit?: number;
+    }
+  | null
+  | undefined;
+
+type WorkflowBlockedParams = {
+  workflowId: string;
+  userId: string;
+  triggerType: WorkflowBlockedTrigger;
+  limitResult: LimitSummary;
+  // biome-ignore lint/suspicious/noExplicitAny: trigger inputs vary by trigger type and are stored verbatim
+  input?: Record<string, any> | null;
+};
+
+type DirectBlockedParams = {
+  organizationId: string;
+  apiKeyId: string;
+  triggerType: DirectBlockedTrigger;
+  limitResult: LimitSummary;
+  network?: string | null;
+  // biome-ignore lint/suspicious/noExplicitAny: input is the redacted request body, structure varies
+  input?: Record<string, any> | null;
+};
+
+function summarize(limitResult: LimitSummary): {
+  reason: string;
+  plan: string;
+  used: number;
+  limit: number;
+} {
+  const debt = limitResult?.debtExecutions ?? 0;
+  return {
+    reason: debt > 0 ? "active_debt" : "free_limit_exceeded",
+    plan: limitResult?.plan ?? "unknown",
+    used: limitResult?.used ?? 0,
+    limit: limitResult?.limit ?? 0,
+  };
+}
+
+function buildErrorMessage(
+  reason: string,
+  plan: string,
+  used: number,
+  limit: number
+): string {
+  return `Billing limit reached: ${reason} (used ${used}/${limit} on ${plan} plan)`;
+}
+
+/**
+ * Insert a workflow_executions row marking the attempt as blocked by the
+ * billing guard. Surfaces the attempt in the workflow's execution history
+ * so users can see why their schedule / webhook / manual run did not fire.
+ *
+ * Count queries in lib/billing/plans-server.ts and the four other read sites
+ * exclude `status = 'blocked_billing'`, so these rows do NOT consume tier
+ * quota -- otherwise they would self-multiply.
+ */
+export async function recordBlockedWorkflowExecution(
+  params: WorkflowBlockedParams
+): Promise<void> {
+  const { reason, plan, used, limit } = summarize(params.limitResult);
+  try {
+    await db.insert(workflowExecutions).values({
+      workflowId: params.workflowId,
+      userId: params.userId,
+      status: "blocked_billing",
+      error: buildErrorMessage(reason, plan, used, limit),
+      input: params.input ?? undefined,
+      completedAt: new Date(),
+    });
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[Billing] Failed to record blocked workflow execution",
+      error,
+      {
+        workflow_id: params.workflowId,
+        trigger_type: params.triggerType,
+      }
+    );
+  }
+}
+
+/**
+ * Same as recordBlockedWorkflowExecution but for the Direct Execution API
+ * (which writes to direct_executions, not workflow_executions).
+ */
+export async function recordBlockedDirectExecution(
+  params: DirectBlockedParams
+): Promise<void> {
+  const { reason, plan, used, limit } = summarize(params.limitResult);
+  try {
+    await db.insert(directExecutions).values({
+      organizationId: params.organizationId,
+      apiKeyId: params.apiKeyId,
+      type: params.triggerType,
+      network: params.network ?? null,
+      status: "blocked_billing",
+      error: buildErrorMessage(reason, plan, used, limit),
+      input: params.input ?? undefined,
+      completedAt: new Date(),
+    });
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[Billing] Failed to record blocked direct execution",
+      error,
+      {
+        org_id: params.organizationId,
+        trigger_type: params.triggerType,
+      }
+    );
+  }
+}

--- a/lib/billing/tier-suggestions.ts
+++ b/lib/billing/tier-suggestions.ts
@@ -59,6 +59,7 @@ export async function getUpgradeSuggestion(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
+               AND we.status <> 'blocked_billing'
           )
           +
           (
@@ -66,6 +67,7 @@ export async function getUpgradeSuggestion(
               FROM direct_executions de
              WHERE de.organization_id = ${organizationId}
                AND de.created_at >= ${startOfMonth.toISOString()}
+               AND de.status <> 'blocked_billing'
           ) AS count`
   );
 

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -360,7 +360,7 @@ export const directExecutions = pgTable(
     input: jsonb("input").$type<any>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - execution result structure varies by execution type
     output: jsonb("output").$type<any>(),
-    status: text("status").notNull().default("pending"), // pending | running | completed | failed
+    status: text("status").notNull().default("pending"), // pending | running | completed | failed | blocked_billing
     transactionHash: text("transaction_hash"),
     network: text("network"),
     error: text("error"),

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -301,7 +301,14 @@ export const workflowExecutions = pgTable(
       .references(() => users.id),
     status: text("status")
       .notNull()
-      .$type<"pending" | "running" | "success" | "error" | "cancelled">(),
+      .$type<
+        | "pending"
+        | "running"
+        | "success"
+        | "error"
+        | "cancelled"
+        | "blocked_billing"
+      >(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     input: jsonb("input").$type<Record<string, any>>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -102,6 +102,11 @@ vi.mock("@/lib/billing/execution-guard", () => ({
   enforceExecutionLimit: mockEnforceExecutionLimit,
 }));
 
+vi.mock("@/lib/billing/record-blocked-execution", () => ({
+  recordBlockedWorkflowExecution: vi.fn().mockResolvedValue(undefined),
+  recordBlockedDirectExecution: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
   checkConcurrencyLimit: mockCheckConcurrency,
 }));

--- a/tests/unit/billing-record-blocked-execution.test.ts
+++ b/tests/unit/billing-record-blocked-execution.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { insertedRows, mockDb, mockLogSystemError } = vi.hoisted(() => {
+  const rows: Array<{ table: string; values: Record<string, unknown> }> = [];
+  const insert = vi.fn(
+    (schema: { _: { name: string } } | { name?: string }) => ({
+      values: vi.fn((values: Record<string, unknown>): Promise<void> => {
+        const tableName =
+          (schema as { _: { name: string } })._?.name ??
+          (schema as { name?: string }).name ??
+          "unknown";
+        rows.push({ table: tableName, values });
+        return Promise.resolve();
+      }),
+    })
+  );
+  return {
+    insertedRows: rows,
+    mockDb: { insert },
+    mockLogSystemError: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { _: { name: "workflow_executions" } },
+  directExecutions: { _: { name: "direct_executions" } },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: mockLogSystemError,
+}));
+
+import {
+  recordBlockedDirectExecution,
+  recordBlockedWorkflowExecution,
+} from "@/lib/billing/record-blocked-execution";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedRows.length = 0;
+});
+
+describe("recordBlockedWorkflowExecution", () => {
+  it("inserts a workflow_executions row with status='blocked_billing'", async () => {
+    await recordBlockedWorkflowExecution({
+      workflowId: "wf_1",
+      userId: "user_1",
+      triggerType: "schedule",
+      limitResult: {
+        plan: "free",
+        used: 5234,
+        limit: 5000,
+        debtExecutions: 0,
+      },
+    });
+
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0].table).toBe("workflow_executions");
+    expect(insertedRows[0].values).toMatchObject({
+      workflowId: "wf_1",
+      userId: "user_1",
+      status: "blocked_billing",
+    });
+    const error = insertedRows[0].values.error as string;
+    expect(error).toContain("free_limit_exceeded");
+    expect(error).toContain("5234/5000");
+    expect(error).toContain("free");
+  });
+
+  it("uses 'active_debt' reason when debtExecutions > 0", async () => {
+    await recordBlockedWorkflowExecution({
+      workflowId: "wf_1",
+      userId: "user_1",
+      triggerType: "manual",
+      limitResult: {
+        plan: "pro",
+        used: 30_000,
+        limit: 25_000,
+        debtExecutions: 1500,
+      },
+    });
+
+    const error = insertedRows[0].values.error as string;
+    expect(error).toContain("active_debt");
+  });
+
+  it("tolerates a missing limitResult (test-mock safety)", async () => {
+    await recordBlockedWorkflowExecution({
+      workflowId: "wf_1",
+      userId: "user_1",
+      triggerType: "webhook",
+      limitResult: null,
+    });
+
+    expect(insertedRows).toHaveLength(1);
+    const error = insertedRows[0].values.error as string;
+    expect(error).toContain("free_limit_exceeded");
+    expect(error).toContain("0/0");
+    expect(error).toContain("unknown");
+  });
+
+  it("does not throw when the DB insert fails -- swallows + logs", async () => {
+    mockDb.insert.mockImplementationOnce(() => ({
+      values: vi.fn(
+        (): Promise<void> => Promise.reject(new Error("fake db failure"))
+      ),
+    }));
+
+    await expect(
+      recordBlockedWorkflowExecution({
+        workflowId: "wf_1",
+        userId: "user_1",
+        triggerType: "event",
+        limitResult: { plan: "free", used: 1, limit: 1, debtExecutions: 0 },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "database",
+      "[Billing] Failed to record blocked workflow execution",
+      expect.any(Error),
+      expect.objectContaining({
+        workflow_id: "wf_1",
+        trigger_type: "event",
+      })
+    );
+  });
+});
+
+describe("recordBlockedDirectExecution", () => {
+  it("inserts a direct_executions row with status='blocked_billing' and the trigger type", async () => {
+    await recordBlockedDirectExecution({
+      organizationId: "org_1",
+      apiKeyId: "key_1",
+      triggerType: "transfer",
+      network: "ethereum",
+      limitResult: {
+        plan: "free",
+        used: 5001,
+        limit: 5000,
+        debtExecutions: 0,
+      },
+    });
+
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0].table).toBe("direct_executions");
+    expect(insertedRows[0].values).toMatchObject({
+      organizationId: "org_1",
+      apiKeyId: "key_1",
+      type: "transfer",
+      network: "ethereum",
+      status: "blocked_billing",
+    });
+  });
+
+  it("does not throw when the DB insert fails", async () => {
+    mockDb.insert.mockImplementationOnce(() => ({
+      values: vi.fn(
+        (): Promise<void> => Promise.reject(new Error("fake db failure"))
+      ),
+    }));
+
+    await expect(
+      recordBlockedDirectExecution({
+        organizationId: "org_1",
+        apiKeyId: "key_1",
+        triggerType: "contract-call",
+        limitResult: { plan: "free", used: 1, limit: 1, debtExecutions: 0 },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "database",
+      "[Billing] Failed to record blocked direct execution",
+      expect.any(Error),
+      expect.objectContaining({
+        org_id: "org_1",
+        trigger_type: "contract-call",
+      })
+    );
+  });
+});

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -923,6 +923,11 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
     EXECUTION_LIMIT_ERROR: "Monthly execution limit exceeded",
   }));
 
+  vi.mock("@/lib/billing/record-blocked-execution", () => ({
+    recordBlockedWorkflowExecution: vi.fn().mockResolvedValue(undefined),
+    recordBlockedDirectExecution: vi.fn().mockResolvedValue(undefined),
+  }));
+
   vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
     checkConcurrencyLimit: mockCheckConcurrencyLimit,
   }));

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -101,6 +101,11 @@ vi.mock("@/lib/billing/execution-guard", () => ({
   EXECUTION_LIMIT_ERROR: "Monthly execution limit exceeded",
 }));
 
+vi.mock("@/lib/billing/record-blocked-execution", () => ({
+  recordBlockedWorkflowExecution: vi.fn().mockResolvedValue(undefined),
+  recordBlockedDirectExecution: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
   checkConcurrencyLimit: mockCheckConcurrencyLimit,
 }));


### PR DESCRIPTION
Stacked on top of #1137. Targets `fix/billing-guard-all-execution-paths` (rebase / re-target to `staging` once #1137 lands).

## Summary

#1137 stopped over-tier executions from being created but left users with no signal: schedule/block/event triggers silently dropped, HTTP routes returned 429 but no row showed in the workflow's run history. Users seeing their cron stop firing had no way to tell why.

This PR makes every blocked attempt visible by inserting a `workflow_executions` row with a new `status = "blocked_billing"` and a descriptive error message, so the existing **Recent Executions** UI surfaces it natively — no frontend changes needed yet.

## Coverage

| Trigger | Recorded as blocked row? |
|---|---|
| Schedule (cron, SQS) | yes |
| Block trigger (SQS) | yes |
| Event trigger (SQS) | yes |
| Manual / API key | yes |
| Webhook | yes |
| MCP / marketplace / x402-paid | yes |
| Internal services | yes |
| `/api/execute/transfer` | **not in this PR** (per product call — can be added later) |
| `/api/execute/contract-call` | **not in this PR** |
| `/api/execute/check-and-execute` | **not in this PR** |
| `/api/execute/node` | **not in this PR** |

The helper for direct executions is implemented and exported (`recordBlockedDirectExecution`) but not wired into the routes.

## Implementation

### New status (no DB migration)
- `workflow_executions.status` type union extended with `"blocked_billing"` ([lib/db/schema.ts:304](lib/db/schema.ts#L304-L312))
- `direct_executions.status` documented value updated ([lib/db/schema-extensions.ts:363](lib/db/schema-extensions.ts#L363))
- Both columns are plain `text` — no migration required

### New helpers
- [lib/billing/record-blocked-execution.ts](lib/billing/record-blocked-execution.ts):
  - `recordBlockedWorkflowExecution(params)` — inserts into `workflow_executions`
  - `recordBlockedDirectExecution(params)` — inserts into `direct_executions`
  - Both swallow DB errors via `logSystemError` and tolerate missing/partial `limitResult` (test-safe)
  - Single `summarize(limitResult)` extracts `{ reason, plan, used, limit }` with safe defaults
- [keeperhub-executor/billing-guard.ts](keeperhub-executor/billing-guard.ts) — adds `recordBlockedWorkflowExecutionForExecutor` mirroring the workflow recorder for the standalone Node executor (no `import "server-only"`)

### Guard return type extended
[lib/billing/execution-guard.ts](lib/billing/execution-guard.ts) — `enforceExecutionLimit`'s blocked variant now exposes `limitResult` so callers pass it straight into the recorder. Backward compatible (existing call sites still work).

### Self-multiplication prevention
All 5 count-query read sites now filter `status <> 'blocked_billing'` so blocked rows do NOT consume tier quota:
- `lib/billing/plans-server.ts` (canonical guard)
- `keeperhub-executor/billing-guard.ts` (executor mirror)
- `lib/billing/overage.ts` (Stripe overage billing)
- `lib/billing/tier-suggestions.ts` (upsell heuristic)
- `app/api/billing/subscription/route.ts` (dashboard widget)

If we ever forget to filter, blocked rows would push `used` higher → more blocks → more rows. Lock-step covered.

## Tests

### New
[tests/unit/billing-record-blocked-execution.test.ts](tests/unit/billing-record-blocked-execution.test.ts) — 6 unit tests:
- inserts `workflow_executions` row with `status='blocked_billing'`
- uses `'active_debt'` reason when `debtExecutions > 0`
- tolerates `limitResult: null` (test-mock safety)
- swallows DB insert errors and routes them through `logSystemError`
- inserts `direct_executions` row with the trigger type
- swallows DB insert errors for direct executions

### Updated mocks (3 existing tests)
- `tests/integration/webhook-route.test.ts`
- `tests/unit/x402-call-route.test.ts`
- `tests/unit/mcp-meta-tools.test.ts`

Each gets a `vi.mock("@/lib/billing/record-blocked-execution", ...)` block so the new helper module isn't loaded (it imports `"server-only"`).

### Local verification
- 10 impacted test files / **171 tests pass**
- `pnpm type-check` clean
- `pnpm check` clean on all 18 modified files

## What users will see after this ships

- A schedule that exhausts its tier shows up in the workflow's **Recent Executions** with status `blocked_billing` and error `Billing limit reached: free_limit_exceeded (used 5234/5000 on free plan)` — no more silent failures.
- Same for webhook / MCP / manual / internal — already get a 429 today, plus now the row in history for audit.
- Direct API endpoints unchanged in this PR (only return 429).

## Follow-up tickets (not in this PR)

1. Optional UI banner: "Your free plan blocked X executions this month — upgrade." Would query `COUNT(*) FROM workflow_executions WHERE status='blocked_billing' AND ...`.
2. Wire `recordBlockedDirectExecution` into the 4 `/api/execute/*` routes if/when product wants direct calls also visible in execution history.

## Test plan

- [ ] Free org over its 5,000 limit — hit `/api/workflow/:id/execute`, confirm 429 + row inserted with `status='blocked_billing'`
- [ ] Same for webhook + MCP + internal endpoints
- [ ] Schedule with cron `* * * * *` on a free org over the limit — confirm row inserted per minute, no actual workflow run
- [ ] Confirm under-limit calls succeed and don't insert a `blocked_billing` row
- [ ] Confirm count queries still work as expected (`SELECT used FROM /api/billing/subscription`)
- [ ] Verify enterprise (unlimited) orgs are unaffected