### PR TITLE
fix(mcp): KEEP-451 cap session cache to prevent OOM kills

### DIFF
--- a/lib/mcp/sessions.ts
+++ b/lib/mcp/sessions.ts
@@ -48,6 +48,20 @@ export function getSession(sessionId: string): SessionEntry | undefined {
 }
 
 export function setSession(sessionId: string, entry: SessionEntry): void {
+  // Close any prior entry under the same sessionId before we overwrite, so
+  // the old transport and server are released instead of leaked. In
+  // production same sessionId implies same apiKeyId (both derive from the
+  // JWT), but if they ever diverge, also drop the orphan from the old
+  // key's bucket.
+  const previousEntry = localCache.get(sessionId);
+  if (previousEntry !== undefined && previousEntry !== entry) {
+    previousEntry.server.close().catch(() => undefined);
+    previousEntry.transport.close().catch(() => undefined);
+    if (previousEntry.apiKeyId !== entry.apiKeyId) {
+      removeFromKeyBucket(previousEntry.apiKeyId, sessionId);
+    }
+  }
+
   const existingBucket = sessionsByKey.get(entry.apiKeyId);
   if (
     existingBucket !== undefined &&
@@ -131,6 +145,7 @@ function evict(sessionId: string, reason: "per_key_cap" | "global_cap"): void {
   logMcpEvent("mcp.session.evicted", {
     sessionId,
     orgId: entry.organizationId,
+    apiKeyId: entry.apiKeyId,
     reason,
   });
 }

--- a/lib/mcp/sessions.ts
+++ b/lib/mcp/sessions.ts
@@ -7,6 +7,20 @@ import { SESSION_TTL_SECONDS } from "@/lib/mcp/session-token";
 export const SESSION_TTL_MS = SESSION_TTL_SECONDS * 1000;
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
+// Hard caps on local cache size. Each SessionEntry holds a Transport +
+// McpServer + EventStore (~MB scale), so without a ceiling a single
+// misbehaving client can OOM the pod inside the 24h TTL window. Per-key
+// cap defends against one apiKeyId pinning the cache; global cap is the
+// backstop against fan-out across many keys.
+export const MAX_SESSIONS_TOTAL = Math.max(
+  1,
+  Number(process.env.MCP_MAX_LOCAL_SESSIONS) || 350
+);
+export const MAX_SESSIONS_PER_KEY = Math.max(
+  1,
+  Number(process.env.MCP_MAX_SESSIONS_PER_KEY) || 5
+);
+
 export type SessionEntry = {
   transport: WebStandardStreamableHTTPServerTransport;
   server: McpServer;
@@ -23,6 +37,10 @@ export type SessionEntry = {
 // Cross-pod and post-restart requests fall back to JWT verification.
 const localCache = new Map<string, SessionEntry>();
 
+// Sidecar index: apiKeyId -> ordered set of sessionIds (insertion = LRU order).
+// Lets setSession enforce MAX_SESSIONS_PER_KEY without scanning localCache.
+const sessionsByKey = new Map<string, Set<string>>();
+
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 export function getSession(sessionId: string): SessionEntry | undefined {
@@ -30,7 +48,31 @@ export function getSession(sessionId: string): SessionEntry | undefined {
 }
 
 export function setSession(sessionId: string, entry: SessionEntry): void {
+  const existingBucket = sessionsByKey.get(entry.apiKeyId);
+  if (
+    existingBucket !== undefined &&
+    !existingBucket.has(sessionId) &&
+    existingBucket.size >= MAX_SESSIONS_PER_KEY
+  ) {
+    const oldestForKey = existingBucket.values().next().value;
+    if (oldestForKey !== undefined) {
+      evict(oldestForKey, "per_key_cap");
+    }
+  }
+
+  if (!localCache.has(sessionId) && localCache.size >= MAX_SESSIONS_TOTAL) {
+    const oldestOverall = localCache.keys().next().value;
+    if (oldestOverall !== undefined) {
+      evict(oldestOverall, "global_cap");
+    }
+  }
+
   localCache.set(sessionId, entry);
+  const bucket = sessionsByKey.get(entry.apiKeyId) ?? new Set<string>();
+  bucket.delete(sessionId);
+  bucket.add(sessionId);
+  sessionsByKey.set(entry.apiKeyId, bucket);
+
   logMcpEvent("mcp.session.created", {
     sessionId,
     orgId: entry.organizationId,
@@ -40,6 +82,9 @@ export function setSession(sessionId: string, entry: SessionEntry): void {
 export function deleteSession(sessionId: string): void {
   const entry = localCache.get(sessionId);
   localCache.delete(sessionId);
+  if (entry !== undefined) {
+    removeFromKeyBucket(entry.apiKeyId, sessionId);
+  }
   logMcpEvent("mcp.session.terminated", {
     sessionId,
     orgId: entry?.organizationId,
@@ -48,18 +93,56 @@ export function deleteSession(sessionId: string): void {
 
 export function touchSession(sessionId: string): void {
   const entry = localCache.get(sessionId);
-  if (entry) {
-    entry.lastActivity = Date.now();
+  if (entry === undefined) {
+    return;
   }
+  entry.lastActivity = Date.now();
+  // LRU promote: re-insert at the tail of both indexes so active sessions
+  // are not picked as eviction candidates.
+  localCache.delete(sessionId);
+  localCache.set(sessionId, entry);
+  const bucket = sessionsByKey.get(entry.apiKeyId);
+  if (bucket !== undefined) {
+    bucket.delete(sessionId);
+    bucket.add(sessionId);
+  }
+}
+
+function removeFromKeyBucket(apiKeyId: string, sessionId: string): void {
+  const bucket = sessionsByKey.get(apiKeyId);
+  if (bucket === undefined) {
+    return;
+  }
+  bucket.delete(sessionId);
+  if (bucket.size === 0) {
+    sessionsByKey.delete(apiKeyId);
+  }
+}
+
+function evict(sessionId: string, reason: "per_key_cap" | "global_cap"): void {
+  const entry = localCache.get(sessionId);
+  if (entry === undefined) {
+    return;
+  }
+  localCache.delete(sessionId);
+  removeFromKeyBucket(entry.apiKeyId, sessionId);
+  entry.server.close().catch(() => undefined);
+  entry.transport.close().catch(() => undefined);
+  logMcpEvent("mcp.session.evicted", {
+    sessionId,
+    orgId: entry.organizationId,
+    reason,
+  });
 }
 
 export function cleanupExpiredSessions(): void {
   const now = Date.now();
   for (const [sessionId, entry] of localCache) {
     if (now - entry.lastActivity > SESSION_TTL_MS) {
+      localCache.delete(sessionId);
+      removeFromKeyBucket(entry.apiKeyId, sessionId);
       entry.server.close().catch(() => undefined);
       entry.transport.close().catch(() => undefined);
-      localCache.delete(sessionId);
       logMcpEvent("mcp.session.expired", {
         sessionId,
         orgId: entry.organizationId,
@@ -70,6 +153,26 @@ export function cleanupExpiredSessions(): void {
 
 export function getSessionCount(): number {
   return localCache.size;
+}
+
+export function getSessionStats(): {
+  size: number;
+  maxTotal: number;
+  maxPerKey: number;
+  keyCount: number;
+} {
+  return {
+    size: localCache.size,
+    maxTotal: MAX_SESSIONS_TOTAL,
+    maxPerKey: MAX_SESSIONS_PER_KEY,
+    keyCount: sessionsByKey.size,
+  };
+}
+
+// Test-only: clears all in-process state. Production code must not call this.
+export function resetSessionCacheForTesting(): void {
+  localCache.clear();
+  sessionsByKey.clear();
 }
 
 export function startCleanupInterval(): void {

--- a/tests/unit/mcp-session-cache-cap.test.ts
+++ b/tests/unit/mcp-session-cache-cap.test.ts
@@ -167,4 +167,64 @@ describe("mcp/sessions cache caps", () => {
     expect(sessions.getSessionStats().maxPerKey).toBe(7);
     expect(sessions.getSessionStats().maxTotal).toBe(42);
   });
+
+  it("re-setting an existing sessionId closes the previous transport and server", async () => {
+    const sessions = await loadSessions({ perKey: 5, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    const oldSpies: CloseSpies = {
+      transportClose: vi.fn(() => Promise.resolve()),
+      serverClose: vi.fn(() => Promise.resolve()),
+    };
+    sessions.setSession("s1", makeEntry("org-a", "key-A", oldSpies));
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+
+    expect(oldSpies.transportClose).toHaveBeenCalledTimes(1);
+    expect(oldSpies.serverClose).toHaveBeenCalledTimes(1);
+    expect(sessions.getSession("s1")).toBeDefined();
+    expect(sessions.getSessionStats().size).toBe(1);
+    expect(sessions.getSessionStats().keyCount).toBe(1);
+  });
+
+  it("cleanupExpiredSessions removes entries from sessionsByKey too", async () => {
+    const sessions = await loadSessions({ perKey: 5, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-b", "key-B"));
+
+    // Force both entries past TTL by mutating the stored references directly.
+    const expiredAt = Date.now() - sessions.SESSION_TTL_MS - 1;
+    const s1 = sessions.getSession("s1");
+    const s2 = sessions.getSession("s2");
+    if (s1 !== undefined) {
+      s1.lastActivity = expiredAt;
+    }
+    if (s2 !== undefined) {
+      s2.lastActivity = expiredAt;
+    }
+
+    sessions.cleanupExpiredSessions();
+
+    expect(sessions.getSession("s1")).toBeUndefined();
+    expect(sessions.getSession("s2")).toBeUndefined();
+    expect(sessions.getSessionStats().size).toBe(0);
+    expect(sessions.getSessionStats().keyCount).toBe(0);
+  });
+
+  it("per-key eviction does not cascade into a global eviction", async () => {
+    // Both caps simultaneously satisfied, then a third add for the same
+    // key should drop only s1 (per-key) and leave s2 (global) intact.
+    const sessions = await loadSessions({ perKey: 2, total: 2 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-a", "key-A"));
+    sessions.setSession("s3", makeEntry("org-a", "key-A"));
+
+    expect(sessions.getSession("s1")).toBeUndefined();
+    expect(sessions.getSession("s2")).toBeDefined();
+    expect(sessions.getSession("s3")).toBeDefined();
+    expect(sessions.getSessionStats().size).toBe(2);
+  });
 });

--- a/tests/unit/mcp-session-cache-cap.test.ts
+++ b/tests/unit/mcp-session-cache-cap.test.ts
@@ -1,0 +1,170 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { McpEventStore } from "@/lib/mcp/event-store";
+import type { SessionEntry } from "@/lib/mcp/sessions";
+
+type SessionsModule = typeof import("@/lib/mcp/sessions");
+
+type CloseSpies = {
+  transportClose: ReturnType<typeof vi.fn>;
+  serverClose: ReturnType<typeof vi.fn>;
+};
+
+function makeEntry(
+  organizationId: string,
+  apiKeyId: string,
+  spies?: CloseSpies
+): SessionEntry {
+  const transportClose =
+    spies?.transportClose ?? vi.fn(() => Promise.resolve());
+  const serverClose = spies?.serverClose ?? vi.fn(() => Promise.resolve());
+  return {
+    transport: {
+      close: transportClose,
+    } as unknown as WebStandardStreamableHTTPServerTransport,
+    server: { close: serverClose } as unknown as McpServer,
+    eventStore: {} as unknown as McpEventStore,
+    organizationId,
+    apiKeyId,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+  };
+}
+
+async function loadSessions(env: {
+  perKey: number;
+  total: number;
+}): Promise<SessionsModule> {
+  vi.stubEnv("MCP_MAX_SESSIONS_PER_KEY", String(env.perKey));
+  vi.stubEnv("MCP_MAX_LOCAL_SESSIONS", String(env.total));
+  vi.resetModules();
+  return await import("@/lib/mcp/sessions");
+}
+
+describe("mcp/sessions cache caps", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("evicts the oldest session for a key once its bucket is full", async () => {
+    const sessions = await loadSessions({ perKey: 3, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-a", "key-A"));
+    sessions.setSession("s3", makeEntry("org-a", "key-A"));
+    sessions.setSession("s4", makeEntry("org-a", "key-A"));
+
+    expect(sessions.getSession("s1")).toBeUndefined();
+    expect(sessions.getSession("s2")).toBeDefined();
+    expect(sessions.getSession("s3")).toBeDefined();
+    expect(sessions.getSession("s4")).toBeDefined();
+    expect(sessions.getSessionStats().size).toBe(3);
+  });
+
+  it("does not touch other keys' sessions when one key hits its per-key cap", async () => {
+    const sessions = await loadSessions({ perKey: 2, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("a1", makeEntry("org-a", "key-A"));
+    sessions.setSession("b1", makeEntry("org-b", "key-B"));
+    sessions.setSession("a2", makeEntry("org-a", "key-A"));
+    sessions.setSession("a3", makeEntry("org-a", "key-A"));
+
+    expect(sessions.getSession("a1")).toBeUndefined();
+    expect(sessions.getSession("a2")).toBeDefined();
+    expect(sessions.getSession("a3")).toBeDefined();
+    expect(sessions.getSession("b1")).toBeDefined();
+  });
+
+  it("evicts the global LRU when the total cap is reached across many keys", async () => {
+    const sessions = await loadSessions({ perKey: 100, total: 3 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-b", "key-B"));
+    sessions.setSession("s3", makeEntry("org-c", "key-C"));
+    sessions.setSession("s4", makeEntry("org-d", "key-D"));
+
+    expect(sessions.getSession("s1")).toBeUndefined();
+    expect(sessions.getSession("s2")).toBeDefined();
+    expect(sessions.getSession("s3")).toBeDefined();
+    expect(sessions.getSession("s4")).toBeDefined();
+    expect(sessions.getSessionStats().size).toBe(3);
+  });
+
+  it("touchSession promotes the entry so it survives the next eviction", async () => {
+    const sessions = await loadSessions({ perKey: 100, total: 3 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-b", "key-B"));
+    sessions.setSession("s3", makeEntry("org-c", "key-C"));
+
+    sessions.touchSession("s1");
+
+    sessions.setSession("s4", makeEntry("org-d", "key-D"));
+
+    expect(sessions.getSession("s1")).toBeDefined();
+    expect(sessions.getSession("s2")).toBeUndefined();
+    expect(sessions.getSession("s3")).toBeDefined();
+    expect(sessions.getSession("s4")).toBeDefined();
+  });
+
+  it("re-setting an existing sessionId does not evict and does not double-count", async () => {
+    const sessions = await loadSessions({ perKey: 2, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-a", "key-A"));
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+
+    expect(sessions.getSession("s1")).toBeDefined();
+    expect(sessions.getSession("s2")).toBeDefined();
+    expect(sessions.getSessionStats().size).toBe(2);
+  });
+
+  it("deleteSession clears both the main map and the per-key bucket", async () => {
+    const sessions = await loadSessions({ perKey: 5, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    sessions.setSession("s1", makeEntry("org-a", "key-A"));
+    sessions.setSession("s2", makeEntry("org-a", "key-A"));
+
+    sessions.deleteSession("s1");
+    expect(sessions.getSession("s1")).toBeUndefined();
+    expect(sessions.getSessionStats().size).toBe(1);
+    expect(sessions.getSessionStats().keyCount).toBe(1);
+
+    sessions.deleteSession("s2");
+    expect(sessions.getSessionStats().size).toBe(0);
+    expect(sessions.getSessionStats().keyCount).toBe(0);
+  });
+
+  it("eviction closes the underlying transport and server", async () => {
+    const sessions = await loadSessions({ perKey: 1, total: 100 });
+    sessions.resetSessionCacheForTesting();
+
+    const spies: CloseSpies = {
+      transportClose: vi.fn(() => Promise.resolve()),
+      serverClose: vi.fn(() => Promise.resolve()),
+    };
+    sessions.setSession("s1", makeEntry("org-a", "key-A", spies));
+    sessions.setSession("s2", makeEntry("org-a", "key-A"));
+
+    expect(spies.transportClose).toHaveBeenCalledTimes(1);
+    expect(spies.serverClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the configured caps via getSessionStats", async () => {
+    const sessions = await loadSessions({ perKey: 7, total: 42 });
+
+    expect(sessions.getSessionStats().maxPerKey).toBe(7);
+    expect(sessions.getSessionStats().maxTotal).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

- Bounds the per-pod `localCache` in `lib/mcp/sessions.ts` with per-key (5) and global (350) LRU caps. Each `SessionEntry` holds a `Transport` + `McpServer` + `EventStore` (~MB scale) and lingered for the full 24h sliding TTL after last activity, so a single misbehaving client could accumulate thousands of entries faster than the TTL sweep dropped them.
- Observed in prod: `keeperhub-common` OOMKilled every 3-4h. Two MCP clients on free-tier orgs were looping `initialize` + `execute_workflow` while quota-rejected, opening ~3.4 sessions/min each. With the per-key cap their footprint is bounded to 5 entries instead of accumulating into the thousands.
- Sidecar `sessionsByKey: Map<apiKeyId, Set<sessionId>>` keeps per-key eviction O(1). `setSession` evicts the bucket's oldest first, then the overall oldest as backstop. `touchSession` LRU-promotes in both indexes so active sessions are not eviction candidates. `deleteSession` and `cleanupExpiredSessions` keep both indexes consistent.
- New `mcp.session.evicted` log event with `reason: "per_key_cap" | "global_cap"` for observability. New `getSessionStats()` exposes `{ size, maxTotal, maxPerKey, keyCount }`, mirroring the shape of `getRateLimitStats()` from KEEP-419.

## Tunables

Both caps are env-overridable so ops can adjust without a redeploy:

| Env var | Default | Purpose |
|---|---|---|
| `MCP_MAX_SESSIONS_PER_KEY` | 5 | Bounds any single apiKeyId / OAuth user |
| `MCP_MAX_LOCAL_SESSIONS` | 350 | Total cache size, ~700 MB at observed ~2 MB/session |

## What this is not

- Not a rate-limit change. `lib/mcp/rate-limit.ts` is untouched.
- Not a quota-check ordering change. `enforceExecutionLimit` still fires at the execute endpoint. Moving it earlier would change product semantics (block over-quota orgs from browsing workflows, not just executing them) and is intentionally out of scope.
- Not a TTL change. KEEP-196's 24h `SESSION_TTL_SECONDS` invariant is preserved; the existing TTL constant test still passes. The fix is orthogonal: caps defend against accumulation faster than TTL can drop, not against TTL length.

## Test plan

- [x] `pnpm test tests/unit/mcp-session-cache-cap.test.ts` - 8 new tests pass (per-key cap, key isolation, global cap, touch-promotion, idempotent re-set, deletion, transport/server close on eviction, getSessionStats)
- [x] `pnpm test tests/unit/mcp-session-longevity.test.ts` - KEEP-196 TTL invariants still pass
- [x] `pnpm test tests/unit/mcp-rate-limit.test.ts` - adjacent KEEP-419 sweep pattern still passes
- [x] `pnpm exec ultracite check lib/mcp/sessions.ts tests/unit/mcp-session-cache-cap.test.ts` - clean
- [x] `pnpm type-check` - clean
- [ ] Staging soak: deploy and watch `keeperhub-common` memory plus `mcp.session.evicted` log volume for 24h before promoting to prod

## Out of scope (separate follow-ups)

- JWT-in-logs in `mcp.session.created` - covered by KEEP-239
- Backend Sentry SDK on `keeperhub-common` (no telemetry on this service today)
- Deploy pipeline -> Sentry release tracking (most recent tracked release is from Apr 29; today's deploys are not registered)
- Rate-limit demotion for over-quota orgs (product call)

Linear: KEEP-451