### PR TITLE
fix(workflows): KEEP-542 reset workflow identity atoms on navigation

### DIFF
--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -3,7 +3,15 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { ChevronLeft, ChevronRight, Globe, Plus } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  use,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { NodeConfigPanel } from "@/components/workflow/node-config-panel";
@@ -504,6 +512,52 @@ const WorkflowEditor = ({ workflowId }: WorkflowEditorProps) => {
   const lastAutoFixRef = useRef<{ workflowId: string; version: number } | null>(
     null
   );
+
+  // KEEP-542: workflow identity atoms are global Jotai singletons that persist
+  // across navigation. After viewing a hub workflow (isOwner=false,
+  // visibility=public), those values leak into the next workflow page until
+  // loadExistingWorkflow resolves — leaving the persistent toolbar showing
+  // "Use Template" for the user's own workflow, and worse, wiring its
+  // currentWorkflowId to the previously viewed hub template (so clicking
+  // "Use Template" duplicates the hub workflow). useLayoutEffect resets the
+  // identity/content atoms before paint so the toolbar never sees stale state.
+  const previousWorkflowIdRef = useRef<string | null>(null);
+  useLayoutEffect((): (() => void) => {
+    if (previousWorkflowIdRef.current !== workflowId) {
+      previousWorkflowIdRef.current = workflowId;
+      setCurrentWorkflowId(null);
+      setCurrentWorkflowName("");
+      setCurrentWorkflowDescription("");
+      setCurrentWorkflowVisibility("private");
+      setIsWorkflowOwner(true);
+      setNodes([]);
+      setEdges([]);
+      setSelectedNode(null);
+      setWorkflowNotFound(false);
+    }
+    return (): void => {
+      setCurrentWorkflowId(null);
+      setCurrentWorkflowName("");
+      setCurrentWorkflowDescription("");
+      setCurrentWorkflowVisibility("private");
+      setIsWorkflowOwner(true);
+      setNodes([]);
+      setEdges([]);
+      setSelectedNode(null);
+      setWorkflowNotFound(false);
+    };
+  }, [
+    workflowId,
+    setCurrentWorkflowId,
+    setCurrentWorkflowName,
+    setCurrentWorkflowDescription,
+    setCurrentWorkflowVisibility,
+    setIsWorkflowOwner,
+    setNodes,
+    setEdges,
+    setSelectedNode,
+    setWorkflowNotFound,
+  ]);
 
   useEffect(() => {
     const loadWorkflowData = async () => {


### PR DESCRIPTION
## Summary

Closes [KEEP-542](https://linear.app/keeperhubapp/issue/KEEP-542/hub-workflow-preview-mode-persists-after-navigation-no-way-to-exit).

After previewing a workflow in the Community Hub and navigating to one of your own workflows, the editor stayed stuck on the "Use template" CTA and the full editor toolbar disappeared. Clicking "Use template" then duplicated the originally previewed hub workflow instead of the workflow the user was on.

## Root cause

`currentWorkflowIdAtom`, `isWorkflowOwnerAtom`, and `currentWorkflowVisibilityAtom` are global Jotai singletons. The persistent `WorkflowToolbar` mounted in `components/layout-content.tsx` reads them on every page. A hub preview sets `isOwner=false` / `visibility=public` / `currentWorkflowId=hubId`, and those values leaked into the next workflow page until `loadExistingWorkflow` resolved. `handleUseTemplate` in `components/workflow/workflow-toolbar.tsx` then duplicated the stale `currentWorkflowId`, matching the reported repro exactly.

## Fix

Added a `useLayoutEffect` in `WorkflowEditor` that resets the workflow identity and content atoms (`id`, `name`, `description`, `visibility`, `isOwner`, `nodes`, `edges`, `selectedNode`, `notFound`) when `workflowId` changes and on unmount. Runs synchronously before paint so the toolbar never observes stale preview state between mount and the first API resolution. The existing `loadExistingWorkflow` then populates the atoms with the new workflow's data.