### PR TITLE
feat: KEEP-546 add submitSignedTransactionWithFailover helper

### DIFF
--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -17,7 +17,11 @@ export type RpcErrorType =
   | "connection"
   | "rpc_error";
 
-export type RpcOperationType = "read" | "write" | "preflight";
+export type RpcOperationType =
+  | "read"
+  | "write"
+  | "preflight"
+  | "write-broadcast";
 
 export type RpcMetricsCollector = {
   recordPrimaryAttempt(chainName: string, operation?: RpcOperationType): void;

--- a/lib/web3/submit-signed.ts
+++ b/lib/web3/submit-signed.ts
@@ -1,0 +1,28 @@
+import type { ethers } from "ethers";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+
+/**
+ * Sign once, broadcast with RPC failover.
+ *
+ * Wrapping `signer.sendTransaction` in failover is unsafe because ethers
+ * re-populates and re-signs on each call, producing a different signed tx
+ * (different gas, possibly stale nonce). Splitting populate -> sign -> broadcast
+ * keeps the signed bytes fixed across retries; the tx hash is determined by
+ * the signature so broadcasting the same hex to multiple endpoints is
+ * idempotent.
+ *
+ * The returned response is pinned to whichever provider succeeded; `tx.wait()`
+ * polls on that provider. Wait-side failover is a separate concern.
+ */
+export async function submitSignedTransactionWithFailover(
+  signer: ethers.Signer,
+  txRequest: ethers.TransactionRequest,
+  rpcManager: RpcProviderManager
+): Promise<ethers.TransactionResponse> {
+  const populated = await signer.populateTransaction(txRequest);
+  const signedHex = await signer.signTransaction(populated);
+  return await rpcManager.executeWithFailover(
+    (provider) => provider.broadcastTransaction(signedHex),
+    "write-broadcast"
+  );
+}

--- a/lib/web3/submit-signed.ts
+++ b/lib/web3/submit-signed.ts
@@ -1,28 +1,157 @@
-import type { ethers } from "ethers";
+import "server-only";
+import { ethers, isError } from "ethers";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 
+export type BroadcastResult = {
+  hash: string;
+  response: ethers.TransactionResponse;
+  /**
+   * Populated only when on-chain reconciliation found the tx already mined
+   * before/during our broadcast attempt. Callers may skip `response.wait()`.
+   */
+  preExistingReceipt?: ethers.TransactionReceipt;
+};
+
 /**
- * Sign once, broadcast with RPC failover.
+ * Thrown when broadcast failed AND on-chain reconciliation found no trace of
+ * the signed transaction. The nonce slot was consumed by a different tx;
+ * callers should treat the nonce as lost and resync from chain state.
+ */
+export class NonceConflictError extends Error {
+  override readonly name = "NonceConflictError" as const;
+  readonly expectedHash: string;
+  readonly nonce: number | null;
+  override readonly cause: unknown;
+
+  constructor(expectedHash: string, nonce: number | null, cause: unknown) {
+    super(
+      `Broadcast for ${expectedHash} (nonce ${nonce ?? "unknown"}) failed; ` +
+        "nonce slot was consumed by a different transaction."
+    );
+    this.expectedHash = expectedHash;
+    this.nonce = nonce;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Sign once, broadcast with RPC failover, reconcile on error.
  *
  * Wrapping `signer.sendTransaction` in failover is unsafe because ethers
- * re-populates and re-signs on each call, producing a different signed tx
- * (different gas, possibly stale nonce). Splitting populate -> sign -> broadcast
- * keeps the signed bytes fixed across retries; the tx hash is determined by
- * the signature so broadcasting the same hex to multiple endpoints is
- * idempotent.
+ * re-populates and re-signs on each retry, producing different signed bytes
+ * (different gas, possibly stale nonce). This helper signs once so the tx
+ * hash is fixed before any retry.
  *
- * The returned response is pinned to whichever provider succeeded; `tx.wait()`
- * polls on that provider. Wait-side failover is a separate concern.
+ * On broadcast error, "already known" / "nonce too low" / "replacement
+ * underpriced" cannot be distinguished by message alone: each can mean
+ * either "our tx already landed somewhere" or "a competing tx took our
+ * nonce." We disambiguate by on-chain lookup:
+ *   1. getTransactionReceipt(expectedHash) -> if found, tx mined; success.
+ *   2. getTransaction(expectedHash)        -> if found, in mempool; success.
+ *   3. Neither found AND error looks like nonce conflict -> NonceConflictError.
+ *   4. Neither found AND other error      -> re-throw original.
+ *
+ * Caller invariants:
+ * - txRequest must be fully populated (nonce, chainId, gas, fees). The helper
+ *   does not failover during populateTransaction.
+ * - `response.wait()` polls on the provider that successfully broadcast;
+ *   wait-side failover is a separate concern.
  */
 export async function submitSignedTransactionWithFailover(
   signer: ethers.Signer,
   txRequest: ethers.TransactionRequest,
   rpcManager: RpcProviderManager
-): Promise<ethers.TransactionResponse> {
+): Promise<BroadcastResult> {
   const populated = await signer.populateTransaction(txRequest);
   const signedHex = await signer.signTransaction(populated);
-  return await rpcManager.executeWithFailover(
-    (provider) => provider.broadcastTransaction(signedHex),
-    "write-broadcast"
+  const expectedHash = computeTxHash(signedHex);
+
+  try {
+    const response = await rpcManager.executeWithFailover(
+      (provider) => provider.broadcastTransaction(signedHex),
+      "write-broadcast"
+    );
+    return { hash: response.hash, response };
+  } catch (err) {
+    return await reconcile(rpcManager, expectedHash, populated.nonce, err);
+  }
+}
+
+function computeTxHash(signedHex: string): string {
+  const tx = ethers.Transaction.from(signedHex);
+  if (!tx.hash) {
+    throw new Error("Failed to derive transaction hash from signed bytes");
+  }
+  return tx.hash;
+}
+
+async function reconcile(
+  rpcManager: RpcProviderManager,
+  expectedHash: string,
+  nonce: number | null | undefined,
+  originalError: unknown
+): Promise<BroadcastResult> {
+  const receipt = await rpcManager.executeWithFailover(
+    (provider) => provider.getTransactionReceipt(expectedHash),
+    "read"
   );
+  const pending = await rpcManager.executeWithFailover(
+    (provider) => provider.getTransaction(expectedHash),
+    "read"
+  );
+
+  if (receipt && pending) {
+    return {
+      hash: expectedHash,
+      response: pending,
+      preExistingReceipt: receipt,
+    };
+  }
+  if (pending) {
+    return { hash: expectedHash, response: pending };
+  }
+  if (isNonceConflictError(originalError)) {
+    throw new NonceConflictError(
+      expectedHash,
+      typeof nonce === "number" ? nonce : null,
+      originalError
+    );
+  }
+  throw originalError;
+}
+
+/**
+ * ethers v6 translates two of the three relevant node error patterns into
+ * typed error codes (provider-jsonrpc.ts :: getRpcError):
+ *   - "nonce too low" / "transaction nonce is too low" -> NONCE_EXPIRED
+ *   - "replacement transaction underpriced"            -> REPLACEMENT_UNDERPRICED
+ *
+ * It does NOT translate geth's `ErrAlreadyKnown` ("already known" / "known
+ * transaction") - that arrives as SERVER_ERROR with the raw message. Until
+ * ethers covers it, we match on the message for that case only.
+ */
+const ALREADY_KNOWN_PATTERNS: readonly string[] = [
+  "already known",
+  "known transaction",
+];
+
+export function isNonceConflictError(err: unknown): boolean {
+  if (isError(err, "NONCE_EXPIRED")) {
+    return true;
+  }
+  if (isError(err, "REPLACEMENT_UNDERPRICED")) {
+    return true;
+  }
+  const msg = errorMessage(err).toLowerCase();
+  return ALREADY_KNOWN_PATTERNS.some((pattern) => msg.includes(pattern));
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  return String(err);
 }

--- a/tests/unit/submit-signed.test.ts
+++ b/tests/unit/submit-signed.test.ts
@@ -1,25 +1,62 @@
-import type { ethers } from "ethers";
-import { describe, expect, it, vi } from "vitest";
+import { ethers, makeError } from "ethers";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
 import type { RpcOperationType, RpcProviderManager } from "@/lib/rpc/providers";
-import { submitSignedTransactionWithFailover } from "@/lib/web3/submit-signed";
+import {
+  isNonceConflictError,
+  NonceConflictError,
+  submitSignedTransactionWithFailover,
+} from "@/lib/web3/submit-signed";
 
-type BroadcastOp = (
-  provider: ethers.JsonRpcProvider
-) => Promise<ethers.TransactionResponse>;
+// ---------------------------------------------------------------------------
+// Real signed-tx fixture, so expectedHash is derived the same way the helper
+// derives it under test.
+// ---------------------------------------------------------------------------
 
-function makeMockTxResponse(hash: string): ethers.TransactionResponse {
-  return { hash } as unknown as ethers.TransactionResponse;
-}
+const TEST_PRIV_KEY = `0x${"1".repeat(64)}`;
+const TEST_TX_REQUEST: ethers.TransactionRequest = {
+  to: "0x000000000000000000000000000000000000dEaD",
+  nonce: 42,
+  value: BigInt(0),
+  gasLimit: BigInt(21_000),
+  maxFeePerGas: BigInt(10_000_000_000),
+  maxPriorityFeePerGas: BigInt(1_000_000_000),
+  chainId: 1,
+  type: 2,
+};
 
-function makeMockSigner(populatedNonce: number, signedHex: string) {
-  const populate = vi.fn().mockImplementation(
-    async (tx: ethers.TransactionRequest) =>
-      ({
-        ...tx,
-        nonce: tx.nonce ?? populatedNonce,
-      }) as ethers.TransactionLike<string>
-  );
-  const sign = vi.fn().mockResolvedValue(signedHex);
+let SIGNED_HEX: string;
+let EXPECTED_HASH: string;
+
+beforeAll(async () => {
+  const wallet = new ethers.Wallet(TEST_PRIV_KEY);
+  SIGNED_HEX = await wallet.signTransaction(TEST_TX_REQUEST);
+  const parsed = ethers.Transaction.from(SIGNED_HEX);
+  if (!parsed.hash) {
+    throw new Error("test fixture: failed to derive hash");
+  }
+  EXPECTED_HASH = parsed.hash;
+});
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+type ScenarioProvider = {
+  broadcastTransaction?: ReturnType<typeof vi.fn>;
+  getTransactionReceipt?: ReturnType<typeof vi.fn>;
+  getTransaction?: ReturnType<typeof vi.fn>;
+};
+
+function makeMockSigner(populated?: ethers.TransactionLike<string>) {
+  const populate = vi
+    .fn()
+    .mockResolvedValue(
+      (populated ?? TEST_TX_REQUEST) as ethers.TransactionLike<string>
+    );
+  const sign = vi.fn().mockResolvedValue(SIGNED_HEX);
   return {
     signer: {
       populateTransaction: populate,
@@ -30,16 +67,14 @@ function makeMockSigner(populatedNonce: number, signedHex: string) {
   };
 }
 
-function makeMockRpcManager(
-  invoke: (op: BroadcastOp) => Promise<ethers.TransactionResponse>
-): {
-  rpcManager: RpcProviderManager;
-  executeWithFailover: ReturnType<typeof vi.fn>;
-} {
+function makeMockRpcManager(provider: ScenarioProvider) {
   const executeWithFailover = vi
     .fn()
     .mockImplementation(
-      async (op: BroadcastOp, _operationType: RpcOperationType) => invoke(op)
+      async (
+        op: (p: ethers.JsonRpcProvider) => Promise<unknown>,
+        _opType: RpcOperationType
+      ) => await op(provider as unknown as ethers.JsonRpcProvider)
     );
   return {
     rpcManager: { executeWithFailover } as unknown as RpcProviderManager,
@@ -47,42 +82,45 @@ function makeMockRpcManager(
   };
 }
 
-describe("submitSignedTransactionWithFailover", () => {
-  const txRequest: ethers.TransactionRequest = {
-    to: "0x000000000000000000000000000000000000dEaD",
-    data: "0xdeadbeef",
-    value: BigInt(0),
-    nonce: 42,
-    gasLimit: BigInt(21_000),
-    maxFeePerGas: BigInt(10_000_000_000),
-    maxPriorityFeePerGas: BigInt(1_000_000_000),
-    chainId: 1,
-  };
-  const signedHex = "0xf86c0a8502540be40082520894aabb...";
+function makeMockTxResponse(hash: string): ethers.TransactionResponse {
+  return { hash } as unknown as ethers.TransactionResponse;
+}
 
+function makeMockReceipt(hash: string): ethers.TransactionReceipt {
+  return {
+    hash,
+    blockNumber: 1_000_000,
+    status: 1,
+  } as unknown as ethers.TransactionReceipt;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("submitSignedTransactionWithFailover", () => {
   it("returns the response from the broadcasting provider on first-try success", async () => {
-    const { signer, sign, populate } = makeMockSigner(42, signedHex);
+    const { signer, sign, populate } = makeMockSigner();
     const broadcastTransaction = vi
       .fn()
-      .mockResolvedValue(makeMockTxResponse("0xhash"));
-    const provider = {
+      .mockResolvedValue(makeMockTxResponse(EXPECTED_HASH));
+    const { rpcManager, executeWithFailover } = makeMockRpcManager({
       broadcastTransaction,
-    } as unknown as ethers.JsonRpcProvider;
-    const { rpcManager, executeWithFailover } = makeMockRpcManager((op) =>
-      op(provider)
-    );
+    });
 
-    const tx = await submitSignedTransactionWithFailover(
+    const result = await submitSignedTransactionWithFailover(
       signer,
-      txRequest,
+      TEST_TX_REQUEST,
       rpcManager
     );
 
-    expect(tx.hash).toBe("0xhash");
+    expect(result.hash).toBe(EXPECTED_HASH);
+    expect(result.response.hash).toBe(EXPECTED_HASH);
+    expect(result.preExistingReceipt).toBeUndefined();
     expect(populate).toHaveBeenCalledTimes(1);
     expect(sign).toHaveBeenCalledTimes(1);
     expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-    expect(broadcastTransaction).toHaveBeenCalledWith(signedHex);
+    expect(broadcastTransaction).toHaveBeenCalledWith(SIGNED_HEX);
     expect(executeWithFailover).toHaveBeenCalledWith(
       expect.any(Function),
       "write-broadcast"
@@ -90,67 +128,267 @@ describe("submitSignedTransactionWithFailover", () => {
   });
 
   it("signs exactly once even when failover invokes the closure twice", async () => {
-    const { signer, sign } = makeMockSigner(42, signedHex);
-    const primary = {
-      broadcastTransaction: vi
-        .fn()
-        .mockRejectedValue(new Error("primary down")),
-    } as unknown as ethers.JsonRpcProvider;
-    const fallback = {
-      broadcastTransaction: vi
-        .fn()
-        .mockResolvedValue(makeMockTxResponse("0xhash")),
-    } as unknown as ethers.JsonRpcProvider;
-    const { rpcManager } = makeMockRpcManager(async (op) => {
-      try {
-        return await op(primary);
-      } catch {
-        return await op(fallback);
-      }
-    });
+    const { signer, sign } = makeMockSigner();
+    const broadcastTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("primary down"))
+      .mockResolvedValueOnce(makeMockTxResponse(EXPECTED_HASH));
+    const executeWithFailover = vi
+      .fn()
+      .mockImplementation(
+        async (op: (p: ethers.JsonRpcProvider) => Promise<unknown>) => {
+          const provider = {
+            broadcastTransaction,
+          } as unknown as ethers.JsonRpcProvider;
+          try {
+            return await op(provider);
+          } catch {
+            return await op(provider);
+          }
+        }
+      );
+    const rpcManager = {
+      executeWithFailover,
+    } as unknown as RpcProviderManager;
 
-    const tx = await submitSignedTransactionWithFailover(
+    const result = await submitSignedTransactionWithFailover(
       signer,
-      txRequest,
+      TEST_TX_REQUEST,
       rpcManager
     );
 
-    expect(tx.hash).toBe("0xhash");
+    expect(result.hash).toBe(EXPECTED_HASH);
     expect(sign).toHaveBeenCalledTimes(1);
-    expect(primary.broadcastTransaction).toHaveBeenCalledWith(signedHex);
-    expect(fallback.broadcastTransaction).toHaveBeenCalledWith(signedHex);
+    expect(broadcastTransaction).toHaveBeenCalledTimes(2);
+    expect(broadcastTransaction).toHaveBeenNthCalledWith(1, SIGNED_HEX);
+    expect(broadcastTransaction).toHaveBeenNthCalledWith(2, SIGNED_HEX);
   });
 
-  it("uses the populated tx for signing (nonce/gas pinned before broadcast)", async () => {
-    const { signer, sign, populate } = makeMockSigner(42, signedHex);
-    const broadcastTransaction = vi
-      .fn()
-      .mockResolvedValue(makeMockTxResponse("0xhash"));
-    const provider = {
-      broadcastTransaction,
-    } as unknown as ethers.JsonRpcProvider;
-    const { rpcManager } = makeMockRpcManager((op) => op(provider));
+  it("returns preExistingReceipt when broadcast fails but tx already mined", async () => {
+    const { signer } = makeMockSigner();
+    const receipt = makeMockReceipt(EXPECTED_HASH);
+    const minedResponse = makeMockTxResponse(EXPECTED_HASH);
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi.fn().mockRejectedValue(
+        makeError("nonce has already been used", "NONCE_EXPIRED", {
+          transaction: { from: "0x", to: "0x" },
+        })
+      ),
+      getTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+      getTransaction: vi.fn().mockResolvedValue(minedResponse),
+    });
 
-    await submitSignedTransactionWithFailover(signer, txRequest, rpcManager);
+    const result = await submitSignedTransactionWithFailover(
+      signer,
+      TEST_TX_REQUEST,
+      rpcManager
+    );
 
-    expect(populate).toHaveBeenCalledWith(txRequest);
-    const populatedArg = (
-      sign.mock.calls[0] as [ethers.TransactionLike<string>]
-    )[0];
-    expect(populatedArg.nonce).toBe(42);
-    expect(populatedArg.maxFeePerGas).toBe(BigInt(10_000_000_000));
+    expect(result.hash).toBe(EXPECTED_HASH);
+    expect(result.response).toBe(minedResponse);
+    expect(result.preExistingReceipt).toBe(receipt);
   });
 
-  it("propagates terminal failure from executeWithFailover after sign", async () => {
-    const { signer, sign } = makeMockSigner(42, signedHex);
-    const terminal = new Error("both endpoints failed");
-    const { rpcManager } = makeMockRpcManager(() => {
-      throw terminal;
+  it("returns success when broadcast fails but tx is in mempool", async () => {
+    const { signer } = makeMockSigner();
+    const pendingResponse = makeMockTxResponse(EXPECTED_HASH);
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi
+        .fn()
+        .mockRejectedValue(new Error("already known")),
+      getTransactionReceipt: vi.fn().mockResolvedValue(null),
+      getTransaction: vi.fn().mockResolvedValue(pendingResponse),
+    });
+
+    const result = await submitSignedTransactionWithFailover(
+      signer,
+      TEST_TX_REQUEST,
+      rpcManager
+    );
+
+    expect(result.hash).toBe(EXPECTED_HASH);
+    expect(result.response).toBe(pendingResponse);
+    expect(result.preExistingReceipt).toBeUndefined();
+  });
+
+  it("throws NonceConflictError when broadcast fails with REPLACEMENT_UNDERPRICED and no on-chain trace", async () => {
+    const { signer } = makeMockSigner();
+    const originalError = makeError(
+      "replacement fee too low",
+      "REPLACEMENT_UNDERPRICED",
+      { transaction: { from: "0x", to: "0x" } }
+    );
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi.fn().mockRejectedValue(originalError),
+      getTransactionReceipt: vi.fn().mockResolvedValue(null),
+      getTransaction: vi.fn().mockResolvedValue(null),
     });
 
     await expect(
-      submitSignedTransactionWithFailover(signer, txRequest, rpcManager)
-    ).rejects.toBe(terminal);
-    expect(sign).toHaveBeenCalledTimes(1);
+      submitSignedTransactionWithFailover(signer, TEST_TX_REQUEST, rpcManager)
+    ).rejects.toMatchObject({
+      name: "NonceConflictError",
+      expectedHash: EXPECTED_HASH,
+      nonce: 42,
+      cause: originalError,
+    });
+  });
+
+  it("throws NonceConflictError on geth 'already known' (ethers leaves this as SERVER_ERROR)", async () => {
+    const { signer } = makeMockSigner();
+    const originalError = new Error("already known");
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi.fn().mockRejectedValue(originalError),
+      getTransactionReceipt: vi.fn().mockResolvedValue(null),
+      getTransaction: vi.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      submitSignedTransactionWithFailover(signer, TEST_TX_REQUEST, rpcManager)
+    ).rejects.toBeInstanceOf(NonceConflictError);
+  });
+
+  it("re-throws original error when broadcast fails with non-conflict error and no on-chain trace", async () => {
+    const { signer } = makeMockSigner();
+    const originalError = new Error("ECONNREFUSED");
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi.fn().mockRejectedValue(originalError),
+      getTransactionReceipt: vi.fn().mockResolvedValue(null),
+      getTransaction: vi.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      submitSignedTransactionWithFailover(signer, TEST_TX_REQUEST, rpcManager)
+    ).rejects.toBe(originalError);
+  });
+
+  it("does not invoke sign or any rpc call when populateTransaction throws", async () => {
+    const populateError = new Error("populate boom");
+    const populate = vi.fn().mockRejectedValue(populateError);
+    const sign = vi.fn();
+    const signer = {
+      populateTransaction: populate,
+      signTransaction: sign,
+    } as unknown as ethers.Signer;
+    const { rpcManager, executeWithFailover } = makeMockRpcManager({});
+
+    await expect(
+      submitSignedTransactionWithFailover(signer, TEST_TX_REQUEST, rpcManager)
+    ).rejects.toBe(populateError);
+    expect(sign).not.toHaveBeenCalled();
+    expect(executeWithFailover).not.toHaveBeenCalled();
+  });
+
+  it("derives expectedHash deterministically from the signed bytes", async () => {
+    const { signer } = makeMockSigner();
+    const originalError = makeError(
+      "nonce has already been used",
+      "NONCE_EXPIRED",
+      { transaction: { from: "0x", to: "0x" } }
+    );
+    let observedHash: string | undefined;
+    const getTransactionReceipt = vi.fn().mockImplementation((hash: string) => {
+      observedHash = hash;
+      return Promise.resolve(null);
+    });
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi.fn().mockRejectedValue(originalError),
+      getTransactionReceipt,
+      getTransaction: vi.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      submitSignedTransactionWithFailover(signer, TEST_TX_REQUEST, rpcManager)
+    ).rejects.toBeInstanceOf(NonceConflictError);
+    expect(observedHash).toBe(EXPECTED_HASH);
+  });
+
+  it("nonce-conflict path probes on-chain even when error message is non-conflict-y", async () => {
+    const { signer } = makeMockSigner();
+    const receipt = makeMockReceipt(EXPECTED_HASH);
+    const minedResponse = makeMockTxResponse(EXPECTED_HASH);
+    const { rpcManager } = makeMockRpcManager({
+      broadcastTransaction: vi.fn().mockRejectedValue(new Error("timeout")),
+      getTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+      getTransaction: vi.fn().mockResolvedValue(minedResponse),
+    });
+
+    const result = await submitSignedTransactionWithFailover(
+      signer,
+      TEST_TX_REQUEST,
+      rpcManager
+    );
+
+    expect(result.preExistingReceipt).toBe(receipt);
+  });
+});
+
+describe("isNonceConflictError", () => {
+  it("matches ethers NONCE_EXPIRED code", () => {
+    const err = makeError("nonce has already been used", "NONCE_EXPIRED", {
+      transaction: { from: "0x", to: "0x" },
+    });
+    expect(isNonceConflictError(err)).toBe(true);
+  });
+
+  it("matches ethers REPLACEMENT_UNDERPRICED code", () => {
+    const err = makeError(
+      "replacement fee too low",
+      "REPLACEMENT_UNDERPRICED",
+      {
+        transaction: { from: "0x", to: "0x" },
+      }
+    );
+    expect(isNonceConflictError(err)).toBe(true);
+  });
+
+  it.each([
+    "already known",
+    "Already known",
+    "RPC error: ALREADY KNOWN",
+    "known transaction",
+  ])("matches geth 'already known' family by message: %s", (msg) => {
+    expect(isNonceConflictError(new Error(msg))).toBe(true);
+  });
+
+  it.each([
+    "nonce too low",
+    "nonce has already been used",
+    "replacement transaction underpriced",
+  ])("does NOT match bare Error with conflict-y message (no ethers code): %s", (msg) => {
+    // These strings come from nodes but ethers translates them to typed codes.
+    // A bare `Error` without a code should not pretend to be a typed ethers
+    // error - this guards against accidentally classifying user-thrown errors.
+    expect(isNonceConflictError(new Error(msg))).toBe(false);
+  });
+
+  it.each([
+    "ECONNREFUSED",
+    "timeout",
+    "internal server error",
+    "invalid signature",
+    "intrinsic gas too low",
+    "execution reverted",
+  ])("does not match unrelated error: %s", (msg) => {
+    expect(isNonceConflictError(new Error(msg))).toBe(false);
+  });
+
+  it("handles non-Error values without throwing", () => {
+    expect(isNonceConflictError("already known")).toBe(true);
+    expect(isNonceConflictError(null)).toBe(false);
+    expect(isNonceConflictError(undefined)).toBe(false);
+    expect(isNonceConflictError({ message: "already known" })).toBe(false);
+  });
+
+  it("matches CALL_EXCEPTION etc. as false (sanity)", () => {
+    const err = makeError("execution reverted", "CALL_EXCEPTION", {
+      action: "estimateGas",
+      data: null,
+      reason: null,
+      transaction: { from: "0x", to: "0x", data: "0x" },
+      invocation: null,
+      revert: null,
+    });
+    expect(isNonceConflictError(err)).toBe(false);
   });
 });

--- a/tests/unit/submit-signed.test.ts
+++ b/tests/unit/submit-signed.test.ts
@@ -1,0 +1,156 @@
+import type { ethers } from "ethers";
+import { describe, expect, it, vi } from "vitest";
+import type { RpcOperationType, RpcProviderManager } from "@/lib/rpc/providers";
+import { submitSignedTransactionWithFailover } from "@/lib/web3/submit-signed";
+
+type BroadcastOp = (
+  provider: ethers.JsonRpcProvider
+) => Promise<ethers.TransactionResponse>;
+
+function makeMockTxResponse(hash: string): ethers.TransactionResponse {
+  return { hash } as unknown as ethers.TransactionResponse;
+}
+
+function makeMockSigner(populatedNonce: number, signedHex: string) {
+  const populate = vi.fn().mockImplementation(
+    async (tx: ethers.TransactionRequest) =>
+      ({
+        ...tx,
+        nonce: tx.nonce ?? populatedNonce,
+      }) as ethers.TransactionLike<string>
+  );
+  const sign = vi.fn().mockResolvedValue(signedHex);
+  return {
+    signer: {
+      populateTransaction: populate,
+      signTransaction: sign,
+    } as unknown as ethers.Signer,
+    populate,
+    sign,
+  };
+}
+
+function makeMockRpcManager(
+  invoke: (op: BroadcastOp) => Promise<ethers.TransactionResponse>
+): {
+  rpcManager: RpcProviderManager;
+  executeWithFailover: ReturnType<typeof vi.fn>;
+} {
+  const executeWithFailover = vi
+    .fn()
+    .mockImplementation(
+      async (op: BroadcastOp, _operationType: RpcOperationType) => invoke(op)
+    );
+  return {
+    rpcManager: { executeWithFailover } as unknown as RpcProviderManager,
+    executeWithFailover,
+  };
+}
+
+describe("submitSignedTransactionWithFailover", () => {
+  const txRequest: ethers.TransactionRequest = {
+    to: "0x000000000000000000000000000000000000dEaD",
+    data: "0xdeadbeef",
+    value: BigInt(0),
+    nonce: 42,
+    gasLimit: BigInt(21_000),
+    maxFeePerGas: BigInt(10_000_000_000),
+    maxPriorityFeePerGas: BigInt(1_000_000_000),
+    chainId: 1,
+  };
+  const signedHex = "0xf86c0a8502540be40082520894aabb...";
+
+  it("returns the response from the broadcasting provider on first-try success", async () => {
+    const { signer, sign, populate } = makeMockSigner(42, signedHex);
+    const broadcastTransaction = vi
+      .fn()
+      .mockResolvedValue(makeMockTxResponse("0xhash"));
+    const provider = {
+      broadcastTransaction,
+    } as unknown as ethers.JsonRpcProvider;
+    const { rpcManager, executeWithFailover } = makeMockRpcManager((op) =>
+      op(provider)
+    );
+
+    const tx = await submitSignedTransactionWithFailover(
+      signer,
+      txRequest,
+      rpcManager
+    );
+
+    expect(tx.hash).toBe("0xhash");
+    expect(populate).toHaveBeenCalledTimes(1);
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(broadcastTransaction).toHaveBeenCalledTimes(1);
+    expect(broadcastTransaction).toHaveBeenCalledWith(signedHex);
+    expect(executeWithFailover).toHaveBeenCalledWith(
+      expect.any(Function),
+      "write-broadcast"
+    );
+  });
+
+  it("signs exactly once even when failover invokes the closure twice", async () => {
+    const { signer, sign } = makeMockSigner(42, signedHex);
+    const primary = {
+      broadcastTransaction: vi
+        .fn()
+        .mockRejectedValue(new Error("primary down")),
+    } as unknown as ethers.JsonRpcProvider;
+    const fallback = {
+      broadcastTransaction: vi
+        .fn()
+        .mockResolvedValue(makeMockTxResponse("0xhash")),
+    } as unknown as ethers.JsonRpcProvider;
+    const { rpcManager } = makeMockRpcManager(async (op) => {
+      try {
+        return await op(primary);
+      } catch {
+        return await op(fallback);
+      }
+    });
+
+    const tx = await submitSignedTransactionWithFailover(
+      signer,
+      txRequest,
+      rpcManager
+    );
+
+    expect(tx.hash).toBe("0xhash");
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(primary.broadcastTransaction).toHaveBeenCalledWith(signedHex);
+    expect(fallback.broadcastTransaction).toHaveBeenCalledWith(signedHex);
+  });
+
+  it("uses the populated tx for signing (nonce/gas pinned before broadcast)", async () => {
+    const { signer, sign, populate } = makeMockSigner(42, signedHex);
+    const broadcastTransaction = vi
+      .fn()
+      .mockResolvedValue(makeMockTxResponse("0xhash"));
+    const provider = {
+      broadcastTransaction,
+    } as unknown as ethers.JsonRpcProvider;
+    const { rpcManager } = makeMockRpcManager((op) => op(provider));
+
+    await submitSignedTransactionWithFailover(signer, txRequest, rpcManager);
+
+    expect(populate).toHaveBeenCalledWith(txRequest);
+    const populatedArg = (
+      sign.mock.calls[0] as [ethers.TransactionLike<string>]
+    )[0];
+    expect(populatedArg.nonce).toBe(42);
+    expect(populatedArg.maxFeePerGas).toBe(BigInt(10_000_000_000));
+  });
+
+  it("propagates terminal failure from executeWithFailover after sign", async () => {
+    const { signer, sign } = makeMockSigner(42, signedHex);
+    const terminal = new Error("both endpoints failed");
+    const { rpcManager } = makeMockRpcManager(() => {
+      throw terminal;
+    });
+
+    await expect(
+      submitSignedTransactionWithFailover(signer, txRequest, rpcManager)
+    ).rejects.toBe(terminal);
+    expect(sign).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

A generic helper that broadcasts a signed transaction with RPC failover **and reconciles broadcast errors against on-chain state**. This is the safe way to combine signed transactions with failover: the tx hash is fixed by the signature, so we can verify post-hoc whether the tx actually landed regardless of what individual RPC endpoints reported.

This PR is helper + tests only. No callers are converted yet. The Safe paths in `lib/safe/execute-as-safe.ts` and the EOA paths in `lib/web3/transaction-manager.ts` will be migrated in a follow-up — the API can be shaped by real callers from there.

## Why a one-line wrap is not enough

`signer.sendTransaction(tx)` populates + signs + broadcasts in one call. Wrapping that in `rpcManager.executeWithFailover` is unsafe because ethers re-populates and re-signs internally on each retry, producing a different signed tx (different gas, possibly stale nonce). That risks dropped txs and stuck nonces.

The naive "sign once, broadcast same hex with failover" version is also not enough:

- Primary may accept the broadcast but its response is slow/lost.
- We fail over to fallback.
- Fallback sees our tx propagating in mempool and returns `"already known"`, or our tx already mined and it returns `"nonce too low"`.
- These look like errors to the failover loop, even though our tx is in-flight or already on-chain.

The error message alone cannot distinguish "our tx already landed" from "a competing tx took our nonce." The signed hex's hash is what disambiguates: if it has a receipt or is in some mempool, we won.

## Algorithm

```ts
populate, sign, expectedHash = ethers.Transaction.from(signedHex).hash
try:
  response = executeWithFailover(broadcast, "write-broadcast")
  return { hash, response }
catch err:
  receipt = executeWithFailover(getTransactionReceipt(expectedHash), "read")
  pending = executeWithFailover(getTransaction(expectedHash),       "read")

  if receipt && pending: return { hash, response: pending, preExistingReceipt: receipt }
  if pending:            return { hash, response: pending }
  if isNonceConflict(err): throw new NonceConflictError(expectedHash, nonce, err)
  throw err  // genuine broadcast failure
```

## Return shape

```ts
type BroadcastResult = {
  hash: string;
  response: ethers.TransactionResponse;
  preExistingReceipt?: ethers.TransactionReceipt;  // present only if already mined
};
```

Caller pattern:

```ts
const result = await submitSignedTransactionWithFailover(signer, tx, rpcManager);
await nonceManager.recordTransaction(session, nonce, result.hash, ...);
const receipt = result.preExistingReceipt ?? (await result.response.wait());
```

## Typed error for genuine nonce loss

```ts
class NonceConflictError extends Error {
  readonly expectedHash: string;
  readonly nonce: number | null;
  override readonly cause: unknown;
}
```

Thrown when broadcast failed AND on-chain has no trace of our hash AND the original error matches the nonce-conflict family. Callers (`nonceManager`) catch this specifically and treat the nonce as lost — resync from chain state rather than retry.

## Nonce-conflict detection — prefer ethers codes, message-match only the gap

ethers v6's `provider-jsonrpc.ts :: getRpcError` translates node responses for `eth_sendRawTransaction`:

| Node message pattern | ethers code |
|---|---|
| `/nonce/i + /too low/i` | `NONCE_EXPIRED` |
| `/replacement transaction/i + /underpriced/i` | `REPLACEMENT_UNDERPRICED` |
| `"already known"` / `"known transaction"` (geth's `ErrAlreadyKnown`) | **not translated** — stays as `SERVER_ERROR` |

The matcher uses `isError(err, "NONCE_EXPIRED")` and `isError(err, "REPLACEMENT_UNDERPRICED")` for the first two. The "already known" gap is the only case still done by message inspection. If the matcher returns a false negative (some weird node wording), the helper degrades gracefully: caller gets the original error instead of a typed `NonceConflictError`, and treats it as a generic broadcast failure. The on-chain receipt check above the matcher is the authoritative source of truth.

## Changes

- `lib/web3/submit-signed.ts` — helper + `BroadcastResult` + `NonceConflictError` + `isNonceConflictError`
- `lib/rpc/providers/index.ts` — extend `RpcOperationType` with `"write-broadcast"`
- `tests/unit/submit-signed.test.ts` — 27 tests

## Tests (27)

- Fresh broadcast success
- Sign-exactly-once across failover retries
- Reconcile finds receipt → `preExistingReceipt` populated
- Reconcile finds mempool entry only → no `preExistingReceipt`
- `NonceConflictError` thrown on ethers `REPLACEMENT_UNDERPRICED` + no on-chain trace
- `NonceConflictError` thrown on geth `"already known"` + no on-chain trace (the SERVER_ERROR gap)
- Original error re-thrown when matcher does not fire AND no on-chain trace
- Populate failure short-circuits (sign / broadcast / reads never called)
- `expectedHash` derived from the real signed bytes (uses `ethers.Wallet.signTransaction` in `beforeAll`)
- Reconcile probes on-chain regardless of error message (so a timeout that actually landed is detected)
- `isNonceConflictError` matcher: hits on `NONCE_EXPIRED` code, `REPLACEMENT_UNDERPRICED` code, `"already known"`/`"known transaction"` messages; misses on bare `Error("nonce too low")` (no code), `CALL_EXCEPTION`, unrelated errors, non-Error inputs

## Verification done

- All 27 unit tests pass.
- `ultracite check` clean on the 2 changed files (excluding pre-existing project-wide noise).
- `pnpm type-check` clean.
- `@turnkey/ethers@1.3.28` exposes `signTransaction(tx)` as a first-class method (single Turnkey round-trip, no internal `sendTransaction` detour). Verified in `node_modules/@turnkey/ethers/dist/index.js`.

## Out of scope (deliberately)

- Call-site conversion in `lib/safe/execute-as-safe.ts` (4 sites) and `lib/web3/transaction-manager.ts` — follow-up.
- `tx.wait()` failover. The returned `response.wait()` polls on the broadcasting provider; if that endpoint dies, wait fails. Folding wait into the helper means owning receipt-polling-with-failover, which is the separate ticket already noted.
- Synthetic `TransactionResponse` for the case where the error was `"already known"` but `getTransaction` returns null. Throw and surface — wait for real callers to tell us if this case happens before engineering around it.
- Retry/backoff on the reconcile reads themselves. One probe each. Caller retries the whole operation if a propagation-race surfaces.

## Ops note: Grafana

The new `operation="write-broadcast"` label flows to Prometheus automatically. Existing Grafana panels will not show this label until someone adds a panel filtering or grouping by it. Worth a heads-up to whoever owns the RPC dashboard so broadcast-retry traffic is not invisible once callers are migrated.

## Related

- KEEP-547 — transaction outbox for broadcast crash recovery (separate ticket; durability under process death, not RPC failover)
- KEEP-549 — `getCurrentNonce` mislabels its RPC operation as `"write"` (low-priority cleanup)

## Test plan

- [ ] CI green
- [ ] Reviewer confirms helper is called nowhere (no behaviour change in this PR)
- [ ] Reviewer agrees `BroadcastResult` shape is what the call-site PR can absorb cleanly
- [ ] Reviewer agrees the "prefer ethers codes, message-match only the gap" approach is the right tradeoff