### PR TITLE
fix: KEEP-532 downgrade pre-reconciliation workflow logs to warn

### DIFF
--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -285,8 +285,16 @@ export function logSystemError(
  *   - Emits NO Prometheus metric (so it cannot trip system-error alerts)
  *
  * Differs from logUserError:
- *   - is_user_error=false (caller is system code, not user input)
  *   - Emits no metric (logUserError emits a user-error counter)
+ *   - No is_user_error Sentry tag (see below)
+ *
+ * Sentry tag policy:
+ *   - is_user_error is intentionally NOT set. At the call site for a
+ *     logSystemWarn we typically do not yet know whether the underlying
+ *     failure is user-caused or engine-caused -- forcing it to "false"
+ *     would let alerts filtering `is_user_error:false` match these events
+ *     and re-trip the same dashboards we are trying to keep quiet. The
+ *     event's `level=warning` is the canonical filter for these.
  */
 export function logSystemWarn(
   category: ErrorCategory,
@@ -306,7 +314,6 @@ export function logSystemWarn(
     tags: {
       error_category: category,
       error_context: context,
-      is_user_error: "false",
     },
     extra: fullLabels,
   });

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -271,30 +271,30 @@ export function logSystemError(
 }
 
 /**
- * Log a system-level warning with forensic context but no alert.
+ * Log a system-level warning. Emits a Sentry event at warning level and a
+ * console.warn line. Does NOT emit a Prometheus metric and does NOT page.
  *
  * Use for events in system-owned code that need ALS context (org/owner ids)
- * and Sentry forensics, but are NOT operational failures. Examples:
+ * for later investigation but are NOT operational failures. Examples:
  * - Pre-reconciliation notes where the final classification is not yet known
  * - Recovery events (spurious SDK error overridden back to success)
  * - Expected fallbacks worth recording for debugging
  *
- * Differs from logSystemError:
- *   - console.warn instead of console.error
- *   - Sentry captured at level=warning (does not page oncall)
- *   - Emits NO Prometheus metric (so it cannot trip system-error alerts)
+ * Side effects (compare to siblings):
  *
- * Differs from logUserError:
- *   - Emits no metric (logUserError emits a user-error counter)
- *   - No is_user_error Sentry tag (see below)
+ * |                        | console     | Sentry          | Metric    |
+ * | ---------------------- | ----------- | --------------- | --------- |
+ * | logSystemError         | error       | error event     | counter+1 |
+ * | logSystemWarn (this)   | warn        | warning event   | none      |
+ * | logUserError           | warn        | warning event   | counter+1 |
  *
  * Sentry tag policy:
- *   - is_user_error is intentionally NOT set. At the call site for a
- *     logSystemWarn we typically do not yet know whether the underlying
- *     failure is user-caused or engine-caused -- forcing it to "false"
+ *   - is_user_error is intentionally NOT set. At the call sites where this
+ *     helper fires we typically do not yet know whether the underlying
+ *     failure is user-caused or engine-caused -- forcing the tag to "false"
  *     would let alerts filtering `is_user_error:false` match these events
  *     and re-trip the same dashboards we are trying to keep quiet. The
- *     event's `level=warning` is the canonical filter for these.
+ *     event's `level=warning` is the canonical filter.
  */
 export function logSystemWarn(
   category: ErrorCategory,

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -269,3 +269,45 @@ export function logSystemError(
     extra: fullLabels,
   });
 }
