### PR TITLE
fix: KEEP-519/521 workflow editor UI polish + earnings pagination

### DIFF
--- a/app/api/earnings/route.ts
+++ b/app/api/earnings/route.ts
@@ -3,7 +3,7 @@ import { getEarningsSummary } from "@/lib/earnings/queries";
 import { requireOrganization } from "@/lib/middleware/require-org";
 
 const DEFAULT_PAGE = 1;
-const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 50;
 
 /**

--- a/app/api/earnings/route.ts
+++ b/app/api/earnings/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { EARNINGS_PAGE_SIZE } from "@/lib/earnings/constants";
 import { getEarningsSummary } from "@/lib/earnings/queries";
 import { requireOrganization } from "@/lib/middleware/require-org";
 
 const DEFAULT_PAGE = 1;
-const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 50;
 
 /**
@@ -47,7 +47,7 @@ export const GET = requireOrganization(
     );
     const pageSize = parseIntParam(
       url.searchParams.get("pageSize"),
-      DEFAULT_PAGE_SIZE,
+      EARNINGS_PAGE_SIZE,
       1,
       MAX_PAGE_SIZE
     );

--- a/components/earnings/use-earnings.ts
+++ b/components/earnings/use-earnings.ts
@@ -9,6 +9,7 @@ import {
   earningsLoadingAtom,
 } from "@/lib/atoms/earnings";
 import { authClient } from "@/lib/auth-client";
+import { EARNINGS_PAGE_SIZE } from "@/lib/earnings/constants";
 import type { EarningsSummary } from "@/lib/earnings/types";
 
 type UseEarningsReturn = {
@@ -49,7 +50,7 @@ export function useEarnings(): UseEarningsReturn {
     try {
       const params = new URLSearchParams({
         page: String(page),
-        pageSize: "20",
+        pageSize: String(EARNINGS_PAGE_SIZE),
       });
 
       const res = await fetch(`/api/earnings?${params.toString()}`, { signal });

--- a/components/earnings/use-earnings.ts
+++ b/components/earnings/use-earnings.ts
@@ -49,7 +49,7 @@ export function useEarnings(): UseEarningsReturn {
     try {
       const params = new URLSearchParams({
         page: String(page),
-        pageSize: "10",
+        pageSize: "20",
       });
 
       const res = await fetch(`/api/earnings?${params.toString()}`, { signal });

--- a/components/earnings/workflow-earnings-table.tsx
+++ b/components/earnings/workflow-earnings-table.tsx
@@ -153,7 +153,7 @@ export function WorkflowEarningsTable({
   const loading = useAtomValue(earningsLoadingAtom);
 
   const total = data?.total ?? 0;
-  const pageSize = data?.pageSize ?? 10;
+  const pageSize = data?.pageSize ?? 20;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   const rangeStart = total === 0 ? 0 : (page - 1) * pageSize + 1;

--- a/components/earnings/workflow-earnings-table.tsx
+++ b/components/earnings/workflow-earnings-table.tsx
@@ -21,6 +21,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { earningsDataAtom, earningsLoadingAtom } from "@/lib/atoms/earnings";
+import { EARNINGS_PAGE_SIZE } from "@/lib/earnings/constants";
 import type {
   SettlementStatus,
   WorkflowEarningsRow,
@@ -153,7 +154,7 @@ export function WorkflowEarningsTable({
   const loading = useAtomValue(earningsLoadingAtom);
 
   const total = data?.total ?? 0;
-  const pageSize = data?.pageSize ?? 20;
+  const pageSize = data?.pageSize ?? EARNINGS_PAGE_SIZE;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   const rangeStart = total === 0 ? 0 : (page - 1) * pageSize + 1;

--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -741,11 +741,13 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="description">Description</Label>
-                  <Input
+                  <Textarea
+                    className="max-h-64 resize-y"
                     disabled={isGenerating || !isOwner}
                     id="description"
                     onChange={(e) => handleUpdateDescription(e.target.value)}
                     placeholder="Optional description"
+                    rows={3}
                     value={(selectedNode.data.description as string) || ""}
                   />
                 </div>

--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -742,7 +742,7 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
                 <div className="space-y-2">
                   <Label htmlFor="description">Description</Label>
                   <Textarea
-                    className="max-h-64 resize-y"
+                    className="max-h-64 resize-y bg-transparent dark:bg-transparent"
                     disabled={isGenerating || !isOwner}
                     id="description"
                     onChange={(e) => handleUpdateDescription(e.target.value)}

--- a/components/overlays/workflow-io-overlay.tsx
+++ b/components/overlays/workflow-io-overlay.tsx
@@ -160,7 +160,7 @@ export function WorkflowIOOverlay({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Workflow Import / Export</DialogTitle>
           <DialogDescription>

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -1144,11 +1144,13 @@ export const PanelInner = () => {
                     <Label className="ml-1" htmlFor="description">
                       Description
                     </Label>
-                    <Input
+                    <Textarea
+                      className="max-h-64 resize-y"
                       disabled={isGenerating || !isOwner}
                       id="description"
                       onChange={(e) => handleUpdateDescription(e.target.value)}
                       placeholder="Optional description"
+                      rows={3}
                       value={selectedNode.data.description || ""}
                     />
                   </div>

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -1145,7 +1145,7 @@ export const PanelInner = () => {
                       Description
                     </Label>
                     <Textarea
-                      className="max-h-64 resize-y"
+                      className="max-h-64 resize-y bg-transparent dark:bg-transparent"
                       disabled={isGenerating || !isOwner}
                       id="description"
                       onChange={(e) => handleUpdateDescription(e.target.value)}

--- a/lib/earnings/constants.ts
+++ b/lib/earnings/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Default page size for the Workflow Earnings table.
+ *
+ * Shared by:
+ *   - app/api/earnings/route.ts (server default when no pageSize query param)
+ *   - components/earnings/use-earnings.ts (client fetch parameter)
+ *   - components/earnings/workflow-earnings-table.tsx (UI fallback when the
+ *     API response omits pageSize)
+ *
+ * Keeping these in sync prevents pagination math drift between the page-size
+ * value the client requests and the value the UI assumes when rendering
+ * "X-Y of N" and computing totalPages.
+ */
+export const EARNINGS_PAGE_SIZE = 20;

