### PR TITLE
fix(ci): pin pnpm version on pin-agent-card workflow

### DIFF
--- a/.github/workflows/pin-agent-card.yml
+++ b/.github/workflows/pin-agent-card.yml
@@ -23,7 +23,9 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Pins pnpm to v10 on the new \`pin-agent-card\` workflow added in #1173. The first prod run failed with \`Error: No pnpm version is specified.\` because \`package.json\` has no \`packageManager\` field, so \`pnpm/action-setup\` could not infer a version.
- Bumps the action from v4 to v6 (v4 was also flagged by the Node 20 deprecation warning).
- pnpm 10 matches the version pinned in the docs-site Dockerfile in #1172.

Failure context: https://github.com/KeeperHub/keeperhub/actions/runs/25533157212/job/74945672224

## Test plan

- [ ] Wait for staging CI to confirm the workflow file parses
- [ ] After the next prod release, confirm the \`pin-agent-card\` job runs to completion (Pinata pin + on-chain drift log)