### PR TITLE
fix(block-dispatcher): reap zombie chain monitors via staleness check

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -21,7 +21,22 @@ const MAX_DELAY_MS = 30_000;
 const CONNECT_TIMEOUT_MS = 15_000;
 const PING_INTERVAL_MS = 30_000;
 const PONG_TIMEOUT_MS = 5_000;
-const NO_BLOCK_TIMEOUT_MS = 5 * 60_000; // 5 minutes
+const NO_BLOCK_TIMEOUT_DEFAULT_MS = 5 * 60_000; // 5 minutes
+// Overridable so tests can exercise the staleness path in isolation from the
+// in-monitor no-block timer. Read on each resetNoBlockTimer() call so the
+// override applies even when set after module load.
+function getNoBlockTimeoutMs(): number {
+  return Number(process.env.NO_BLOCK_TIMEOUT_MS) || NO_BLOCK_TIMEOUT_DEFAULT_MS;
+}
+// Reconciler-level staleness threshold. Backstop for the in-monitor no-block
+// timer above:
+// observed in prod that the timer can fail to fire after a reconnect (root
+// cause unconfirmed; suspected ethers v6 subscription + upstream WSS half-open
+// state). When that happens, the monitor reports hasActiveSubscription=true
+// indefinitely and the reconciler never restarts it. Treating "no blocks for
+// N minutes" as not-alive lets the reconciler tear down and restart the
+// monitor regardless of why the in-monitor timer failed.
+const STALE_SUBSCRIPTION_MS = 10 * 60_000; // 10 minutes
 const STALE_BLOCK_THRESHOLD_S = 120; // warn if block timestamp >2 min behind
 const HEARTBEAT_INTERVAL_MS = 60_000;
 const MAX_BACKFILL_BLOCKS = 100;
