### PR TITLE
fix(scheduler): trigger schedules whose cron lands exactly on the dispatch tick

### DIFF
--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -56,8 +56,13 @@ export function shouldTriggerNow(
   now: Date,
 ): boolean {
   try {
+    // cron-parser's prev() is strict — at exactly 09:00:00.000 with cron
+    // `0 9 * * *`, prev() returns yesterday's 9am rather than today's, so
+    // a dispatch tick that happens to land on a minute boundary skips the
+    // schedule. Bump currentDate by 1ms so an occurrence at exactly `now`
+    // is treated as in the past.
     const interval = CronExpressionParser.parse(cronExpression, {
-      currentDate: now,
+      currentDate: new Date(now.getTime() + 1),
       tz: timezone,
     });
 

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -72,6 +72,22 @@ describe("shouldTriggerNow", () => {
     expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(true);
   });
 
+  it("triggers at the exact occurrence boundary (now == cron firing time)", () => {
+    // Regression: cron-parser's prev() is strict, so without an epsilon
+    // on currentDate a tick landing at exactly 09:00:00.000 with cron
+    // "0 9 * * *" returns yesterday's 9am and the schedule is skipped.
+    const now = new Date("2024-01-15T09:00:00.000Z");
+    expect(shouldTriggerNow("0 9 * * *", "UTC", now)).toBe(true);
+  });
+
+  it("triggers at the exact minute boundary for an every-minute cron", () => {
+    // Same boundary case as above but for "* * * * *" -- the dispatcher's
+    // 60s setInterval can land on minute boundaries depending on startup
+    // alignment. Without the epsilon, every such tick was missed.
+    const now = new Date("2024-01-15T09:01:00.000Z");
+    expect(shouldTriggerNow("* * * * *", "UTC", now)).toBe(true);
+  });
+
   it("returns false at 60 seconds (window is exclusive)", () => {
     // At 9:01:00, diff from 9:00:00 is exactly 60_000ms -- not < 60_000.
     const now = new Date("2024-01-15T09:01:00Z");


### PR DESCRIPTION
## Summary

`shouldTriggerNow` in the schedule dispatcher passes `currentDate: now` to `cron-parser`, whose `prev()` is strictly less-than. At exactly `09:00:00.000` with cron `0 9 * * *`, `prev()` returns yesterday's 9am, the diff exceeds 60s, and the schedule is silently skipped. The same boundary issue was acknowledged in the pre-existing tests with comments like "prev() returns 9:00:00 which is 1 second ago" — they used `09:00:01Z` to dodge the bug rather than fix it.

In production this is rare but real: the dispatcher's `setInterval(..., 60_000)` runs at process-startup time + N\*60s. If startup happens to land on a minute boundary, every subsequent tick lands on a minute boundary and every `* * * * *` fire is missed.

## Fix

Bump the `currentDate` passed to the parser by 1ms so an occurrence at exactly `now` is treated as in the past. The `now - prev` window arithmetic is unchanged, so existing window-edge behavior (e.g. the 60-second exclusive boundary) is preserved.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec vitest run tests/unit/schedule-dispatcher.test.ts` -> 29/29 passing (27 existing + 2 new)
- [x] New regression tests cover both `0 9 * * *` at `09:00:00.000` and `* * * * *` at a minute boundary
- [x] Pre-existing "returns false at 60 seconds (window is exclusive)" still passes — the `now` value used for the diff calc is unchanged