### PR TITLE
fix(agentic-wallet): allow data-chain workflow listings to accept payment (KEEP-432)

### DIFF
--- a/lib/agentic-wallet/workflow-binding.ts
+++ b/lib/agentic-wallet/workflow-binding.ts
@@ -33,6 +33,33 @@
  * mismatch (defensive) rather than null (permissive) so we never silently
  * widen access on an unrecognised tag.
  *
+ * Fix-pack-5 (KEEP-432): the chain field on a listing is overloaded — for
+ * Base-data workflows the data chain and the payment chain happen to be the
+ * same ("base"/"8453"), so the registered chain doubles as the payment-chain
+ * pin. For workflows whose data chain is *not* a payment chain (Ethereum,
+ * Optimism, Polygon, Arbitrum), the listing's chain identifies WHERE THE
+ * CONTRACTS LIVE, not which chain payment must arrive on. Such listings now
+ * accept either Base x402 or Tempo MPP. The defensive-mismatch behaviour for
+ * unknown / unparseable tags is preserved — only the explicitly whitelisted
+ * data-chain ids in `KNOWN_DATA_CHAIN_IDS` widen the payment side.
+ *
+ * Security: even on data-chain listings the binding still server-derives
+ * payTo from the registry on the Base path, and the Tempo path still resolves
+ * the workflow's price for the daily-spend deduction. The fix-pack-3 N-1
+ * concern (dual-chain victim, attacker chooses weaker chain) is unchanged for
+ * Base- and Tempo-pinned listings. For data-chain listings there is no
+ * payment-chain preference inherent to the workflow, so the pin doesn't apply.
+ *
+ * Note on creator degree-of-freedom: workflows.chain is a free-form text
+ * column written by the listing API (lib/mcp/listing.ts) without an input
+ * allowlist. A creator can intentionally tag a Base-only workflow with
+ * chain="1" to widen acceptance to either payment chain. This isn't a
+ * security boundary violation — payTo is still server-derived from the
+ * org's wallet so payers are paying the legit creator regardless — but it
+ * does mean which payment chains a listing accepts is author-controlled,
+ * not platform-enforced. Tighten at the listing API if that ever becomes
+ * a policy concern.
+ *
  * Lookup chain mirrors lib/x402/payment-gate.ts:resolveCreatorWallet.
  */
 import { and, eq } from "drizzle-orm";
@@ -75,36 +102,65 @@ const TEMPO_MAINNET_CHAIN_ID_STR = String(TEMPO_MAINNET_CHAIN_ID);
 const TEMPO_TESTNET_CHAIN_ID_STR = String(TEMPO_TESTNET_CHAIN_ID);
 
 /**
- * Map any chain tag we accept on a workflow listing — slug ("base",
- * "tempo") or numeric chain id ("8453", "4217", "4218") — into the
- * canonical BindingChain form used by /sign callers. Returns null for
- * unrecognised values so the caller can decide whether null means
- * "permissive legacy" (when wf.chain itself is null) or "defensive
- * mismatch" (when wf.chain is set but unparseable).
+ * Whitelisted data-chain ids — chains that KeeperHub workflows can READ from
+ * but that are NOT payment chains. Listings with one of these chains accept
+ * payment via either Base x402 or Tempo MPP. Mirrors the mainnet set declared
+ * in lib/rpc/rpc-config.ts; extend by editing this set when adding support
+ * for a new read-only chain.
  *
- * Case-insensitive on slug input; whitespace-trimmed. Numeric forms
- * are matched as decimal strings against the canonical constants in
- * lib/agentic-wallet/constants.ts so a future chain-id rename only
- * has to be done in one place.
+ * Decimal string form to match the format stored in workflows.chain.
  */
