### PR TITLE
chore: KEEP-528 bump axios override to ^1.15.2 to close 13 advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
       "minimatch": "^10.2.3",
       "devalue": "^5.6.4",
       "serialize-javascript": "^7.0.3",
-      "axios": "^1.13.5",
+      "axios": "^1.15.2",
       "undici": "^6.24.0",
       "fast-xml-parser": "^5.5.6",
       "ajv": "^8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   minimatch: ^10.2.3
   devalue: ^5.6.4
   serialize-javascript: ^7.0.3
-  axios: ^1.13.5
+  axios: ^1.15.2
   undici: ^6.24.0
   fast-xml-parser: ^5.5.6
   ajv: ^8.18.0
@@ -5374,10 +5374,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: ^1.13.5
+      axios: ^1.15.2
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -6582,8 +6582,8 @@ packages:
     resolution: {integrity: sha512-7SJ/FWhZBtW2gTCE/BsvU+gbfIpfTq+D9IH82l9MacauLVptaY6EdYAhrK3YSMC9yr5NxvxRcpZKcXG/nqjiiQ==}
     engines: {node: '>=22.0.0'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -10107,8 +10107,8 @@ snapshots:
       '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.15.0
-      axios-retry: 4.5.0(axios@1.15.0)
+      axios: 1.16.0
+      axios-retry: 4.5.0(axios@1.16.0)
       jose: 6.2.2
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -10687,7 +10687,7 @@ snapshots:
       '@ethereumjs/util': 9.1.0
       '@getpara/user-management-client': 2.20.0
       '@noble/hashes': 1.8.0
-      axios: 1.15.0
+      axios: 1.16.0
       base64url: 3.0.1
       elliptic: 6.6.1
       libphonenumber-js: 1.12.40
@@ -10722,8 +10722,8 @@ snapshots:
   '@getpara/user-management-client@2.20.0':
     dependencies:
       '@getpara/shared': 1.14.0
-      axios: 1.15.0
-      axios-retry: 4.5.0(axios@1.15.0)
+      axios: 1.16.0
+      axios-retry: 4.5.0(axios@1.16.0)
       libphonenumber-js: 1.12.40
     transitivePeerDependencies:
       - debug
@@ -11052,7 +11052,7 @@ snapshots:
 
   '@mendable/firecrawl-js@4.18.1':
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       firecrawl: 4.16.0
       typescript-event-target: 1.1.2
       zod: 3.25.76
@@ -13067,7 +13067,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@types/node': 24.12.2
       '@types/retry': 0.12.0
-      axios: 1.15.0
+      axios: 1.16.0
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -15406,14 +15406,14 @@ snapshots:
   aws-ssl-profiles@1.1.2:
     optional: true
 
-  axios-retry@4.5.0(axios@1.15.0):
+  axios-retry@4.5.0(axios@1.16.0):
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       is-retry-allowed: 2.2.0
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -16663,14 +16663,14 @@ snapshots:
 
   firecrawl@4.16.0:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       typescript-event-target: 1.1.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - debug
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

Bump the existing root `pnpm.overrides` entry for `axios` from `^1.13.5` to `^1.15.2`. Closes 13 Dependabot alerts (3 high, 9 medium, 1 low) from the 2026-04-24 advisory batch — almost the entire prototype-pollution + adapter-bypass cluster Axios maintainers published after the late-March incident response.

pnpm resolves to **axios 1.16.0** (latest 1.x line, published 2026-05-02).

## Supply chain safety check

This bump is being made after [the March 30 2026 axios supply chain compromise](https://www.cisa.gov/news-events/alerts/2026/04/20/supply-chain-compromise-impacts-axios-node-package-manager), so the resolved version was checked against:

- **Compromised versions** (`1.14.1`, `0.30.4`) are hard-unpublished from npm — registry returns 404, lockfile contains neither
- **Resolved version 1.16.0** carries [SLSA v1 build provenance](https://registry.npmjs.org/-/npm/v1/attestations/axios@1.16.0) and an npm publish attestation — built and signed in the official `axios/axios` GitHub Actions pipeline
- **3-day release-age gate** already configured in `.npmrc` (PR #798, post-incident) — 1.16.0 was published 9 days ago, well past the gate; future installs of newly-published axios versions will be deferred 3 days

## Closes

13 alerts: #228 (low), #229 (high), #230 (medium), #231 (high), #232 (medium), #233 (medium), #234 (high), #235 (high), #236 (medium), #237 (medium), #238 (medium), #239 (medium), #240 (medium). All map to GHSAs / CVEs in the [axios security advisories list](https://github.com/axios/axios/security/advisories) published 2026-04-24.

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528).

## Test plan

- [x] `pnpm install` regenerates lockfile; only axios 1.16.0 remains
- [x] Provenance + unpublication checks above
- [ ] CI