### PR TITLE
fix: ERC-8004 policy reconcile + rename feedback tool

### DIFF
--- a/lib/agentic-wallet/policy-migration.ts
+++ b/lib/agentic-wallet/policy-migration.ts
@@ -109,14 +109,16 @@ export async function reconcileBaselinePolicies(args: {
       actions.push({ action: "noop", policyName: baseline.policyName });
       continue;
     }
-    // Replace (delete + create). Order matters: create FIRST so we never
-    // leave the sub-org without coverage between calls. If create succeeds
-    // but delete fails, we have a duplicate policy under the same name --
-    // Turnkey's listPolicies will surface both, and a re-run picks the
-    // first match arbitrarily. To avoid that pile-up, delete first ONLY
-    // when the create-first path is impossible (it isn't here -- Turnkey
-    // permits multiple policies with the same name, so create-first is
-    // safe). Net: brief duplicate, never a gap.
+    // Replace (delete + create). Turnkey rejects duplicate policy names
+    // ("policy label must be unique") on the v1 createPolicy API, so we
+    // CANNOT create-before-delete. We accept a brief coverage gap between
+    // delete and create. If create fails after delete succeeds, the caller
+    // MUST retry -- the throw propagates out of this function so the
+    // operator script surfaces it.
+    await client.deletePolicy({
+      organizationId: subOrgId,
+      policyId: existing.policyId,
+    });
     const created = (await client.createPolicy({
       organizationId: subOrgId,
       policyName: baseline.policyName,
@@ -125,10 +127,6 @@ export async function reconcileBaselinePolicies(args: {
       consensus: "true",
       notes: baseline.notes,
     })) as unknown as { policyId?: string };
-    await client.deletePolicy({
-      organizationId: subOrgId,
-      policyId: existing.policyId,
-    });
     actions.push({
       action: "replace",
       policyName: baseline.policyName,

--- a/lib/payments/x402/execution-wait.ts
+++ b/lib/payments/x402/execution-wait.ts
@@ -109,7 +109,7 @@ export async function applyOutputMapping(
 
 // ERC-8004 feedback CTA appended to every successful workflow execution
 // response. The calling agent (LLM) reads this and can prompt the user to
-// rate the workflow, then invoke the keeperhub-wallet `submit_feedback`
+// rate the workflow, then invoke the keeperhub-wallet `feedback`
 // MCP tool to submit on-chain feedback to the ERC-8004 ReputationRegistry.
 //
 // Hardcoded to the canonical KeeperHub agent on Ethereum mainnet (NFT 31875).
@@ -132,8 +132,8 @@ export type FeedbackCta = {
 
 const KEEPERHUB_FEEDBACK_CTA: Omit<FeedbackCta, "context"> = {
   prompt:
-    "Was this workflow useful? Rate it (1-5) on the ERC-8004 ReputationRegistry — your wallet signs and submits on-chain in one call. Use the keeperhub-wallet `submit_feedback` tool with this executionId.",
-  tool: "keeperhub-wallet:submit_feedback",
+    "Was this workflow useful? Rate it (1-5) on the ERC-8004 ReputationRegistry — your wallet signs and submits on-chain in one call. Use the keeperhub-wallet `feedback` tool with this executionId.",
+  tool: "keeperhub-wallet:feedback",
 };
 
 function buildFeedbackCta(executionId: string): FeedbackCta {

--- a/tests/unit/agentic-wallet-policy-migration.test.ts
+++ b/tests/unit/agentic-wallet-policy-migration.test.ts
@@ -115,15 +115,16 @@ describe("reconcileBaselinePolicies", () => {
     expect(client.createPolicy).toHaveBeenCalledTimes(1);
     expect(client.deletePolicy).toHaveBeenCalledTimes(1);
 
-    // Order: create must happen BEFORE delete in invocation history so the
-    // sub-org never has zero coverage of this policy slot. We sort by call
-    // index via mock invocationCallOrder.
+    // Order: delete must happen BEFORE create -- Turnkey rejects duplicate
+    // policy names ("policy label must be unique"), so we cannot
+    // create-before-delete. We accept a brief coverage gap and the
+    // operator-side retry contract.
     const createOrder = client.createPolicy.mock.invocationCallOrder[0];
     const deleteOrder = client.deletePolicy.mock.invocationCallOrder[0];
     expect(createOrder).toBeDefined();
     expect(deleteOrder).toBeDefined();
     if (createOrder !== undefined && deleteOrder !== undefined) {
-      expect(createOrder).toBeLessThan(deleteOrder);
+      expect(deleteOrder).toBeLessThan(createOrder);
     }
   });
 

--- a/tests/unit/execution-wait.test.ts
+++ b/tests/unit/execution-wait.test.ts
@@ -230,7 +230,7 @@ describe("buildCallCompletionResponse (KEEP-265)", () => {
       // KeeperHub's own ERC-8004 agent (NFT 31875 on Ethereum mainnet).
       feedback: {
         prompt: expect.stringContaining("ERC-8004"),
-        tool: "keeperhub-wallet:submit_feedback",
+        tool: "keeperhub-wallet:feedback",
         context: {
           executionId: "exec-success",
           agent: {


### PR DESCRIPTION
## Summary

- The Turnkey baseline policy reconcile (lib/agentic-wallet/policy-migration.ts) hit a real failure during the live E2E migration: Turnkey rejects creating a 2nd policy with the same name on the v1 createPolicy API. My original create-before-delete strategy assumed Turnkey would tolerate transient duplicates -- it doesn't. Flipped to delete-then-create. There's now a brief coverage gap between the two calls; the operator script surfaces a hard error if create fails so it's never silent.
- Renamed the wallet-side tool/command from \`submit_feedback\` to \`feedback\` for a shorter MCP/CLI surface. The execution-wait CTA in workflow responses now references \`keeperhub-wallet:feedback\`. Companion rename in the agentic-wallet npm package is a separate PR.

## Validation

The fix has already been validated end-to-end:
- Migration ran successfully against the live test wallet sub-org \`bd212786-d5ca-4097-9122-98719513c711\` (8 policies post-migration, 1 replaced + 2 created)
- giveFeedback() tx [\`0xd8391d...3e92\`](https://etherscan.io/tx/0xd8391dcc4d74283533e344f2428f25bfd2b7ed4170d2ffb2df4681770bc13e92) confirmed on Ethereum mainnet (block 25041073, status 0x1, gas 171813)
- 8004scan picked up the feedback (per visual confirmation on the agent page)

## Test plan

- [x] \`pnpm type-check\` clean
- [x] \`pnpm vitest run --dir tests/unit tests/unit/execution-wait.test.ts tests/unit/agentic-wallet-policy-migration.test.ts\` -- the policy-migration test now asserts delete-before-create order; the execution-wait test asserts the new tool name