### PR TITLE
feat: KEEP-417 stable per-org execution series and tier labels

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -277,46 +277,46 @@ const orgWithWorkflows = getOrCreateGauge(
   []
 );
 
-// Organization info gauge (DB-sourced, one series per org)
-// Includes plan + billing_status so the Organization Directory table panel
-// in Grafana can show those columns directly off this gauge without an
-// extra Prometheus join.
+// Organization info gauge (DB-sourced, one series per org).
+// Includes plan + tier + billing_status so the Organization Directory
+// table panel in Grafana can show those columns directly off this gauge
+// without an extra Prometheus join. tier is "" (empty string) for free
+// and enterprise orgs (no tier system).
 const orgInfo = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_info",
-  "Organization info with name, slug, plan, and billing_status labels",
-  ["org_name", "slug", "plan", "billing_status"]
+  "Organization info with name, slug, plan, tier, and billing_status labels",
+  ["org_name", "slug", "plan", "tier", "billing_status"]
 );
 
 // Billing-aware org metrics (DB-sourced)
 //
-// Org count broken down by (plan, billing_status). One series per
-// (plan, billing_status) combination — bounded cardinality (4 plans x
-// ~7 statuses).
+// Org count broken down by (plan, tier, billing_status). One series per
+// unique combination. tier="" for free / enterprise.
 const orgTotalByPlan = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_total_by_plan",
-  "Organizations grouped by plan and billing status",
-  ["plan", "billing_status"]
+  "Organizations grouped by plan, tier, and billing status",
+  ["plan", "tier", "billing_status"]
 );
 
-// Per-org execution counts (rolling 30-day window). Cardinality control:
-// paid orgs (pro/business/enterprise) emit individual series; free-tier
-// orgs aggregate into a single series with org_slug="_free".
+// Per-org execution counts (rolling 30-day window). Keyed only on
+// org_slug so the series identity stays stable when an org changes plan.
+// Join with keeperhub_org_info for plan/billing_status context.
 const orgExecutions30d = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_executions_30d",
-  'Workflow executions per org in the last 30 days (paid orgs individually; free orgs aggregated under org_slug="_free")',
-  ["org_slug", "plan"]
+  "Workflow executions per org in the last 30 days",
+  ["org_slug"]
 );
 
 // Per-org execution counts (current calendar month, used for plan limit
-// pressure). Same cardinality rules as orgExecutions30d.
+// pressure).
 const orgExecutionsMonth = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_executions_month",
   "Workflow executions per org since start of the current calendar month",
-  ["org_slug", "plan"]
+  ["org_slug"]
 );
 
 // Plan usage ratio: current-month executions / monthly limit. 0 when the
@@ -326,18 +326,18 @@ const orgPlanUsageRatio = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_plan_usage_ratio",
   "Current-month executions divided by the org's plan monthly limit (0 = no pressure or unlimited)",
-  ["org_slug", "plan"]
+  ["org_slug"]
 );
 
