### PR TITLE
chore(dev): make pnpm dev usable for workflow routes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,12 +184,19 @@ services:
     working_dir: /app
     ports:
       - "${APP_DEV_PORT:-3000}:3000"
-    # Two-volume layout: bind-mount source for hot reload, but isolate
-    # node_modules per container via an anonymous volume so the baked
-    # image content survives the bind-mount overlay.
+    # Volume layout:
+    #   - source bind-mounted for hot reload
+    #   - anonymous volume on /app/node_modules to preserve the baked
+    #     image content past the source bind-mount overlay
+    #   - anonymous volume on /app/.next so turbopack's filesystem cache
+    #     writes hit container-local storage instead of the bind-mounted
+    #     host fs (turbopack reports "Slow filesystem detected" with
+    #     5s+ benchmarks on the host fs through the bind mount, which
+    #     compounds with the workflow DevKit's per-route bundle work)
     volumes:
       - .:/app
       - /app/node_modules
+      - /app/.next
     env_file:
       - .env
     environment:
@@ -200,11 +207,22 @@ services:
       # Turbopack's bundler, which crashes a 3GB heap on cold compile.
       NODE_OPTIONS: "--max-old-space-size=6144"
       METRICS_COLLECTOR: prometheus
+      # /etc/hosts in this container resolves `localhost` to `::1` first,
+      # but the Next.js dev server only binds IPv4 (0.0.0.0:3000). Node's
+      # fetch() tries IPv6 first and dies with "fetch failed" on connect-
+      # refused before falling back to IPv4. The workflow DevKit's
+      # graphile worker uses fetch() to dispatch /.well-known/workflow/v1/*
+      # routes back into this same Next.js process, so without this override
+      # all workflow runs sit at status=pending until the worker hits its
+      # 5-minute timeout. Pinning to the IPv4 loopback bypasses DNS.
+      WORKFLOW_LOCAL_BASE_URL: "http://127.0.0.1:3000"
     deploy:
       resources:
         limits:
           memory: 8g
-          cpus: "2.0"
+          # Turbopack + workflow DevKit's deferred builder both report
+          # "Available parallelism of 2 is less than needed 4". Bump to 4.
+          cpus: "4.0"
     depends_on:
       db:
         condition: service_healthy

