### PR TITLE
fix(docs-site): install from frozen lockfile in Docker build

### DIFF
--- a/docs-site/Dockerfile
+++ b/docs-site/Dockerfile
@@ -5,9 +5,13 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Copy package files
-COPY docs-site/package.json ./
-RUN corepack enable pnpm && pnpm install
+# Copy package files. Both package.json AND pnpm-lock.yaml are required so
+# the install resolves to the exact versions the lockfile pins. Without the
+# lockfile, pnpm floats every range fresh on each build, which has caused
+# transparent registry-side dep regressions to break the docs build with
+# Server Components prerender errors.
+COPY docs-site/package.json docs-site/pnpm-lock.yaml ./
+RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary

Follow-up to #1172. That PR fixed `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` by pinning pnpm to 10.x, but the next prod docs deploy ([run #25533157215](https://github.com/KeeperHub/keeperhub/actions/runs/25533157215)) failed at a different layer:

```
Error occurred prerendering page "/ai-tools/agentic-wallet"
[Error: An error occurred in the Server Components render. The specific message
 is omitted in production builds to avoid leaking sensitive details.]
Export encountered an error on /[[...mdxPath]]/page: /ai-tools/agentic-wallet,
exiting the build.
```

### Root cause

`docs-site/Dockerfile` was copying only `package.json` into the `deps` stage and running plain `pnpm install`. With no lockfile present, pnpm re-resolves every dependency range fresh from the registry on each build. The same `docs/ai-tools/agentic-wallet.md` file that built fine on 2026-05-05 and 2026-05-06 (147/147 pages including this one) failed in this run on a commit that didn't touch the file -- because the registry-side versions of nextra and/or its transitive deps drifted under the package's `^4.0.0` range.

Reproduced locally: with the committed `pnpm-lock.yaml` (which pins `next 16.2.4`, `nextra 4.6.1`, `nextra-theme-docs 4.6.1`), `pnpm run build` produces all 147 static pages cleanly, including `/ai-tools/agentic-wallet`.

### Fix

Copy `docs-site/pnpm-lock.yaml` alongside `package.json` in the `deps` stage and switch to `pnpm install --frozen-lockfile`, so:

- Installs are byte-for-byte reproducible across local and CI.
- CI fails loudly if anyone updates `package.json` without regenerating the lockfile, instead of silently floating to broken upstream versions.

### Build context note

The workflow invokes the build with `file: ./docs-site/Dockerfile`, which makes BuildKit apply `docs-site/Dockerfile.dockerignore` in place of the root `.dockerignore`. That file does not exclude `pnpm-lock.yaml`, so the lockfile is already available in the build context -- only the `COPY` line was missing.

## Test plan

- [ ] CI workflow runs green on this PR
- [ ] After merge to `staging` and promotion to `prod`, the `prod deploy-keeperhub-docs` workflow succeeds end-to-end and renders 147/147 pages including `/ai-tools/agentic-wallet`
- [ ] docs.keeperhub.com serves the new revision