### PR TITLE
feat: KEEP-434 use defaultFallbackWss when primary fails, add probe timeout

### DIFF
--- a/keeperhub-events/event-tracker/package.json
+++ b/keeperhub-events/event-tracker/package.json
@@ -20,11 +20,13 @@
     "@aws-sdk/client-sqs": "^3.1005.0",
     "ethers": "^6.13.4",
     "ioredis": "^5.4.2",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "ws": "^8.17.1"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.5.13",
     "tsup": "^8.3.5",
     "tsx": "^4.0.0",
     "vite": "^8.0.9",

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -39,6 +39,15 @@ const HEARTBEAT_TIMEOUT_MS = 10_000;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const MAX_RECONNECT_ATTEMPTS = 10;
+/**
+ * Cap on `eth_subscribe(["newHeads"])` round-trip during the probe in
+ * `probeSubscriptionSupport`. An upstream that accepts the WS handshake
+ * but never answers the JSON-RPC frame (silent backend, broken proxy) would
+ * otherwise block `createProvider` forever. 10 s matches the heartbeat
+ * timeout in `startHeartbeat` so the two reachability gates fail at the
+ * same scale.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
 
 export type LogHandler = (log: ethers.Log) => void | Promise<void>;
 export type Unsubscribe = () => void;
@@ -60,7 +69,17 @@ export type DisconnectHandler = (ev: DisconnectEvent) => void | Promise<void>;
 
 export interface ChainHealth {
   chainId: number;
+  /**
+   * The URL the live provider was opened against, or the configured
+   * primary if no provider is currently connected. May be the configured
+   * fallback if the primary failed at the most recent (re)connect.
+   */
   wssUrl: string;
+  /**
+   * Configured fallback URL, or null if none. Surfaced so operators can
+   * see whether failover capacity exists for this chain.
+   */
+  fallbackWssUrl: string | null;
   connected: boolean;
   reconnecting: boolean;
   lastBlockAt: number | null;