-// Directional MRR per plan in USD cents. Computed from PLANS[plan].tiers
-// monthlyPrice × current (plan, tier) of every active/trialing/past_due
+// Directional MRR per (plan, tier) in USD cents. Computed from
+// PLANS[plan].tiers[tier].monthlyPrice for every active/trialing/past_due
 // subscription. Stripe Dashboard remains the source of truth for actual
 // revenue accounting; this gauge is for trend/observability only.
 const mrrUsdCents = getOrCreateGauge(
   dbRegistry,
   "keeperhub_mrr_usd_cents",
-  "Approximate MRR in USD cents per plan (PLANS table * current tier)",
-  ["plan"]
+  "Approximate MRR in USD cents per (plan, tier)",
+  ["plan", "tier"]
 );
 
 const mrrUsdCentsTotal = getOrCreateGauge(
@@ -1300,6 +1300,7 @@ export async function updateDbMetrics(): Promise<void> {
           org_name: org.name,
           slug: org.slug,
           plan: org.plan,
+          tier: org.tier ?? "",
           billing_status: org.billingStatus,
         },
         1
@@ -1308,17 +1309,22 @@ export async function updateDbMetrics(): Promise<void> {
 
     // Update billing-aware metrics
     orgTotalByPlan.reset();
-    for (const [plan, byStatus] of Object.entries(billingStats.orgsByPlan)) {
-      for (const [billingStatus, orgCount] of Object.entries(byStatus)) {
-        orgTotalByPlan.set({ plan, billing_status: billingStatus }, orgCount);
-      }
+    for (const entry of billingStats.orgsByPlan) {
+      orgTotalByPlan.set(
+        {
+          plan: entry.plan,
+          tier: entry.tier ?? "",
+          billing_status: entry.billingStatus,
+        },
+        entry.count
+      );
     }
 
     orgExecutions30d.reset();
     orgExecutionsMonth.reset();
     orgPlanUsageRatio.reset();
     for (const row of billingStats.orgsExecutions) {
-      const labels = { org_slug: row.orgSlug, plan: row.plan };
+      const labels = { org_slug: row.orgSlug };
       orgExecutions30d.set(labels, row.exec30d);
       orgExecutionsMonth.set(labels, row.execMonth);
       // Unlimited plan (enterprise) -> ratio 0 to avoid alerting noise.
@@ -1328,8 +1334,8 @@ export async function updateDbMetrics(): Promise<void> {
     }
 
     mrrUsdCents.reset();
-    for (const [plan, cents] of Object.entries(billingStats.mrrCentsByPlan)) {
-      mrrUsdCents.set({ plan }, cents);
+    for (const entry of billingStats.mrrCentsByPlan) {
+      mrrUsdCents.set({ plan: entry.plan, tier: entry.tier ?? "" }, entry.cents);
     }
     mrrUsdCentsTotal.set(billingStats.mrrCentsTotal);
 

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -907,23 +907,21 @@ export async function getEnabledChainNamesFromDb(): Promise<string[]> {
   }
 }
 
-// Bucket label used for aggregating free-tier orgs in per-org execution
-// gauges. Free-tier orgs share a single series to keep Prometheus
-// cardinality bounded. Paid orgs (pro/business/enterprise) are emitted as
-// individual series so each one is filterable in Grafana.
-export const FREE_ORG_AGGREGATE_SLUG = "_free";
-
 // Subscription statuses that count toward MRR — kept inline in the SQL
 // query (active / trialing / past_due). Canceled / unpaid / paused
 // subscriptions do not contribute.
 
 export type BillingStats = {
-  // Org count per (plan, billing_status). Free orgs without a subscription
-  // row are reported under plan="free", billing_status="none".
-  orgsByPlan: Record<PlanName, Record<BillingStatus, number>>;
+  // Org count per (plan, tier, billing_status). One entry per unique
+  // combination. tier is null for free and enterprise (no tier system).
+  orgsByPlan: Array<{
+    plan: PlanName;
+    tier: TierKey | null;
+    billingStatus: BillingStatus;
+    count: number;
+  }>;
 
-  // Per-org execution counts. Paid orgs appear individually with their slug;
-  // all free-tier orgs are aggregated under FREE_ORG_AGGREGATE_SLUG.
+  // Per-org execution counts. One entry per org (free + paid).
   orgsExecutions: Array<{
     orgSlug: string;
     plan: PlanName;
@@ -934,31 +932,24 @@ export type BillingStats = {
     monthlyLimit: number;
   }>;
 
-  // Approximate MRR in USD cents per plan, computed from PLANS[plan].tiers
-  // matched by org's tier. Stripe remains the source of truth for accounting.
-  mrrCentsByPlan: Record<PlanName, number>;
+  // Approximate MRR in USD cents per (plan, tier), computed from
+  // PLANS[plan].tiers[tier].monthlyPrice. Stripe remains the source of
+  // truth for accounting.
+  mrrCentsByPlan: Array<{
+    plan: PlanName;
+    tier: TierKey | null;
+    cents: number;
+  }>;
 
-  // Total MRR in USD cents across all plans (sum of mrrCentsByPlan).
+  // Total MRR in USD cents across all plans and tiers.
   mrrCentsTotal: number;
 };
 
 function emptyBillingStats(): BillingStats {
-  const orgsByPlan: Record<PlanName, Record<BillingStatus, number>> = {
-    free: {} as Record<BillingStatus, number>,
-    pro: {} as Record<BillingStatus, number>,
-    business: {} as Record<BillingStatus, number>,
-    enterprise: {} as Record<BillingStatus, number>,
-  };
-  const mrrCentsByPlan: Record<PlanName, number> = {
-    free: 0,
-    pro: 0,
-    business: 0,
-    enterprise: 0,
-  };
   return {
-    orgsByPlan,
+    orgsByPlan: [],
     orgsExecutions: [],
-    mrrCentsByPlan,
+    mrrCentsByPlan: [],
     mrrCentsTotal: 0,
   };
 }
@@ -978,18 +969,16 @@ function tierMonthlyPriceCents(plan: PlanName, tier: TierKey | null): number {
  * Joins workflow_executions -> workflows -> organization -> organization_subscriptions
  * to produce per-org execution counts (30-day rolling and current-month-to-date),
  * org distribution by plan/billing status, and a directional MRR figure.
- *
- * Free-tier orgs are aggregated into a single FREE_ORG_AGGREGATE_SLUG series
- * for the per-org executions gauge to bound Prometheus cardinality.
  */
 export async function getBillingStatsFromDb(): Promise<BillingStats> {
   try {
-    // Aggregate counts: orgs by (plan, billing_status). LEFT JOIN handles
-    // legacy orgs without a subscription row (mapped to plan="free",
+    // Aggregate counts: orgs by (plan, tier, billing_status). LEFT JOIN
+    // handles legacy orgs without a subscription row (mapped to plan="free",
     // billing_status="none" via fallback in OrgListEntry parsing).
     const orgsByPlanResult = await db
       .select({
         plan: organizationSubscriptions.plan,
+        tier: organizationSubscriptions.tier,
         status: organizationSubscriptions.status,
         count: count(),
       })
@@ -1000,6 +989,7 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
       )
       .groupBy(
         organizationSubscriptions.plan,
+        organizationSubscriptions.tier,
         organizationSubscriptions.status
       );
 
@@ -1045,29 +1035,32 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
 
     const stats = emptyBillingStats();
 
-    // Tally orgs by plan + billing_status
+    // Tally orgs by plan + tier + billing_status
     for (const row of orgsByPlanResult) {
       const plan = parsePlanName(row.plan, "free");
-      const status: BillingStatus =
+      const tier = parseTierKey(row.tier);
+      const billingStatus: BillingStatus =
         row.status === null ? "none" : parseBillingStatus(row.status);
-      const planBucket = stats.orgsByPlan[plan];
-      planBucket[status] = (planBucket[status] ?? 0) + Number(row.count);
+      const count = Number(row.count);
+      const existing = stats.orgsByPlan.find(
+        (e) =>
+          e.plan === plan &&
+          e.tier === tier &&
+          e.billingStatus === billingStatus
+      );
+      if (existing) {
+        existing.count += count;
+      } else {
+        stats.orgsByPlan.push({ plan, tier, billingStatus, count });
+      }
     }
 
-    // Tally per-org executions, bucketing free orgs into a single series
-    let freeExec30d = 0;
-    let freeExecMonth = 0;
+    // Tally per-org executions — one entry per org (free + paid)
     for (const row of execByOrgResult) {
       const plan = parsePlanName(row.plan, "free");
       const tier = parseTierKey(row.tier);
       const exec30d = Number(row.exec30d) || 0;
       const execMonth = Number(row.execMonth) || 0;
-
-      if (plan === "free") {
-        freeExec30d += exec30d;
-        freeExecMonth += execMonth;
-        continue;
-      }
 
       const monthlyLimit = PLANS[plan].features.maxExecutionsPerMonth;
       const tierLimit =
@@ -1085,23 +1078,19 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
       });
     }
 
-    // Free aggregate row: plan=free, monthlyLimit from free defaults
-    if (freeExec30d > 0 || freeExecMonth > 0) {
-      stats.orgsExecutions.push({
-        orgSlug: FREE_ORG_AGGREGATE_SLUG,
-        plan: "free",
-        exec30d: freeExec30d,
-        execMonth: freeExecMonth,
-        monthlyLimit: PLANS.free.features.maxExecutionsPerMonth,
-      });
-    }
-
-    // Compute MRR per plan from active subscriptions × tier price
+    // Compute MRR per (plan, tier) from active subscriptions × tier price
     for (const row of mrrSubsResult) {
       const plan = parsePlanName(row.plan, "free");
       const tier = parseTierKey(row.tier);
       const cents = tierMonthlyPriceCents(plan, tier);
-      stats.mrrCentsByPlan[plan] += cents;
+      const existing = stats.mrrCentsByPlan.find(
+        (e) => e.plan === plan && e.tier === tier
+      );
+      if (existing) {
+        existing.cents += cents;
+      } else {
+        stats.mrrCentsByPlan.push({ plan, tier, cents });
+      }
       stats.mrrCentsTotal += cents;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to [#1131](https://github.com/KeeperHub/keeperhub/pull/1131) (the initial billing metrics drop), addressing two observability gaps surfaced while validating the Grafana dashboard:

### 1. Stable per-org execution series

- `keeperhub_org_executions_30d`, `_month`, and `_plan_usage_ratio` no longer collapse free-tier orgs into a single `org_slug="_free"` bucket. Every org emits its own series, so each free user's runs and plan-limit pressure are individually visible.
- Same three metrics are now keyed only on `org_slug` (dropped `plan` label). Series identity stays stable when an org upgrades free to pro or pro to business, so Prometheus does not see a continuity break and historical trend lines stay intact. Plan and tier context joins in via `keeperhub_org_info` when needed.

### 2. Tier as a first-class label

`PLANS` defines three pro tiers (25k/50k/100k) and three business tiers (250k/500k/1m) with different execution allowances and prices. The math already used the right tier limit for usage ratio and the right tier price for MRR, but observability was blind to which tier each org was on.

- Added `tier` label to `keeperhub_org_info`, `keeperhub_org_total_by_plan`, and `keeperhub_mrr_usd_cents`. Empty string for free and enterprise (no tier system).
- Org counts and MRR can now be broken down by `(plan, tier)` in Grafana.

### Cardinality

Per-free-org series adds roughly `3 × N_free_orgs` series. With ~390 free orgs today that is ~1170 additional series total across the three execution gauges. `keeperhub_org_info` already emitted one series per org, so the per-org pattern is not new.

Tier dimension on the three gauges adds at most 8 new combinations (1 free + 3 pro + 3 business + 1 enterprise), bounded.

## Companion change

[techops-services/infrastructure PR](https://github.com/techops-services/infrastructure) updates the Grafana dashboard JSON to surface the `Tier` column and rewrites the Organization Directory table transform pipeline to use `joinByField` on slug (the previous merge-based pipeline silently dropped columns in V2 dashboards).

Resolves [KEEP-417](https://linear.app/keeperhubapp/issue/KEEP-417/add-billing-metrics-and-update-grafana-dashboard) observability gaps.