### PR TITLE
ci: KEEP-531 extract reusable build-docs-image.yml + PR validation orchestrator

### DIFF
--- a/.github/workflows/build-docs-image.yml
+++ b/.github/workflows/build-docs-image.yml
@@ -1,0 +1,93 @@
+# Type: reusable | Called by deploy-docs.yaml and pr-docs-site-build.yaml
+# Builds the docs-site Docker image. Optionally pushes to ECR for prod
+# deploys; PR validation calls with push: false and uses GHA cache so the
+# build runs without AWS credentials.
+name: Build Docs Image
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: 'Push the built image to ECR. False for PR build validation.'
+        type: boolean
+        default: false
+    outputs:
+      image_tag:
+        description: 'Short SHA used as image tag'
+        value: ${{ jobs.build.outputs.image_tag }}
+      ecr_registry:
+        description: 'ECR registry URL (only set when push=true)'
+        value: ${{ jobs.build.outputs.ecr_registry }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Environment context is only relevant when pushing to ECR (needs the
+    # prod/staging-scoped secrets and vars). For PR validation we deliberately
+    # skip the environment so the build does not require any environment
+    # protection rules.
+    environment: ${{ inputs.push && (github.ref == 'refs/heads/prod' && 'prod' || 'staging') || '' }}
+    outputs:
+      image_tag: ${{ steps.vars.outputs.sha_short }}
+      ecr_registry: ${{ steps.login-ecr.outputs.registry }}
+    env:
+      REGION: ${{ vars.TO_REGION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract commit hash
+        id: vars
+        shell: bash
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        if: ${{ inputs.push }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        if: ${{ inputs.push }}
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # PR validation path: build the image, do not load or push. Cache via
+      # GHA so the build is reasonably incremental across PR pushes without
+      # touching ECR.
+      - name: Build docs-site image (validate only)
+        if: ${{ !inputs.push }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docs-site/Dockerfile
+          push: false
+          cache-from: type=gha,scope=docs-site
+          cache-to: type=gha,scope=docs-site,mode=max
+
+      # Prod deploy path: same Dockerfile and context, but push to ECR with
+      # commit-pinned and :latest tags. Cache via the ECR registry to match
+      # deploy-docs.yaml's previous behaviour exactly. AWS_ECR_NAME is scoped
+      # to this step so it does not appear (unused) when push=false.
+      - name: Build and push docs-site image to ECR
+        if: ${{ inputs.push }}
+        env:
+          AWS_ECR_NAME: keeperhub-docs-${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docs-site/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ steps.vars.outputs.sha_short }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:latest
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache,mode=max

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,3 +1,8 @@
+# Type: standalone | Builds and deploys the docs site.
+# The build step lives in the reusable build-docs-image.yml so PR validation
+# (pr-docs-site-build.yaml) can exercise the same Dockerfile + build inputs
+# without pushing to ECR. This file owns the prod deploy: helm upgrade with
+# the freshly built image.
 on:
   push:
     branches:
@@ -5,23 +10,29 @@ on:
     paths:
       - 'docs/**'
       - 'docs-site/**'
+      - '.github/workflows/build-docs-image.yml'
       - '.github/workflows/deploy-docs.yaml'
   workflow_dispatch:
 
 name: deploy-keeperhub-docs
 
 jobs:
-  build-and-deploy-docs:
-    environment: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
+  build:
+    uses: ./.github/workflows/build-docs-image.yml
+    with:
+      push: true
+    secrets: inherit
+
+  deploy:
+    needs: build
     runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
     env:
       HELM_FILE: deploy/docs-site/${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}/values.yaml
       REGION: ${{ vars.TO_REGION }}
       CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
-      ENVIRONMENT_TAG: ${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
       NAMESPACE: keeperhub
       SERVICE_NAME: keeperhub-docs
-      AWS_ECR_NAME: keeperhub-docs-${{ github.ref == 'refs/heads/prod' && 'prod' || 'staging' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -35,37 +46,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.REGION }}
 
-      - name: Login to AWS ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Extract commit hash
-        id: vars
-        shell: bash
-        run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Build, tag, and push docs image to ECR
-        id: build-docs-image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./docs-site/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ steps.vars.outputs.sha_short }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:latest
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache,mode=max
-
       - name: Replace variables in the Helm values file
         id: replace-vars
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          ECR_REGISTRY: ${{ needs.build.outputs.ecr_registry }}
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
           sed -i 's|${ECR_REGISTRY}|'"$ECR_REGISTRY"'|g' $HELM_FILE
           sed -i 's|${IMAGE_TAG}|'"$IMAGE_TAG"'|g' $HELM_FILE

--- a/.github/workflows/pr-docs-site-build.yaml
+++ b/.github/workflows/pr-docs-site-build.yaml
@@ -1,0 +1,26 @@
+# Type: orchestrator | Calls build-docs-image.yml for PR validation
+# Validates that the docs-site image builds on every PR that touches
+# docs-site/, docs/, or this workflow. Prod deploys still happen via
+# deploy-docs.yaml on push to prod (which calls the same reusable with
+# push: true).
+name: PR Docs Site Build
+
+on:
+  pull_request:
+    paths:
+      - 'docs-site/**'
+      - 'docs/**'
+      - '.github/workflows/build-docs-image.yml'
+      - '.github/workflows/pr-docs-site-build.yaml'
+
+# Cancel an in-progress build when a new commit lands on the same PR.
+# Docs builds are stateless and only the latest commit's result matters.
+concurrency:
+  group: pr-docs-site-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-docs-image.yml
+    with:
+      push: false


### PR DESCRIPTION
## Summary

Refactor the docs-site build to follow the repo's existing **orchestrator + reusable workflow** pattern (`ci-pipeline.yml` -> `build-images.yml` / `e2e-tests-ephemeral.yml` / `deploy-keeperhub.yaml` / `deploy-executor.yaml`).

Three files:

1. **New `.github/workflows/build-docs-image.yml`** (reusable, `workflow_call`)
   - Single source of truth for how the docs-site image is built
   - Takes one input: `push: bool` (default false)
   - When `push: true`: configures AWS, logs into ECR, builds and pushes with commit-SHA + `:latest` tags, ECR registry cache. Exposes `image_tag` and `ecr_registry` outputs.
   - When `push: false`: skips AWS entirely, builds with GHA cache, does not load or push. Works for PRs from forks (no secrets needed).

2. **`.github/workflows/deploy-docs.yaml`** (refactored)
   - Two jobs now: `build` (calls the reusable with `push: true`) and `deploy` (needs `build`, runs the helm upgrade using the reusable's outputs).
   - Same Dockerfile, same tags, same ECR registry cache, same helm release as before. No prod-deploy behaviour change.
   - Adds `.github/workflows/build-docs-image.yml` to the trigger `paths` so a change in the reusable also re-runs the prod deploy on push-to-prod.

3. **New `.github/workflows/pr-docs-site-build.yaml`** (orchestrator)
   - Trigger: `pull_request` on `docs-site/**`, `docs/**`, `build-docs-image.yml`, `pr-docs-site-build.yaml`.
   - Single job: calls the reusable with `push: false`. Nothing else.
   - Concurrency group cancels in-progress builds on rapid PR pushes.

## Why this design

`deploy-docs.yaml` was structurally aligned with `deploy-events.yaml` and `deploy-scheduler.yaml` -- a "standalone" workflow that built and deployed one service inline. A first draft of this PR added a sibling standalone workflow for PR validation, which duplicated the docker build logic. That violates the orchestrator/reusable pattern the rest of this repo uses for builds that need to run from multiple triggers (prod deploy, PR validation, e2e tests).

Extracting `build-docs-image.yml` deduplicates the build steps and makes future additions (e.g. a docs preview deploy, a manual workflow_dispatch build for debugging) trivial -- just another tiny orchestrator that calls the reusable.

## Why

Discovered during PR [#1195](https://github.com/KeeperHub/keeperhub/pull/1195) (lodash-es bump in `docs-site/`). The previous `deploy-docs.yaml` only triggered on `push` to `prod`, so a PR touching `docs-site/` reached prod before anyone had run `pnpm install --frozen-lockfile` + `pnpm build` against the new tree. If the build was broken, the docs site would only fail on the prod deploy.

The new `PR Docs Site Build` check closes that gap.

## Trigger paths

- `docs-site/**` -- package.json, lockfile, next.config, content, the Dockerfile itself
- `docs/**` -- `docs-site/Dockerfile` copies `docs/` into the image as `./content/`, so docs changes can also break the build
- `.github/workflows/build-docs-image.yml` -- changes to the build steps themselves need to retrigger validation
- `.github/workflows/pr-docs-site-build.yaml` -- changes to the orchestrator itself

The same first three paths are also added to `deploy-docs.yaml`'s prod trigger.

## Closes

[KEEP-531](https://linear.app/keeperhubapp/issue/KEEP-531).

## Test plan

- [x] On this PR: `PR Docs Site Build` check ran and passed (workflow self-triggered via the `.github/workflows/build-docs-image.yml` entry in the orchestrator `paths` — confirmed green at 06:15:06Z).
- [ ] After merge, rebase PR [#1195](https://github.com/KeeperHub/keeperhub/pull/1195) onto `staging` -- the new check should run and validate the lodash-es bump end-to-end.
- [ ] Verify that a PR touching only root files (no `docs-site/`, `docs/`, or workflow changes) does NOT trigger this workflow.
- [ ] On next push to `prod` touching `docs-site/**`, confirm `deploy-keeperhub-docs` still builds and deploys correctly with the two-job structure.

## Follow-up

Making `PR Docs Site Build` a required check in branch protection on `staging` is a repo-settings change, not committable here. Worth doing once the check is observed to be reliable across a few PRs.
