### PR TITLE
fix(web3): resolve ABI function via getFunction to avoid BaseContract collisions

### DIFF
--- a/app/api/gas/estimate/route.ts
+++ b/app/api/gas/estimate/route.ts
@@ -155,8 +155,13 @@ function estimateWriteContract(
     provider
   );
 
-  const fn = contract[config.abiFunction];
-  if (typeof fn !== "function") {
+  // Use getFunction() so ABI names that collide with BaseContract built-ins
+  // (e.g. getAddress, attach, connect, queryFilter) resolve to the ABI fragment
+  // instead of the inherited method (which lacks `.estimateGas`).
+  let fn: ethers.BaseContractMethod;
+  try {
+    fn = contract.getFunction(config.abiFunction);
+  } catch {
     return badRequest(`Function '${config.abiFunction}' not found in ABI`);
   }
 

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -119,11 +119,10 @@ export class EvmChainAdapter implements ChainAdapter {
       );
     }
 
-    if (typeof contract[request.functionKey] !== "function") {
-      throw new Error(
-        `Function '${request.functionKey}' not found in contract ABI`
-      );
-    }
+    // Use getFunction() so ABI names that collide with BaseContract built-ins
+    // (e.g. getAddress, attach, connect, queryFilter) resolve to the ABI fragment
+    // instead of the inherited method.
+    const fn = contract.getFunction(request.functionKey);
 
     const signerAddress = await signer.getAddress();
     const callOverrides = {
@@ -138,16 +137,12 @@ export class EvmChainAdapter implements ChainAdapter {
           request.abi,
           rpcProvider
         );
-        return readContract[request.functionKey].staticCall(
-          ...request.args,
-          callOverrides
-        );
+        return readContract
+          .getFunction(request.functionKey)
+          .staticCall(...request.args, callOverrides);
       }, "preflight");
     } else {
-      await contract[request.functionKey].staticCall(
-        ...request.args,
-        callOverrides
-      );
+      await fn.staticCall(...request.args, callOverrides);
     }
 
     const nonce = this.nonceManager.getNextNonce(session);
@@ -159,15 +154,11 @@ export class EvmChainAdapter implements ChainAdapter {
             request.abi,
             rpcProvider
           );
-          return readContract[request.functionKey].estimateGas(
-            ...request.args,
-            callOverrides
-          );
+          return readContract
+            .getFunction(request.functionKey)
+            .estimateGas(...request.args, callOverrides);
         }, "preflight")
