### PR TITLE
release: to prod

### DIFF
--- a/.github/workflows/pin-agent-card.yml
+++ b/.github/workflows/pin-agent-card.yml
@@ -23,7 +23,9 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/docs-site/Dockerfile
+++ b/docs-site/Dockerfile
@@ -5,9 +5,13 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Copy package files
-COPY docs-site/package.json ./
-RUN corepack enable pnpm && pnpm install
+# Copy package files. Both package.json AND pnpm-lock.yaml are required so
+# the install resolves to the exact versions the lockfile pins. Without the
+# lockfile, pnpm floats every range fresh on each build, which has caused
+# transparent registry-side dep regressions to break the docs build with
+# Server Components prerender errors.
+COPY docs-site/package.json docs-site/pnpm-lock.yaml ./
+RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary

Promote the following merged PRs from staging to prod:

- #1176 fix(docs-site): install from frozen lockfile in Docker build
- #1175 fix(ci): pin pnpm version on pin-agent-card workflow

## Post-deploy verification

- [ ] `deploy-keeperhub` workflow finishes green
- [ ] `curl -fsS https://app.keeperhub.com/api/health` returns 200
- [ ] Smoke-test the surfaces affected by the merged PRs above
- [ ] Watch Sentry / logs for ~10 minutes after the rollout
