### PR TITLE
ci: KEEP-404 add distinct CI checks for keeperhub-scheduler

### DIFF
--- a/.github/actions/setup-scheduler-deps/action.yml
+++ b/.github/actions/setup-scheduler-deps/action.yml
@@ -1,0 +1,38 @@
+name: Setup scheduler workspace deps
+description: Install Node, pnpm, and dependencies for the keeperhub-scheduler package.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "22"
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.STORE_PATH }}
+        # Key only on the scheduler lockfile so main-app lockfile churn does
+        # not invalidate the scheduler cache.
+        key: ${{ runner.os }}-pnpm-scheduler-${{ hashFiles('keeperhub-scheduler/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-scheduler-
+
+    - name: Install scheduler deps
+      shell: bash
+      working-directory: keeperhub-scheduler
+      # --ignore-workspace prevents pnpm from walking up to the repo-root
+      # pnpm-workspace.yaml (which only includes the main app + sandbox).
+      # The scheduler is a standalone package with its own lockfile, not
+      # a nested workspace like keeperhub-events.
+      run: pnpm install --frozen-lockfile --ignore-workspace

--- a/.github/workflows/pr-checks-scheduler.yml
+++ b/.github/workflows/pr-checks-scheduler.yml
@@ -1,0 +1,52 @@
+# Type: standalone | PR checks for the keeperhub-scheduler package.
+# Runs only when keeperhub-scheduler/**, this workflow, or the setup
+# composite action change. The scheduler package has its own pnpm
+# lockfile (not part of the root pnpm workspace), so the existing
+# setup-node-pnpm action (which installs from the repo root) is not reused.
+name: PR Checks (Scheduler)
+
+on:
+  pull_request:
+    paths:
+      - "keeperhub-scheduler/**"
+      - ".github/workflows/pr-checks-scheduler.yml"
+      - ".github/actions/setup-scheduler-deps/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-scheduler-deps
+      - name: Run lint
+        working-directory: keeperhub-scheduler
+        run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-scheduler-deps
+      - name: Run typecheck
+        working-directory: keeperhub-scheduler
+        run: pnpm typecheck
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-scheduler-deps
+      - name: Run build
+        # `pnpm build` runs `tsc` (with emit), catching d.ts generation
+        # and rootDir/outDir errors that `--noEmit` typecheck does not.
+        working-directory: keeperhub-scheduler
+        run: pnpm build
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-scheduler-deps
+      - name: Run unit tests
+        working-directory: keeperhub-scheduler
+        run: pnpm test:unit

--- a/.github/workflows/pr-checks-scheduler.yml
+++ b/.github/workflows/pr-checks-scheduler.yml
@@ -12,9 +12,26 @@ on:
       - ".github/workflows/pr-checks-scheduler.yml"
       - ".github/actions/setup-scheduler-deps/**"
 
+# Cancel superseded runs on new pushes to the same PR branch. PR checks
+# are advisory; the latest commit is the only one that matters. Mirrors
+# the convention in deploy-scheduler.yaml (which uses
+# cancel-in-progress: false because deploys must not interrupt themselves).
+concurrency:
+  group: pr-checks-scheduler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Default GHA token grants more than this workflow needs. Restrict to
+# read-only contents access; no job here writes to the repo, comments on
+# the PR, or pushes packages.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Local runs complete in <30s; 5min cap surfaces hangs (network,
+    # registry stalls) without burning the default 6h GHA budget.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-scheduler-deps
@@ -24,6 +41,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-scheduler-deps
@@ -33,6 +51,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-scheduler-deps
@@ -44,6 +63,7 @@ jobs:
 
   test-unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-scheduler-deps

--- a/keeperhub-scheduler/biome.jsonc
+++ b/keeperhub-scheduler/biome.jsonc
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", "dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  }
+}

--- a/keeperhub-scheduler/block-dispatcher/api-client.ts
+++ b/keeperhub-scheduler/block-dispatcher/api-client.ts
@@ -19,11 +19,15 @@ type GroupedWorkflows = Map<
 
 export async function fetchBlockWorkflows(): Promise<GroupedWorkflows> {
   const data = await apiRequest<FetchBlockWorkflowsResponse>(
-    "/api/internal/block-workflows?active=true"
+    "/api/internal/block-workflows?active=true",
   );
 
   console.log(
-    `[APIClient] Fetched ${data.workflows.length} workflow(s), ${Object.keys(data.networks).length} network(s) available: ${Object.entries(data.networks).map(([id, n]) => `${n.name}(${id})`).join(", ") || "none"}`
+    `[APIClient] Fetched ${data.workflows.length} workflow(s), ${Object.keys(data.networks).length} network(s) available: ${
+      Object.entries(data.networks)
+        .map(([id, n]) => `${n.name}(${id})`)
+        .join(", ") || "none"
+    }`,
   );
 
   const grouped: GroupedWorkflows = new Map();
@@ -35,7 +39,7 @@ export async function fetchBlockWorkflows(): Promise<GroupedWorkflows> {
 
     if (!network) {
       console.warn(
-        `[APIClient] Workflow ${workflow.id} (${workflow.name}): SKIPPED — no network configured in trigger node`
+        `[APIClient] Workflow ${workflow.id} (${workflow.name}): SKIPPED — no network configured in trigger node`,
       );
       continue;
     }
@@ -46,13 +50,13 @@ export async function fetchBlockWorkflows(): Promise<GroupedWorkflows> {
 
     if (!chainData) {
       console.warn(
-        `[APIClient] Workflow ${workflow.id} (${workflow.name}): SKIPPED — network ${chainId} not found in available networks`
+        `[APIClient] Workflow ${workflow.id} (${workflow.name}): SKIPPED — network ${chainId} not found in available networks`,
       );
       continue;
     }
 
     console.log(
-      `[APIClient] Workflow ${workflow.id} (${workflow.name}): chainId=${chainId} (${chainData.name}), blockInterval=${blockInterval}, primaryWss=${chainData.defaultPrimaryWss ? "yes" : "NO"}, fallbackWss=${chainData.defaultFallbackWss ? "yes" : "NO"}`
+      `[APIClient] Workflow ${workflow.id} (${workflow.name}): chainId=${chainId} (${chainData.name}), blockInterval=${blockInterval}, primaryWss=${chainData.defaultPrimaryWss ? "yes" : "NO"}, fallbackWss=${chainData.defaultFallbackWss ? "yes" : "NO"}`,
     );
 
     const blockWorkflow: BlockWorkflow = {

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -12,8 +12,8 @@
  */
 
 import { ethers } from "ethers";
-import { enqueueBlockTrigger } from "./sqs-enqueue.js";
 import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
+import { enqueueBlockTrigger } from "./sqs-enqueue.js";
 
 const MAX_RECONNECT_ATTEMPTS = 10;
 const BASE_DELAY_MS = 1000;
@@ -126,7 +126,9 @@ export class ChainMonitor {
   }
 
   isAlive(): boolean {
-    return this.isRunning && (this.hasActiveSubscription || this.isReconnecting);
+    return (
+      this.isRunning && (this.hasActiveSubscription || this.isReconnecting)
+    );
   }
 
   getStatus(): {
@@ -183,12 +185,12 @@ export class ChainMonitor {
 
   private async connect(): Promise<void> {
     const urls = [this.primaryWss, this.fallbackWss].filter(
-      (url): url is string => url !== null && url !== ""
+      (url): url is string => url !== null && url !== "",
     );
 
     if (urls.length === 0) {
       throw new Error(
-        `No WSS URLs configured for chain ${this.chainName} (${this.chainId})`
+        `No WSS URLs configured for chain ${this.chainName} (${this.chainId})`,
       );
     }
 
@@ -220,7 +222,7 @@ export class ChainMonitor {
           new Promise<number>((_, reject) => {
             setTimeout(
               () => reject(new Error("Connection timeout")),
-              CONNECT_TIMEOUT_MS
+              CONNECT_TIMEOUT_MS,
             );
           }),
         ])) as number;
@@ -228,7 +230,7 @@ export class ChainMonitor {
         this.provider = provider;
         this.currentUrlIndex = index;
         console.log(
-          `[BlockMonitor:${this.chainName}] Connected to ${label} WSS (block: ${blockNumber})`
+          `[BlockMonitor:${this.chainName}] Connected to ${label} WSS (block: ${blockNumber})`,
         );
         return;
       } catch (error) {
@@ -239,7 +241,7 @@ export class ChainMonitor {
         }
         console.warn(
           `[BlockMonitor:${this.chainName}] Failed to connect to ${label} WSS:`,
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         if (index === urls.length - 1) {
           throw error;
@@ -251,7 +253,7 @@ export class ChainMonitor {
   }
 
   private attachConnectErrorListener(
-    provider: ethers.WebSocketProvider
+    provider: ethers.WebSocketProvider,
   ): Promise<never> {
     const ws = provider.websocket as unknown as {
       on?: (event: string, cb: (err: Error) => void) => void;
@@ -261,7 +263,7 @@ export class ChainMonitor {
       ws?.on?.("error", (err: Error) => {
         const message = err?.message ?? String(err);
         console.warn(
-          `[BlockMonitor:${this.chainName}] WebSocket error during connect: ${message}`
+          `[BlockMonitor:${this.chainName}] WebSocket error during connect: ${message}`,
         );
         reject(new Error(`WebSocket error: ${message}`));
       });
@@ -277,9 +279,7 @@ export class ChainMonitor {
       return;
     }
 
-    console.log(
-      `[BlockMonitor:${this.chainName}] Subscribing to block events`
-    );
+    console.log(`[BlockMonitor:${this.chainName}] Subscribing to block events`);
 
     // ethers v6 provider.on() is async - it sends eth_subscribe over the
     // WebSocket and waits for the subscription ID. Must be awaited or the
@@ -288,15 +288,13 @@ export class ChainMonitor {
       this.onBlock(blockNumber).catch((error: unknown) => {
         console.error(
           `[BlockMonitor:${this.chainName}] Error processing block ${blockNumber}:`,
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
       });
     });
 
     this.hasActiveSubscription = true;
-    console.log(
-      `[BlockMonitor:${this.chainName}] Block subscription active`
-    );
+    console.log(`[BlockMonitor:${this.chainName}] Block subscription active`);
 
     // Handle WebSocket close for reconnection - store reference for cleanup
     const ws = this.provider.websocket as unknown as {
@@ -345,10 +343,7 @@ export class ChainMonitor {
       const next = this.pendingBlock;
       this.pendingBlock = null;
 
-      if (
-        this.lastProcessedBlock !== null &&
-        next <= this.lastProcessedBlock
-      ) {
+      if (this.lastProcessedBlock !== null && next <= this.lastProcessedBlock) {
         continue;
       }
 
@@ -364,7 +359,7 @@ export class ChainMonitor {
   private async processBlockRange(blockNumber: number): Promise<void> {
     if (this.lastProcessedBlock === null) {
       console.log(
-        `[BlockMonitor:${this.chainName}] First block received: ${blockNumber}, tracking ${this.workflows.length} workflow(s): ${this.workflows.map((wf) => `${wf.id}(interval=${wf.blockInterval})`).join(", ")}`
+        `[BlockMonitor:${this.chainName}] First block received: ${blockNumber}, tracking ${this.workflows.length} workflow(s): ${this.workflows.map((wf) => `${wf.id}(interval=${wf.blockInterval})`).join(", ")}`,
       );
     }
 
@@ -377,11 +372,11 @@ export class ChainMonitor {
 
     if (gap > MAX_BACKFILL_BLOCKS) {
       console.warn(
-        `[BlockMonitor:${this.chainName}] Gap too large (${gap} blocks), skipping backfill. Resuming from block ${blockNumber}`
+        `[BlockMonitor:${this.chainName}] Gap too large (${gap} blocks), skipping backfill. Resuming from block ${blockNumber}`,
       );
     } else if (fromBlock < blockNumber) {
       console.log(
-        `[BlockMonitor:${this.chainName}] Gap detected: last=${this.lastProcessedBlock}, received=${blockNumber}, backfilling ${gap} block(s)`
+        `[BlockMonitor:${this.chainName}] Gap detected: last=${this.lastProcessedBlock}, received=${blockNumber}, backfilling ${gap} block(s)`,
       );
 
       for (let bn = fromBlock; bn < blockNumber; bn++) {
@@ -397,7 +392,7 @@ export class ChainMonitor {
     const now = Date.now();
     if (now - this.lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
       console.log(
-        `[BlockMonitor:${this.chainName}] Heartbeat: block=${blockNumber}, received=${this.blocksReceived}, matched=${this.blocksMatched}, workflows=${this.workflows.length}`
+        `[BlockMonitor:${this.chainName}] Heartbeat: block=${blockNumber}, received=${this.blocksReceived}, matched=${this.blocksMatched}, workflows=${this.workflows.length}`,
       );
       this.lastHeartbeat = now;
     }
@@ -405,7 +400,7 @@ export class ChainMonitor {
 
   private async processBlockNumber(blockNumber: number): Promise<void> {
     const matchingWorkflows = this.workflows.filter(
-      (wf) => blockNumber > 0 && blockNumber % wf.blockInterval === 0
+      (wf) => blockNumber > 0 && blockNumber % wf.blockInterval === 0,
     );
 
     if (matchingWorkflows.length === 0) {
@@ -422,13 +417,13 @@ export class ChainMonitor {
     const nowSeconds = Math.floor(Date.now() / 1000);
     if (nowSeconds - block.timestamp > STALE_BLOCK_THRESHOLD_S) {
       console.warn(
-        `[BlockMonitor:${this.chainName}] Block ${blockNumber} timestamp is ${nowSeconds - block.timestamp}s behind wall clock`
+        `[BlockMonitor:${this.chainName}] Block ${blockNumber} timestamp is ${nowSeconds - block.timestamp}s behind wall clock`,
       );
     }
 
     this.blocksMatched++;
     console.log(
-      `[BlockMonitor:${this.chainName}] Block ${blockNumber} matched ${matchingWorkflows.length} workflow(s): ${matchingWorkflows.map((wf) => `${wf.id}(interval=${wf.blockInterval})`).join(", ")}`
+      `[BlockMonitor:${this.chainName}] Block ${blockNumber} matched ${matchingWorkflows.length} workflow(s): ${matchingWorkflows.map((wf) => `${wf.id}(interval=${wf.blockInterval})`).join(", ")}`,
     );
 
     const results = await Promise.allSettled(
@@ -443,15 +438,15 @@ export class ChainMonitor {
             blockTimestamp: block.timestamp,
             parentHash: block.parentHash,
           },
-        })
-      )
+        }),
+      ),
     );
 
     for (const [index, result] of results.entries()) {
       if (result.status === "rejected") {
         console.error(
           `[BlockMonitor:${this.chainName}] Failed to enqueue workflow ${matchingWorkflows[index].id}:`,
-          result.reason
+          result.reason,
         );
       }
     }
@@ -480,7 +475,7 @@ export class ChainMonitor {
         if (attempt === 1) {
           console.warn(
             `[BlockMonitor:${this.chainName}] Failed to fetch block ${blockNumber} after 2 attempts:`,
-            error instanceof Error ? error.message : error
+            error instanceof Error ? error.message : error,
           );
         }
       }
@@ -504,7 +499,7 @@ export class ChainMonitor {
 
     if (!ws?.ping || !ws?.on) {
       console.warn(
-        `[BlockMonitor:${this.chainName}] WebSocket does not support ping/pong, skipping keepalive`
+        `[BlockMonitor:${this.chainName}] WebSocket does not support ping/pong, skipping keepalive`,
       );
       return;
     }
@@ -526,7 +521,7 @@ export class ChainMonitor {
         ws.ping!();
       } catch {
         console.warn(
-          `[BlockMonitor:${this.chainName}] Failed to send ping, triggering reconnect`
+          `[BlockMonitor:${this.chainName}] Failed to send ping, triggering reconnect`,
         );
         this.handleDisconnect();
         return;
@@ -535,14 +530,14 @@ export class ChainMonitor {
       // If no pong arrives within timeout, connection is dead
       this.pongTimer = setTimeout(() => {
         console.warn(
-          `[BlockMonitor:${this.chainName}] Pong timeout (${PONG_TIMEOUT_MS}ms), triggering reconnect`
+          `[BlockMonitor:${this.chainName}] Pong timeout (${PONG_TIMEOUT_MS}ms), triggering reconnect`,
         );
         this.handleDisconnect();
       }, PONG_TIMEOUT_MS);
     }, PING_INTERVAL_MS);
 
     console.log(
-      `[BlockMonitor:${this.chainName}] Ping/pong keepalive started (interval=${PING_INTERVAL_MS}ms, timeout=${PONG_TIMEOUT_MS}ms)`
+      `[BlockMonitor:${this.chainName}] Ping/pong keepalive started (interval=${PING_INTERVAL_MS}ms, timeout=${PONG_TIMEOUT_MS}ms)`,
     );
   }
 
@@ -562,7 +557,7 @@ export class ChainMonitor {
     this.noBlockTimer = setTimeout(() => {
       if (this.isRunning) {
         console.warn(
-          `[BlockMonitor:${this.chainName}] No blocks received in ${NO_BLOCK_TIMEOUT_MS / 1000}s, triggering reconnect`
+          `[BlockMonitor:${this.chainName}] No blocks received in ${NO_BLOCK_TIMEOUT_MS / 1000}s, triggering reconnect`,
         );
         this.handleDisconnect();
       }
@@ -639,13 +634,13 @@ export class ChainMonitor {
         new Promise<never>((_, reject) => {
           setTimeout(
             () => reject(new Error("Primary probe timeout")),
-            PRIMARY_PROBE_TIMEOUT_MS
+            PRIMARY_PROBE_TIMEOUT_MS,
           );
         }),
       ]);
 
       console.log(
-        `[BlockMonitor:${this.chainName}] Primary recovered, switching back from fallback`
+        `[BlockMonitor:${this.chainName}] Primary recovered, switching back from fallback`,
       );
       await probeProvider.removeAllListeners();
       await probeProvider.destroy().catch(() => {
@@ -655,7 +650,7 @@ export class ChainMonitor {
     } catch (error) {
       const reason = summarizeProbeError(error);
       console.warn(
-        `[BlockMonitor:${this.chainName}] Primary probe failed: ${reason}`
+        `[BlockMonitor:${this.chainName}] Primary probe failed: ${reason}`,
       );
       if (probeProvider) {
         await probeProvider.removeAllListeners();
@@ -681,7 +676,7 @@ export class ChainMonitor {
     this.reconnectWithBackoff().catch((error: unknown) => {
       console.error(
         `[BlockMonitor:${this.chainName}] Reconnect loop failed:`,
-        error instanceof Error ? error.message : error
+        error instanceof Error ? error.message : error,
       );
       this.isReconnecting = false;
     });
@@ -693,7 +688,7 @@ export class ChainMonitor {
     while (this.isRunning) {
       if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
         console.error(
-          `[BlockMonitor:${this.chainName}] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached, stopping monitor`
+          `[BlockMonitor:${this.chainName}] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached, stopping monitor`,
         );
         this.isRunning = false;
         this.isReconnecting = false;
@@ -703,11 +698,11 @@ export class ChainMonitor {
       this.reconnectAttempts++;
       const delay = Math.min(
         BASE_DELAY_MS * 2 ** (this.reconnectAttempts - 1),
-        MAX_DELAY_MS
+        MAX_DELAY_MS,
       );
 
       console.log(
-        `[BlockMonitor:${this.chainName}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`
+        `[BlockMonitor:${this.chainName}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`,
       );
 
       await new Promise<void>((resolve) => {
@@ -730,7 +725,7 @@ export class ChainMonitor {
       } catch (error) {
         console.warn(
           `[BlockMonitor:${this.chainName}] Reconnect attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS} failed:`,
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
         // Clean up the provider if connect succeeded but subscribe failed
         await this.destroyProvider();

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -18,14 +18,14 @@
  */
 
 import express from "express";
-import { fetchBlockWorkflows } from "./api-client.js";
-import { ChainMonitor } from "./chain-monitor.js";
 import {
   KEEPERHUB_URL,
   RECONCILE_INTERVAL_MS,
   SQS_QUEUE_URL,
 } from "../lib/config.js";
 import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
+import { fetchBlockWorkflows } from "./api-client.js";
+import { ChainMonitor } from "./chain-monitor.js";
 
 class BlockMonitorService {
   private readonly monitors: Map<number, ChainMonitor> = new Map();
@@ -34,7 +34,7 @@ class BlockMonitorService {
 
   async start(): Promise<void> {
     console.log(
-      `[BlockMonitorService] Starting (reconcile every ${RECONCILE_INTERVAL_MS}ms)`
+      `[BlockMonitorService] Starting (reconcile every ${RECONCILE_INTERVAL_MS}ms)`,
     );
 
     await this.reconcile();
@@ -43,7 +43,7 @@ class BlockMonitorService {
       this.reconcile().catch((error: unknown) => {
         console.error(
           "[BlockMonitorService] Reconciliation error:",
-          error instanceof Error ? error.message : error
+          error instanceof Error ? error.message : error,
         );
       });
     }, RECONCILE_INTERVAL_MS);
@@ -59,14 +59,14 @@ class BlockMonitorService {
     }
 
     const stopResults = await Promise.allSettled(
-      [...this.monitors.values()].map((monitor) => monitor.stop())
+      [...this.monitors.values()].map((monitor) => monitor.stop()),
     );
 
     for (const result of stopResults) {
       if (result.status === "rejected") {
         console.error(
           "[BlockMonitorService] Error stopping monitor:",
-          result.reason
+          result.reason,
         );
       }
     }
@@ -97,26 +97,29 @@ class BlockMonitorService {
       await this.syncActiveMonitors(grouped);
 
       const chainNames = [...grouped.entries()]
-        .map(([id, { chain, workflows }]) => `${chain.name}(${id}): ${workflows.length} wf`)
+        .map(
+          ([id, { chain, workflows }]) =>
+            `${chain.name}(${id}): ${workflows.length} wf`,
+        )
         .join(", ");
       console.log(
-        `[BlockMonitorService] Reconciled: ${this.monitors.size} chain(s) monitored [${chainNames}]`
+        `[BlockMonitorService] Reconciled: ${this.monitors.size} chain(s) monitored [${chainNames}]`,
       );
     } catch (error) {
       console.error(
         "[BlockMonitorService] Reconciliation failed:",
-        error instanceof Error ? error.message : error
+        error instanceof Error ? error.message : error,
       );
     }
   }
 
   private async removeStaleMonitors(
-    activeChainIds: Set<number>
+    activeChainIds: Set<number>,
   ): Promise<void> {
     for (const [chainId, monitor] of this.monitors) {
       if (!activeChainIds.has(chainId)) {
         console.log(
-          `[BlockMonitorService] Stopping monitor for chain ${chainId} (no active workflows)`
+          `[BlockMonitorService] Stopping monitor for chain ${chainId} (no active workflows)`,
         );
         await monitor.stop();
         this.monitors.delete(chainId);
@@ -125,7 +128,7 @@ class BlockMonitorService {
   }
 
   private async syncActiveMonitors(
-    grouped: Map<number, { chain: ChainConfig; workflows: BlockWorkflow[] }>
+    grouped: Map<number, { chain: ChainConfig; workflows: BlockWorkflow[] }>,
   ): Promise<void> {
     for (const [chainId, { chain, workflows }] of grouped) {
       const existing = this.monitors.get(chainId);
@@ -137,7 +140,7 @@ class BlockMonitorService {
         await this.startNewMonitor(chainId, chain, workflows);
       } else if (!existing.isAlive()) {
         console.warn(
-          `[BlockMonitorService] Monitor for ${chain.name} (${chainId}) is dead, restarting`
+          `[BlockMonitorService] Monitor for ${chain.name} (${chainId}) is dead, restarting`,
         );
         await existing.stop();
         this.monitors.delete(chainId);
@@ -151,10 +154,10 @@ class BlockMonitorService {
   private async startNewMonitor(
     chainId: number,
     chain: ChainConfig,
-    workflows: BlockWorkflow[]
+    workflows: BlockWorkflow[],
   ): Promise<void> {
     console.log(
-      `[BlockMonitorService] Starting monitor for ${chain.name} (${chainId}) with ${workflows.length} workflow(s), primaryWss=${chain.defaultPrimaryWss ? "configured" : "MISSING"}, fallbackWss=${chain.defaultFallbackWss ? "configured" : "MISSING"}`
+      `[BlockMonitorService] Starting monitor for ${chain.name} (${chainId}) with ${workflows.length} workflow(s), primaryWss=${chain.defaultPrimaryWss ? "configured" : "MISSING"}, fallbackWss=${chain.defaultFallbackWss ? "configured" : "MISSING"}`,
     );
     const monitor = new ChainMonitor({ chain, workflows });
     this.monitors.set(chainId, monitor);
@@ -163,7 +166,7 @@ class BlockMonitorService {
     } catch (error) {
       console.error(
         `[BlockMonitorService] Failed to start monitor for ${chain.name}:`,
-        error instanceof Error ? error.message : error
+        error instanceof Error ? error.message : error,
       );
       this.monitors.delete(chainId);
     }
@@ -217,13 +220,13 @@ function isRecoverableNetworkError(error: Error): boolean {
 process.on("uncaughtException", (error: Error) => {
   if (isRecoverableNetworkError(error)) {
     console.warn(
-      `[BlockDispatcher] Recoverable network error (continuing): ${error.message}`
+      `[BlockDispatcher] Recoverable network error (continuing): ${error.message}`,
     );
     return;
   }
   console.error(
     `[BlockDispatcher] Uncaught exception: ${error.message}`,
-    error.stack ?? ""
+    error.stack ?? "",
   );
   process.exit(1);
 });
@@ -234,7 +237,7 @@ async function main(): Promise<void> {
   console.log(`[BlockDispatcher] KeeperHub URL: ${KEEPERHUB_URL}`);
   console.log(`[BlockDispatcher] SQS Queue URL: ${SQS_QUEUE_URL}`);
   console.log(
-    `[BlockDispatcher] Reconcile interval: ${RECONCILE_INTERVAL_MS}ms`
+    `[BlockDispatcher] Reconcile interval: ${RECONCILE_INTERVAL_MS}ms`,
   );
 
   const service = new BlockMonitorService();
@@ -256,7 +259,7 @@ async function main(): Promise<void> {
 
   const healthServer = healthApp.listen(HEALTH_PORT, () => {
     console.log(
-      `[BlockDispatcher] Health check server listening on port ${HEALTH_PORT}`
+      `[BlockDispatcher] Health check server listening on port ${HEALTH_PORT}`,
     );
   });
 

--- a/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
+++ b/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
@@ -5,15 +5,15 @@
  */
 
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
-import { sqs } from "../lib/sqs-client.js";
 import { SQS_QUEUE_URL } from "../lib/config.js";
+import { sqs } from "../lib/sqs-client.js";
 import type { BlockMessage } from "../lib/types.js";
 
 export async function enqueueBlockTrigger(
-  message: BlockMessage
+  message: BlockMessage,
 ): Promise<void> {
   console.log(
-    `[SQS] Enqueuing block trigger: workflow=${message.workflowId}, block=${message.triggerData.blockNumber}`
+    `[SQS] Enqueuing block trigger: workflow=${message.workflowId}, block=${message.triggerData.blockNumber}`,
   );
   await sqs.send(
     new SendMessageCommand({
@@ -29,6 +29,6 @@ export async function enqueueBlockTrigger(
           StringValue: message.workflowId,
         },
       },
-    })
+    }),
   );
 }

--- a/keeperhub-scheduler/lib/config.ts
+++ b/keeperhub-scheduler/lib/config.ts
@@ -2,7 +2,8 @@
  * Configuration for KeeperHub Scheduler
  */
 
-export const KEEPERHUB_URL = process.env.KEEPERHUB_API_URL || "http://localhost:3000";
+export const KEEPERHUB_URL =
+  process.env.KEEPERHUB_API_URL || "http://localhost:3000";
 export const SERVICE_API_KEY = process.env.KEEPERHUB_API_KEY || "";
 
 export const AWS_REGION = process.env.AWS_REGION || "us-east-1";
@@ -13,4 +14,5 @@ export const SQS_QUEUE_URL =
   "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/keeperhub-workflow-queue";
 
 // Block dispatcher config
-export const RECONCILE_INTERVAL_MS = Number(process.env.RECONCILE_INTERVAL_MS) || 30_000;
+export const RECONCILE_INTERVAL_MS =
+  Number(process.env.RECONCILE_INTERVAL_MS) || 30_000;

--- a/keeperhub-scheduler/lib/http-client.ts
+++ b/keeperhub-scheduler/lib/http-client.ts
@@ -11,7 +11,7 @@ import { KEEPERHUB_URL, SERVICE_API_KEY } from "./config.js";
  */
 export async function apiRequest<T>(
   path: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
 ): Promise<T> {
   const response = await fetch(`${KEEPERHUB_URL}${path}`, {
     ...options,
@@ -24,7 +24,9 @@ export async function apiRequest<T>(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`API ${options.method || "GET"} ${path} failed: ${response.status} ${text}`);
+    throw new Error(
+      `API ${options.method || "GET"} ${path} failed: ${response.status} ${text}`,
+    );
   }
 
   return response.json() as Promise<T>;

--- a/keeperhub-scheduler/package.json
+++ b/keeperhub-scheduler/package.json
@@ -8,7 +8,12 @@
     "dispatcher": "tsx schedule-dispatcher/index.ts",
     "block-dispatcher": "tsx block-dispatcher/index.ts",
     "typecheck": "tsc --noEmit",
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:unit": "vitest run tests/unit"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1038.0",
@@ -17,9 +22,12 @@
     "express": "^4.21.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/express": "^5.0.0",
     "@types/node": "^24.10.0",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vite": "^8.0.9",
+    "vitest": "4.1.2"
   }
 }

--- a/keeperhub-scheduler/pnpm-lock.yaml
+++ b/keeperhub-scheduler/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@aws-sdk/client-sqs':
         specifier: ^3.1038.0
-        version: 3.1038.0
+        version: 3.1044.0
       cron-parser:
         specifier: ^5.4.0
         version: 5.5.0
@@ -21,18 +21,27 @@ importers:
         specifier: ^4.21.2
         version: 4.22.1
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
       '@types/node':
         specifier: ^24.10.0
-        version: 24.10.9
+        version: 24.12.2
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^8.0.9
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vitest:
+        specifier: 4.1.2
+        version: 4.1.2(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -52,44 +61,44 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-sqs@3.1038.0':
-    resolution: {integrity: sha512-tGJ131fvczx8+79Kbs6mfeRBqnSzuDOIqS/3es9iRTE6ohHqQ2phUjBCLGlfwBkhsp0chOa+i5nvJssTZ3dCUQ==}
+  '@aws-sdk/client-sqs@3.1044.0':
+    resolution: {integrity: sha512-Vf46G/luWJeRFTUF9gL3+IeH3CWCOxgJew9ZD5Lnd4vFMlFmlx8/SA1KFYTvmLjG9V61hVxS4u68Ssn1L9E8ow==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.6':
-    resolution: {integrity: sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==}
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.32':
-    resolution: {integrity: sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==}
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.34':
-    resolution: {integrity: sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==}
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.36':
-    resolution: {integrity: sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==}
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.36':
-    resolution: {integrity: sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==}
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.37':
-    resolution: {integrity: sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==}
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.32':
-    resolution: {integrity: sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==}
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.36':
-    resolution: {integrity: sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==}
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.36':
-    resolution: {integrity: sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==}
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.10':
@@ -104,32 +113,32 @@ packages:
     resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.35':
-    resolution: {integrity: sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==}
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-sqs@3.972.22':
     resolution: {integrity: sha512-DtR3mEiOUJcnEX/QuXmvbJto6xvQzp2ftnHb29c0aQYdmmzbKf0gsu9ovx1i/yy4ZR6m0rttTucS0iiP32dlGA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.36':
-    resolution: {integrity: sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==}
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.4':
-    resolution: {integrity: sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==}
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.13':
     resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.23':
-    resolution: {integrity: sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==}
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1038.0':
-    resolution: {integrity: sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==}
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
@@ -151,8 +160,8 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.972.10':
     resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
 
-  '@aws-sdk/util-user-agent-node@3.973.22':
-    resolution: {integrity: sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==}
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -160,13 +169,75 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.21':
-    resolution: {integrity: sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==}
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -324,6 +395,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -333,6 +413,101 @@ packages:
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@smithy/config-resolver@4.4.17':
     resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
@@ -378,8 +553,8 @@ packages:
     resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.5.6':
-    resolution: {integrity: sha512-5zhmo2AkstmM/RMKYP0NHfmuYWBR+/umlmSuALgajLxf0X0rLE6d17MfzTxpzkILWVhwvCJkCyPH0AfMlbaucQ==}
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.20':
@@ -482,8 +657,8 @@ packages:
     resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.3.5':
-    resolution: {integrity: sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg==}
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.25':
@@ -506,11 +681,26 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
@@ -524,11 +714,11 @@ packages:
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
-  '@types/node@24.10.9':
-    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
-  '@types/qs@6.14.0':
-    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
@@ -538,6 +728,35 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -549,8 +768,12 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
-  body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bowser@2.14.1:
@@ -568,6 +791,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -575,6 +802,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -603,6 +833,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -622,6 +856,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -634,6 +871,9 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -642,16 +882,29 @@ packages:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
-  fast-xml-builder@1.1.5:
-    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+  fast-xml-builder@1.1.9:
+    resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
@@ -681,8 +934,8 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -692,8 +945,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   http-errors@2.0.1:
@@ -711,9 +964,82 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -749,6 +1075,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -756,6 +1087,9 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -772,12 +1106,30 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -790,6 +1142,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -808,8 +1165,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -824,12 +1181,40 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -873,6 +1258,89 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
@@ -915,22 +1383,22 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-sqs@3.1038.0':
+  '@aws-sdk/client-sqs@3.1044.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.6
-      '@aws-sdk/credential-provider-node': 3.972.37
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
       '@aws-sdk/middleware-host-header': 3.972.10
       '@aws-sdk/middleware-logger': 3.972.10
       '@aws-sdk/middleware-recursion-detection': 3.972.11
       '@aws-sdk/middleware-sdk-sqs': 3.972.22
-      '@aws-sdk/middleware-user-agent': 3.972.36
+      '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/region-config-resolver': 3.972.13
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.22
+      '@aws-sdk/util-user-agent-node': 3.973.24
       '@smithy/config-resolver': 4.4.17
       '@smithy/core': 3.23.17
       '@smithy/fetch-http-handler': 5.3.17
@@ -939,7 +1407,7 @@ snapshots:
       '@smithy/md5-js': 4.2.14
       '@smithy/middleware-content-length': 4.2.14
       '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.6
+      '@smithy/middleware-retry': 4.5.7
       '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
@@ -955,16 +1423,16 @@ snapshots:
       '@smithy/util-defaults-mode-node': 4.2.54
       '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.5
+      '@smithy/util-retry': 4.3.8
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.974.6':
+  '@aws-sdk/core@3.974.8':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.21
+      '@aws-sdk/xml-builder': 3.972.22
       '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
@@ -974,21 +1442,21 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.5
+      '@smithy/util-retry': 4.3.8
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.32':
+  '@aws-sdk/credential-provider-env@3.972.34':
     dependencies:
-      '@aws-sdk/core': 3.974.6
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.34':
+  '@aws-sdk/credential-provider-http@3.972.36':
     dependencies:
-      '@aws-sdk/core': 3.974.6
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/node-http-handler': 4.6.1
@@ -999,16 +1467,16 @@ snapshots:
       '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.36':
+  '@aws-sdk/credential-provider-ini@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.6
-      '@aws-sdk/credential-provider-env': 3.972.32
-      '@aws-sdk/credential-provider-http': 3.972.34
-      '@aws-sdk/credential-provider-login': 3.972.36
-      '@aws-sdk/credential-provider-process': 3.972.32
-      '@aws-sdk/credential-provider-sso': 3.972.36
-      '@aws-sdk/credential-provider-web-identity': 3.972.36
-      '@aws-sdk/nested-clients': 3.997.4
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
@@ -1018,10 +1486,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.36':
+  '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.6
-      '@aws-sdk/nested-clients': 3.997.4
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
@@ -1031,14 +1499,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.37':
+  '@aws-sdk/credential-provider-node@3.972.39':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.32
-      '@aws-sdk/credential-provider-http': 3.972.34
-      '@aws-sdk/credential-provider-ini': 3.972.36
-      '@aws-sdk/credential-provider-process': 3.972.32
-      '@aws-sdk/credential-provider-sso': 3.972.36
-      '@aws-sdk/credential-provider-web-identity': 3.972.36
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
       '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
@@ -1048,20 +1516,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.32':
+  '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
-      '@aws-sdk/core': 3.974.6
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.36':
+  '@aws-sdk/credential-provider-sso@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.6
-      '@aws-sdk/nested-clients': 3.997.4
-      '@aws-sdk/token-providers': 3.1038.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -1070,10 +1538,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.36':
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.6
-      '@aws-sdk/nested-clients': 3.997.4
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -1103,9 +1571,9 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.35':
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
     dependencies:
-      '@aws-sdk/core': 3.974.6
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.17
@@ -1129,32 +1597,32 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.36':
+  '@aws-sdk/middleware-user-agent@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.6
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-endpoints': 3.996.8
       '@smithy/core': 3.23.17
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
-      '@smithy/util-retry': 4.3.5
+      '@smithy/util-retry': 4.3.8
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.4':
+  '@aws-sdk/nested-clients@3.997.6':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.6
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/middleware-host-header': 3.972.10
       '@aws-sdk/middleware-logger': 3.972.10
       '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.36
+      '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.22
+      '@aws-sdk/util-user-agent-node': 3.973.24
       '@smithy/config-resolver': 4.4.17
       '@smithy/core': 3.23.17
       '@smithy/fetch-http-handler': 5.3.17
@@ -1162,7 +1630,7 @@ snapshots:
       '@smithy/invalid-dependency': 4.2.14
       '@smithy/middleware-content-length': 4.2.14
       '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.6
+      '@smithy/middleware-retry': 4.5.7
       '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
@@ -1178,7 +1646,7 @@ snapshots:
       '@smithy/util-defaults-mode-node': 4.2.54
       '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.5
+      '@smithy/util-retry': 4.3.8
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -1192,19 +1660,19 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.23':
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.35
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
       '@aws-sdk/types': 3.973.8
       '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.3.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1038.0':
+  '@aws-sdk/token-providers@3.1041.0':
     dependencies:
-      '@aws-sdk/core': 3.974.6
-      '@aws-sdk/nested-clients': 3.997.4
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -1241,16 +1709,16 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.22':
+  '@aws-sdk/util-user-agent-node@3.973.24':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.36
+      '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/types': 3.973.8
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.21':
+  '@aws-sdk/xml-builder@3.972.22':
     dependencies:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
@@ -1258,6 +1726,57 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -1337,6 +1856,15 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -1344,6 +1872,59 @@ snapshots:
   '@noble/hashes@1.3.2': {}
 
   '@nodable/entities@2.1.0': {}
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@smithy/config-resolver@4.4.17':
     dependencies:
@@ -1426,7 +2007,7 @@ snapshots:
       '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.5.6':
+  '@smithy/middleware-retry@4.5.7':
     dependencies:
       '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
@@ -1435,7 +2016,7 @@ snapshots:
       '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.5
+      '@smithy/util-retry': 4.3.8
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
@@ -1586,7 +2167,7 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.3.5':
+  '@smithy/util-retry@4.3.8':
     dependencies:
       '@smithy/service-error-classification': 4.3.1
       '@smithy/types': 4.14.1
@@ -1621,19 +2202,35 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.10.9
+      '@types/node': 24.12.2
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.10.9
+      '@types/node': 24.12.2
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 24.10.9
-      '@types/qs': 6.14.0
+      '@types/node': 24.12.2
+      '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
@@ -1649,22 +2246,63 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@24.10.9':
+  '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
 
-  '@types/qs@6.14.0': {}
+  '@types/qs@6.15.1': {}
 
   '@types/range-parser@1.2.7': {}
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 24.10.9
+      '@types/node': 24.12.2
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.10.9
+      '@types/node': 24.12.2
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   accepts@1.3.8:
     dependencies:
@@ -1675,7 +2313,9 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
-  body-parser@1.20.4:
+  assertion-error@2.0.1: {}
+
+  body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -1685,7 +2325,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.1
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -1706,11 +2346,15 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chai@6.2.2: {}
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
 
@@ -1728,6 +2372,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-libc@2.1.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -1741,6 +2387,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -1777,6 +2425,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   etag@1.8.1: {}
 
   ethers@6.16.0:
@@ -1792,11 +2444,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  expect-type@1.3.0: {}
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4
+      body-parser: 1.20.5
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -1828,16 +2482,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-xml-builder@1.1.5:
+  fast-xml-builder@1.1.9:
     dependencies:
       path-expression-matcher: 1.5.0
 
   fast-xml-parser@5.7.2:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.5
+      fast-xml-builder: 1.1.9
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   finalhandler@1.3.2:
     dependencies:
@@ -1870,7 +2528,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -1878,7 +2536,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-tsconfig@4.13.0:
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -1886,7 +2544,7 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -1906,7 +2564,60 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   luxon@3.7.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -1928,9 +2639,13 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.12: {}
+
   negotiator@0.6.3: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.1: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -1942,12 +2657,28 @@ snapshots:
 
   path-to-regexp@0.1.13: {}
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
   qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -1961,6 +2692,27 @@ snapshots:
       unpipe: 1.0.0
 
   resolve-pkg-maps@1.0.0: {}
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   safe-buffer@5.2.1: {}
 
@@ -1995,7 +2747,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -2019,13 +2771,32 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
 
+  std-env@4.1.0: {}
+
   strnum@2.2.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -2036,7 +2807,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -2056,5 +2827,50 @@ snapshots:
   utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
+
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.1.2(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.17.1: {}

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -4,6 +4,11 @@
  * Pure functions extracted from index.ts so they can be unit-tested in
  * isolation. index.ts is now only the entry point: it composes these
  * functions, registers signal handlers, and runs the polling loop.
+ *
+ * Note: importing this module triggers SQS client instantiation as a
+ * side effect (via lib/sqs-client.js, which calls `new SQSClient(...)` at
+ * module load). The functions below are pure, but the import is not.
+ * Tests must mock "../lib/sqs-client.js" to avoid contacting AWS.
  */
 
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
@@ -22,9 +27,6 @@ export type DispatchResult = {
   errors: number;
 };
 
-/**
- * Fetch enabled schedules from KeeperHub API.
- */
 export async function fetchSchedules(): Promise<Schedule[]> {
   const response = await fetch(`${KEEPERHUB_URL}/api/internal/schedules`, {
     method: "GET",
@@ -69,9 +71,6 @@ export function shouldTriggerNow(
   }
 }
 
-/**
- * Send a schedule trigger message to the SQS queue.
- */
 export async function sendToQueue(message: ScheduleMessage): Promise<void> {
   const command = new SendMessageCommand({
     QueueUrl: SQS_QUEUE_URL,

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -1,0 +1,154 @@
+/**
+ * Schedule dispatcher logic.
+ *
+ * Pure functions extracted from index.ts so they can be unit-tested in
+ * isolation. index.ts is now only the entry point: it composes these
+ * functions, registers signal handlers, and runs the polling loop.
+ */
+
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { CronExpressionParser } from "cron-parser";
+import {
+  KEEPERHUB_URL,
+  SERVICE_API_KEY,
+  SQS_QUEUE_URL,
+} from "../lib/config.js";
+import { sqs } from "../lib/sqs-client.js";
+import type { Schedule, ScheduleMessage } from "../lib/types.js";
+
+export type DispatchResult = {
+  evaluated: number;
+  triggered: number;
+  errors: number;
+};
+
+/**
+ * Fetch enabled schedules from KeeperHub API.
+ */
+export async function fetchSchedules(): Promise<Schedule[]> {
+  const response = await fetch(`${KEEPERHUB_URL}/api/internal/schedules`, {
+    method: "GET",
+    headers: {
+      "X-Service-Key": SERVICE_API_KEY,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch schedules: ${response.status} ${await response.text()}`,
+    );
+  }
+
+  const data = (await response.json()) as { schedules: Schedule[] };
+  return data.schedules;
+}
+
+/**
+ * Returns true when the cron expression's most recent occurrence is within
+ * the current minute (now - prev < 60_000ms). Returns false on invalid
+ * expressions and logs the error.
+ */
+export function shouldTriggerNow(
+  cronExpression: string,
+  timezone: string,
+  now: Date,
+): boolean {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, {
+      currentDate: now,
+      tz: timezone,
+    });
+
+    const prev = interval.prev().toDate();
+    const diffMs = now.getTime() - prev.getTime();
+
+    return diffMs >= 0 && diffMs < 60_000;
+  } catch (error) {
+    console.error(`Invalid cron expression: ${cronExpression}`, error);
+    return false;
+  }
+}
+
+/**
+ * Send a schedule trigger message to the SQS queue.
+ */
+export async function sendToQueue(message: ScheduleMessage): Promise<void> {
+  const command = new SendMessageCommand({
+    QueueUrl: SQS_QUEUE_URL,
+    MessageBody: JSON.stringify(message),
+    MessageAttributes: {
+      TriggerType: {
+        DataType: "String",
+        StringValue: "schedule",
+      },
+      WorkflowId: {
+        DataType: "String",
+        StringValue: message.workflowId,
+      },
+    },
+  });
+
+  await sqs.send(command);
+}
+
+/**
+ * One dispatch pass: fetch schedules, evaluate each against the current
+ * time, enqueue triggers for matching ones. Per-schedule failures are
+ * logged and counted but do not abort the pass.
+ */
+export async function dispatch(): Promise<DispatchResult> {
+  const runId = crypto.randomUUID().slice(0, 8);
+  console.log(
+    `[${runId}] Starting dispatch run at ${new Date().toISOString()}`,
+  );
+
+  const schedules = await fetchSchedules();
+
+  console.log(`[${runId}] Found ${schedules.length} enabled schedules`);
+
+  const now = new Date();
+  let triggered = 0;
+  let errors = 0;
+
+  for (const schedule of schedules) {
+    try {
+      const shouldTrigger = shouldTriggerNow(
+        schedule.cronExpression,
+        schedule.timezone,
+        now,
+      );
+
+      if (shouldTrigger) {
+        console.log(
+          `[${runId}] Triggering workflow ${schedule.workflowId} ` +
+            `(cron: ${schedule.cronExpression}, tz: ${schedule.timezone})`,
+        );
+
+        await sendToQueue({
+          workflowId: schedule.workflowId,
+          scheduleId: schedule.id,
+          triggerTime: now.toISOString(),
+          triggerType: "schedule",
+        });
+
+        triggered += 1;
+      }
+    } catch (error) {
+      console.error(
+        `[${runId}] Error processing schedule ${schedule.id}:`,
+        error,
+      );
+      errors += 1;
+    }
+  }
+
+  console.log(
+    `[${runId}] Dispatch complete: evaluated=${schedules.length}, triggered=${triggered}, errors=${errors}`,
+  );
+
+  return {
+    evaluated: schedules.length,
+    triggered,
+    errors,
+  };
+}

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -18,12 +18,12 @@
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { CronExpressionParser } from "cron-parser";
 import express from "express";
-import { sqs } from "../lib/sqs-client.js";
 import {
   KEEPERHUB_URL,
   SERVICE_API_KEY,
   SQS_QUEUE_URL,
 } from "../lib/config.js";
+import { sqs } from "../lib/sqs-client.js";
 import type { Schedule, ScheduleMessage } from "../lib/types.js";
 
 /**
@@ -39,7 +39,7 @@ async function fetchSchedules(): Promise<Schedule[]> {
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch schedules: ${response.status} ${await response.text()}`
+      `Failed to fetch schedules: ${response.status} ${await response.text()}`,
     );
   }
 
@@ -53,7 +53,7 @@ async function fetchSchedules(): Promise<Schedule[]> {
 function shouldTriggerNow(
   cronExpression: string,
   timezone: string,
-  now: Date
+  now: Date,
 ): boolean {
   try {
     const interval = CronExpressionParser.parse(cronExpression, {
@@ -107,7 +107,7 @@ async function dispatch(): Promise<{
 }> {
   const runId = crypto.randomUUID().slice(0, 8);
   console.log(
-    `[${runId}] Starting dispatch run at ${new Date().toISOString()}`
+    `[${runId}] Starting dispatch run at ${new Date().toISOString()}`,
   );
 
   // Fetch all enabled schedules via API
@@ -124,13 +124,13 @@ async function dispatch(): Promise<{
       const shouldTrigger = shouldTriggerNow(
         schedule.cronExpression,
         schedule.timezone,
-        now
+        now,
       );
 
       if (shouldTrigger) {
         console.log(
           `[${runId}] Triggering workflow ${schedule.workflowId} ` +
-            `(cron: ${schedule.cronExpression}, tz: ${schedule.timezone})`
+            `(cron: ${schedule.cronExpression}, tz: ${schedule.timezone})`,
         );
 
         await sendToQueue({
@@ -145,14 +145,14 @@ async function dispatch(): Promise<{
     } catch (error) {
       console.error(
         `[${runId}] Error processing schedule ${schedule.id}:`,
-        error
+        error,
       );
       errors += 1;
     }
   }
 
   console.log(
-    `[${runId}] Dispatch complete: evaluated=${schedules.length}, triggered=${triggered}, errors=${errors}`
+    `[${runId}] Dispatch complete: evaluated=${schedules.length}, triggered=${triggered}, errors=${errors}`,
   );
 
   return {
@@ -175,7 +175,7 @@ process.on("unhandledRejection", (reason: unknown) => {
 process.on("uncaughtException", (error: Error) => {
   console.error(
     `[Dispatcher] Uncaught exception: ${error.message}`,
-    error.stack ?? ""
+    error.stack ?? "",
   );
   process.exit(1);
 });
@@ -200,7 +200,7 @@ async function main() {
 
   const healthServer = healthApp.listen(HEALTH_PORT, () => {
     console.log(
-      `[Dispatcher] Health check server listening on port ${HEALTH_PORT}`
+      `[Dispatcher] Health check server listening on port ${HEALTH_PORT}`,
     );
   });
 

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -12,155 +12,12 @@
  *   KEEPERHUB_API_KEY - Service API key for authentication
  *   AWS_ENDPOINT_URL - LocalStack endpoint (default: http://localhost:4566)
  *   SQS_QUEUE_URL - SQS queue URL (default: LocalStack queue)
- *   HEALTH_PORT - Health check server port (default: 3000)
+ *   HEALTH_PORT - Health check server port (default: 3060)
  */
 
-import { SendMessageCommand } from "@aws-sdk/client-sqs";
-import { CronExpressionParser } from "cron-parser";
 import express from "express";
-import {
-  KEEPERHUB_URL,
-  SERVICE_API_KEY,
-  SQS_QUEUE_URL,
-} from "../lib/config.js";
-import { sqs } from "../lib/sqs-client.js";
-import type { Schedule, ScheduleMessage } from "../lib/types.js";
-
-/**
- * Fetch enabled schedules from KeeperHub API
- */
-async function fetchSchedules(): Promise<Schedule[]> {
-  const response = await fetch(`${KEEPERHUB_URL}/api/internal/schedules`, {
-    method: "GET",
-    headers: {
-      "X-Service-Key": SERVICE_API_KEY,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch schedules: ${response.status} ${await response.text()}`,
-    );
-  }
-
-  const data = (await response.json()) as { schedules: Schedule[] };
-  return data.schedules;
-}
-
-/**
- * Check if a cron expression should trigger at the given time
- */
-function shouldTriggerNow(
-  cronExpression: string,
-  timezone: string,
-  now: Date,
-): boolean {
-  try {
-    const interval = CronExpressionParser.parse(cronExpression, {
-      currentDate: now,
-      tz: timezone,
-    });
-
-    // Get the previous occurrence
-    const prev = interval.prev().toDate();
-
-    // Check if the previous occurrence is within the current minute
-    const diffMs = now.getTime() - prev.getTime();
-
-    // Within current minute (0-59 seconds)
-    return diffMs >= 0 && diffMs < 60_000;
-  } catch (error) {
-    console.error(`Invalid cron expression: ${cronExpression}`, error);
-    return false;
-  }
-}
-
-/**
- * Send message to SQS queue
- */
-async function sendToQueue(message: ScheduleMessage): Promise<void> {
-  const command = new SendMessageCommand({
-    QueueUrl: SQS_QUEUE_URL,
-    MessageBody: JSON.stringify(message),
-    MessageAttributes: {
-      TriggerType: {
-        DataType: "String",
-        StringValue: "schedule",
-      },
-      WorkflowId: {
-        DataType: "String",
-        StringValue: message.workflowId,
-      },
-    },
-  });
-
-  await sqs.send(command);
-}
-
-/**
- * Main dispatch function
- */
-async function dispatch(): Promise<{
-  evaluated: number;
-  triggered: number;
-  errors: number;
-}> {
-  const runId = crypto.randomUUID().slice(0, 8);
-  console.log(
-    `[${runId}] Starting dispatch run at ${new Date().toISOString()}`,
-  );
-
-  // Fetch all enabled schedules via API
-  const schedules = await fetchSchedules();
-
-  console.log(`[${runId}] Found ${schedules.length} enabled schedules`);
-
-  const now = new Date();
-  let triggered = 0;
-  let errors = 0;
-
-  for (const schedule of schedules) {
-    try {
-      const shouldTrigger = shouldTriggerNow(
-        schedule.cronExpression,
-        schedule.timezone,
-        now,
-      );
-
-      if (shouldTrigger) {
-        console.log(
-          `[${runId}] Triggering workflow ${schedule.workflowId} ` +
-            `(cron: ${schedule.cronExpression}, tz: ${schedule.timezone})`,
-        );
-
-        await sendToQueue({
-          workflowId: schedule.workflowId,
-          scheduleId: schedule.id,
-          triggerTime: now.toISOString(),
-          triggerType: "schedule",
-        });
-
-        triggered += 1;
-      }
-    } catch (error) {
-      console.error(
-        `[${runId}] Error processing schedule ${schedule.id}:`,
-        error,
-      );
-      errors += 1;
-    }
-  }
-
-  console.log(
-    `[${runId}] Dispatch complete: evaluated=${schedules.length}, triggered=${triggered}, errors=${errors}`,
-  );
-
-  return {
-    evaluated: schedules.length,
-    triggered,
-    errors,
-  };
-}
+import { KEEPERHUB_URL, SQS_QUEUE_URL } from "../lib/config.js";
+import { dispatch } from "./dispatch.js";
 
 // Log and swallow detached promise rejections so transient failures do not
 // crash the dispatcher (Node v15+ exits on unhandled rejection by default).
@@ -180,17 +37,15 @@ process.on("uncaughtException", (error: Error) => {
   process.exit(1);
 });
 
-// Main entry point
-async function main() {
+async function main(): Promise<void> {
   console.log("[Dispatcher] Starting schedule dispatcher...");
   console.log(`[Dispatcher] KeeperHub URL: ${KEEPERHUB_URL}`);
   console.log(`[Dispatcher] SQS Queue URL: ${SQS_QUEUE_URL}`);
 
-  // Start health check server
   const healthApp = express();
   const HEALTH_PORT = process.env.HEALTH_PORT || 3060;
 
-  healthApp.get("/health", (req, res) => {
+  healthApp.get("/health", (_req, res) => {
     res.status(200).json({
       status: "ok",
       service: "schedule-dispatcher",
@@ -204,8 +59,7 @@ async function main() {
     );
   });
 
-  // Close health server on shutdown
-  const shutdownHandler = () => {
+  const shutdownHandler = (): void => {
     console.log("\n[Dispatcher] Shutting down...");
     healthServer.close(() => {
       console.log("[Dispatcher] Health server closed");
@@ -216,7 +70,6 @@ async function main() {
   process.on("SIGINT", shutdownHandler);
   process.on("SIGTERM", shutdownHandler);
 
-  // Run dispatch immediately on startup
   console.log("[Dispatcher] Running initial dispatch...");
   try {
     await dispatch();
@@ -224,7 +77,6 @@ async function main() {
     console.error("[Dispatcher] Initial dispatch failed:", error);
   }
 
-  // Then run every minute
   console.log("[Dispatcher] Starting interval (runs every 60 seconds)");
   setInterval(async () => {
     try {
@@ -232,7 +84,7 @@ async function main() {
     } catch (error) {
       console.error("[Dispatcher] Dispatch failed:", error);
     }
-  }, 60_000); // 60 seconds
+  }, 60_000);
 }
 
 main().catch((error: unknown) => {

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -1,21 +1,15 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChainMonitor } from "../../keeperhub-scheduler/block-dispatcher/chain-monitor.js";
-import type {
-  BlockWorkflow,
-  ChainConfig,
-} from "../../keeperhub-scheduler/lib/types.js";
+import { ChainMonitor } from "../../block-dispatcher/chain-monitor.js";
+import type { BlockWorkflow, ChainConfig } from "../../lib/types.js";
 
 // ---------------------------------------------------------------------------
 // Mock SQS enqueue - prevent real AWS calls
 // ---------------------------------------------------------------------------
 
-vi.mock(
-  "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js",
-  () => ({
-    enqueueBlockTrigger: vi.fn().mockResolvedValue(undefined),
-  })
-);
+vi.mock("../../block-dispatcher/sqs-enqueue.js", () => ({
+  enqueueBlockTrigger: vi.fn().mockResolvedValue(undefined),
+}));
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket that supports ping/pong and close events
@@ -58,9 +52,7 @@ class MockProvider {
     return 100;
   }
 
-  async getBlock(
-    blockNumber: number
-  ): Promise<{
+  async getBlock(blockNumber: number): Promise<{
     hash: string;
     timestamp: number;
     parentHash: string;
@@ -101,7 +93,8 @@ class MockProvider {
 // ---------------------------------------------------------------------------
 
 let providerInstances: MockProvider[] = [];
-let providerFactory: (url: string) => MockProvider = (url) => new MockProvider(url);
+let providerFactory: (url: string) => MockProvider = (url) =>
+  new MockProvider(url);
 
 vi.mock("ethers", () => ({
   ethers: {
@@ -109,6 +102,7 @@ vi.mock("ethers", () => ({
       constructor(url: string) {
         const instance = providerFactory(url);
         providerInstances.push(instance);
+        // biome-ignore lint/correctness/noConstructorReturn: intentional mock idiom -- `new` honors object returns from constructors, used here to substitute the factory-built instance
         return instance;
       }
     },
@@ -236,7 +230,7 @@ describe("ChainMonitor", () => {
       // Verify the on() was called - provider has block listeners
       // Emit a block to confirm the listener was wired up
       const { enqueueBlockTrigger } = await import(
-        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+        "../../block-dispatcher/sqs-enqueue.js"
       );
       provider.emitBlock(10);
       await vi.advanceTimersByTimeAsync(0);
@@ -245,7 +239,7 @@ describe("ChainMonitor", () => {
         expect.objectContaining({
           workflowId: "wf-1",
           triggerData: expect.objectContaining({ blockNumber: 10 }),
-        })
+        }),
       );
     });
 
@@ -258,7 +252,7 @@ describe("ChainMonitor", () => {
       await monitor.start();
 
       const { enqueueBlockTrigger } = await import(
-        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+        "../../block-dispatcher/sqs-enqueue.js"
       );
       const provider = latestProvider();
 
@@ -288,7 +282,7 @@ describe("ChainMonitor", () => {
       await monitor.start();
 
       const { enqueueBlockTrigger } = await import(
-        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+        "../../block-dispatcher/sqs-enqueue.js"
       );
       const provider = latestProvider();
 
@@ -379,7 +373,7 @@ describe("ChainMonitor", () => {
 
       // Old provider's close handler should have been removed
       expect(firstProvider.websocket.listenerCount("close")).toBeLessThan(
-        closeListenerCount
+        closeListenerCount,
       );
     });
 
@@ -392,7 +386,7 @@ describe("ChainMonitor", () => {
       await monitor.start();
 
       const { enqueueBlockTrigger } = await import(
-        "../../keeperhub-scheduler/block-dispatcher/sqs-enqueue.js"
+        "../../block-dispatcher/sqs-enqueue.js"
       );
 
       // First provider delivers a matching block
@@ -492,7 +486,7 @@ describe("ChainMonitor", () => {
         monitor.hasConfigChanged({
           ...chain,
           defaultPrimaryWss: "wss://new-primary.test",
-        })
+        }),
       ).toBe(true);
     });
 
@@ -556,7 +550,7 @@ describe("ChainMonitor", () => {
           setTimeout(() => {
             instance.websocket.emit(
               "error",
-              new Error("Unexpected server response: 429")
+              new Error("Unexpected server response: 429"),
             );
           }, 0);
         }
@@ -591,7 +585,7 @@ describe("ChainMonitor", () => {
           setTimeout(() => {
             instance.websocket.emit(
               "error",
-              new Error("Unexpected server response: 429")
+              new Error("Unexpected server response: 429"),
             );
           }, 0);
         }
@@ -671,7 +665,7 @@ describe("ChainMonitor", () => {
       // Find the most recent provider matching the primary URL — that is the
       // one we are now connected on.
       const primaryProviders = providerInstances.filter(
-        (p) => p.url === "wss://primary.test"
+        (p) => p.url === "wss://primary.test",
       );
       expect(primaryProviders.length).toBeGreaterThanOrEqual(2);
       expect(lastConnectedUrl).toBe("wss://primary.test");
@@ -707,7 +701,7 @@ describe("ChainMonitor", () => {
       expect(monitor.isAlive()).toBe(true);
       // At least one warn was the probe-failure summary
       const probeWarn = warnSpy.mock.calls.find(([msg]) =>
-        String(msg).includes("Primary probe failed")
+        String(msg).includes("Primary probe failed"),
       );
       expect(probeWarn).toBeDefined();
       // The summary should be tight: contain "HTTP 429" and not run for hundreds of chars

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -36,7 +36,7 @@ describe("schedule-dispatcher", () => {
     function shouldTriggerNow(
       cronExpression: string,
       timezone: string,
-      now: Date
+      now: Date,
     ): boolean {
       const { CronExpressionParser } = require("cron-parser");
       try {

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -1,224 +1,418 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
-// Mock dependencies before importing the module
-vi.mock("@aws-sdk/client-sqs", () => ({
-  SQSClient: vi.fn().mockImplementation(() => ({
+// Mock the sqs-client module so importing dispatch.ts does not instantiate
+// a real SQS client. The mock object's `send` is replaced per-test via
+// vi.mocked(sqs.send) so each test can choose its own behavior.
+vi.mock("../../lib/sqs-client.js", () => ({
+  sqs: {
     send: vi.fn(),
-  })),
-  SendMessageCommand: vi.fn().mockImplementation((input) => input),
+  },
 }));
 
-vi.mock("drizzle-orm/postgres-js", () => ({
-  drizzle: vi.fn().mockReturnValue({
-    select: vi.fn(),
-  }),
-}));
+import { sqs } from "../../lib/sqs-client.js";
+import {
+  dispatch,
+  fetchSchedules,
+  sendToQueue,
+  shouldTriggerNow,
+} from "../../schedule-dispatcher/dispatch.js";
 
-vi.mock("postgres", () => ({
-  default: vi.fn().mockReturnValue({
-    end: vi.fn(),
-  }),
-}));
+const mockedSqsSend = vi.mocked(sqs.send);
 
-// Test the shouldTriggerNow logic directly
-describe("schedule-dispatcher", () => {
-  describe("shouldTriggerNow logic", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
+// Silence the dispatcher's console output -- every dispatch run logs
+// half a dozen lines per schedule. Restore in afterEach so test failures
+// keep their stack traces visible.
+let consoleLogSpy: MockInstance;
+let consoleErrorSpy: MockInstance;
+
+beforeEach(() => {
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {
+    /* swallow */
+  });
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+    /* swallow */
+  });
+  mockedSqsSend.mockReset();
+});
+
+afterEach(() => {
+  consoleLogSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+describe("shouldTriggerNow", () => {
+  it("returns true when prev() is within the current minute", () => {
+    // 9:00:01 UTC -- prev() of "0 9 * * *" returns 9:00:00, diff=1s.
+    const now = new Date("2024-01-15T09:00:01Z");
+    expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(true);
+  });
+
+  it("returns true at 30 seconds into the matching minute", () => {
+    const now = new Date("2024-01-15T09:00:30Z");
+    expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(true);
+  });
+
+  it("returns false at 60 seconds (window is exclusive)", () => {
+    // At 9:01:00, diff from 9:00:00 is exactly 60_000ms -- not < 60_000.
+    const now = new Date("2024-01-15T09:01:00Z");
+    expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(false);
+  });
+
+  it("returns false outside the matching minute", () => {
+    const now = new Date("2024-01-15T08:30:00Z");
+    expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(false);
+  });
+
+  it("matches at every minute for '* * * * *'", () => {
+    const at = (s: string): Date => new Date(s);
+    expect(
+      shouldTriggerNow("* * * * *", "UTC", at("2024-01-15T14:37:01Z")),
+    ).toBe(true);
+    expect(
+      shouldTriggerNow("* * * * *", "UTC", at("2024-01-15T03:00:30Z")),
+    ).toBe(true);
+  });
+
+  it("matches an hourly cron at the top of the hour", () => {
+    expect(
+      shouldTriggerNow("0 * * * *", "UTC", new Date("2024-01-15T14:00:01Z")),
+    ).toBe(true);
+    expect(
+      shouldTriggerNow("0 * * * *", "UTC", new Date("2024-01-15T14:30:00Z")),
+    ).toBe(false);
+  });
+
+  it("respects the timezone parameter (NY 9am = 14:00 UTC in January)", () => {
+    // EST is UTC-5 in January, so 9 AM NY == 14:00 UTC.
+    expect(
+      shouldTriggerNow(
+        "0 9 * * *",
+        "America/New_York",
+        new Date("2024-01-15T14:00:01Z"),
+      ),
+    ).toBe(true);
+    // 9 AM UTC is not 9 AM NY -- should not trigger.
+    expect(
+      shouldTriggerNow(
+        "0 9 * * *",
+        "America/New_York",
+        new Date("2024-01-15T09:00:00Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false and logs on an invalid cron expression", () => {
+    const now = new Date("2024-01-15T09:00:00Z");
+    expect(shouldTriggerNow("not a cron", "UTC", now)).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid cron expression: not a cron"),
+      expect.anything(),
+    );
+  });
+
+  it("respects day-of-week constraints", () => {
+    // 2024-01-15 is a Monday at 9:00:01.
+    const monday = new Date("2024-01-15T09:00:01Z");
+    expect(shouldTriggerNow("0 9 * * 1", "UTC", monday)).toBe(true);
+    // Tuesday-only cron should not match on Monday.
+    expect(shouldTriggerNow("0 9 * * 2", "UTC", monday)).toBe(false);
+  });
+
+  it("respects step values", () => {
+    // Every 15 minutes -- triggers at :00, :15, :30, :45 (+1s).
+    expect(
+      shouldTriggerNow("*/15 * * * *", "UTC", new Date("2024-01-15T09:00:01Z")),
+    ).toBe(true);
+    expect(
+      shouldTriggerNow("*/15 * * * *", "UTC", new Date("2024-01-15T09:15:01Z")),
+    ).toBe(true);
+    // :10 is mid-window -- prev() returns :00, diff is ~10min -> false.
+    expect(
+      shouldTriggerNow("*/15 * * * *", "UTC", new Date("2024-01-15T09:10:01Z")),
+    ).toBe(false);
+  });
+});
+
+describe("fetchSchedules", () => {
+  it("returns the schedules array on a 200 response", async () => {
+    const schedules = [
+      {
+        id: "s1",
+        workflowId: "w1",
+        cronExpression: "* * * * *",
+        timezone: "UTC",
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ schedules }),
+      }),
+    );
+
+    await expect(fetchSchedules()).resolves.toEqual(schedules);
+  });
+
+  it("returns an empty array when the API returns no schedules", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ schedules: [] }),
+      }),
+    );
+
+    await expect(fetchSchedules()).resolves.toEqual([]);
+  });
+
+  it("throws including the status and body on a non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => "service unavailable",
+      }),
+    );
+
+    await expect(fetchSchedules()).rejects.toThrow(
+      /Failed to fetch schedules: 503 service unavailable/,
+    );
+  });
+
+  it("calls fetch with the schedules path and X-Service-Key header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ schedules: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchSchedules();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toMatch(/\/api\/internal\/schedules$/);
+    expect(init).toMatchObject({
+      method: "GET",
+      headers: expect.objectContaining({ "X-Service-Key": expect.any(String) }),
+    });
+  });
+});
+
+describe("sendToQueue", () => {
+  it("sends one SQS message with the correct body and attributes", async () => {
+    mockedSqsSend.mockResolvedValue({} as never);
+
+    await sendToQueue({
+      workflowId: "wf-1",
+      scheduleId: "sched-1",
+      triggerTime: "2024-01-15T09:00:00.000Z",
+      triggerType: "schedule",
     });
 
-    afterEach(() => {
-      vi.useRealTimers();
+    expect(mockedSqsSend).toHaveBeenCalledOnce();
+    const command = mockedSqsSend.mock.calls[0][0] as {
+      input: {
+        QueueUrl: string;
+        MessageBody: string;
+        MessageAttributes: Record<
+          string,
+          { DataType: string; StringValue: string }
+        >;
+      };
+    };
+    expect(command.input.QueueUrl).toBeTruthy();
+    expect(JSON.parse(command.input.MessageBody)).toEqual({
+      workflowId: "wf-1",
+      scheduleId: "sched-1",
+      triggerTime: "2024-01-15T09:00:00.000Z",
+      triggerType: "schedule",
     });
-
-    // Recreate the shouldTriggerNow logic for testing
-    // This matches the logic in schedule-dispatcher.ts
-    function shouldTriggerNow(
-      cronExpression: string,
-      timezone: string,
-      now: Date,
-    ): boolean {
-      const { CronExpressionParser } = require("cron-parser");
-      try {
-        // Parse with current time
-        const interval = CronExpressionParser.parse(cronExpression, {
-          currentDate: now,
-          tz: timezone,
-        });
-
-        // Get the previous occurrence from the current time
-        const prev = interval.prev().toDate();
-        const diffMs = now.getTime() - prev.getTime();
-
-        // The prev() returns the most recent match before/at currentDate
-        // If we're exactly at 9:00:00, prev() returns the previous 9:00 (yesterday)
-        // So we need to check if we're within 60 seconds of a match
-        // But the actual check is: is the previous match within the current minute?
-        return diffMs >= 0 && diffMs < 60_000;
-      } catch {
-        return false;
-      }
-    }
-
-    // The actual behavior: prev() goes to BEFORE currentDate
-    // So at exactly 9:00:00, it returns 9:00 from the previous occurrence (yesterday for daily)
-    // The dispatcher logic checks if the diff is < 60 seconds
-    // This means we need to test 1 second AFTER the cron time to catch it within the window
-
-    it("returns true when cron matches current minute", () => {
-      // Set time to 9:00:01 AM - prev() returns 9:00:00 which is 1 second ago
-      // This is within the 60 second window
-      const now = new Date("2024-01-15T09:00:01Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 9 * * *", "UTC", now);
-      expect(result).toBe(true);
+    expect(command.input.MessageAttributes.TriggerType).toEqual({
+      DataType: "String",
+      StringValue: "schedule",
     });
-
-    it("returns true when within the same minute", () => {
-      // Set time to 9:00:30 (30 seconds into the minute)
-      const now = new Date("2024-01-15T09:00:30Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 9 * * *", "UTC", now);
-      expect(result).toBe(true);
-    });
-
-    it("returns false when cron does not match current minute", () => {
-      // Set time to 8:30 AM
-      const now = new Date("2024-01-15T08:30:00Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 9 * * *", "UTC", now);
-      expect(result).toBe(false);
-    });
-
-    it("returns true for every-minute cron at any time", () => {
-      // At 14:37:01, prev() returns 14:37:00 which is 1 second ago
-      const now = new Date("2024-01-15T14:37:01Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("* * * * *", "UTC", now);
-      expect(result).toBe(true);
-    });
-
-    it("returns true for hourly cron at the start of each hour", () => {
-      // At 14:00:01, prev() returns 14:00:00 which is 1 second ago
-      const now = new Date("2024-01-15T14:00:01Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 * * * *", "UTC", now);
-      expect(result).toBe(true);
-    });
-
-    it("returns false for hourly cron at minute 30", () => {
-      const now = new Date("2024-01-15T14:30:00Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 * * * *", "UTC", now);
-      expect(result).toBe(false);
-    });
-
-    it("handles timezone correctly - New York 9am", () => {
-      // 9:00 AM EST = 2:00 PM UTC (January, EST is UTC-5)
-      // At 14:00:01 UTC, prev() returns 14:00:00 UTC (9:00 AM EST) which is 1 second ago
-      const now = new Date("2024-01-15T14:00:01Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 9 * * *", "America/New_York", now);
-      expect(result).toBe(true);
-    });
-
-    it("handles timezone correctly - New York 9am not triggered at wrong UTC time", () => {
-      // 9:00 AM UTC != 9:00 AM EST
-      const now = new Date("2024-01-15T09:00:00Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("0 9 * * *", "America/New_York", now);
-      expect(result).toBe(false);
-    });
-
-    it("returns false for invalid cron expression", () => {
-      const now = new Date("2024-01-15T09:00:00Z");
-      vi.setSystemTime(now);
-
-      const result = shouldTriggerNow("invalid cron", "UTC", now);
-      expect(result).toBe(false);
-    });
-
-    it("handles day-of-week constraints", () => {
-      // 2024-01-15 is a Monday, at 9:00:01
-      const monday = new Date("2024-01-15T09:00:01Z");
-      vi.setSystemTime(monday);
-
-      // Every Monday at 9am - should trigger (prev returns 9:00:00 today)
-      expect(shouldTriggerNow("0 9 * * 1", "UTC", monday)).toBe(true);
-
-      // Every Tuesday at 9am - should not trigger on Monday
-      // prev() returns last Tuesday's 9am which is days ago
-      expect(shouldTriggerNow("0 9 * * 2", "UTC", monday)).toBe(false);
-    });
-
-    it("handles weekday range", () => {
-      // 2024-01-15 is a Monday at 9:00:01
-      const monday = new Date("2024-01-15T09:00:01Z");
-      vi.setSystemTime(monday);
-
-      // Weekdays at 9am (Mon-Fri) - should trigger
-      expect(shouldTriggerNow("0 9 * * 1-5", "UTC", monday)).toBe(true);
-
-      // Saturday 2024-01-20 at 9:00:01
-      // prev() returns Friday's 9am which is > 60 seconds ago
-      const saturday = new Date("2024-01-20T09:00:01Z");
-      expect(shouldTriggerNow("0 9 * * 1-5", "UTC", saturday)).toBe(false);
-    });
-
-    it("handles step values", () => {
-      // Every 15 minutes - should trigger at :00, :15, :30, :45
-      // Add 1 second so prev() returns the current minute
-      const at00 = new Date("2024-01-15T09:00:01Z");
-      const at15 = new Date("2024-01-15T09:15:01Z");
-      const at30 = new Date("2024-01-15T09:30:01Z");
-      const at10 = new Date("2024-01-15T09:10:01Z"); // prev() returns 09:00, which is 10+ minutes ago
-
-      expect(shouldTriggerNow("*/15 * * * *", "UTC", at00)).toBe(true);
-      expect(shouldTriggerNow("*/15 * * * *", "UTC", at15)).toBe(true);
-      expect(shouldTriggerNow("*/15 * * * *", "UTC", at30)).toBe(true);
-      expect(shouldTriggerNow("*/15 * * * *", "UTC", at10)).toBe(false);
+    expect(command.input.MessageAttributes.WorkflowId).toEqual({
+      DataType: "String",
+      StringValue: "wf-1",
     });
   });
 
-  describe("message structure", () => {
-    it("creates correct SQS message format", () => {
-      const message = {
-        workflowId: "wf_123",
-        scheduleId: "sched_456",
-        triggerTime: "2024-01-15T09:00:00.000Z",
-        triggerType: "schedule" as const,
-      };
+  it("propagates errors from sqs.send", async () => {
+    mockedSqsSend.mockRejectedValue(new Error("SQS unavailable"));
 
-      expect(message).toEqual({
-        workflowId: "wf_123",
-        scheduleId: "sched_456",
+    await expect(
+      sendToQueue({
+        workflowId: "wf-1",
+        scheduleId: "sched-1",
         triggerTime: "2024-01-15T09:00:00.000Z",
         triggerType: "schedule",
-      });
-    });
+      }),
+    ).rejects.toThrow("SQS unavailable");
+  });
+});
 
-    it("includes required message attributes", () => {
-      const messageAttributes = {
-        TriggerType: {
-          DataType: "String",
-          StringValue: "schedule",
-        },
-        WorkflowId: {
-          DataType: "String",
-          StringValue: "wf_123",
-        },
-      };
+describe("dispatch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 9:00:01 UTC -- inside the matching minute for "0 9 * * *".
+    vi.setSystemTime(new Date("2024-01-15T09:00:01Z"));
+  });
 
-      expect(messageAttributes.TriggerType.StringValue).toBe("schedule");
-      expect(messageAttributes.WorkflowId.StringValue).toBe("wf_123");
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function stubFetch(schedules: unknown[]): void {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ schedules }),
+      }),
+    );
+  }
+
+  it("returns zero counts when no schedules are returned", async () => {
+    stubFetch([]);
+
+    await expect(dispatch()).resolves.toEqual({
+      evaluated: 0,
+      triggered: 0,
+      errors: 0,
     });
+    expect(mockedSqsSend).not.toHaveBeenCalled();
+  });
+
+  it("triggers a matching schedule and counts it once", async () => {
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend.mockResolvedValue({} as never);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 1, triggered: 1, errors: 0 });
+    expect(mockedSqsSend).toHaveBeenCalledOnce();
+  });
+
+  it("does not enqueue a schedule that is not due", async () => {
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 10 * * *",
+        timezone: "UTC",
+      },
+    ]);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 1, triggered: 0, errors: 0 });
+    expect(mockedSqsSend).not.toHaveBeenCalled();
+  });
+
+  it("counts SQS failures as errors but keeps processing", async () => {
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+      {
+        id: "sched-2",
+        workflowId: "wf-2",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend
+      .mockRejectedValueOnce(new Error("SQS down"))
+      .mockResolvedValueOnce({} as never);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 2, triggered: 1, errors: 1 });
+    expect(mockedSqsSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a malformed cron as not-due rather than as an error", async () => {
+    // shouldTriggerNow logs the parse failure and returns false; dispatch
+    // sees that as "not due" and does not increment errors. Pinned so a
+    // future change here is a deliberate decision, not an accident.
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "this is not cron",
+        timezone: "UTC",
+      },
+    ]);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 1, triggered: 0, errors: 0 });
+    expect(mockedSqsSend).not.toHaveBeenCalled();
+  });
+
+  it("processes a mixed batch (due, not-due, due-but-sqs-fails)", async () => {
+    stubFetch([
+      {
+        id: "s-ok",
+        workflowId: "wf-ok",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+      {
+        id: "s-skip",
+        workflowId: "wf-skip",
+        cronExpression: "0 10 * * *",
+        timezone: "UTC",
+      },
+      {
+        id: "s-fail",
+        workflowId: "wf-fail",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend
+      .mockResolvedValueOnce({} as never)
+      .mockRejectedValueOnce(new Error("SQS down"));
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 3, triggered: 1, errors: 1 });
+    expect(mockedSqsSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates fetchSchedules failures to the caller", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "boom",
+      }),
+    );
+
+    await expect(dispatch()).rejects.toThrow(/Failed to fetch schedules: 500/);
+    expect(mockedSqsSend).not.toHaveBeenCalled();
   });
 });

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -1,4 +1,9 @@
 import {
+  SendMessageCommand,
+  type SendMessageCommandOutput,
+} from "@aws-sdk/client-sqs";
+import { CronExpressionParser } from "cron-parser";
+import {
   type MockInstance,
   afterEach,
   beforeEach,
@@ -27,6 +32,11 @@ import {
 
 const mockedSqsSend = vi.mocked(sqs.send);
 
+// `sqs.send` is overloaded per-command and infers a wide return union;
+// concrete output for SendMessageCommand is the only one the dispatcher
+// uses, so type the mock resolution to that rather than `as never`.
+const sqsOkResponse = {} as SendMessageCommandOutput;
+
 // Silence the dispatcher's console output -- every dispatch run logs
 // half a dozen lines per schedule. Restore in afterEach so test failures
 // keep their stack traces visible.
@@ -47,6 +57,7 @@ afterEach(() => {
   consoleLogSpy.mockRestore();
   consoleErrorSpy.mockRestore();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("shouldTriggerNow", () => {
@@ -115,6 +126,25 @@ describe("shouldTriggerNow", () => {
     expect(shouldTriggerNow("not a cron", "UTC", now)).toBe(false);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Invalid cron expression: not a cron"),
+      expect.anything(),
+    );
+  });
+
+  it("returns false and logs when interval.prev() throws at runtime", () => {
+    // cron-parser can throw on prev() for expressions that parse but have
+    // no past occurrence in the supported range. Mock the parser to force
+    // that branch so the test does not depend on which exact expressions
+    // trigger that condition in the current cron-parser version.
+    vi.spyOn(CronExpressionParser, "parse").mockReturnValueOnce({
+      prev: () => {
+        throw new Error("Out of the timespan range");
+      },
+    } as never);
+
+    const now = new Date("2024-01-15T09:00:00Z");
+    expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid cron expression: 0 9 * * *"),
       expect.anything(),
     );
   });
@@ -190,6 +220,18 @@ describe("fetchSchedules", () => {
     );
   });
 
+  it("propagates fetch network errors to the caller", async () => {
+    // fetch itself rejecting (DNS failure, TLS error, socket reset) is a
+    // distinct branch from the non-2xx path -- no `response` object exists
+    // to inspect, so the error reaches the caller unwrapped.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+
+    await expect(fetchSchedules()).rejects.toThrow("ECONNREFUSED");
+  });
+
   it("calls fetch with the schedules path and X-Service-Key header", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -210,8 +252,8 @@ describe("fetchSchedules", () => {
 });
 
 describe("sendToQueue", () => {
-  it("sends one SQS message with the correct body and attributes", async () => {
-    mockedSqsSend.mockResolvedValue({} as never);
+  it("sends one SendMessageCommand with the correct body and attributes", async () => {
+    mockedSqsSend.mockResolvedValue(sqsOkResponse);
 
     await sendToQueue({
       workflowId: "wf-1",
@@ -221,28 +263,23 @@ describe("sendToQueue", () => {
     });
 
     expect(mockedSqsSend).toHaveBeenCalledOnce();
-    const command = mockedSqsSend.mock.calls[0][0] as {
-      input: {
-        QueueUrl: string;
-        MessageBody: string;
-        MessageAttributes: Record<
-          string,
-          { DataType: string; StringValue: string }
-        >;
-      };
-    };
-    expect(command.input.QueueUrl).toBeTruthy();
-    expect(JSON.parse(command.input.MessageBody)).toEqual({
+    const command = mockedSqsSend.mock.calls[0][0];
+    // instanceof check is the public API contract; .input is the documented
+    // public field on AWS SDK v3 commands.
+    expect(command).toBeInstanceOf(SendMessageCommand);
+    const { input } = command as SendMessageCommand;
+    expect(input.QueueUrl).toBeTruthy();
+    expect(JSON.parse(input.MessageBody ?? "")).toEqual({
       workflowId: "wf-1",
       scheduleId: "sched-1",
       triggerTime: "2024-01-15T09:00:00.000Z",
       triggerType: "schedule",
     });
-    expect(command.input.MessageAttributes.TriggerType).toEqual({
+    expect(input.MessageAttributes?.TriggerType).toEqual({
       DataType: "String",
       StringValue: "schedule",
     });
-    expect(command.input.MessageAttributes.WorkflowId).toEqual({
+    expect(input.MessageAttributes?.WorkflowId).toEqual({
       DataType: "String",
       StringValue: "wf-1",
     });
@@ -294,7 +331,7 @@ describe("dispatch", () => {
     expect(mockedSqsSend).not.toHaveBeenCalled();
   });
 
-  it("triggers a matching schedule and counts it once", async () => {
+  it("triggers a matching schedule, counts it once, and logs the trigger", async () => {
     stubFetch([
       {
         id: "sched-1",
@@ -303,12 +340,20 @@ describe("dispatch", () => {
         timezone: "UTC",
       },
     ]);
-    mockedSqsSend.mockResolvedValue({} as never);
+    mockedSqsSend.mockResolvedValue(sqsOkResponse);
 
     const result = await dispatch();
 
     expect(result).toEqual({ evaluated: 1, triggered: 1, errors: 0 });
     expect(mockedSqsSend).toHaveBeenCalledOnce();
+    // Logging is the primary operational signal for stuck workflows;
+    // pin that the trigger line includes the workflow id and cron, so a
+    // future "drop the logs" refactor surfaces as a test failure.
+    const triggerLog = consoleLogSpy.mock.calls.find((call) =>
+      String(call[0]).includes("Triggering workflow wf-1"),
+    );
+    expect(triggerLog).toBeDefined();
+    expect(String(triggerLog?.[0])).toContain("0 9 * * *");
   });
 
   it("does not enqueue a schedule that is not due", async () => {
@@ -344,7 +389,7 @@ describe("dispatch", () => {
     ]);
     mockedSqsSend
       .mockRejectedValueOnce(new Error("SQS down"))
-      .mockResolvedValueOnce({} as never);
+      .mockResolvedValueOnce(sqsOkResponse);
 
     const result = await dispatch();
 
@@ -352,10 +397,44 @@ describe("dispatch", () => {
     expect(mockedSqsSend).toHaveBeenCalledTimes(2);
   });
 
-  it("treats a malformed cron as not-due rather than as an error", async () => {
+  it("counts every failure when SQS is down for the whole batch", async () => {
+    // No successful triggers -- distinct from the partial-failure case
+    // because triggered=0 means the result tuple is (evaluated, 0, N).
+    stubFetch([
+      {
+        id: "s1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+      {
+        id: "s2",
+        workflowId: "wf-2",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+      {
+        id: "s3",
+        workflowId: "wf-3",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend.mockRejectedValue(new Error("SQS down for the whole batch"));
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 3, triggered: 0, errors: 3 });
+    expect(mockedSqsSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("pins current behavior: malformed cron is silently skipped, not counted as an error", async () => {
     // shouldTriggerNow logs the parse failure and returns false; dispatch
-    // sees that as "not due" and does not increment errors. Pinned so a
-    // future change here is a deliberate decision, not an accident.
+    // sees that as "not due" and does not increment errors. This is the
+    // current behavior -- pinned so a future change is a deliberate
+    // decision, not an accident. Worth revisiting whether silent skip is
+    // the desired prod behavior (a misconfigured workflow never fires
+    // and only shows up in logs).
     stubFetch([
       {
         id: "sched-1",
@@ -393,12 +472,48 @@ describe("dispatch", () => {
       },
     ]);
     mockedSqsSend
-      .mockResolvedValueOnce({} as never)
+      .mockResolvedValueOnce(sqsOkResponse)
       .mockRejectedValueOnce(new Error("SQS down"));
 
     const result = await dispatch();
 
     expect(result).toEqual({ evaluated: 3, triggered: 1, errors: 1 });
+    expect(mockedSqsSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("captures `now` once per pass (clock advance mid-batch does not change evaluation)", async () => {
+    // dispatch() does `const now = new Date()` once before the loop. If
+    // a future refactor moves `new Date()` into the loop body, schedules
+    // late in a slow batch could fall outside the trigger window. Pin the
+    // current behavior: advance the wall clock by 2 minutes between
+    // sends -- both schedules still trigger because they are evaluated
+    // against the original `now` snapshot.
+    stubFetch([
+      {
+        id: "s1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+      {
+        id: "s2",
+        workflowId: "wf-2",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend
+      .mockImplementationOnce(async () => {
+        // Jump past the matching minute. If `now` were re-read per
+        // iteration, sched-2 would no longer be due.
+        vi.setSystemTime(new Date("2024-01-15T09:02:30Z"));
+        return sqsOkResponse;
+      })
+      .mockResolvedValueOnce(sqsOkResponse);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 2, triggered: 2, errors: 0 });
     expect(mockedSqsSend).toHaveBeenCalledTimes(2);
   });
 

--- a/keeperhub-scheduler/tsconfig.json
+++ b/keeperhub-scheduler/tsconfig.json
@@ -14,6 +14,10 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  "include": ["schedule-dispatcher/**/*.ts", "block-dispatcher/**/*.ts", "lib/**/*.ts"],
+  "include": [
+    "schedule-dispatcher/**/*.ts",
+    "block-dispatcher/**/*.ts",
+    "lib/**/*.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/keeperhub-scheduler/vitest.config.ts
+++ b/keeperhub-scheduler/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    exclude: ["node_modules", "dist"],
+    testTimeout: 10_000,
+  },
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -22,6 +22,12 @@ export default defineConfig({
       // picks up keeperhub-events/event-tracker/tests/integration via
       // positional path filter and fails on missing deps.
       "keeperhub-events/**",
+      // keeperhub-scheduler has its own package, vitest config, and
+      // pnpm-lock. Tests there are run by pr-checks-scheduler.yml; the
+      // main app's vitest must not pick them up (the chain-monitor test
+      // imports from ../../block-dispatcher/* which only resolves when
+      // run from within keeperhub-scheduler/).
+      "keeperhub-scheduler/**",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Adds a distinct CI workflow for `keeperhub-scheduler/` mirroring the events workspace pattern: lint, typecheck, build, and unit-test jobs gated by a path filter on `keeperhub-scheduler/**`.
- Relocates the existing scheduler unit tests from the main app's `tests/unit/` into the scheduler package so they run against the package's own deps.
- Refactors `schedule-dispatcher/` to expose its logic via a new `dispatch.ts` module so it can be unit-tested without starting the express health server and 60s polling loop. `index.ts` slims to ~90 lines (entry point only).
- Replaces the previous `schedule-dispatcher.test.ts` (which copy-pasted `shouldTriggerNow` and tested cron-parser indirectly) with 27 real unit tests against the new exports.
- Hardens the new workflow with `concurrency`, `permissions: contents: read`, and per-job `timeout-minutes: 5` to match the convention in `deploy-scheduler.yaml`.
- Closes [KEEP-404](https://linear.app/keeperhubapp/issue/KEEP-404/add-ci-coverage-for-block-trigger-system-tests) and [KEEP-454](https://linear.app/keeperhubapp/issue/KEEP-454/write-real-unit-tests-for-schedule-dispatcher) (KEEP-454 was originally stacked as #1156, now merged into this branch).

## What changed

**New CI surface**
- `.github/workflows/pr-checks-scheduler.yml` -- jobs: lint, typecheck, build, test-unit. Path filter on `keeperhub-scheduler/**`, the workflow itself, and the new composite action. Concurrency cancels superseded runs on new pushes; `permissions: contents: read` strips the default token surface; per-job `timeout-minutes: 5` caps hangs without burning the GHA budget.
- `.github/actions/setup-scheduler-deps/action.yml` -- composite action installing scheduler deps. Uses `pnpm install --frozen-lockfile --ignore-workspace` because the scheduler is a standalone package (its own lockfile) and lacks an inner `pnpm-workspace.yaml` -- without `--ignore-workspace`, pnpm walks up to the repo-root workspace which doesn't include the scheduler.

**Scheduler package**
- `package.json` -- new scripts (`lint`, `lint:fix`, `test`, `test:unit`, `test:watch`); new devDeps (`@biomejs/biome`, `vite`, `vitest`). `vite` is pinned alongside `vitest` to match the events workspace pattern (events declares both at the same versions).
- `biome.jsonc`, `vitest.config.ts` -- standalone configs, mirroring `keeperhub-events/biome.json` and equivalent.
- `schedule-dispatcher/dispatch.ts` (new) -- exports `fetchSchedules`, `shouldTriggerNow`, `sendToQueue`, `dispatch`, `DispatchResult`. Pure functions; the only import-time side effect is SQS client instantiation via `lib/sqs-client.js`, documented in the file's header comment.
- `schedule-dispatcher/index.ts` -- slimmed from 242 to ~90 lines: signal handlers, express health server, 60s `setInterval` calling `dispatch()`. Behavior preserved 1:1.
- Two test files relocated into `keeperhub-scheduler/tests/unit/`, with relative imports rewritten in `chain-monitor.test.ts`.
- `pnpm lint:fix` auto-format pass on existing source (trailing commas, multi-line wrapping). Single targeted `biome-ignore` for an intentional constructor-return mock idiom in `chain-monitor.test.ts`.

**Main app**
- `vitest.config.mts` -- adds `keeperhub-scheduler/**` to `exclude`, mirroring the existing events exclusion. Without this, the main app's `test-unit` job double-picks the relocated tests and `chain-monitor.test.ts`'s relative imports fail to resolve from the wrong cwd.
- `tests/unit/schedule-dispatcher.test.ts` and `tests/unit/chain-monitor.test.ts` -- deleted (relocated to the scheduler package).

## Why a distinct workflow rather than reusing the main `test-unit`

Before this PR, scheduler unit tests lived inside the main app and rode the main `pr-checks.yml` `test-unit` job (no path filter, runs on every PR). That worked but conflated scheduler signal with main-app signal. A distinct path-filtered workflow gives scheduler changes their own gate -- failures point at scheduler code without scrolling through unrelated main-app test output, and PRs that don't touch the scheduler skip the job entirely.

## Why a refactor was needed for KEEP-454

`schedule-dispatcher/index.ts` originally exported nothing -- everything was module-local, and `main()` was invoked at module load time, so just `import`-ing the file would start the express server and the 60s polling loop. The previous test couldn't reach the dispatcher source and had to copy-paste `shouldTriggerNow` to test cron-parser indirectly. The minimum-needed refactor extracts the four functions into `dispatch.ts` (reachable from tests) and leaves `index.ts` as the bootable entry point. Mirrors the block-dispatcher split (`chain-monitor.ts` logic + `index.ts` entry).

## Test coverage added

| Function | Tests | Coverage |
|---|---|---|
| `shouldTriggerNow` | 11 | within-minute window incl. exclusive 60s boundary, invalid cron at parse and at runtime `prev()`, timezone (NY 9am vs UTC), step values, day-of-week |
| `fetchSchedules` | 5 | 200 (with schedules / empty), non-2xx with status+body, fetch network rejection, header check |
| `sendToQueue` | 2 | correct `SendMessageCommand` shape (asserted via `instanceof` + typed `.input`), propagates `send` errors |
| `dispatch` | 9 | empty schedules, single-due (with log assertion), single-not-due, partial SQS fail, all-fail batch, malformed cron pin, mixed batch, `now` snapshot consistency, `fetchSchedules` failure propagates |
| `chain-monitor` | 25 | (unchanged from KEEP-404 work; reachable now that the test lives with the package) |

## Behaviors pinned by tests (worth knowing for future maintainers)

- **Window check is exclusive at 60_000ms.** At `:01:00`, `prev=:00:00`, `diff=60_000` -> false. If anyone "rounds up" the window later, the test fails.
- **Malformed cron logs but counts as not-due, not as an error.** A misconfigured workflow silently never fires. Pinned so the choice is deliberate; worth revisiting whether silent skip is the desired prod behavior.
- **`fetchSchedules` errors abort the whole pass.** Not per-schedule. A flaky API takes the whole minute's dispatch with it.
- **`now` is captured once per pass, before the loop.** Long-running passes evaluate later schedules against the original `now`. Pinned against a future "move `new Date()` into the loop" refactor.

## Local verification (node 22)

```
pnpm lint        Checked 16 files, no errors
pnpm typecheck   tsc --noEmit, clean
pnpm build       tsc, clean
pnpm test:unit   52 passed (25 chain-monitor + 27 dispatcher) in ~540ms
```

Note: `pnpm typecheck` does not include the `tests/` directory (per `tsconfig.json` `include`). Vitest type-checks tests at runtime. Mirrors the events package behavior; flag if you want a separate test tsconfig as a follow-up.

## Out of scope / known follow-ups

- Docker stage validation in PR checks (e.g. `docker buildx bake scheduler`). Today the root `Dockerfile` copies the entire `keeperhub-scheduler/schedule-dispatcher/` directory, so `dispatch.ts` is picked up automatically; a Dockerfile regression would only surface at deploy time.
- Inner `pnpm-workspace.yaml` in `keeperhub-scheduler/` to drop the `--ignore-workspace` flag.
- `tests/**` in tsconfig (or separate `tsconfig.test.json`) for typecheck-time test coverage instead of vitest-runtime-only.
- Integration tests against real Postgres / LocalStack (would require adding a `test-integration` job and bringing up the docker-compose `test` profile, mirroring `pr-checks-events.yml`).

## Test plan

- [ ] All four `PR Checks (Scheduler)` jobs (lint, typecheck, build, test-unit) pass on this PR
- [ ] Main `PR Checks` workflow's `test-unit` no longer references the relocated scheduler tests (passes; tests moved cleanly)
- [ ] Concurrency cancels older runs when new commits push to this branch (verifiable by inspecting GH Actions UI on consecutive pushes)
- [ ] After deploy to staging, `keeperhub-scheduler-dispatcher` and `keeperhub-block-dispatcher` pods come up healthy (smoke -- the dispatcher refactor preserved behavior 1:1, but the bootable entry point moved)