+
+/**
+ * Log a system-level warning with forensic context but no alert.
+ *
+ * Use for events in system-owned code that need ALS context (org/owner ids)
+ * and Sentry forensics, but are NOT operational failures. Examples:
+ * - Pre-reconciliation notes where the final classification is not yet known
+ * - Recovery events (spurious SDK error overridden back to success)
+ * - Expected fallbacks worth recording for debugging
+ *
+ * Differs from logSystemError:
+ *   - console.warn instead of console.error
+ *   - Sentry captured at level=warning (does not page oncall)
+ *   - Emits NO Prometheus metric (so it cannot trip system-error alerts)
+ *
+ * Differs from logUserError:
+ *   - is_user_error=false (caller is system code, not user input)
+ *   - Emits no metric (logUserError emits a user-error counter)
+ */
+export function logSystemWarn(
+  category: ErrorCategory,
+  message: string,
+  error: unknown,
+  labels?: Record<string, string>
+): void {
+  const context = extractContext(message);
+  const fullLabels = mergeLabels(labels);
+
+  const tag = buildLogTag(fullLabels);
+  console.warn(`${message}${tag}`, error);
+
+  const sentryError = error instanceof Error ? error : new Error(String(error));
+  captureException(sentryError, {
+    level: "warning",
+    tags: {
+      error_category: category,
+      error_context: context,
+      is_user_error: "false",
+    },
+    extra: fullLabels,
+  });
+}

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -7,7 +7,7 @@ import "server-only";
 import { and, eq, isNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
@@ -427,8 +427,13 @@ export async function logWorkflowCompleteDb(
   let resolvedError: string | undefined = params.error;
 
   if (params.status === "error") {
-    // Route through unified logger so org/owner ALS context is attached.
-    logSystemError(
+    // KEEP-532: warn, not error -- at this point we do not yet know whether
+    // the failure is user-caused (e.g. user's HTTP step hit a dead URL) or a
+    // real engine fault. logSystemError here unconditionally tripped the
+    // workflow_engine system-error metric on every user-config failure.
+    // Reconciliation below decides the final status; this call is just for
+    // forensic context (ALS org/owner labels attached).
+    logSystemWarn(
       ErrorCategory.WORKFLOW_ENGINE,
       "[Workflow Logging] Execution completed with error, checking node logs for reconciliation",
       params.error ?? "unknown",
@@ -439,7 +444,9 @@ export async function logWorkflowCompleteDb(
       const trulyFailedNodes = await listTrulyFailedNodes(params.executionId);
 
       if (trulyFailedNodes.length === 0) {
-        logSystemError(
+        // KEEP-532: Recovery event -- spurious SDK error overridden to success.
+        // Not an error condition; warn-level keeps it in traces without paging.
+        logSystemWarn(
           ErrorCategory.WORKFLOW_ENGINE,
           "[Workflow Logging] No node-level errors found, overriding spurious SDK error to success",
           params.error ?? "unknown",

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -81,6 +81,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+import { logSystemError, logSystemWarn } from "@/lib/logging";
 import { logWorkflowCompleteDb } from "@/lib/workflow/executor/logging";
 
 function getExecUpdate(): UpdateCall | undefined {
@@ -152,6 +153,26 @@ describe("logWorkflowCompleteDb", () => {
         error: undefined,
       })
     );
+
+    // KEEP-532 regression guard: both the pre-reconciliation log and the
+    // spurious-recovery log must route through logSystemWarn (no metric),
+    // not logSystemError (which would re-trip errors.system.workflow_engine.total).
+    expect(logSystemWarn).toHaveBeenCalledTimes(2);
+    expect(logSystemWarn).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.stringContaining("checking node logs for reconciliation"),
+      expect.anything(),
+      expect.objectContaining({ execution_id: "exec_1" })
+    );
+    expect(logSystemWarn).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.stringContaining("overriding spurious SDK error to success"),
+      expect.anything(),
+      expect.objectContaining({ execution_id: "exec_1" })
+    );
+    expect(logSystemError).not.toHaveBeenCalled();
   });
 
   // KEEP-333: If a step started but never recorded completion, the workflow

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/logging", () => ({
     DATABASE: "database",
   },
   logSystemError: vi.fn(),
+  logSystemWarn: vi.fn(),
 }));
 
 // Hoisted schema stubs so the vi.mock factory can reference them.

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSystemError,
+  logSystemWarn,
+  logUserError,
+} from "@/lib/logging";
 import { resetMetricsCollector, setMetricsCollector } from "@/lib/metrics";
 import {
   LabelKeys,
@@ -234,6 +239,58 @@ describe("Unified Logging Helpers", () => {
         expect.anything(),
         expect.anything()
       );
+    });
+  });
+
+  describe("logSystemWarn", () => {
+    it("should log as warn and NOT emit any metric", () => {
+      const error = new Error("Spurious SDK error");
+      logSystemWarn(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Workflow Logging] Pre-reconciliation",
+        error,
+        { execution_id: "exec-123" }
+      );
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[Workflow Logging] Pre-reconciliation"),
+        error
+      );
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      // The key invariant: warn helper does not increment ANY metric counter,
+      // so it cannot trip system-error or user-error dashboards.
+      expect(mockCollector.recordError).not.toHaveBeenCalled();
+    });
+
+    it("should handle non-Error error values", () => {
+      logSystemWarn(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Test] Warn",
+        "string detail"
+      );
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[Test] Warn"),
+        "string detail"
+      );
+      expect(mockCollector.recordError).not.toHaveBeenCalled();
+    });
+
+    it("should not emit a metric for any error category", () => {
+      // Regression guard against accidentally re-introducing metric emission.
+      const categories = [
+        ErrorCategory.WORKFLOW_ENGINE,
+        ErrorCategory.DATABASE,
+        ErrorCategory.INFRASTRUCTURE,
+        ErrorCategory.UNKNOWN,
+      ];
+
+      for (const category of categories) {
+        vi.clearAllMocks();
+        logSystemWarn(category, "[Test] Warn", new Error("test"));
+        expect(mockCollector.recordError).not.toHaveBeenCalled();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- `logWorkflowCompleteDb` was calling `logSystemError(WORKFLOW_ENGINE)` on every `status === "error"` completion before reconciliation determined whether the failure was user-caused or a real engine fault. User-config failures (dead URL in HTTP step, user webhook returning 500) tripped the `errors.system.workflow_engine.total` metric and paged oncall.
- The spurious-SDK-error recovery path also logged at error level even though it was overriding the status back to success.
- Adds `logSystemWarn` to `lib/logging.ts`: `console.warn`, Sentry `level=warning`, no Prometheus metric. Used at the two pre-reconciliation call sites. The two remaining `logSystemError` calls in the function (reconciliation DB query failure, orphaned-log cleanup failure) stay — those are genuine engine failures.

## Linear

[KEEP-532](https://linear.app/keeperhubapp/issue/KEEP-532)

## Repro (production)

Three workflows owned by a user have an HTTP node pointing at a dead Cloudflare quick tunnel. Every retry triggers the system alert below:

\`\`\`
errors.system.workflow_engine.total{error_category="workflow_engine", error_context="Workflow Logging", is_user_error="false"}
"HTTP request failed: fetch failed: getaddrinfo ENOTFOUND holdings-cash-mind-converted.trycloudflare.com"
\`\`\`

## Test plan

- [ ] After deploy, observe `errors.system.workflow_engine.total` rate drop back to baseline (carl's workflows will keep failing; they just won't page).
- [ ] Trigger a confirmed engine failure (e.g. force `closeOrphanedRunningLogs` to throw in staging) — verify `logSystemError` still fires at line 467 and the metric still increments.
- [ ] Verify reconciliation events still appear in Sentry at `level=warning` for forensics.