### PR TITLE
chore: KEEP-528 pin ip-address to ^10.1.1 to close XSS in Address6 advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
       "@hono/node-server": ">=1.19.10",
       "file-type": ">=21.3.1",
       "yauzl": ">=3.2.1",
-      "drizzle-orm": "^0.45.2"
+      "drizzle-orm": "^0.45.2",
+      "ip-address": "^10.1.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   file-type: '>=21.3.1'
   yauzl: '>=3.2.1'
   drizzle-orm: ^0.45.2
+  ip-address: ^10.1.1
 
 importers:
 
@@ -6894,8 +6895,8 @@ packages:
     peerDependencies:
       fp-ts: ^2.0.0
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -16456,7 +16457,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@4.22.1:
     dependencies:
@@ -17021,7 +17022,7 @@ snapshots:
     dependencies:
       fp-ts: 2.16.9
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -18628,7 +18629,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:


### PR DESCRIPTION
## Summary

Add `pnpm.overrides` entry for `ip-address`. Bumps the vulnerable `10.1.0` install to the patched 10.1.1+ line.

## Closes

- Dependabot alert [#242](https://github.com/KeeperHub/keeperhub/security/dependabot/242) (medium) GHSA-v2v4-37r5-5v8g / CVE-2026-42338: `ip-address` has XSS in `Address6` HTML-emitting methods (vulnerable `<=10.1.0`, patched `10.1.1`)

Linear: [KEEP-528](https://linear.app/keeperhubapp/issue/KEEP-528).

## Test plan

- [x] `pnpm install` regenerates lockfile; `ip-address@10.1.0` -> `10.1.1+`
- [ ] CI