### PR TITLE
docs: correct HEALTH_PORT defaults in keeperhub-scheduler

### DIFF
--- a/keeperhub-scheduler/README.md
+++ b/keeperhub-scheduler/README.md
@@ -80,7 +80,7 @@ Polls SQS for workflow triggers and executes them.
 | `KEEPERHUB_API_KEY` | Internal service API key | All |
 | `AWS_REGION` | AWS region | All |
 | `SQS_QUEUE_URL` | SQS queue URL for workflow triggers | All |
-| `HEALTH_PORT` | HTTP health check port (default: 3000) | All |
+| `HEALTH_PORT` | HTTP health check port (defaults: 3060 schedule-dispatcher, 3050 block-dispatcher) | All |
 | `RECONCILE_INTERVAL_MS` | How often to refetch block workflows (default: 30000) | Block Dispatcher |
 | `AWS_ENDPOINT_URL` | LocalStack endpoint (local dev only) | All |
 

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -14,7 +14,7 @@
  *   SQS_QUEUE_URL          - SQS queue URL
  *   AWS_REGION             - AWS region
  *   AWS_ENDPOINT_URL       - LocalStack endpoint (local dev only)
- *   HEALTH_PORT            - Health check server port (default: 3000)
+ *   HEALTH_PORT            - Health check server port (default: 3050)
  */
 
 import express from "express";


### PR DESCRIPTION
## Summary

The `keeperhub-scheduler/README.md` env-vars table and the JSDoc header in `block-dispatcher/index.ts` claim `HEALTH_PORT` defaults to `3000`. The actual code defaults are:

- `schedule-dispatcher/index.ts` — `3060`
- `block-dispatcher/index.ts` — `3050`

Port `3000` is the local KeeperHub API; running a dispatcher with the documented default would collide with it. The non-3000 ports in the source are intentional.

The `schedule-dispatcher` JSDoc was already corrected upstream. This PR finishes the fix:

- README table entry now lists both real defaults
- `block-dispatcher` JSDoc updated to `3050`

Docs-only, no runtime change.

## Test plan

- [x] CI lint/type-check passes (no code changes)
- [x] README renders correctly in GitHub view