### PR TITLE
feat: enable ERC-8004 feedback from agentic-wallet

### DIFF
--- a/app/api/agentic-wallet/feedback/route.ts
+++ b/app/api/agentic-wallet/feedback/route.ts
@@ -1,0 +1,558 @@
+/**
+ * POST /api/agentic-wallet/feedback
+ *
+ * HMAC-authenticated entry point that lets a caller wallet submit ERC-8004
+ * feedback for a workflow execution it paid for. The route is the
+ * orchestrator: it builds the off-chain feedback JSON, computes its
+ * keccak256 hash, encodes the giveFeedback() call, signs the unsigned EVM
+ * tx via Turnkey (policy-gated to ReputationRegistry::giveFeedback on
+ * Ethereum mainnet only), and broadcasts via the configured eth-mainnet
+ * RPC. Returns the new feedback row id, on-chain tx hash, and the public
+ * URL of the canonical feedback JSON (the feedbackURI committed on-chain).
+ *
+ * Request body:
+ *   {
+ *     executionId: string,         // workflow_executions.id
+ *     value: string | number,      // raw int128 (string for safety)
+ *     valueDecimals: number,       // 0..18
+ *     comment?: string,            // optional, surfaced in feedbackURI JSON
+ *     agentChainId?: number,       // default 1 (Ethereum mainnet)
+ *     agentId?: string,            // default KEEPERHUB_ERC_8004_AGENT_ID
+ *   }
+ *
+ * Response:
+ *   200 { feedbackId, txHash, publicUrl }
+ *   400 BAD_INPUT
+ *   401 missing/invalid HMAC
+ *   403 NOT_PAYER  -- caller's wallet did not pay for the referenced execution
+ *   404 EXECUTION_NOT_FOUND
+ *   409 ALREADY_RATED -- caller already rated this execution
+ *   502 TURNKEY_UPSTREAM | RPC_UPSTREAM
+ *
+ * Anti-spam: payerAddress on the workflow_payments row must match the
+ * caller's wallet address. ERC-8004 contract itself blocks self-feedback
+ * (agent owner can't rate themselves) -- we don't replicate that gate
+ * here, the chain enforces it.
+ */
+import { and, eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+import { createPublicClient, type Hex, http, serializeTransaction } from "viem";
+import { mainnet } from "viem/chains";
+import {
+  ERC_8004_REPUTATION_REGISTRY_ADDRESS,
+  ETHEREUM_MAINNET_CHAIN_ID,
+  KEEPERHUB_ERC_8004_AGENT_ID,
+} from "@/lib/agentic-wallet/constants";
+import {
+  buildFeedbackUriContent,
+  buildGiveFeedbackCalldata,
+  hashFeedbackContent,
+} from "@/lib/agentic-wallet/erc-8004";
+import { verifyHmacRequest } from "@/lib/agentic-wallet/hmac";
+import {
+  PolicyBlockedError,
+  TurnkeyUpstreamError,
+} from "@/lib/agentic-wallet/sign";
+import {
+  broadcastSignedTransaction,
+  signEthereumTransaction,
+} from "@/lib/agentic-wallet/sign-eth-tx";
+import { db } from "@/lib/db";
+import {
+  agenticWallets,
+  feedback,
+  workflowExecutions,
+  workflowPayments,
+  workflows,
+} from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
+
+export const dynamic = "force-dynamic";
+
+type FeedbackRequestBody = {
+  executionId?: unknown;
+  value?: unknown;
+  valueDecimals?: unknown;
+  comment?: unknown;
+  agentChainId?: unknown;
+  agentId?: unknown;
+};
+
+type ValidatedInput = {
+  executionId: string;
+  value: bigint;
+  valueDecimals: number;
+  comment?: string;
+  agentChainId: number;
+  agentId: bigint;
+};
+
+function badRequest(message: string, code = "BAD_INPUT"): NextResponse {
+  return NextResponse.json({ error: message, code }, { status: 400 });
+}
+
+// Hoisted to module scope per useTopLevelRegex (avoids re-parsing the
+// pattern on every parse call).
+const INT_LITERAL_RE = /^-?\d+$/;
+
+function tryParseBigInt(value: unknown): bigint | null {
+  if (typeof value === "string" && INT_LITERAL_RE.test(value)) {
+    try {
+      return BigInt(value);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return BigInt(value);
+  }
+  return null;
+}
+
+function validateInput(body: FeedbackRequestBody): ValidatedInput | string {
+  if (typeof body.executionId !== "string" || body.executionId.length === 0) {
+    return "executionId required";
+  }
+  const value = tryParseBigInt(body.value);
+  if (value === null) {
+    return "value must be an integer (string or number)";
+  }
+  // int128 range. BigInt literals (1n) are ES2020 only; this project
+  // targets ES2017 so we go through the constructor.
+  const INT128_MAX = (BigInt(1) << BigInt(127)) - BigInt(1);
+  const INT128_MIN = -(BigInt(1) << BigInt(127));
+  if (value > INT128_MAX || value < INT128_MIN) {
+    return "value outside int128 range";
+  }
+  if (
+    typeof body.valueDecimals !== "number" ||
+    !Number.isInteger(body.valueDecimals) ||
+    body.valueDecimals < 0 ||
+    body.valueDecimals > 18
+  ) {
+    return "valueDecimals must be an integer in [0, 18]";
+  }
+  if (
+    body.comment !== undefined &&
+    (typeof body.comment !== "string" || body.comment.length > 2000)
+  ) {
+    return "comment must be a string <= 2000 chars";
+  }
+  // Default to Ethereum mainnet + KeeperHub agent id; allow override per
+  // user instruction "any agent" (Turnkey policy does not constrain agentId).
+  let agentChainId: number;
+  if (body.agentChainId === undefined) {
+    agentChainId = ETHEREUM_MAINNET_CHAIN_ID;
+  } else if (
+    typeof body.agentChainId === "number" &&
+    Number.isInteger(body.agentChainId)
+  ) {
+    agentChainId = body.agentChainId;
+  } else {
+    return "agentChainId must be an integer";
+  }
+  // Today the Turnkey signTransaction policy only allows chain_id=1 for the
+  // ReputationRegistry. Reject any other agentChainId at the application
+  // layer before the Turnkey roundtrip wastes time.
+  if (agentChainId !== ETHEREUM_MAINNET_CHAIN_ID) {
+    return `agentChainId ${agentChainId} not supported (only ${ETHEREUM_MAINNET_CHAIN_ID} today)`;
+  }
+  const agentIdRaw = body.agentId ?? KEEPERHUB_ERC_8004_AGENT_ID;
+  const agentId = tryParseBigInt(agentIdRaw);
+  if (agentId === null || agentId < BigInt(0)) {
+    return "agentId must be a non-negative integer";
+  }
+  return {
+    executionId: body.executionId,
+    value,
+    valueDecimals: body.valueDecimals,
+    comment: typeof body.comment === "string" ? body.comment : undefined,
+    agentChainId,
+    agentId,
+  };
+}
+
+type WalletResolveResult =
+  | { ok: true; subOrgId: string; walletAddress: `0x${string}` }
+  | { ok: false; status: number; error: string };
+
+async function resolveWallet(subOrgId: string): Promise<WalletResolveResult> {
+  const rows = await db
+    .select({
+      walletAddress: agenticWallets.walletAddressBase,
+    })
+    .from(agenticWallets)
+    .where(eq(agenticWallets.subOrgId, subOrgId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) {
+    return { ok: false, status: 401, error: "Sub-org not found" };
+  }
+  return {
+    ok: true,
+    subOrgId,
+    walletAddress: row.walletAddress as `0x${string}`,
+  };
+}
+
+type ExecutionVerifyResult =
+  | { ok: true; workflowId: string; workflowSlug: string | null }
+  | { ok: false; status: number; error: string; code: string };
+
+async function verifyExecutionAndPayer(args: {
+  executionId: string;
+  walletAddress: `0x${string}`;
+}): Promise<ExecutionVerifyResult> {
+  const rows = await db
+    .select({
+      executionId: workflowExecutions.id,
+      workflowId: workflowExecutions.workflowId,
+      executionStatus: workflowExecutions.status,
+      workflowSlug: workflows.listedSlug,
+      payerAddress: workflowPayments.payerAddress,
+    })
+    .from(workflowExecutions)
+    .leftJoin(workflows, eq(workflows.id, workflowExecutions.workflowId))
+    .leftJoin(
+      workflowPayments,
+      eq(workflowPayments.executionId, workflowExecutions.id)
+    )
+    .where(eq(workflowExecutions.id, args.executionId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) {
+    return {
+      ok: false,
+      status: 404,
+      error: "Execution not found",
+      code: "EXECUTION_NOT_FOUND",
+    };
+  }
+  // Allow rating successful and errored executions, but not still-running
+  // ones (caller might retract). cancelled/error are still rate-able since
+  // they represent a real interaction.
+  if (row.executionStatus === "running" || row.executionStatus === "pending") {
+    return {
+      ok: false,
+      status: 409,
+      error: "Execution still in progress",
+      code: "EXECUTION_NOT_FINAL",
+    };
+  }
+  // payerAddress is null for free executions; we permit free rating so
+  // the agent score moves on free workflows too. For paid executions the
+  // payer must match.
+  if (
+    row.payerAddress !== null &&
+    row.payerAddress !== undefined &&
+    row.payerAddress.toLowerCase() !== args.walletAddress.toLowerCase()
+  ) {
+    return {
+      ok: false,
+      status: 403,
+      error: "Caller wallet did not pay for this execution",
+      code: "NOT_PAYER",
+    };
+  }
+  return {
+    ok: true,
+    workflowId: row.workflowId,
+    workflowSlug: row.workflowSlug ?? null,
+  };
+}
+
+async function ensureNotAlreadyRated(args: {
+  executionId: string;
+  payerWallet: string;
+}): Promise<NextResponse | null> {
+  const existing = await db
+    .select({ id: feedback.id })
+    .from(feedback)
+    .where(
+      and(
+        eq(feedback.executionId, args.executionId),
+        eq(feedback.payerWallet, args.payerWallet.toLowerCase())
+      )
+    )
+    .limit(1);
+  if (existing.length > 0) {
+    return NextResponse.json(
+      {
+        error: "Wallet has already submitted feedback for this execution",
+        code: "ALREADY_RATED",
+        feedbackId: existing[0]?.id,
+      },
+      { status: 409 }
+    );
+  }
+  return null;
+}
+
+async function buildAndSignTx(args: {
+  subOrgId: string;
+  walletAddress: `0x${string}`;
+  agentChainId: number;
+  agentId: bigint;
+  value: bigint;
+  valueDecimals: number;
+  feedbackId: string;
+  feedbackHash: Hex;
+}): Promise<{ signedTx: Hex; publicBaseUrl: string }> {
+  const publicBaseUrl =
+    process.env.KEEPERHUB_PUBLIC_BASE_URL ?? "https://app.keeperhub.com";
+  const feedbackURI = `${publicBaseUrl}/api/feedback/${args.feedbackId}`;
+
+  const calldata = buildGiveFeedbackCalldata({
+    agentId: args.agentId,
+    value: args.value,
+    valueDecimals: args.valueDecimals,
+    feedbackURI,
+    feedbackHash: args.feedbackHash,
+  });
+
+  const rpcUrl = getRpcUrlByChainId(args.agentChainId);
+  const publicClient = createPublicClient({
+    chain: mainnet,
+    transport: http(rpcUrl),
+  });
+
+  // Live network reads -- nonce + gas estimate + fee estimate. Each one
+  // hits the upstream RPC; we await sequentially to keep error surfacing
+  // crisp (and Promise.all would still be sequential because of viem's
+  // single-connection transport in practice).
+  const nonce = await publicClient.getTransactionCount({
+    address: args.walletAddress,
+    blockTag: "pending",
+  });
+  const gas = await publicClient.estimateGas({
+    account: args.walletAddress,
+    to: ERC_8004_REPUTATION_REGISTRY_ADDRESS,
+    data: calldata,
+    value: BigInt(0),
+  });
+  // 20% headroom over the estimate -- defends against mid-mempool gas
+  // bumps invalidating the broadcast. Cheap insurance on a $3-10 tx.
+  const gasWithHeadroom = (gas * BigInt(12)) / BigInt(10);
+  const fees = await publicClient.estimateFeesPerGas();
+
+  const unsignedTx = serializeTransaction({
+    chainId: args.agentChainId,
+    type: "eip1559",
+    nonce,
+    to: ERC_8004_REPUTATION_REGISTRY_ADDRESS,
+    value: BigInt(0),
+    data: calldata,
+    gas: gasWithHeadroom,
+    maxFeePerGas: fees.maxFeePerGas,
+    maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+  });
+
+  const { signedTransaction } = await signEthereumTransaction({
+    subOrgId: args.subOrgId,
+    walletAddress: args.walletAddress,
+    // Turnkey expects the unsigned RLP without the 0x prefix.
+    unsignedTransactionHex: unsignedTx.startsWith("0x")
+      ? unsignedTx.slice(2)
+      : unsignedTx,
+  });
+  return { signedTx: signedTransaction, publicBaseUrl };
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const rawBody = await request.text();
+  const verify = await verifyHmacRequest(request, rawBody);
+  if (!verify.ok) {
+    return NextResponse.json(
+      { error: verify.error },
+      { status: verify.status }
+    );
+  }
+
+  let parsed: FeedbackRequestBody;
+  try {
+    parsed = JSON.parse(rawBody) as FeedbackRequestBody;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  const validated = validateInput(parsed);
+  if (typeof validated === "string") {
+    return badRequest(validated);
+  }
+
+  const wallet = await resolveWallet(verify.subOrgId);
+  if (!wallet.ok) {
+    return NextResponse.json(
+      { error: wallet.error },
+      { status: wallet.status }
+    );
+  }
+
+  const exec = await verifyExecutionAndPayer({
+    executionId: validated.executionId,
+    walletAddress: wallet.walletAddress,
+  });
+  if (!exec.ok) {
+    return NextResponse.json(
+      { error: exec.error, code: exec.code },
+      { status: exec.status }
+    );
+  }
+
+  const dup = await ensureNotAlreadyRated({
+    executionId: validated.executionId,
+    payerWallet: wallet.walletAddress,
+  });
+  if (dup) {
+    return dup;
+  }
+
+  // Insert feedback row first -- we need the id for the feedbackURI before
+  // we can compute the hash and build the giveFeedback call. We update the
+  // row with feedbackHash + txHash + status="broadcast" once we've signed
+  // and broadcast. If signing or broadcast fails, the row stays at status=
+  // "pending" with the error column set, providing a debug breadcrumb
+  // without re-issuing an id (the URI is already committed-to nowhere).
+  const inserted = await db
+    .insert(feedback)
+    .values({
+      executionId: validated.executionId,
+      workflowId: exec.workflowId,
+      agentChainId: validated.agentChainId,
+      agentId: validated.agentId.toString(),
+      payerWallet: wallet.walletAddress.toLowerCase(),
+      value: validated.value.toString(),
+      valueDecimals: validated.valueDecimals,
+      comment: validated.comment ?? null,
+      txChainId: validated.agentChainId,
+      status: "pending",
+    })
+    .returning({ id: feedback.id, createdAt: feedback.createdAt });
+  const newRow = inserted[0];
+  if (!newRow) {
+    return NextResponse.json(
+      { error: "Failed to insert feedback row" },
+      { status: 500 }
+    );
+  }
+
+  // Compute the canonical feedbackURI JSON + its keccak256. The hash MUST
+  // match what `/api/feedback/[id]` will serve later for the on-chain
+  // commitment to verify.
+  const content = buildFeedbackUriContent({
+    agentChainId: validated.agentChainId,
+    agentId: validated.agentId,
+    clientAddress: wallet.walletAddress,
+    createdAt: newRow.createdAt,
+    value: validated.value,
+    valueDecimals: validated.valueDecimals,
+    comment: validated.comment,
+    workflowSlug: exec.workflowSlug ?? undefined,
+    executionId: validated.executionId,
+  });
+  const feedbackHash = hashFeedbackContent(content);
+
+  let signedTx: Hex;
+  let publicBaseUrl: string;
+  try {
+    const result = await buildAndSignTx({
+      subOrgId: wallet.subOrgId,
+      walletAddress: wallet.walletAddress,
+      agentChainId: validated.agentChainId,
+      agentId: validated.agentId,
+      value: validated.value,
+      valueDecimals: validated.valueDecimals,
+      feedbackId: newRow.id,
+      feedbackHash,
+    });
+    signedTx = result.signedTx;
+    publicBaseUrl = result.publicBaseUrl;
+  } catch (err) {
+    await db
+      .update(feedback)
+      .set({
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+      })
+      .where(eq(feedback.id, newRow.id));
+    if (err instanceof PolicyBlockedError) {
+      return NextResponse.json(
+        { error: err.message, code: "POLICY_BLOCKED", feedbackId: newRow.id },
+        { status: 403 }
+      );
+    }
+    if (err instanceof TurnkeyUpstreamError) {
+      logSystemError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[feedback] Turnkey signing failed",
+        err,
+        { endpoint: "/api/agentic-wallet/feedback", feedbackId: newRow.id }
+      );
+      return NextResponse.json(
+        {
+          error: "Upstream signing failed",
+          code: "TURNKEY_UPSTREAM",
+          feedbackId: newRow.id,
+        },
+        { status: 502 }
+      );
+    }
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[feedback] Build/sign failed",
+      err,
+      { endpoint: "/api/agentic-wallet/feedback", feedbackId: newRow.id }
+    );
+    return NextResponse.json(
+      { error: "Failed to prepare or sign tx", feedbackId: newRow.id },
+      { status: 500 }
+    );
+  }
+
+  let txHash: Hex;
+  try {
+    const broadcast = await broadcastSignedTransaction({
+      signedTransaction: signedTx,
+      chainId: validated.agentChainId,
+    });
+    txHash = broadcast.txHash;
+  } catch (err) {
+    await db
+      .update(feedback)
+      .set({
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+      })
+      .where(eq(feedback.id, newRow.id));
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[feedback] RPC broadcast failed",
+      err,
+      { endpoint: "/api/agentic-wallet/feedback", feedbackId: newRow.id }
+    );
+    return NextResponse.json(
+      {
+        error: "Broadcast failed",
+        code: "RPC_UPSTREAM",
+        feedbackId: newRow.id,
+      },
+      { status: 502 }
+    );
+  }
+
+  await db
+    .update(feedback)
+    .set({
+      status: "broadcast",
+      txHash,
+      feedbackHash,
+      broadcastAt: new Date(),
+    })
+    .where(eq(feedback.id, newRow.id));
+
+  return NextResponse.json({
+    feedbackId: newRow.id,
+    txHash,
+    publicUrl: `${publicBaseUrl}/api/feedback/${newRow.id}`,
+  });
+}

--- a/app/api/feedback/[id]/route.ts
+++ b/app/api/feedback/[id]/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET /api/feedback/[id]
+ *
+ * Public, unauthenticated endpoint that serves the canonical off-chain
+ * feedback JSON referenced by ERC-8004 ReputationRegistry::giveFeedback's
+ * `feedbackURI` argument. The `feedbackHash` (bytes32) on-chain is the
+ * keccak256 of the bytes returned here, so this content MUST be
+ * deterministic and immutable for a given id.
+ *
+ * The JSON shape is reconstructed from the feedback row + the referenced
+ * execution -- not from a stored blob -- because the canonicaliser
+ * (lib/agentic-wallet/erc-8004.ts:canonicaliseFeedbackContent) is the
+ * source of truth for byte order. Any future field addition there
+ * propagates to all historical rows uniformly.
+ *
+ * Cache-Control: long-lived (mutable rows would invalidate the on-chain
+ * hash, so we treat them as immutable). Caches keyed on the id are safe.
+ */
+import { eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  buildFeedbackUriContent,
+  canonicaliseFeedbackContent,
+} from "@/lib/agentic-wallet/erc-8004";
+import { db } from "@/lib/db";
+import { feedback, workflows } from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+  const rows = await db
+    .select({
+      id: feedback.id,
+      executionId: feedback.executionId,
+      workflowId: feedback.workflowId,
+      agentChainId: feedback.agentChainId,
+      agentId: feedback.agentId,
+      payerWallet: feedback.payerWallet,
+      value: feedback.value,
+      valueDecimals: feedback.valueDecimals,
+      comment: feedback.comment,
+      createdAt: feedback.createdAt,
+      workflowSlug: workflows.listedSlug,
+    })
+    .from(feedback)
+    .leftJoin(workflows, eq(workflows.id, feedback.workflowId))
+    .where(eq(feedback.id, id))
+    .limit(1);
+  const row = rows[0];
+  if (!row) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const content = buildFeedbackUriContent({
+    agentChainId: row.agentChainId,
+    agentId: BigInt(row.agentId),
+    clientAddress: row.payerWallet as `0x${string}`,
+    createdAt: row.createdAt,
+    value: BigInt(row.value),
+    valueDecimals: row.valueDecimals,
+    comment: row.comment ?? undefined,
+    workflowSlug: row.workflowSlug ?? undefined,
+    executionId: row.executionId,
+  });
+
+  // Serve the canonicalised string (NOT JSON.stringify of `content`) so the
+  // bytes match the keccak256 the on-chain feedbackHash committed to.
+  const body = canonicaliseFeedbackContent(content);
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "public, max-age=31536000, immutable",
+    },
+  });
+}

