### PR TITLE
hotfix: stabilize bfcache back/forward test against billing-details fetch race

### DIFF
--- a/tests/e2e/playwright/back-forward-hydration.test.ts
+++ b/tests/e2e/playwright/back-forward-hydration.test.ts
@@ -31,11 +31,25 @@ const PAGES_TO_TEST = ["/hub", "/billing"] as const;
 test.describe(`back/forward hydration recovery (${buildModeLabel})`, () => {
   for (const targetPath of PAGES_TO_TEST) {
     test(`${targetPath}: hydrates after back navigation`, async ({ page }) => {
+      // Component-level fetches (e.g. <BillingDetails> on /billing) render
+      // conditional buttons only after their useEffect fetch resolves —
+      // hide their "Loading..." indicator at that point. The hydration
+      // sentinel below proves AuthProvider hydrated; it does NOT prove
+      // those fetches are done. Without this wait the baseline (fresh
+      // nav) usually wins the race and the rehydrated count (back nav)
+      // usually loses it, producing a deterministic off-by-one.
+      const settleClientDataFetches = async (): Promise<void> => {
+        await expect(page.getByText("Loading...", { exact: true })).toBeHidden({
+          timeout: 10_000,
+        });
+      };
+
       // 1. Navigate to target page first; wait for hydration sentinel.
       await page.goto(targetPath, { waitUntil: "domcontentloaded" });
       await expect(page.locator('button[role="combobox"]')).toBeVisible({
         timeout: 15_000,
       });
+      await settleClientDataFetches();
 
       // 2. Capture button count after fresh hydration as the baseline.
       const baselineButtonCount = await page.locator("button").count();
@@ -55,6 +69,7 @@ test.describe(`back/forward hydration recovery (${buildModeLabel})`, () => {
       await expect(page.locator('button[role="combobox"]')).toBeVisible({
         timeout: 15_000,
       });
+      await settleClientDataFetches();
 
       // 5. Behavior assertion: the rehydrated page has at least as many
       //    interactive buttons as the fresh-nav baseline. This is the proxy


### PR DESCRIPTION
## Summary

- The `/billing` case of `tests/e2e/playwright/back-forward-hydration.test.ts` (added in 69063092) deterministically failed on staging push run [25720028519](https://github.com/KeeperHub/keeperhub/actions/runs/25720028519/job/75520325408) with `Expected: >= 21, Received: 20`, three identical attempts. Page snapshot at failure showed `<BillingDetails>` still on its `Loading...` spinner, so the conditional "Edit billing details" pencil had not yet rendered when the rehydrated button count was taken.
- This is a test-side race, not a real hydration regression. The `button[role="combobox"]` sentinel proves AuthProvider hydrated; it does not prove that components doing post-mount `useEffect` fetches (like `<BillingDetails>`) have finished. On a fresh `goto` the fetch usually wins; on `goBack` the assertion usually wins. `/hub` was never affected because none of its buttons are gated on a post-mount fetch.
- Fix: before both the baseline and rehydrated counts, wait for any `Loading...` text to be hidden. `toBeHidden` also passes when the element is never attached, so `/hub` is unaffected. This makes the two counts comparable instead of racing their respective fetches.

## Test plan

- [x] E2E Playwright (ephemeral) job is green on this PR, specifically `back/forward hydration recovery (pnpm start) > /billing: hydrates after back navigation` and the matching dev-mode variant.
- [ ] `/hub` cases remain green (sanity — they were not affected by the bug and should not be affected by the fix).
- [ ] No new lint or type errors introduced (`pnpm check` and `pnpm type-check` were run locally against the changed file).

## Notes

- Does not touch product code; only the test setup.
- The Phase 45 build-mode-specific `navigation.type` assertion at the end of the test is preserved unchanged.