### PR TITLE
chore: KEEP-528 pin drizzle-orm to ^0.45.2 to close SQL injection advisory

### DIFF
--- a/keeperhub-executor/package.json
+++ b/keeperhub-executor/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-sqs": "^3.0.0",
     "@kubernetes/client-node": "^1.0.0",
     "cron-parser": "^5.0.0",
-    "drizzle-orm": "^0.43.0",
+    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
       "lodash": "^4.17.23",
       "@hono/node-server": ">=1.19.10",
       "file-type": ">=21.3.1",
-      "yauzl": ">=3.2.1"
+      "yauzl": ">=3.2.1",
+      "drizzle-orm": "^0.45.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   '@hono/node-server': '>=1.19.10'
   file-type: '>=21.3.1'
   yauzl: '>=3.2.1'
+  drizzle-orm: ^0.45.2
 
 importers:
 
@@ -590,7 +591,7 @@ packages:
     peerDependencies:
       '@better-auth/core': 1.5.6
       '@better-auth/utils': ^0.3.0
-      drizzle-orm: '>=0.41.0'
+      drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
@@ -5499,7 +5500,7 @@ packages:
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
       drizzle-kit: '>=0.31.4'
-      drizzle-orm: '>=0.41.0'
+      drizzle-orm: ^0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -6143,98 +6144,6 @@ packages:
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
-
-  drizzle-orm@0.45.1:
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
-    peerDependencies:
-      '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=4'
-      '@electric-sql/pglite': '>=0.2.0'
-      '@libsql/client': '>=0.10.0'
-      '@libsql/client-wasm': '>=0.10.0'
-      '@neondatabase/serverless': '>=0.10.0'
-      '@op-engineering/op-sqlite': '>=2'
-      '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1.13'
-      '@prisma/client': '*'
-      '@tidbcloud/serverless': '*'
-      '@types/better-sqlite3': '*'
-      '@types/pg': '*'
-      '@types/sql.js': '*'
-      '@upstash/redis': '>=1.34.7'
-      '@vercel/postgres': '>=0.8.0'
-      '@xata.io/client': '*'
-      better-sqlite3: '>=7'
-      bun-types: '*'
-      expo-sqlite: '>=14.0.0'
-      gel: '>=2'
-      knex: '*'
-      kysely: '*'
-      mysql2: '>=2'
-      pg: '>=8'
-      postgres: '>=3'
-      prisma: '*'
-      sql.js: '>=1'
-      sqlite3: '>=5'
-    peerDependenciesMeta:
-      '@aws-sdk/client-rds-data':
-        optional: true
-      '@cloudflare/workers-types':
-        optional: true
-      '@electric-sql/pglite':
-        optional: true
-      '@libsql/client':
-        optional: true
-      '@libsql/client-wasm':
-        optional: true
-      '@neondatabase/serverless':
-        optional: true
-      '@op-engineering/op-sqlite':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@prisma/client':
-        optional: true
-      '@tidbcloud/serverless':
-        optional: true
-      '@types/better-sqlite3':
-        optional: true
-      '@types/pg':
-        optional: true
-      '@types/sql.js':
-        optional: true
-      '@upstash/redis':
-        optional: true
-      '@vercel/postgres':
-        optional: true
-      '@xata.io/client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      bun-types:
-        optional: true
-      expo-sqlite:
-        optional: true
-      gel:
-        optional: true
-      knex:
-        optional: true
-      kysely:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      postgres:
-        optional: true
-      prisma:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
 
   drizzle-orm@0.45.2:
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
@@ -15127,7 +15036,7 @@ snapshots:
       '@workflow/world-local': 4.1.0-beta.49(@opentelemetry/api@1.9.1)
       cbor-x: 1.6.0
       dotenv: 17.3.1
-      drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.14)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.14)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
       graphile-worker: 0.16.6(typescript@5.9.3)
       pg: 8.20.0
       ulid: 3.0.2
@@ -16222,18 +16131,6 @@ snapshots:
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.12
       tsx: 4.21.0
-
-  drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.14)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.3.15
-      '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
-      '@types/pg': 8.20.0
-      kysely: 0.28.14
-      mysql2: 3.15.3
-      pg: 8.20.0
-      postgres: 3.4.9
-      prisma: 7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
 
   drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.14)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Pin `drizzle-orm` to `^0.45.2` via root `pnpm.overrides` and align `keeperhub-executor/package.json`'s declared dep, closing two high-severity Dependabot advisories for GHSA-gpj5-g38j-94v9 / CVE-2026-39356 (SQL injection via improperly escaped identifiers in `sql.identifier()` / `sql.as()`).

