### PR TITLE
chore(dev): bake app-dev node_modules into image and add dev-min profile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,14 @@
 # Reject packages published less than 3 days ago to mitigate supply chain attacks
 minimum-release-age=3d
 
+# Skip the pre-script lockfile freshness check. Recent pnpm versions
+# re-run `pnpm install` at the start of every script (`pnpm dev`,
+# `pnpm test`, etc); if that internal install exits non-zero (e.g.
+# ERR_PNPM_IGNORED_BUILDS warning), the script itself fails before
+# running. Dev environments hit this on every restart. The check is
+# helpful for CI but counter-productive for hot-reload dev loops.
+verify-deps-before-run=false
+
 # Force-hoist the full transitive dependency tree of @workflow/world-postgres.
 # Next.js standalone output tracing cannot follow the dynamic
 # require(process.env.WORKFLOW_TARGET_WORLD) in the workflow SDK.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,21 @@ COPY .npmrc* ./
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
 
+# Stage: Dev (deps baked; source provided by bind mount at runtime)
+# Used by docker-compose --profile dev to eliminate the runtime
+# `pnpm install` that previously ran in every container start.
+# Two app-dev containers can now run concurrently without racing on a
+# shared node_modules volume.
+FROM node:24-alpine AS dev
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+RUN npm install -g pnpm@9
+COPY --link --from=deps /app/node_modules ./node_modules
+COPY package.json pnpm-lock.yaml* .npmrc* ./
+ENV HOSTNAME=0.0.0.0
+EXPOSE 3000
+CMD ["pnpm", "dev", "--hostname", "0.0.0.0"]
+
 # Stage 2: Source (dependencies + source files, no build)
 FROM node:24-alpine AS source
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,33 @@
 # KeeperHub Docker Compose
 #
 # Profiles:
-#   dev              - Full development stack (no K8s Jobs, dispatcher runs as cron)
+#   dev              - Full development stack (app + db + localstack + redis +
+#                      workers: dispatcher, executor, reaper, event-tracker,
+#                      block-dispatcher, sandbox). Use when exercising end-to-end
+#                      workflow execution.
+#   dev-min          - Minimal dev stack (app + db + localstack + redis only).
+#                      Workers excluded. Faster boot, less compile contention
+#                      from concurrent worker traffic. Use for UI development,
+#                      route smoke tests, and when running two app containers.
 #   minikube         - Hybrid mode (services in Docker, executor in Minikube)
 #   prod             - Production-ready containers
 #   test             - Isolated E2E test stack (separate DB, ports, volumes)
 #   profile-workflows - Workflow profiling tools (js-sandbox for WASM fuel calibration)
 #
 # Usage:
-#   docker compose --profile dev up -d              # Development (no K8s)
+#   docker compose --profile dev up -d              # Development with workers
+#   docker compose --profile dev-min up -d          # App + infra only
 #   docker compose --profile minikube up -d         # Hybrid mode
 #   docker compose --profile test up -d             # E2E test environment
 #   docker compose --profile profile-workflows up -d # Profiling tools
 #   make hybrid-setup                               # Full hybrid setup
+#
+# Notes:
+#   - The app-dev image bakes node_modules at build time. After a
+#     pnpm-lock.yaml change run: docker compose build app-dev
+#   - APP_DEV_PORT env var lets you run a second app-dev on a different
+#     host port (e.g. APP_DEV_PORT=3001 docker compose up app-dev) so
+#     two worktrees can serve concurrently from this same compose file.
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -37,6 +52,9 @@ x-env-db: &env_db
 
 x-env-db-connection: &env_db_connection
   DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-keeperhub}
+  # Workflow DevKit world. Same in-cluster Postgres as the app DB.
+  # sslmode=disable since the local Postgres image has no SSL configured.
+  WORKFLOW_POSTGRES_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-keeperhub}?sslmode=disable
 
 x-env-aws: &env_aws
   AWS_REGION: *aws_region
@@ -44,6 +62,11 @@ x-env-aws: &env_aws
   AWS_SECRET_ACCESS_KEY: *aws_secret_key
   # Use host.minikube.internal so URLs work from both host and Minikube
   AWS_ENDPOINT_URL: http://host.minikube.internal:4566
+  # AWS IRSA env vars only make sense in EKS pods; clear them here so the
+  # app doesn't try to read /var/run/secrets/.../token (which doesn't exist
+  # in this container).
+  AWS_WEB_IDENTITY_TOKEN_FILE: ""
+  AWS_ROLE_ARN: ""
 
 x-env-sqs: &env_sqs
   SQS_QUEUE_URL: http://host.minikube.internal:4566/000000000000/keeperhub-workflow-queue
@@ -78,6 +101,7 @@ services:
       retries: 5
     profiles:
       - dev
+      - dev-min
       - minikube
       - prod
       - profile-workflows
@@ -109,6 +133,7 @@ services:
       start_period: 15s
     profiles:
       - dev
+      - dev-min
       - minikube
 
   # ===========================================================================
@@ -137,36 +162,61 @@ services:
 
   # Development app with hot reload
   app-dev:
-    image: node:22-alpine
-    container_name: keeperhub-app-dev
+    # Build the `dev` Dockerfile stage instead of starting from a bare
+    # node:alpine and running `pnpm install` at container start. Baking
+    # node_modules into the image:
+    #   - eliminates the 1-3 min runtime install on every container start
+    #   - lets two app-dev containers run concurrently without racing on a
+    #     shared keeperhub_node_modules volume
+    #   - makes start-up deterministic (no partial-install failures like
+    #     missing transitive packages from a half-completed pnpm install)
+    # Rebuild explicitly with `docker compose build app-dev` whenever
+    # pnpm-lock.yaml changes.
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    # container_name intentionally omitted so multiple worktrees can each
+    # run app-dev under their own compose project name (e.g.
+    # keep-470-app-dev-1 vs chore-dev-env-app-dev-1). Combine with
+    # APP_DEV_PORT to give each its own host port.
     hostname: keeperhub
     working_dir: /app
     ports:
