### PR TITLE
perf(db): KEEP-432 add missing indexes for hot tables and FKs

### DIFF
--- a/drizzle/0075_keep_432_db_indexes.sql
+++ b/drizzle/0075_keep_432_db_indexes.sql
@@ -1,0 +1,73 @@
+-- @requires-db-prep
+-- KEEP-432: post-incident additive index migration.
+--
+-- The `-- @requires-db-prep` directive on line 1 makes the
+-- `.github/workflows/db-prep-check.yml` workflow block merge of this PR
+-- (and any future PR including this file) until the matching
+-- `db-prepped-<target-branch>` label is set. The label signals that an
+-- operator has applied each index via `CREATE INDEX CONCURRENTLY IF NOT
+-- EXISTS` against the real DB out-of-band, BEFORE the deploy runs the
+-- normal `drizzle-kit migrate`.
+--
+-- Why: drizzle-kit wraps every migration in a transaction, and
+-- `CREATE INDEX CONCURRENTLY` cannot run in a transaction. Without the
+-- pre-applied CONCURRENTLY indexes, the plain CREATE INDEX statements
+-- below would take an ACCESS EXCLUSIVE lock on workflow_execution_logs
+-- (1.9 GB on prod) for the duration of the build - the multi-minute lock
+-- this PR exists to avoid. With CONCURRENTLY pre-applied, the IF NOT
+-- EXISTS clauses make each statement here a no-op on real envs. On dev /
+-- PR-environment DBs the tables are small or empty so the plain CREATE
+-- INDEX runs without user-visible impact.
+--
+-- Operator runbook (per target environment):
+--   1. Connect to the target DB via psql or kubectl exec.
+--   2. Run each statement below with `CREATE INDEX CONCURRENTLY IF NOT
+--      EXISTS` instead of `CREATE INDEX IF NOT EXISTS`. CONCURRENTLY
+--      statements must be run one-at-a-time, NOT inside a transaction
+--      block.
+--   3. Verify no INVALID indexes were left behind:
+--      `SELECT relname FROM pg_index JOIN pg_class ON pg_class.oid =
+--      indexrelid WHERE NOT indisvalid;`
+--   4. Add the `db-prepped-<branch>` label to the PR.
+--
+-- Background: the 2026-05-05 RDS CPU incident traced to a per-org
+-- gas-usage aggregate over workflow_execution_logs which seq-scanned a
+-- 1.9 GB table. That query path now has direct index support via
+-- idx_exec_logs_started_at. The rest of this migration adds the missing
+-- FK indexes Postgres does not auto-create.
+
+CREATE INDEX IF NOT EXISTS "idx_exec_logs_started_at"
+  ON "workflow_execution_logs" ("started_at");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_user_id"
+  ON "workflow_executions" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflows_tag_id"
+  ON "workflows" ("tag_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflows_project_id"
+  ON "workflows" ("project_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflows_user_id"
+  ON "workflows" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_accounts_user_id"
+  ON "accounts" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_sessions_user_id"
+  ON "sessions" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_member_user_id"
+  ON "member" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_member_organization_id"
+  ON "member" ("organization_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_org_api_keys_org_id"
+  ON "organization_api_keys" ("organization_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_org_api_keys_created_by"
+  ON "organization_api_keys" ("created_by");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_integrations_user_id"
+  ON "integrations" ("user_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1777760000008,
       "tag": "0074_keep440_workflows_soft_delete",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1777760000009,
+      "tag": "0075_keep_432_db_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -122,24 +122,31 @@ export const keyExportCodes = pgTable("key_export_codes", {
  * NOTE: This is separate from the user-scoped apiKeys table in the main schema.
  * Organization keys have broader permissions and are meant for API/MCP access.
  */
-export const organizationApiKeys = pgTable("organization_api_keys", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => generateId()),
-  organizationId: text("organization_id")
-    .notNull()
-    .references(() => organization.id, { onDelete: "cascade" }),
-  name: text("name").notNull(), // User-provided label for the key
-  keyHash: text("key_hash").notNull().unique(), // SHA-256 hash of the key
-  keyPrefix: text("key_prefix").notNull(), // First 8 chars for identification (e.g., "kh_abc12")
-  createdBy: text("created_by").references(() => users.id, {
-    onDelete: "set null",
-  }), // User who created the key
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  lastUsedAt: timestamp("last_used_at"), // Track usage for audit
-  expiresAt: timestamp("expires_at"), // Optional expiration
-  revokedAt: timestamp("revoked_at"), // Soft delete via revocation
-});
+export const organizationApiKeys = pgTable(
+  "organization_api_keys",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull(), // User-provided label for the key
+    keyHash: text("key_hash").notNull().unique(), // SHA-256 hash of the key
+    keyPrefix: text("key_prefix").notNull(), // First 8 chars for identification (e.g., "kh_abc12")
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }), // User who created the key
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at"), // Track usage for audit
+    expiresAt: timestamp("expires_at"), // Optional expiration
+    revokedAt: timestamp("revoked_at"), // Soft delete via revocation
+  },
+  (table) => [
+    index("idx_org_api_keys_org_id").on(table.organizationId),
+    index("idx_org_api_keys_created_by").on(table.createdBy),
+  ]
+);
 
 // Type exports for the Organization API Keys table
 export type OrganizationApiKey = typeof organizationApiKeys.$inferSelect;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -46,37 +46,45 @@ export const users = pgTable("users", {
   deactivatedAt: timestamp("deactivated_at"),
 });
 
