### PR TITLE
fix(billing): gate gas credits row in confirm-plan-change dialog (KEEP-446)

### DIFF
--- a/components/billing/confirm-plan-change-dialog.tsx
+++ b/components/billing/confirm-plan-change-dialog.tsx
@@ -26,6 +26,7 @@ import {
   type TierKey,
 } from "@/lib/billing/plans";
 import { cn } from "@/lib/utils";
+import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import type { GasCreditCapsMap } from "./pricing-table/types";
 
 type ChangeDirection = "upgrade" | "downgrade" | "same";
@@ -195,14 +196,20 @@ function buildFeatureChanges(
   currentExecs: number,
   newExecs: number
 ): FeatureChange[] {
-  const candidates = [
+  const candidates: (FeatureChange | null)[] = [
     compareExecutions(currentExecs, newExecs),
-    compareSimpleNumeric(
-      "Gas credits",
-      currentFeatures.gasCreditsCents,
-      newFeatures.gasCreditsCents,
-      (v) => `$${(v / 100).toFixed(0)}/mo`
-    ),
+  ];
+  if (isGasSponsorshipEnabled()) {
+    candidates.push(
+      compareSimpleNumeric(
+        "Gas credits",
+        currentFeatures.gasCreditsCents,
+        newFeatures.gasCreditsCents,
+        (v) => `$${(v / 100).toFixed(0)}/mo`
+      )
+    );
+  }
+  candidates.push(
     compareSimpleNumeric(
       "Log retention",
       currentFeatures.logRetentionDays,
@@ -211,8 +218,8 @@ function buildFeatureChanges(
     ),
     compareApiAccess(currentFeatures, newFeatures),
     compareSupport(currentFeatures, newFeatures),
-    compareSla(currentFeatures.sla, newFeatures.sla),
-  ];
+    compareSla(currentFeatures.sla, newFeatures.sla)
+  );
   return candidates.filter((c): c is FeatureChange => c !== null);
 }
 


### PR DESCRIPTION
## Summary

- Gates the "Gas credits" row in the plan-change confirm dialog behind `isGasSponsorshipEnabled()`, so it stays hidden while `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=false`.
- Mirrors gating already applied in [`plan-card.tsx`](components/billing/pricing-table/plan-card.tsx) and [`billing-status.tsx`](components/billing/billing-status.tsx); the confirm dialog was the missing third spot.
- No behavior change when the flag is on — same row, same formatting.

## Why

Gas sponsorship is not yet shipped (flag is `false` in `.env`, staging, prod). Today, when a user upgrades Free → Pro or Pro → Business, the confirm dialog's "What changes" panel advertises e.g. `Gas credits  $1/mo → $5/mo`, suggesting a feature that doesn't exist. This fix removes that misleading row until the feature is launched.

Linear: [KEEP-446](https://linear.app/keeperhubapp/issue/KEEP-446)