@@ -78,6 +97,11 @@ export interface ChainHealth {
 export interface SubscribeOptions {
   chainId: number;
   wssUrl: string;
+  /**
+   * Optional secondary URL tried when the primary fails at provider
+   * creation or reconnect. See `ChainEntry.fallbackWssUrl`.
+   */
+  fallbackWssUrl?: string;
   address: string;
   topic0: string;
   handler: LogHandler;
@@ -96,7 +120,24 @@ interface Subscriber {
 
 interface ChainEntry {
   chainId: number;
+  /**
+   * Configured primary URL; immutable once the entry is created. Each
+   * (re)connect attempt tries this first.
+   */
   wssUrl: string;
+  /**
+   * Configured fallback URL, immutable once the entry is created. Tried
+   * only when the primary attempt fails (factory throws, `provider.ready`
+   * rejects, or `eth_subscribe` probe rejects). Reconnects always start
+   * over from primary so a primary that recovers is preferred.
+   */
+  fallbackWssUrl: string | null;
+  /**
+   * Which URL the live provider was created from. Equal to `wssUrl` on
+   * the common path, equal to `fallbackWssUrl` when the primary failed
+   * at the last (re)connect, null when no provider is live.
+   */
+  activeWssUrl: string | null;
   provider: ethers.WebSocketProvider | null;
   readyPromise: Promise<ethers.WebSocketProvider> | null;
   /**
@@ -160,8 +201,9 @@ export class ChainProviderManager {
   async getOrCreateProvider(
     chainId: number,
     wssUrl: string,
+    fallbackWssUrl?: string,
   ): Promise<ethers.WebSocketProvider> {
-    const entry = this.ensureEntry(chainId, wssUrl);
+    const entry = this.ensureEntry(chainId, wssUrl, fallbackWssUrl);
 
     // If a reconnect loop is live, wait for it to settle before checking
     // the provider. Without this, a new subscriber arriving while the
@@ -200,8 +242,16 @@ export class ChainProviderManager {
   }
 
   async subscribeToLogs(opts: SubscribeOptions): Promise<Unsubscribe> {
-    const entry = this.ensureEntry(opts.chainId, opts.wssUrl);
-    await this.getOrCreateProvider(opts.chainId, opts.wssUrl);
+    const entry = this.ensureEntry(
+      opts.chainId,
+      opts.wssUrl,
+      opts.fallbackWssUrl,
+    );
+    await this.getOrCreateProvider(
+      opts.chainId,
+      opts.wssUrl,
+      opts.fallbackWssUrl,
+    );
 
     const subscriber: Subscriber = {
       address: opts.address.toLowerCase(),
@@ -290,31 +340,31 @@ export class ChainProviderManager {
     if (!entry) {
       return null;
     }
+    return this.toHealth(entry);
+  }
+
+  getAllHealth(): ChainHealth[] {
+    const out: ChainHealth[] = [];
+    for (const entry of this.chains.values()) {
+      out.push(this.toHealth(entry));
+    }
+    return out;
+  }
+
+  private toHealth(entry: ChainEntry): ChainHealth {
     return {
       chainId: entry.chainId,
-      wssUrl: entry.wssUrl,
+      // Active URL when a provider is live, primary otherwise. Lets
+      // operators see whether failover kicked in without exposing a
+      // stale "active" value when nothing is connected.
+      wssUrl: entry.activeWssUrl ?? entry.wssUrl,
+      fallbackWssUrl: entry.fallbackWssUrl,
       connected: entry.provider != null && !entry.isReconnecting,
       reconnecting: entry.isReconnecting,
       lastBlockAt: entry.lastBlockAt,
       subscriberCount: entry.subscribers.size,
       lastCreateError: entry.lastCreateError,
     };
-  }
-
-  getAllHealth(): ChainHealth[] {
-    const out: ChainHealth[] = [];
-    for (const entry of this.chains.values()) {
-      out.push({
-        chainId: entry.chainId,
-        wssUrl: entry.wssUrl,
-        connected: entry.provider != null && !entry.isReconnecting,
-        reconnecting: entry.isReconnecting,
-        lastBlockAt: entry.lastBlockAt,
-        subscriberCount: entry.subscribers.size,
-        lastCreateError: entry.lastCreateError,
-      });
-    }
-    return out;
   }
 
   async destroy(): Promise<void> {
@@ -346,6 +396,7 @@ export class ChainProviderManager {
       entry.subscribers.clear();
       entry.disconnectHandlers.clear();
       entry.provider = null;
+      entry.activeWssUrl = null;
       entry.readyPromise = null;
     }
     this.chains.clear();
@@ -358,12 +409,20 @@ export class ChainProviderManager {
     }
   }
 
-  private ensureEntry(chainId: number, wssUrl: string): ChainEntry {
+  private ensureEntry(
+    chainId: number,
+    wssUrl: string,
+    fallbackWssUrl?: string,
+  ): ChainEntry {
+    const fallback = fallbackWssUrl ?? null;
     const existing = this.chains.get(chainId);
     if (existing) {
-      if (existing.wssUrl !== wssUrl) {
+      // Identity is the (primary, fallback) tuple. Two callers must agree
+      // on both; otherwise the second caller would silently inherit the
+      // first caller's failover behaviour.
+      if (existing.wssUrl !== wssUrl || existing.fallbackWssUrl !== fallback) {
         throw new Error(
-          `chainId ${chainId} already registered with wssUrl ${existing.wssUrl}; refusing to reuse for ${wssUrl}`,
+          `chainId ${chainId} already registered with wssUrl=${existing.wssUrl} fallbackWssUrl=${existing.fallbackWssUrl}; refusing to reuse for wssUrl=${wssUrl} fallbackWssUrl=${fallback}`,
         );
       }
       return existing;
@@ -371,6 +430,8 @@ export class ChainProviderManager {
     const entry: ChainEntry = {
       chainId,
       wssUrl,
+      fallbackWssUrl: fallback,
+      activeWssUrl: null,
       provider: null,
       readyPromise: null,
       reconnectPromise: null,
@@ -387,13 +448,66 @@ export class ChainProviderManager {
     return entry;
   }
 
+  /**
+   * Ordered list of URLs to try at (re)connect time: primary first,
+   * fallback (if configured) second. Returned fresh on every call so a
+   * caller can iterate without mutating entry state.
+   */
+  private candidateUrls(entry: ChainEntry): string[] {
+    return entry.fallbackWssUrl
+      ? [entry.wssUrl, entry.fallbackWssUrl]
+      : [entry.wssUrl];
+  }
+
+  /**
+   * Walk the candidate URL list in order, returning the first
+   * `(provider, urlUsed)` pair that satisfies factory + ready + probe.
+   * On failure of one URL the partially-constructed provider is
+   * destroyed best-effort before moving on, so we do not leak sockets
+   * across attempts. If every URL fails, throws an aggregate error
+   * containing each URL's failure message.
+   */
+  private async openProvider(
+    entry: ChainEntry,
+  ): Promise<{ provider: ethers.WebSocketProvider; urlUsed: string }> {
+    const urls = this.candidateUrls(entry);
+    const failures: string[] = [];
+    for (const url of urls) {
+      let provider: ethers.WebSocketProvider | null = null;
+      try {
+        provider = this.factory(url);
+        await provider.ready;
+        await this.probeSubscriptionSupport(provider, entry, url);
+        return { provider, urlUsed: url };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        failures.push(`${url}: ${message}`);
+        if (provider) {
+          try {
+            await provider.destroy();
+          } catch {
+            // Best-effort: socket may already be gone (probe failure
+            // already destroys), and we are about to throw or move on.
+          }
+        }
+      }
+    }
+    throw new Error(
+      `chain ${entry.chainId}: all ${urls.length} WSS URL(s) failed:\n  ${failures.join("\n  ")}`,
+    );
+  }
+
   private async createProvider(
     entry: ChainEntry,
   ): Promise<ethers.WebSocketProvider> {
-    const provider = this.factory(entry.wssUrl);
-    await provider.ready;
-    await this.probeSubscriptionSupport(provider, entry);
+    const { provider, urlUsed } = await this.openProvider(entry);
     entry.provider = provider;
+    entry.activeWssUrl = urlUsed;
+    if (urlUsed !== entry.wssUrl) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} primary failed; running on fallback ${urlUsed}`,
+      );
+    }
     // Clear the prior failure marker now that we have a working provider.
     // Without this, a chain that recovered after a probe failure would
     // still report `lastCreateError` indefinitely.
@@ -427,21 +541,44 @@ export class ChainProviderManager {
   private async probeSubscriptionSupport(
     provider: ethers.WebSocketProvider,
     entry: ChainEntry,
+    urlUsed: string,
   ): Promise<void> {
     let filterId: unknown;
     try {
-      filterId = await provider.send("eth_subscribe", ["newHeads"]);
-    } catch (err) {
+      // Race the RPC call against an explicit timeout. ethers does not
+      // give us an externally controllable timeout on `provider.send`,
+      // and an upstream that accepts the WS handshake but never answers
+      // the JSON-RPC frame would otherwise hang createProvider for the
+      // life of the socket. The Node 20 native timer doesn't need clearing
+      // because the race winner discards the loser's result, but we still
+      // clear it explicitly so the timeout doesn't keep the event loop
+      // alive after a fast probe.
+      let timeoutHandle: NodeJS.Timeout | null = null;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `eth_subscribe probe timed out after ${PROBE_TIMEOUT_MS}ms`,
+              ),
+            ),
+          PROBE_TIMEOUT_MS,
+        );
+      });
       try {
-        await provider.destroy();
-      } catch {
-        // Best-effort: the failed provider is already unusable; if
-        // destroy throws (e.g. socket already closed) there is nothing
-        // to do but proceed to the throw below.
+        filterId = await Promise.race([
+          provider.send("eth_subscribe", ["newHeads"]),
+          timeoutPromise,
+        ]);
+      } finally {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
       }
+    } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `chain ${entry.chainId} (${entry.wssUrl}): RPC does not support eth_subscribe: ${message}`,
+        `chain ${entry.chainId} (${urlUsed}): RPC does not support eth_subscribe: ${message}`,
       );
     }
     try {
@@ -654,21 +791,23 @@ export class ChainProviderManager {
       }
     }
     entry.provider = null;
+    entry.activeWssUrl = null;
     entry.readyPromise = null;
 
     if (this.isDestroyed) {
       return;
     }
 
-    // Re-create. Any throw here propagates to the loop which handles
-    // backoff.
-    const provider = this.factory(entry.wssUrl);
-    await provider.ready;
+    // Re-create using the same primary-then-fallback walk as
+    // createProvider. Each (re)connect tries primary first so a primary
+    // that recovers is preferred. Any throw here propagates to the loop
+    // which handles backoff.
+    const { provider, urlUsed } = await this.openProvider(entry);
 
-    // Destroy may have run while we were waiting for `ready`. If so, the
-    // entry we are about to populate is no longer in `this.chains` and
-    // attaching listeners would leak a provider that never gets
-    // destroyed by the second pass.
+    // Destroy may have run while we were waiting for `ready` / probe. If
+    // so, the entry we are about to populate is no longer in
+    // `this.chains` and attaching listeners would leak a provider that
+    // never gets destroyed by the second pass.
     if (this.isDestroyed) {
       try {
         await provider.destroy();
@@ -678,14 +817,13 @@ export class ChainProviderManager {
       return;
     }
 
-    // Same probe as createProvider: confirm the rebuilt connection still
-    // accepts eth_subscribe before any .on("block") call exposes us to
-    // ethers' uncaught-rejection path. A failure here propagates out and
-    // the reconnect loop counts it as a failed attempt, falling back on
-    // exponential backoff.
-    await this.probeSubscriptionSupport(provider, entry);
-
     entry.provider = provider;
+    entry.activeWssUrl = urlUsed;
+    if (urlUsed !== entry.wssUrl) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} reconnected on fallback ${urlUsed}`,
+      );
+    }
     // Successful reconnect clears any prior failure marker so /healthz
     // stops reporting a stale error on a now-healthy chain.
     entry.lastCreateError = null;

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -71,8 +71,10 @@ export interface ChainHealth {
   chainId: number;
   /**
    * The URL the live provider was opened against, or the configured
-   * primary if no provider is currently connected. May be the configured
-   * fallback if the primary failed at the most recent (re)connect.
+   * primary if no provider is currently connected. Equals the configured
+   * fallback when the most recent successful (re)connect landed on it;
+   * resets to the configured primary during a mid-reconnect window
+   * because `reconnect()` clears `activeWssUrl` before re-attempting.
    */
   wssUrl: string;
   /**

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { WebSocket } from "ws";
 import { logger } from "../../lib/utils/logger";
 
 /**
@@ -164,8 +165,30 @@ interface ChainEntry {
   disconnectHandlers: Set<DisconnectHandler>;
 }
 
+/**
+ * Wrap socket construction so we can attach an EventEmitter-style `error`
+ * listener synchronously, before ethers' WebSocketProvider has had a
+ * chance to assign its own `onerror`. Without this, an early ws-layer
+ * error (DNS NXDOMAIN, ECONNREFUSED, non-WS server returning HTTP 200)
+ * fires on a listenerless EventEmitter, gets re-thrown synchronously,
+ * escapes openProvider's try/catch as `uncaughtException`, and `index.ts`
+ * exits the pod - which would crashloop the whole event-tracker on a
+ * misconfigured WSS URL even when a healthy fallback is configured.
+ *
+ * The listener is a no-op: failures still reject `provider.ready` via
+ * ethers' onerror (assigned shortly after we return), and that rejection
+ * is what openProvider catches to walk to the fallback. We just need
+ * *some* error listener to be on the ws by the time the connection
+ * attempt resolves.
+ */
 const defaultFactory: ProviderFactory = (wssUrl) =>
-  new ethers.WebSocketProvider(wssUrl);
+  new ethers.WebSocketProvider(() => {
+    const socket = new WebSocket(wssUrl);
+    socket.on("error", () => {
+      // intentionally empty - see comment on defaultFactory
+    });
+    return socket;
+  });
 
 const defaultOnPermanentFailure = (chainId: number): void => {
   logger.error(

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -29,6 +29,7 @@ export interface EventListenerOptions {
   workflowName: string;
   chainId: number;
   wssUrl: string;
+  fallbackWssUrl?: string;
   contractAddress: string;
   eventName: string;
   eventsAbiStrings: string[];
@@ -82,6 +83,7 @@ export class EventListener {
     this.unsubscribe = await this.opts.providerManager.subscribeToLogs({
       chainId: this.opts.chainId,
       wssUrl: this.opts.wssUrl,
+      fallbackWssUrl: this.opts.fallbackWssUrl,
       address: this.opts.contractAddress,
       topic0: eventFragment.topicHash,
       handler: (log) => this.onLog(log),

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -26,6 +26,13 @@ export interface WorkflowRegistration {
   workflowName: string;
   chainId: number;
   wssUrl: string;
+  /**
+   * Optional secondary WSS endpoint. If primary is unreachable or rejects
+   * `eth_subscribe`, ChainProviderManager falls through to this URL before
+   * giving up. Populated from `chains.default_fallback_wss` when it parses
+   * as a valid `ws://` / `wss://` URL.
+   */
+  fallbackWssUrl?: string;
   contractAddress: string;
   eventName: string;
   eventsAbiStrings: string[];

--- a/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
+++ b/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
@@ -80,6 +80,25 @@ export function buildRegistration(
     return null;
   }
 
+  // Fallback is optional. Same nullable-DB-column caveat as primary: the
+  // type says `string` but rows can be null/empty. A bad fallback (wrong
+  // scheme, empty) is logged and dropped rather than failing the whole
+  // workflow; the listener still runs on primary alone.
+  const rawFallbackWssUrl: unknown = network.defaultFallbackWss;
+  let fallbackWssUrl: string | undefined;
+  if (typeof rawFallbackWssUrl === "string" && rawFallbackWssUrl.length > 0) {
+    if (
+      rawFallbackWssUrl.startsWith("wss://") ||
+      rawFallbackWssUrl.startsWith("ws://")
+    ) {
+      fallbackWssUrl = rawFallbackWssUrl;
+    } else {
+      logger.warn(
+        `[workflow-mapper] workflow ${workflowId} chain ${chainId} defaultFallbackWss is not a WebSocket URL ("${rawFallbackWssUrl}"); ignoring fallback`,
+      );
+    }
+  }
+
   const contractAddress =
     typeof config.contractAddress === "string" ? config.contractAddress : null;
   if (!contractAddress) {
@@ -140,7 +159,8 @@ export function buildRegistration(
     userId,
     workflowName,
     chainId,
-    wssUrl: network.defaultPrimaryWss,
+    wssUrl,
+    fallbackWssUrl,
     contractAddress,
     eventName,
     eventsAbiStrings,
@@ -167,6 +187,7 @@ export function hashRegistration(
   const canonical = JSON.stringify({
     chainId: reg.chainId,
     wssUrl: reg.wssUrl,
+    fallbackWssUrl: reg.fallbackWssUrl ?? null,
     contractAddress: reg.contractAddress,
     eventName: reg.eventName,
     eventsAbiStrings: reg.eventsAbiStrings,

--- a/keeperhub-events/event-tracker/tests/integration/provider-manager-bad-url.test.ts
+++ b/keeperhub-events/event-tracker/tests/integration/provider-manager-bad-url.test.ts
@@ -70,4 +70,24 @@ describe("ChainProviderManager (real ws): bad-URL safety", () => {
 
     expect(capturedExceptions).toEqual([]);
   });
+
+  it("rejects cleanly when the host does not resolve (DNS NXDOMAIN)", async () => {
+    // Different failure mode than ECONNREFUSED: the .invalid TLD is
+    // reserved per RFC 6761 and guaranteed to never resolve, so this
+    // exercises the dns.lookup error path (`getaddrinfo ENOTFOUND`).
+    // That was the original failure mode I hit during KEEP-434 manual
+    // verification - the error came from `node:dns` rather than
+    // `ws.ClientRequest`, but the same EventEmitter-throw rule made it
+    // crash the pod. The fix's defensive listener covers both because
+    // ws emits 'error' on the WebSocket regardless of which network
+    // layer surfaced the failure.
+    await expect(
+      manager.getOrCreateProvider(
+        31_339,
+        "wss://does-not-exist-keep434.invalid/",
+      ),
+    ).rejects.toThrow(/does-not-exist-keep434\.invalid/);
+
+    expect(capturedExceptions).toEqual([]);
+  });
 });

--- a/keeperhub-events/event-tracker/tests/integration/provider-manager-bad-url.test.ts
+++ b/keeperhub-events/event-tracker/tests/integration/provider-manager-bad-url.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ChainProviderManager } from "../../src/chains/provider-manager";
+
+/**
+ * Live-network test for the failure modes that crashed the pod during
+ * KEEP-434 manual verification: a misconfigured WSS URL throwing at the
+ * underlying `ws` socket level (DNS NXDOMAIN, ECONNREFUSED, non-WS server)
+ * was leaking past `openProvider`'s try/catch and reaching
+ * `process.on("uncaughtException")` in `index.ts`, which exits the pod.
+ *
+ * Uses `ws://127.0.0.1:1` (port 1 is unused on Linux, ECONNREFUSED is
+ * synchronous and deterministic - no real DNS or remote network).
+ *
+ * Exercises the REAL `defaultFactory` path (no injected mock) because the
+ * bug is in the ws library's interaction with ethers' WebSocketProvider,
+ * which the unit-test MockProvider does not simulate.
+ */
+describe("ChainProviderManager (real ws): bad-URL safety", () => {
+  let onPermanentFailure: () => void;
+  let manager: ChainProviderManager;
+
+  // Capture any uncaughtException that escapes during a test. Vitest
+  // installs its own listener for failure reporting; we record errors
+  // alongside it without removing it.
+  const capturedExceptions: unknown[] = [];
+  const listener = (err: unknown): void => {
+    capturedExceptions.push(err);
+  };
+
+  beforeEach(() => {
+    capturedExceptions.length = 0;
+    process.on("uncaughtException", listener);
+    onPermanentFailure = (): void => {
+      // No-op so reconnect exhaustion does not call process.exit during
+      // tests. Real prod uses defaultOnPermanentFailure which exits.
+    };
+    manager = new ChainProviderManager({ onPermanentFailure });
+  });
+
+  afterEach(async () => {
+    process.off("uncaughtException", listener);
+    await manager.destroy();
+  });
+
+  it("rejects cleanly when the only URL is unreachable (ECONNREFUSED)", async () => {
+    // Pre-fix: this leaked `Error: connect ECONNREFUSED 127.0.0.1:1`
+    // to process.uncaughtException via ws's EventEmitter throw, the
+    // fatal handler in index.ts called process.exit(1), and K8s would
+    // crashloop the pod. Post-fix: the no-op error listener in
+    // defaultFactory keeps the ws emit harmless and the rejection
+    // surfaces through the awaited path.
+    await expect(
+      manager.getOrCreateProvider(31337, "ws://127.0.0.1:1"),
+    ).rejects.toThrow(/ws:\/\/127\.0\.0\.1:1/);
+
+    expect(capturedExceptions).toEqual([]);
+  });
+
+  it("walks to the fallback when the primary is unreachable, surfacing both failures if both die", async () => {
+    // Both URLs unreachable - same crash path as above for each
+    // attempt. The aggregate error must mention both URLs and no
+    // uncaughtException is allowed.
+    await expect(
+      manager.getOrCreateProvider(
+        31_338,
+        "ws://127.0.0.1:1",
+        "ws://127.0.0.1:2",
+      ),
+    ).rejects.toThrow(/ws:\/\/127\.0\.0\.1:1.*ws:\/\/127\.0\.0\.1:2/s);
+
+    expect(capturedExceptions).toEqual([]);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager-default-factory.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager-default-factory.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from "node:events";
+import { ethers } from "ethers";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Locks in the invariant that the bad-URL crash fix
+ * (provider-manager.ts:165 defaultFactory) relies on:
+ *
+ * `ethers.WebSocketProvider(creator)` does NOT remove or replace
+ * EventEmitter-style listeners attached to the underlying socket. ethers
+ * assigns to `socket.onerror` (a property), which coexists with
+ * `socket.on("error", ...)` listeners on the same EventEmitter. If a
+ * future ethers upgrade started calling `socket.removeAllListeners`
+ * inside `_start()`, our defensive listener would be stripped and the
+ * crash-on-bad-URL bug would resurface.
+ *
+ * Distinct from `provider-manager-bad-url.test.ts` which uses real
+ * network. This one is offline and runs as a fast unit check.
+ */
+
+class MockWsSocket extends EventEmitter {
+  url: string;
+  onerror: ((ev: unknown) => void) | null = null;
+  onopen: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    super();
+    this.url = url;
+  }
+  send(_payload: string): void {
+    // not used in this test
+  }
+  close(_code?: number, _reason?: string): void {
+    // not used in this test
+  }
+}
+
+describe("defaultFactory creator pattern: ethers compatibility", () => {
+  const providers: ethers.WebSocketProvider[] = [];
+
+  afterEach(async () => {
+    while (providers.length) {
+      const p = providers.pop();
+      if (p) {
+        await p.destroy().catch(() => undefined);
+      }
+    }
+  });
+
+  it("EventEmitter on('error') listener attached inside the creator survives ethers' WebSocketProvider construction", () => {
+    // Mirror what defaultFactory does: create a socket, attach the
+    // defensive `on("error", noop)` listener synchronously, then hand
+    // it to ethers via the creator overload.
+    const socket = new MockWsSocket("ws://test/");
+    socket.on("error", () => {
+      // Mirrors the no-op in defaultFactory.
+    });
+    expect(socket.listenerCount("error")).toBe(1);
+
+    const provider = new ethers.WebSocketProvider(
+      () => socket as unknown as ethers.WebSocketLike,
+    );
+    providers.push(provider);
+
+    // The defensive listener must still be attached after ethers wires
+    // up its own onerror. ethers uses property assignment (independent
+    // of EventEmitter listener storage), so listenerCount stays >= 1.
+    // This is the load-bearing invariant: if it ever drops to 0, an
+    // early `error` event from the underlying ws would re-throw and
+    // crash the pod again.
+    expect(socket.listenerCount("error")).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ethers does not call removeAllListeners on the socket after construction", () => {
+    // Belt-and-suspenders: even if ethers attaches its own
+    // EventEmitter-style listener on top of ours, what matters is that
+    // it does not remove ours. Spy removeAllListeners and assert it is
+    // never called by ethers.
+    const socket = new MockWsSocket("ws://test/");
+    let removeAllCalled = 0;
+    const orig = socket.removeAllListeners.bind(socket);
+    socket.removeAllListeners = ((event?: string | symbol) => {
+      removeAllCalled++;
+      return orig(event);
+    }) as typeof socket.removeAllListeners;
+
+    socket.on("error", () => {
+      // defensive
+    });
+
+    const provider = new ethers.WebSocketProvider(
+      () => socket as unknown as ethers.WebSocketLike,
+    );
+    providers.push(provider);
+
+    expect(removeAllCalled).toBe(0);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -303,6 +303,65 @@ describe("ChainProviderManager", () => {
         await localManager.destroy();
       });
     });
+
+    // Fallback URL is opt-in via the optional third parameter on
+    // getOrCreateProvider / SubscribeOptions. When the primary fails at
+    // factory + ready + probe, the manager walks to the fallback before
+    // surfacing failure. Reconnect uses the same walk, so a primary that
+    // recovers is preferred on the next reconnect.
+    describe("fallback wssUrl", () => {
+      it("uses the primary when it works and never invokes the fallback", async () => {
+        await manager.getOrCreateProvider(CHAIN_A, "ws://primary", "ws://fb");
+        expect(factoryBundle.created).toHaveLength(1);
+        expect(manager.getHealth(CHAIN_A)?.wssUrl).toBe("ws://primary");
+        expect(manager.getHealth(CHAIN_A)?.fallbackWssUrl).toBe("ws://fb");
+      });
+
+      it("falls through to the fallback when the primary probe fails", async () => {
+        // One-shot: only the first provider created (i.e. the one for the
+        // primary URL) gets the subscribe failure. The fallback's fresh
+        // provider has no failure armed, so its probe succeeds.
+        factoryBundle.setNextSubscribeFailure(
+          new Error('unsupported operation (operation="eth_subscribe")'),
+        );
+        await manager.getOrCreateProvider(CHAIN_A, "ws://primary", "ws://fb");
+        expect(factoryBundle.created).toHaveLength(2);
+        // Failed primary provider is destroyed before we move on so the
+        // socket does not leak across the failover.
+        expect(factoryBundle.created[0].destroyed).toBe(true);
+        expect(factoryBundle.created[1].destroyed).toBe(false);
+        // Health surface reflects the active URL, not the configured
+        // primary, so operators can see failover at a glance.
+        expect(manager.getHealth(CHAIN_A)?.wssUrl).toBe("ws://fb");
+      });
+
+      it("aggregates errors from both URLs when both fail", async () => {
+        // Persistent failure makes every factory call throw. Both primary
+        // and fallback fail before the call resolves, and the surfaced
+        // error must mention both URLs so operators can debug.
+        factoryBundle.setPersistentFailure(new Error("connect refused"));
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://primary", "ws://fb"),
+        ).rejects.toThrow(/ws:\/\/primary.*ws:\/\/fb/s);
+      });
+
+      it("rejects a mismatched fallback for a known chainId", async () => {
+        // The primary+fallback tuple is the entry's identity. A second
+        // caller with a different fallback would silently inherit the
+        // first caller's failover URL, so we throw instead.
+        await manager.getOrCreateProvider(CHAIN_A, "ws://primary", "ws://fb");
+        await expect(
+          manager.getOrCreateProvider(CHAIN_A, "ws://primary", "ws://other"),
+        ).rejects.toThrow(/already registered/);
+      });
+
+      it("works without a fallback (single-URL backwards compatibility)", async () => {
+        // Existing call sites that pass no fallback still work and report
+        // null in the fallback health field.
+        await manager.getOrCreateProvider(CHAIN_A, "ws://primary");
+        expect(manager.getHealth(CHAIN_A)?.fallbackWssUrl).toBeNull();
+      });
+    });
   });
 
   describe("subscribeToLogs block listener lifecycle", () => {
@@ -683,6 +742,7 @@ describe("ChainProviderManager", () => {
       expect(h).toEqual({
         chainId: CHAIN_A,
         wssUrl: "ws://a",
+        fallbackWssUrl: null,
         connected: true,
         reconnecting: false,
         lastBlockAt: null,

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1140,6 +1140,81 @@ describe("ChainProviderManager", () => {
       await vi.advanceTimersByTimeAsync(2_500);
       expect(manager.isHealthy(CHAIN_A)).toBe(true);
     });
+
+    it("walks to the fallback URL when the primary fails on reconnect", async () => {
+      // Reconnect runs the same primary-then-fallback walk as the
+      // initial createProvider. With one armed probe failure, the
+      // reconnect's primary attempt fails and openProvider falls
+      // through to the fallback. The active URL surfaces through
+      // getHealth so operators can see failover via /healthz mid-incident.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://primary",
+        fallbackWssUrl: "ws://fb",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      expect(factoryBundle.created).toHaveLength(1);
+      expect(manager.getHealth(CHAIN_A)?.wssUrl).toBe("ws://primary");
+
+      // Arm a one-shot probe failure. The reconnect's primary attempt
+      // gets it; the fallback attempt that follows has no failure armed.
+      factoryBundle.setNextSubscribeFailure(
+        new Error('unsupported operation (operation="eth_subscribe")'),
+      );
+      factoryBundle.created[0].emitError(new Error("wss dropped"));
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      // openProvider tore down the failed primary attempt before
+      // moving on, then created a fresh mock for the fallback.
+      // Initial + primary attempt + fallback attempt = 3 providers.
+      expect(factoryBundle.created).toHaveLength(3);
+      expect(factoryBundle.created[1].destroyed).toBe(true);
+      expect(factoryBundle.created[2].destroyed).toBe(false);
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+      expect(manager.getHealth(CHAIN_A)?.wssUrl).toBe("ws://fb");
+      // Block listener and heartbeat must be re-attached on the
+      // fallback provider; otherwise events would be silently dropped
+      // after failover.
+      expect(factoryBundle.created[2].hasBlockHandler()).toBe(true);
+      expect(factoryBundle.created[2].hasErrorHandler()).toBe(true);
+    });
+
+    it("flips back to the primary on the next reconnect once the primary recovers", async () => {
+      // Running on the fallback is a degraded state, not a sticky one.
+      // When the primary recovers, the next reconnect's primary-first
+      // walk picks it up. Without this, a transient primary blip would
+      // strand the chain on the fallback until process restart.
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://primary",
+        fallbackWssUrl: "ws://fb",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      // First reconnect: primary fails, manager runs on fallback.
+      factoryBundle.setNextSubscribeFailure(new Error("transient"));
+      factoryBundle.created[0].emitError(new Error("drop"));
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(manager.getHealth(CHAIN_A)?.wssUrl).toBe("ws://fb");
+      const fallbackProvider = factoryBundle.created.at(-1);
+      const createdBeforeSecond = factoryBundle.created.length;
+
+      // Second reconnect: nothing armed, so the primary attempt
+      // succeeds and openProvider returns on the first URL it tries.
+      // The fallback URL is never even hit.
+      fallbackProvider?.emitError(new Error("drop 2"));
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      // Exactly one new provider for the recovered primary - no
+      // wasted fallback factory call.
+      expect(factoryBundle.created.length - createdBeforeSecond).toBe(1);
+      expect(manager.isHealthy(CHAIN_A)).toBe(true);
+      expect(manager.getHealth(CHAIN_A)?.wssUrl).toBe("ws://primary");
+    });
   });
 
   describe("heartbeat", () => {

--- a/keeperhub-events/event-tracker/tests/unit/workflow-mapper.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/workflow-mapper.test.ts
@@ -79,6 +79,7 @@ describe("buildRegistration", () => {
       workflowName: "Test Workflow",
       chainId: CHAIN_ID,
       wssUrl: "ws://localhost:8546",
+      fallbackWssUrl: "ws://localhost:8546",
       contractAddress: "0x1111111111111111111111111111111111111111",
       eventName: "Transfer",
     });
@@ -149,6 +150,21 @@ describe("buildRegistration", () => {
     it("changes when userId changes", () => {
       const a = buildRegistration(makeWorkflow(), NETWORKS);
       const b = buildRegistration(makeWorkflow({ userId: "user-2" }), NETWORKS);
+      expect(a?.configHash).not.toBe(b?.configHash);
+    });
+
+    it("changes when fallbackWssUrl changes", () => {
+      // Switching fallback providers is a real config change: the
+      // reconciler must restart the listener so the new URL becomes the
+      // entry's identity in the provider manager.
+      const a = buildRegistration(makeWorkflow(), NETWORKS);
+      const networksB: NetworksMap = {
+        [CHAIN_ID]: {
+          ...NETWORK,
+          defaultFallbackWss: "wss://different-fallback.example.com",
+        },
+      };
+      const b = buildRegistration(makeWorkflow(), networksB);
       expect(a?.configHash).not.toBe(b?.configHash);
     });
 
@@ -234,6 +250,54 @@ describe("buildRegistration", () => {
     };
     const reg = buildRegistration(makeWorkflow(), networks);
     expect(reg?.wssUrl).toBe("wss://eth-mainnet.example.com");
+  });
+
+  // defaultFallbackWss has the same nullable-DB-column issue as the
+  // primary, but a bad fallback should NOT fail the whole workflow - the
+  // listener can still run on primary alone.
+  describe("defaultFallbackWss handling", () => {
+    it("includes fallbackWssUrl when valid", () => {
+      const networks: NetworksMap = {
+        [CHAIN_ID]: {
+          ...NETWORK,
+          defaultPrimaryWss: "wss://primary.example.com",
+          defaultFallbackWss: "wss://fallback.example.com",
+        },
+      };
+      const reg = buildRegistration(makeWorkflow(), networks);
+      expect(reg?.fallbackWssUrl).toBe("wss://fallback.example.com");
+    });
+
+    it("drops a null fallback (workflow still runs on primary)", () => {
+      const networks: NetworksMap = {
+        [CHAIN_ID]: {
+          ...NETWORK,
+          defaultFallbackWss: null as unknown as string,
+        },
+      };
+      const reg = buildRegistration(makeWorkflow(), networks);
+      expect(reg).not.toBeNull();
+      expect(reg?.fallbackWssUrl).toBeUndefined();
+    });
+
+    it("drops an empty fallback", () => {
+      const networks: NetworksMap = {
+        [CHAIN_ID]: { ...NETWORK, defaultFallbackWss: "" },
+      };
+      const reg = buildRegistration(makeWorkflow(), networks);
+      expect(reg?.fallbackWssUrl).toBeUndefined();
+    });
+
+    it("drops a fallback with the wrong scheme", () => {
+      const networks: NetworksMap = {
+        [CHAIN_ID]: {
+          ...NETWORK,
+          defaultFallbackWss: "https://eth-mainnet.example.com",
+        },
+      };
+      const reg = buildRegistration(makeWorkflow(), networks);
+      expect(reg?.fallbackWssUrl).toBeUndefined();
+    });
   });
 
   it("returns null when contractAddress is missing", () => {

--- a/keeperhub-events/pnpm-lock.yaml
+++ b/keeperhub-events/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
+      ws:
+        specifier: ^8.17.1
+        version: 8.17.1
     devDependencies:
       '@types/node':
         specifier: ^24.12.2
@@ -42,6 +45,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
@@ -846,6 +852,9 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
@@ -2318,6 +2327,10 @@ snapshots:
       undici-types: 7.16.0
 
   '@types/uuid@10.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.12.2
 
   '@vitest/expect@4.1.2':
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up to [KEEP-418](https://linear.app/keeperhubapp/issue/KEEP-418) (PR #1122). KEEP-418 closed the unhandled-rejection path that crashed `keeperhub-event-common` by probing `eth_subscribe` before any block listener attaches. This PR closes three remaining gaps -- two planned, one found during live verification against `chain-config/staging.json`.

### Gap 1: `defaultFallbackWss` was unused

`NetworkConfig` exposed `defaultFallbackWss` but `provider-manager` only ever used `defaultPrimaryWss`. A chain with a permanently-bad primary (wrong host, dead service, no `eth_subscribe` support) would loop on the same URL forever. The chain-config repo already populates fallback URLs (drpc-hosted) for every chain ([chain-config PR #17](https://github.com/KeeperHub/chain-config/pull/17)) -- this PR makes the consumer actually use them.

### Gap 2: probe had no externally-controllable timeout

`probeSubscriptionSupport` awaited `provider.send("eth_subscribe", [...])` with no timeout. An upstream that completes the WS handshake but never answers the JSON-RPC frame would block `createProvider` for the life of the socket.

### Gap 3: a misconfigured WSS URL crashed the pod regardless of fallback (found during live verification)

Live-running the patched event-tracker against staging.json with a deliberately-broken primary (`wss://does-not-exist.invalid/`, then `wss://example.com/`) revealed a separate crash path the fallback walk did not protect against. The underlying `ws` library emits an `error` event on the socket as soon as the connection attempt fails. Between `new ethers.WebSocketProvider(url)` returning and ethers' `_start()` assigning `onerror`, there is a microtask window with no listener attached. Node's EventEmitter re-throws the error synchronously, it escapes `openProvider`'s try/catch as `uncaughtException`, and `index.ts`'s fatal handler exits the pod. The fallback URL is never tried because the loop body's catch block is bypassed. The pod would crashloop indefinitely on the bad URL even with a healthy fallback configured.

Repro stack trace (commit `9ac8fd89` adds the test that locks this in):
```
[Fatal] uncaughtException: Unexpected server response: 200
  at ClientRequest.<anonymous> (.../ws@8.17.1/node_modules/ws/lib/websocket.js:912:7)
```

Fix: switch `defaultFactory` to the `WebSocketCreator` overload of `ethers.WebSocketProvider` so we own `ws.WebSocket` construction. Attach a no-op `error` listener synchronously inside the creator, before returning to ethers. The listener satisfies EventEmitter's "must have a listener" rule. Failures still reject `provider.ready` via ethers' `onerror` once it gets assigned, and that rejection lands in `openProvider`'s existing catch which walks to the fallback as designed.

## Changes

- **Plumbs `fallbackWssUrl` through** `workflow-mapper` -> `WorkflowRegistration` -> `EventListener` -> `SubscribeOptions` -> `ChainEntry`. `workflow-mapper` validates the same scheme rules as primary; an invalid fallback is logged and dropped (the listener still runs on primary alone). `configHash` includes the fallback so a fallback swap restarts the listener.
- **`createProvider` and `reconnect` share `openProvider`** that walks `[primary, fallback?]` in order, returning the first URL whose factory + `.ready` + probe all succeed. Failed providers are `destroy()`'d before moving on so sockets don't leak across the failover. Reconnects always start from primary so a recovered primary is preferred.
- **Probe timeout:** `probeSubscriptionSupport` wraps `eth_subscribe` in `Promise.race` with a 10s timeout (matches `startHeartbeat`'s timeout).
- **Defensive ws error guard:** `defaultFactory` uses ethers' `WebSocketCreator` overload to construct `ws.WebSocket` itself and attach a no-op `error` listener synchronously, preventing transport-level errors from crashing the pod via `process.uncaughtException`.
- **Health surface:** `ChainHealth.wssUrl` now reflects the active URL (primary or fallback), and a new `ChainHealth.fallbackWssUrl` exposes the configured fallback. Operators can see at a glance whether failover is active and whether failover capacity exists.
- **Identity check tightened:** `ensureEntry` requires both URLs to match for a reused chain entry, preventing two callers from silently inheriting one another's failover URL.
- **New deps:** `ws@^8.17.1`, `@types/ws@^8.5.13` (already pulled in transitively via ethers; making the dep explicit since the new code imports `ws.WebSocket`).

## Test plan

- [x] 135/135 tests pass locally (`pnpm test`; 3 pre-existing files require Anvil running, unrelated)
  - **`tests/unit/provider-manager.test.ts`** -- 7 new cases: primary used when it works, falls through on primary probe failure, aggregates errors when both fail, mismatched fallback rejected, single-URL backwards compat, reconnect walks to fallback when primary fails on reconnect, primary recovery flips back on next reconnect.
  - **`tests/unit/workflow-mapper.test.ts`** -- 5 new cases: valid fallback included, null/empty/wrong-scheme fallback dropped, fallback swap changes configHash.
  - **`tests/unit/provider-manager-default-factory.test.ts`** (new) -- 2 cases locking in the ethers invariants the bad-URL fix relies on: `WebSocketProvider(creator)` does not strip EventEmitter-style listeners and does not call `removeAllListeners` on the underlying socket. Future ethers upgrades that change this break the test loudly.
  - **`tests/integration/provider-manager-bad-url.test.ts`** (new) -- 3 cases using the real `ws` library against `ws://127.0.0.1:1` (ECONNREFUSED), `ws://127.0.0.1:1` + `ws://127.0.0.1:2` (both fail, aggregate error), and `wss://does-not-exist-keep434.invalid/` (DNS NXDOMAIN). Each asserts the manager rejects through the awaited path AND no `uncaughtException` leaks during the test. Reverting the bad-URL fix makes all three fail with captured errors.
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] **Live verification** against `chain-config/staging.json`:
  - 18/18 EVM chains: WSS probe succeeds on primary on first attempt; `/healthz` reflects active URL and configured fallback per chain.
  - 18/18 primary HTTP RPCs respond with matching chainId; 17/17 fallback HTTP RPCs OK (Tempo mainnet primary == fallback, deduped).
  - Failover walk fires correctly when primary is misconfigured on chain 11155111; pod stays up post-fix; reverting the fix reproduces the crash loop.
- [ ] CI runs unit + integration on this PR
- [ ] Verify `/healthz` shape change is acceptable to downstream consumers (added `fallbackWssUrl: string | null`, no removed fields)

## Out-of-scope but worth flagging

1. **Prod is running an old image.** Current prod deployment is `event-3ba4bd4` from 2026-05-04, which **does not contain KEEP-418's fix** despite KEEP-418 merging to `prod` on 2026-05-05 via PR #1135. The rollout never landed. Whoever owns the deploy pipeline should investigate; this PR doesn't help prod until a new image is built and rolled out.

2. **Preexisting `ensureEntry` cache bug.** Live verification surfaced a separate, preexisting issue: when a chain's URL changes in the DB at runtime, the reconciler computes a new configHash, calls `remove(workflowId)` then `add(registration)`. `ensureEntry` rejects the new URL because the old `ChainEntry` is cached in the manager's `chains` map -- there is no eviction path for entries between subscribers leaving and arriving. The listener cannot restart until pod restart. This PR did not introduce it; the `ensureEntry` URL check existed before. Worth filing as a follow-up. Mitigation today: redeploy event-tracker after changing chain URLs.

## Files changed

```
keeperhub-events/event-tracker/src/chains/provider-manager.ts                       | ~270 +++
keeperhub-events/event-tracker/src/listener/event-listener.ts                       |    2 +
keeperhub-events/event-tracker/src/listener/registry.ts                             |    7 +
keeperhub-events/event-tracker/src/listener/workflow-mapper.ts                      |   23 +-
keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts                  |  135 ++
keeperhub-events/event-tracker/tests/unit/provider-manager-default-factory.test.ts  |   97 ++ (new)
keeperhub-events/event-tracker/tests/unit/workflow-mapper.test.ts                   |   64 ++
keeperhub-events/event-tracker/tests/integration/provider-manager-bad-url.test.ts   |   90 ++ (new)
keeperhub-events/event-tracker/package.json                                         |    4 +
```