### PR TITLE
fix(webhook-route): explain wfb_ vs kh_ key mismatch on 401

### DIFF
--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -60,7 +60,7 @@ async function validateApiKey(
           code: "wrong_key_type",
           expected: "wfb_*",
           received: "kh_*",
-          hint: "Generate a webhook key at /settings/api-keys and pass it as `Authorization: Bearer wfb_...`.",
+          hint: "Generate a webhook key from the user menu > API Keys > Webhook tab, then pass it as `Authorization: Bearer wfb_...`.",
         },
       };
     }

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -20,11 +20,18 @@ import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+type ValidateApiKeyResult = {
+  valid: boolean;
+  error?: string;
+  statusCode?: number;
+  errorBody?: Record<string, unknown>;
+};
+
 // Validate API key and return the user ID if valid
 async function validateApiKey(
   authHeader: string | null,
   workflowUserId: string
-): Promise<{ valid: boolean; error?: string; statusCode?: number }> {
+): Promise<ValidateApiKeyResult> {
   if (!authHeader) {
     return {
       valid: false,
@@ -39,7 +46,34 @@ async function validateApiKey(
     : authHeader;
 
   if (!key?.startsWith("wfb_")) {
-    return { valid: false, error: "Invalid API key format", statusCode: 401 };
+    // Builders frequently paste their org-scoped kh_* key here because the
+    // rest of the API accepts it. Surface the prefix mismatch explicitly so
+    // they don't have to discover via Discord that this endpoint expects a
+    // user webhook key (KEEP-469).
+    if (key?.startsWith("kh_")) {
+      return {
+        valid: false,
+        statusCode: 401,
+        error:
+          "Wrong API key type. This endpoint requires a user webhook key (wfb_*). The kh_* prefix is an org API key for /api/execute/* and /mcp.",
+        errorBody: {
+          code: "wrong_key_type",
+          expected: "wfb_*",
+          received: "kh_*",
+          hint: "Generate a webhook key at /settings/api-keys and pass it as `Authorization: Bearer wfb_...`.",
+        },
+      };
+    }
+    return {
+      valid: false,
+      statusCode: 401,
+      error:
+        "Invalid API key format. Expected a user webhook key starting with wfb_.",
+      errorBody: {
+        code: "invalid_key_format",
+        expected: "wfb_*",
+      },
+    };
   }
 
   // Hash the key to compare with stored hash
@@ -89,7 +123,8 @@ function failResponse(
   workflowId: string,
   timer: () => number,
   statusCode: number,
-  message: string
+  message: string,
+  extraBody?: Record<string, unknown>
 ): NextResponse {
   recordWebhookMetrics({
     workflowId,
@@ -98,7 +133,7 @@ function failResponse(
     error: message,
   });
   return NextResponse.json(
-    { error: message },
+    { error: message, ...extraBody },
     { status: statusCode, headers: corsHeaders }
   );
 }
@@ -195,8 +230,9 @@ export async function POST(
       return failResponse(
         workflowId,
         timer,
-        apiKeyValidation.statusCode || 401,
-        apiKeyValidation.error ?? "Invalid API key"
+        apiKeyValidation.statusCode ?? 401,
+        apiKeyValidation.error ?? "Invalid API key",
+        apiKeyValidation.errorBody
       );
     }
 

--- a/tests/e2e/vitest/workflow-runner.test.ts
+++ b/tests/e2e/vitest/workflow-runner.test.ts
@@ -599,7 +599,8 @@ describe.skipIf(shouldSkip)("Webhook API E2E", () => {
 
         expect(response.status).toBe(401);
         const body = await response.json();
-        expect(body.error).toBe("Invalid API key format");
+        expect(body.error).toContain("wfb_");
+        expect(body.code).toBe("invalid_key_format");
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
           console.warn("API request timed out - server may be slow");

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -231,7 +231,7 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
       expect(data.error).toBe("Missing Authorization header");
     });
 
-    it("should return 401 for non-wfb key format", async () => {
+    it("should return 401 with wrong_key_type hint when a kh_ org key is used", async () => {
       mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
 
       const response = await POST(
@@ -240,7 +240,26 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
       );
       expect(response.status).toBe(401);
       const data = await response.json();
-      expect(data.error).toBe("Invalid API key format");
+      expect(data.error).toContain("wfb_");
+      expect(data.error).toContain("kh_");
+      expect(data.code).toBe("wrong_key_type");
+      expect(data.expected).toBe("wfb_*");
+      expect(data.received).toBe("kh_*");
+      expect(typeof data.hint).toBe("string");
+    });
+
+    it("should return 401 with expected prefix when key has unknown prefix", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+
+      const response = await POST(
+        createWebhookRequest("totally_unknown_key"),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("wfb_");
+      expect(data.code).toBe("invalid_key_format");
+      expect(data.expected).toBe("wfb_*");
     });
 
     it("should return 401 when key not found in database", async () => {


### PR DESCRIPTION
## Summary

Fixes [KEEP-469](https://linear.app/keeperhubapp/issue/KEEP-469). `POST /api/workflows/{id}/webhook` was returning a flat 401 with the generic message `Invalid API key format` when builders passed a `kh_*` org key. Nothing in the response hinted that this endpoint expects a `wfb_*` user webhook key, so 9 hackathon teams reported it as a P0/P1 UX issue.

## Changes

- `app/api/workflows/[workflowId]/webhook/route.ts`
  - Detect `kh_*` prefix and return `code: "wrong_key_type"`, `expected: "wfb_*"`, `received: "kh_*"`, plus a human `error` and a `hint` that points at `/settings/api-keys`.
  - For any other unknown prefix, return `code: "invalid_key_format"` and an `error` that names the expected `wfb_` prefix.
  - `failResponse` extended with an optional `extraBody` so the structured fields ride alongside the existing `error` field. Old clients reading just `error` keep working.
- `tests/integration/webhook-route.test.ts` - split the old non-wfb assertion into two cases (kh_ and unknown prefix) covering the structured fields.
- `tests/e2e/vitest/workflow-runner.test.ts` - updated to match the new shape.

## Out of scope

The Linear ticket also called for a docs page listing the two key types and an inline form-validation hint in the trigger panel. Tracking those as separate follow-ups since this PR focuses on the API response.