### PR TITLE
hotfix(block-dispatcher): KEEP-544 prevent zombie WSS subscription and recycle long-lived sockets

### DIFF
--- a/deploy/scheduler/prod/block-dispatcher-values.yaml
+++ b/deploy/scheduler/prod/block-dispatcher-values.yaml
@@ -71,6 +71,11 @@ env:
   RECONCILE_INTERVAL_MS:
     type: kv
     value: "30000"
+  # Periodic socket recycle: force-reconnect each ChainMonitor's WSS at this
+  # cadence to guard against half-open / silently degraded upstream sockets.
+  SOCKET_MAX_AGE_MS:
+    type: kv
+    value: "3600000"
   # Health check server port
   HEALTH_PORT:
     type: kv

--- a/deploy/scheduler/staging/block-dispatcher-values.yaml
+++ b/deploy/scheduler/staging/block-dispatcher-values.yaml
@@ -71,6 +71,11 @@ env:
   RECONCILE_INTERVAL_MS:
     type: kv
     value: "30000"
+  # Periodic socket recycle: force-reconnect each ChainMonitor's WSS at this
+  # cadence to guard against half-open / silently degraded upstream sockets.
+  SOCKET_MAX_AGE_MS:
+    type: kv
+    value: "3600000"
   # Health check server port
   HEALTH_PORT:
     type: kv

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -48,6 +48,46 @@ function getPrimaryProbeIntervalMs(): number {
   return Number(process.env.PRIMARY_PROBE_INTERVAL_MS) || 5 * 60_000;
 }
 
