### PR TITLE
chore: KEEP-528 pin fast-xml-builder to ~1.1.7 across both workspaces

### DIFF
--- a/keeperhub-events/package.json
+++ b/keeperhub-events/package.json
@@ -16,7 +16,8 @@
   },
   "pnpm": {
     "overrides": {
-      "fast-xml-parser": "^5.7.0"
+      "fast-xml-parser": "^5.7.0",
+      "fast-xml-builder": "~1.1.7"
     }
   }
 }

--- a/keeperhub-events/pnpm-lock.yaml
+++ b/keeperhub-events/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   fast-xml-parser: ^5.7.0
+  fast-xml-builder: ~1.1.7
 
 importers:
 
@@ -981,8 +982,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+  fast-xml-builder@1.1.9:
+    resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
 
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
@@ -1401,10 +1402,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
 
 snapshots:
 
@@ -2480,15 +2477,14 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  fast-xml-builder@1.2.0:
+  fast-xml-builder@1.1.9:
     dependencies:
       path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
 
   fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.2.0
+      fast-xml-builder: 1.1.9
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
 
@@ -2846,5 +2842,3 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.17.1: {}
-
-  xml-naming@0.1.0: {}

--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
       "uuid@11": "^11.1.1",
       "postcss": "^8.5.10",
       "effect": "^3.20.0",
-      "follow-redirects": "^1.16.0"
+      "follow-redirects": "^1.16.0",
+      "fast-xml-builder": "~1.1.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   postcss: ^8.5.10
   effect: ^3.20.0
   follow-redirects: ^1.16.0
+  fast-xml-builder: ~1.1.7
 
 importers:
 
@@ -6519,8 +6520,8 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+  fast-xml-builder@1.1.9:
+    resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
 
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
@@ -9300,10 +9301,6 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
-
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -16587,15 +16584,14 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.2.0:
+  fast-xml-builder@1.1.9:
     dependencies:
       path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
 
   fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.2.0
+      fast-xml-builder: 1.1.9
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -19456,8 +19452,6 @@ snapshots:
       os-paths: 4.4.0
 
   xml-name-validator@5.0.0: {}
-
-  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

Pin `fast-xml-builder` in root and `keeperhub-events` workspaces. Both lockfiles resolve to **1.1.9** (latest in `~1.1.7`).

## Why `~1.1.7` not `^1.1.7`

Using the tilde range keeps us on the 1.1.x line and skips `1.2.0`, which was published only 63 hours before this PR — inside the `.npmrc` `minimum-release-age=3d` window. The tighter range avoids relying on the gate to filter `1.2.0` for us, while still picking up `1.1.9` (5 days old, well past the gate).

Note: testing showed that pnpm did install `1.2.0` under `^1.1.7` despite the 3-day gate. That may indicate the gate doesn't apply to versions selected via `pnpm.overrides`, or doesn't apply to transitives — worth a separate investigation (not blocking this PR, but tracked as a follow-up).

## Closes

- Dependabot alert [#245](https://github.com/KeeperHub/keeperhub/security/dependabot/245) (high) GHSA-5wm8-gmm8-39j9 / CVE-2026-44665: attribute values with unwanted quotes bypass malicious-attribute filters (`keeperhub-events`). Patched in 1.1.7.
- Dependabot alert [#246](https://github.com/KeeperHub/keeperhub/security/dependabot/246) (high) GHSA-5wm8-gmm8-39j9 / CVE-2026-44665: same advisory, root `pnpm-lock.yaml`.

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528).

## Test plan

- [x] `pnpm install` in root and `keeperhub-events/` regenerate lockfiles cleanly
- [x] Both resolve to 1.1.9
- [ ] CI