### PR TITLE
fix(executor): set NEXT_PUBLIC_BILLING_ENABLED in deploy values (KEEP-447)

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -142,6 +142,12 @@ env:
   FROM_ADDRESS:
     type: kv
     value: "noreply@keeperhub.com"
+  # Billing guard. Read by keeperhub-executor/billing-guard.ts to gate
+  # SQS-triggered runs (schedule / block / event) on the monthly tier.
+  # Must mirror NEXT_PUBLIC_BILLING_ENABLED in deploy/keeperhub/prod/values.yaml.
+  NEXT_PUBLIC_BILLING_ENABLED:
+    type: kv
+    value: "true"
   # Gas credit caps per plan (cents, server-only)
   GAS_CREDITS_FREE_CENTS:
     type: kv

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -142,6 +142,12 @@ env:
   FROM_ADDRESS:
     type: kv
     value: "noreply@keeperhub.com"
+  # Billing guard. Read by keeperhub-executor/billing-guard.ts to gate
+  # SQS-triggered runs (schedule / block / event) on the monthly tier.
+  # Must mirror NEXT_PUBLIC_BILLING_ENABLED in deploy/keeperhub/staging/values.yaml.
+  NEXT_PUBLIC_BILLING_ENABLED:
+    type: kv
+    value: "true"
   # Gas credit caps per plan (cents, server-only)
   GAS_CREDITS_FREE_CENTS:
     type: kv


### PR DESCRIPTION
Linear: [KEEP-447](https://linear.app/keeperhubapp/issue/KEEP-447/billing-executor-missing-next-public-billing-enabled)

## Summary

The billing-guard hotfix (PR #1137, deployed in prod as `a7385e5`) added `checkExecutionLimitForExecutor` to the standalone executor. The helper short-circuits to `{ allowed: true, reason: "billing_disabled" }` when `process.env.NEXT_PUBLIC_BILLING_ENABLED !== "true"`. That env var was added to `keeperhub-common` long ago but **never propagated to the executor's deployment**, so every schedule/block/event trigger has been bypassing the cap in prod.

## Evidence (prod, 2026-05-06)

- `keeperhub-common-*` pod env: `NEXT_PUBLIC_BILLING_ENABLED=true`
- `keeperhub-executor-common-*` pod env: 133 vars, **none matching billing**
- joel's Organization (free plan, 5,000/mo limit): **16,121 month-to-date** (3.2× over)
- Hourly execution rate flat at **122/hour for 25h** — exactly the sum of all 9 active cron schedules at full cadence. Mainnet USDC (`* * * * *`) ran exactly **1,440** times in 24h.
- Deployed image `executor-a7385e5` includes the hotfix code — code is right; the env var is missing.

## Change

Mirror `deploy/keeperhub/{prod,staging}/values.yaml:NEXT_PUBLIC_BILLING_ENABLED` into:

- `deploy/executor/prod/values.yaml`
- `deploy/executor/staging/values.yaml`

Same shape, same value (`"true"`), with a comment cross-referencing the keeperhub-common values so future deploys don't drift.

## Test plan

- [ ] Deploy executor with the new values, confirm pod env now contains `NEXT_PUBLIC_BILLING_ENABLED=true`
- [ ] Verify joel's Organization (already 3× over free tier) stops accumulating new schedule-triggered runs (rate should drop to ~0/hour)
- [ ] Pod logs should show `[Executor] Billing guard blocked schedule trigger ...` warnings on each blocked attempt
- [ ] Confirm enterprise / unlimited orgs still run normally
- [ ] Confirm under-tier orgs still run normally

## Follow-up (not in this PR)

The env var name `NEXT_PUBLIC_*` is a Next.js convention. Reading it in a standalone Node process is confusing and contributed to this oversight. Consider aliasing to a non-prefixed `BILLING_ENABLED` for the executor, or having the executor's helper accept either name.