### PR TITLE
chore(seed): KEEP-529 migrate persistent E2E test wallet to Turnkey

### DIFF
--- a/.github/actions/setup-e2e-db/action.yml
+++ b/.github/actions/setup-e2e-db/action.yml
@@ -5,14 +5,20 @@ inputs:
   database_url:
     description: 'PostgreSQL connection string'
     required: true
-  test_para_user_share:
-    description: 'TEST_PARA_USER_SHARE secret for wallet seeding'
-    required: true
-  wallet_encryption_key:
-    description: 'WALLET_ENCRYPTION_KEY secret for wallet seeding'
-    required: true
   chain_rpc_config:
     description: 'CHAIN_RPC_CONFIG for RPC endpoint resolution'
+    required: false
+    default: ''
+  turnkey_api_public_key:
+    description: 'TURNKEY_API_PUBLIC_KEY for the parent org used by createTurnkeyWallet during db:seed-test-wallet'
+    required: false
+    default: ''
+  turnkey_api_private_key:
+    description: 'TURNKEY_API_PRIVATE_KEY for the parent org used by createTurnkeyWallet during db:seed-test-wallet'
+    required: false
+    default: ''
+  turnkey_organization_id:
+    description: 'TURNKEY_ORGANIZATION_ID (parent org) used by createTurnkeyWallet during db:seed-test-wallet'
     required: false
     default: ''
 
@@ -42,6 +48,7 @@ runs:
       shell: bash
       env:
         DATABASE_URL: ${{ inputs.database_url }}
-        TEST_PARA_USER_SHARE: ${{ inputs.test_para_user_share }}
-        WALLET_ENCRYPTION_KEY: ${{ inputs.wallet_encryption_key }}
+        TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
+        TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
+        TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
       run: pnpm db:seed-test-wallet

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -181,9 +181,10 @@ jobs:
         uses: ./.github/actions/setup-e2e-db
         with:
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          test_para_user_share: ${{ secrets.TEST_PARA_USER_SHARE }}
-          wallet_encryption_key: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
           chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
+          turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
+          turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
+          turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
 
       - name: Start application
         uses: ./.github/actions/start-app
@@ -274,9 +275,10 @@ jobs:
         uses: ./.github/actions/setup-e2e-db
         with:
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
-          test_para_user_share: ${{ secrets.TEST_PARA_USER_SHARE }}
-          wallet_encryption_key: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
           chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
+          turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
+          turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
+          turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
 
       - name: Start application
         uses: ./.github/actions/start-app

--- a/scripts/seed/seed-test-wallet.ts
+++ b/scripts/seed/seed-test-wallet.ts
@@ -1,22 +1,24 @@
 /**
- * Seed script for persistent E2E test account
+ * Seed script for persistent E2E test account (KEEP-529).
  *
- * Seeds a test user (with login credentials) + organization + Para wallet
+ * Seeds a test user (with login credentials) + organization + Turnkey wallet
  * for write-contract E2E tests and Playwright tests.
  * Idempotent: skips records that already exist.
  *
- * The wallet data is hardcoded from the pre-provisioned Para wallet
- * (same wallet used by keeper-app). This avoids calling the Para API
- * at seed time and ensures deterministic wallet addresses across CI runs.
+ * Para has been decommissioned. On first run the script calls Turnkey to
+ * provision a fresh sub-org + wallet for the test user; the resulting EVM
+ * address is non-deterministic (HSM-generated) and is persisted in
+ * `organization_wallets`. Subsequent runs reuse the existing wallet row.
  *
  * Test credentials:
  *   Email:    pr-test-do-not-delete@techops.services
  *   Password: TestPassword123!
  *
  * Environment variables:
- *   DATABASE_URL                - PostgreSQL connection string (required)
- *   TEST_WALLET_ENCRYPTION_KEY  - 32-byte hex key for encrypting user share (required for wallet)
- *   TEST_PARA_USER_SHARE        - Raw Para user share base64 string (required for wallet)
+ *   DATABASE_URL              - PostgreSQL connection string (required)
+ *   TURNKEY_API_PUBLIC_KEY    - parent-org API public key (required for first-time provisioning)
+ *   TURNKEY_API_PRIVATE_KEY   - parent-org API private key (required for first-time provisioning)
+ *   TURNKEY_ORGANIZATION_ID   - parent-org id (required for first-time provisioning)
  *
  * Run with: pnpm db:seed-test-wallet
  */