-export const sessions = pgTable("sessions", {
-  id: text("id").primaryKey(),
-  expiresAt: timestamp("expires_at").notNull(),
-  token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-  ipAddress: text("ip_address"),
-  userAgent: text("user_agent"),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  activeOrganizationId: text("active_organization_id"),
-});
+export const sessions = pgTable(
+  "sessions",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    activeOrganizationId: text("active_organization_id"),
+  },
+  (table) => [index("idx_sessions_user_id").on(table.userId)]
+);
 
-export const accounts = pgTable("accounts", {
-  id: text("id").primaryKey(),
-  accountId: text("account_id").notNull(),
-  providerId: text("provider_id").notNull(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  accessToken: text("access_token"),
-  refreshToken: text("refresh_token"),
-  idToken: text("id_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at"),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-  scope: text("scope"),
-  password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-});
+export const accounts = pgTable(
+  "accounts",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+  },
+  (table) => [index("idx_accounts_user_id").on(table.userId)]
+);
 
 export const verifications = pgTable("verifications", {
   id: text("id").primaryKey(),
@@ -97,17 +105,24 @@ export const organization = pgTable("organization", {
   metadata: text("metadata"),
 });
 
-export const member = pgTable("member", {
-  id: text("id").primaryKey(),
-  organizationId: text("organization_id")
-    .notNull()
-    .references(() => organization.id, { onDelete: "cascade" }),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  role: text("role").default("member").notNull(),
-  createdAt: timestamp("created_at").notNull(),
-});
+export const member = pgTable(
+  "member",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: text("role").default("member").notNull(),
+    createdAt: timestamp("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_member_user_id").on(table.userId),
+    index("idx_member_organization_id").on(table.organizationId),
+  ]
+);
 
 export const invitation = pgTable("invitation", {
   id: text("id").primaryKey(),
@@ -254,6 +269,9 @@ export const workflows = pgTable(
     uniqueIndex("idx_workflows_listed_slug")
       .on(table.listedSlug)
       .where(isNotNull(table.listedSlug)),
+    index("idx_workflows_user_id").on(table.userId),
+    index("idx_workflows_tag_id").on(table.tagId),
+    index("idx_workflows_project_id").on(table.projectId),
   ]
 );
 
@@ -290,6 +308,7 @@ export const integrations = pgTable(
       .where(
         sql`${table.type} = 'web3' AND ${table.organizationId} IS NOT NULL`
       ),
+    index("idx_integrations_user_id").on(table.userId),
   ]
 );
 
@@ -369,14 +388,19 @@ export const workflowExecutions = pgTable(
      */
     billable: boolean("billable").notNull().default(true),
   },
-  (table) => [index("idx_workflow_executions_status").on(table.status)]
+  (table) => [
+    index("idx_workflow_executions_status").on(table.status),
+    index("idx_workflow_executions_user_id").on(table.userId),
+  ]
 );
 
 // Workflow execution logs to track individual node executions
