### PR TITLE
fix(docs-site): pin pnpm to 10.x and set CI=true in Dockerfile

### DIFF
--- a/docs-site/Dockerfile
+++ b/docs-site/Dockerfile
@@ -25,6 +25,9 @@ COPY docs/ ./content/
 # Build the application
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
+# Tell pnpm it's running non-interactively so v11+ doesn't abort on its
+# pre-script deps-status check (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
+ENV CI=true
 
 RUN corepack enable pnpm && pnpm run build
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -21,5 +21,6 @@
     "@types/react": "^19.2.14",
     "pagefind": "^1.5.2",
     "typescript": "^5.7.0"
-  }
+  },
+  "packageManager": "pnpm@10.33.3"
 }


### PR DESCRIPTION
## Summary

The prod docs deploy ([run #25523401513](https://github.com/KeeperHub/keeperhub/actions/runs/25523401513)) failed in the `builder` stage of `docs-site/Dockerfile` with:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
If you are running pnpm in CI, set the CI environment variable to "true",
or set "confirmModulesPurge" to "false".
```

### Root cause

- `docs-site/package.json` had no `packageManager` field, so `corepack enable pnpm` resolved to the latest pnpm release.
- The previous successful docs deploy (2026-05-05, run 25364607809) pulled **pnpm 10.33.3**. The failing run pulled the freshly-released **pnpm 11.0.8**.
- pnpm 11 runs a pre-script deps-status check before `pnpm run build`. In the `builder` stage there is no lockfile next to the forwarded `node_modules` (the `deps` stage only copies `package.json`, generates a lockfile internally, and only `node_modules` is forwarded), so pnpm 11 decides `node_modules` is stale, tries to purge it, and aborts because the Docker build has no TTY and `CI` is unset.

### Fix

- **Pin `packageManager` to `pnpm@10.33.3`** in `docs-site/package.json` so corepack stops floating to whatever pnpm major just shipped.
- **Set `ENV CI=true`** in the builder stage as defence-in-depth, matching pnpm's own remediation hint, so a future intentional bump to pnpm 11+ does not break the docs deploy again.

## Test plan

- [ ] CI workflow runs green on this PR
- [ ] After merge to `staging` and promotion to `prod`, the `prod deploy-keeperhub-docs` workflow succeeds end-to-end (build + helm deploy)
- [ ] docs.keeperhub.com serves the new revision