+// Proactive socket recycle: tear down and re-subscribe any socket that has
+// been continuously connected longer than this. Belt-and-suspenders against
+// half-open WSS state that doesn't surface as a 'close' event.
+const SOCKET_MAX_AGE_DEFAULT_MS = 60 * 60_000; // 1 hour
+function getSocketMaxAgeMs(): number {
+  return Number(process.env.SOCKET_MAX_AGE_MS) || SOCKET_MAX_AGE_DEFAULT_MS;
+}
+
+// destroyProvider awaits ethers v6 cleanup which can hang when the upstream
+// WSS is half-open (the internal eth_unsubscribe never settles). Bound each
+// cleanup step so the reconnect loop cannot get stuck mid-teardown.
+const DESTROY_PROVIDER_TIMEOUT_MS = 3_000;
+
+// If isReconnecting stays true longer than this, treat the monitor as dead
+// so the reconciler can tear it down and start a fresh one. The normal
+// reconnect-with-backoff path (max 10 attempts, max 30s each) completes well
+// under this threshold; only a hung destroy/connect await can exceed it.
+const STUCK_RECONNECT_MS = 5 * 60_000;
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise.finally(() => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }),
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`${label} timeout after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    }),
+  ]);
+}
+
 type ChainMonitorConfig = {
   chain: ChainConfig;
   workflows: BlockWorkflow[];
@@ -89,6 +129,8 @@ export class ChainMonitor {
   private pongTimer: ReturnType<typeof setTimeout> | null = null;
   private noBlockTimer: ReturnType<typeof setTimeout> | null = null;
   private primaryProbeTimer: ReturnType<typeof setInterval> | null = null;
+  private socketAgeTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectingStartedAt: number | null = null;
   private currentUrlIndex = 0;
   private hasActiveSubscription = false;
   private wsCloseHandler: (() => void) | null = null;
@@ -122,6 +164,7 @@ export class ChainMonitor {
   async stop(): Promise<void> {
     this.isRunning = false;
     this.isReconnecting = false;
+    this.reconnectingStartedAt = null;
     this.stopTimers();
     await this.destroyProvider();
   }
@@ -146,6 +189,15 @@ export class ChainMonitor {
       return false;
     }
     if (this.isReconnecting) {
+      // Normal reconnect-with-backoff (max ~3 min) is well under
+      // STUCK_RECONNECT_MS. Anything longer indicates destroyProvider() or
+      // connect() got hung mid-await, and the reconciler must intervene.
+      if (
+        this.reconnectingStartedAt !== null &&
+        Date.now() - this.reconnectingStartedAt > STUCK_RECONNECT_MS
+      ) {
+        return false;
+      }
       return true;
     }
     if (!this.hasActiveSubscription) {
@@ -206,11 +258,30 @@ export class ChainMonitor {
         this.wsCloseHandler = null;
       }
 
-      await this.provider.removeAllListeners();
+      // ethers v6 removeAllListeners/destroy fire an internal eth_unsubscribe
+      // over the WSS. On a half-open socket that promise can hang and block
+      // the reconnect loop forever; bound both steps with a hard timeout.
       try {
-        await this.provider.destroy();
-      } catch {
-        // ignore cleanup errors
+        await withTimeout(
+          this.provider.removeAllListeners(),
+          DESTROY_PROVIDER_TIMEOUT_MS,
+          "removeAllListeners",
+        );
+      } catch (error) {
+        console.warn(
+          `[BlockMonitor:${this.chainName}] destroyProvider.removeAllListeners: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      try {
+        await withTimeout(
+          this.provider.destroy(),
+          DESTROY_PROVIDER_TIMEOUT_MS,
+          "destroy",
+        );
+      } catch (error) {
+        console.warn(
+          `[BlockMonitor:${this.chainName}] destroyProvider.destroy: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
       this.provider = null;
     }
@@ -331,6 +402,7 @@ export class ChainMonitor {
     // by isAlive() before the first block arrives. Real blocks will refresh
     // this in onBlock().
     this.lastBlockReceivedAt = Date.now();
+    this.startSocketAgeTimer();
     console.log(`[BlockMonitor:${this.chainName}] Block subscription active`);
 
     // Handle WebSocket close for reconnection - store reference for cleanup
@@ -614,6 +686,37 @@ export class ChainMonitor {
     this.stopPingPong();
     this.stopNoBlockTimer();
     this.stopPrimaryProbe();
+    this.stopSocketAgeTimer();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Periodic socket recycle
+  //
+  // Even when blocks keep arriving, a long-lived WSS can drift into a degraded
+  // state (server-side rate limits, partial routing failures, half-open TCP).
+  // Recycling on a fixed schedule guarantees we exercise the reconnect path
+  // routinely so subtle staleness can't accumulate undetected.
+  // ---------------------------------------------------------------------------
+
+  private startSocketAgeTimer(): void {
+    this.stopSocketAgeTimer();
+    const maxAgeMs = getSocketMaxAgeMs();
+    this.socketAgeTimer = setTimeout(() => {
+      if (!this.isRunning || this.isReconnecting) {
+        return;
+      }
+      console.log(
+        `[BlockMonitor:${this.chainName}] Socket age exceeded ${Math.floor(maxAgeMs / 1000)}s, recycling`,
+      );
+      this.handleDisconnect();
+    }, maxAgeMs);
+  }
+
+  private stopSocketAgeTimer(): void {
+    if (this.socketAgeTimer) {
+      clearTimeout(this.socketAgeTimer);
+      this.socketAgeTimer = null;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -710,6 +813,7 @@ export class ChainMonitor {
     }
 
     this.isReconnecting = true;
+    this.reconnectingStartedAt = Date.now();
     this.stopTimers();
 
     this.reconnectWithBackoff().catch((error: unknown) => {
@@ -718,6 +822,7 @@ export class ChainMonitor {
         error instanceof Error ? error.message : error,
       );
       this.isReconnecting = false;
+      this.reconnectingStartedAt = null;
     });
   }
 
@@ -731,6 +836,7 @@ export class ChainMonitor {
         );
         this.isRunning = false;
         this.isReconnecting = false;
+        this.reconnectingStartedAt = null;
         return;
       }
 
@@ -757,6 +863,7 @@ export class ChainMonitor {
         await this.subscribeToBlocks();
         this.reconnectAttempts = 0;
         this.isReconnecting = false;
+        this.reconnectingStartedAt = null;
         this.startPingPong();
         this.resetNoBlockTimer();
         this.startPrimaryProbe();

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -732,6 +732,36 @@ describe("ChainMonitor", () => {
       expect(lastConnectedUrl).toBe("wss://primary.test");
     });
 
+    it("recycles the socket after SOCKET_MAX_AGE_MS elapses", async () => {
+      // Health-restart safety net: even when the socket appears healthy
+      // (no close event, blocks still arriving), drop and re-subscribe on a
+      // fixed schedule so a degraded WSS cannot accumulate undetected.
+      // 30s here for the local fast-test path; staging/prod use 1h.
+      vi.stubEnv("SOCKET_MAX_AGE_MS", "30000");
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(providerInstances).toHaveLength(1);
+      const originalProvider = latestProvider();
+
+      // Just before the recycle window: no new provider yet.
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(providerInstances).toHaveLength(1);
+
+      // Cross the window plus the first reconnect backoff (1s).
+      await vi.advanceTimersByTimeAsync(2_500);
+
+      expect(providerInstances.length).toBeGreaterThanOrEqual(2);
+      expect(latestProvider()).not.toBe(originalProvider);
+      expect(monitor.isAlive()).toBe(true);
+
+      await monitor.stop();
+    });
+
     it("keeps the fallback connection when probe fails", async () => {
       // Primary always rejects; fallback works. Probe should fail silently
       // (one warn line) and the monitor should remain alive on fallback.


### PR DESCRIPTION
## Summary

Fixes [KEEP-544](https://linear.app/keeperhubapp/issue/KEEP-544/hotfixblock-dispatcher-prevent-zombie-wss-subscription-and-add). Block-trigger workflows on Ethereum Mainnet (`dm9yya82syn05w8juw1c8` "Flap job keeper", `xrpwncxes7hh066w9hia7` "d3m-keeper", etc.) stopped firing on 2026-05-11 ~20:11 UTC. The `keeperhub-block-common` pod had been up 3d17h with 0 restarts but the Ethereum Mainnet `ChainMonitor` had emitted zero log lines (no heartbeats, no reconnects) for the visible kubectl log window, while the reconciler kept reporting it as one of three monitored chains. Avalanche and Base Sepolia monitors in the same pod were healthy.

## Root cause

In `chain-monitor.ts`:

1. `handleDisconnect()` sets `isReconnecting = true`, then `reconnectWithBackoff()` awaits `destroyProvider()` which awaits `provider.removeAllListeners()`. In ethers v6 this fires an internal `eth_unsubscribe` over the WSS. On a half-open socket that promise can hang.
2. While `destroyProvider()` is hung, `isAlive()` short-circuits to `true` because of `if (this.isReconnecting) return true;`, so the existing `STALE_SUBSCRIPTION_MS` backstop is bypassed.
3. The reconciler therefore never restarts the monitor and the chain goes silent indefinitely.

The unhandled rejection visible in prod logs (`provider destroyed; cancelled request (operation="eth_unsubscribe")` at `chain-monitor.ts:725`) confirmed this code path was running.

## Changes

`keeperhub-scheduler/block-dispatcher/chain-monitor.ts`:
- Bound `destroyProvider()` operations with `DESTROY_PROVIDER_TIMEOUT_MS=3s` via a new `withTimeout` helper so a hung `removeAllListeners()` / `destroy()` cannot block the reconnect loop.
- Added `reconnectingStartedAt` and `STUCK_RECONNECT_MS=5min`; `isAlive()` now returns `false` if a reconnect is stuck past that threshold so the reconciler can tear the monitor down.
- Added periodic socket recycle: a new `socketAgeTimer` triggers a clean reconnect after `SOCKET_MAX_AGE_MS` (env, default 1h). Belt-and-suspenders against half-open WSS state that never surfaces as a `close` event.

`deploy/scheduler/staging/block-dispatcher-values.yaml` and `deploy/scheduler/prod/block-dispatcher-values.yaml`:
- Set `SOCKET_MAX_AGE_MS: "3600000"` (1h).

`keeperhub-scheduler/tests/unit/chain-monitor.test.ts`:
- New test stubs `SOCKET_MAX_AGE_MS=30000` and verifies a new provider instance is created after the recycle window elapses.

All 58 vitest tests pass (was 57).