--- a/next.config.ts
+++ b/next.config.ts
@@ -307,7 +307,17 @@ const nextConfig = {
 
 const { SENTRY_ORG, SENTRY_PROJECT, SENTRY_RELEASE } = process.env;
 
-export default withSentryConfig(withWorkflow(nextConfig), {
+// Enable the workflow DevKit's deferred builder to avoid the eager
+// builder's per-route esbuild scan of every "use step" file. The eager
+// scan + intermediate bundle takes 2-5 min on first hit per route in
+// dev, making /api/workflow/* effectively unusable on a normal laptop.
+// The deferred builder uses socket-driven lazy discovery and only
+// pre-bundles the well-known /flow, /step, /webhook routes. Requires
+// Next.js >= 16.2.0-canary.48 (we're on 16.2.2). The builder itself
+// branches on phase (development vs build) so this is safe for prod.
+export default withSentryConfig(
+  withWorkflow(nextConfig, { workflows: { lazyDiscovery: true } }),
+  {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 


### PR DESCRIPTION
## Summary

Follow-up to #1196. Three changes that turn the dev compile of any `/api/workflow/*` or `/.well-known/workflow/v1/*` route from a 10-20 minute exercise (or a permanent "fetch failed") into a ~70-90s cold cost that's actually workable.

## Changes

### `next.config.ts` — enable workflow DevKit lazy discovery

Pass `{ workflows: { lazyDiscovery: true } }` to `withWorkflow`. Swaps the eager builder (which does an esbuild scan of every `"use step"` file across the project on each cold route compile) for the deferred builder (only pre-bundles the well-known `/flow`, `/step`, `/webhook` entrypoints; discovers user step files via socket notifications). Requires Next.js >= 16.2.0-canary.48 — we're on 16.2.2. Build path is unchanged for production.

- One-time directive discovery scan: **126s → 34s** on this codebase (407 step files)
- Per-route compile: **"never returns" → ~75s cold**

### `docker-compose.yml` — anonymous volume on `/app/.next`

Turbopack writes its filesystem cache to `/app/.next/dev`. With the source dir bind-mounted from host (`.:/app`), every cache write goes through the OverlayFS bind mount, and turbopack logs **`Slow filesystem detected. The benchmark took 5195ms`**. An anonymous volume on `/app/.next` puts the cache on the container's writable layer.

### `docker-compose.yml` — `cpus 2.0 → 4.0`

Both turbopack and the DevKit's deferred builder log:
> `Available parallelism of 2 is less than needed 4. This can cause workflows/steps to fail to discover properly`

The 2-core limit also serialized the build pipeline; 4 lets the discoverer and the route compiler run in parallel.

### `docker-compose.yml` — env `WORKFLOW_LOCAL_BASE_URL=http://127.0.0.1:3000`

The hard one. The DevKit's graphile worker runs in the same Next.js process and uses `fetch()` to dispatch `/.well-known/workflow/v1/{flow,step}` back to that process. Resolution path: `process.env.PORT` (unset) → `http://localhost:${detectedPort}`.

Inside this container `/etc/hosts` resolves `localhost` to `::1` first (IPv6 loopback) and `127.0.0.1` second. The Next.js dev server binds only the IPv4 wildcard `0.0.0.0:3000`, with no IPv6 listener. Node's `fetch()` tries IPv6 first, gets `ECONNREFUSED` on `[::1]:3000`, and rejects with `TypeError: fetch failed` before falling back to IPv4. The worker reports "fetch failed", graphile retries up to its 3-attempt cap, and **every workflow run sits at `status=pending` forever**.

Pinning `WORKFLOW_LOCAL_BASE_URL` to the IPv4 literal bypasses the DNS step entirely.

## Measured impact (single container, dev-min profile)

| | Before | After |
|---|---|---|
| Boot to "Ready" | 1.5s | ~600ms - 2.8s |
| First cold compile of `/api/auth/sign-in/email` | 4-5 min (timeout) | 78s |
| First cold compile of `/api/workflow/[id]/execute` | 10+ min (timeout) | 13s |
| First cold compile of `/.well-known/workflow/v1/flow` | "fetch failed" | 75s, HTTP 200 |
| Workflow run state after execute | `pending` forever | `running` → step execution |
| Warm request (any route) | n/a | <1s |

## Known remaining limit (out of scope for this PR)

`/.well-known/workflow/v1/step` cold compile is still slow enough on a resource-constrained host that the graphile worker's 5-minute per-attempt timeout can fire before the compile finishes. Workers retry and eventually succeed, but the first real on-chain workflow execution after a fresh boot can take 10+ minutes wall clock. Suggested follow-ups:

- Pre-warm the well-known routes at boot (single HEAD/GET to each)
- Bump graphile worker's lock timeout for dev
- Investigate if the workflow DevKit can ship a pre-compiled step entrypoint instead of compiling at runtime

## Test plan

- [x] `docker compose --profile dev-min up -d` boots to Ready in <3s
- [x] Sign in via `POST /api/auth/sign-in/email` returns HTTP 200 (cold ~78s, warm ~0.4s)
- [x] Trigger workflow via `POST /api/workflow/[id]/execute` returns HTTP 200 (cold ~13s)
- [x] Workflow run transitions from `pending` → `running` (no more "fetch failed" on worker dispatch)
- [x] Workflow Executor logs trigger node execution + step dispatch
- [x] Two app-dev containers simultaneously (still RAM-bound on a 15GB host but no longer races on shared volumes after #1196)
- [x] Production build still passes (`docker compose build app`)