### PR TITLE
fix(workflows): KEEP-323 rehydrate Stop button state on page refresh

### DIFF
--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
 import {
+  currentExecutionIdAtom,
   currentWorkflowDescriptionAtom,
   currentWorkflowIdAtom,
   currentWorkflowInputSchemaAtom,
@@ -45,6 +46,7 @@ import {
   edgesAtom,
   hasSidebarBeenShownAtom,
   hasUnsavedChangesAtom,
+  isExecutingAtom,
   isGeneratingAtom,
   isPanelAnimatingAtom,
   isSavingAtom,
@@ -147,7 +149,11 @@ const WorkflowEditor = ({ workflowId }: WorkflowEditorProps) => {
   );
   const [edges] = useAtom(edgesAtom);
   const [currentWorkflowId] = useAtom(currentWorkflowIdAtom);
-  const [selectedExecutionId] = useAtom(selectedExecutionIdAtom);
+  const [selectedExecutionId, setSelectedExecutionId] = useAtom(
+    selectedExecutionIdAtom
+  );
+  const [isExecuting, setIsExecuting] = useAtom(isExecutingAtom);
+  const setCurrentExecutionId = useSetAtom(currentExecutionIdAtom);
   const setNodes = useSetAtom(nodesAtom);
   const setEdges = useSetAtom(edgesAtom);
   const setCurrentWorkflowId = useSetAtom(currentWorkflowIdAtom);
@@ -597,6 +603,97 @@ const WorkflowEditor = ({ workflowId }: WorkflowEditorProps) => {
     nodes.length,
     generateWorkflowFromAI,
     loadExistingWorkflow,
+  ]);
+
+  // KEEP-323: Rehydrate the Run/Stop button when the page loads while an
+  // execution is still in-flight. The toolbar's polling lives in component
+  // memory, so a refresh mid-run leaves isExecutingAtom at its default
+  // false and the button reverts to "Run". Here we detect a running
+  // execution server-side, restore the atoms, and poll until it ends so
+  // the button transitions back to "Run" automatically.
+  const rehydratedWorkflowIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!currentWorkflowId) {
+      return;
+    }
+    if (isExecuting) {
+      return;
+    }
+    if (rehydratedWorkflowIdRef.current === currentWorkflowId) {
+      return;
+    }
+
+    let cancelled = false;
+    let intervalId: NodeJS.Timeout | null = null;
+
+    const isInFlightStatus = (status: string): boolean =>
+      status === "running" || status === "pending";
+
+    const pollResumedExecution = (executionId: string): void => {
+      const poll = async (): Promise<void> => {
+        try {
+          const statusData = await api.workflow.getExecutionStatus(executionId);
+          if (isInFlightStatus(statusData.status)) {
+            return;
+          }
+          if (intervalId) {
+            clearInterval(intervalId);
+            intervalId = null;
+          }
+          if (executionPollingIntervalRef.current === intervalId) {
+            executionPollingIntervalRef.current = null;
+          }
+          setIsExecuting(false);
+          setCurrentExecutionId(null);
+        } catch (error) {
+          console.error("Failed to poll resumed execution:", error);
+        }
+      };
+
+      poll();
+      intervalId = setInterval(poll, 500);
+      executionPollingIntervalRef.current = intervalId;
+    };
+
+    const rehydrate = async (): Promise<void> => {
+      try {
+        const executions = await api.workflow.getExecutions(currentWorkflowId);
+        if (cancelled) {
+          return;
+        }
+        rehydratedWorkflowIdRef.current = currentWorkflowId;
+        const inFlight = executions.find((execution) =>
+          isInFlightStatus(execution.status)
+        );
+        if (!inFlight) {
+          return;
+        }
+        setCurrentExecutionId(inFlight.id);
+        setIsExecuting(true);
+        setSelectedExecutionId(inFlight.id);
+        pollResumedExecution(inFlight.id);
+      } catch (error) {
+        console.error("Failed to rehydrate execution state:", error);
+      }
+    };
+
+    rehydrate();
+
+    return (): void => {
+      cancelled = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      if (executionPollingIntervalRef.current === intervalId) {
+        executionPollingIntervalRef.current = null;
+      }
+    };
+  }, [
+    currentWorkflowId,
+    isExecuting,
+    setIsExecuting,
+    setCurrentExecutionId,
+    setSelectedExecutionId,
   ]);
 
   // Auto-fix invalid/missing integrations on workflow load or when integrations change


### PR DESCRIPTION
## Summary
- Fixes [KEEP-323](https://linear.app/keeperhubapp/issue/KEEP-323/stop-button-changes-to-run-after-page-refresh): the Run/Stop button reverted to Run after a page refresh while an execution was still running.
- Root cause: the toolbar's status polling lives in a component-level `useRef`, so a refresh wipes it out and `isExecutingAtom` falls back to its default `false`. The fix hydrates from the server.

## Change
- After the workflow loads (and only if no fresh in-memory run is already underway), `app/workflows/[workflowId]/page.tsx` queries `api.workflow.getExecutions`, looks for an execution with status `running` or `pending`, and restores `isExecutingAtom`, `currentExecutionIdAtom`, and `selectedExecutionIdAtom`.
- The same effect starts a 500ms `getExecutionStatus` poll for that execution and clears both atoms once it reaches a terminal status, so the Stop button automatically flips back to Run when the execution completes.
- A per-workflow `rehydratedWorkflowIdRef` guard prevents the detection from looping on re-renders, and the effect is gated on `isExecuting === false` so it never clobbers a fresh run started via the toolbar.