@@ -66,6 +81,7 @@ export class ChainMonitor {
   private pendingBlock: number | null = null;
   private reconnectAttempts = 0;
   private lastProcessedBlock: number | null = null;
+  private lastBlockReceivedAt: number | null = null;
   private blocksReceived = 0;
   private blocksMatched = 0;
   private lastHeartbeat = Date.now();
@@ -126,9 +142,26 @@ export class ChainMonitor {
   }
 
   isAlive(): boolean {
-    return (
-      this.isRunning && (this.hasActiveSubscription || this.isReconnecting)
-    );
+    if (!this.isRunning) {
+      return false;
+    }
+    if (this.isReconnecting) {
+      return true;
+    }
+    if (!this.hasActiveSubscription) {
+      return false;
+    }
+    // Subscription is set up, but the upstream WSS may have gone silent
+    // (zombie subscription). Treat as not-alive once the gap since the last
+    // block exceeds STALE_SUBSCRIPTION_MS so the BlockMonitorService
+    // reconciler tears it down and starts a fresh monitor.
+    if (
+      this.lastBlockReceivedAt !== null &&
+      Date.now() - this.lastBlockReceivedAt > STALE_SUBSCRIPTION_MS
+    ) {
+      return false;
+    }
+    return true;
   }
 
   getStatus(): {
@@ -294,6 +327,10 @@ export class ChainMonitor {
     });
 
     this.hasActiveSubscription = true;
+    // Seed the staleness clock so a freshly-subscribed monitor isn't reaped
+    // by isAlive() before the first block arrives. Real blocks will refresh
+    // this in onBlock().
+    this.lastBlockReceivedAt = Date.now();
     console.log(`[BlockMonitor:${this.chainName}] Block subscription active`);
 
     // Handle WebSocket close for reconnection - store reference for cleanup
@@ -315,6 +352,7 @@ export class ChainMonitor {
   // ---------------------------------------------------------------------------
 
   private async onBlock(blockNumber: number): Promise<void> {
+    this.lastBlockReceivedAt = Date.now();
     this.resetNoBlockTimer();
 
     // Deduplicate — ethers may fire the same block from both polling and newHeads
@@ -554,14 +592,15 @@ export class ChainMonitor {
 
   private resetNoBlockTimer(): void {
     this.stopNoBlockTimer();
+    const timeoutMs = getNoBlockTimeoutMs();
     this.noBlockTimer = setTimeout(() => {
       if (this.isRunning) {
         console.warn(
-          `[BlockMonitor:${this.chainName}] No blocks received in ${NO_BLOCK_TIMEOUT_MS / 1000}s, triggering reconnect`,
+          `[BlockMonitor:${this.chainName}] No blocks received in ${timeoutMs / 1000}s, triggering reconnect`,
         );
         this.handleDisconnect();
       }
-    }, NO_BLOCK_TIMEOUT_MS);
+    }, timeoutMs);
   }
 
   private stopNoBlockTimer(): void {

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -139,8 +139,9 @@ class BlockMonitorService {
         await existing.stop();
         await this.startNewMonitor(chainId, chain, workflows);
       } else if (!existing.isAlive()) {
+        const status = existing.getStatus();
         console.warn(
-          `[BlockMonitorService] Monitor for ${chain.name} (${chainId}) is dead, restarting`,
+          `[BlockMonitorService] Monitor for ${chain.name} (${chainId}) is dead, restarting (lastBlock=${status.lastBlock}, blocksReceived=${status.blocksReceived}, hasSubscription=${status.hasSubscription}, reconnecting=${status.reconnecting})`,
         );
         await existing.stop();
         this.monitors.delete(chainId);

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -468,6 +468,67 @@ describe("ChainMonitor", () => {
       await monitor.stop();
       expect(monitor.isAlive()).toBe(false);
     });
+
+    it("returns false when subscription has gone silent for >10 minutes", async () => {
+      // Reproduces the prod zombie state: subscription is set up but the
+      // upstream WSS never delivers blocks. The in-monitor no-block timer
+      // failed to fire; the reconciler must catch this via isAlive() so it
+      // can tear down and start a fresh monitor.
+      //
+      // Disable the in-monitor no-block timer for this test so the staleness
+      // path is exercised on its own. (In prod, the timer was demonstrably
+      // not firing — that is the failure mode this fallback exists for.)
+      vi.stubEnv("NO_BLOCK_TIMEOUT_MS", String(60 * 60_000));
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(monitor.isAlive()).toBe(true);
+
+      // Advance 9 minutes — still under the 10-min staleness threshold.
+      await vi.advanceTimersByTimeAsync(9 * 60_000);
+      expect(monitor.isAlive()).toBe(true);
+
+      // Cross the threshold. No blocks have been received since subscribe.
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+      expect(monitor.isAlive()).toBe(false);
+    });
+
+    it("stays alive when blocks are arriving regularly", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow({ blockInterval: 1 })],
+      });
+
+      await monitor.start();
+      const provider = latestProvider();
+
+      // Emit a block every 5 minutes for 30 minutes — well past the 10-min
+      // staleness threshold, but each block resets lastBlockReceivedAt.
+      for (const blockNumber of [101, 102, 103, 104, 105, 106]) {
+        await vi.advanceTimersByTimeAsync(5 * 60_000);
+        provider.emitBlock(blockNumber);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(monitor.isAlive()).toBe(true);
+      }
+    });
+
+    it("does not reap a freshly-subscribed monitor that has yet to receive its first block", async () => {
+      // Edge case: a monitor that just (re)connected but hasn't seen its
+      // first block yet must not be reaped before the staleness window.
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      // Without resetting lastBlockReceivedAt at subscribe time, isAlive()
+      // would compute a stale gap immediately. Sanity check the seed.
+      expect(monitor.isAlive()).toBe(true);
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Block-triggered workflows on Ethereum Mainnet stopped firing in prod for ~14h while the dispatcher pod stayed `Running`. Affected workflows (all on chain 1): Maker Keeper, d3m-keeper, Chronicle Challenger Bot, Flap job keeper, Clipper mom job keeper.

## Symptom

Block-dispatcher pod healthy. Avalanche / Base Sepolia monitors advancing normally. Ethereum Mainnet monitor:

```json
{ "chainId": 1, "alive": true, "hasSubscription": true,
  "lastBlock": 25046769 }   <- frozen 14h before the snapshot
```

DB confirms: workflow `4kxvqkjsni9460ihw4qlv` (Maker Keeper) was firing every ~2.5 min like clockwork until exactly the moment the monitor froze, then nothing.

## What we found in logs

After each WSS reconnect the monitor logs `Connected … Subscribing … Block subscription active … Ping/pong keepalive started`, then goes silent. Across the whole incident there was a 3h44m window with zero block events, zero `WebSocket closed` warnings, zero `No blocks received in 300s` warnings — the in-monitor 5-min `noBlockTimer` (the safeguard meant to catch exactly this) demonstrably did not fire.

Root cause for the timer not firing is unconfirmed. Suspected ethers v6 subscription state over a half-open WSS where the underlying WS still answers pings but `eth_subscribe(newHeads)` is silently dropped server-side. We can't reliably reproduce that locally; what we can fix is the design flaw that lets the symptom be invisible to the reconciler.

## Fix

`isAlive()` previously only checked "subscription was set up at some point" via `hasActiveSubscription`. Now it also returns false when no block has been received in the last 10 minutes. The `BlockMonitorService.reconcile()` loop runs every 30s, sees the false, calls `stop()` and starts a fresh monitor — regardless of why the in-monitor timer failed.

- Track `lastBlockReceivedAt` and update it on every block delivery.
- Seed `lastBlockReceivedAt` at subscribe time so a freshly (re)connected monitor is not reaped before its first block.
- 10-minute threshold sits comfortably above the 5-minute `noBlockTimer`; when the in-monitor timer works (the common case) it still wins. The staleness check is the backstop for when it doesn't.
- `NO_BLOCK_TIMEOUT_MS` is now env-overridable (same pattern as the existing `PRIMARY_PROBE_INTERVAL_MS`) so tests can exercise the staleness path in isolation.
- Reconciler "monitor is dead" warning now includes `lastBlock`, `blocksReceived`, `hasSubscription`, `reconnecting` so future triage doesn't require diffing the health endpoint by hand.

## Tests

`keeperhub-scheduler/tests/unit/chain-monitor.test.ts` — 3 new cases:
- Subscription silent for 11 minutes is reaped (with the in-monitor timer pushed out so the staleness path is exercised on its own).
- A monitor receiving blocks every 5 minutes for 30 minutes stays alive.
- A freshly subscribed monitor is not reaped before its first block.

All 28 chain-monitor tests pass; all 57 scheduler tests pass.