@@ -30,7 +32,6 @@ import { hashPassword } from "better-auth/crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
-import { encryptUserShare } from "@/lib/encryption";
 import { getDatabaseUrl } from "../../lib/db/connection-utils";
 import {
   accounts,
@@ -39,16 +40,12 @@ import {
   paraWallets,
   users,
 } from "../../lib/db/schema";
+import { createTurnkeyWallet } from "../../lib/turnkey/turnkey-operations";
 import { generateId } from "../../lib/utils/id";
 
 const TEST_ORG_SLUG = "e2e-test-org";
 const TEST_USER_EMAIL = "pr-test-do-not-delete@techops.services";
 const TEST_PASSWORD = "TestPassword123!";
-
-// Hardcoded wallet data from pre-provisioned Para wallet
-// Same wallet used by keeper-app (KeeperHub Staging partner)
-const TEST_WALLET_ID = "3b1acc96-170f-4148-800b-7bca3e2ee6ad";
-const TEST_WALLET_ADDRESS = "0x4f1089424dcf25b1290631df483a436b320e51a1";
 
 type Db = ReturnType<typeof drizzle>;
 
@@ -168,7 +165,7 @@ async function ensureOrganization(db: Db, userId: string): Promise<string> {
   return orgId;
 }
 
-async function ensureParaWallet(
+async function ensureTurnkeyWallet(
   db: Db,
   userId: string,
   orgId: string
@@ -176,45 +173,59 @@ async function ensureParaWallet(
   const existing = await db
     .select()
     .from(paraWallets)
-    .where(eq(paraWallets.organizationId, orgId))
+    .where(
+      and(eq(paraWallets.organizationId, orgId), eq(paraWallets.isActive, true))
+    )
     .limit(1);
 
   if (existing.length > 0) {
-    console.log(`Wallet already exists: ${existing[0].walletAddress}`);
-    return;
-  }
-
-  const rawUserShare = process.env.TEST_PARA_USER_SHARE;
-  if (!rawUserShare) {
+    const row = existing[0];
+    if (row.provider !== "turnkey") {
+      throw new Error(
+        `Refusing to seed: an active wallet exists for the test org with provider=${row.provider} ` +
+          "(Para is decommissioned). The executor will reject signing with this wallet. " +
+          `Mark the row inactive (UPDATE para_wallets SET is_active=false WHERE id='${row.id}') ` +
+          "and re-run to provision a Turnkey wallet."
+      );
+    }
     console.log(
-      "TEST_PARA_USER_SHARE not set, skipping wallet seed. " +
-        "Wallet-dependent tests will be skipped."
+      `Wallet already exists: ${row.walletAddress} (provider=${row.provider})`
     );
     return;
   }
 
-  if (!process.env.WALLET_ENCRYPTION_KEY) {
-    console.log(
-      "WALLET_ENCRYPTION_KEY not set, skipping wallet seed. " +
-        "Wallet-dependent tests will be skipped."
+  const missing = [
+    "TURNKEY_API_PUBLIC_KEY",
+    "TURNKEY_API_PRIVATE_KEY",
+    "TURNKEY_ORGANIZATION_ID",
+  ].filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Refusing to seed test wallet: missing required Turnkey env var(s): ${missing.join(", ")}. ` +
+        "The persistent E2E test user must own a Turnkey wallet for any signing test to function. " +
+        "Set the variables (e.g. from TechOps/.secrets/staging-turnkey.env in local dev, or the " +
+        "matching secrets in the CI environment) and re-run."
     );
-    return;
   }
 
-  const encryptedShare = encryptUserShare(rawUserShare);
+  console.log("Provisioning Turnkey sub-org and wallet for E2E test user...");
+  const result = await createTurnkeyWallet(TEST_USER_EMAIL, TEST_ORG_SLUG);
 
   await db.insert(paraWallets).values({
     id: generateId(),
     userId,
     organizationId: orgId,
-    provider: "para",
+    provider: "turnkey",
     email: TEST_USER_EMAIL,
-    paraWalletId: TEST_WALLET_ID,
-    walletAddress: TEST_WALLET_ADDRESS,
-    userShare: encryptedShare,
+    walletAddress: result.walletAddress,
+    turnkeySubOrgId: result.subOrgId,
+    turnkeyWalletId: result.walletId,
+    turnkeyPrivateKeyId: result.privateKeyId,
   });
 
-  console.log(`Created wallet: ${TEST_WALLET_ADDRESS}`);
+  console.log(`Created Turnkey wallet: ${result.walletAddress}`);
+  console.log(`  subOrgId:  ${result.subOrgId}`);
+  console.log(`  walletId:  ${result.walletId}`);
 }
 
 function assertNotProduction(): void {
@@ -263,7 +274,7 @@ async function seedTestWallet(): Promise<void> {
     const userId = await ensureUser(db);
     await ensureCredentialAccount(db, userId);
     const orgId = await ensureOrganization(db, userId);
-    await ensureParaWallet(db, userId, orgId);
+    await ensureTurnkeyWallet(db, userId, orgId);
 
     const wallet = await db
       .select()


### PR DESCRIPTION
## Summary

Para has been decommissioned. `seed-test-wallet.ts` was still provisioning a Para wallet, which the executor's signing path (`lib/para/wallet-helpers.ts:73`) routes to `initializeTurnkeySigner` only when `wallet.provider === "turnkey"`. So any signing test against the seeded persistent test wallet (`pr-test-do-not-delete@techops.services` / `e2e-test-org`) would fail at the signer selection step.

This PR replaces `ensureParaWallet` with `ensureTurnkeyWallet`. The script now uses the existing `createTurnkeyWallet` helper (`lib/turnkey/turnkey-operations.ts:48`) to provision a sub-org + wallet, then inserts a row into `organization_wallets` (aliased `paraWallets`) with `provider: "turnkey"` and the `turnkeySubOrgId` / `turnkeyWalletId` / `turnkeyPrivateKeyId` columns populated.

CI wiring is updated to match:

- `.github/actions/setup-e2e-db/action.yml`: drops the unused `test_para_user_share` and `wallet_encryption_key` inputs; adds the three Turnkey inputs and passes them as env vars to the `pnpm db:seed-test-wallet` step.
- `.github/workflows/e2e-tests-ephemeral.yml`: both call sites of the composite action now pass `TURNKEY_API_PUBLIC_KEY`, `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ORGANIZATION_ID` from the `staging` GH environment's secrets. Those secrets were provisioned by this PR's author using the same values that live in the staging k8s cluster's `keeperhub-common-turnkey-*` secrets, sourced into `TechOps/.secrets/staging-turnkey.env`.

Unblocks **KEEP-458** (Protocol Node Test Coverage) write-action coverage — the setup workflow and any write fixture need the executor to find a Turnkey-provider wallet for the persistent test user.

## Notable

- **The seeded wallet address is no longer `0x4f1089424dcf25b1290631df483a436b320e51a1`.** Turnkey HSM-generates the EVM address. Each environment that runs the seed will get a *different* address. KEEP-458's `CANONICAL_TEST_WALLET` constant must update during the rebase, and ideally be refactored to a runtime DB lookup so it works across environments. `scripts/miscellaneous/fund-test-wallet.ts` already looks the address up dynamically and needs no change.
- The script skips wallet creation gracefully when `TURNKEY_API_PUBLIC_KEY` / `TURNKEY_API_PRIVATE_KEY` / `TURNKEY_ORGANIZATION_ID` aren't set.
- Idempotent: if an active wallet row exists for the test org, the script logs and returns. If the existing row is still `provider: "para"` it logs a warning telling you to deactivate that row before re-running.

## Out of scope (separate follow-ups)

- Migrate `plugins/web3/steps/approve-token-core.ts` away from `lib/para/wallet-helpers` imports (the helper already handles both providers; only the path name is misleading).
- Drop the `paraWallets` schema alias in `lib/db/schema-extensions.ts`.
- Migrate Para-named metric labels in `lib/metrics/{db-metrics,collectors/prometheus}.ts`.
- Provision `TURNKEY_*` secrets for the `prod` GH environment when prod's own Turnkey parent org is ready (this PR only wires staging).

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm db:seed-test-wallet` against a fresh KEEP-529 DB **without** Turnkey creds: user + org + member + credential rows created; wallet step skipped with a clear message; zero rows in `para_wallets`
- [x] Re-run `pnpm db:seed-test-wallet`: no duplicate rows (all counts stay at 1)
- [x] `pnpm db:seed-test-wallet` **with** Turnkey staging creds sourced from `.secrets/staging-turnkey.env`: provisioned a real Turnkey sub-org and wallet; `organization_wallets` row inserted with `provider: "turnkey"`, the sub-org id, and the HSM-generated wallet address
- [x] Re-run after Turnkey provisioning: idempotent — "Wallet already exists" log, no second sub-org created
- [ ] e2e-ephemeral run with the workflow change picks up the new Turnkey inputs and provisions a wallet end-to-end (this is what's running now)