### PR TITLE
fix: KEEP-456 route superfluid grant-flow-operator through CFAv1Forwarder

### DIFF
--- a/protocols/superfluid.ts
+++ b/protocols/superfluid.ts
@@ -104,6 +104,18 @@ const CFA_FORWARDER_ABI = JSON.stringify([
     ],
     outputs: [{ name: "flowRate", type: "int96" }],
   },
+  {
+    type: "function",
+    name: "updateFlowOperatorPermissions",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "flowOperator", type: "address" },
+      { name: "permissions", type: "uint8" },
+      { name: "flowRateAllowance", type: "int96" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
 ]);
 
 /**
@@ -223,17 +235,6 @@ const SUPER_TOKEN_ABI = JSON.stringify([
     stateMutability: "view",
     inputs: [],
     outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "updateFlowOperatorPermissions",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "flowOperator", type: "address" },
-      { name: "permissions", type: "uint8" },
-      { name: "flowRateAllowance", type: "int96" },
-    ],
-    outputs: [{ name: "", type: "bool" }],
   },
 ]);
 
@@ -560,9 +561,10 @@ export default defineProtocol({
       description:
         "Authorize another address to manage your flows of this SuperToken up to a wei/sec allowance",
       type: "write",
-      contract: "superToken",
+      contract: "cfaForwarder",
       function: "updateFlowOperatorPermissions",
       inputs: [
+        { name: "token", type: "address", label: "SuperToken Address" },
         {
           name: "flowOperator",
           type: "address",

--- a/protocols/superfluid.ts
+++ b/protocols/superfluid.ts
@@ -559,7 +559,7 @@ export default defineProtocol({
       slug: "grant-flow-operator",
       label: "Grant Flow-Operator Permissions",
       description:
-        "Authorize another address to manage your flows of this SuperToken up to a wei/sec allowance",
+        "Authorize another address to manage your flows of a SuperToken up to a wei/sec allowance",
       type: "write",
       contract: "cfaForwarder",
       function: "updateFlowOperatorPermissions",

--- a/tests/integration/fixtures/superfluid-workflows/grant-flow-operator.json
+++ b/tests/integration/fixtures/superfluid-workflows/grant-flow-operator.json
@@ -1,6 +1,6 @@
 {
   "name": "Superfluid grant-flow-operator demo (KEEP-415)",
-  "description": "On-chain write demo: grant a no-op flow-operator permission on fUSDCx. Exercises the full keeperhub -> Superfluid write pipeline.",
+  "description": "On-chain write demo: grant create-permission on fUSDCx via the CFAv1Forwarder. Exercises the full keeperhub -> Superfluid write pipeline.",
   "nodes": [
     {
       "id": "trigger-1",
@@ -24,19 +24,17 @@
         "config": {
           "actionType": "superfluid/grant-flow-operator",
           "network": "11155111",
-          "contractAddress": "0xb598E6C621618a9f63788816ffb50Ee2862D443B",
+          "token": "0xb598E6C621618a9f63788816ffb50Ee2862D443B",
           "flowOperator": "0x0000000000000000000000000000000000000001",
           "permissions": "1",
           "flowRateAllowance": "0",
           "integrationId": "t6xtd727ow2up79uy6v0y",
-          "_protocolMeta": "{\"protocolSlug\":\"superfluid\",\"contractKey\":\"superToken\",\"functionName\":\"updateFlowOperatorPermissions\",\"actionType\":\"write\"}"
+          "_protocolMeta": "{\"protocolSlug\":\"superfluid\",\"contractKey\":\"cfaForwarder\",\"functionName\":\"updateFlowOperatorPermissions\",\"actionType\":\"write\"}"
         },
         "status": "idle",
         "description": ""
       }
     }
   ],
-  "edges": [
-    { "id": "e1", "source": "trigger-1", "target": "step-1" }
-  ]
+  "edges": [{ "id": "e1", "source": "trigger-1", "target": "step-1" }]
 }

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -38,6 +38,9 @@ const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
 const CHAIN_ID = "11155111";
 const SEPOLIA_CHAIN_ID = 11_155_111;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
+// Distinct from TEST_ADDRESS: estimateGas runs with `from: TEST_ADDRESS`,
+// and Superfluid's CFA rejects sender == flowOperator (self-grant).
+const TEST_OPERATOR = "0x0000000000000000000000000000000000000002";
 
 // fUSDCx on Sepolia. The forwarders validate the token argument against the
 // Superfluid host registry and revert for unknown addresses, so reads need
@@ -343,7 +346,11 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     // "tolerate any revert" pattern hid a routing bug because the SuperToken's
     // proxy reverts on the Sepolia fUSDCx test token. The CFAv1Forwarder is
     // the canonical entry point and works for any registered SuperToken.
-    const TEST_OPERATOR = "0x0000000000000000000000000000000000000002";
+    //
+    // Note: this on-chain test is gated on INTEGRATION_TEST_RPC_URL and
+    // skipped in CI. The CI-side regression guard for the routing change
+    // lives in tests/unit/superfluid-protocol.test.ts ("grant-flow-operator
+    // action" describe block, asserting `contract === "cfaForwarder"`).
     const msg = await estimateGasError("grant-flow-operator", {
       token: SEPOLIA_FUSDCX,
       flowOperator: TEST_OPERATOR,

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -337,17 +337,20 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     expect(msg).not.toMatch(ENCODING_ERROR_RE);
   }, 15_000);
 
-  it("grant-flow-operator: encodes (address, uint8, int96) against superToken.updateFlowOperatorPermissions", async () => {
-    const msg = await estimateGasError(
-      "grant-flow-operator",
-      {
-        flowOperator: TEST_ADDRESS,
-        permissions: DUMMY_PERMISSIONS_ALL,
-        flowRateAllowance: DUMMY_FLOW_RATE,
-      },
-      SEPOLIA_FUSDCX
-    );
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+  it("grant-flow-operator: simulates successfully against cfaForwarder.updateFlowOperatorPermissions", async () => {
+    // KEEP-456: routed through the CFAv1Forwarder, not the SuperToken proxy.
+    // Asserts the call actually simulates (estimateGas returns) -- the previous
+    // "tolerate any revert" pattern hid a routing bug because the SuperToken's
+    // proxy reverts on the Sepolia fUSDCx test token. The CFAv1Forwarder is
+    // the canonical entry point and works for any registered SuperToken.
+    const TEST_OPERATOR = "0x0000000000000000000000000000000000000002";
+    const msg = await estimateGasError("grant-flow-operator", {
+      token: SEPOLIA_FUSDCX,
+      flowOperator: TEST_OPERATOR,
+      permissions: DUMMY_PERMISSIONS_ALL,
+      flowRateAllowance: DUMMY_FLOW_RATE,
+    });
+    expect(msg).toBe("");
   }, 15_000);
 
   // -- Coverage check ------------------------------------------------------

--- a/tests/unit/superfluid-protocol.test.ts
+++ b/tests/unit/superfluid-protocol.test.ts
@@ -44,7 +44,7 @@ describe("Superfluid protocol", () => {
       }
     });
 
-    it("ships an inline ABI containing the 5 expected functions", () => {
+    it("ships an inline ABI containing the 6 expected functions", () => {
       const contract = superfluidProtocol.contracts.cfaForwarder;
       expect(contract.abi).toBeTruthy();
       const abi = JSON.parse(contract.abi as string) as Array<{
@@ -62,6 +62,7 @@ describe("Superfluid protocol", () => {
           "getAccountFlowrate",
           "getFlowInfo",
           "updateFlow",
+          "updateFlowOperatorPermissions",
         ].sort()
       );
     });
@@ -367,7 +368,7 @@ describe("Superfluid protocol", () => {
       expect(contract.userSpecifiedAddress).toBe(true);
     });
 
-    it("ships an inline ABI with the 5 expected functions", () => {
+    it("ships an inline ABI with the 4 expected functions", () => {
       const contract = superfluidProtocol.contracts.superToken;
       const abi = JSON.parse(contract.abi as string) as Array<{
         type: string;
@@ -378,19 +379,13 @@ describe("Superfluid protocol", () => {
         .map((f) => f.name)
         .sort();
       expect(fnNames).toEqual(
-        [
-          "balanceOf",
-          "downgrade",
-          "getUnderlyingToken",
-          "updateFlowOperatorPermissions",
-          "upgrade",
-        ].sort()
+        ["balanceOf", "downgrade", "getUnderlyingToken", "upgrade"].sort()
       );
     });
   });
 
   describe("SuperToken actions", () => {
-    it("declares the five expected SuperToken action slugs", () => {
+    it("declares the four expected SuperToken action slugs", () => {
       const slugs = superfluidProtocol.actions
         .filter((a) => a.contract === "superToken")
         .map((a) => a.slug)
@@ -399,7 +394,6 @@ describe("Superfluid protocol", () => {
         [
           "get-super-token-balance",
           "get-underlying-token",
-          "grant-flow-operator",
           "unwrap",
           "wrap",
         ].sort()
@@ -419,16 +413,6 @@ describe("Superfluid protocol", () => {
       expect(action?.function).toBe("downgrade");
     });
 
-    it("grant-flow-operator includes the bitmap helpTip on permissions", () => {
-      const action = findAction("grant-flow-operator");
-      const perms = action?.inputs.find((i) => i.name === "permissions");
-      expect(perms?.type).toBe("uint8");
-      expect(perms?.helpTip).toContain("1");
-      expect(perms?.helpTip).toContain("2");
-      expect(perms?.helpTip).toContain("4");
-      expect(perms?.helpTip).toContain("7");
-    });
-
     it("get-super-token-balance returns balance with decimals: 18", () => {
       const action = findAction("get-super-token-balance");
       expect(action?.type).toBe("read");
@@ -440,6 +424,38 @@ describe("Superfluid protocol", () => {
       expect(action?.type).toBe("read");
       expect(action?.inputs).toEqual([]);
       expect(action?.outputs?.[0]?.type).toBe("address");
+    });
+  });
+
+  describe("grant-flow-operator action", () => {
+    // KEEP-456: routes through CFAv1Forwarder, not the SuperToken proxy.
+    // Test pins the routing so the bug can't regress silently.
+    it("is declared as a write action against cfaForwarder.updateFlowOperatorPermissions", () => {
+      const action = findAction("grant-flow-operator");
+      expect(action).toBeDefined();
+      expect(action?.type).toBe("write");
+      expect(action?.contract).toBe("cfaForwarder");
+      expect(action?.function).toBe("updateFlowOperatorPermissions");
+    });
+
+    it("takes token, flowOperator, permissions, flowRateAllowance in that order", () => {
+      const action = findAction("grant-flow-operator");
+      expect(action?.inputs.map((i) => i.name)).toEqual([
+        "token",
+        "flowOperator",
+        "permissions",
+        "flowRateAllowance",
+      ]);
+    });
+
+    it("includes the bitmap helpTip on permissions", () => {
+      const action = findAction("grant-flow-operator");
+      const perms = action?.inputs.find((i) => i.name === "permissions");
+      expect(perms?.type).toBe("uint8");
+      expect(perms?.helpTip).toContain("1");
+      expect(perms?.helpTip).toContain("2");
+      expect(perms?.helpTip).toContain("4");
+      expect(perms?.helpTip).toContain("7");
     });
   });
 


### PR DESCRIPTION
## Summary

Routes the `superfluid/grant-flow-operator` action via the canonical `CFAv1Forwarder` instead of the SuperToken's convenience proxy. The proxy is missing entirely on Sepolia's stubbed `fUSDCx` test token (even view methods revert), and silently relies on every real-deployment SuperToken implementing the thin delegate. The forwarder is the canonical entry point and works for any registered SuperToken.

Also strengthens the on-chain test from "tolerate any non-ABI revert" to **assert positive simulation success** -- the loose assertion masked the routing bug for months.

Closes [KEEP-456](https://linear.app/keeperhubapp/issue/KEEP-456/fix-superfluid-grant-flow-operator-routes-to-supertoken-instead-of).

## Why this matters

The bug surfaced while smoke-testing the [KEEP-438 `kh` CLI patch](https://github.com/KeeperHub/cli/pull/63) end-to-end against prod. Of the four superfluid workflow fixtures, three ran to completion on Sepolia (`get-net-flow`, `create-pool`, `wrap`) but `grant-flow-operator` reverted at the contract layer with no revert reason -- masquerading as the "quirky" behavior implied by the fixture filename.

Reproduction (Sepolia mainnet RPC, sender `0xB367...`):

| Target | Args | Result |
|---|---|---|
| **SuperToken** `0xb598...d443B` (current routing) | `updateFlowOperatorPermissions(0x...0001, 1, 0)` | revert (no data) |
| **SuperToken** `0xb598...d443B` | any `permissions` in `{1,3,7}` and `flowRateAllowance` in `{0, 1000000}` | revert (no data) |
| **SuperToken** `0xb598...d443B` | even view function `CONSTANT_OUTFLOW_NFT()` | revert (no data) |
| **CFAv1Forwarder** `0xcfA132E353cB4E398080B9700609bb008eceB125` | `updateFlowOperatorPermissions(token, 0x...0001, 1, 0)` | returns `true` |

This Sepolia fUSDCx implementation is stripped/stubbed and doesn't expose CFA agreement methods. The bug is invisible on mainnets where SuperTokens have full implementations -- but routing through the forwarder is the right design regardless: it's what Superfluid's docs recommend, it works on every registered SuperToken (no per-implementation dependency), and it matches the sibling `create-flow` / `update-flow` / `delete-flow` actions which already route through `cfaForwarder`.

## What changed

| File | Change |
|---|---|
| `protocols/superfluid.ts` | Added 4-arg `updateFlowOperatorPermissions(token, flowOperator, perms, flowRateAllowance)` to `CFA_FORWARDER_ABI`; removed unused 3-arg from `SUPER_TOKEN_ABI`; rerouted action to `cfaForwarder` with `token` as first input |
| `tests/integration/fixtures/superfluid-workflows/grant-flow-operator.json` | Renamed from `-quirky.json` (the routing was the quirk); `contractAddress` -> `token`; `_protocolMeta.contractKey` -> `cfaForwarder` |
| `tests/integration/protocol-superfluid-onchain.test.ts` | Replaced loose `expect(msg).not.toMatch(ENCODING_ERROR_RE)` with strict `expect(msg).toBe("")` (forwards must simulate cleanly). Pinned routing in test name and inline comment so the bug can't regress silently. |
| `tests/unit/superfluid-protocol.test.ts` | Updated CFA forwarder ABI count (5 -> 6), SuperToken ABI count (5 -> 4), SuperToken action slug count (5 -> 4); moved `grant-flow-operator` into its own describe block with new `contract === "cfaForwarder"` and 4-input-order assertions |

No address-map changes -- forwarders use `sameOnAllChains()` and Superfluid pins identical addresses across every chain in `SUPERFLUID_CHAIN_IDS`.

## Test plan

- [x] `pnpm test tests/unit/superfluid-protocol.test.ts` -- 41/41 pass
- [x] `pnpm test tests/integration/protocol-superfluid-workflow-fixtures.test.ts` -- 21/21 pass
- [x] `INTEGRATION_TEST_RPC_URL=... pnpm test tests/integration/protocol-superfluid-onchain.test.ts` -- 17/17 pass; the `grant-flow-operator` test now asserts positive simulation success
- [x] `pnpm exec biome check` clean on touched files
- [x] `pnpm type-check` -- no errors introduced (pre-existing `@/lib/credential-map` / `@/lib/step-registry` errors unrelated to this change, verified by stash + re-run)
- [ ] Re-run the prod superfluid fixture seeded by KEEP-438 (`w6uj17db1zm3x2764v69p`) after deploy and confirm it succeeds on-chain end-to-end (transaction hash, gas used, no revert)

## Coverage note

The on-chain test file's "every declared action has at least one dispatch test" coverage assertion (line 358) ensures we can't ship a new action without a dispatch test. **However**, this PR's strengthened assertion exposes a wider opportunity: the existing pattern of `expect(msg).not.toMatch(ENCODING_ERROR_RE)` tolerates contract reverts as long as the calldata isn't ABI-mangled. That pattern hid the grant-flow-operator routing bug. Worth a follow-up to convert the other dispatch tests to positive-simulation assertions where the inputs allow it.

## Out of scope

- The Sepolia fUSDCx test token's broken CFA proxy. We work around it; not our problem to fix the test token.
- Equivalent routing audit for other CFA-touching actions (`create-flow`, `update-flow`, `delete-flow`) -- they already route through `cfaForwarder`, so unaffected.
- Strengthening the other dispatch tests (see "coverage note").