-      : await contract[request.functionKey].estimateGas(
-          ...request.args,
-          callOverrides
-        );
+      : await fn.estimateGas(...request.args, callOverrides);
 
     const gasConfig = await this.gasStrategy.getGasConfig(
       provider,
@@ -179,7 +170,7 @@ export class EvmChainAdapter implements ChainAdapter {
       options.gasOverrides.priorityFeeOverride
     );
 
-    const tx = await contract[request.functionKey](...request.args, {
+    const tx = await fn(...request.args, {
       nonce,
       gasLimit: gasConfig.gasLimit,
       maxFeePerGas: gasConfig.maxFeePerGas,
@@ -201,15 +192,14 @@ export class EvmChainAdapter implements ChainAdapter {
         provider
       );
 
-      if (typeof contract[request.functionKey] !== "function") {
-        throw new Error(
-          `Function '${request.functionKey}' not found in contract ABI`
-        );
-      }
+      // Use getFunction() so ABI names that collide with BaseContract built-ins
+      // (e.g. getAddress, attach, connect, queryFilter) resolve to the ABI
+      // fragment instead of the inherited method.
+      const fn = contract.getFunction(request.functionKey);
 
       return request.isView
-        ? await contract[request.functionKey](...request.args)
-        : await contract[request.functionKey].staticCall(...request.args);
+        ? await fn(...request.args)
+        : await fn.staticCall(...request.args);
     });
   }
 

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -166,7 +166,7 @@ export async function submitContractCallAndConfirm(
   let tx: ethers.TransactionResponse;
   try {
     tx = await withRpcMetrics(primaryCtx, () =>
-      contract[method](...args, overrides)
+      contract.getFunction(method)(...args, overrides)
     );
   } catch (primaryError) {
     if (isNonRetryableError(primaryError)) {
@@ -206,7 +206,7 @@ export async function submitContractCallAndConfirm(
       reconnectedSigner
     ) as typeof contract;
     tx = await withRpcMetrics(fallbackCtx, () =>
-      reconnectedContract[method](...args, overrides)
+      reconnectedContract.getFunction(method)(...args, overrides)
     );
   }
 
@@ -388,12 +388,12 @@ export async function executeContractTransaction(
     const estimatedGas = context.rpcManager
       ? await context.rpcManager.executeWithFailover(
           (rpcProvider) =>
-            (contract.connect(rpcProvider) as typeof contract)[
-              method
-            ].estimateGas(...args, { from: walletAddress }),
+            (contract.connect(rpcProvider) as typeof contract)
+              .getFunction(method)
+              .estimateGas(...args, { from: walletAddress }),
           "preflight"
         )
-      : await contract[method].estimateGas(...args);
+      : await contract.getFunction(method).estimateGas(...args);
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider as ethers.Provider,
@@ -404,7 +404,7 @@ export async function executeContractTransaction(
       context.rpcManager
     );
 
-    const tx = await contract[method](...args, {
+    const tx = await contract.getFunction(method)(...args, {
       nonce,
       gasLimit: gasConfig.gasLimit,
       maxFeePerGas: gasConfig.maxFeePerGas,

--- a/tests/unit/evm-chain-adapter-preflight.test.ts
+++ b/tests/unit/evm-chain-adapter-preflight.test.ts
@@ -30,7 +30,15 @@ const mockSendTx = Object.assign(
 
 vi.mock("ethers", () => {
   function MockContract(): Record<string, unknown> {
-    return { approve: mockSendTx };
+    return {
+      approve: mockSendTx,
+      getFunction: (name: string): unknown => {
+        if (name === "approve") {
+          return mockSendTx;
+        }
+        throw new Error(`unknown function: ${name}`);
+      },
+    };
   }
   return {
     ethers: {

--- a/tests/unit/evm-chain-adapter-read.test.ts
+++ b/tests/unit/evm-chain-adapter-read.test.ts
@@ -14,16 +14,38 @@ import { EvmChainAdapter } from "@/lib/web3/chain-adapter/evm";
 
 const SEQUENCER_ADDRESS = "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F";
 const D3M_JOB_ADDRESS = "0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF";
+const TOKEN_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const HOLDER_ADDRESS = "0x2c9F694183A4240B6431771F6c714a8106179dF5";
 const CRON_D3M_JOB_KEY =
   "0x43524f4e5f44334d5f4a4f420000000000000000000000000000000000000000";
 
-const GET_ADDRESS_ABI = [
+const COLLIDING_NAMES = [
+  "getAddress",
+  "connect",
+  "attach",
+  "queryFilter",
+  "getEvent",
+] as const;
+
+function buildAbiFor(name: string): unknown[] {
+  return [
+    {
+      type: "function",
+      name,
+      stateMutability: "view",
+      inputs: [{ name: "_key", type: "bytes32" }],
+      outputs: [{ name: "addr", type: "address" }],
+    },
+  ];
+}
+
+const BALANCE_OF_ABI = [
   {
     type: "function",
-    name: "getAddress",
+    name: "balanceOf",
     stateMutability: "view",
-    inputs: [{ name: "_key", type: "bytes32" }],
-    outputs: [{ name: "addr", type: "address" }],
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
   },
 ] as const;
 
@@ -32,9 +54,7 @@ type ExecuteWithFailover = <T>(
 ) => Promise<T>;
 
 function createAdapter(): EvmChainAdapter {
-  const gasStrategy = {
-    getGasConfig: vi.fn(),
-  };
+  const gasStrategy = { getGasConfig: vi.fn() };
   const nonceManager = { getNextNonce: vi.fn() };
   return new EvmChainAdapter(
     1,
@@ -54,14 +74,18 @@ function createRpcManagerWithCallReturning(rawResult: string): {
   return { executeWithFailover, callMock };
 }
 
+type ReadContractRequest = Parameters<EvmChainAdapter["readContract"]>[1];
+type RpcProviderManagerArg = Parameters<EvmChainAdapter["readContract"]>[0];
+
 describe("EvmChainAdapter.readContract — BaseContract name collision", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("returns the ABI function result for `getAddress`, not the contract address", async () => {
+  it.each(
+    COLLIDING_NAMES
+  )("returns the ABI function result for `%s` (bare name), not the contract address", async (name) => {
     const adapter = createAdapter();
-
     const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
       ["address"],
       [D3M_JOB_ADDRESS]
@@ -70,16 +94,14 @@ describe("EvmChainAdapter.readContract — BaseContract name collision", () => {
       createRpcManagerWithCallReturning(encoded);
 
     const result = (await adapter.readContract(
-      { executeWithFailover } as unknown as Parameters<
-        EvmChainAdapter["readContract"]
-      >[0],
+      { executeWithFailover } as unknown as RpcProviderManagerArg,
       {
         contractAddress: SEQUENCER_ADDRESS,
-        abi: GET_ADDRESS_ABI as unknown as ethers.InterfaceAbi,
-        functionKey: "getAddress(bytes32)",
+        abi: buildAbiFor(name) as unknown as ethers.InterfaceAbi,
+        functionKey: name,
         args: [CRON_D3M_JOB_KEY],
         isView: true,
-      }
+      } as ReadContractRequest
     )) as string;
 
     expect(callMock).toHaveBeenCalledTimes(1);
@@ -89,9 +111,8 @@ describe("EvmChainAdapter.readContract — BaseContract name collision", () => {
     );
   });
 
-  it("uses staticCall when isView is false (nonpayable read)", async () => {
+  it("uses staticCall when isView is false (nonpayable read with colliding name)", async () => {
     const adapter = createAdapter();
-
     const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
       ["address"],
       [D3M_JOB_ADDRESS]
@@ -100,19 +121,42 @@ describe("EvmChainAdapter.readContract — BaseContract name collision", () => {
       createRpcManagerWithCallReturning(encoded);
 
     const result = (await adapter.readContract(
-      { executeWithFailover } as unknown as Parameters<
-        EvmChainAdapter["readContract"]
-      >[0],
+      { executeWithFailover } as unknown as RpcProviderManagerArg,
       {
         contractAddress: SEQUENCER_ADDRESS,
-        abi: GET_ADDRESS_ABI as unknown as ethers.InterfaceAbi,
-        functionKey: "getAddress(bytes32)",
+        abi: buildAbiFor("getAddress") as unknown as ethers.InterfaceAbi,
+        functionKey: "getAddress",
         args: [CRON_D3M_JOB_KEY],
         isView: false,
-      }
+      } as ReadContractRequest
     )) as string;
 
     expect(callMock).toHaveBeenCalledTimes(1);
     expect(ethers.getAddress(result)).toBe(ethers.getAddress(D3M_JOB_ADDRESS));
+  });
+
+  it("non-colliding name (`balanceOf`) keeps working — guards against over-broad fix", async () => {
+    const adapter = createAdapter();
+    const expectedBalance = BigInt("123456789012345678");
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256"],
+      [expectedBalance]
+    );
+    const { executeWithFailover, callMock } =
+      createRpcManagerWithCallReturning(encoded);
+
+    const result = (await adapter.readContract(
+      { executeWithFailover } as unknown as RpcProviderManagerArg,
+      {
+        contractAddress: TOKEN_ADDRESS,
+        abi: BALANCE_OF_ABI as unknown as ethers.InterfaceAbi,
+        functionKey: "balanceOf",
+        args: [HOLDER_ADDRESS],
+        isView: true,
+      } as ReadContractRequest
+    )) as bigint;
+
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedBalance);
   });
 });

--- a/tests/unit/evm-chain-adapter-read.test.ts
+++ b/tests/unit/evm-chain-adapter-read.test.ts
@@ -1,0 +1,118 @@
+import { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/db/schema", () => ({ explorerConfigs: {} }));
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+vi.mock("@/lib/explorer", () => ({
+  getAddressUrl: (): string => "",
+  getTransactionUrl: (): string => "",
+}));
+
+import { EvmChainAdapter } from "@/lib/web3/chain-adapter/evm";
+
+const SEQUENCER_ADDRESS = "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F";
+const D3M_JOB_ADDRESS = "0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF";
+const CRON_D3M_JOB_KEY =
+  "0x43524f4e5f44334d5f4a4f420000000000000000000000000000000000000000";
+
+const GET_ADDRESS_ABI = [
+  {
+    type: "function",
+    name: "getAddress",
+    stateMutability: "view",
+    inputs: [{ name: "_key", type: "bytes32" }],
+    outputs: [{ name: "addr", type: "address" }],
+  },
+] as const;
+
+type ExecuteWithFailover = <T>(
+  op: (provider: unknown) => Promise<T>
+) => Promise<T>;
+
+function createAdapter(): EvmChainAdapter {
+  const gasStrategy = {
+    getGasConfig: vi.fn(),
+  };
+  const nonceManager = { getNextNonce: vi.fn() };
+  return new EvmChainAdapter(
+    1,
+    gasStrategy as unknown as ConstructorParameters<typeof EvmChainAdapter>[1],
+    nonceManager as unknown as ConstructorParameters<typeof EvmChainAdapter>[2]
+  );
+}
+
+function createRpcManagerWithCallReturning(rawResult: string): {
+  executeWithFailover: ExecuteWithFailover;
+  callMock: ReturnType<typeof vi.fn>;
+} {
+  const callMock = vi.fn().mockResolvedValue(rawResult);
+  const provider = { call: callMock };
+  const executeWithFailover: ExecuteWithFailover = async (op) =>
+    await op(provider);
+  return { executeWithFailover, callMock };
+}
+
+describe("EvmChainAdapter.readContract — BaseContract name collision", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the ABI function result for `getAddress`, not the contract address", async () => {
+    const adapter = createAdapter();
+
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address"],
+      [D3M_JOB_ADDRESS]
+    );
+    const { executeWithFailover, callMock } =
+      createRpcManagerWithCallReturning(encoded);
+
+    const result = (await adapter.readContract(
+      { executeWithFailover } as unknown as Parameters<
+        EvmChainAdapter["readContract"]
+      >[0],
+      {
+        contractAddress: SEQUENCER_ADDRESS,
+        abi: GET_ADDRESS_ABI as unknown as ethers.InterfaceAbi,
+        functionKey: "getAddress(bytes32)",
+        args: [CRON_D3M_JOB_KEY],
+        isView: true,
+      }
+    )) as string;
+
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(ethers.getAddress(result)).toBe(ethers.getAddress(D3M_JOB_ADDRESS));
+    expect(ethers.getAddress(result)).not.toBe(
+      ethers.getAddress(SEQUENCER_ADDRESS)
+    );
+  });
+
+  it("uses staticCall when isView is false (nonpayable read)", async () => {
+    const adapter = createAdapter();
+
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address"],
+      [D3M_JOB_ADDRESS]
+    );
+    const { executeWithFailover, callMock } =
+      createRpcManagerWithCallReturning(encoded);
+
+    const result = (await adapter.readContract(
+      { executeWithFailover } as unknown as Parameters<
+        EvmChainAdapter["readContract"]
+      >[0],
+      {
+        contractAddress: SEQUENCER_ADDRESS,
+        abi: GET_ADDRESS_ABI as unknown as ethers.InterfaceAbi,
+        functionKey: "getAddress(bytes32)",
+        args: [CRON_D3M_JOB_KEY],
+        isView: false,
+      }
+    )) as string;
+
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(ethers.getAddress(result)).toBe(ethers.getAddress(D3M_JOB_ADDRESS));
+  });
+});

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -58,6 +58,14 @@ const mockStaticCall = vi.fn();
 
 vi.mock("ethers", async () => {
   const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  function buildAbiFunction(): {
+    (...args: unknown[]): unknown;
+    staticCall: (...args: unknown[]) => unknown;
+  } {
+    const fn = (...args: unknown[]) => mockContractFunction(...args);
+    fn.staticCall = (...args: unknown[]) => mockStaticCall(...args);
+    return fn;
+  }
   return {
     ...actual,
     ethers: {
@@ -69,11 +77,13 @@ vi.mock("ethers", async () => {
           return new Proxy(
             {},
             {
-              get(_target: object, _prop: string | symbol): unknown {
-                const fn = (...args: unknown[]) =>
-                  mockContractFunction(...args);
-                fn.staticCall = (...args: unknown[]) => mockStaticCall(...args);
-                return fn;
+              get(_target: object, prop: string | symbol): unknown {
+                // Production code now calls contract.getFunction(name) to avoid
+                // BaseContract proxy collisions. Honour that surface.
+                if (prop === "getFunction") {
+                  return (_name: string) => buildAbiFunction();
+                }
+                return buildAbiFunction();
               },
             }
           );

--- a/tests/unit/write-failover.test.ts
+++ b/tests/unit/write-failover.test.ts
@@ -260,9 +260,16 @@ describe("submitContractCallAndConfirm", () => {
 
   it("sends contract call on primary and returns result on success", async () => {
     const txResponse = makeMockTxResponse("0xcontract1");
+    const transferFn = vi.fn().mockResolvedValue(txResponse);
     const contract = {
-      transfer: vi.fn().mockResolvedValue(txResponse),
+      transfer: transferFn,
       connect: vi.fn(),
+      getFunction: (name: string): unknown => {
+        if (name === "transfer") {
+          return transferFn;
+        }
+        throw new Error(`unknown function: ${name}`);
+      },
     };
     const signer = { connect: vi.fn() };
 
@@ -284,13 +291,27 @@ describe("submitContractCallAndConfirm", () => {
       code: "SERVER_ERROR",
     });
     const fallbackTx = makeMockTxResponse("0xfallbackContract");
+    const fallbackTransferFn = vi.fn().mockResolvedValue(fallbackTx);
     const reconnectedContract = {
-      transfer: vi.fn().mockResolvedValue(fallbackTx),
+      transfer: fallbackTransferFn,
+      getFunction: (name: string): unknown => {
+        if (name === "transfer") {
+          return fallbackTransferFn;
+        }
+        throw new Error(`unknown function: ${name}`);
+      },
     };
     const reconnectedSigner = {};
+    const primaryTransferFn = vi.fn().mockRejectedValue(error);
     const contract = {
-      transfer: vi.fn().mockRejectedValue(error),
+      transfer: primaryTransferFn,
       connect: vi.fn().mockReturnValue(reconnectedContract),
+      getFunction: (name: string): unknown => {
+        if (name === "transfer") {
+          return primaryTransferFn;
+        }
+        throw new Error(`unknown function: ${name}`);
+      },
     };
     const signer = {
       connect: vi.fn().mockReturnValue(reconnectedSigner),
@@ -337,9 +358,16 @@ describe("submitContractCallAndConfirm", () => {
     const error = Object.assign(new Error("invalid args"), {
       code: "INVALID_ARGUMENT",
     });
+    const approveFn = vi.fn().mockRejectedValue(error);
     const contract = {
-      approve: vi.fn().mockRejectedValue(error),
+      approve: approveFn,
       connect: vi.fn(),
+      getFunction: (name: string): unknown => {
+        if (name === "approve") {
+          return approveFn;
+        }
+        throw new Error(`unknown function: ${name}`);
+      },
     };
     const signer = { connect: vi.fn() };
 


### PR DESCRIPTION
## Summary

`web3/read-contract` (and `web3/write-contract`) silently returned wrong data for any ABI function whose name collides with an `ethers v6` `BaseContract` built-in method. The most common collision in the wild is `getAddress(bytes32) returns (address)` — a canonical signature for registry/lookup contracts (MakerDAO Sequencer/ChainLog, ERC-1820, ENS-style resolvers, KEEP-style key→address registries).

**Root cause.** The chain adapter looked up contract functions via the ethers proxy:

```ts
contract[request.functionKey](...request.args)
```

The ethers v6 `BaseContract` Proxy `get` trap checks `prop in target` *first* and returns the inherited method when there's a collision; only on miss does it fall through to `target.getFunction(prop)`. So for the bare name `"getAddress"`, `BaseContract.prototype.getAddress` shadows the ABI dispatcher entirely. `BaseContract.getAddress()` ignores its arguments and returns the contract's own address — so a workflow calling `Sequencer.getAddress("CRON_D3M_JOB")` got back the Sequencer's address, not the D3MJob it was supposed to look up. No error was surfaced; the workflow `output.success === true` while the data was garbage.

**Fix.** Use `contract.getFunction(name)` everywhere we need to invoke an ABI function dynamically. `getFunction` is ethers' explicit ABI-resolution API — it bypasses the property proxy entirely (see `node_modules/ethers/.../contract/contract.ts:728-737`) and is immune to collisions with `BaseContract` members. The redundant `typeof contract[functionKey] !== "function"` guard was removed — it always passed for collisions (built-ins are functions) and was redundant for the missing-function case (`findAbiFunction()` already validates upstream).

**Reproduction.** Workflow `bko32qiszgbu5scc0w9sw` (test-readcontract-nonview) called `getAddress("CRON_D3M_JOB")` on the MakerDAO Sequencer (`0xdA0Ab1e0…740F`) two ways in one run:
- Raw HTTP `eth_call`: returned `0x2Ea4aDE1…0AeF` (the actual D3MJob address).
- `web3/read-contract`: returned `{ addr: "0xdA0Ab1e0…740F" }` (the Sequencer's own address) and an `addressLink` pointing at the Sequencer.

After this fix, both paths agree.

**Scope.**
- `lib/web3/chain-adapter/evm.ts`: 5 dynamic-method-access sites switched to `getFunction()` across `readContract` (read path) and `executeContractCall` (write/preflight/estimateGas/send).
- `lib/web3/transaction-manager.ts`: same bug class found in `submitContractCallAndConfirm` and `executeContractTransaction` (5 sites). Functions are exported but **not called from production code** — only from unit tests — so the bug was dormant. Fixed anyway to prevent regression resurrection if the path is ever revived.
- `tests/unit/evm-chain-adapter-read.test.ts` (new): regression test using **real** `ethers` against a fake `provider.call` returning an ABI-encoded address. Parameterised over the realistic collision set: `getAddress`, `connect`, `attach`, `queryFilter`, `getEvent` — using **bare names** (the form that actually triggers the prototype collision; the canonical-signature form would dodge it). Includes a `balanceOf` non-colliding control case to guard against an over-broad fix. Validated by temporary revert: 6/7 tests fail without the fix; only the `balanceOf` control passes (as it should).
- `tests/unit/evm-chain-adapter-preflight.test.ts`: extended `MockContract` to expose `getFunction()` so existing write-path tests still pass.
- `tests/unit/write-failover.test.ts`: same mock surface update.

`web3/batch-read-contract` is unaffected — that path uses `iface.encodeFunctionData(...)` directly and never went through the proxy.

## Reviewer feedback addressed

This PR was reviewed by 3 parallel agents. Critical findings:
- **Test fidelity (reviewer 2):** Original test used canonical signature `"getAddress(bytes32)"` which doesn't trigger the collision (Proxy's `prop in target` check finds only the bare name on `BaseContract.prototype`). Switched to bare names and parameterised across collisions.
- **Other vulnerable path (reviewer 1):** `lib/web3/transaction-manager.ts` had the identical bug in 5 sites. Applied the same fix.
- **Deployment risk (reviewer 3):** No backwards-compat hazard; no shipped artifacts use colliding names; non-colliding paths route through identical ethers v6 code (`buildWrappedMethod`); error wording change is dormant since pre-validation never lets it through. Recommendation: ship straight to staging then prod, no flag, no backfill of historical executions (immutable telemetry).

## Test plan

- [x] `pnpm vitest run tests/unit/evm-chain-adapter-read.test.ts tests/unit/evm-chain-adapter-preflight.test.ts tests/unit/write-failover.test.ts tests/unit/approve-token.test.ts` (28/28 pass)
- [x] Temporary revert of evm.ts fix → 6/7 read tests fail (regression caught), `balanceOf` control still passes (no over-broad fix)
- [x] `pnpm exec biome check` on touched files (clean)
- [ ] Re-run workflow `bko32qiszgbu5scc0w9sw` against the deployed PR env and confirm the `via-readcontract` node returns `{ addr: "0x2Ea4aDE1…0AeF" }`, matching the `via-http` raw `eth_call`.
- [ ] Spot-check one ERC-20 read (`balanceOf`) on staging to confirm no regression in the common path.

## Audit follow-up

A SQL scan of the production `workflows` table for ABI function names that collide with `BaseContract` built-ins should be run to identify any user workflows currently returning silently-wrong data:

```sql
SELECT w.id, w.name, w."organizationId",
       n->'data'->'config'->>'abiFunction' AS fn,
       n->'data'->'config'->>'contractAddress' AS contract
FROM workflows w,
     LATERAL jsonb_array_elements(w.nodes) AS n
WHERE n->'data'->'config'->>'actionType' IN ('web3/read-contract','web3/write-contract')
  AND n->'data'->'config'->>'abiFunction' IN (
    'getAddress','getFunction','getEvent','attach','connect',
    'queryFilter','waitForDeployment','addListener','removeListener',
    'on','off','once','emit','listenerCount','listeners',
    'removeAllListeners','interface','runner','target','fallback'
  );
```