### PR TITLE
feat(notifications): surface billing-limit dot on user menu and Billing item (KEEP-448)

### DIFF
--- a/app/api/notifications/status/route.ts
+++ b/app/api/notifications/status/route.ts
@@ -1,4 +1,6 @@
+import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import { isBillingLimitReached } from "@/lib/billing/limit-status";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
@@ -27,8 +29,14 @@ export async function GET(
 
     const types: NotificationType[] = [];
 
-    if (isBillingEnabled() && (await isBillingLimitReached(organizationId))) {
-      types.push("billing_limit_reached");
+    if (isBillingEnabled()) {
+      const activeMember = await auth.api.getActiveMember({
+        headers: await headers(),
+      });
+      const isOwner = activeMember?.role === "owner";
+      if (isOwner && (await isBillingLimitReached(organizationId))) {
+        types.push("billing_limit_reached");
+      }
     }
 
     return NextResponse.json({ unreadCount: types.length, types });

--- a/app/api/notifications/status/route.ts
+++ b/app/api/notifications/status/route.ts
@@ -1,14 +1,6 @@
-import { and, count, eq, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
-import {
-  getPlanLimits,
-  parsePlanName,
-  parseTierKey,
-} from "@/lib/billing/plans";
-import { getOrgSubscription } from "@/lib/billing/plans-server";
-import { db } from "@/lib/db";
-import { workflows } from "@/lib/db/schema";
+import { isBillingLimitReached } from "@/lib/billing/limit-status";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
   auditFromAuth,
@@ -39,11 +31,8 @@ export async function GET(
 
     const types: NotificationType[] = [];
 
-    if (isBillingEnabled()) {
-      const billingLimitReached = await isBillingLimitReached(organizationId);
-      if (billingLimitReached) {
-        types.push("billing_limit_reached");
-      }
+    if (isBillingEnabled() && (await isBillingLimitReached(organizationId))) {
+      types.push("billing_limit_reached");
     }
 
     return NextResponse.json({ unreadCount: types.length, types });
@@ -63,55 +52,4 @@ export async function GET(
       { status: 500 }
     );
   }
-}
-
-async function isBillingLimitReached(organizationId: string): Promise<boolean> {
-  const sub = await getOrgSubscription(organizationId);
-  const plan = parsePlanName(sub?.plan);
-  const tier = parseTierKey(sub?.tier);
-  const limits = getPlanLimits(plan, tier, sub?.planOverrides);
-
-  if (limits.maxExecutionsPerMonth < 0) {
-    return false;
-  }
-
-  const enabledWorkflowsResult = await db
-    .select({ value: count() })
-    .from(workflows)
-    .where(
-      and(
-        eq(workflows.organizationId, organizationId),
-        eq(workflows.enabled, true)
-      )
-    );
-  const enabledWorkflows = enabledWorkflowsResult[0]?.value ?? 0;
-  if (enabledWorkflows === 0) {
-    return false;
-  }
-
-  const startOfMonth = new Date();
-  startOfMonth.setUTCDate(1);
-  startOfMonth.setUTCHours(0, 0, 0, 0);
-
-  const usageResult = await db.execute<{ count: number }>(
-    sql`SELECT
-          (
-            SELECT COUNT(*)
-              FROM workflow_executions we
-              JOIN workflows w ON we.workflow_id = w.id
-             WHERE w.organization_id = ${organizationId}
-               AND we.started_at >= ${startOfMonth.toISOString()}
-               AND we.status <> 'blocked_billing'
-          )
-          +
-          (
-            SELECT COUNT(*)
-              FROM direct_executions de
-             WHERE de.organization_id = ${organizationId}
-               AND de.created_at >= ${startOfMonth.toISOString()}
-               AND de.status <> 'blocked_billing'
-          ) AS count`
-  );
-  const used = usageResult[0]?.count ?? 0;
-  return used >= limits.maxExecutionsPerMonth;
 }

--- a/app/api/notifications/status/route.ts
+++ b/app/api/notifications/status/route.ts
@@ -1,0 +1,117 @@
+import { and, count, eq, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { isBillingEnabled } from "@/lib/billing/feature-flag";
+import {
+  getPlanLimits,
+  parsePlanName,
+  parseTierKey,
+} from "@/lib/billing/plans";
+import { getOrgSubscription } from "@/lib/billing/plans-server";
+import { db } from "@/lib/db";
+import { workflows } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  auditFromAuth,
+  type OrganizationAuthContext,
+  resolveOrganizationId,
+} from "@/lib/middleware/auth-helpers";
+
+export type NotificationType = "billing_limit_reached";
+
+type NotificationStatusResponse = {
+  unreadCount: number;
+  types: NotificationType[];
+};
+
+export async function GET(
+  request: Request
+): Promise<NextResponse<NotificationStatusResponse | { error: string }>> {
+  let authContext: OrganizationAuthContext | null = null;
+  try {
+    authContext = await resolveOrganizationId(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
+    }
+    const { organizationId } = authContext;
+
+    const types: NotificationType[] = [];
+
+    if (isBillingEnabled()) {
+      const billingLimitReached = await isBillingLimitReached(organizationId);
+      if (billingLimitReached) {
+        types.push("billing_limit_reached");
+      }
+    }
+
+    return NextResponse.json({ unreadCount: types.length, types });
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Notifications] Status query error",
+      error,
+      {
+        endpoint: "/api/notifications/status",
+        operation: "get",
+        ...auditFromAuth(authContext),
+      }
+    );
+    return NextResponse.json(
+      { error: "Failed to fetch notifications" },
+      { status: 500 }
+    );
+  }
+}
+
+async function isBillingLimitReached(organizationId: string): Promise<boolean> {
+  const sub = await getOrgSubscription(organizationId);
+  const plan = parsePlanName(sub?.plan);
+  const tier = parseTierKey(sub?.tier);
+  const limits = getPlanLimits(plan, tier, sub?.planOverrides);
+
+  if (limits.maxExecutionsPerMonth < 0) {
+    return false;
+  }
+
+  const enabledWorkflowsResult = await db
+    .select({ value: count() })
+    .from(workflows)
+    .where(
+      and(
+        eq(workflows.organizationId, organizationId),
+        eq(workflows.enabled, true)
+      )
+    );
+  const enabledWorkflows = enabledWorkflowsResult[0]?.value ?? 0;
+  if (enabledWorkflows === 0) {
+    return false;
+  }
+
+  const startOfMonth = new Date();
+  startOfMonth.setUTCDate(1);
+  startOfMonth.setUTCHours(0, 0, 0, 0);
+
+  const usageResult = await db.execute<{ count: number }>(
+    sql`SELECT
+          (
+            SELECT COUNT(*)
+              FROM workflow_executions we
+              JOIN workflows w ON we.workflow_id = w.id
+             WHERE w.organization_id = ${organizationId}
+               AND we.started_at >= ${startOfMonth.toISOString()}
+               AND we.status <> 'blocked_billing'
+          )
+          +
+          (
+            SELECT COUNT(*)
+              FROM direct_executions de
+             WHERE de.organization_id = ${organizationId}
+               AND de.created_at >= ${startOfMonth.toISOString()}
+               AND de.status <> 'blocked_billing'
+          ) AS count`
+  );
+  const used = usageResult[0]?.count ?? 0;
+  return used >= limits.maxExecutionsPerMonth;
+}

--- a/app/api/notifications/status/route.ts
+++ b/app/api/notifications/status/route.ts
@@ -1,12 +1,7 @@
 import { NextResponse } from "next/server";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import { isBillingLimitReached } from "@/lib/billing/limit-status";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
-import {
-  auditFromAuth,
-  type OrganizationAuthContext,
-  resolveOrganizationId,
-} from "@/lib/middleware/auth-helpers";
+import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 
 export type NotificationType = "billing_limit_reached";
 
@@ -15,17 +10,18 @@ type NotificationStatusResponse = {
   types: NotificationType[];
 };
 
+const EMPTY_RESPONSE: NotificationStatusResponse = {
+  unreadCount: 0,
+  types: [],
+};
+
 export async function GET(
   request: Request
-): Promise<NextResponse<NotificationStatusResponse | { error: string }>> {
-  let authContext: OrganizationAuthContext | null = null;
+): Promise<NextResponse<NotificationStatusResponse>> {
   try {
-    authContext = await resolveOrganizationId(request);
+    const authContext = await resolveOrganizationId(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return NextResponse.json(EMPTY_RESPONSE);
     }
     const { organizationId } = authContext;
 
@@ -37,19 +33,10 @@ export async function GET(
 
     return NextResponse.json({ unreadCount: types.length, types });
   } catch (error) {
-    logSystemError(
-      ErrorCategory.EXTERNAL_SERVICE,
-      "[Notifications] Status query error",
-      error,
-      {
-        endpoint: "/api/notifications/status",
-        operation: "get",
-        ...auditFromAuth(authContext),
-      }
+    console.warn(
+      "[notifications-status] degraded; returning empty response",
+      error
     );
-    return NextResponse.json(
-      { error: "Failed to fetch notifications" },
-      { status: 500 }
-    );
+    return NextResponse.json(EMPTY_RESPONSE);
   }
 }

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -33,6 +33,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { signOut, useSession } from "@/lib/auth-client";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
+import {
+  hasNotificationType,
+  useNotificationStatus,
+} from "@/lib/hooks/use-notifications";
 import { useActiveMember, useOrganization } from "@/lib/hooks/use-organization";
 
 export const UserMenu = (): React.ReactElement => {
@@ -89,6 +93,19 @@ const AuthenticatedUserMenu = (): React.ReactElement => {
   const { isOwner } = useActiveMember();
   const router = useRouter();
   const showBilling = isOwner && isBillingEnabled();
+  const { status: notificationStatus, refresh: refreshNotifications } =
+    useNotificationStatus(organization?.id);
+  const showAvatarDot = notificationStatus.unreadCount > 0;
+  const showBillingDot = hasNotificationType(
+    notificationStatus,
+    "billing_limit_reached"
+  );
+
+  const handleDropdownOpenChange = (open: boolean): void => {
+    if (open) {
+      refreshNotifications().catch(() => undefined);
+    }
+  };
 
   const handleLogout = async (): Promise<void> => {
     await signOut();
@@ -113,10 +130,12 @@ const AuthenticatedUserMenu = (): React.ReactElement => {
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu onOpenChange={handleDropdownOpenChange}>
         <DropdownMenuTrigger asChild>
           <Button
-            aria-label="User menu"
+            aria-label={
+              showAvatarDot ? "User menu, unread notifications" : "User menu"
+            }
             className="relative h-9 w-9 rounded-full border p-0"
             data-testid="user-menu"
             variant="ghost"
@@ -128,6 +147,13 @@ const AuthenticatedUserMenu = (): React.ReactElement => {
               />
               <AvatarFallback>{getUserInitials()}</AvatarFallback>
             </Avatar>
+            {showAvatarDot && (
+              <span
+                aria-hidden="true"
+                className="absolute top-0 right-0 size-2.5 rounded-full bg-destructive ring-2 ring-background"
+                data-testid="user-menu-notification-dot"
+              />
+            )}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
@@ -166,7 +192,14 @@ const AuthenticatedUserMenu = (): React.ReactElement => {
           {showBilling && (
             <DropdownMenuItem onClick={() => router.push("/billing")}>
               <CreditCard className="size-4" />
-              <span>Billing</span>
+              <span className="flex-1">Billing</span>
+              {showBillingDot && (
+                <span
+                  aria-hidden="true"
+                  className="size-2 rounded-full bg-destructive"
+                  data-testid="billing-notification-dot"
+                />
+              )}
             </DropdownMenuItem>
           )}
           <DropdownMenuItem onClick={() => openOverlay(ProjectsAndTagsOverlay)}>

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -94,7 +94,7 @@ const AuthenticatedUserMenu = (): React.ReactElement => {
   const router = useRouter();
   const showBilling = isOwner && isBillingEnabled();
   const { status: notificationStatus, refresh: refreshNotifications } =
-    useNotificationStatus(organization?.id);
+    useNotificationStatus(isOwner ? organization?.id : null);
   const showAvatarDot = notificationStatus.unreadCount > 0;
   const showBillingDot = hasNotificationType(
     notificationStatus,

--- a/lib/billing/limit-status.ts
+++ b/lib/billing/limit-status.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { and, count, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { workflows } from "@/lib/db/schema";
+import { getPlanLimits, parsePlanName, parseTierKey } from "./plans";
+import { getOrgSubscription } from "./plans-server";
+
+function getStartOfMonthUtc(): Date {
+  const startOfMonth = new Date();
+  startOfMonth.setUTCDate(1);
+  startOfMonth.setUTCHours(0, 0, 0, 0);
+  return startOfMonth;
+}
+
+async function countEnabledWorkflows(organizationId: string): Promise<number> {
+  const result = await db
+    .select({ value: count() })
+    .from(workflows)
+    .where(
+      and(
+        eq(workflows.organizationId, organizationId),
+        eq(workflows.enabled, true)
+      )
+    );
+  return result[0]?.value ?? 0;
+}
+
+async function getCurrentMonthUsage(organizationId: string): Promise<number> {
+  const startOfMonth = getStartOfMonthUtc().toISOString();
+  const result = await db.execute<{ count: number }>(
+    sql`SELECT
+          (
+            SELECT COUNT(*)
+              FROM workflow_executions we
+              JOIN workflows w ON we.workflow_id = w.id
+             WHERE w.organization_id = ${organizationId}
+               AND we.started_at >= ${startOfMonth}
+               AND we.status <> 'blocked_billing'
+          )
+          +
+          (
+            SELECT COUNT(*)
+              FROM direct_executions de
+             WHERE de.organization_id = ${organizationId}
+               AND de.created_at >= ${startOfMonth}
+               AND de.status <> 'blocked_billing'
+          ) AS count`
+  );
+  return result[0]?.count ?? 0;
+}
+
+export async function isBillingLimitReached(
+  organizationId: string
+): Promise<boolean> {
+  const sub = await getOrgSubscription(organizationId);
+  const plan = parsePlanName(sub?.plan);
+  const tier = parseTierKey(sub?.tier);
+  const limits = getPlanLimits(plan, tier, sub?.planOverrides);
+
+  if (limits.maxExecutionsPerMonth < 0) {
+    return false;
+  }
+
+  const enabledWorkflows = await countEnabledWorkflows(organizationId);
+  if (enabledWorkflows === 0) {
+    return false;
+  }
+
+  const used = await getCurrentMonthUsage(organizationId);
+  return used >= limits.maxExecutionsPerMonth;
+}

--- a/lib/billing/limit-status.ts
+++ b/lib/billing/limit-status.ts
@@ -53,20 +53,28 @@ async function getCurrentMonthUsage(organizationId: string): Promise<number> {
 export async function isBillingLimitReached(
   organizationId: string
 ): Promise<boolean> {
-  const sub = await getOrgSubscription(organizationId);
-  const plan = parsePlanName(sub?.plan);
-  const tier = parseTierKey(sub?.tier);
-  const limits = getPlanLimits(plan, tier, sub?.planOverrides);
+  try {
+    const sub = await getOrgSubscription(organizationId);
+    const plan = parsePlanName(sub?.plan);
+    const tier = parseTierKey(sub?.tier);
+    const limits = getPlanLimits(plan, tier, sub?.planOverrides);
 
-  if (limits.maxExecutionsPerMonth < 0) {
+    if (limits.maxExecutionsPerMonth < 0) {
+      return false;
+    }
+
+    const enabledWorkflows = await countEnabledWorkflows(organizationId);
+    if (enabledWorkflows === 0) {
+      return false;
+    }
+
+    const used = await getCurrentMonthUsage(organizationId);
+    return used >= limits.maxExecutionsPerMonth;
+  } catch (error) {
+    console.warn(
+      "[limit-status] isBillingLimitReached failed; treating as not-reached",
+      error
+    );
     return false;
   }
-
-  const enabledWorkflows = await countEnabledWorkflows(organizationId);
-  if (enabledWorkflows === 0) {
-    return false;
-  }
-
-  const used = await getCurrentMonthUsage(organizationId);
-  return used >= limits.maxExecutionsPerMonth;
 }

--- a/lib/hooks/use-notifications.ts
+++ b/lib/hooks/use-notifications.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type NotificationType = "billing_limit_reached";
+
+type NotificationStatus = {
+  unreadCount: number;
+  types: NotificationType[];
+};
+
+const EMPTY_STATUS: NotificationStatus = { unreadCount: 0, types: [] };
+
+export function useNotificationStatus(organizationId?: string | null): {
+  status: NotificationStatus;
+  refresh: () => Promise<void>;
+} {
+  const [status, setStatus] = useState<NotificationStatus>(EMPTY_STATUS);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!organizationId) {
+      setStatus(EMPTY_STATUS);
+      return;
+    }
+    try {
+      const response = await fetch("/api/notifications/status", {
+        credentials: "include",
+      });
+      if (!response.ok) {
+        setStatus(EMPTY_STATUS);
+        return;
+      }
+      const data = (await response.json()) as NotificationStatus;
+      setStatus({
+        unreadCount: data.unreadCount ?? 0,
+        types: data.types ?? [],
+      });
+    } catch {
+      setStatus(EMPTY_STATUS);
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
+    refresh().catch(() => undefined);
+  }, [refresh]);
+
+  return { status, refresh };
+}
+
+export function hasNotificationType(
+  status: NotificationStatus,
+  type: NotificationType
+): boolean {
+  return status.types.includes(type);
+}

--- a/tests/e2e/playwright/notifications.test.ts
+++ b/tests/e2e/playwright/notifications.test.ts
@@ -1,0 +1,76 @@
+import type { Page, Route } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { signIn } from "./utils/auth";
+import {
+  PERSISTENT_TEST_PASSWORD,
+  PERSISTENT_TEST_USER_EMAIL,
+} from "./utils/db";
+
+type NotificationStatus = {
+  unreadCount: number;
+  types: string[];
+};
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("Notifications dot", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  async function mockNotificationsStatus(
+    page: Page,
+    status: NotificationStatus
+  ): Promise<void> {
+    await page.route("**/api/notifications/status", (route: Route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(status),
+      })
+    );
+  }
+
+  test("shows red dot on avatar and Billing item when billing limit reached", async ({
+    page,
+  }) => {
+    await mockNotificationsStatus(page, {
+      unreadCount: 1,
+      types: ["billing_limit_reached"],
+    });
+
+    await signIn(page, PERSISTENT_TEST_USER_EMAIL, PERSISTENT_TEST_PASSWORD);
+
+    const avatarDot = page.getByTestId("user-menu-notification-dot");
+    await expect(avatarDot).toBeVisible({ timeout: 10_000 });
+
+    await page.screenshot({
+      path: "tests/e2e/playwright/.probes/notifications-avatar-dot.png",
+      fullPage: false,
+    });
+
+    await page.getByTestId("user-menu").click();
+
+    const billingDot = page.getByTestId("billing-notification-dot");
+    await expect(billingDot).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({
+      path: "tests/e2e/playwright/.probes/notifications-billing-dot.png",
+      fullPage: false,
+    });
+  });
+
+  test("hides dots when no notifications are present", async ({ page }) => {
+    await mockNotificationsStatus(page, { unreadCount: 0, types: [] });
+
+    await signIn(page, PERSISTENT_TEST_USER_EMAIL, PERSISTENT_TEST_PASSWORD);
+
+    await expect(page.getByTestId("user-menu-notification-dot")).toHaveCount(0);
+
+    await page.getByTestId("user-menu").click();
+
+    await expect(page.getByTestId("billing-notification-dot")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a red notification dot on the user-menu avatar (when closed) and next to the **Billing** dropdown item (when open) whenever the active org has reached its monthly execution limit *and* has at least one enabled workflow.
- Derived signal — no notifications table, no migration. Uses the same usage query already running in `/api/billing/subscription`.
- Refetches on dropdown open and on org switch.

## Why

PR #1137 / #1140 land the billing guard + record blocked attempts as `status='blocked_billing'` rows, but until now there was no in-app signal that the limit had been hit. Cron-driven workflows would silently stop firing and users had no way to know unless they inspected execution history. This is the lightest possible surface to fix that — first user-visible notification mechanism.

Linear: [KEEP-448](https://linear.app/keeperhubapp/issue/KEEP-448)

## Implementation

- **`GET /api/notifications/status`** ([app/api/notifications/status/route.ts](app/api/notifications/status/route.ts)) — resolves the active org via the existing `resolveOrganizationId` middleware, computes `used vs limit` (same SQL as the billing-subscription endpoint, including the `status <> 'blocked_billing'` filter so blocked rows don't self-multiply), and only flags `billing_limit_reached` when there's also at least one enabled workflow. Returns `{ unreadCount, types }`.
- **`useNotificationStatus(organizationId?)`** ([lib/hooks/use-notifications.ts](lib/hooks/use-notifications.ts)) — fetches on mount, returns empty status when no org is set, recomputes when `organizationId` changes (handles org switching). Exposes a `refresh` callback the UI calls on dropdown open so freshly-blocked attempts surface without a page reload.
- **`AuthenticatedUserMenu`** ([components/workflows/user-menu.tsx](components/workflows/user-menu.tsx)) — small dot on the avatar trigger and on the `Billing` row, gated by `showAvatarDot` / `showBillingDot`. The avatar's existing `aria-label` is extended to "User menu, unread notifications" when the dot is showing; the dots themselves are `aria-hidden` decorative spans.

## Why no schema yet

Discussed beforehand: a generic `notifications` table with `type / payload / dedupe_key / read_at` is the right destination once we have 2-3 producer types. Today we only have one signal (billing-limit-reached) and it's cheap to derive. Promote to a real table when the second producer shows up.

## Tests

Playwright test at [tests/e2e/playwright/notifications.test.ts](tests/e2e/playwright/notifications.test.ts):
- `shows red dot on avatar and Billing item when billing limit reached` — mocks `/api/notifications/status` with `unreadCount=1, types=['billing_limit_reached']`, signs in as the persistent test user, asserts both `[data-testid=user-menu-notification-dot]` and `[data-testid=billing-notification-dot]` become visible. Captures screenshots to `.probes/`.
- `hides dots when no notifications are present` — mocks empty status and asserts both dots have count 0.

## Manual verification

Filled `joel's Organization` (free plan, 5,000/mo) to exactly 5,000 executions in local docker DB with one enabled workflow — confirmed both dots render and that hitting `/api/notifications/status` returns `{ unreadCount: 1, types: ["billing_limit_reached"] }`.