-function normaliseChainTag(
+export const KNOWN_DATA_CHAIN_IDS = new Set<string>([
+  "1", // Ethereum mainnet
+  "42161", // Arbitrum One
+  "43114", // Avalanche C-Chain
+  "56", // BNB Chain
+  "137", // Polygon
+  "16661", // 0G Mainnet (Aristotle)
+  "9745", // Plasma Mainnet
+]);
+
+type ChainClassification =
+  | { readonly kind: "payment"; readonly chain: BindingChain }
+  | { readonly kind: "data" }
+  | { readonly kind: "unrecognised" };
+
+/**
+ * Classify a workflow.chain tag into one of three buckets:
+ * - "payment": a recognised payment-chain slug or chain id; the listing is
+ *   pinned to that payment chain and the caller must match.
+ * - "data": a recognised data-chain id (Ethereum, OP, Polygon, Arbitrum); the
+ *   listing's chain identifies where the contracts live, not which chain
+ *   payment must arrive on. Either Base or Tempo payment is accepted.
+ * - "unrecognised": a non-empty value we can't parse. Treated as defensive
+ *   mismatch by the binding so a typo or future tag never silently widens
+ *   access.
+ *
+ * Case-insensitive on slug input; whitespace-trimmed. Numeric forms match
+ * the canonical constants in lib/agentic-wallet/constants.ts so a chain-id
+ * rename only happens in one place.
+ */
+function classifyChainTag(
   value: string | null | undefined
-): BindingChain | null {
+): ChainClassification {
   if (typeof value !== "string") {
-    return null;
+    return { kind: "unrecognised" };
   }
   const v = value.trim().toLowerCase();
   if (v === "base" || v === BASE_CHAIN_ID_STR) {
-    return "base";
+    return { kind: "payment", chain: "base" };
   }
   if (
     v === "tempo" ||
     v === TEMPO_MAINNET_CHAIN_ID_STR ||
     v === TEMPO_TESTNET_CHAIN_ID_STR
   ) {
-    return "tempo";
+    return { kind: "payment", chain: "tempo" };
   }
-  return null;
+  if (KNOWN_DATA_CHAIN_IDS.has(v)) {
+    return { kind: "data" };
+  }
+  return { kind: "unrecognised" };
 }
 
 function priceToMicro(
@@ -156,17 +212,21 @@ export async function verifyWorkflowBinding(
     };
   }
 
-  // Fix-pack-3 N-1 + Fix-pack-4 (KEEP-391): reject requests whose
-  // caller-supplied chain does not match the workflow's registered chain,
-  // comparing on a normalised tag so listings stored with a numeric chain
-  // id ("8453", "4217", "4218") compare equal to the slug forms ("base",
-  // "tempo"). Null is permissive for legacy listings that pre-date the
-  // workflows.chain column. Unknown / unparseable values are treated as a
-  // mismatch (defensive) rather than null (permissive) so we never silently
-  // widen access on an unrecognised tag.
+  // Fix-pack-3 N-1 + Fix-pack-4 (KEEP-391) + Fix-pack-5 (KEEP-432): classify
+  // the workflow's chain tag into payment / data / unrecognised. Payment-
+  // chain listings stay pinned to that chain (the original cross-chain-proof
+  // defence). Data-chain listings (Ethereum, Arbitrum, Polygon, BNB, Avalanche, 0G, Plasma) only
+  // describe where the workflow READS contracts from — they have no inherent
+  // payment-chain preference, so either Base x402 or Tempo MPP is accepted.
+  // Unrecognised tags stay defensive (mismatch) so a typo never widens access.
+  // A null wf.chain remains permissive for legacy listings that pre-date the
+  // workflows.chain column.
   if (wf.chain) {
-    const wfNorm = normaliseChainTag(wf.chain);
-    if (wfNorm === null || wfNorm !== chain) {
+    const wfClass = classifyChainTag(wf.chain);
+    const matched =
+      wfClass.kind === "data" ||
+      (wfClass.kind === "payment" && wfClass.chain === chain);
+    if (!matched) {
       return {
         ok: false,
         status: 403,

--- a/tests/unit/agentic-wallet-workflow-binding.test.ts
+++ b/tests/unit/agentic-wallet-workflow-binding.test.ts
@@ -59,7 +59,7 @@ vi.mock("@/lib/db/schema", () => ({
   organizationWallets: { _table: "para_wallets" },
 }));
 
-const { verifyWorkflowBinding } = await import(
+const { verifyWorkflowBinding, KNOWN_DATA_CHAIN_IDS } = await import(
   "@/lib/agentic-wallet/workflow-binding"
 );
 
@@ -291,10 +291,10 @@ describe("verifyWorkflowBinding", () => {
     });
 
     it("rejects an unrecognised wf.chain tag (defensive — no silent widening)", async () => {
-      // wf.chain is a non-null string we cannot normalise. Treat as
-      // mismatch rather than falling through to permissive null branch,
-      // so a typo or future chain stored as "ethereum" can never pass
-      // a stolen-HMAC attacker's request through.
+      // wf.chain is a non-null string we cannot classify (slug form, not in
+      // the data-chain whitelist, not a payment chain). Treat as mismatch
+      // rather than falling through to permissive null branch, so a typo or
+      // future chain stored as "ethereum" / "9999" can never pass through.
       queueWorkflow({ chain: "ethereum" });
       const rBase = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
       expect(rBase).toMatchObject({
@@ -303,9 +303,210 @@ describe("verifyWorkflowBinding", () => {
         code: "CHAIN_MISMATCH",
       });
 
-      queueWorkflow({ chain: "1" });
+      queueWorkflow({ chain: "9999" });
       const rTempo = await verifyWorkflowBinding(SLUG, "tempo", "", "0");
       expect(rTempo).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "CHAIN_MISMATCH",
+      });
+    });
+  });
+
+  // KEEP-432 (Fix-pack-5): listings whose chain identifies a data chain
+  // (Ethereum, Optimism, Polygon, Arbitrum) have no inherent payment-chain
+  // preference. Either Base x402 or Tempo MPP must be accepted, otherwise
+  // priced cross-chain-data workflows are unreachable from the wallet.
+  describe("data-chain listings (KEEP-432)", () => {
+    it("accepts Base payment for an Ethereum-data listing (chain=1)", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r.ok).toBe(true);
+    });
+
+    it("accepts Tempo payment for an Ethereum-data listing (chain=1)", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "tempo", "", "0");
+      expect(r.ok).toBe(true);
+    });
+
+    it("accepts either payment chain for every whitelisted data-chain listing", async () => {
+      // Sourced directly from production to eliminate manual-sync drift —
+      // adding a chain id to KNOWN_DATA_CHAIN_IDS now extends test coverage
+      // automatically. Skip "1" because it's covered by the explicit
+      // Ethereum tests above.
+      for (const dataChain of KNOWN_DATA_CHAIN_IDS) {
+        if (dataChain === "1") {
+          continue;
+        }
+
+        queueWorkflow({ chain: dataChain });
+        queueWallet({});
+        const rBase = await verifyWorkflowBinding(
+          SLUG,
+          "base",
+          CREATOR,
+          "50000"
+        );
+        expect(rBase.ok).toBe(true);
+
+        queueWorkflow({ chain: dataChain });
+        queueWallet({});
+        const rTempo = await verifyWorkflowBinding(SLUG, "tempo", "", "0");
+        expect(rTempo.ok).toBe(true);
+      }
+    });
+
+    it("still enforces payTo equality on the Base path for a data-chain listing", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", ATTACKER, "50000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "PAYTO_MISMATCH",
+      });
+    });
+
+    it("still enforces amount equality on the Base path for a data-chain listing", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "100000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "AMOUNT_MISMATCH",
+      });
+    });
+
+    it("rejects non-integer amount on Base for a data-chain listing", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "abc");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "AMOUNT_MISMATCH",
+      });
+    });
+
+    it("compares payTo case-insensitively on a data-chain listing", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet({ walletAddress: CREATOR.toUpperCase() });
+      const r = await verifyWorkflowBinding(
+        SLUG,
+        "base",
+        CREATOR.toLowerCase(),
+        "50000"
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    it("returns 403 WORKFLOW_NOT_PAYABLE for a data-chain listing without an active wallet", async () => {
+      queueWorkflow({ chain: "1" });
+      queueWallet(null);
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "WORKFLOW_NOT_PAYABLE",
+      });
+    });
+  });
+
+  // KEEP-432 negative-set integrity: lock in the strict-decimal classifier
+  // semantics so a future producer change (hex serialisation, leading-zero
+  // normalisation, etc.) can't silently break existing listings or widen
+  // acceptance to a chain that was meant to reject.
+  describe("classifier strictness (KEEP-432 negative set)", () => {
+    it("rejects whitespace-only wf.chain as unrecognised", async () => {
+      // " " is truthy so reaches classifyChainTag, then trims to "" which
+      // doesn't match any known tag.
+      queueWorkflow({ chain: "   " });
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "CHAIN_MISMATCH",
+      });
+    });
+
+    it("rejects leading-zero numeric ids ('08453', '01')", async () => {
+      queueWorkflow({ chain: "08453" });
+      const r1 = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r1).toMatchObject({ ok: false, code: "CHAIN_MISMATCH" });
+
+      queueWorkflow({ chain: "01" });
+      const r2 = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r2).toMatchObject({ ok: false, code: "CHAIN_MISMATCH" });
+    });
+
+    it("rejects 0x-prefixed hex chain ids", async () => {
+      queueWorkflow({ chain: "0x1" });
+      const r1 = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r1).toMatchObject({ ok: false, code: "CHAIN_MISMATCH" });
+
+      queueWorkflow({ chain: "0x2105" }); // 8453 in hex
+      const r2 = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r2).toMatchObject({ ok: false, code: "CHAIN_MISMATCH" });
+    });
+
+    it("rejects float / decimal chain forms ('8453.0')", async () => {
+      queueWorkflow({ chain: "8453.0" });
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r).toMatchObject({ ok: false, code: "CHAIN_MISMATCH" });
+    });
+
+    it("rejects testnet ids that aren't on the mainnet whitelist", async () => {
+      // Mainnet-only by intent. If KeeperHub starts supporting testnet
+      // listings, extend KNOWN_DATA_CHAIN_IDS and update this test.
+      const testnetIds = [
+        "11155111", // Sepolia
+        "421614", // Arbitrum Sepolia
+        "80002", // Polygon Amoy
+        "43113", // Avalanche Fuji
+        "9746", // Plasma testnet
+        "16602", // 0G Galileo testnet
+      ];
+      for (const t of testnetIds) {
+        queueWorkflow({ chain: t });
+        const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+        expect(r).toMatchObject({ ok: false, code: "CHAIN_MISMATCH" });
+      }
+    });
+  });
+
+  // KEEP-432 symmetric cross-chain-proof tests: the original Fix-pack-3 N-1
+  // defence is bidirectional. The KEEP-391 test suite covers Base-pinned +
+  // tempo-caller; these cover the inverse so a future code change that
+  // flips the equality direction is caught.
+  describe("payment-chain pin is symmetric (KEEP-432)", () => {
+    it("rejects tempo-pinned listing with base caller", async () => {
+      queueWorkflow({ chain: "tempo" });
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "CHAIN_MISMATCH",
+      });
+    });
+
+    it("rejects Tempo-mainnet-id listing with base caller", async () => {
+      queueWorkflow({ chain: "4217" });
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "CHAIN_MISMATCH",
+      });
+    });
+
+    it("rejects Tempo-testnet-id listing with base caller", async () => {
+      queueWorkflow({ chain: "4218" });
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r).toMatchObject({
         ok: false,
         status: 403,
         code: "CHAIN_MISMATCH",


### PR DESCRIPTION
## Summary

Priced workflow listings whose chain identifies a data chain (Ethereum, Arbitrum, Polygon, BNB, Avalanche, 0G, Plasma) used to 403 with `CHAIN_MISMATCH` on every paid invocation. Root cause: `wf.chain` was required to normalise to `"base"` or `"tempo"`, but the chain field is overloaded — for Base-data workflows it doubles as the payment-chain pin, while for Ethereum-data workflows it identifies *where the contracts live*, not which chain payment must arrive on.

This PR replaces `normaliseChainTag` (`BindingChain | null`) with `classifyChainTag` returning a discriminated `{kind: "payment" | "data" | "unrecognised"}`. Data-chain listings (whitelist matches `lib/rpc/rpc-config.ts` mainnet entries) accept either Base x402 or Tempo MPP payment. Payment-chain pinning, the fix-pack-3 N-1 cross-chain-proof defence, and the unrecognised-tag defensive reject are all preserved.

## Repro

Before:
- List a workflow with `chain: "1"` and `priceUsdcPerCall: "0.05"`
- Call via `mcp__keeperhub-wallet__call_workflow` → `403 {code: "CHAIN_MISMATCH"}`

After: same call returns `200 {paid: true, protocolUsed: "x402"}` (or `mpp`).

## Security

- **Base path:** server-derived `payTo` equality and amount equality still enforced on data-chain listings. Two new tests pin this contract.
- **Tempo path:** workflow price still resolved for daily-spend deduction (Fix-pack-2 R1 unchanged).
- **Cross-chain-proof defence (Fix-pack-3 N-1 / KEEP-391):** unchanged for Base/Tempo-pinned listings. Three new symmetric tests verify both directions of the pin.
- **Unrecognised tags:** still defensive-reject. Five new tests pin strict-decimal classifier semantics (rejects whitespace, leading zeros, hex, floats, testnet ids).
- **Listing creator degree-of-freedom:** flagged in the doc comment — `workflows.chain` is free-form text written by the listing API without an input allowlist, so a creator can intentionally tag a Base-only workflow with `chain="1"` to widen acceptance. Not a security boundary violation (`payTo` is still server-derived from the org's wallet) but worth knowing.

## Coverage

11 new tests across 3 new `describe` blocks. **35/35 tests pass** (was 24).

| Block | Cases |
|---|---|
| `data-chain listings (KEEP-432)` | Base/Tempo accept × Ethereum + whitelist loop, security equality (PAYTO/AMOUNT), edge cases (non-integer amount, case-insensitive payTo, WORKFLOW_NOT_PAYABLE) |
| `classifier strictness (KEEP-432 negative set)` | Whitespace-only, leading-zero, 0x-hex, float, testnet ids — all reject |
| `payment-chain pin is symmetric (KEEP-432)` | Tempo-pinned (slug + mainnet id + testnet id) × base caller — all reject |

## Test plan

- [ ] CI green (vitest + biome + tsc)
- [ ] On staging deploy: re-list `liquidation-watcher-ethereum` at `priceUsdcPerCall: "0.05"` and verify `mcp__keeperhub-wallet__call_workflow` returns `paid: true, protocolUsed: "x402"`
- [ ] On staging deploy: confirm existing Base-pinned `liquidation-watcher-base` (already paid) still returns `paid: true` (regression check)
- [ ] On staging deploy: confirm a Tempo-pinned listing (if available) still rejects Base callers (cross-chain-proof regression check)

## Out of scope (mentioned for context)

- Pre-existing testnet-id drift (`4218` in `lib/agentic-wallet/constants.ts` vs `42431` in `lib/rpc/rpc-config.ts:106`) is untouched.
- `KNOWN_DATA_CHAIN_IDS` is hardcoded; deriving from a single source-of-truth (DB `chains` table or filtered `CHAIN_CONFIG`) would eliminate manual sync. Filed as follow-up.