## Root cause

The repo's root `package.json` already declares `drizzle-orm: ^0.45.2` as a direct dep, so the workspace tree resolves it correctly. **But** `@workflow/world-postgres@4.1.0-beta.51` (Workflow DevKit) pins `drizzle-orm: 0.45.1` **exactly** (not a range) as a transitive — pnpm cannot dedupe against the root's `^0.45.2` without an override. The result was a dual install in `pnpm-lock.yaml`, with the vulnerable 0.45.1 copy used by `@workflow/world-postgres`'s internal queries.

Adding `drizzle-orm: ^0.45.2` to `pnpm.overrides` forces every consumer (including the Workflow DevKit transitive) onto 0.45.2 and collapses the dual install — `pnpm-lock.yaml` shrinks by ~110 lines.

## On `keeperhub-executor/package.json`

`keeperhub-executor` is **not** in `pnpm-workspace.yaml`, so pnpm install does not read its `package.json` for resolution. But it is **real production code** — the workflow executor running inside Docker:

```
Dockerfile:216  CMD ["tsx", "keeperhub-executor/workflow-runner.ts"]
Dockerfile:249  CMD ["tsx", "keeperhub-executor/index.ts"]
```

It imports `drizzle-orm` in 8+ files (`index.ts`, `workflow-runner.ts`, `in-process.ts`, `billing-guard.ts`, `startup-checks.ts`, `lib/db-helpers.ts`, etc.) and builds SQL with `eq`, `and`, `sql` plus `drizzle()` for the connection. At runtime, Node module resolution walks from `keeperhub-executor/` up to root `node_modules/drizzle-orm`, which is the root's direct dep — so the executor was already getting 0.45.2, not the vulnerable 0.45.1.

What the declaration update achieves:
- Closes Dependabot file-scan alert #191
- Brings the declared version in line with what Node actually resolves at runtime
- Useful for TypeScript / editor type resolution that may consult this file

The `^0.43.0` value was not enforced by pnpm install, but it was not purely cosmetic either.

## Reachability

The CVE patches escaping in `sql.identifier()` and `sql.as()` — both require an application to pass attacker-controlled input to those functions for the vulnerability to fire.

- **`@workflow/world-postgres`** uses drizzle internally to manage its own schema (workflow runs, locks, etc.). Identifiers there are hard-coded, not user-derived. The vulnerable 0.45.1 install in this chain had effectively zero exposure.
- **`keeperhub-executor`** queries spot-checked use Drizzle's type-safe builders (`eq`, `and`, schema-typed columns) rather than `sql.identifier()` / `sql.as()`. No user-controlled identifier paths surfaced in a quick grep.

The bump is still the right call as defense-in-depth — there's no good reason to ship the known-vulnerable 0.45.1 in any subtree, and the 0.45.1 → 0.45.2 changelog is **only** this security fix, so the upgrade carries no other behavioral risk.

## Closes

- Dependabot alert [#191](https://github.com/KeeperHub/keeperhub/security/dependabot/191) (high, CVSS 7.5) GHSA-gpj5-g38j-94v9 / CVE-2026-39356: direct dep in `keeperhub-executor/package.json`
- Dependabot alert [#192](https://github.com/KeeperHub/keeperhub/security/dependabot/192) (high, CVSS 7.5) GHSA-gpj5-g38j-94v9 / CVE-2026-39356: transitive in root `pnpm-lock.yaml` via `@workflow/world-postgres`

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528) — umbrella ticket tracking the full Dependabot backlog.

## Side effect

pnpm rewrote two peer-dep ranges in the lockfile from `drizzle-orm: '>=0.41.0'` to `drizzle-orm: ^0.45.2`:

- `better-auth`'s drizzle adapter (we use better-auth — relevant; peer is `optional`)
- A `@tanstack/solid-start`-style adapter (we don't use Solid Start — not installed in our tree)

This is pnpm's standard behavior when an override is active: it narrows the declared peer expectations to match the forced version. It doesn't affect installed code. Could create future peer-warning noise if `better-auth` ships a stricter adapter — non-blocking.

## Test plan

- [x] `pnpm install` regenerates lockfile; only `drizzle-orm@0.45.2` remains (0.45.1 dual-tree gone, lockfile -110 lines)
- [x] No pre-existing peer-dep warnings worsen (prisma/c12/magicast, permissionless/ox unchanged)
- [x] CI: `lint`, `typecheck`, `build`, `test-unit`, `test-unit-sandbox-remote`, `test-integration` all green on this branch