### PR TITLE
chore: KEEP-528 bump dompurify override to ^3.4.0 to close 4 XSS / bypass advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
       "@isaacs/brace-expansion": "^5.0.1",
       "@trpc/server": "^11.8.0",
       "glob": "^11.1.0",
-      "dompurify": "^3.3.2",
+      "dompurify": "^3.4.0",
       "hono": "^4.12.7",
       "lodash": "^4.17.23",
       "@hono/node-server": ">=1.19.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   '@isaacs/brace-expansion': ^5.0.1
   '@trpc/server': ^11.8.0
   glob: ^11.1.0
-  dompurify: ^3.3.2
+  dompurify: ^3.4.0
   hono: ^4.12.7
   lodash: ^4.17.23
   '@hono/node-server': '>=1.19.10'
@@ -6123,8 +6123,8 @@ packages:
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   dotenv-expand@12.0.3:
     resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
@@ -16112,7 +16112,7 @@ snapshots:
 
   devalue@5.6.4: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -17478,7 +17478,7 @@ snapshots:
 
   monaco-editor@0.54.0:
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.2
       marked: 14.0.0
 
   mongodb-connection-string-url@7.0.1:


### PR DESCRIPTION
## Summary

Bump existing root `pnpm.overrides` entry for `dompurify` from `^3.3.2` to `^3.4.0`. pnpm resolves to **3.4.2** (latest 3.4.x, published 2026-04-30, 10 days old — well past the `.npmrc` 3-day release-age gate).

## Closes

- Dependabot alert [#204](https://github.com/KeeperHub/keeperhub/security/dependabot/204) (medium) GHSA-39q2-94rc-95cp: `ADD_TAGS` function form bypasses `FORBID_TAGS` via short-circuit evaluation
- Dependabot alert [#206](https://github.com/KeeperHub/keeperhub/security/dependabot/206) (medium) GHSA-v9jr-rg53-9pgp / CVE-2026-41238: prototype pollution to XSS bypass via `CUSTOM_ELEMENT_HANDLING` fallback
- Dependabot alert [#207](https://github.com/KeeperHub/keeperhub/security/dependabot/207) (medium) GHSA-h7mw-gpvr-xq4m / CVE-2026-41240: `FORBID_TAGS` bypassed by function-based `ADD_TAGS` predicate (asymmetry with `FORBID_ATTR` fix)
- Dependabot alert [#208](https://github.com/KeeperHub/keeperhub/security/dependabot/208) (medium) GHSA-crv5-9vww-q3g8 / CVE-2026-41239: `SAFE_FOR_TEMPLATES` bypass in `RETURN_DOM` mode

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528).

## Test plan

- [x] `pnpm install` regenerates lockfile; dompurify 3.3.3 -> 3.4.2
- [ ] CI