### PR TITLE
feat(marketplace): search by owner and clickable owner filter

### DIFF
--- a/app/hub/_marketplace-tab.tsx
+++ b/app/hub/_marketplace-tab.tsx
@@ -136,8 +136,10 @@ export async function HubMarketplaceTab({
           {ownerName !== null && (
             // Absolutely positioned into the always-reserved top spacer
             // (mb-4 h-9 above) so toggling the owner filter doesn't shift
-            // the table down. -52px = -(spacer h-9 36px + mb-4 16px).
-            <div className="-top-[52px] absolute right-0 left-0 flex items-center gap-2 text-xs">
+            // the table down. -top-9 (-36px) sits the pill near the bottom
+            // of the spacer so the visible gap to the table matches the
+            // pre-overlay mb-3 layout (~12px between pill and table top).
+            <div className="-top-9 absolute right-0 left-0 flex items-center gap-2 text-xs">
               <span className="text-muted-foreground">Filtered by owner:</span>
               <Link
                 aria-label={`Clear owner filter ${ownerName}`}

--- a/app/hub/_marketplace-tab.tsx
+++ b/app/hub/_marketplace-tab.tsx
@@ -1,5 +1,5 @@
 import { asc, eq } from "drizzle-orm";
-import { Box } from "lucide-react";
+import { Box, X } from "lucide-react";
 import Link from "next/link";
 import { MarketplaceRow } from "@/components/hub/marketplace-row";
 import {
@@ -14,6 +14,7 @@ import {
   fetchMarketplaceLeaderboard,
   type MarketplaceSort,
 } from "@/lib/marketplace/leaderboard-query";
+import { readOwnerParam } from "@/lib/marketplace/read-search-params";
 
 const VALID_SORTS: readonly MarketplaceSort[] = [
   "popular",
@@ -83,16 +84,20 @@ export async function HubMarketplaceTab({
   const sort = readSort(searchParams.sort);
   const cursor = readCursor(searchParams.cursor);
   const tagSlug = readTag(searchParams.tag);
+  const ownerName = readOwnerParam(searchParams.owner);
   const [{ rows, total }, tags] = await Promise.all([
-    fetchMarketplaceLeaderboard(sort, cursor, query, tagSlug),
+    fetchMarketplaceLeaderboard(sort, cursor, query, tagSlug, ownerName),
     fetchMarketplaceTags(),
   ]);
 
   const hasQuery = query.trim().length > 0;
-  const hasFilter = hasQuery || tagSlug !== null;
+  const hasFilter = hasQuery || tagSlug !== null || ownerName !== null;
   const emptyHeading = (() => {
     if (hasQuery) {
       return `No marketplace services match “${query}”.`;
+    }
+    if (ownerName !== null) {
+      return `No marketplace services listed by ${ownerName}.`;
     }
     if (hasFilter) {
       return "No marketplace services match this filter.";
@@ -100,8 +105,23 @@ export async function HubMarketplaceTab({
     return "No paid services listed yet.";
   })();
   // Clear-filters target preserves sort (sort is a view choice, not a
-  // filter) and tab. Drops q, tag, cursor.
+  // filter) and tab. Drops q, tag, cursor, owner.
   const clearFiltersHref = `/hub?tab=marketplace&sort=${sort}`;
+  // Owner-only clear: drops owner + cursor (cursor was paged against the
+  // owner-filtered set). Preserves q, tag, sort so a search/tag pair
+  // survives clearing just the owner pill.
+  const clearOwnerHref = (() => {
+    const params = new URLSearchParams();
+    params.set("tab", "marketplace");
+    params.set("sort", sort);
+    if (query.trim() !== "") {
+      params.set("q", query.trim());
+    }
+    if (tagSlug !== null) {
+      params.set("tag", tagSlug);
+    }
+    return `/hub?${params.toString()}`;
+  })();
 
   return (
     // Top spacer mirrors the height of the Workflows tab's view-toggle row
@@ -113,6 +133,20 @@ export async function HubMarketplaceTab({
       <section aria-label="Marketplace results" className="flex gap-6">
         <MarketplaceSidebar active={sort} activeTagSlug={tagSlug} tags={tags} />
         <div className="min-w-0 flex-1">
+          {ownerName !== null && (
+            <div className="mb-3 flex items-center gap-2 text-xs">
+              <span className="text-muted-foreground">Filtered by owner:</span>
+              <Link
+                aria-label={`Clear owner filter ${ownerName}`}
+                className="inline-flex items-center gap-1.5 rounded-full bg-foreground/10 px-2.5 py-1 font-medium text-foreground transition-colors hover:bg-foreground/15 motion-reduce:transition-none"
+                href={clearOwnerHref}
+                scroll={false}
+              >
+                <span className="max-w-[16rem] truncate">{ownerName}</span>
+                <X aria-hidden="true" className="size-3" />
+              </Link>
+            </div>
+          )}
           {rows.length === 0 ? (
             <section
               aria-label="No marketplace results"

--- a/app/hub/_marketplace-tab.tsx
+++ b/app/hub/_marketplace-tab.tsx
@@ -132,9 +132,12 @@ export async function HubMarketplaceTab({
       <div aria-hidden="true" className="mb-4 h-9" />
       <section aria-label="Marketplace results" className="flex gap-6">
         <MarketplaceSidebar active={sort} activeTagSlug={tagSlug} tags={tags} />
-        <div className="min-w-0 flex-1">
+        <div className="relative min-w-0 flex-1">
           {ownerName !== null && (
-            <div className="mb-3 flex items-center gap-2 text-xs">
+            // Absolutely positioned into the always-reserved top spacer
+            // (mb-4 h-9 above) so toggling the owner filter doesn't shift
+            // the table down. -52px = -(spacer h-9 36px + mb-4 16px).
+            <div className="-top-[52px] absolute right-0 left-0 flex items-center gap-2 text-xs">
               <span className="text-muted-foreground">Filtered by owner:</span>
               <Link
                 aria-label={`Clear owner filter ${ownerName}`}

--- a/components/hub/marketplace-row.tsx
+++ b/components/hub/marketplace-row.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Copy } from "lucide-react";
-import type { KeyboardEvent, MouseEvent } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { type KeyboardEvent, type MouseEvent, useTransition } from "react";
 import { toast } from "sonner";
 import { MarketplaceListingOverlay } from "@/components/overlays/marketplace-listing-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
@@ -60,8 +61,13 @@ export function MarketplaceRow({
   rank,
 }: MarketplaceRowProps): React.ReactElement {
   const { open } = useOverlay();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
   const badge = chainBadge(row.chain);
   const price = priceLabel(row.priceUsdcPerCall);
+  const ownerName = row.organizationName;
+  const isOwnerClickable = ownerName !== null && ownerName.trim() !== "";
 
   const openModal = (): void => {
     open(MarketplaceListingOverlay, {
@@ -94,6 +100,27 @@ export function MarketplaceRow({
     }
     await navigator.clipboard.writeText(row.listedSlug);
     toast.success(`Copied ${row.listedSlug}`);
+  };
+
+  // Owner click: filter the marketplace to that organization. Mirrors the
+  // sort writer's pattern in marketplace-sidebar.tsx — pin tab=marketplace,
+  // set owner, drop cursor (cursor was paged against the unfiltered set).
+  // Also drop q + tag so the filter lands on a clean owner-only view; the
+  // active-owner pill in _marketplace-tab.tsx provides the clear affordance.
+  const filterByOwner = (e: MouseEvent<HTMLButtonElement>): void => {
+    e.stopPropagation();
+    if (!isOwnerClickable) {
+      return;
+    }
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", "marketplace");
+    params.set("owner", ownerName);
+    params.delete("cursor");
+    params.delete("q");
+    params.delete("tag");
+    startTransition(() => {
+      router.replace(`/hub?${params.toString()}`, { scroll: false });
+    });
   };
 
   return (
@@ -161,9 +188,24 @@ export function MarketplaceRow({
         ))}
       </div>
 
-      <span className="pointer-events-none relative z-[2] hidden max-w-full truncate justify-self-end text-muted-foreground text-xs md:inline">
-        {row.organizationName ?? "Anonymous"}
-      </span>
+      {isOwnerClickable ? (
+        <button
+          aria-label={`Filter marketplace by ${ownerName}`}
+          // pointer-events-auto + stopPropagation lift this out of the
+          // row's ::before click overlay (the same trick the copy-slug
+          // button uses); without it the row's openModal would fire
+          // alongside the owner filter.
+          className="pointer-events-auto relative z-[2] hidden max-w-full truncate justify-self-end rounded text-right text-muted-foreground text-xs transition-colors hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring motion-reduce:transition-none md:inline-block"
+          onClick={filterByOwner}
+          type="button"
+        >
+          {ownerName}
+        </button>
+      ) : (
+        <span className="pointer-events-none relative z-[2] hidden max-w-full truncate justify-self-end text-muted-foreground text-xs md:inline">
+          Anonymous
+        </span>
+      )}
 
       <span className="pointer-events-none relative z-[2] justify-self-end font-semibold text-foreground text-sm tabular-nums">
         {callCountLabel(row.callCount)}

--- a/lib/marketplace/leaderboard-query.ts
+++ b/lib/marketplace/leaderboard-query.ts
@@ -72,7 +72,8 @@ async function runLeaderboardQuery(
   sort: MarketplaceSort,
   cursor: CursorPayload | null,
   query: string,
-  tagSlug: string | null
+  tagSlug: string | null,
+  ownerName: string | null
 ): Promise<MarketplaceLeaderboardResult> {
   // PUBLIC COLUMN WHITELIST -- see MARKET-04. Adding fields here requires
   // re-reading MARKET-04 + MARKET-13 first. NEVER add private columns:
@@ -102,14 +103,31 @@ async function runLeaderboardQuery(
         )
       : undefined;
 
-  // Free-text filter on the public display name. Case-insensitive, simple
-  // substring match; no full-text indexing yet — fine at v1.11 scale. Escape
-  // LIKE metacharacters so a user typing `_` or `%` doesn't get unexpected
-  // wildcard semantics.
-  const queryFilter =
-    query === ""
+  // Free-text filter spanning the public display name and the joined
+  // organization name (the marketplace's two human-facing labels). A user
+  // typing "keeperhub" finds rows whose name or owner contains the term.
+  // Case-insensitive, simple substring match; no full-text indexing yet —
+  // fine at v1.11 scale. Escape LIKE metacharacters so a user typing `_` or
+  // `%` doesn't get unexpected wildcard semantics.
+  const queryFilter = (() => {
+    if (query === "") {
+      return undefined;
+    }
+    const pattern = `%${escapeLikePattern(query)}%`;
+    return or(
+      ilike(workflows.name, pattern),
+      ilike(organization.name, pattern)
+    );
+  })();
+
+  // Owner filter — exact case-insensitive match on the joined organization
+  // name. Used by the clickable owner cell so clicking "KeeperHub" returns
+  // only that org's listings, not "KeeperHub Demo" too. The COUNT query
+  // below applies the same filter for an accurate "Showing N of TOTAL".
+  const ownerFilter =
+    ownerName === null
       ? undefined
-      : ilike(workflows.name, `%${escapeLikePattern(query)}%`);
+      : sql`lower(${organization.name}) = lower(${ownerName})`;
 
   // Tag filter — restrict to workflows linked to the given public tag slug.
   // Resolved via a sub-select on workflow_public_tags + public_tags (slug is
@@ -128,7 +146,13 @@ async function runLeaderboardQuery(
       )
     : undefined;
 
-  const whereClause = and(baseFilter, cursorFilter, queryFilter, tagFilter);
+  const whereClause = and(
+    baseFilter,
+    cursorFilter,
+    queryFilter,
+    tagFilter,
+    ownerFilter
+  );
 
   const orderClause = (() => {
     if (sort === "newest") {
@@ -145,10 +169,7 @@ async function runLeaderboardQuery(
     if (sort === "owner") {
       // Owner sort: A→Z by joined organization name; anonymous (null)
       // listings sink to the bottom so named providers lead. Tiebreak by id.
-      return [
-        sql`${organization.name} asc nulls last`,
-        desc(workflows.id),
-      ];
+      return [sql`${organization.name} asc nulls last`, desc(workflows.id)];
     }
     return [desc(callCountExpr), desc(workflows.id)];
   })();
@@ -185,9 +206,10 @@ async function runLeaderboardQuery(
   // workflows.is_listed has an index path; the optional ILIKE adds a
   // small linear scan over the listed subset.
   const totalRow = await db
-    .select({ value: sql<number>`count(*)::int` })
+    .select({ value: sql<number>`count(distinct ${workflows.id})::int` })
     .from(workflows)
-    .where(and(baseFilter, queryFilter, tagFilter));
+    .leftJoin(organization, eq(organization.id, workflows.organizationId))
+    .where(and(baseFilter, queryFilter, tagFilter, ownerFilter));
   const total = totalRow[0]?.value ?? 0;
 
   const hasMore = rows.length > PAGE_LIMIT;
@@ -248,10 +270,11 @@ async function fetchUncached(
   sort: MarketplaceSort,
   cursorRaw: string | null,
   query: string,
-  tagSlug: string | null
+  tagSlug: string | null,
+  ownerName: string | null
 ): Promise<MarketplaceLeaderboardResult> {
   const cursor = decodeCursor(cursorRaw);
-  return await runLeaderboardQuery(sort, cursor, query, tagSlug);
+  return await runLeaderboardQuery(sort, cursor, query, tagSlug, ownerName);
 }
 
 // Bypass unstable_cache in dev so editor changes (schema, sort columns,

--- a/lib/marketplace/read-search-params.ts
+++ b/lib/marketplace/read-search-params.ts
@@ -1,0 +1,28 @@
+// Pure helpers for reading marketplace `searchParams` values. Kept in a
+// dependency-free module so they can be unit-tested without dragging in
+// drizzle/db imports from the RSC tab module.
+
+// Cap reader-side string length to prevent unstable_cache key pollution
+// via random `?q=` / `?owner=` spam — each distinct cache key triggers a
+// fresh DB hit before the data cache.
+export const MAX_QUERY_LENGTH = 100;
+
+export function readQueryParam(value: string | string[] | undefined): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim().slice(0, MAX_QUERY_LENGTH);
+}
+
+// Owner filter (?owner=<organization-name>). Matches readQuery's bound
+// and collapses empty-after-trim to null so the query path skips the
+// filter cleanly.
+export function readOwnerParam(
+  value: string | string[] | undefined
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim().slice(0, MAX_QUERY_LENGTH);
+  return trimmed === "" ? null : trimmed;
+}

--- a/tests/unit/marketplace-read-search-params.test.ts
+++ b/tests/unit/marketplace-read-search-params.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_QUERY_LENGTH,
+  readOwnerParam,
+  readQueryParam,
+} from "@/lib/marketplace/read-search-params";
+
+describe("readOwnerParam", () => {
+  it("returns null for non-string values (missing, array, undefined)", () => {
+    expect(readOwnerParam(undefined)).toBeNull();
+    expect(readOwnerParam(["KeeperHub", "KeeperHub Demo"])).toBeNull();
+  });
+
+  it("returns null for empty / whitespace-only strings", () => {
+    expect(readOwnerParam("")).toBeNull();
+    expect(readOwnerParam("   ")).toBeNull();
+    expect(readOwnerParam("\t \n")).toBeNull();
+  });
+
+  it("trims surrounding whitespace and returns the literal value", () => {
+    expect(readOwnerParam("  KeeperHub  ")).toBe("KeeperHub");
+    expect(readOwnerParam("Shelly's Organization")).toBe(
+      "Shelly's Organization"
+    );
+  });
+
+  it("preserves case (filter applies case-insensitive equality at SQL layer)", () => {
+    expect(readOwnerParam("KeeperHub")).toBe("KeeperHub");
+    expect(readOwnerParam("keeperhub")).toBe("keeperhub");
+    expect(readOwnerParam("KEEPERHUB")).toBe("KEEPERHUB");
+  });
+
+  it("caps overly long values at MAX_QUERY_LENGTH to prevent cache-key pollution", () => {
+    const long = "x".repeat(MAX_QUERY_LENGTH * 3);
+    const result = readOwnerParam(long);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(MAX_QUERY_LENGTH);
+  });
+
+  it("does not collapse a non-empty owner that contains LIKE metacharacters (treated as literal at SQL layer)", () => {
+    // The SQL layer uses `lower(name) = lower(value)` for owner — no LIKE
+    // wildcards. So `%` and `_` should pass through verbatim.
+    expect(readOwnerParam("100% Org")).toBe("100% Org");
+    expect(readOwnerParam("ACME_Co")).toBe("ACME_Co");
+  });
+});
+
+describe("readQueryParam", () => {
+  it("returns empty string for non-string values", () => {
+    expect(readQueryParam(undefined)).toBe("");
+    expect(readQueryParam(["a", "b"])).toBe("");
+  });
+
+  it("trims and length-caps", () => {
+    expect(readQueryParam("  hello  ")).toBe("hello");
+    const long = "y".repeat(MAX_QUERY_LENGTH + 50);
+    expect(readQueryParam(long)).toHaveLength(MAX_QUERY_LENGTH);
+  });
+});


### PR DESCRIPTION
## Summary

Two UI improvements on `/hub?tab=marketplace`:

- **Search by owner.** The search input now matches the workflow's display name *or* its organization name. Typing `keeperhub` surfaces every listing whose name or owner contains that string.
- **Clickable owner cells.** Each owner cell becomes a button. Clicking it sets `?owner=<name>` on the URL, filters the table to that exact organization (case-insensitive equality, so `KeeperHub` doesn't sweep up `KeeperHub Demo`), and renders a `Filtered by owner: X x` pill above the table. Anonymous listings remain plain text.
- **Round-trippable URL.** Deep-linking to `?owner=KeeperHub` lands on the filtered view directly. Clearing the pill drops just `owner` + `cursor` and preserves sort / search / tag.

## Implementation notes

- `lib/marketplace/leaderboard-query.ts`: search filter is now `ilike(name) OR ilike(org.name)`. New `ownerName` parameter applies `lower(org.name) = lower(value)`. The COUNT query mirrors the same filter for an accurate "Showing N of TOTAL".
- `app/hub/_marketplace-tab.tsx`: reads `?owner=` via the new shared `lib/marketplace/read-search-params` helper, threads it to the fetcher, renders the active-filter pill, updates empty-state copy.
- `components/hub/marketplace-row.tsx`: owner span is now a `pointer-events-auto` button that calls `e.stopPropagation()` (mirrors the existing copy-slug button pattern), then `router.replace` with the new param.
- New unit tests cover the URL-param reader contract (trim, max-length cap against unstable_cache key pollution, null vs empty, case preservation, LIKE-metacharacter pass-through).

## Test plan

- [x] `pnpm check` (clean for changed files)
- [x] `pnpm type-check` (clean)
- [x] `pnpm test:unit` (210 files / 3758 tests pass, no regressions)
- [x] `node scripts/token-audit.js` (zero new violations from changed files)
- [x] Local dev: search `helix` -> matches "UAT listed workflow" via owner "Helix Research" (workflow name has no "helix")
- [x] Local dev: click owner "Acme Labs" -> URL becomes `?owner=Acme+Labs`, table filtered, modal stays closed (stopPropagation works)
- [x] Local dev: direct navigate `?owner=Helix+Research` -> deep-link works
- [x] Local dev: click pill x -> owner cleared, sort preserved