-      - "3000:3000"
+      - "${APP_DEV_PORT:-3000}:3000"
+    # Two-volume layout: bind-mount source for hot reload, but isolate
+    # node_modules per container via an anonymous volume so the baked
+    # image content survives the bind-mount overlay.
     volumes:
       - .:/app
-      - keeperhub_node_modules:/app/node_modules
+      - /app/node_modules
     env_file:
       - .env
     environment:
       <<: [*env_db_connection, *env_aws, *env_sqs, *env_service_keys]
       HOSTNAME: "0.0.0.0"
       KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-some-random-api-key}
-      NODE_OPTIONS: "--max-old-space-size=3072"
+      # 6GB heap leaves headroom on top of the 8GB container cap for
+      # Turbopack's bundler, which crashes a 3GB heap on cold compile.
+      NODE_OPTIONS: "--max-old-space-size=6144"
       METRICS_COLLECTOR: prometheus
     deploy:
       resources:
         limits:
-          memory: 4g
+          memory: 8g
           cpus: "2.0"
     depends_on:
       db:
         condition: service_healthy
       localstack:
         condition: service_healthy
-    command: sh -c "npm install -g pnpm && CI=true pnpm install && pnpm dev --hostname 0.0.0.0"
+    # Source is bind-mounted, so a baked Dockerfile CMD would point at
+    # stale files. Re-declare the dev command here so it always reads
+    # the live host source.
+    command: pnpm dev --hostname 0.0.0.0
     profiles:
       - dev
+      - dev-min
       - minikube
 
   # ===========================================================================
@@ -423,6 +473,7 @@ services:
     restart: unless-stopped
     profiles:
       - dev
+      - dev-min
       - minikube
 
   # ===========================================================================


### PR DESCRIPTION
## Summary

- Adds a Dockerfile `dev` target that bakes `node_modules` at image build time, eliminating the runtime `pnpm install` from every container start
- Adds a `dev-min` compose profile that brings up just the app + db + localstack + redis (no workers) for faster UI / route work
- Unblocks running two `app-dev` instances in different worktrees: removed the hardcoded `container_name`, switched to an anonymous per-container `/app/node_modules` volume (no more shared-volume races), and exposed `APP_DEV_PORT` so the host port is overridable
- Sets `verify-deps-before-run=false` in `.npmrc` so `pnpm dev` doesn't fail on the pre-script lockfile check (which currently exits non-zero on `ERR_PNPM_IGNORED_BUILDS`, a warning the team works around manually)
- Bumps `app-dev` memory cap from 4GB → 8GB and `NODE_OPTIONS` heap from 3072 → 6144 (turbopack's bundler crashed a 3GB heap on cold compile)
- Threads `WORKFLOW_POSTGRES_URL` and `sslmode=disable` through the `env_db_connection` anchor so the Workflow DevKit instrumentation hook points at the local in-cluster postgres instead of inheriting a staging URL from a developer's `.env`
- Clears `AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN` in `env_aws` since those K8s IRSA paths don't exist in a docker container

## Measured impact (single container)

| | Before | After |
|---|---|---|
| Container start → "Ready" | 2-3 min (runtime install) | 1.5s (baked image) |
| First cold request | failed: missing `undici` / `tsx` | HTTP 200 in 40s |
| Warm request | ~3-4 min through compile + 500s | ~1s |
| Reliability | partial-install / deadlock | stable |

## Two-instance concurrency

Structurally unblocked (no name conflict, no shared volume contention, port override available), but each app-dev needs ~5GB during cold compile. On a 15GB host two simultaneous cold starts saturate memory and one crashes with an esbuild goroutine deadlock. Workarounds today: stagger boots, OR follow up with a pre-warmed `.next/cache` baked into the image.

## Usage

```bash
# App + infra only (recommended for UI / route work)
docker compose --profile dev-min up -d

# Full stack including workers (recommended for end-to-end workflow runs)
docker compose --profile dev up -d

# Second instance on port 3001 (different worktree, different compose project)
APP_DEV_PORT=3001 docker compose --profile dev-min up -d app-dev

# Rebuild after a pnpm-lock.yaml change
docker compose build app-dev
```

## Test plan

- [x] `docker compose build app-dev` succeeds (~3 min first build with cache cold; ~30s incremental)
- [x] `docker compose --profile dev-min up -d` reaches Ready in <5s wall clock from container start
- [x] First HTTP request returns 200 (not 500 with "Module not found")
- [x] Warm HTTP requests return in ~1s
- [x] Two `app-dev` containers can both start (one crashes during simultaneous cold compile on a 15GB host — see "Two-instance concurrency" note above)
- [ ] Verify `pnpm-lock.yaml` change triggers correct image rebuild on next build
- [ ] Verify `dev` profile (with workers) still works for end-to-end workflow execution

## Out of scope (follow-ups)

- Pre-warmed `.next/cache` in image build — biggest remaining win for concurrent containers
- Other services (`sandbox`, `dispatcher`, `executor`, `reaper`, `event-tracker`, `block-dispatcher`) still have hardcoded `container_name` and `keeperhub_node_modules` shared volume; same treatment if multi-worktree workflow execution is needed