### PR TITLE
chore: KEEP-528 bump hono override to ^4.12.18 to close 6 advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
       "@trpc/server": "^11.8.0",
       "glob": "^11.1.0",
       "dompurify": "^3.4.0",
-      "hono": "^4.12.7",
+      "hono": "^4.12.18",
       "lodash": "^4.17.23",
       "@hono/node-server": ">=1.19.10",
       "file-type": ">=21.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   '@trpc/server': ^11.8.0
   glob: ^11.1.0
   dompurify: ^3.4.0
-  hono: ^4.12.7
+  hono: ^4.12.18
   lodash: ^4.17.23
   '@hono/node-server': '>=1.19.10'
   file-type: '>=21.3.1'
@@ -173,7 +173,7 @@ importers:
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       mppx:
         specifier: ^0.5.12
-        version: 0.5.12(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 0.5.12(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
@@ -1590,7 +1590,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.7
+      hono: ^4.12.18
 
   '@hpke/chacha20poly1305@1.8.0':
     resolution: {integrity: sha512-FcBfAQ+Y99vMNJP2yrZ9wpL8V0GOwp1+zMyzvc6alasrBygfFjFm1yeUtyADJCu/27C3Lm5mJzx6u7pwg+cX5w==}
@@ -6783,8 +6783,8 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   hpagent@1.2.0:
@@ -7509,7 +7509,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: ^4.12.7
+      hono: ^4.12.18
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -10742,9 +10742,9 @@ snapshots:
     dependencies:
       graphql: 15.10.1
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.18
 
   '@hpke/chacha20poly1305@1.8.0':
     dependencies:
@@ -11063,7 +11063,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -11073,7 +11073,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -11813,13 +11813,13 @@ snapshots:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.12
+      hono: 4.12.18
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -16894,7 +16894,7 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  hono@4.12.12: {}
+  hono@4.12.18: {}
 
   hpagent@1.2.0: {}
 
@@ -17509,7 +17509,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  mppx@0.5.12(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.5.12(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       incur: 0.3.25
       ox: 0.14.10(typescript@5.9.3)(zod@4.3.6)
@@ -17518,7 +17518,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       express: 5.2.1
-      hono: 4.12.12
+      hono: 4.12.18
     transitivePeerDependencies:
       - typescript
 


### PR DESCRIPTION
## Summary

Bump existing root `pnpm.overrides` entry for `hono` from `^4.12.7` to `^4.12.18`. pnpm resolves to **4.12.18** (published 2026-05-06, 112h old — past the 3-day release-age gate).

## Closes

- Dependabot alert [#205](https://github.com/KeeperHub/keeperhub/security/dependabot/205) (medium) GHSA-458j-xx4x-4375: `hono/jsx` SSR HTML injection via improperly handled JSX attribute names
- Dependabot alert [#243](https://github.com/KeeperHub/keeperhub/security/dependabot/243) (medium) GHSA-69xw-7hcm-h432 / CVE-2026-44455: unvalidated JSX tag names may allow HTML injection
- Dependabot alert [#244](https://github.com/KeeperHub/keeperhub/security/dependabot/244) (medium) GHSA-9vqf-7f2p-gf9v / CVE-2026-44456: `bodyLimit()` can be bypassed for chunked / unknown-length requests
- Dependabot alert [#248](https://github.com/KeeperHub/keeperhub/security/dependabot/248) (medium) GHSA-p77w-8qqv-26rm / CVE-2026-44457: Cache middleware ignores `Vary: Authorization` / `Vary: Cookie` — cross-user cache leakage
- Dependabot alert [#249](https://github.com/KeeperHub/keeperhub/security/dependabot/249) (low) GHSA-hm8q-7f3q-5f36 / CVE-2026-44459: improper validation of `NumericDate` claims (`exp`, `nbf`, `iat`) in JWT `verify()`
- Dependabot alert [#250](https://github.com/KeeperHub/keeperhub/security/dependabot/250) (medium) GHSA-qp7p-654g-cw7p / CVE-2026-44458: CSS declaration injection via style object values in JSX SSR

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528).

## Test plan

- [x] `pnpm install` regenerates lockfile; hono 4.12.12 -> 4.12.18
- [ ] CI