### PR TITLE
chore: KEEP-528 pin path-to-regexp@8 to ^8.4.0 to close ReDoS advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
       "lodash": "^4.17.23",
       "@hono/node-server": ">=1.19.10",
       "file-type": ">=21.3.1",
-      "yauzl": ">=3.2.1"
+      "yauzl": ">=3.2.1",
+      "path-to-regexp@8": "^8.4.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   '@hono/node-server': '>=1.19.10'
   file-type: '>=21.3.1'
   yauzl: '>=3.2.1'
+  path-to-regexp@8: ^8.4.0
 
 importers:
 
@@ -7916,9 +7917,6 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
@@ -11303,7 +11301,7 @@ snapshots:
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -17975,8 +17973,6 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
-
-  path-to-regexp@8.3.0: {}
 
   path-to-regexp@8.4.0: {}
 


### PR DESCRIPTION
## Summary

Pin the 8.x line of `path-to-regexp` to `^8.4.0` via `pnpm.overrides`. Closes two ReDoS advisories (one high, one medium).

## Scoping detail

The lockfile carries `path-to-regexp` twice on different majors:
- `0.1.13` via `express@4.x`
- `8.3.0` via `@nestjs/core@11.1.12`

Only the 8.x line is in the advisories' vulnerable range (`>= 8.0.0, < 8.4.0`). The override uses the range-scoped key `"path-to-regexp@8": "^8.4.0"` so it bumps the 8.x install without trying to force `express`'s `0.1.x` consumer onto a different major it never had.

## Closes

- Dependabot alert [#169](https://github.com/KeeperHub/keeperhub/security/dependabot/169) (high) GHSA-j3q9-mxjg-w52f / CVE-2026-4926: DoS via sequential optional groups (patched 8.4.0)
- Dependabot alert [#170](https://github.com/KeeperHub/keeperhub/security/dependabot/170) (medium) GHSA-27v5-c462-wpq7 / CVE-2026-4923: ReDoS via multiple wildcards (patched 8.4.0)

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528).

## Test plan

- [x] `pnpm install` regenerates lockfile; 8.3.0 → 8.4.0; 0.1.13 unchanged
- [ ] CI