### PR TITLE
fix: KEEP-445 raise keeperhub-common memory request and limit

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -125,10 +125,13 @@ serviceMonitors:
 
 resources:
   limits:
-    memory: 3Gi
+    # Must exceed NODE_OPTIONS --max-old-space-size by ~1 GiB to leave headroom
+    # for off-heap RSS (Buffers, source maps, native addons, worker threads).
+    # Setting these equal causes the kernel OOM-killer to fire before V8 GCs.
+    memory: 4Gi
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 2Gi
 
 env:
   <<: *shared_env

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -125,10 +125,14 @@ serviceMonitors:
 
 resources:
   limits:
-    memory: 2Gi
+    # Must exceed NODE_OPTIONS --max-old-space-size by ~1 GiB to leave headroom
+    # for off-heap RSS (Buffers, source maps, native addons, worker threads).
+    # Setting these equal causes the kernel OOM-killer to fire before V8 GCs.
+    # Kept in lockstep with prod so staging is predictive of prod memory behaviour.
+    memory: 4Gi
   requests:
     cpu: 1m
-    memory: 256Mi
+    memory: 2Gi
 
 env:
   <<: *shared_env
@@ -146,7 +150,7 @@ env:
     value: "5000"
   NODE_OPTIONS:
     type: kv
-    value: "--enable-source-maps --trace-warnings --trace-uncaught --trace-exit"
+    value: "--enable-source-maps --max-old-space-size=3072 --trace-warnings --trace-uncaught --trace-exit"
   NODE_ENV:
     type: kv
     value: "development"


### PR DESCRIPTION
## Summary

Prod `keeperhub-common` pods are being evicted (`Reason: Evicted`) by kubelet under node memory pressure because actual working set (~2.3 GiB) is ~4.6x the `requests.memory` of 512Mi. The pod is the obvious eviction target whenever a node tightens up.

This PR raises `requests.memory` (the load-bearing fix) and `limits.memory` (secondary protection for the cgroup-OOM mode the original ticket called out), and brings staging into the same memory shape so it is predictive of prod for memory changes going forward.

## Changes

prod (`deploy/keeperhub/prod/values.yaml`):
- `resources.requests.memory`: `512Mi` -> `2Gi`
- `resources.limits.memory`: `3Gi` -> `4Gi`
- `--max-old-space-size=3072` unchanged

staging (`deploy/keeperhub/staging/values.yaml`):
- `resources.requests.memory`: `256Mi` -> `2Gi`
- `resources.limits.memory`: `2Gi` -> `4Gi`
- `NODE_OPTIONS`: append `--max-old-space-size=3072` (was absent; V8 was using its cgroup-aware default)

Comment block on the `resources.limits` field in both files documents the heap-vs-cgroup-limit invariant to deter future regressions.

## Failure mode vs original RCA

The ticket title focused on cgroup OOMKill from `--max-old-space-size` equaling `limits.memory`. Direct evidence on a recent ReplicaSet shows the active prod failure is kubelet eviction, not kernel cgroup OOM (same exit code 137 but different killer, different fix lever). Both modes share this fix shape; the `requests.memory` bump is the actual lever, the `limits.memory` raise covers the cgroup-OOM class as a secondary defence.

## Test plan

- [ ] PR-title check passes
- [ ] Staging deploy renders chart and pods schedule (note: `requests.memory: 2Gi` x `replicaCount: 2` = 4 GiB reserved on staging cluster - confirm node capacity)
- [ ] Staging soak: no `Evicted` or `OOMKilled` events on `keeperhub-common` over 24h
- [ ] Prod rollout outside business hours; watch `container_memory_working_set_bytes` and the Grafana High Memory Usage alert for 24h
- [ ] Prod soak: no `Evicted` or `OOMKilled` events on `keeperhub-common` over 7 days (per ticket acceptance criteria, broadened to include `Evicted`)
- [ ] `container_memory_working_set_bytes` p95 sits below 4 GiB limit