### PR TITLE
release: to prod

### DIFF
--- a/.github/workflows/pin-agent-card.yml
+++ b/.github/workflows/pin-agent-card.yml
@@ -39,5 +39,4 @@ jobs:
       - name: Pin agent-registry.json to Pinata
         env:
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
-          CHAIN_ETH_MAINNET_PRIMARY_RPC: ${{ secrets.CHAIN_ETH_MAINNET_PRIMARY_RPC }}
         run: pnpm tsx scripts/pin-agent-card.ts

--- a/scripts/pin-agent-card.ts
+++ b/scripts/pin-agent-card.ts
@@ -23,7 +23,16 @@ import { ethers } from "ethers";
 
 const DEFAULT_AGENT_ID = "31875";
 const DEFAULT_REGISTRY = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
-const DEFAULT_RPC = "https://chain.techops.services/eth-mainnet";
+// Public RPC that doesn't require auth headers. The repo's primary RPC
+// (chain.techops.services) sits behind Cloudflare Access and isn't reachable
+// from the GHA runner, so we fall back to a public endpoint for the drift read.
+const DEFAULT_RPC = "https://eth.llamarpc.com";
+
+function envOrDefault(key: string, fallback: string): string {
+  const value = process.env[key];
+  // GHA passes ${{ secrets.X }} as "" when X is unset, so treat empty as missing.
+  return value && value.length > 0 ? value : fallback;
+}
 const PINATA_PIN_FILE_URL = "https://api.pinata.cloud/pinning/pinFileToIPFS";
 const CARD_PATH = join(process.cwd(), "data/agent-registry.json");
 
@@ -88,9 +97,9 @@ export async function pinAgentCard(): Promise<void> {
     throw new Error("PINATA_JWT environment variable is required");
   }
 
-  const agentId = process.env.AGENT_ID ?? DEFAULT_AGENT_ID;
-  const registry = process.env.IDENTITY_REGISTRY_ADDRESS ?? DEFAULT_REGISTRY;
-  const rpcUrl = process.env.CHAIN_ETH_MAINNET_PRIMARY_RPC ?? DEFAULT_RPC;
+  const agentId = envOrDefault("AGENT_ID", DEFAULT_AGENT_ID);
+  const registry = envOrDefault("IDENTITY_REGISTRY_ADDRESS", DEFAULT_REGISTRY);
+  const rpcUrl = envOrDefault("CHAIN_ETH_MAINNET_PRIMARY_RPC", DEFAULT_RPC);
 
   const bytes = readFileSync(CARD_PATH);
   console.log(`[pin] Pinning ${CARD_PATH} (${bytes.length} bytes) to Pinata...`);

--- a/scripts/update-agent-uri.ts
+++ b/scripts/update-agent-uri.ts
@@ -24,7 +24,7 @@ import { ethers } from "ethers";
 
 const DEFAULT_AGENT_ID = "31875";
 const DEFAULT_REGISTRY = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
-const DEFAULT_RPC = "https://chain.techops.services/eth-mainnet";
+const DEFAULT_RPC = "https://eth.llamarpc.com";
 
 // Conservative floor for setAgentURI gas. The call is a single SSTORE plus a
 // string write; on mainnet at typical gas prices this is ~$1-3, but we want to


### PR DESCRIPTION
## Summary

Promote the following merged PRs from staging to prod:

- #1178 fix(pin-agent-card): use public RPC and treat empty env as unset

## Post-deploy verification

- [ ] `deploy-keeperhub` workflow finishes green
- [ ] `curl -fsS https://app.keeperhub.com/api/health` returns 200
- [ ] Smoke-test the surfaces affected by the merged PRs above
- [ ] Watch Sentry / logs for ~10 minutes after the rollout