-export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => generateId()),
+export const workflowExecutionLogs = pgTable(
+  "workflow_execution_logs",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
   executionId: text("execution_id")
     .notNull()
     .references(() => workflowExecutions.id),
@@ -403,7 +427,9 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
   timestamp: timestamp("timestamp").notNull().defaultNow(),
   iterationIndex: integer("iteration_index"), // 0-based loop iteration (null for non-loop nodes)
   forEachNodeId: text("for_each_node_id"), // parent For Each node ID (null for non-loop nodes)
-});
+  },
+  (table) => [index("idx_exec_logs_started_at").on(table.startedAt)]
+);
 
 export {
   type AgenticWalletCredit,


### PR DESCRIPTION
## Summary

Post-incident additive index migration. Closes the seq-scan path used by the per-org gas-usage analytics query that caused the 2026-05-05 RDS CPU incident, plus the 11 highest-impact missing FK indexes Postgres does not auto-create.

Tracking: [KEEP-432](https://linear.app/keeperhubapp/issue/KEEP-432)

## What this adds

**Critical index for the incident query:**
- ``workflow_execution_logs(started_at)``

**Missing FK indexes:**
- ``workflow_executions(user_id)``
- ``workflows(user_id, tag_id, project_id)``
- ``accounts(user_id)``, ``sessions(user_id)``
- ``member(user_id, organization_id)``
- ``organization_api_keys(organization_id, created_by)``
- ``integrations(user_id)``

All declared in ``lib/db/schema.ts`` / ``lib/db/schema-extensions.ts`` via the ``index()`` helper so drizzle-kit does not see them as drift. Migration uses plain ``CREATE INDEX IF NOT EXISTS``.

## Why CONCURRENTLY is not in the migration file

drizzle-kit wraps every migration in a transaction. ``CREATE INDEX CONCURRENTLY`` cannot run inside a transaction, so it cannot live in a drizzle-kit-managed migration without replacing the runner - which we did not want to do.

Plain ``CREATE INDEX`` is safe on dev / PR-env DBs (tables small or empty, locks irrelevant), but on prod ``workflow_execution_logs`` is 1.9 GB and a plain CREATE INDEX would take a multi-minute ``ACCESS EXCLUSIVE`` lock - the exact incident this PR exists to prevent. So real envs get CONCURRENTLY out-of-band, then ``IF NOT EXISTS`` makes the migration a no-op when ``db:migrate`` runs.

## Enforcement (the gate)

The "remember to run CONCURRENTLY before merge" step is no longer a runbook - it is a required GitHub status check.

- New workflow ``.github/workflows/db-prep-check.yml``: on every PR event, inspects each newly-added ``drizzle/*.sql`` for the directive ``-- @requires-db-prep`` near the top. If found, the check fails unless the matching label is present.
- New labels: ``db-prepped-staging`` and ``db-prepped-prod``. Operator applies them ONLY after running the lock-free DDL against the real target DB.
- The repo's existing branch-protection ruleset for ``staging`` / ``prod`` / ``main`` has ``db-prep-check`` added as a required status check, so a missing label blocks the merge button at the branch-protection level.
- For normal PRs without the directive, the check passes automatically and is invisible.

This is suisuss's option (b) from the v1 review.

## Roll-out for this PR

- **Staging DB**: already done. All 12 indexes applied via ``CREATE INDEX CONCURRENTLY`` (2s total, no locks). 0 invalid indexes. ``db-prepped-staging`` label is set.
- **Merge to staging**: ``drizzle-kit migrate`` runs the plain ``CREATE INDEX IF NOT EXISTS`` statements; they are no-ops since the indexes already exist.
- **Prod**: when the staging -> prod PR opens, an operator applies CONCURRENTLY to prod the same way, then sets ``db-prepped-prod``.

## What this intentionally does NOT do

- **No composite ``(status, started_at DESC)`` on ``workflow_executions``.** The v1 justification I gave was inferred from ``idx_tup_read / idx_tup_fetch`` ratios, not from the actual query. After reading ``lib/analytics/queries.ts``, the discarded predicate is not ``started_at``, so the composite column choice was wrong. A separate evidence-backed PR can revisit it if real prod traffic shows the simple ``idx_workflow_executions_status`` is still doing meaningful wasted work.
- **No FK index on ``para_wallets(user_id)``**. Table is on the Turnkey-as-canonical-wallet deprecation path; write overhead not justified through the decommission window.
- **No drops in this PR.** A follow-up will drop the unused / duplicate / superseded indexes (``workflow_events_correlation_id_index``, ``idx_exec_logs_success_lookup``, the four duplicate-column indexes, etc.) once these adds are verified in prod.

## Test plan

- [x] PR environment deploys cleanly with the simplified migration
- [x] PR-env DB shows 12 valid + ready indexes, 0 invalid indexes
- [x] PR-env DB has the ``seeded_at`` column from the concurrent KEEP-458 migration (proves drizzle-kit migrate runs all migrations in order)
- [x] CI Pipeline / PR Checks / Maintainability / PR Title Check all green
- [x] ``db-prep-check`` correctly **failed** before the ``db-prepped-staging`` label was applied
- [x] ``db-prep-check`` passes once the label is set
- [x] Staging DB has all 12 indexes applied via CONCURRENTLY, 0 invalid
- [ ] After merge, staging deploy's ``db:migrate`` is a no-op for these 12 indexes (verify in deploy logs)
- [ ] Soak in staging for 24-48h, verify via ``pg_stat_user_indexes`` that the new indexes are being scanned
- [ ] When opening staging -> prod PR: apply CONCURRENTLY to prod, set ``db-prepped-prod`` label