### PR TITLE
feat: KEEP-449 skip billing for marketplace listings priced >= $0.05

### DIFF
--- a/app/api/billing/subscription/route.ts
+++ b/app/api/billing/subscription/route.ts
@@ -5,6 +5,7 @@ import {
   getGasCreditBalance,
   getGasCreditCaps,
 } from "@/lib/billing/gas-credits";
+import { billableWorkflowRawSql } from "@/lib/billing/marketplace-billing";
 import {
   getPlanLimits,
   parsePlanName,
@@ -57,6 +58,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                 JOIN workflows w ON we.workflow_id = w.id
                WHERE w.organization_id = ${activeOrgId}
                  AND we.started_at >= ${startOfMonth.toISOString()}
+                 AND ${billableWorkflowRawSql}
             )
             +
             (

--- a/app/api/billing/subscription/route.ts
+++ b/app/api/billing/subscription/route.ts
@@ -5,7 +5,6 @@ import {
   getGasCreditBalance,
   getGasCreditCaps,
 } from "@/lib/billing/gas-credits";
-import { billableWorkflowRawSql } from "@/lib/billing/marketplace-billing";
 import {
   getPlanLimits,
   parsePlanName,
@@ -58,7 +57,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                 JOIN workflows w ON we.workflow_id = w.id
                WHERE w.organization_id = ${activeOrgId}
                  AND we.started_at >= ${startOfMonth.toISOString()}
-                 AND ${billableWorkflowRawSql()}
+                 AND we.billable = TRUE
             )
             +
             (

--- a/app/api/billing/subscription/route.ts
+++ b/app/api/billing/subscription/route.ts
@@ -58,7 +58,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                 JOIN workflows w ON we.workflow_id = w.id
                WHERE w.organization_id = ${activeOrgId}
                  AND we.started_at >= ${startOfMonth.toISOString()}
-                 AND ${billableWorkflowRawSql}
+                 AND ${billableWorkflowRawSql()}
             )
             +
             (

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
-import { FREE_MARKETPLACE_BILLING_THRESHOLD_USDC } from "@/lib/billing/marketplace-billing";
+import { priceQualifiesForMarketplaceExemption } from "@/lib/billing/marketplace-billing";
 import { db } from "@/lib/db";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { tags, workflowExecutions, workflows } from "@/lib/db/schema";
@@ -352,8 +352,7 @@ async function handlePaidWorkflow(
         // actual payment receipt, not just to the workflow's listing state.
         // Owner-initiated runs, scheduled runs, block/event triggers, etc.
         // never reach this branch and stay billable=TRUE (the column default).
-        const priceUsdc = Number(workflow.priceUsdcPerCall ?? 0);
-        if (priceUsdc >= Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)) {
+        if (priceQualifiesForMarketplaceExemption(workflow.priceUsdcPerCall)) {
           await db
             .update(workflowExecutions)
             .set({ billable: false })

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -321,16 +321,42 @@ async function handlePaidWorkflow(
             : executionId;
         }
 
+        // recordPayment + the KEEP-449 billable flip run in one transaction
+        // so the workflow_payments row and the workflow_executions.billable
+        // bit can never disagree. If the flip fails after recordPayment
+        // succeeds, the whole transaction rolls back and the caller sees an
+        // error -- preferable to silently over-billing the owner one quota
+        // credit and leaving an exempt payment row dangling.
+        //
+        // Marketplace-paid calls at or above FREE_MARKETPLACE_BILLING_THRESHOLD_USDC
+        // are exempt from the owner's monthly execution quota. The flip is
+        // tied to actual payment receipt, so owner-initiated runs, scheduled
+        // runs, block/event triggers etc. never reach this branch and stay
+        // billable=TRUE (the column default).
         try {
-          await recordPayment({
-            workflowId: workflow.id,
-            paymentHash,
-            executionId,
-            amountUsdc: workflow.priceUsdcPerCall ?? "0",
-            payerAddress: meta.payerAddress,
-            creatorWalletAddress,
-            protocol: meta.protocol,
-            chain: meta.chain,
+          await db.transaction(async (tx) => {
+            await recordPayment(
+              {
+                workflowId: workflow.id,
+                paymentHash,
+                executionId,
+                amountUsdc: workflow.priceUsdcPerCall ?? "0",
+                payerAddress: meta.payerAddress,
+                creatorWalletAddress,
+                protocol: meta.protocol,
+                chain: meta.chain,
+              },
+              tx
+            );
+
+            if (
+              priceQualifiesForMarketplaceExemption(workflow.priceUsdcPerCall)
+            ) {
+              await tx
+                .update(workflowExecutions)
+                .set({ billable: false })
+                .where(eq(workflowExecutions.id, executionId));
+            }
           });
         } catch (err) {
           await db
@@ -344,19 +370,6 @@ async function handlePaidWorkflow(
             })
             .where(eq(workflowExecutions.id, executionId));
           throw err;
-        }
-
-        // KEEP-449: marketplace-paid calls at or above the threshold are
-        // exempt from the owner's monthly execution quota. The flip lives
-        // here (after recordPayment succeeds) so the exemption is tied to
-        // actual payment receipt, not just to the workflow's listing state.
-        // Owner-initiated runs, scheduled runs, block/event triggers, etc.
-        // never reach this branch and stay billable=TRUE (the column default).
-        if (priceQualifiesForMarketplaceExemption(workflow.priceUsdcPerCall)) {
-          await db
-            .update(workflowExecutions)
-            .set({ billable: false })
-            .where(eq(workflowExecutions.id, executionId));
         }
 
         await startExecutionInBackground(workflow, body, executionId);

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
+import { FREE_MARKETPLACE_BILLING_THRESHOLD_USDC } from "@/lib/billing/marketplace-billing";
 import { db } from "@/lib/db";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { tags, workflowExecutions, workflows } from "@/lib/db/schema";
@@ -14,15 +15,18 @@ import {
   gatePayment,
   type PaymentMeta,
 } from "@/lib/payments/router";
-import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
-import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { buildCallCompletionResponse } from "@/lib/payments/x402/execution-wait";
 import {
   hashPaymentSignature,
   recordPayment,
   resolveCreatorWallet,
 } from "@/lib/payments/x402/payment-gate";
-import { CALL_ROUTE_COLUMNS, type CallRouteWorkflow } from "@/lib/payments/x402/types";
+import {
+  CALL_ROUTE_COLUMNS,
+  type CallRouteWorkflow,
+} from "@/lib/payments/x402/types";
+import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -340,6 +344,20 @@ async function handlePaidWorkflow(
             })
             .where(eq(workflowExecutions.id, executionId));
           throw err;
+        }
+
+        // KEEP-449: marketplace-paid calls at or above the threshold are
+        // exempt from the owner's monthly execution quota. The flip lives
+        // here (after recordPayment succeeds) so the exemption is tied to
+        // actual payment receipt, not just to the workflow's listing state.
+        // Owner-initiated runs, scheduled runs, block/event triggers, etc.
+        // never reach this branch and stay billable=TRUE (the column default).
+        const priceUsdc = Number(workflow.priceUsdcPerCall ?? 0);
+        if (priceUsdc >= Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)) {
+          await db
+            .update(workflowExecutions)
+            .set({ billable: false })
+            .where(eq(workflowExecutions.id, executionId));
         }
 
         await startExecutionInBackground(workflow, body, executionId);

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,10 +1,23 @@
-import { notFound } from "next/navigation";
+import { headers } from "next/headers";
+import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
 import { BillingPage } from "@/components/billing/billing-page";
+import { auth } from "@/lib/auth";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
 
-export default function BillingRoute(): React.ReactElement {
+export default async function BillingRoute(): Promise<React.ReactElement> {
   if (!isBillingEnabled()) {
+    notFound();
+  }
+
+  const hdrs = await headers();
+  const session = await auth.api.getSession({ headers: hdrs });
+  if (!session?.user) {
+    redirect("/?returnTo=%2Fbilling");
+  }
+
+  const activeMember = await auth.api.getActiveMember({ headers: hdrs });
+  if (activeMember?.role !== "owner") {
     notFound();
   }
 

--- a/docs/workflows/marketplace.md
+++ b/docs/workflows/marketplace.md
@@ -115,6 +115,18 @@ You can see your earnings breakdown on the **Earnings** page in KeeperHub:
 
 Earnings are broken down by payment network (Base via x402, Tempo via MPP).
 
+### Execution quota
+
+Calls to a workflow you've listed at **$0.05 USDC per call or higher** don't count toward your organization's monthly execution limit. Marketplace revenue covers the cost on KeeperHub's side, so charging your plan's quota on top would be double-counting.
+
+Listings priced below $0.05 still count toward your monthly executions, just like any private workflow. The floor exists to keep the rule fair: without it, an owner could publish at $0 and self-call to bypass their plan limit.
+
+A few things follow from this:
+
+- **Delisting is retroactive.** If you unpublish a workflow mid-month, every call to it earlier that month is added back to your usage immediately. If you're close to your limit, double-check the Earnings page before unpublishing.
+- **The threshold is a hard cutoff.** A listing priced at $0.049 gives no quota relief; one at $0.05 is fully exempt.
+- **Direct API and private workflows are unaffected.** Direct executions and runs of any workflow you haven't listed always count toward your quota.
+
 ### Receiving revenue on two chains
 
 After a caller pays, the USDC (on Base) or USDC.e (on Tempo) lands directly in your organization's creator wallet. The split between them is just a function of which agents called your workflow. There's nothing to configure, and a zero balance on one chain isn't a problem.
@@ -202,7 +214,7 @@ Your slug, on the other hand, is public. x402scan.com and mppscan.com index it u
 
 Reliability is on you. Callers are only charged on successful execution, but repeat failures cost you trust (and revenue, since agents stop calling you). Watch the Earnings page after any workflow change.
 
-Calls run inside your KeeperHub organization. Whichever connected wallets, integrations, and execution credits the workflow uses are charged to your org, not the caller's.
+Calls run inside your KeeperHub organization. Connected wallets and integrations the workflow uses are billed to your org, not the caller's. Executions of listings priced at $0.05 USDC or higher are exempt from your monthly execution quota — see [Execution quota](#execution-quota).
 
 ## Reference implementation
 

--- a/docs/workflows/marketplace.md
+++ b/docs/workflows/marketplace.md
@@ -214,7 +214,7 @@ Your slug, on the other hand, is public. x402scan.com and mppscan.com index it u
 
 Reliability is on you. Callers are only charged on successful execution, but repeat failures cost you trust (and revenue, since agents stop calling you). Watch the Earnings page after any workflow change.
 
-Calls run inside your KeeperHub organization. Connected wallets and integrations the workflow uses are billed to your org, not the caller's. Executions of listings priced at $0.05 USDC or higher are exempt from your monthly execution quota — see [Execution quota](#execution-quota).
+Calls run inside your KeeperHub organization. Connected wallets and integrations the workflow uses are billed to your org, not the caller's. Executions of listings priced at $0.05 USDC or higher are exempt from your monthly execution quota; see [Execution quota](#execution-quota) above.
 
 ## Reference implementation
 

--- a/docs/workflows/marketplace.md
+++ b/docs/workflows/marketplace.md
@@ -123,7 +123,7 @@ Listings priced below $0.05 still count toward your monthly executions, just lik
 
 A few things follow from this:
 
-- **Delisting is retroactive.** If you unpublish a workflow mid-month, every call to it earlier that month is added back to your usage immediately. If you're close to your limit, double-check the Earnings page before unpublishing.
+- **The exemption is snapshotted at call time.** Each execution is stamped as billable or exempt at the moment it runs, based on the listing state then. Changing the price or unpublishing afterward only affects future calls; past calls stay where they were.
 - **The threshold is a hard cutoff.** A listing priced at $0.049 gives no quota relief; one at $0.05 is fully exempt.
 - **Direct API and private workflows are unaffected.** Direct executions and runs of any workflow you haven't listed always count toward your quota.
 

--- a/docs/workflows/marketplace.md
+++ b/docs/workflows/marketplace.md
@@ -117,14 +117,13 @@ Earnings are broken down by payment network (Base via x402, Tempo via MPP).
 
 ### Execution quota
 
-Calls to a workflow you've listed at **$0.05 USDC per call or higher** don't count toward your organization's monthly execution limit. Marketplace revenue covers the cost on KeeperHub's side, so charging your plan's quota on top would be double-counting.
+When a Marketplace caller pays for one of your listed workflows at **$0.05 USDC per call or higher**, that execution does not count toward your organization's monthly execution limit. Marketplace revenue covers the cost on KeeperHub's side, so charging your plan's quota on top would be double-counting.
 
-Listings priced below $0.05 still count toward your monthly executions, just like any private workflow. The floor exists to keep the rule fair: without it, an owner could publish at $0 and self-call to bypass their plan limit.
+The exemption is gated on actual payment receipt, not on listing state alone. So:
 
-A few things follow from this:
-
-- **The exemption is snapshotted at call time.** Each execution is stamped as billable or exempt at the moment it runs, based on the listing state then. Changing the price or unpublishing afterward only affects future calls; past calls stay where they were.
-- **The threshold is a hard cutoff.** A listing priced at $0.049 gives no quota relief; one at $0.05 is fully exempt.
+- **Only paid Marketplace calls qualify.** When you click Run in the editor, or the workflow fires from a schedule, block trigger, event, webhook, or direct API call, no payment is recorded and the run counts toward your quota normally, even if the workflow is listed at the threshold price. The exemption is for revenue you actually received, not for the act of listing.
+- **The price floor is a hard cutoff.** A listing priced at $0.049 gives no quota relief; one at $0.05 is fully exempt. The floor prevents an owner from publishing at $0 (or near it) and self-calling through the marketplace to accumulate free executions.
+- **The exemption is locked in per call.** Once a paid call is recorded as exempt, raising or lowering the listing price afterward does not change the verdict for past calls. Future calls are evaluated against the price in effect at their moment of payment.
 - **Direct API and private workflows are unaffected.** Direct executions and runs of any workflow you haven't listed always count toward your quota.
 
 ### Receiving revenue on two chains

--- a/drizzle/0070_workflow_executions_billable.sql
+++ b/drizzle/0070_workflow_executions_billable.sql
@@ -1,51 +1,22 @@
--- Snapshot whether each workflow execution counts toward the owner org's
--- monthly execution quota and overage billing. Stamped at insert time so
--- subsequent listing/price changes cannot retroactively shift past rows in
--- or out of billable usage.
+-- Whether a workflow execution counts toward the owner org's monthly
+-- execution quota and overage billing.
 --
--- Apply prospectively: existing rows keep `billable = TRUE` (the column
--- default) so historical plan-quota usage does not shift at deploy. From
--- the moment the trigger is installed, new inserts are stamped from the
--- workflow's listing state at that moment and never change again.
+-- Apply prospectively: the column defaults to TRUE so historical plan-quota
+-- usage is preserved exactly. The exemption is opt-out, not opt-in: every
+-- insert path defaults to billable=TRUE (counted toward quota), and the
+-- marketplace payment gate is the only thing that flips a row to FALSE,
+-- after it verifies an x402 / MPP payment at or above the
+-- FREE_MARKETPLACE_BILLING_THRESHOLD_USDC threshold (see
+-- app/api/mcp/workflows/[slug]/call/route.ts and
+-- lib/billing/marketplace-billing.ts).
 --
--- The threshold (0.05 USDC) is duplicated between this migration and
--- lib/billing/marketplace-billing.ts#FREE_MARKETPLACE_BILLING_THRESHOLD_USDC.
--- The trigger is the source of truth at insert time; any future change
--- must go through a new migration so historical rows stay frozen at the
--- value that was in effect when they were created.
---
--- All wrapped in a single transaction so the column add and trigger
--- install land together; otherwise a new insert in the gap between the
--- two could default to TRUE when it should be FALSE.
-
-BEGIN;
+-- An earlier draft of this migration installed a BEFORE INSERT trigger that
+-- computed billable from the workflow's listing state. That checked the
+-- wrong invariant: an owner could list at the threshold price and click Run
+-- repeatedly to get free quota credits, since the trigger fired on any
+-- insert, not just on paid marketplace calls. Tying the exemption to actual
+-- payment receipt closes that loophole; the cost is that the marketplace
+-- route is now responsible for flipping the flag.
 
 ALTER TABLE "workflow_executions"
   ADD COLUMN IF NOT EXISTS "billable" boolean NOT NULL DEFAULT TRUE;
-
-CREATE OR REPLACE FUNCTION "set_workflow_execution_billable"()
-RETURNS TRIGGER AS $$
-BEGIN
-  -- Always overwrite at insert time; callers cannot opt out, since this
-  -- column exists for billing integrity. The default value (TRUE) is just
-  -- a fallback in case the workflow row cannot be found.
-  SELECT NOT (
-           w."is_listed" = TRUE
-           AND COALESCE(w."price_usdc_per_call"::numeric, 0) >= 0.05::numeric
-         )
-    INTO NEW."billable"
-    FROM "workflows" w
-   WHERE w."id" = NEW."workflow_id";
-  NEW."billable" := COALESCE(NEW."billable", TRUE);
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS "workflow_executions_set_billable" ON "workflow_executions";
-
-CREATE TRIGGER "workflow_executions_set_billable"
-BEFORE INSERT ON "workflow_executions"
-FOR EACH ROW
-EXECUTE FUNCTION "set_workflow_execution_billable"();
-
-COMMIT;

--- a/drizzle/0070_workflow_executions_billable.sql
+++ b/drizzle/0070_workflow_executions_billable.sql
@@ -1,0 +1,53 @@
+-- Snapshot whether each workflow execution counts toward the owner org's
+-- monthly execution quota and overage billing. Stamped at insert time so
+-- subsequent listing/price changes cannot retroactively shift past rows in
+-- or out of billable usage.
+--
+-- The threshold (0.05 USDC) is duplicated between this migration and
+-- lib/billing/marketplace-billing.ts#FREE_MARKETPLACE_BILLING_THRESHOLD_USDC.
+-- The trigger is the source of truth at insert time; any future change must
+-- go through a new migration so historical rows stay frozen at the value
+-- that was in effect when they were created.
+
+ALTER TABLE "workflow_executions"
+  ADD COLUMN IF NOT EXISTS "billable" boolean NOT NULL DEFAULT TRUE;
+--> statement-breakpoint
+
+-- Backfill existing rows from the workflow's current state. This is
+-- deliberately a one-shot snapshot at deploy time; thereafter the trigger
+-- below owns the value for new rows.
+UPDATE "workflow_executions" we
+   SET "billable" = NOT (
+         w."is_listed" = TRUE
+         AND COALESCE(w."price_usdc_per_call"::numeric, 0) >= 0.05::numeric
+       )
+  FROM "workflows" w
+ WHERE we."workflow_id" = w."id";
+--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION "set_workflow_execution_billable"()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Always overwrite at insert time; callers cannot opt out, since this
+  -- column exists for billing integrity. The default value (TRUE) is just
+  -- a fallback in case the workflow row cannot be found.
+  SELECT NOT (
+           w."is_listed" = TRUE
+           AND COALESCE(w."price_usdc_per_call"::numeric, 0) >= 0.05::numeric
+         )
+    INTO NEW."billable"
+    FROM "workflows" w
+   WHERE w."id" = NEW."workflow_id";
+  NEW."billable" := COALESCE(NEW."billable", TRUE);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS "workflow_executions_set_billable" ON "workflow_executions";
+--> statement-breakpoint
+
+CREATE TRIGGER "workflow_executions_set_billable"
+BEFORE INSERT ON "workflow_executions"
+FOR EACH ROW
+EXECUTE FUNCTION "set_workflow_execution_billable"();

--- a/drizzle/0070_workflow_executions_billable.sql
+++ b/drizzle/0070_workflow_executions_billable.sql
@@ -3,27 +3,25 @@
 -- subsequent listing/price changes cannot retroactively shift past rows in
 -- or out of billable usage.
 --
+-- Apply prospectively: existing rows keep `billable = TRUE` (the column
+-- default) so historical plan-quota usage does not shift at deploy. From
+-- the moment the trigger is installed, new inserts are stamped from the
+-- workflow's listing state at that moment and never change again.
+--
 -- The threshold (0.05 USDC) is duplicated between this migration and
 -- lib/billing/marketplace-billing.ts#FREE_MARKETPLACE_BILLING_THRESHOLD_USDC.
--- The trigger is the source of truth at insert time; any future change must
--- go through a new migration so historical rows stay frozen at the value
--- that was in effect when they were created.
+-- The trigger is the source of truth at insert time; any future change
+-- must go through a new migration so historical rows stay frozen at the
+-- value that was in effect when they were created.
+--
+-- All wrapped in a single transaction so the column add and trigger
+-- install land together; otherwise a new insert in the gap between the
+-- two could default to TRUE when it should be FALSE.
+
+BEGIN;
 
 ALTER TABLE "workflow_executions"
   ADD COLUMN IF NOT EXISTS "billable" boolean NOT NULL DEFAULT TRUE;
---> statement-breakpoint
-
--- Backfill existing rows from the workflow's current state. This is
--- deliberately a one-shot snapshot at deploy time; thereafter the trigger
--- below owns the value for new rows.
-UPDATE "workflow_executions" we
-   SET "billable" = NOT (
-         w."is_listed" = TRUE
-         AND COALESCE(w."price_usdc_per_call"::numeric, 0) >= 0.05::numeric
-       )
-  FROM "workflows" w
- WHERE we."workflow_id" = w."id";
---> statement-breakpoint
 
 CREATE OR REPLACE FUNCTION "set_workflow_execution_billable"()
 RETURNS TRIGGER AS $$
@@ -42,12 +40,12 @@ BEGIN
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
---> statement-breakpoint
 
 DROP TRIGGER IF EXISTS "workflow_executions_set_billable" ON "workflow_executions";
---> statement-breakpoint
 
 CREATE TRIGGER "workflow_executions_set_billable"
 BEFORE INSERT ON "workflow_executions"
 FOR EACH ROW
 EXECUTE FUNCTION "set_workflow_execution_billable"();
+
+COMMIT;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1777760000003,
       "tag": "0069_add_feedback_table",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1777760000004,
+      "tag": "0070_workflow_executions_billable",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -120,7 +120,7 @@ export async function checkExecutionLimitForExecutor(
       and(
         eq(workflows.organizationId, organizationId),
         sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`,
-        billableWorkflowFilter
+        billableWorkflowFilter()
       )
     );
 

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -1,6 +1,5 @@
 import { and, eq, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import { billableWorkflowFilter } from "../lib/billing/marketplace-billing";
 import {
   getPlanLimits,
   PLANS,
@@ -120,7 +119,7 @@ export async function checkExecutionLimitForExecutor(
       and(
         eq(workflows.organizationId, organizationId),
         sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`,
-        billableWorkflowFilter()
+        eq(workflowExecutions.billable, true)
       )
     );
 

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -1,5 +1,6 @@
 import { and, eq, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { billableWorkflowFilter } from "../lib/billing/marketplace-billing";
 import {
   getPlanLimits,
   PLANS,
@@ -118,7 +119,8 @@ export async function checkExecutionLimitForExecutor(
     .where(
       and(
         eq(workflows.organizationId, organizationId),
-        sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`
+        sql`${workflowExecutions.startedAt} >= ${startOfMonth.toISOString()}`,
+        billableWorkflowFilter
       )
     );
 

--- a/lib/billing/limit-status.ts
+++ b/lib/billing/limit-status.ts
@@ -38,7 +38,7 @@ async function getCurrentMonthUsage(organizationId: string): Promise<number> {
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth}
                AND we.status <> 'blocked_billing'
-               AND ${billableWorkflowRawSql}
+               AND ${billableWorkflowRawSql()}
           )
           +
           (

--- a/lib/billing/limit-status.ts
+++ b/lib/billing/limit-status.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { and, count, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
+import { billableWorkflowRawSql } from "./marketplace-billing";
 import { getPlanLimits, parsePlanName, parseTierKey } from "./plans";
 import { getOrgSubscription } from "./plans-server";
 
@@ -37,6 +38,7 @@ async function getCurrentMonthUsage(organizationId: string): Promise<number> {
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth}
                AND we.status <> 'blocked_billing'
+               AND ${billableWorkflowRawSql}
           )
           +
           (

--- a/lib/billing/limit-status.ts
+++ b/lib/billing/limit-status.ts
@@ -3,7 +3,6 @@ import "server-only";
 import { and, count, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
-import { billableWorkflowRawSql } from "./marketplace-billing";
 import { getPlanLimits, parsePlanName, parseTierKey } from "./plans";
 import { getOrgSubscription } from "./plans-server";
 
@@ -38,7 +37,7 @@ async function getCurrentMonthUsage(organizationId: string): Promise<number> {
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth}
                AND we.status <> 'blocked_billing'
-               AND ${billableWorkflowRawSql()}
+               AND we.billable = TRUE
           )
           +
           (

--- a/lib/billing/marketplace-billing.ts
+++ b/lib/billing/marketplace-billing.ts
@@ -19,21 +19,29 @@ export const FREE_MARKETPLACE_BILLING_THRESHOLD_USDC = "0.05";
  *
  * Evaluates TRUE for rows that should count toward billing, FALSE for
  * Marketplace-listed workflows priced at or above the free-billing threshold.
+ *
+ * Built lazily so that simply importing this module does not require
+ * `drizzle-orm`'s `sql` export to be present (some unit tests partially mock
+ * the module).
  */
-export const billableWorkflowRawSql: SQL = sql`
-  NOT (
-    w.is_listed = TRUE
-    AND COALESCE(w.price_usdc_per_call::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
-  )
-`;
+export function billableWorkflowRawSql(): SQL {
+  return sql`
+    NOT (
+      w.is_listed = TRUE
+      AND COALESCE(w.price_usdc_per_call::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
+    )
+  `;
+}
 
 /**
  * Drizzle query-builder fragment equivalent to {@link billableWorkflowRawSql}.
  * Use inside `and(...)` when querying workflows via the typed builder.
  */
-export const billableWorkflowFilter: SQL = sql`
-  NOT (
-    ${workflows.isListed} = TRUE
-    AND COALESCE(${workflows.priceUsdcPerCall}::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
-  )
-`;
+export function billableWorkflowFilter(): SQL {
+  return sql`
+    NOT (
+      ${workflows.isListed} = TRUE
+      AND COALESCE(${workflows.priceUsdcPerCall}::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
+    )
+  `;
+}

--- a/lib/billing/marketplace-billing.ts
+++ b/lib/billing/marketplace-billing.ts
@@ -1,34 +1,22 @@
 /**
- * Minimum price (USDC per call) at which a Marketplace-listed workflow's
- * executions stop counting toward the owner's monthly execution quota and
+ * Minimum price (USDC per call) at which a successful Marketplace payment
+ * makes that execution exempt from the owner's monthly execution quota and
  * overage invoicing.
  *
- * Why a floor exists: without one, an owner could list a workflow at $0 (or
- * an irrationally low price), self-call it, and run unlimited "free"
- * executions while bypassing their plan limit.
+ * The exemption is gated on actual payment receipt, not on the workflow's
+ * listing state alone:
  *
- * The actual gate runs in Postgres: a BEFORE INSERT trigger on
- * `workflow_executions` snapshots `billable = NOT (is_listed AND price >=
- * threshold)` at insert time so future listing changes cannot retroactively
- * shift past rows in or out of billable usage. See
- * drizzle/0070_workflow_executions_billable.sql for the trigger definition;
- * it is the source of truth for the threshold at insert time. This constant
- * is exposed for UI copy and documentation only.
+ *   billable = TRUE by default on every workflow_executions insert; the
+ *   marketplace call route flips it to FALSE only after `recordPayment`
+ *   succeeds and the recorded price is at or above this threshold. Owner-
+ *   initiated runs (manual Run, scheduled, block, event, webhook, direct
+ *   API) never reach that flip and always count toward the quota.
+ *
+ * Why a floor exists: without one, an owner could publish a workflow at $0
+ * (or any irrationally low price), self-call it through the marketplace,
+ * and accumulate "free" executions while bypassing their plan limit.
+ *
+ * See drizzle/0070_workflow_executions_billable.sql for the column
+ * definition and app/api/mcp/workflows/[slug]/call/route.ts for the flip.
  */
 export const FREE_MARKETPLACE_BILLING_THRESHOLD_USDC = "0.05";
-
-/**
- * Pure helper mirroring the Postgres trigger logic for use in unit tests
- * and any non-DB caller that needs to predict whether an execution would be
- * billable. Production code should rely on the stamped `billable` column.
- */
-export function isWorkflowBillable(workflow: {
-  isListed: boolean | null;
-  priceUsdcPerCall: string | null;
-}): boolean {
-  if (workflow.isListed !== true) {
-    return true;
-  }
-  const price = Number(workflow.priceUsdcPerCall ?? 0);
-  return price < Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC);
-}

--- a/lib/billing/marketplace-billing.ts
+++ b/lib/billing/marketplace-billing.ts
@@ -1,6 +1,3 @@
-import { type SQL, sql } from "drizzle-orm";
-import { workflows } from "../db/schema";
-
 /**
  * Minimum price (USDC per call) at which a Marketplace-listed workflow's
  * executions stop counting toward the owner's monthly execution quota and
@@ -9,39 +6,29 @@ import { workflows } from "../db/schema";
  * Why a floor exists: without one, an owner could list a workflow at $0 (or
  * an irrationally low price), self-call it, and run unlimited "free"
  * executions while bypassing their plan limit.
+ *
+ * The actual gate runs in Postgres: a BEFORE INSERT trigger on
+ * `workflow_executions` snapshots `billable = NOT (is_listed AND price >=
+ * threshold)` at insert time so future listing changes cannot retroactively
+ * shift past rows in or out of billable usage. See
+ * drizzle/0070_workflow_executions_billable.sql for the trigger definition;
+ * it is the source of truth for the threshold at insert time. This constant
+ * is exposed for UI copy and documentation only.
  */
 export const FREE_MARKETPLACE_BILLING_THRESHOLD_USDC = "0.05";
 
 /**
- * Raw-SQL fragment for use inside `db.execute(sql\`...\`)` queries that count
- * workflow_executions for billing. The surrounding query MUST alias the
- * workflows table as `w` (matching the existing usage queries).
- *
- * Evaluates TRUE for rows that should count toward billing, FALSE for
- * Marketplace-listed workflows priced at or above the free-billing threshold.
- *
- * Built lazily so that simply importing this module does not require
- * `drizzle-orm`'s `sql` export to be present (some unit tests partially mock
- * the module).
+ * Pure helper mirroring the Postgres trigger logic for use in unit tests
+ * and any non-DB caller that needs to predict whether an execution would be
+ * billable. Production code should rely on the stamped `billable` column.
  */
-export function billableWorkflowRawSql(): SQL {
-  return sql`
-    NOT (
-      w.is_listed = TRUE
-      AND COALESCE(w.price_usdc_per_call::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
-    )
-  `;
-}
-
-/**
- * Drizzle query-builder fragment equivalent to {@link billableWorkflowRawSql}.
- * Use inside `and(...)` when querying workflows via the typed builder.
- */
-export function billableWorkflowFilter(): SQL {
-  return sql`
-    NOT (
-      ${workflows.isListed} = TRUE
-      AND COALESCE(${workflows.priceUsdcPerCall}::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
-    )
-  `;
+export function isWorkflowBillable(workflow: {
+  isListed: boolean | null;
+  priceUsdcPerCall: string | null;
+}): boolean {
+  if (workflow.isListed !== true) {
+    return true;
+  }
+  const price = Number(workflow.priceUsdcPerCall ?? 0);
+  return price < Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC);
 }

--- a/lib/billing/marketplace-billing.ts
+++ b/lib/billing/marketplace-billing.ts
@@ -1,0 +1,39 @@
+import { type SQL, sql } from "drizzle-orm";
+import { workflows } from "../db/schema";
+
+/**
+ * Minimum price (USDC per call) at which a Marketplace-listed workflow's
+ * executions stop counting toward the owner's monthly execution quota and
+ * overage invoicing.
+ *
+ * Why a floor exists: without one, an owner could list a workflow at $0 (or
+ * an irrationally low price), self-call it, and run unlimited "free"
+ * executions while bypassing their plan limit.
+ */
+export const FREE_MARKETPLACE_BILLING_THRESHOLD_USDC = "0.05";
+
+/**
+ * Raw-SQL fragment for use inside `db.execute(sql\`...\`)` queries that count
+ * workflow_executions for billing. The surrounding query MUST alias the
+ * workflows table as `w` (matching the existing usage queries).
+ *
+ * Evaluates TRUE for rows that should count toward billing, FALSE for
+ * Marketplace-listed workflows priced at or above the free-billing threshold.
+ */
+export const billableWorkflowRawSql: SQL = sql`
+  NOT (
+    w.is_listed = TRUE
+    AND COALESCE(w.price_usdc_per_call::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
+  )
+`;
+
+/**
+ * Drizzle query-builder fragment equivalent to {@link billableWorkflowRawSql}.
+ * Use inside `and(...)` when querying workflows via the typed builder.
+ */
+export const billableWorkflowFilter: SQL = sql`
+  NOT (
+    ${workflows.isListed} = TRUE
+    AND COALESCE(${workflows.priceUsdcPerCall}::numeric, 0) >= ${sql.raw(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)}::numeric
+  )
+`;

--- a/lib/billing/marketplace-billing.ts
+++ b/lib/billing/marketplace-billing.ts
@@ -18,5 +18,35 @@
  *
  * See drizzle/0070_workflow_executions_billable.sql for the column
  * definition and app/api/mcp/workflows/[slug]/call/route.ts for the flip.
+ *
+ * Stored as a string because USDC prices are persisted as Postgres `numeric`
+ * and read back into TS as strings; keeping the threshold a string avoids
+ * implicit float coercion at the constant-definition site. Use
+ * {@link priceQualifiesForMarketplaceExemption} for comparisons rather than
+ * coercing this value at every call site.
  */
 export const FREE_MARKETPLACE_BILLING_THRESHOLD_USDC = "0.05";
+
+/**
+ * Whether a successful Marketplace payment at the given listing price
+ * qualifies for the execution-quota exemption.
+ *
+ * Returns true if the recorded price is at or above
+ * FREE_MARKETPLACE_BILLING_THRESHOLD_USDC. Treats null / undefined / empty
+ * as 0 (does not qualify), which matches how Postgres COALESCE handles a
+ * missing price.
+ *
+ * NOTE: callers in the marketplace call route currently pass
+ * `workflow.priceUsdcPerCall` (the listing price loaded with the request)
+ * as a stand-in for "amount actually paid". This is correct today because
+ * the upstream payment gate validates the signature against the listing
+ * price, so signature-mismatch traffic never reaches this branch. If that
+ * gate ever loosens (partial payments, dynamic pricing, refunds), this
+ * helper should be invoked with the verified payment amount instead.
+ */
+export function priceQualifiesForMarketplaceExemption(
+  priceUsdcPerCall: string | null | undefined
+): boolean {
+  const price = Number(priceUsdcPerCall ?? 0);
+  return price >= Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC);
+}

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/db/schema";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
+import { billableWorkflowRawSql } from "./marketplace-billing";
 import { getPlanLimits, PLANS, parsePlanName, parseTierKey } from "./plans";
 import { getBillingProvider } from "./providers";
 
@@ -77,6 +78,7 @@ export async function billOverageForOrg(
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${periodStart.toISOString()}
                AND we.started_at <  ${periodEnd.toISOString()}
+               AND ${billableWorkflowRawSql}
           )
           +
           (

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -78,7 +78,7 @@ export async function billOverageForOrg(
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${periodStart.toISOString()}
                AND we.started_at <  ${periodEnd.toISOString()}
-               AND ${billableWorkflowRawSql}
+               AND ${billableWorkflowRawSql()}
           )
           +
           (

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -8,7 +8,6 @@ import {
 } from "@/lib/db/schema";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
-import { billableWorkflowRawSql } from "./marketplace-billing";
 import { getPlanLimits, PLANS, parsePlanName, parseTierKey } from "./plans";
 import { getBillingProvider } from "./providers";
 
@@ -78,7 +77,7 @@ export async function billOverageForOrg(
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${periodStart.toISOString()}
                AND we.started_at <  ${periodEnd.toISOString()}
-               AND ${billableWorkflowRawSql()}
+               AND we.billable = TRUE
           )
           +
           (

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -261,7 +261,7 @@ export async function checkExecutionLimit(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
-               AND ${billableWorkflowRawSql}
+               AND ${billableWorkflowRawSql()}
           )
           +
           (

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -4,6 +4,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organizationSubscriptions } from "@/lib/db/schema";
 import { getActiveDebtExecutions } from "./execution-debt";
+import { billableWorkflowRawSql } from "./marketplace-billing";
 import {
   type BillingInterval,
   getPlanLimits,
@@ -260,6 +261,7 @@ export async function checkExecutionLimit(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
+               AND ${billableWorkflowRawSql}
           )
           +
           (

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -4,7 +4,6 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organizationSubscriptions } from "@/lib/db/schema";
 import { getActiveDebtExecutions } from "./execution-debt";
-import { billableWorkflowRawSql } from "./marketplace-billing";
 import {
   type BillingInterval,
   getPlanLimits,
@@ -261,7 +260,7 @@ export async function checkExecutionLimit(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
-               AND ${billableWorkflowRawSql()}
+               AND we.billable = TRUE
           )
           +
           (

--- a/lib/billing/tier-suggestions.ts
+++ b/lib/billing/tier-suggestions.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { billableWorkflowRawSql } from "./marketplace-billing";
 import {
   getPlanLimits,
   PLANS,
@@ -60,7 +59,7 @@ export async function getUpgradeSuggestion(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
-               AND ${billableWorkflowRawSql()}
+               AND we.billable = TRUE
           )
           +
           (

--- a/lib/billing/tier-suggestions.ts
+++ b/lib/billing/tier-suggestions.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { billableWorkflowRawSql } from "./marketplace-billing";
 import {
   getPlanLimits,
   PLANS,
@@ -59,6 +60,7 @@ export async function getUpgradeSuggestion(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
+               AND ${billableWorkflowRawSql}
           )
           +
           (

--- a/lib/billing/tier-suggestions.ts
+++ b/lib/billing/tier-suggestions.ts
@@ -60,7 +60,7 @@ export async function getUpgradeSuggestion(
               JOIN workflows w ON we.workflow_id = w.id
              WHERE w.organization_id = ${organizationId}
                AND we.started_at >= ${startOfMonth.toISOString()}
-               AND ${billableWorkflowRawSql}
+               AND ${billableWorkflowRawSql()}
           )
           +
           (

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -319,6 +319,14 @@ export const workflowExecutions = pgTable(
     lastSuccessfulNodeName: text("last_successful_node_name"),
     executionTrace: jsonb("execution_trace").$type<string[]>(),
     runId: text("run_id"),
+    /**
+     * Whether this execution counts toward the owner organisation's monthly
+     * execution quota and overage billing. Snapshotted at insert time by a
+     * BEFORE INSERT trigger from the workflow's `is_listed` and
+     * `price_usdc_per_call` (see migration 0070), so later listing changes do
+     * not retroactively rewrite an org's billable usage.
+     */
+    billable: boolean("billable").notNull().default(true),
   },
   (table) => [index("idx_workflow_executions_status").on(table.status)]
 );

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -321,10 +321,18 @@ export const workflowExecutions = pgTable(
     runId: text("run_id"),
     /**
      * Whether this execution counts toward the owner organisation's monthly
-     * execution quota and overage billing. Snapshotted at insert time by a
-     * BEFORE INSERT trigger from the workflow's `is_listed` and
-     * `price_usdc_per_call` (see migration 0070), so later listing changes do
-     * not retroactively rewrite an org's billable usage.
+     * execution quota and overage billing.
+     *
+     * Defaults to TRUE on every insert. The marketplace call route is the
+     * only path that ever flips a row to FALSE, and only after recordPayment
+     * succeeds and the recorded price is at or above
+     * FREE_MARKETPLACE_BILLING_THRESHOLD_USDC. Owner-initiated runs (manual
+     * Run, scheduled, block, event, webhook) and direct API calls always
+     * stay TRUE.
+     *
+     * See drizzle/0070_workflow_executions_billable.sql,
+     * lib/billing/marketplace-billing.ts, and
+     * app/api/mcp/workflows/[slug]/call/route.ts.
      */
     billable: boolean("billable").notNull().default(true),
   },

--- a/lib/payments/x402/payment-gate.ts
+++ b/lib/payments/x402/payment-gate.ts
@@ -88,13 +88,28 @@ export async function findExistingPayment(
 }
 
 /**
+ * Connection or open transaction used by recordPayment. Using a Pick of
+ * `typeof db` lets the marketplace call route pass either the global
+ * `db` or a Drizzle `tx` from `db.transaction(...)` without dragging in
+ * the full Drizzle generic surface.
+ */
+type PaymentRecorderDb = Pick<typeof db, "insert">;
+
+/**
  * Inserts a new payment record into workflow_payments.
  * On Postgres unique violation (code 23505), returns silently --
  * the idempotency check via findExistingPayment handles the response.
+ *
+ * Accepts an optional connection so the caller can compose this insert
+ * with a sibling write (for example flipping `workflow_executions.billable`
+ * for KEEP-449) inside a single transaction. Defaults to the global db.
  */
-export async function recordPayment(data: NewWorkflowPayment): Promise<void> {
+export async function recordPayment(
+  data: NewWorkflowPayment,
+  conn: PaymentRecorderDb = db
+): Promise<void> {
   try {
-    await db.insert(workflowPayments).values(data);
+    await conn.insert(workflowPayments).values(data);
   } catch (err) {
     const cause = (err as { cause?: { code?: string } }).cause;
     if (cause?.code === "23505") {

--- a/tests/unit/billing-marketplace-billing.test.ts
+++ b/tests/unit/billing-marketplace-billing.test.ts
@@ -1,41 +1,49 @@
-import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 import {
-  billableWorkflowFilter,
-  billableWorkflowRawSql,
   FREE_MARKETPLACE_BILLING_THRESHOLD_USDC,
+  isWorkflowBillable,
 } from "@/lib/billing/marketplace-billing";
-
-const dialect = new PgDialect();
 
 describe("marketplace-billing", () => {
   it("threshold is 0.05 USDC", () => {
     expect(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC).toBe("0.05");
   });
 
-  describe("billableWorkflowRawSql", () => {
-    it("excludes listed workflows priced at or above the threshold (uses w. alias)", () => {
-      const { sql } = dialect.sqlToQuery(billableWorkflowRawSql());
-      const normalized = sql.replace(/\s+/g, " ").toLowerCase();
-
-      expect(normalized).toContain("not (");
-      expect(normalized).toContain("w.is_listed = true");
-      expect(normalized).toContain(
-        "coalesce(w.price_usdc_per_call::numeric, 0) >= 0.05::numeric"
-      );
+  describe("isWorkflowBillable", () => {
+    it("returns true for unlisted workflows regardless of price", () => {
+      expect(
+        isWorkflowBillable({ isListed: false, priceUsdcPerCall: "0.50" })
+      ).toBe(true);
+      expect(
+        isWorkflowBillable({ isListed: null, priceUsdcPerCall: "1.00" })
+      ).toBe(true);
     });
-  });
 
-  describe("billableWorkflowFilter", () => {
-    it("excludes listed workflows priced at or above the threshold (uses workflows table)", () => {
-      const { sql } = dialect.sqlToQuery(billableWorkflowFilter());
-      const normalized = sql.replace(/\s+/g, " ").toLowerCase();
+    it("returns true for listed workflows priced below the threshold", () => {
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.04" })
+      ).toBe(true);
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.0001" })
+      ).toBe(true);
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0" })
+      ).toBe(true);
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: null })
+      ).toBe(true);
+    });
 
-      expect(normalized).toContain("not (");
-      expect(normalized).toContain('"workflows"."is_listed" = true');
-      expect(normalized).toContain(
-        'coalesce("workflows"."price_usdc_per_call"::numeric, 0) >= 0.05::numeric'
-      );
+    it("returns false for listed workflows at or above the threshold", () => {
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.05" })
+      ).toBe(false);
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.50" })
+      ).toBe(false);
+      expect(
+        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "100" })
+      ).toBe(false);
     });
   });
 });

--- a/tests/unit/billing-marketplace-billing.test.ts
+++ b/tests/unit/billing-marketplace-billing.test.ts
@@ -15,7 +15,7 @@ describe("marketplace-billing", () => {
 
   describe("billableWorkflowRawSql", () => {
     it("excludes listed workflows priced at or above the threshold (uses w. alias)", () => {
-      const { sql } = dialect.sqlToQuery(billableWorkflowRawSql);
+      const { sql } = dialect.sqlToQuery(billableWorkflowRawSql());
       const normalized = sql.replace(/\s+/g, " ").toLowerCase();
 
       expect(normalized).toContain("not (");
@@ -28,7 +28,7 @@ describe("marketplace-billing", () => {
 
   describe("billableWorkflowFilter", () => {
     it("excludes listed workflows priced at or above the threshold (uses workflows table)", () => {
-      const { sql } = dialect.sqlToQuery(billableWorkflowFilter);
+      const { sql } = dialect.sqlToQuery(billableWorkflowFilter());
       const normalized = sql.replace(/\s+/g, " ").toLowerCase();
 
       expect(normalized).toContain("not (");

--- a/tests/unit/billing-marketplace-billing.test.ts
+++ b/tests/unit/billing-marketplace-billing.test.ts
@@ -1,49 +1,28 @@
 import { describe, expect, it } from "vitest";
-import {
-  FREE_MARKETPLACE_BILLING_THRESHOLD_USDC,
-  isWorkflowBillable,
-} from "@/lib/billing/marketplace-billing";
+import { FREE_MARKETPLACE_BILLING_THRESHOLD_USDC } from "@/lib/billing/marketplace-billing";
 
 describe("marketplace-billing", () => {
   it("threshold is 0.05 USDC", () => {
     expect(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC).toBe("0.05");
   });
 
-  describe("isWorkflowBillable", () => {
-    it("returns true for unlisted workflows regardless of price", () => {
-      expect(
-        isWorkflowBillable({ isListed: false, priceUsdcPerCall: "0.50" })
-      ).toBe(true);
-      expect(
-        isWorkflowBillable({ isListed: null, priceUsdcPerCall: "1.00" })
-      ).toBe(true);
+  it("threshold parses as a number for numeric comparisons", () => {
+    expect(Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)).toBe(0.05);
+  });
+
+  describe("threshold comparison semantics (mirrors the marketplace call route)", () => {
+    const threshold = Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC);
+
+    it("treats prices below the threshold as not exempt", () => {
+      expect(threshold <= 0.04).toBe(false);
+      expect(threshold <= 0.0001).toBe(false);
+      expect(threshold <= 0).toBe(false);
     });
 
-    it("returns true for listed workflows priced below the threshold", () => {
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.04" })
-      ).toBe(true);
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.0001" })
-      ).toBe(true);
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0" })
-      ).toBe(true);
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: null })
-      ).toBe(true);
-    });
-
-    it("returns false for listed workflows at or above the threshold", () => {
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.05" })
-      ).toBe(false);
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "0.50" })
-      ).toBe(false);
-      expect(
-        isWorkflowBillable({ isListed: true, priceUsdcPerCall: "100" })
-      ).toBe(false);
+    it("treats prices at or above the threshold as exempt", () => {
+      expect(threshold <= 0.05).toBe(true);
+      expect(threshold <= 0.5).toBe(true);
+      expect(threshold <= 100).toBe(true);
     });
   });
 });

--- a/tests/unit/billing-marketplace-billing.test.ts
+++ b/tests/unit/billing-marketplace-billing.test.ts
@@ -1,0 +1,41 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import {
+  billableWorkflowFilter,
+  billableWorkflowRawSql,
+  FREE_MARKETPLACE_BILLING_THRESHOLD_USDC,
+} from "@/lib/billing/marketplace-billing";
+
+const dialect = new PgDialect();
+
+describe("marketplace-billing", () => {
+  it("threshold is 0.05 USDC", () => {
+    expect(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC).toBe("0.05");
+  });
+
+  describe("billableWorkflowRawSql", () => {
+    it("excludes listed workflows priced at or above the threshold (uses w. alias)", () => {
+      const { sql } = dialect.sqlToQuery(billableWorkflowRawSql);
+      const normalized = sql.replace(/\s+/g, " ").toLowerCase();
+
+      expect(normalized).toContain("not (");
+      expect(normalized).toContain("w.is_listed = true");
+      expect(normalized).toContain(
+        "coalesce(w.price_usdc_per_call::numeric, 0) >= 0.05::numeric"
+      );
+    });
+  });
+
+  describe("billableWorkflowFilter", () => {
+    it("excludes listed workflows priced at or above the threshold (uses workflows table)", () => {
+      const { sql } = dialect.sqlToQuery(billableWorkflowFilter);
+      const normalized = sql.replace(/\s+/g, " ").toLowerCase();
+
+      expect(normalized).toContain("not (");
+      expect(normalized).toContain('"workflows"."is_listed" = true');
+      expect(normalized).toContain(
+        'coalesce("workflows"."price_usdc_per_call"::numeric, 0) >= 0.05::numeric'
+      );
+    });
+  });
+});

--- a/tests/unit/billing-marketplace-billing.test.ts
+++ b/tests/unit/billing-marketplace-billing.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { FREE_MARKETPLACE_BILLING_THRESHOLD_USDC } from "@/lib/billing/marketplace-billing";
+import {
+  FREE_MARKETPLACE_BILLING_THRESHOLD_USDC,
+  priceQualifiesForMarketplaceExemption,
+} from "@/lib/billing/marketplace-billing";
 
 describe("marketplace-billing", () => {
   it("threshold is 0.05 USDC", () => {
@@ -10,19 +13,23 @@ describe("marketplace-billing", () => {
     expect(Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC)).toBe(0.05);
   });
 
-  describe("threshold comparison semantics (mirrors the marketplace call route)", () => {
-    const threshold = Number(FREE_MARKETPLACE_BILLING_THRESHOLD_USDC);
-
-    it("treats prices below the threshold as not exempt", () => {
-      expect(threshold <= 0.04).toBe(false);
-      expect(threshold <= 0.0001).toBe(false);
-      expect(threshold <= 0).toBe(false);
+  describe("priceQualifiesForMarketplaceExemption", () => {
+    it("returns false for prices below the threshold", () => {
+      expect(priceQualifiesForMarketplaceExemption("0.04")).toBe(false);
+      expect(priceQualifiesForMarketplaceExemption("0.0001")).toBe(false);
+      expect(priceQualifiesForMarketplaceExemption("0")).toBe(false);
     });
 
-    it("treats prices at or above the threshold as exempt", () => {
-      expect(threshold <= 0.05).toBe(true);
-      expect(threshold <= 0.5).toBe(true);
-      expect(threshold <= 100).toBe(true);
+    it("returns true for prices at or above the threshold", () => {
+      expect(priceQualifiesForMarketplaceExemption("0.05")).toBe(true);
+      expect(priceQualifiesForMarketplaceExemption("0.5")).toBe(true);
+      expect(priceQualifiesForMarketplaceExemption("100")).toBe(true);
+    });
+
+    it("treats null/undefined/empty as 0 (does not qualify)", () => {
+      expect(priceQualifiesForMarketplaceExemption(null)).toBe(false);
+      expect(priceQualifiesForMarketplaceExemption(undefined)).toBe(false);
+      expect(priceQualifiesForMarketplaceExemption("")).toBe(false);
     });
   });
 });

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -8,6 +8,8 @@ const {
   mockDbSelect,
   mockDbInsert,
   mockDbUpdate,
+  mockDbUpdateSet,
+  mockDbTransaction,
   mockHashPaymentSignature,
   mockHashMppCredential,
   mockRecordPayment,
@@ -26,6 +28,8 @@ const {
   mockDbSelect: vi.fn(),
   mockDbInsert: vi.fn(),
   mockDbUpdate: vi.fn(),
+  mockDbUpdateSet: vi.fn(),
+  mockDbTransaction: vi.fn(),
   mockHashPaymentSignature: vi.fn(),
   mockHashMppCredential: vi.fn(),
   mockRecordPayment: vi.fn(),
@@ -51,6 +55,7 @@ vi.mock("@/lib/db", () => ({
     select: mockDbSelect,
     insert: mockDbInsert,
     update: mockDbUpdate,
+    transaction: mockDbTransaction,
   },
 }));
 
@@ -234,12 +239,29 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     mockBuildCallCompletionResponse.mockImplementation((executionId: string) =>
       Promise.resolve({ executionId, status: "running" })
     );
-    // Default no-op update chain: db.update(table).set(values).where(filter)
-    mockDbUpdate.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
+    // Default no-op update chain: db.update(table).set(values).where(filter).
+    // mockDbUpdateSet captures the values argument so tests can assert on it
+    // (used for the KEEP-449 billable=false flip and the status=error path).
+    mockDbUpdateSet.mockReset();
+    mockDbUpdateSet.mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
     });
+    mockDbUpdate.mockReturnValue({ set: mockDbUpdateSet });
+    // db.transaction(cb) calls cb with a tx that exposes the same insert /
+    // update mocks, so all of recordPayment + the billable flip route through
+    // the same spies the tests already inspect.
+    mockDbTransaction.mockImplementation(
+      async (
+        cb: (tx: {
+          insert: typeof mockDbInsert;
+          update: typeof mockDbUpdate;
+        }) => Promise<unknown>
+      ) =>
+        cb({
+          insert: mockDbInsert,
+          update: mockDbUpdate,
+        })
+    );
     // Default: caller is authenticated. Tests that exercise the unauthenticated
     // path must explicitly override these to return { authenticated: false }.
     mockAuthenticateOAuthToken.mockResolvedValue({
@@ -658,5 +680,79 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     const response = await POST(request, { params });
     expect(response.status).toBe(402);
     expect(mockGatePayment).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // KEEP-449: marketplace-paid calls at or above the threshold ($0.05 USDC) are
+  // exempt from the owner's monthly execution quota. The flip is performed by
+  // an UPDATE on workflow_executions inside the same transaction as
+  // recordPayment, so the workflow_payments row and billable bit can never
+  // disagree.
+  // ---------------------------------------------------------------------------
+
+  it("Test 17 (KEEP-449): paid call at or above the threshold flips billable=false", async () => {
+    setupDbSelectWorkflow(LISTED_WORKFLOW); // priceUsdcPerCall = "1.50"
+    setupDbInsertExecution("exec-paid-above");
+    makePassThroughGatePayment();
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow", {
+      paymentSignature: "sig-above",
+    });
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    expect(mockRecordPayment).toHaveBeenCalled();
+    expect(mockDbTransaction).toHaveBeenCalledTimes(1);
+    expect(mockDbUpdateSet).toHaveBeenCalledWith({ billable: false });
+  });
+
+  it("Test 18 (KEEP-449): paid call below the threshold leaves billable at default (true)", async () => {
+    const cheapWorkflow = { ...LISTED_WORKFLOW, priceUsdcPerCall: "0.04" };
+    setupDbSelectWorkflow(cheapWorkflow);
+    setupDbInsertExecution("exec-paid-below");
+    makePassThroughGatePayment();
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow", {
+      paymentSignature: "sig-below",
+    });
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    expect(mockRecordPayment).toHaveBeenCalled();
+    expect(mockDbTransaction).toHaveBeenCalledTimes(1);
+    expect(mockDbUpdateSet).not.toHaveBeenCalledWith({ billable: false });
+  });
+
+  it("Test 19 (KEEP-449): paid call exactly at the threshold flips billable=false", async () => {
+    const thresholdWorkflow = {
+      ...LISTED_WORKFLOW,
+      priceUsdcPerCall: "0.05",
+    };
+    setupDbSelectWorkflow(thresholdWorkflow);
+    setupDbInsertExecution("exec-paid-threshold");
+    makePassThroughGatePayment();
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow", {
+      paymentSignature: "sig-threshold",
+    });
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    expect(mockDbUpdateSet).toHaveBeenCalledWith({ billable: false });
+  });
+
+  it("Test 20 (KEEP-449): free workflow path never flips billable", async () => {
+    setupDbSelectWorkflow(FREE_WORKFLOW); // price = "0"
+    setupDbInsertExecution("exec-free-keep449");
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const request = makeRequest("test-workflow");
+    const params = Promise.resolve({ slug: "test-workflow" });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(200);
+    // Free path bypasses gatePayment entirely, so neither recordPayment nor
+    // the transaction wrapper run.
+    expect(mockGatePayment).not.toHaveBeenCalled();
+    expect(mockDbTransaction).not.toHaveBeenCalled();
+    expect(mockDbUpdateSet).not.toHaveBeenCalledWith({ billable: false });
   });
 });


### PR DESCRIPTION
## Summary

- Marketplace callers who pay for a listed workflow at $0.05 USDC per call or higher no longer cause the owner's monthly execution quota or overage invoicing to tick up. Below the floor, paid calls still count. The threshold prevents owners from publishing at $0 (or any irrationally low price) and self-calling through the marketplace to accumulate free executions. Closes [KEEP-449](https://linear.app/keeperhubapp/issue/KEEP-449).
- The exemption is gated on **actual payment receipt**, not on the workflow's listing state alone. Owner Run from the editor, scheduled runs, block / event triggers, webhooks, and direct API calls of a listed workflow all keep counting toward quota normally. Only a successful x402 / MPP payment recorded for the row flips it.
- Mechanism: a new `workflow_executions.billable boolean NOT NULL DEFAULT TRUE` column. Every insert path defaults to TRUE. The marketplace call route is the only writer of FALSE, and only after `recordPayment` succeeds and the recorded price is at or above `FREE_MARKETPLACE_BILLING_THRESHOLD_USDC`. `recordPayment` and the `billable=false` UPDATE run inside one `db.transaction` so the `workflow_payments` row and the billable bit can never disagree.
- Six count queries (limit gate in Next.js and the standalone executor, overage invoicing, limit-reached indicator, billing settings usage display, tier-upgrade suggestion) now filter on `we.billable = TRUE`.
- Public docs at `docs/workflows/marketplace.md` get a new "Execution quota" section that describes the payment-gated rule, the floor, the snapshot semantics, and which trigger sources do or do not qualify.
- Drive-by fix: `/billing` had no server-side auth or role gating beyond the feature flag, so any signed-in user could navigate there directly and see another member's billing data. The page now mirrors the gating that `require-org-owner.ts` already enforces on billing API routes (redirect unauthenticated, 404 for non-owners).

## Notes for review

- Branch went through a snapshot-via-trigger design earlier (commits 34fbe659 / beb6cb1b) that was replaced because it gated on the workflow's listing state and let an owner click Run repeatedly to accumulate free quota. The current payment-gated design closes that loophole. Squash on merge to keep history clean; the squashed commit message should describe only the final design.
- Today the helper compares against `workflow.priceUsdcPerCall` (the listing price loaded with the request) as a stand-in for "amount paid", which is correct because the upstream payment gate validates the signature against that listing price. If that gate ever loosens (partial payments, dynamic pricing, refunds), the helper should be invoked with the verified payment amount instead. Noted in the helper's docblock.

## Out of scope

- Partial index on `workflow_executions(billable)` for query plan stability as the table grows. Not needed today; can land as a follow-up if the count queries become hot.
- `notFound()` vs `redirect("/")` UX choice on the `/billing` page guard. Current behavior 404s non-owners (silent) rather than redirecting to home. Judgement call; either is defensible.