### PR TITLE
chore: KEEP-528 bump lodash-es to 4.18.1 in docs-site

### DIFF
--- a/docs-site/.npmrc
+++ b/docs-site/.npmrc
@@ -1,1 +1,6 @@
 enable-pre-post-scripts=true
+
+# Reject packages published less than 3 days ago to mitigate supply chain attacks.
+# Mirrors the root .npmrc setting; docs-site is a standalone pnpm project
+# (own pnpm-lock.yaml, own install context) so the root setting does not apply here.
+minimum-release-age=3d

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -22,5 +22,10 @@
     "pagefind": "^1.5.2",
     "typescript": "^5.7.0"
   },
-  "packageManager": "pnpm@10.33.3"
+  "packageManager": "pnpm@10.33.3",
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "^4.18.1"
+    }
+  }
 }

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: ^4.18.1
+
 importers:
 
   .:
@@ -1218,11 +1221,8 @@ packages:
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
-  lodash-es@4.17.22:
-    resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -1979,12 +1979,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -2642,7 +2642,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.0.3):
     dependencies:
       chevrotain: 11.0.3
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
 
   chevrotain@11.0.3:
     dependencies:
@@ -2651,7 +2651,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
 
   client-only@0.0.1: {}
 
@@ -2877,7 +2877,7 @@ snapshots:
   dagre-d3-es@7.0.13:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
 
   dayjs@1.11.19: {}
 
@@ -3231,9 +3231,7 @@ snapshots:
 
   layout-base@2.0.1: {}
 
-  lodash-es@4.17.21: {}
-
-  lodash-es@4.17.22: {}
+  lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
 
@@ -3456,7 +3454,7 @@ snapshots:
       dompurify: 3.4.1
       katex: 0.16.27
       khroma: 2.1.0
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6


### PR DESCRIPTION
## Summary

Two changes to `docs-site/`:

1. Pin `lodash-es` to `^4.18.1` via `pnpm.overrides` in `docs-site/package.json` to close three Dependabot advisories.
2. Add `minimum-release-age=3d` to `docs-site/.npmrc` to mirror the supply-chain gate that exists in the root `.npmrc`. docs-site is a standalone pnpm project (own `pnpm-lock.yaml`, installed in isolation by `docs-site/Dockerfile`) so the root setting doesn't reach it. This was a real gap regardless of the lodash bump.

The vulnerable transitive `lodash-es` enters via Mermaid (`chevrotain`, `chevrotain-allstar`, `@chevrotain/cst-dts-gen`, `@chevrotain/gast`, `dagre-d3-es`) which the docs site uses for diagram rendering.

## Why 4.18.1 and not 4.17.23 or 4.18.0

The lodash-es deprecation note on npm says `"Bad release. Please use lodash-es@4.17.23 instead."` for 4.18.0 — but that recommendation is **security-incomplete**:

| Version | #32 (medium) | #176 (medium) | #177 (high) | Deprecated |
|---|---|---|---|---|
| 4.17.22 (current) | vulnerable | vulnerable | vulnerable | — |
| 4.17.23 (maintainer's recommendation) | fixed | vulnerable | vulnerable | — |
| 4.18.0 | fixed | fixed | fixed | yes ("bad release") |
| **4.18.1 (this PR)** | fixed | fixed | fixed | no — current `latest` |

4.18.1 is the only non-deprecated version that carries all three security fixes. The maintainer's deprecation pointer to 4.17.23 only addresses #32; #176 and #177 are unpatched in that line.

## Closes

- Dependabot alert [#177](https://github.com/KeeperHub/keeperhub/security/dependabot/177) (high) GHSA-r5fr-rjxr-66jc / CVE-2026-4800: code injection via `_.template` `imports` key names
- Dependabot alert [#176](https://github.com/KeeperHub/keeperhub/security/dependabot/176) (medium) GHSA-f23m-r3pf-42rh / CVE-2026-2950: prototype pollution via array path in `_.unset` / `_.omit`
- Dependabot alert [#32](https://github.com/KeeperHub/keeperhub/security/dependabot/32) (medium) GHSA-xxjr-mmjv-4gpg / CVE-2025-13465: prototype pollution in `_.unset` / `_.omit`

## Reachability note

The practical attack surface in docs-site is plausibly zero:

- docs-site is statically built; lodash-es runs at build time, not in response to user input
- Diagram content is authored by the KeeperHub team
- Chevrotain (the consumer) is a parser library that uses lodash for internal AST/collection helpers, not user-template compilation or attacker-controlled key paths
- We didn't audit chevrotain's call sites to confirm `_.template` / `_.unset` / `_.omit` are unreachable from input data

This PR closes the alerts as hygiene; the same outcome could have been achieved by dismissing them as `tolerable_risk` with the above reasoning. Bumping was chosen because it's the smaller change and keeps the open Dependabot list clean — but reviewers should know the bump isn't load-bearing for security in practice.

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528) — umbrella ticket tracking the full Dependabot backlog.

## Test plan / validation actually performed

- [x] `pnpm install --ignore-workspace` in `docs-site/` regenerates lockfile cleanly; 5 consumers move from 4.17.21 / 4.17.22 to 4.18.1
- [x] `tsc --noEmit` (docs-site) passes
- [x] Install re-runs cleanly with `minimum-release-age=3d` in place; lodash-es 4.18.1 is 944h (39 days) old, well past the gate
- [ ] **Not run before merge**: `pnpm build` (next build + pagefind) inside `docs-site/`. The repo's `deploy-docs.yaml` triggers only on `push` to `prod`, not on PRs, so the docs build is **not** validated by CI on this branch. The bump is a lodash minor (4.17 → 4.18) and pnpm respects integrity hashes, so the risk is low — but this is a real gap that this PR does not close.

## Note on docs-site as a standalone pnpm project

`docs-site` is not part of the root `pnpm-workspace.yaml` (it has its own `pnpm-lock.yaml` and is built in isolation by `docs-site/Dockerfile`). Local installs need `--ignore-workspace`, otherwise pnpm walks up and acts on the root workspace. The new `.npmrc` `minimum-release-age=3d` aligns docs-site with the root's supply-chain posture.