--- a/lib/workflow/editor/template-helpers.ts
+++ b/lib/workflow/editor/template-helpers.ts
@@ -197,6 +197,24 @@ export function getActionFields(node: WorkflowNode): FieldEntry[] | null {
     }
   }
 
+  if (actionType === "For Each") {
+    return [
+      {
+        field: "currentItem",
+        description: "Current array element (inside loop body)",
+      },
+      { field: "index", description: "Current iteration index (0-based)" },
+      { field: "totalItems", description: "Total number of items in array" },
+    ];
+  }
+
+  if (actionType === "Collect") {
+    return [
+      { field: "results", description: "Array of outputs from each iteration" },
+      { field: "count", description: "Number of completed iterations" },
+    ];
+  }
+
   if (actionType) {
     const action = findActionById(actionType);
     if (action?.outputFields && action.outputFields.length > 0) {

--- a/tests/unit/template-helpers-action-fields.test.ts
+++ b/tests/unit/template-helpers-action-fields.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  getActionFields,
+  getCommonFields,
+} from "@/lib/workflow/editor/template-helpers";
+import type { WorkflowNode } from "@/lib/workflow/store";
+
+function actionNode(
+  config: Record<string, unknown>,
+  overrides: Partial<WorkflowNode> = {}
+): WorkflowNode {
+  return {
+    id: "action-1",
+    type: "action",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "Action",
+      type: "action",
+      config,
+    },
+    ...overrides,
+  };
+}
+
+describe("getActionFields - For Each", () => {
+  it("returns currentItem, index, and totalItems for For Each nodes", () => {
+    const fields = getActionFields(actionNode({ actionType: "For Each" }));
+    expect(fields?.map((f) => f.field)).toEqual([
+      "currentItem",
+      "index",
+      "totalItems",
+    ]);
+  });
+
+  it("attaches a description to each For Each field", () => {
+    const fields = getActionFields(actionNode({ actionType: "For Each" }));
+    for (const field of fields ?? []) {
+      expect(field.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getActionFields - Collect", () => {
+  it("returns results and count for Collect nodes", () => {
+    const fields = getActionFields(actionNode({ actionType: "Collect" }));
+    expect(fields?.map((f) => f.field)).toEqual(["results", "count"]);
+  });
+
+  it("describes results as an array of per-iteration outputs", () => {
+    const fields = getActionFields(actionNode({ actionType: "Collect" }));
+    const resultsField = fields?.find((f) => f.field === "results");
+    expect(resultsField?.description).toMatch(/iteration/i);
+  });
+
+  it("describes count as the number of completed iterations", () => {
+    const fields = getActionFields(actionNode({ actionType: "Collect" }));
+    const countField = fields?.find((f) => f.field === "count");
+    expect(countField?.description).toMatch(/iteration/i);
+  });
+});
+
+describe("getCommonFields exposes Collect and For Each fields for action nodes", () => {
+  it("returns Collect.results and Collect.count via getCommonFields", () => {
+    const fields = getCommonFields(actionNode({ actionType: "Collect" }));
+    const fieldNames = fields.map((f) => f.field);
+    expect(fieldNames).toContain("results");
+    expect(fieldNames).toContain("count");
+    expect(fieldNames).not.toContain("data");
+  });
+
+  it("returns For Each loop variables via getCommonFields", () => {
+    const fields = getCommonFields(actionNode({ actionType: "For Each" }));
+    const fieldNames = fields.map((f) => f.field);
+    expect(fieldNames).toEqual(["currentItem", "index", "totalItems"]);
+  });
+
+  it("falls back to data for unknown action types", () => {
+    const fields = getCommonFields(
+      actionNode({ actionType: "SomeUnregisteredAction" })
+    );
+    expect(fields).toEqual([{ field: "data", description: "Output data" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Bundle of small UI polish fixes targeting [KEEP-519](https://linear.app/keeperhubapp/issue/KEEP-519) plus an unrelated quality-of-life fix on the Earnings page ([KEEP-521](https://linear.app/keeperhubapp/issue/KEEP-521)).

### [KEEP-466](https://linear.app/keeperhubapp/issue/KEEP-466) — Collect node `.count` / `.results` missing in code+SQL template autocomplete

Two `getCommonFields` resolvers had drifted: [components/ui/template-autocomplete.tsx](components/ui/template-autocomplete.tsx) (the main `{{@}}` dropdown) had explicit Collect / For Each branches, but the exported [lib/workflow/editor/template-helpers.ts](lib/workflow/editor/template-helpers.ts) (used by the code-editor and SQL-editor template autocompletes) did not, falling through to `[{ field: "data" }]`. Result: typing `{{@collectId.` inside an HTTP body / SQL Query / etc. only suggested `.data`, even though the executor was already producing `{ results, count }`.

Added explicit branches for both Collect (`results`, `count`) and For Each (`currentItem`, `index`, `totalItems`). Runtime is unchanged. New test file `tests/unit/template-helpers-action-fields.test.ts` covers both branches plus the unknown-action-type fallback (8 cases, all passing).

### [KEEP-380](https://linear.app/keeperhubapp/issue/KEEP-380) — Node Description field unreadable for long text

The Description field was a single-line `<Input>`, so long text scrolled horizontally inside a narrow box. Swapped to `<Textarea>` in both editing surfaces ([node-config-panel](components/workflow/node-config-panel.tsx) and [configuration-overlay](components/overlays/configuration-overlay.tsx)) with `rows={3}`, `field-sizing-content` (auto-grow with content, inherited from the Textarea component), `max-h-64` cap, and `resize-y` so users can drag to expand. Background overridden to transparent to match the other inputs in the panel.

### [KEEP-518](https://linear.app/keeperhubapp/issue/KEEP-518) — Import modal breaks UI for big workflows

`DialogContent` had no max-height, so the import dialog could grow past the viewport (especially with many code-step warning rows), pushing the close button off-screen. Added `max-h-[90vh] overflow-y-auto` on [components/overlays/workflow-io-overlay.tsx](components/overlays/workflow-io-overlay.tsx).

### [KEEP-521](https://linear.app/keeperhubapp/issue/KEEP-521) — Earnings: bump Workflow Earnings pagination 10 -> 20

Three matching constants were updated together so the API default, the client fetch, and the UI fallback all agree on 20:

- `DEFAULT_PAGE_SIZE` in [app/api/earnings/route.ts](app/api/earnings/route.ts) (still bounded by `MAX_PAGE_SIZE=50`).
- Hardcoded `pageSize` in the client fetch ([components/earnings/use-earnings.ts](components/earnings/use-earnings.ts)).
- `pageSize` fallback in the table when the API response is missing the field ([components/earnings/workflow-earnings-table.tsx](components/earnings/workflow-earnings-table.tsx)).