--- a/drizzle/0069_add_feedback_table.sql
+++ b/drizzle/0069_add_feedback_table.sql
@@ -1,0 +1,58 @@
+-- ERC-8004 feedback table.
+--
+-- One row per submitted feedback. The id is used as the path segment of
+-- the canonical feedbackURI (`/api/feedback/<id>`) referenced on-chain in
+-- ReputationRegistry::giveFeedback. The off-chain JSON served at that URI
+-- is reconstructed deterministically from this row + the referenced
+-- workflow_executions row -- there is no denormalised JSON blob on the
+-- table.
+--
+-- See lib/db/schema-feedback.ts for column rationale and lifecycle.
+
+DO $$ BEGIN
+  CREATE TYPE "feedback_status" AS ENUM ('pending', 'broadcast', 'confirmed', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "feedback" (
+  "id" text PRIMARY KEY NOT NULL,
+  "execution_id" text NOT NULL,
+  "workflow_id" text NOT NULL,
+  "agent_registry" text NOT NULL DEFAULT 'erc-8004',
+  "agent_chain_id" integer NOT NULL,
+  "agent_id" text NOT NULL,
+  "payer_wallet" text NOT NULL,
+  "value" text NOT NULL,
+  "value_decimals" integer NOT NULL,
+  "comment" text,
+  "feedback_hash" text,
+  "tx_chain_id" integer NOT NULL,
+  "tx_hash" text,
+  "status" "feedback_status" NOT NULL DEFAULT 'pending',
+  "error" text,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "broadcast_at" timestamp,
+  "confirmed_at" timestamp
+);
+
+DO $$ BEGIN
+  ALTER TABLE "feedback"
+    ADD CONSTRAINT "feedback_execution_id_workflow_executions_id_fk"
+    FOREIGN KEY ("execution_id") REFERENCES "public"."workflow_executions"("id");
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "feedback"
+    ADD CONSTRAINT "feedback_workflow_id_workflows_id_fk"
+    FOREIGN KEY ("workflow_id") REFERENCES "public"."workflows"("id");
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "idx_feedback_execution" ON "feedback" ("execution_id");
+CREATE INDEX IF NOT EXISTS "idx_feedback_payer" ON "feedback" ("payer_wallet");
+CREATE INDEX IF NOT EXISTS "idx_feedback_agent" ON "feedback" ("agent_registry", "agent_chain_id", "agent_id");
+CREATE INDEX IF NOT EXISTS "idx_feedback_status" ON "feedback" ("status");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1777760000002,
       "tag": "0068_listing_version",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1777760000003,
+      "tag": "0069_add_feedback_table",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/agentic-wallet/constants.ts
+++ b/lib/agentic-wallet/constants.ts
@@ -27,3 +27,25 @@ export const ALLOWED_TEMPO_CHAIN_IDS: readonly number[] = [
   TEMPO_MAINNET_CHAIN_ID,
   TEMPO_TESTNET_CHAIN_ID,
 ] as const;
+
+// ERC-8004 Trustless Agents — Ethereum mainnet deployments (2026-01-29 launch).
+// Vanity prefix 0x8004 distinguishes the registries on-chain. Source-of-truth:
+// https://github.com/erc-8004/erc-8004-contracts
+export const ETHEREUM_MAINNET_CHAIN_ID = 1 as const;
+export const ERC_8004_IDENTITY_REGISTRY_ADDRESS =
+  "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432" as const;
+export const ERC_8004_REPUTATION_REGISTRY_ADDRESS =
+  "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63" as const;
+export const ERC_8004_IDENTITY_REGISTRY_LC =
+  ERC_8004_IDENTITY_REGISTRY_ADDRESS.toLowerCase();
+export const ERC_8004_REPUTATION_REGISTRY_LC =
+  ERC_8004_REPUTATION_REGISTRY_ADDRESS.toLowerCase();
+
+// keccak256("giveFeedback(uint256,int128,uint8,string,string,string,string,bytes32)")[0:4]
+export const GIVE_FEEDBACK_SELECTOR = "0x3c036a7e" as const;
+
+// KeeperHub's own ERC-8004 agent NFT id on Ethereum mainnet. Used as the
+// default rated agent when injecting feedback CTAs into workflow execution
+// responses; users can rate any agent id (the Turnkey policy does not
+// constrain the agentId argument).
+export const KEEPERHUB_ERC_8004_AGENT_ID = 31_875 as const;

--- a/lib/agentic-wallet/erc-8004.ts
+++ b/lib/agentic-wallet/erc-8004.ts
@@ -1,0 +1,165 @@
+/**
+ * ERC-8004 ReputationRegistry helpers.
+ *
+ * Two pure functions:
+ *   - `buildGiveFeedbackCalldata`: encode the giveFeedback(...) call for the
+ *     EVM. Returns the calldata hex; the caller bundles it into an unsigned
+ *     EIP-1559 tx.
+ *   - `buildFeedbackUriContent`: produce the canonical off-chain JSON the
+ *     feedbackURI on-chain reference resolves to. The caller hashes this
+ *     deterministically (`keccak256(toUtf8Bytes(JSON.stringify(content)))`)
+ *     and passes the hash as the bytes32 `feedbackHash` arg.
+ *
+ * The on-chain function signature (per ERC-8004 spec):
+ *   giveFeedback(
+ *     uint256 agentId,
+ *     int128  value,
+ *     uint8   valueDecimals,
+ *     string  tag1,
+ *     string  tag2,
+ *     string  endpoint,
+ *     string  feedbackURI,
+ *     bytes32 feedbackHash,
+ *   )
+ *
+ * Selector: 0x3c036a7e (validated against ethers + viem; see constants).
+ */
+import { encodeFunctionData, type Hex, keccak256, stringToBytes } from "viem";
+
+const GIVE_FEEDBACK_ABI = [
+  {
+    type: "function",
+    name: "giveFeedback",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "value", type: "int128" },
+      { name: "valueDecimals", type: "uint8" },
+      { name: "tag1", type: "string" },
+      { name: "tag2", type: "string" },
+      { name: "endpoint", type: "string" },
+      { name: "feedbackURI", type: "string" },
+      { name: "feedbackHash", type: "bytes32" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+export type GiveFeedbackArgs = {
+  agentId: bigint;
+  value: bigint;
+  valueDecimals: number;
+  tag1?: string;
+  tag2?: string;
+  endpoint?: string;
+  feedbackURI: string;
+  feedbackHash: Hex;
+};
+
+export function buildGiveFeedbackCalldata(args: GiveFeedbackArgs): Hex {
+  return encodeFunctionData({
+    abi: GIVE_FEEDBACK_ABI,
+    functionName: "giveFeedback",
+    args: [
+      args.agentId,
+      args.value,
+      args.valueDecimals,
+      args.tag1 ?? "",
+      args.tag2 ?? "",
+      args.endpoint ?? "",
+      args.feedbackURI,
+      args.feedbackHash,
+    ],
+  });
+}
+
+/**
+ * Off-chain JSON shape served at /api/feedback/<id>.
+ *
+ * Derived from the ERC-8004 spec's "feedbackURI content" recommendation
+ * (agentRegistry, agentId, clientAddress, createdAt, value, optional
+ * tag1/tag2/endpoint/mcp/a2a context). KeeperHub-specific extension: the
+ * `mcp` block carries `workflowSlug` + `executionId` so a downstream reader
+ * knows what was actually rated.
+ */
+export type FeedbackUriContent = {
+  agentRegistry: "erc-8004";
+  agentChainId: number;
+  agentId: string;
+  clientAddress: `0x${string}`;
+  createdAt: string;
+  value: string;
+  valueDecimals: number;
+  comment?: string;
+  mcp?: {
+    workflowSlug: string;
+    executionId: string;
+  };
+};
+
+export function buildFeedbackUriContent(args: {
+  agentChainId: number;
+  agentId: bigint;
+  clientAddress: `0x${string}`;
+  createdAt: Date;
+  value: bigint;
+  valueDecimals: number;
+  comment?: string;
+  workflowSlug?: string;
+  executionId?: string;
+}): FeedbackUriContent {
+  const out: FeedbackUriContent = {
+    agentRegistry: "erc-8004",
+    agentChainId: args.agentChainId,
+    agentId: args.agentId.toString(),
+    clientAddress: args.clientAddress,
+    createdAt: args.createdAt.toISOString(),
+    value: args.value.toString(),
+    valueDecimals: args.valueDecimals,
+  };
+  if (args.comment !== undefined) {
+    out.comment = args.comment;
+  }
+  if (args.workflowSlug !== undefined && args.executionId !== undefined) {
+    out.mcp = {
+      workflowSlug: args.workflowSlug,
+      executionId: args.executionId,
+    };
+  }
+  return out;
+}
+
+/**
+ * Canonicalised serialization for hashing. Keys are emitted in stable order
+ * so the on-chain `feedbackHash` always matches the JSON we serve at
+ * `/api/feedback/<id>` regardless of how the object was constructed.
+ *
+ * Required keys go first in their spec order; optional keys (comment, mcp)
+ * trail. Any future field MUST be added at the end to preserve hash
+ * stability for historical rows.
+ */
+export function canonicaliseFeedbackContent(
+  content: FeedbackUriContent
+): string {
+  const required = {
+    agentRegistry: content.agentRegistry,
+    agentChainId: content.agentChainId,
+    agentId: content.agentId,
+    clientAddress: content.clientAddress,
+    createdAt: content.createdAt,
+    value: content.value,
+    valueDecimals: content.valueDecimals,
+  };
+  const ordered: Record<string, unknown> = { ...required };
+  if (content.comment !== undefined) {
+    ordered.comment = content.comment;
+  }
+  if (content.mcp !== undefined) {
+    ordered.mcp = content.mcp;
+  }
+  return JSON.stringify(ordered);
+}
+
+export function hashFeedbackContent(content: FeedbackUriContent): Hex {
+  return keccak256(stringToBytes(canonicaliseFeedbackContent(content)));
+}

--- a/lib/agentic-wallet/policy-migration.ts
+++ b/lib/agentic-wallet/policy-migration.ts
@@ -1,0 +1,141 @@
+/**
+ * Reconcile a sub-org's Turnkey policies against the current BASELINE_POLICIES
+ * snapshot.
+ *
+ * Existing wallets created before the ERC-8004 policy update have an OLDER
+ * baseline (e.g. allowlist-outbound-contracts only allowing USDC). To enable
+ * giveFeedback() signing on those wallets we must either: (a) re-provision
+ * them (loses funds), or (b) reconcile their on-chain Turnkey policy set to
+ * the new baseline. This module is path (b).
+ *
+ * Strategy:
+ *   - Fetch current policies for the sub-org
+ *   - For each BASELINE_POLICIES entry, compare condition+notes against the
+ *     existing policy with the same name
+ *     - absent  -> createPolicy
+ *     - stale   -> deletePolicy + createPolicy (Turnkey policies are immutable
+ *                  in their condition, so update == delete+recreate)
+ *     - fresh   -> no-op
+ *   - Best-effort consistency: if any create fails partway, throw -- the
+ *     caller (lazy-migrate path or admin script) can retry safely.
+ *
+ * Idempotent. Safe to run repeatedly. Read-only when nothing has drifted.
+ *
+ * SECURITY NOTE: This function modifies sub-org policy state. Call sites:
+ *   - scripts/upgrade-agentic-wallet-policies.ts (operator, one-shot)
+ *   - lazy-migrate path on first feedback submission (server-only)
+ * It MUST NOT be exposed via an HTTP endpoint without auth. Caller is
+ * responsible for authentication; this module trusts its arguments.
+ */
+import type { Turnkey } from "@turnkey/sdk-server";
+import { BASELINE_POLICIES, type BaselinePolicy } from "./policy";
+
+type ApiClient = ReturnType<Turnkey["apiClient"]>;
+
+type ListedPolicy = {
+  policyId: string;
+  policyName: string;
+  effect: string;
+  condition?: string;
+  notes?: string;
+};
+
+export type ReconcileAction =
+  | { action: "noop"; policyName: string }
+  | { action: "create"; policyName: string; policyId: string }
+  | {
+      action: "replace";
+      policyName: string;
+      oldPolicyId: string;
+      newPolicyId: string;
+    };
+
+export type ReconcileResult = {
+  subOrgId: string;
+  actions: ReconcileAction[];
+};
+
+/**
+ * Compare a baseline definition against a listed policy to decide whether
+ * the listed copy is up-to-date. Notes are intentionally NOT compared --
+ * cosmetic edits to the notes string should not trigger a destructive
+ * delete+create round-trip. Only `condition` and `effect` decide drift.
+ */
+function isStale(baseline: BaselinePolicy, listed: ListedPolicy): boolean {
+  if (listed.effect !== baseline.effect) {
+    return true;
+  }
+  if ((listed.condition ?? "") !== baseline.condition) {
+    return true;
+  }
+  return false;
+}
+
+export async function reconcileBaselinePolicies(args: {
+  client: ApiClient;
+  subOrgId: string;
+}): Promise<ReconcileResult> {
+  const { client, subOrgId } = args;
+
+  const listedRaw = (await client.getPolicies({
+    organizationId: subOrgId,
+  })) as { policies?: ListedPolicy[] };
+  const byName = new Map<string, ListedPolicy>();
+  for (const p of listedRaw.policies ?? []) {
+    byName.set(p.policyName, p);
+  }
+
+  const actions: ReconcileAction[] = [];
+
+  for (const baseline of BASELINE_POLICIES) {
+    const existing = byName.get(baseline.policyName);
+    if (!existing) {
+      const created = (await client.createPolicy({
+        organizationId: subOrgId,
+        policyName: baseline.policyName,
+        effect: baseline.effect,
+        condition: baseline.condition,
+        consensus: "true",
+        notes: baseline.notes,
+      })) as unknown as { policyId?: string };
+      actions.push({
+        action: "create",
+        policyName: baseline.policyName,
+        policyId: created.policyId ?? "",
+      });
+      continue;
+    }
+    if (!isStale(baseline, existing)) {
+      actions.push({ action: "noop", policyName: baseline.policyName });
+      continue;
+    }
+    // Replace (delete + create). Order matters: create FIRST so we never
+    // leave the sub-org without coverage between calls. If create succeeds
+    // but delete fails, we have a duplicate policy under the same name --
+    // Turnkey's listPolicies will surface both, and a re-run picks the
+    // first match arbitrarily. To avoid that pile-up, delete first ONLY
+    // when the create-first path is impossible (it isn't here -- Turnkey
+    // permits multiple policies with the same name, so create-first is
+    // safe). Net: brief duplicate, never a gap.
+    const created = (await client.createPolicy({
+      organizationId: subOrgId,
+      policyName: baseline.policyName,
+      effect: baseline.effect,
+      condition: baseline.condition,
+      consensus: "true",
+      notes: baseline.notes,
+    })) as unknown as { policyId?: string };
+    await client.deletePolicy({
+      organizationId: subOrgId,
+      policyId: existing.policyId,
+    });
+    actions.push({
+      action: "replace",
+      policyName: baseline.policyName,
+      oldPolicyId: existing.policyId,
+      newPolicyId: created.policyId ?? "",
+    });
+  }
+
+  return { subOrgId, actions };
+}

--- a/lib/agentic-wallet/policy.ts
+++ b/lib/agentic-wallet/policy.ts
@@ -4,17 +4,37 @@
  * GUARD-06 baseline policies applied ONCE at sub-org creation time.
  * Plan 33-02 (/sign) must NOT call createPolicy or updatePolicy.
  *
- * Phase 37: the eth.tx.* policies fire on signTransaction activities (not
- * exercised by /sign today, kept for future-proofing). The eth.eip_712.*
- * policies fire on signRawPayload + PAYLOAD_ENCODING_EIP712 (the current
- * /sign codepath). Server-side payTo + chainId checks in /sign route are
- * defence-in-depth on top of these.
+ * Phase 37: the eth.tx.* policies fire on signTransaction activities. The
+ * eth.eip_712.* policies fire on signRawPayload + PAYLOAD_ENCODING_EIP712
+ * (the x402/MPP USDC payment path). Server-side payTo + chainId checks in
+ * /sign route are defence-in-depth on top of these.
+ *
+ * ERC-8004 update (2026-05): signTransaction is now exercised by the
+ * /api/agentic-wallet/sign-tx + /api/agentic-wallet/feedback routes for
+ * giveFeedback() calls on the ERC-8004 ReputationRegistry on Ethereum
+ * mainnet. Three new gates were added: outbound contract allowlist now
+ * includes the ReputationRegistry; chain-binding ties each allowed
+ * contract to its native chain id (USDC<->Base/Tempo, ReputationRegistry
+ * <->Ethereum); selector allowlist limits ReputationRegistry interactions
+ * to giveFeedback() only.
+ *
+ * Gas sponsorship (TODO): Today the user wallet pays gas natively for
+ * giveFeedback (~$3-10 per feedback at current Ethereum gas). Both
+ * existing payment paths are gasless from the user's perspective (Base:
+ * EIP-3009 meta-tx, Tempo: MPP sponsor). Future work: sponsor giveFeedback
+ * via either Pimlico (current sponsored-tx infra in lib/web3/pimlico-config.ts)
+ * or Turnkey's native sponsorship. Keeping the policy strict so that
+ * sponsorship can be layered on without policy widening.
  */
 import type { Turnkey } from "@turnkey/sdk-server";
 
-// USDC contract addresses — CONTEXT Resolution #2 (locked 2026-04-21).
-// Single source of truth lives in ./constants.
+// USDC contract addresses + ERC-8004 ReputationRegistry — single source of
+// truth lives in ./constants.
 import {
+  ERC_8004_REPUTATION_REGISTRY_ADDRESS,
+  ERC_8004_REPUTATION_REGISTRY_LC,
+  ETHEREUM_MAINNET_CHAIN_ID,
+  GIVE_FEEDBACK_SELECTOR,
   USDC_BASE_ADDRESS,
   USDC_BASE_LC,
   USDC_TEMPO_ADDRESS,
@@ -24,6 +44,7 @@ import {
 export const FACILITATOR_ALLOWLIST: readonly string[] = [
   USDC_BASE_ADDRESS,
   USDC_TEMPO_ADDRESS,
+  ERC_8004_REPUTATION_REGISTRY_ADDRESS,
 ] as const;
 
 export type BaselinePolicy = {
@@ -60,8 +81,34 @@ export const BASELINE_POLICIES: readonly BaselinePolicy[] = [
   {
     policyName: "allowlist-outbound-contracts",
     effect: "EFFECT_DENY",
-    condition: `!(eth.tx.to in ['${USDC_BASE_LC}', '${USDC_TEMPO_LC}'])`,
-    notes: "GUARD-06: only permit outbound calls to allowlisted USDC contracts",
+    condition: `!(eth.tx.to in ['${USDC_BASE_LC}', '${USDC_TEMPO_LC}', '${ERC_8004_REPUTATION_REGISTRY_LC}'])`,
+    notes:
+      "GUARD-06: only permit outbound calls to allowlisted USDC contracts and the ERC-8004 ReputationRegistry",
+  },
+  // ERC-8004 chain binding (signTransaction). The eth.tx.* condition keys
+  // populate only on ACTIVITY_TYPE_SIGN_TRANSACTION_V2; we gate that
+  // activity discriminator explicitly so unrelated signRawPayload paths do
+  // not incidentally fail this rule. Each allowed contract is bound to its
+  // native chain id so a stolen HMAC cannot replay a USDC payment shape on
+  // Ethereum or, conversely, sign feedback on Base.
+  {
+    policyName: "allowlist-tx-chain-binding",
+    effect: "EFFECT_DENY",
+    condition: `activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2' && !((eth.tx.to == '${USDC_BASE_LC}' && eth.tx.chain_id == 8453) || (eth.tx.to == '${USDC_TEMPO_LC}' && (eth.tx.chain_id == 4217 || eth.tx.chain_id == 4218)) || (eth.tx.to == '${ERC_8004_REPUTATION_REGISTRY_LC}' && eth.tx.chain_id == ${ETHEREUM_MAINNET_CHAIN_ID}))`,
+    notes:
+      "GUARD-06 (signTransaction): bind each allowed contract to its native chain id (USDC<->Base/Tempo, ReputationRegistry<->Ethereum)",
+  },
+  // ERC-8004 selector allowlist. Restricts ReputationRegistry interactions
+  // to giveFeedback() — no register, no revokeFeedback, no appendResponse.
+  // This narrows the policy hole to the single function we need; the
+  // agentId argument is intentionally NOT constrained (users can rate any
+  // agent).
+  {
+    policyName: "allowlist-erc8004-selector",
+    effect: "EFFECT_DENY",
+    condition: `eth.tx.to == '${ERC_8004_REPUTATION_REGISTRY_LC}' && eth.tx.function_signature != '${GIVE_FEEDBACK_SELECTOR}'`,
+    notes:
+      "GUARD-06 (ERC-8004): only permit giveFeedback() on the ReputationRegistry",
   },
   // Phase 37 fix #1 (revised): eth.tx.* fields are NOT populated for
   // signRawPayload with PAYLOAD_ENCODING_EIP712. The three policies below are

--- a/lib/agentic-wallet/sign-eth-tx.ts
+++ b/lib/agentic-wallet/sign-eth-tx.ts
@@ -1,0 +1,128 @@
+/**
+ * Turnkey signTransaction primitive (ACTIVITY_TYPE_SIGN_TRANSACTION_V2) + a
+ * thin viem broadcast helper.
+ *
+ * Sibling to ./sign.ts which proxies signRawPayload for x402/MPP USDC EIP-712
+ * payment challenges. This module is the path for raw EVM tx signing on
+ * Ethereum mainnet (the ERC-8004 ReputationRegistry::giveFeedback flow).
+ *
+ * Both files share the same Turnkey client factory (getTurnkeyClientForOrg)
+ * and the same PolicyBlockedError / TurnkeyUpstreamError surface so callers
+ * see a uniform error contract.
+ *
+ * Policy contract (lib/agentic-wallet/policy.ts BASELINE_POLICIES):
+ *   - allowlist-outbound-contracts: eth.tx.to in {USDC_BASE, USDC_TEMPO,
+ *     ERC_8004_REPUTATION_REGISTRY}
+ *   - allowlist-tx-chain-binding: each contract bound to its native chain id
+ *     (USDC_BASE<->8453, USDC_TEMPO<->4217|4218, ReputationRegistry<->1)
+ *   - allowlist-erc8004-selector: ReputationRegistry calls must invoke
+ *     giveFeedback() (selector 0x3c036a7e)
+ *
+ * Anything else gets rejected by Turnkey with CONSENSUS_NEEDED -- we surface
+ * that as PolicyBlockedError, never leaking the policy text upstream.
+ */
+import { createPublicClient, type Hex, http, parseTransaction } from "viem";
+import { mainnet } from "viem/chains";
+import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
+import { getTurnkeyClientForOrg } from "@/lib/turnkey/agentic-wallet";
+import { PolicyBlockedError, TurnkeyUpstreamError } from "./sign";
+
+type TurnkeySignTransactionResult = {
+  signedTransaction?: string;
+};
+
+type TurnkeyActivityResponse = {
+  activity?: {
+    status?: string;
+    result?: {
+      signTransactionResult?: TurnkeySignTransactionResult;
+    };
+  };
+};
+
+/**
+ * Sign a serialized EIP-1559 Ethereum transaction via Turnkey. The caller
+ * is responsible for nonce + gas estimation + RLP serialization (typically
+ * via viem's `serializeTransaction({...})` with no `r/s/v`).
+ *
+ * Returns the fully-signed serialized tx hex (`0x...`), ready for
+ * `eth_sendRawTransaction`.
+ *
+ * Throws:
+ *   - PolicyBlockedError when Turnkey returns CONSENSUS_NEEDED. The caller's
+ *     unsigned tx violated one of the BASELINE_POLICIES gates above.
+ *   - TurnkeyUpstreamError on transport failures or COMPLETED status with a
+ *     missing signedTransaction (rare but documented).
+ */
+export async function signEthereumTransaction(args: {
+  subOrgId: string;
+  walletAddress: `0x${string}`;
+  /** RLP-encoded unsigned tx hex; MUST NOT include the 0x prefix. */
+  unsignedTransactionHex: string;
+}): Promise<{ signedTransaction: `0x${string}` }> {
+  const { subOrgId, walletAddress, unsignedTransactionHex } = args;
+  const client = getTurnkeyClientForOrg(subOrgId).apiClient();
+  const activity = (await (
+    client as unknown as {
+      signTransaction: (args: unknown) => Promise<TurnkeyActivityResponse>;
+    }
+  ).signTransaction({
+    signWith: walletAddress,
+    type: "TRANSACTION_TYPE_ETHEREUM",
+    unsignedTransaction: unsignedTransactionHex,
+  })) as TurnkeyActivityResponse;
+
+  const status = activity.activity?.status;
+  if (status === "ACTIVITY_STATUS_CONSENSUS_NEEDED") {
+    throw new PolicyBlockedError(
+      "Turnkey policy blocked the activity (CONSENSUS_NEEDED)"
+    );
+  }
+  if (status !== "ACTIVITY_STATUS_COMPLETED") {
+    throw new TurnkeyUpstreamError(
+      `Turnkey returned status ${status ?? "unknown"}`
+    );
+  }
+  const signed =
+    activity.activity?.result?.signTransactionResult?.signedTransaction;
+  if (!signed) {
+    throw new TurnkeyUpstreamError(
+      "signedTransaction missing from Turnkey response"
+    );
+  }
+  const prefixed = signed.startsWith("0x") ? signed : `0x${signed}`;
+  return { signedTransaction: prefixed as `0x${string}` };
+}
+
+/**
+ * Broadcast a signed serialized tx via the chain's configured RPC. Returns
+ * the canonical tx hash. Verifies the parsed transaction's chain id matches
+ * the requested chain id before broadcast as a defence-in-depth gate against
+ * a Turnkey policy regression silently signing on the wrong chain.
+ */
+export async function broadcastSignedTransaction(args: {
+  signedTransaction: Hex;
+  chainId: number;
+}): Promise<{ txHash: Hex }> {
+  const { signedTransaction, chainId } = args;
+  const parsed = parseTransaction(signedTransaction);
+  if (parsed.chainId !== chainId) {
+    throw new Error(
+      `Signed tx chainId ${parsed.chainId} does not match requested chainId ${chainId}`
+    );
+  }
+  // getRpcUrlByChainId throws on unknown chain id; that maps to our existing
+  // contract (No RPC configured for chainId X).
+  const rpcUrl = getRpcUrlByChainId(chainId);
+  // Mainnet only today; if/when we sign on more chains, extend the chain
+  // selection here. viem's mainnet chain is sufficient for serialization
+  // checks regardless of the actual chain since we only need the transport.
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http(rpcUrl),
+  });
+  const txHash = await client.sendRawTransaction({
+    serializedTransaction: signedTransaction,
+  });
+  return { txHash };
+}

--- a/lib/db/schema-feedback.ts
+++ b/lib/db/schema-feedback.ts
@@ -1,0 +1,119 @@
+import {
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+import { workflowExecutions, workflows } from "@/lib/db/schema";
+import { generateId } from "@/lib/utils/id";
+
+/**
+ * Feedback lifecycle pgEnum.
+ *
+ *   pending    -- row inserted, no on-chain broadcast yet
+ *   broadcast  -- giveFeedback() tx sent, hash recorded, awaiting confirmation
+ *   confirmed  -- tx mined and indexed on-chain
+ *   failed     -- broadcast or confirmation failed (reason in error column)
+ *
+ * Distinct DB type name to avoid collisions with workflow status enums.
+ */
+export const feedbackStatus = pgEnum("feedback_status", [
+  "pending",
+  "broadcast",
+  "confirmed",
+  "failed",
+]);
+
+/**
+ * Feedback table -- ERC-8004 ReputationRegistry feedback authored via the
+ * agentic-wallet flow.
+ *
+ * One row per submitted feedback. The `id` is used as the path segment in
+ * the canonical feedbackURI (`/api/feedback/<id>`) which is referenced
+ * on-chain in the giveFeedback() transaction. The off-chain JSON served
+ * at that URI is reconstructed deterministically from this row + the
+ * referenced execution; we do NOT persist a denormalised JSON blob, so
+ * any rendering change applies to all historical rows uniformly.
+ *
+ * Lifecycle: caller hits POST /api/agentic-wallet/feedback with executionId
+ * + value + valueDecimals (+ optional comment). The route inserts the row
+ * with status="pending", builds the giveFeedback tx, signs+broadcasts via
+ * Turnkey, then updates txHash + status="broadcast". A separate poller
+ * watches for receipts and bumps to "confirmed" / "failed".
+ *
+ * Sybil note: 8004scan is expected to discount feedback whose payerWallet
+ * is associated with the rated agent's owner wallet. We persist payerWallet
+ * regardless to keep an audit trail; downstream presentation can filter.
+ */
+export const feedback = pgTable(
+  "feedback",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+
+    // Execution that produced this feedback. Establishes that the payer
+    // actually used the workflow before rating it (anti-spam at the
+    // application layer; the Turnkey policy already gates raw signing).
+    executionId: text("execution_id")
+      .notNull()
+      .references(() => workflowExecutions.id),
+    workflowId: text("workflow_id")
+      .notNull()
+      .references(() => workflows.id),
+
+    // Rated agent identity. agentRegistry pinned to "erc-8004" today --
+    // kept as a column so other registries can be added without a schema
+    // migration. agentChainId records WHERE the agent NFT lives (Ethereum
+    // mainnet = 1 for all current ERC-8004 agents). agentId is the NFT id.
+    agentRegistry: text("agent_registry").notNull().default("erc-8004"),
+    agentChainId: integer("agent_chain_id").notNull(),
+    agentId: text("agent_id").notNull(), // uint256 -- text avoids JS number precision loss
+
+    // Caller wallet that signed giveFeedback(). Always lowercased 0x EVM
+    // address. Indexed for "show me my feedback history" queries.
+    payerWallet: text("payer_wallet").notNull(),
+
+    // Rating. ERC-8004 spec carries an int128 + uint8 decimals. We store
+    // the raw integer (text -- int128 exceeds Postgres bigint range) and
+    // the decimals scalar separately, mirroring the contract args. Display
+    // logic computes value / 10^decimals.
+    value: text("value").notNull(),
+    valueDecimals: integer("value_decimals").notNull(),
+
+    // Optional plain-text comment. Surfaced on app.keeperhub.com workflow
+    // pages; included verbatim in the feedbackURI JSON.
+    comment: text("comment"),
+
+    // keccak256 of the feedbackURI JSON content. Stored so the route can
+    // emit it as the bytes32 feedbackHash arg of giveFeedback() without
+    // recomputing on every request, and so a downstream verifier can
+    // detect tampering of the hosted JSON.
+    feedbackHash: text("feedback_hash"),
+
+    // On-chain bookkeeping. txChainId is where the giveFeedback() call was
+    // submitted (always == agentChainId today since the spec colocates
+    // them). txHash null until broadcast.
+    txChainId: integer("tx_chain_id").notNull(),
+    txHash: text("tx_hash"),
+
+    status: feedbackStatus("status").notNull().default("pending"),
+    error: text("error"),
+
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    broadcastAt: timestamp("broadcast_at"),
+    confirmedAt: timestamp("confirmed_at"),
+  },
+  (table) => [
+    index("idx_feedback_execution").on(table.executionId),
+    index("idx_feedback_payer").on(table.payerWallet),
+    index("idx_feedback_agent").on(
+      table.agentRegistry,
+      table.agentChainId,
+      table.agentId
+    ),
+    index("idx_feedback_status").on(table.status),
+  ]
+);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -433,6 +433,7 @@ export {
   workflowPublicTags,
   workflowRatings,
 } from "./schema-extensions";
+export { feedback, feedbackStatus } from "./schema-feedback";
 export {
   type McpOauthAuthCode,
   type McpOauthClient,

--- a/lib/payments/x402/execution-wait.ts
+++ b/lib/payments/x402/execution-wait.ts
@@ -107,8 +107,57 @@ export async function applyOutputMapping(
   return nodeOutput;
 }
 
+// ERC-8004 feedback CTA appended to every successful workflow execution
+// response. The calling agent (LLM) reads this and can prompt the user to
+// rate the workflow, then invoke the keeperhub-wallet `submit_feedback`
+// MCP tool to submit on-chain feedback to the ERC-8004 ReputationRegistry.
+//
+// Hardcoded to the canonical KeeperHub agent on Ethereum mainnet (NFT 31875).
+// User instruction "any agent" is honoured at the SUBMISSION layer (the
+// /api/agentic-wallet/feedback route accepts an override agentId); this CTA
+// just suggests the default target.
+export type FeedbackCta = {
+  prompt: string;
+  tool: string;
+  context: {
+    executionId: string;
+    agent: {
+      registry: "erc-8004";
+      chainId: number;
+      id: string;
+      explorerUrl: string;
+    };
+  };
+};
+
+const KEEPERHUB_FEEDBACK_CTA: Omit<FeedbackCta, "context"> = {
+  prompt:
+    "Was this workflow useful? Rate it (1-5) on the ERC-8004 ReputationRegistry — your wallet signs and submits on-chain in one call. Use the keeperhub-wallet `submit_feedback` tool with this executionId.",
+  tool: "keeperhub-wallet:submit_feedback",
+};
+
+function buildFeedbackCta(executionId: string): FeedbackCta {
+  return {
+    ...KEEPERHUB_FEEDBACK_CTA,
+    context: {
+      executionId,
+      agent: {
+        registry: "erc-8004",
+        chainId: 1,
+        id: "31875",
+        explorerUrl: "https://8004scan.io/agents/ethereum/31875",
+      },
+    },
+  };
+}
+
 export type CallCompletionResponse =
-  | { executionId: string; status: "success"; output: unknown }
+  | {
+      executionId: string;
+      status: "success";
+      output: unknown;
+      feedback: FeedbackCta;
+    }
   | { executionId: string; status: "error"; error: string }
   | { executionId: string; status: "running" };
 
@@ -132,7 +181,12 @@ export async function buildCallCompletionResponse(
       result.output,
       outputMapping
     );
-    return { executionId, status: "success", output };
+    return {
+      executionId,
+      status: "success",
+      output,
+      feedback: buildFeedbackCta(executionId),
+    };
   }
   if (result.status === "cancelled") {
     return { executionId, status: "error", error: "Execution cancelled" };

--- a/scripts/upgrade-agentic-wallet-policies.ts
+++ b/scripts/upgrade-agentic-wallet-policies.ts
@@ -1,0 +1,110 @@
+/**
+ * Operator script: reconcile Turnkey baseline policies for one or all
+ * agentic-wallet sub-orgs.
+ *
+ * Why: when BASELINE_POLICIES changes (e.g. ERC-8004 update added two new
+ * policies and modified the outbound allowlist condition), already-provisioned
+ * sub-orgs lag behind. This script brings them up to date without
+ * re-provisioning the wallet (which would invalidate the wallet address).
+ *
+ * Usage:
+ *   pnpm tsx scripts/upgrade-agentic-wallet-policies.ts [--sub-org=<id>] [--dry-run]
+ *
+ * Without --sub-org, iterates EVERY row in agentic_wallets. Use --dry-run to
+ * preview the actions without mutating Turnkey state.
+ *
+ * Required env: TURNKEY_API_PUBLIC_KEY, TURNKEY_API_PRIVATE_KEY,
+ * TURNKEY_ORGANIZATION_ID, DATABASE_URL.
+ */
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { agenticWallets } from "@/lib/db/schema";
+import { reconcileBaselinePolicies } from "@/lib/agentic-wallet/policy-migration";
+import { getTurnkeyClientForOrg } from "@/lib/turnkey/agentic-wallet";
+
+type Args = {
+  subOrgId: string | null;
+  dryRun: boolean;
+};
+
+function parseArgs(): Args {
+  const out: Args = { subOrgId: null, dryRun: false };
+  for (const arg of process.argv.slice(2)) {
+    if (arg === "--dry-run") {
+      out.dryRun = true;
+    } else if (arg.startsWith("--sub-org=")) {
+      out.subOrgId = arg.slice("--sub-org=".length);
+    } else {
+      throw new Error(`Unknown arg: ${arg}`);
+    }
+  }
+  return out;
+}
+
+async function getTargetSubOrgs(filter: string | null): Promise<string[]> {
+  if (filter) {
+    const rows = await db
+      .select({ subOrgId: agenticWallets.subOrgId })
+      .from(agenticWallets)
+      .where(eq(agenticWallets.subOrgId, filter));
+    return rows.map((r) => r.subOrgId);
+  }
+  const rows = await db
+    .select({ subOrgId: agenticWallets.subOrgId })
+    .from(agenticWallets);
+  return rows.map((r) => r.subOrgId);
+}
+
+async function reconcileOne(args: {
+  subOrgId: string;
+  dryRun: boolean;
+}): Promise<void> {
+  const { subOrgId, dryRun } = args;
+  if (dryRun) {
+    process.stdout.write(`[dry-run] would reconcile ${subOrgId}\n`);
+    return;
+  }
+  const client = getTurnkeyClientForOrg(subOrgId).apiClient();
+  const result = await reconcileBaselinePolicies({ client, subOrgId });
+  for (const action of result.actions) {
+    if (action.action === "noop") {
+      process.stdout.write(`  ${subOrgId}: noop ${action.policyName}\n`);
+    } else if (action.action === "create") {
+      process.stdout.write(
+        `  ${subOrgId}: create ${action.policyName} -> ${action.policyId}\n`,
+      );
+    } else {
+      process.stdout.write(
+        `  ${subOrgId}: replace ${action.policyName} ${action.oldPolicyId} -> ${action.newPolicyId}\n`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const targets = await getTargetSubOrgs(args.subOrgId);
+  if (targets.length === 0) {
+    process.stdout.write("No matching sub-orgs found\n");
+    return;
+  }
+  process.stdout.write(
+    `Reconciling ${targets.length} sub-org(s)${args.dryRun ? " (dry-run)" : ""}\n`,
+  );
+  for (const subOrgId of targets) {
+    try {
+      await reconcileOne({ subOrgId, dryRun: args.dryRun });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`  ${subOrgId}: FAILED ${message}\n`);
+    }
+  }
+  process.stdout.write("Done\n");
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `Fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/tests/unit/agentic-wallet-erc-8004.test.ts
+++ b/tests/unit/agentic-wallet-erc-8004.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for lib/agentic-wallet/erc-8004.ts.
+ *
+ * The two critical invariants we lock here:
+ *
+ *   1. The giveFeedback() calldata begins with selector 0x3c036a7e (validated
+ *      against ethers + viem at write time). A regression in the ABI literal
+ *      would silently break the on-chain commitment.
+ *
+ *   2. The canonical feedbackURI JSON is byte-stable: the same input must
+ *      produce the same UTF-8 string regardless of insertion order, and
+ *      `hashFeedbackContent` must equal `keccak256(canonicaliseFeedbackContent
+ *      (...))`. This is what allows the on-chain `feedbackHash` to verify
+ *      against the JSON served at /api/feedback/[id] later.
+ */
+import { describe, expect, it } from "vitest";
+import { keccak256, stringToBytes } from "viem";
+import {
+  buildFeedbackUriContent,
+  buildGiveFeedbackCalldata,
+  canonicaliseFeedbackContent,
+  type FeedbackUriContent,
+  hashFeedbackContent,
+} from "@/lib/agentic-wallet/erc-8004";
+
+describe("buildGiveFeedbackCalldata", () => {
+  it("encodes with selector 0x3c036a7e", () => {
+    const calldata = buildGiveFeedbackCalldata({
+      agentId: BigInt(31875),
+      value: BigInt(5),
+      valueDecimals: 0,
+      feedbackURI: "https://app.keeperhub.com/api/feedback/test123",
+      feedbackHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+    });
+    expect(calldata.startsWith("0x3c036a7e")).toBe(true);
+  });
+
+  it("defaults tag1, tag2, endpoint to empty strings when omitted", () => {
+    const a = buildGiveFeedbackCalldata({
+      agentId: BigInt(1),
+      value: BigInt(1),
+      valueDecimals: 0,
+      feedbackURI: "u",
+      feedbackHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    const b = buildGiveFeedbackCalldata({
+      agentId: BigInt(1),
+      value: BigInt(1),
+      valueDecimals: 0,
+      tag1: "",
+      tag2: "",
+      endpoint: "",
+      feedbackURI: "u",
+      feedbackHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("produces different calldata for different agentIds", () => {
+    const a = buildGiveFeedbackCalldata({
+      agentId: BigInt(1),
+      value: BigInt(5),
+      valueDecimals: 0,
+      feedbackURI: "u",
+      feedbackHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    const b = buildGiveFeedbackCalldata({
+      agentId: BigInt(2),
+      value: BigInt(5),
+      valueDecimals: 0,
+      feedbackURI: "u",
+      feedbackHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildFeedbackUriContent", () => {
+  const fixedDate = new Date("2026-05-07T01:23:45.000Z");
+  const args = {
+    agentChainId: 1,
+    agentId: BigInt(31875),
+    clientAddress: "0x8d56386b7beb7904072705def7d818aaa29c5421" as const,
+    createdAt: fixedDate,
+    value: BigInt(5),
+    valueDecimals: 0,
+  };
+
+  it("emits required fields with stringified bigint values", () => {
+    const out = buildFeedbackUriContent(args);
+    expect(out.agentRegistry).toBe("erc-8004");
+    expect(out.agentId).toBe("31875");
+    expect(out.value).toBe("5");
+    expect(out.createdAt).toBe(fixedDate.toISOString());
+    expect(out.clientAddress).toBe(args.clientAddress);
+  });
+
+  it("omits comment when not provided", () => {
+    const out = buildFeedbackUriContent(args);
+    expect(out.comment).toBeUndefined();
+  });
+
+  it("includes mcp block only when both workflowSlug and executionId are provided", () => {
+    const withMcp = buildFeedbackUriContent({
+      ...args,
+      workflowSlug: "usdc-yield-rates",
+      executionId: "exec-1",
+    });
+    expect(withMcp.mcp).toEqual({
+      workflowSlug: "usdc-yield-rates",
+      executionId: "exec-1",
+    });
+
+    const withoutSlug = buildFeedbackUriContent({
+      ...args,
+      executionId: "exec-1",
+    });
+    expect(withoutSlug.mcp).toBeUndefined();
+  });
+});
+
+describe("canonicaliseFeedbackContent", () => {
+  const base: FeedbackUriContent = {
+    agentRegistry: "erc-8004",
+    agentChainId: 1,
+    agentId: "31875",
+    clientAddress: "0x8d56386b7beb7904072705def7d818aaa29c5421",
+    createdAt: "2026-05-07T01:23:45.000Z",
+    value: "5",
+    valueDecimals: 0,
+  };
+
+  it("produces a deterministic byte string for the required-only shape", () => {
+    const a = canonicaliseFeedbackContent(base);
+    const b = canonicaliseFeedbackContent({ ...base });
+    expect(a).toBe(b);
+    // Required keys appear in spec order.
+    expect(a.indexOf("agentRegistry")).toBeLessThan(a.indexOf("agentChainId"));
+    expect(a.indexOf("agentChainId")).toBeLessThan(a.indexOf("agentId"));
+    expect(a.indexOf("agentId")).toBeLessThan(a.indexOf("clientAddress"));
+    expect(a.indexOf("clientAddress")).toBeLessThan(a.indexOf("createdAt"));
+    expect(a.indexOf("createdAt")).toBeLessThan(a.indexOf("value"));
+    expect(a.indexOf("value")).toBeLessThan(a.indexOf("valueDecimals"));
+  });
+
+  it("appends comment after required keys when present", () => {
+    const out = canonicaliseFeedbackContent({ ...base, comment: "great" });
+    expect(out.indexOf("valueDecimals")).toBeLessThan(out.indexOf("comment"));
+  });
+
+  it("appends mcp last when present", () => {
+    const out = canonicaliseFeedbackContent({
+      ...base,
+      comment: "great",
+      mcp: { workflowSlug: "wf", executionId: "ex" },
+    });
+    expect(out.indexOf("comment")).toBeLessThan(out.indexOf("mcp"));
+  });
+});
+
+describe("hashFeedbackContent", () => {
+  it("matches keccak256(canonicaliseFeedbackContent(content))", () => {
+    const content: FeedbackUriContent = {
+      agentRegistry: "erc-8004",
+      agentChainId: 1,
+      agentId: "31875",
+      clientAddress: "0x8d56386b7beb7904072705def7d818aaa29c5421",
+      createdAt: "2026-05-07T01:23:45.000Z",
+      value: "5",
+      valueDecimals: 0,
+    };
+    const expected = keccak256(stringToBytes(canonicaliseFeedbackContent(content)));
+    expect(hashFeedbackContent(content)).toBe(expected);
+  });
+
+  it("is sensitive to value changes", () => {
+    const a: FeedbackUriContent = {
+      agentRegistry: "erc-8004",
+      agentChainId: 1,
+      agentId: "31875",
+      clientAddress: "0x8d56386b7beb7904072705def7d818aaa29c5421",
+      createdAt: "2026-05-07T01:23:45.000Z",
+      value: "5",
+      valueDecimals: 0,
+    };
+    const b: FeedbackUriContent = { ...a, value: "4" };
+    expect(hashFeedbackContent(a)).not.toBe(hashFeedbackContent(b));
+  });
+});

--- a/tests/unit/agentic-wallet-policy-migration.test.ts
+++ b/tests/unit/agentic-wallet-policy-migration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for lib/agentic-wallet/policy-migration.ts.
+ *
+ * The reconcile function is the only safe path to upgrade an existing
+ * sub-org's policy set when BASELINE_POLICIES changes (e.g. ERC-8004
+ * additions). It must:
+ *
+ *   1. Be idempotent: re-running on an up-to-date sub-org produces only
+ *      "noop" actions and zero create/delete calls.
+ *   2. Detect drift on the `condition` field and reissue (Turnkey policies
+ *      are immutable in their condition).
+ *   3. Create-then-delete on replace, never delete-then-create — avoiding
+ *      a coverage gap between calls.
+ *   4. Skip the notes field when comparing — cosmetic edits should not
+ *      trigger destructive round-trips.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { BASELINE_POLICIES } from "@/lib/agentic-wallet/policy";
+import { reconcileBaselinePolicies } from "@/lib/agentic-wallet/policy-migration";
+
+type ListedPolicy = {
+  policyId: string;
+  policyName: string;
+  effect: string;
+  condition: string;
+  notes?: string;
+};
+
+type StubClient = {
+  getPolicies: ReturnType<typeof vi.fn>;
+  createPolicy: ReturnType<typeof vi.fn>;
+  deletePolicy: ReturnType<typeof vi.fn>;
+};
+
+function buildClient(initialPolicies: ListedPolicy[]): StubClient {
+  let counter = 1;
+  const policies = [...initialPolicies];
+  const client: StubClient = {
+    getPolicies: vi.fn(async () => ({ policies })),
+    createPolicy: vi.fn(async (input: { policyName: string }) => {
+      const newId = `policy-${counter++}`;
+      policies.push({
+        policyId: newId,
+        policyName: input.policyName,
+        effect: "EFFECT_DENY",
+        condition: "stub",
+      });
+      return { activity: { id: "a", status: "COMPLETED" }, policyId: newId };
+    }),
+    deletePolicy: vi.fn(async () => undefined),
+  };
+  return client;
+}
+
+function buildClientWithExactBaseline(): StubClient {
+  const initial: ListedPolicy[] = BASELINE_POLICIES.map((p, i) => ({
+    policyId: `existing-${i}`,
+    policyName: p.policyName,
+    effect: p.effect,
+    condition: p.condition,
+  }));
+  return buildClient(initial);
+}
+
+describe("reconcileBaselinePolicies", () => {
+  it("returns noop for every baseline when sub-org is up-to-date", async () => {
+    const client = buildClientWithExactBaseline();
+    const result = await reconcileBaselinePolicies({
+      // biome-ignore lint/suspicious/noExplicitAny: stub matches Turnkey ApiClient surface for the methods used
+      client: client as any,
+      subOrgId: "sub-1",
+    });
+    expect(result.subOrgId).toBe("sub-1");
+    expect(result.actions.length).toBe(BASELINE_POLICIES.length);
+    expect(result.actions.every((a) => a.action === "noop")).toBe(true);
+    expect(client.createPolicy).not.toHaveBeenCalled();
+    expect(client.deletePolicy).not.toHaveBeenCalled();
+  });
+
+  it("creates missing policies (empty starting state)", async () => {
+    const client = buildClient([]);
+    const result = await reconcileBaselinePolicies({
+      // biome-ignore lint/suspicious/noExplicitAny: stub matches Turnkey ApiClient surface for the methods used
+      client: client as any,
+      subOrgId: "sub-1",
+    });
+    expect(result.actions.every((a) => a.action === "create")).toBe(true);
+    expect(client.createPolicy).toHaveBeenCalledTimes(BASELINE_POLICIES.length);
+    expect(client.deletePolicy).not.toHaveBeenCalled();
+  });
+
+  it("replaces stale policies (condition drift) with create-before-delete order", async () => {
+    // Seed with one stale policy and the rest fresh.
+    const stalePolicyName = "allowlist-outbound-contracts";
+    const initial: ListedPolicy[] = BASELINE_POLICIES.map((p, i) => ({
+      policyId: `existing-${i}`,
+      policyName: p.policyName,
+      effect: p.effect,
+      condition:
+        p.policyName === stalePolicyName ? "OUTDATED_CONDITION" : p.condition,
+    }));
+    const client = buildClient(initial);
+    const result = await reconcileBaselinePolicies({
+      // biome-ignore lint/suspicious/noExplicitAny: stub matches Turnkey ApiClient surface for the methods used
+      client: client as any,
+      subOrgId: "sub-1",
+    });
+
+    const replaceActions = result.actions.filter(
+      (a) => a.action === "replace"
+    );
+    expect(replaceActions.length).toBe(1);
+    expect(replaceActions[0]?.policyName).toBe(stalePolicyName);
+
+    expect(client.createPolicy).toHaveBeenCalledTimes(1);
+    expect(client.deletePolicy).toHaveBeenCalledTimes(1);
+
+    // Order: create must happen BEFORE delete in invocation history so the
+    // sub-org never has zero coverage of this policy slot. We sort by call
+    // index via mock invocationCallOrder.
+    const createOrder = client.createPolicy.mock.invocationCallOrder[0];
+    const deleteOrder = client.deletePolicy.mock.invocationCallOrder[0];
+    expect(createOrder).toBeDefined();
+    expect(deleteOrder).toBeDefined();
+    if (createOrder !== undefined && deleteOrder !== undefined) {
+      expect(createOrder).toBeLessThan(deleteOrder);
+    }
+  });
+
+  it("does not reissue on notes-only drift", async () => {
+    // Seed with all baseline conditions correct but notes mutated.
+    const initial: ListedPolicy[] = BASELINE_POLICIES.map((p, i) => ({
+      policyId: `existing-${i}`,
+      policyName: p.policyName,
+      effect: p.effect,
+      condition: p.condition,
+      notes: "stale notes -- should not trigger replacement",
+    }));
+    const client = buildClient(initial);
+    const result = await reconcileBaselinePolicies({
+      // biome-ignore lint/suspicious/noExplicitAny: stub matches Turnkey ApiClient surface for the methods used
+      client: client as any,
+      subOrgId: "sub-1",
+    });
+    expect(result.actions.every((a) => a.action === "noop")).toBe(true);
+    expect(client.createPolicy).not.toHaveBeenCalled();
+    expect(client.deletePolicy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/agentic-wallet-policy.test.ts
+++ b/tests/unit/agentic-wallet-policy.test.ts
@@ -20,8 +20,11 @@ import {
 } from "@/lib/agentic-wallet/policy";
 
 describe("BASELINE_POLICIES", () => {
-  it("contains exactly 6 entries (3 eth.tx.* + 3 eth.eip_712.* per Phase 37)", () => {
-    expect(BASELINE_POLICIES.length).toBe(6);
+  it("contains exactly 8 entries (5 eth.tx.* + 3 eth.eip_712.*)", () => {
+    // 3 original eth.tx.* policies (block-erc20-approve, block-erc20-transfer,
+    // allowlist-outbound) + 2 new ERC-8004 eth.tx.* policies (chain-binding,
+    // selector) + 3 original eth.eip_712.* policies = 8.
+    expect(BASELINE_POLICIES.length).toBe(8);
   });
 
   it("entry 0 blocks ERC-20 approvals over 100 USDC (selector 0x095ea7b3)", () => {
@@ -150,7 +153,10 @@ describe("applyBaselinePolicies (HI-04)", () => {
       async (_input: PolicyCreateInput): Promise<PolicyCreateResult> => {
         counter += 1;
         return {
-          activity: { id: `act_${counter}`, status: "ACTIVITY_STATUS_COMPLETED" },
+          activity: {
+            id: `act_${counter}`,
+            status: "ACTIVITY_STATUS_COMPLETED",
+          },
           policyId: `policy_${counter}`,
         };
       }
@@ -253,7 +259,10 @@ describe("applyBaselinePolicies (HI-04)", () => {
       async (_input: PolicyCreateInput): Promise<PolicyCreateResult> => {
         counter += 1;
         return {
-          activity: { id: `act_${counter}`, status: "ACTIVITY_STATUS_COMPLETED" },
+          activity: {
+            id: `act_${counter}`,
+            status: "ACTIVITY_STATUS_COMPLETED",
+          },
           policyId: `policy_${counter}`,
         };
       }
@@ -280,8 +289,8 @@ describe("applyBaselinePolicies (HI-04)", () => {
 });
 
 describe("BASELINE_POLICIES — EIP-712 coverage (Phase 37)", () => {
-  it("contains 6 entries (3 eth.tx.* + 3 eth.eip_712.*)", () => {
-    expect(BASELINE_POLICIES.length).toBe(6);
+  it("contains 8 entries (5 eth.tx.* + 3 eth.eip_712.*)", () => {
+    expect(BASELINE_POLICIES.length).toBe(8);
   });
 
   it("block-erc20-unlimited-approve threshold is > 100 USDC, not 2^32", () => {
@@ -326,5 +335,68 @@ describe("BASELINE_POLICIES — EIP-712 coverage (Phase 37)", () => {
     expect(p?.condition).toContain("8453");
     expect(p?.condition).toContain("4217");
     expect(p?.condition).toContain("4218");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ERC-8004 (2026-05): the outbound contract allowlist now includes the
+// ReputationRegistry on Ethereum mainnet for giveFeedback() calls. Two new
+// policies bind contracts to chains and restrict ReputationRegistry to a
+// single function selector.
+// ---------------------------------------------------------------------------
+
+const ERC_8004_REPUTATION_REGISTRY_LC =
+  "0x8004baa17c55a88189ae136b182e5fda19de9b63";
+const GIVE_FEEDBACK_SELECTOR = "0x3c036a7e";
+
+describe("BASELINE_POLICIES — ERC-8004 coverage", () => {
+  it("allowlist-outbound-contracts includes the ReputationRegistry", () => {
+    const p = BASELINE_POLICIES.find(
+      (x) => x.policyName === "allowlist-outbound-contracts"
+    );
+    expect(p).toBeDefined();
+    expect(p?.condition.toLowerCase()).toContain(
+      ERC_8004_REPUTATION_REGISTRY_LC
+    );
+  });
+
+  it("includes allowlist-tx-chain-binding gating signTransaction", () => {
+    const p = BASELINE_POLICIES.find(
+      (x) => x.policyName === "allowlist-tx-chain-binding"
+    );
+    expect(p).toBeDefined();
+    expect(p?.condition).toContain("ACTIVITY_TYPE_SIGN_TRANSACTION_V2");
+    // Each contract bound to its native chain id.
+    expect(p?.condition).toContain("8453"); // Base mainnet for USDC_BASE
+    expect(p?.condition).toContain("4217"); // Tempo mainnet for USDC_TEMPO
+    expect(p?.condition).toContain("4218"); // Tempo testnet for USDC_TEMPO
+    // Ethereum mainnet (chain id 1) for the ReputationRegistry.
+    expect(p?.condition).toContain("eth.tx.chain_id == 1");
+    expect(p?.condition.toLowerCase()).toContain(
+      ERC_8004_REPUTATION_REGISTRY_LC
+    );
+    expect(p?.effect).toBe("EFFECT_DENY");
+  });
+
+  it("includes allowlist-erc8004-selector restricting to giveFeedback()", () => {
+    const p = BASELINE_POLICIES.find(
+      (x) => x.policyName === "allowlist-erc8004-selector"
+    );
+    expect(p).toBeDefined();
+    expect(p?.condition.toLowerCase()).toContain(
+      ERC_8004_REPUTATION_REGISTRY_LC
+    );
+    expect(p?.condition).toContain(GIVE_FEEDBACK_SELECTOR);
+    // Inverted match: the policy DENIES if function_signature != giveFeedback.
+    expect(p?.condition).toContain("function_signature !=");
+    expect(p?.effect).toBe("EFFECT_DENY");
+  });
+});
+
+describe("FACILITATOR_ALLOWLIST — ERC-8004", () => {
+  it("includes the ReputationRegistry contract", () => {
+    expect(
+      FACILITATOR_ALLOWLIST.map((a) => a.toLowerCase())
+    ).toContain(ERC_8004_REPUTATION_REGISTRY_LC);
   });
 });

--- a/tests/unit/execution-wait.test.ts
+++ b/tests/unit/execution-wait.test.ts
@@ -225,6 +225,22 @@ describe("buildCallCompletionResponse (KEEP-265)", () => {
       executionId: "exec-success",
       status: "success",
       output: { balance: "1.3286 ETH" },
+      // ERC-8004 feedback CTA appended to every successful response so the
+      // calling LLM can prompt the user to rate the workflow. Hardcoded to
+      // KeeperHub's own ERC-8004 agent (NFT 31875 on Ethereum mainnet).
+      feedback: {
+        prompt: expect.stringContaining("ERC-8004"),
+        tool: "keeperhub-wallet:submit_feedback",
+        context: {
+          executionId: "exec-success",
+          agent: {
+            registry: "erc-8004",
+            chainId: 1,
+            id: "31875",
+            explorerUrl: "https://8004scan.io/agents/ethereum/31875",
+          },
+        },
+      },
     });
   });
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -28,6 +28,11 @@ export default defineConfig({
       // imports from ../../block-dispatcher/* which only resolves when
       // run from within keeperhub-scheduler/).
       "keeperhub-scheduler/**",
+      // .planning/ contains hackathon archives with frozen forks of the
+      // codebase + their stale test snapshots. Including them in vitest
+      // means any change to a baseline (like BASELINE_POLICIES) breaks
+      // archived test files that no longer match the live source.
+      ".planning/**",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- 8004scan ranks ERC-8004 agents primarily by reputation events. KeeperHub had no path for users to leave on-chain feedback after a paid workflow execution, which was capping our agent score at the services component (~30/100). This PR closes the loop so a successful workflow can prompt the calling LLM to invoke a single MCP tool that signs and broadcasts `giveFeedback()` through the user's Turnkey-backed wallet.
- Three new Turnkey baseline policies widen the wallet's signing surface narrowly: ReputationRegistry on Ethereum mainnet only, `giveFeedback()` selector only, with each allowed contract bound to its native chain id (USDC<->Base/Tempo, ReputationRegistry<->Ethereum). Defense in depth means a stolen HMAC still cannot sign anything else.
- Existing wallets are reconciled via a separate operator script (`scripts/upgrade-agentic-wallet-policies.ts`) without re-provisioning -- caller paths preserved.
- User wallet pays gas natively today (~\$3-10 USD per feedback). Gas sponsorship via Pimlico (existing infra) or Turnkey native is documented as a follow-up.

## Components

- New routes: `/api/agentic-wallet/feedback` (HMAC orchestrator) + `/api/feedback/[id]` (canonical URI host)
- New helpers: `erc-8004.ts` (calldata + canonicaliser + hash), `sign-eth-tx.ts` (Turnkey signTransaction + viem broadcast), `policy-migration.ts` (idempotent baseline reconcile)
- New `feedback` table + migration `0069_add_feedback_table.sql`
- Workflow execution responses (`buildCallCompletionResponse`) now carry a `feedback` CTA pointing at the MCP tool

## Test plan

- [x] `pnpm type-check` clean
- [x] `npx biome check` clean on all touched files
- [x] `pnpm vitest run --dir tests/unit tests/unit/agentic-wallet-policy.test.ts tests/unit/agentic-wallet-policy-migration.test.ts tests/unit/agentic-wallet-erc-8004.test.ts` -- 37/37 passing
- [ ] Apply DB migration on staging: `pnpm db:migrate`
- [ ] Apply Turnkey policy migration to test sub-org: `pnpm tsx scripts/upgrade-agentic-wallet-policies.ts --sub-org=<id> --dry-run` then real
- [ ] Build + locally link the `@keeperhub/wallet` companion package (separate repo at `KeeperHub/agentic-wallet`)
- [ ] Fund the test wallet with ~\$10 ETH on Ethereum mainnet (separate funding source from the agent owner address to keep sybil graph clean)
- [ ] Manual E2E: call a listed workflow via `call_workflow`, then use `submit_feedback` with the returned executionId, verify on-chain tx via Etherscan, wait for 8004scan re-index

## Notes for reviewers

- The Turnkey policy diff is the riskiest piece. `tests/unit/agentic-wallet-policy.test.ts` pins selector `0x3c036a7e`, the chain-binding clauses for each allowed contract, and the ReputationRegistry membership in the outbound allowlist.
- The companion MCP tool (`submit_feedback` in `@keeperhub/wallet`) is in a separate repo; its npm publish is gated on this PR landing so the tool's URL points at the deployed `/api/agentic-wallet/feedback` endpoint.
- `vitest.config.mts` adds `.planning/**` to `exclude` to stop archived hackathon clones from breaking when baselines move.

Replaces #1159 (which was opened against a stale branch with merge conflicts).