### PR TITLE
feat: KEEP-551 route Safe + EOA write paths through submitSignedTransactionWithFailover

### DIFF
--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -14,6 +14,7 @@ import {
   getOrganizationWalletAddress,
   initializeWalletSigner,
 } from "@/lib/para/wallet-helpers";
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import {
   executeContractCallAsSafe,
   executeNativeTransferAsSafe,
@@ -241,12 +242,16 @@ export async function POST(request: Request) {
     // Generate a unique execution ID for this API call
     const executionId = `withdraw-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
-    // Build transaction context
+    // Build transaction context. Single-armed RPC manager (no fallback URL)
+    // matches the pattern used in lib/safe/deployment.ts and
+    // lib/safe/roles-orchestrator.ts; broadcast reconcile still works.
+    const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, chainId);
     const txContext: TransactionContext = {
       organizationId,
       executionId,
       chainId,
       rpcUrl,
+      rpcManager,
     };
 
     // Execute transaction with nonce management
@@ -345,7 +350,7 @@ export async function POST(request: Request) {
                     args: [recipientAddr, safeAmountWei],
                   },
                   session,
-                  { chainId }
+                  { chainId, rpcManager }
                 )
               : await executeNativeTransferAsSafe(
                   signer,
@@ -356,7 +361,7 @@ export async function POST(request: Request) {
                     amount: safeAmountWei,
                   },
                   session,
-                  { chainId }
+                  { chainId, rpcManager }
                 );
           } catch (err) {
             recordSafeWithdraw({

--- a/lib/metrics/instrumentation/safe.ts
+++ b/lib/metrics/instrumentation/safe.ts
@@ -39,7 +39,7 @@ function chainLabel(chainId: number): string {
  */
 export function startSafeTxMetrics(
   options: SafeTxOptions
-): (outcome: "success" | "failure") => void {
+): (outcome: "success" | "failure" | "nonce-conflict") => void {
   const metrics = getMetricsCollector();
   const timer = createTimer();
   const baseLabels = {

--- a/lib/safe/execute-as-safe.ts
+++ b/lib/safe/execute-as-safe.ts
@@ -8,6 +8,10 @@ import { buildExecTransactionWithRoleCalldata } from "@/lib/safe/zodiac-roles";
 import type { TransactionReceipt } from "@/lib/web3/chain-adapter/types";
 import { getGasStrategy } from "@/lib/web3/gas-strategy";
 import { getNonceManager, type NonceSession } from "@/lib/web3/nonce-manager";
+import {
+  NonceConflictError,
+  submitSignedTransactionWithFailover,
+} from "@/lib/web3/submit-signed";
 
 /**
  * Execute an arbitrary contract call from a deployed Safe's perspective.
@@ -34,7 +38,7 @@ export type ExecuteAsSafeRequest = {
 export type ExecuteAsSafeOptions = {
   chainId: number;
   workflowId?: string;
-  rpcManager?: RpcProviderManager;
+  rpcManager: RpcProviderManager;
 };
 
 /**
@@ -53,6 +57,16 @@ function classifyInnerKind(
     return "native";
   }
   return "contract";
+}
+
+function finishOnError(
+  finishMetrics: (outcome: "success" | "failure" | "nonce-conflict") => void,
+  err: unknown
+): never {
+  finishMetrics(
+    err instanceof NonceConflictError ? "nonce-conflict" : "failure"
+  );
+  throw err;
 }
 
 export async function executeContractCallAsSafe(
@@ -88,21 +102,15 @@ export async function executeContractCallAsSafe(
     const nonceManager = getNonceManager();
     const gasStrategy = getGasStrategy();
 
-    const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (rpcProvider) =>
-            rpcProvider.estimateGas({
-              to: request.safeAddress,
-              data: outerCalldata,
-              from: request.ownerAddress,
-            }),
-          "preflight"
-        )
-      : await provider.estimateGas({
+    const estimatedGas = await options.rpcManager.executeWithFailover(
+      (rpcProvider) =>
+        rpcProvider.estimateGas({
           to: request.safeAddress,
           data: outerCalldata,
           from: request.ownerAddress,
-        });
+        }),
+      "preflight"
+    );
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider,
@@ -115,36 +123,40 @@ export async function executeContractCallAsSafe(
 
     const nonce = nonceManager.getNextNonce(session);
 
-    const tx = await signer.sendTransaction({
-      to: request.safeAddress,
-      data: outerCalldata,
-      value: BigInt(0),
-      nonce,
-      gasLimit: gasConfig.gasLimit,
-      maxFeePerGas: gasConfig.maxFeePerGas,
-      maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
-      chainId: options.chainId,
-    });
+    const broadcast = await submitSignedTransactionWithFailover(
+      signer,
+      {
+        to: request.safeAddress,
+        data: outerCalldata,
+        value: BigInt(0),
+        nonce,
+        gasLimit: gasConfig.gasLimit,
+        maxFeePerGas: gasConfig.maxFeePerGas,
+        maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+        chainId: options.chainId,
+      },
+      options.rpcManager
+    );
 
     await nonceManager.recordTransaction(
       session,
       nonce,
-      tx.hash,
+      broadcast.hash,
       options.workflowId,
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (p) => p.waitForTransaction(tx.hash),
-          "read"
-        )
-      : await tx.wait();
+    const receipt =
+      broadcast.preExistingReceipt ??
+      (await options.rpcManager.executeWithFailover(
+        (p) => p.waitForTransaction(broadcast.hash),
+        "read"
+      ));
     if (!receipt) {
       throw new Error("Safe-routed transaction sent but receipt unavailable");
     }
 
-    await nonceManager.confirmTransaction(tx.hash);
+    await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
     return {
       hash: receipt.hash,
@@ -153,8 +165,7 @@ export async function executeContractCallAsSafe(
       blockNumber: receipt.blockNumber,
     };
   } catch (err) {
-    finishMetrics("failure");
-    throw err;
+    finishOnError(finishMetrics, err);
   }
 }
 
@@ -219,21 +230,15 @@ export async function executeContractCallAsRole(
     const nonceManager = getNonceManager();
     const gasStrategy = getGasStrategy();
 
-    const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (rpcProvider) =>
-            rpcProvider.estimateGas({
-              to: request.rolesModifierAddress,
-              data: outerCalldata,
-              from: request.delegateAddress,
-            }),
-          "preflight"
-        )
-      : await provider.estimateGas({
+    const estimatedGas = await options.rpcManager.executeWithFailover(
+      (rpcProvider) =>
+        rpcProvider.estimateGas({
           to: request.rolesModifierAddress,
           data: outerCalldata,
           from: request.delegateAddress,
-        });
+        }),
+      "preflight"
+    );
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider,
@@ -246,35 +251,39 @@ export async function executeContractCallAsRole(
 
     const nonce = nonceManager.getNextNonce(session);
 
-    const tx = await signer.sendTransaction({
-      to: request.rolesModifierAddress,
-      data: outerCalldata,
-      value: BigInt(0),
-      nonce,
-      gasLimit: gasConfig.gasLimit,
-      maxFeePerGas: gasConfig.maxFeePerGas,
-      maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
-      chainId: options.chainId,
-    });
+    const broadcast = await submitSignedTransactionWithFailover(
+      signer,
+      {
+        to: request.rolesModifierAddress,
+        data: outerCalldata,
+        value: BigInt(0),
+        nonce,
+        gasLimit: gasConfig.gasLimit,
+        maxFeePerGas: gasConfig.maxFeePerGas,
+        maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+        chainId: options.chainId,
+      },
+      options.rpcManager
+    );
 
     await nonceManager.recordTransaction(
       session,
       nonce,
-      tx.hash,
+      broadcast.hash,
       options.workflowId,
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (p) => p.waitForTransaction(tx.hash),
-          "read"
-        )
-      : await tx.wait();
+    const receipt =
+      broadcast.preExistingReceipt ??
+      (await options.rpcManager.executeWithFailover(
+        (p) => p.waitForTransaction(broadcast.hash),
+        "read"
+      ));
     if (!receipt) {
       throw new Error("Role-routed transaction sent but receipt unavailable");
     }
-    await nonceManager.confirmTransaction(tx.hash);
+    await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
     return {
       hash: receipt.hash,
@@ -283,8 +292,7 @@ export async function executeContractCallAsRole(
       blockNumber: receipt.blockNumber,
     };
   } catch (err) {
-    finishMetrics("failure");
-    throw err;
+    finishOnError(finishMetrics, err);
   }
 }
 
@@ -326,21 +334,15 @@ export async function executeNativeTransferAsRole(
     const nonceManager = getNonceManager();
     const gasStrategy = getGasStrategy();
 
-    const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (rpcProvider) =>
-            rpcProvider.estimateGas({
-              to: request.rolesModifierAddress,
-              data: outerCalldata,
-              from: request.delegateAddress,
-            }),
-          "preflight"
-        )
-      : await provider.estimateGas({
+    const estimatedGas = await options.rpcManager.executeWithFailover(
+      (rpcProvider) =>
+        rpcProvider.estimateGas({
           to: request.rolesModifierAddress,
           data: outerCalldata,
           from: request.delegateAddress,
-        });
+        }),
+      "preflight"
+    );
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider,
@@ -353,37 +355,41 @@ export async function executeNativeTransferAsRole(
 
     const nonce = nonceManager.getNextNonce(session);
 
-    const tx = await signer.sendTransaction({
-      to: request.rolesModifierAddress,
-      data: outerCalldata,
-      value: BigInt(0),
-      nonce,
-      gasLimit: gasConfig.gasLimit,
-      maxFeePerGas: gasConfig.maxFeePerGas,
-      maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
-      chainId: options.chainId,
-    });
+    const broadcast = await submitSignedTransactionWithFailover(
+      signer,
+      {
+        to: request.rolesModifierAddress,
+        data: outerCalldata,
+        value: BigInt(0),
+        nonce,
+        gasLimit: gasConfig.gasLimit,
+        maxFeePerGas: gasConfig.maxFeePerGas,
+        maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+        chainId: options.chainId,
+      },
+      options.rpcManager
+    );
 
     await nonceManager.recordTransaction(
       session,
       nonce,
-      tx.hash,
+      broadcast.hash,
       options.workflowId,
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (p) => p.waitForTransaction(tx.hash),
-          "read"
-        )
-      : await tx.wait();
+    const receipt =
+      broadcast.preExistingReceipt ??
+      (await options.rpcManager.executeWithFailover(
+        (p) => p.waitForTransaction(broadcast.hash),
+        "read"
+      ));
     if (!receipt) {
       throw new Error(
         "Role-routed native transfer sent but receipt unavailable"
       );
     }
-    await nonceManager.confirmTransaction(tx.hash);
+    await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
     return {
       hash: receipt.hash,
@@ -392,8 +398,7 @@ export async function executeNativeTransferAsRole(
       blockNumber: receipt.blockNumber,
     };
   } catch (err) {
-    finishMetrics("failure");
-    throw err;
+    finishOnError(finishMetrics, err);
   }
 }
 
@@ -436,21 +441,15 @@ export async function executeNativeTransferAsSafe(
     const nonceManager = getNonceManager();
     const gasStrategy = getGasStrategy();
 
-    const estimatedGas = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (rpcProvider) =>
-            rpcProvider.estimateGas({
-              to: request.safeAddress,
-              data: outerCalldata,
-              from: request.ownerAddress,
-            }),
-          "preflight"
-        )
-      : await provider.estimateGas({
+    const estimatedGas = await options.rpcManager.executeWithFailover(
+      (rpcProvider) =>
+        rpcProvider.estimateGas({
           to: request.safeAddress,
           data: outerCalldata,
           from: request.ownerAddress,
-        });
+        }),
+      "preflight"
+    );
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider,
@@ -463,38 +462,42 @@ export async function executeNativeTransferAsSafe(
 
     const nonce = nonceManager.getNextNonce(session);
 
-    const tx = await signer.sendTransaction({
-      to: request.safeAddress,
-      data: outerCalldata,
-      value: BigInt(0),
-      nonce,
-      gasLimit: gasConfig.gasLimit,
-      maxFeePerGas: gasConfig.maxFeePerGas,
-      maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
-      chainId: options.chainId,
-    });
+    const broadcast = await submitSignedTransactionWithFailover(
+      signer,
+      {
+        to: request.safeAddress,
+        data: outerCalldata,
+        value: BigInt(0),
+        nonce,
+        gasLimit: gasConfig.gasLimit,
+        maxFeePerGas: gasConfig.maxFeePerGas,
+        maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+        chainId: options.chainId,
+      },
+      options.rpcManager
+    );
 
     await nonceManager.recordTransaction(
       session,
       nonce,
-      tx.hash,
+      broadcast.hash,
       options.workflowId,
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = options.rpcManager
-      ? await options.rpcManager.executeWithFailover(
-          (p) => p.waitForTransaction(tx.hash),
-          "read"
-        )
-      : await tx.wait();
+    const receipt =
+      broadcast.preExistingReceipt ??
+      (await options.rpcManager.executeWithFailover(
+        (p) => p.waitForTransaction(broadcast.hash),
+        "read"
+      ));
     if (!receipt) {
       throw new Error(
         "Safe-routed native transfer sent but receipt unavailable"
       );
     }
 
-    await nonceManager.confirmTransaction(tx.hash);
+    await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
     return {
       hash: receipt.hash,
@@ -503,7 +506,6 @@ export async function executeNativeTransferAsSafe(
       blockNumber: receipt.blockNumber,
     };
   } catch (err) {
-    finishMetrics("failure");
-    throw err;
+    finishOnError(finishMetrics, err);
   }
 }

--- a/lib/web3/submit-signed.ts
+++ b/lib/web3/submit-signed.ts
@@ -121,18 +121,34 @@ async function reconcile(
 }
 
 /**
- * ethers v6 translates two of the three relevant node error patterns into
- * typed error codes (provider-jsonrpc.ts :: getRpcError):
- *   - "nonce too low" / "transaction nonce is too low" -> NONCE_EXPIRED
- *   - "replacement transaction underpriced"            -> REPLACEMENT_UNDERPRICED
+ * Recognise nonce-conflict errors across two layers:
  *
- * It does NOT translate geth's `ErrAlreadyKnown` ("already known" / "known
- * transaction") - that arrives as SERVER_ERROR with the raw message. Until
- * ethers covers it, we match on the message for that case only.
+ * 1. Direct EthersError thrown from broadcastTransaction. ethers v6 translates
+ *    raw node messages to typed codes in provider-jsonrpc.ts :: getRpcError:
+ *      - "nonce too low" / "transaction nonce is too low" -> NONCE_EXPIRED
+ *      - "replacement transaction underpriced"            -> REPLACEMENT_UNDERPRICED
+ *    These are matched by code via isError(...).
+ *
+ * 2. Wrapped Error thrown by rpcManager.executeWithFailover when both
+ *    endpoints fail. It re-throws a plain Error with the inner error
+ *    messages interpolated as text, dropping the typed code. We fall back
+ *    to substring matching on the message for those cases.
+ *
+ * The substring list covers BOTH raw node phrasings AND the canonical text
+ * ethers picks when it constructs the typed error (e.g. "nonce has already
+ * been used" is ethers' NONCE_EXPIRED message, distinct from the raw node
+ * "nonce too low"). geth's ErrAlreadyKnown is not translated by ethers at
+ * all, so its raw text is included too.
  */
-const ALREADY_KNOWN_PATTERNS: readonly string[] = [
+const NONCE_CONFLICT_MESSAGE_PATTERNS: readonly string[] = [
   "already known",
   "known transaction",
+  "nonce too low",
+  "nonce is too low",
+  "nonce has already been used",
+  "replacement transaction underpriced",
+  "replacement underpriced",
+  "replacement fee too low",
 ];
 
 export function isNonceConflictError(err: unknown): boolean {
@@ -143,7 +159,9 @@ export function isNonceConflictError(err: unknown): boolean {
     return true;
   }
   const msg = errorMessage(err).toLowerCase();
-  return ALREADY_KNOWN_PATTERNS.some((pattern) => msg.includes(pattern));
+  return NONCE_CONFLICT_MESSAGE_PATTERNS.some((pattern) =>
+    msg.includes(pattern)
+  );
 }
 
 function errorMessage(err: unknown): string {

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -6,11 +6,10 @@
  * steps to execute transactions with proper nonce handling and adaptive
  * gas estimation.
  *
- * submitAndConfirm / submitContractCallAndConfirm consolidate the
- * send -> record -> wait -> confirm -> explorer-link flow into one place
- * and add RPC failover: if the primary provider fails with a retryable
- * error, the signer (or contract) is reconnected to the fallback provider
- * and the send is retried once. Same nonce ensures idempotency.
+ * submitAndConfirm / submitContractCallAndConfirm / executeTransaction /
+ * executeContractTransaction all route the broadcast through
+ * submitSignedTransactionWithFailover (sign once, broadcast same bytes
+ * across the RPC failover loop, reconcile on error via on-chain lookup).
  *
  * @see docs/keeperhub/KEEP-1240/nonce.md for nonce specification
  * @see docs/keeperhub/KEEP-1240/gas.md for gas strategy specification
@@ -25,14 +24,12 @@ import { ErrorCategory, logUserError } from "@/lib/logging";
 import { initializeWalletSigner } from "@/lib/para/wallet-helpers";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
-import { isNonRetryableError } from "@/lib/rpc/providers/error-classification";
-import {
-  type RpcMetricsContext,
-  rpcMetricsCtx,
-  withRpcMetrics,
-} from "@/lib/rpc/providers/with-rpc-metrics";
 import { getGasStrategy } from "./gas-strategy";
 import { getNonceManager, type NonceSession } from "./nonce-manager";
+import {
+  type BroadcastResult,
+  submitSignedTransactionWithFailover,
+} from "./submit-signed";
 
 export type TransactionContext = {
   organizationId: string;
@@ -40,7 +37,7 @@ export type TransactionContext = {
   workflowId?: string;
   chainId: number;
   rpcUrl: string;
-  rpcManager?: RpcProviderManager;
+  rpcManager: RpcProviderManager;
 };
 
 export type TransactionResult = {
@@ -68,13 +65,8 @@ export type SubmitAndConfirmResult = {
 };
 
 /**
- * Attempt to send a signer-based transaction with RPC failover.
- *
- * 1. Try sendTransaction on the current provider.
- * 2. If the error is non-retryable, throw immediately.
- * 3. If retryable and a fallback provider exists, reconnect the signer
- *    and retry once. Same nonce ensures idempotency.
- * 4. After successful send: record -> wait -> confirm -> explorer link.
+ * Send a signer-based transaction with sign-once + failover broadcast,
+ * then record -> wait -> confirm -> explorer link.
  */
 export async function submitAndConfirm(
   signer: ReturnType<typeof initializeWalletSigner> extends Promise<infer T>
@@ -83,172 +75,71 @@ export async function submitAndConfirm(
   txRequest: ethers.TransactionRequest,
   options: SubmitAndConfirmOptions
 ): Promise<SubmitAndConfirmResult> {
-  const { rpcManager, session, nonce, workflowId, chainId, maxFeePerGas } =
-    options;
-  const nonceManager = getNonceManager();
-  const primaryCtx = rpcMetricsCtx(rpcManager);
-
-  let tx: ethers.TransactionResponse;
-  try {
-    tx = await withRpcMetrics(primaryCtx, () =>
-      signer.sendTransaction(txRequest)
-    );
-  } catch (primaryError) {
-    if (isNonRetryableError(primaryError)) {
-      throw primaryError;
-    }
-
-    const fallbackProvider = rpcManager.getFallbackProvider();
-    if (!fallbackProvider) {
-      throw primaryError;
-    }
-
-    rpcManager
-      .getMetricsCollector()
-      .recordFailoverEvent(rpcManager.getChainName());
-
-    console.warn(
-      JSON.stringify({
-        level: "warn",
-        event: "WRITE_TX_FAILOVER",
-        message: `Primary RPC failed during sendTransaction for chain ${rpcManager.getChainName()}, retrying on fallback`,
-        chain: rpcManager.getChainName(),
-        error:
-          primaryError instanceof Error
-            ? primaryError.message
-            : String(primaryError),
-        timestamp: new Date().toISOString(),
-      })
-    );
-
-    const fallbackCtx: RpcMetricsContext = {
-      ...primaryCtx,
-      providerType: "fallback",
-    };
-    const reconnectedSigner = signer.connect(fallbackProvider) as typeof signer;
-    tx = await withRpcMetrics(fallbackCtx, () =>
-      reconnectedSigner.sendTransaction(txRequest)
-    );
-  }
-
-  return await confirmAndBuildResult(
-    tx,
-    nonceManager,
-    session,
-    nonce,
-    workflowId,
-    chainId,
-    maxFeePerGas
+  const broadcast = await submitSignedTransactionWithFailover(
+    signer,
+    txRequest,
+    options.rpcManager
   );
+  return await confirmAndBuildResult(broadcast, options);
 }
 
 /**
- * Attempt to send a contract method call with RPC failover.
- *
- * Same failover logic as submitAndConfirm but for contract interactions.
- * On failover, both the signer and contract are reconnected to the fallback.
+ * Send a contract method call with sign-once + failover broadcast.
+ * Builds calldata once, then routes through the same helper as submitAndConfirm.
  */
 export async function submitContractCallAndConfirm(
   contract: ethers.Contract,
   method: string,
   args: unknown[],
-  overrides: Record<string, unknown>,
+  overrides: ethers.TransactionRequest,
   signer: ReturnType<typeof initializeWalletSigner> extends Promise<infer T>
     ? T
     : never,
   options: SubmitAndConfirmOptions
 ): Promise<SubmitAndConfirmResult> {
-  const { rpcManager, session, nonce, workflowId, chainId, maxFeePerGas } =
-    options;
-  const nonceManager = getNonceManager();
-  const primaryCtx = rpcMetricsCtx(rpcManager);
-
-  let tx: ethers.TransactionResponse;
-  try {
-    tx = await withRpcMetrics(primaryCtx, () =>
-      contract.getFunction(method)(...args, overrides)
-    );
-  } catch (primaryError) {
-    if (isNonRetryableError(primaryError)) {
-      throw primaryError;
-    }
-
-    const fallbackProvider = rpcManager.getFallbackProvider();
-    if (!fallbackProvider) {
-      throw primaryError;
-    }
-
-    rpcManager
-      .getMetricsCollector()
-      .recordFailoverEvent(rpcManager.getChainName());
-
-    console.warn(
-      JSON.stringify({
-        level: "warn",
-        event: "WRITE_TX_CONTRACT_FAILOVER",
-        message: `Primary RPC failed during ${method}() for chain ${rpcManager.getChainName()}, retrying on fallback`,
-        chain: rpcManager.getChainName(),
-        method,
-        error:
-          primaryError instanceof Error
-            ? primaryError.message
-            : String(primaryError),
-        timestamp: new Date().toISOString(),
-      })
-    );
-
-    const fallbackCtx: RpcMetricsContext = {
-      ...primaryCtx,
-      providerType: "fallback",
-    };
-    const reconnectedSigner = signer.connect(fallbackProvider) as typeof signer;
-    const reconnectedContract = contract.connect(
-      reconnectedSigner
-    ) as typeof contract;
-    tx = await withRpcMetrics(fallbackCtx, () =>
-      reconnectedContract.getFunction(method)(...args, overrides)
-    );
-  }
-
-  return await confirmAndBuildResult(
-    tx,
-    nonceManager,
-    session,
-    nonce,
-    workflowId,
-    chainId,
-    maxFeePerGas
-  );
+  const data = contract.interface.encodeFunctionData(method, args);
+  const to = await contract.getAddress();
+  const txRequest: ethers.TransactionRequest = {
+    ...overrides,
+    to,
+    data,
+  };
+  return await submitAndConfirm(signer, txRequest, options);
 }
 
 /**
- * Shared post-send flow: record pending tx, wait for mining, confirm,
- * compute gas cost, and build explorer link.
+ * Shared post-broadcast flow: record pending tx, wait for mining (with
+ * failover), confirm, compute gas cost, and build explorer link. Skips
+ * waitForTransaction when broadcast reconciliation already returned a receipt.
  */
 async function confirmAndBuildResult(
-  tx: ethers.TransactionResponse,
-  nonceManager: ReturnType<typeof getNonceManager>,
-  session: NonceSession,
-  nonce: number,
-  workflowId: string | undefined,
-  chainId: number,
-  maxFeePerGas: bigint
+  broadcast: BroadcastResult,
+  options: SubmitAndConfirmOptions
 ): Promise<SubmitAndConfirmResult> {
+  const { rpcManager, session, nonce, workflowId, chainId, maxFeePerGas } =
+    options;
+  const nonceManager = getNonceManager();
+
   await nonceManager.recordTransaction(
     session,
     nonce,
-    tx.hash,
+    broadcast.hash,
     workflowId,
     maxFeePerGas.toString()
   );
 
-  const receipt = await tx.wait();
+  const receipt =
+    broadcast.preExistingReceipt ??
+    (await rpcManager.executeWithFailover(
+      (provider) => provider.waitForTransaction(broadcast.hash),
+      "read"
+    ));
 
   if (!receipt) {
     throw new Error("Transaction sent but receipt not available");
   }
 
-  await nonceManager.confirmTransaction(tx.hash);
+  await nonceManager.confirmTransaction(broadcast.hash);
 
   const gasCostWei = (receipt.gasUsed * receipt.gasPrice).toString();
 
@@ -268,7 +159,7 @@ async function confirmAndBuildResult(
 }
 
 // ---------------------------------------------------------------------------
-// Legacy helpers (still used by executeTransaction / executeContractTransaction)
+// High-level helpers used by Safe deployment and roles-orchestrator
 // ---------------------------------------------------------------------------
 
 /**
@@ -299,13 +190,11 @@ export async function executeTransaction(
       throw new Error("Signer has no provider");
     }
 
-    const estimatedGas = context.rpcManager
-      ? await context.rpcManager.executeWithFailover(
-          (rpcProvider) =>
-            rpcProvider.estimateGas({ ...baseTx, from: walletAddress }),
-          "preflight"
-        )
-      : await provider.estimateGas({ ...baseTx, from: walletAddress });
+    const estimatedGas = await context.rpcManager.executeWithFailover(
+      (rpcProvider) =>
+        rpcProvider.estimateGas({ ...baseTx, from: walletAddress }),
+      "preflight"
+    );
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider,
@@ -322,25 +211,35 @@ export async function executeTransaction(
       gasLimit: gasConfig.gasLimit,
       maxFeePerGas: gasConfig.maxFeePerGas,
       maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+      chainId: context.chainId,
     };
 
-    const tx = await signer.sendTransaction(txRequest);
+    const broadcast = await submitSignedTransactionWithFailover(
+      signer,
+      txRequest,
+      context.rpcManager
+    );
 
     await nonceManager.recordTransaction(
       session,
       nonce,
-      tx.hash,
+      broadcast.hash,
       context.workflowId,
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = await tx.wait();
+    const receipt =
+      broadcast.preExistingReceipt ??
+      (await context.rpcManager.executeWithFailover(
+        (rpcProvider) => rpcProvider.waitForTransaction(broadcast.hash),
+        "read"
+      ));
 
-    await nonceManager.confirmTransaction(tx.hash);
+    await nonceManager.confirmTransaction(broadcast.hash);
 
     return {
       success: true,
-      txHash: tx.hash,
+      txHash: broadcast.hash,
       receipt: receipt ?? undefined,
       nonce,
     };
@@ -383,16 +282,18 @@ export async function executeContractTransaction(
     if (!provider) {
       throw new Error("Contract has no provider");
     }
+    const signer = contract.runner as ethers.Signer;
+    if (typeof signer.signTransaction !== "function") {
+      throw new Error("Contract runner is not a signer");
+    }
 
-    const estimatedGas = context.rpcManager
-      ? await context.rpcManager.executeWithFailover(
-          (rpcProvider) =>
-            (contract.connect(rpcProvider) as typeof contract)
-              .getFunction(method)
-              .estimateGas(...args, { from: walletAddress }),
-          "preflight"
-        )
-      : await contract.getFunction(method).estimateGas(...args);
+    const estimatedGas = await context.rpcManager.executeWithFailover(
+      (rpcProvider) =>
+        (contract.connect(rpcProvider) as typeof contract)
+          .getFunction(method)
+          .estimateGas(...args, { from: walletAddress }),
+      "preflight"
+    );
 
     const gasConfig = await gasStrategy.getGasConfig(
       provider as ethers.Provider,
@@ -403,28 +304,44 @@ export async function executeContractTransaction(
       context.rpcManager
     );
 
-    const tx = await contract.getFunction(method)(...args, {
+    const data = contract.interface.encodeFunctionData(method, args);
+    const to = await contract.getAddress();
+    const txRequest: ethers.TransactionRequest = {
+      to,
+      data,
       nonce,
       gasLimit: gasConfig.gasLimit,
       maxFeePerGas: gasConfig.maxFeePerGas,
       maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
-    });
+      chainId: context.chainId,
+    };
+
+    const broadcast = await submitSignedTransactionWithFailover(
+      signer,
+      txRequest,
+      context.rpcManager
+    );
 
     await nonceManager.recordTransaction(
       session,
       nonce,
-      tx.hash,
+      broadcast.hash,
       context.workflowId,
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = await tx.wait();
+    const receipt =
+      broadcast.preExistingReceipt ??
+      (await context.rpcManager.executeWithFailover(
+        (rpcProvider) => rpcProvider.waitForTransaction(broadcast.hash),
+        "read"
+      ));
 
-    await nonceManager.confirmTransaction(tx.hash);
+    await nonceManager.confirmTransaction(broadcast.hash);
 
     return {
       success: true,
-      txHash: tx.hash,
+      txHash: broadcast.hash,
       receipt: receipt ?? undefined,
       nonce,
     };
@@ -456,10 +373,7 @@ export async function withNonceSession<T>(
   fn: (session: NonceSession) => Promise<T>
 ): Promise<T> {
   const nonceManager = getNonceManager();
-  const rpcManager =
-    context.rpcManager ??
-    (await getRpcProviderFromUrls(context.rpcUrl, undefined, context.chainId));
-  const provider = rpcManager.getProvider();
+  const provider = context.rpcManager.getProvider();
 
   const { session, validation } = await nonceManager.startSession(
     walletAddress,

--- a/tests/e2e/vitest/submit-signed-anvil.test.ts
+++ b/tests/e2e/vitest/submit-signed-anvil.test.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E test for submitSignedTransactionWithFailover against a local anvil.
+ *
+ * Exercises the helper's two load-bearing properties end-to-end against a
+ * real EVM:
+ *
+ *   1. Failover: a dead primary RPC is paired with a healthy anvil
+ *      fallback. The same signed bytes broadcast on the fallback land
+ *      on-chain. The signature (and therefore the hash) does NOT change
+ *      between the failed primary attempt and the fallback attempt.
+ *
+ *   2. Nonce-conflict reconcile: re-broadcasting a different tx with a
+ *      nonce that was already consumed yields a NonceConflictError after
+ *      the helper's on-chain lookup confirms our hash is nowhere to be
+ *      found.
+ *
+ * Prerequisites: docker compose --profile test up -d test-anvil
+ * (Foundry anvil on localhost:8546, chain-id 31337.)
+ *
+ * Skipped when SKIP_INFRA_TESTS=true or when the anvil port is not
+ * reachable, so CI without infra does not fail this file.
+ */
+
+import { ethers } from "ethers";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import {
+  NonceConflictError,
+  submitSignedTransactionWithFailover,
+} from "@/lib/web3/submit-signed";
+
+const ANVIL_URL = process.env.ANVIL_URL ?? "http://localhost:8546";
+// 127.0.0.1:1 is the IANA TCP port 0 reserved range -- guaranteed
+// connection-refused, making it a deterministic "dead primary" target.
+const DEAD_PRIMARY_URL = "http://127.0.0.1:1";
+const CHAIN_ID = 31_337;
+
+// First two anvil default accounts (deterministic mnemonic).
+const ANVIL_PRIV_0 =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const ANVIL_ADDR_1 = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+async function isAnvilReachable(): Promise<boolean> {
+  try {
+    const response = await fetch(ANVIL_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "eth_chainId",
+        id: 1,
+      }),
+      signal: AbortSignal.timeout(1000),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const body = (await response.json()) as { result?: string };
+    return body.result === `0x${CHAIN_ID.toString(16)}`;
+  } catch {
+    return false;
+  }
+}
+
+const skipForCi = process.env.SKIP_INFRA_TESTS === "true";
+const anvilUp = skipForCi ? false : await isAnvilReachable();
+const shouldSkip = skipForCi || !anvilUp;
+
+describe.skipIf(shouldSkip)(
+  "submitSignedTransactionWithFailover (anvil E2E)",
+  () => {
+    let rpcManager: RpcProviderManager;
+    let fallbackProvider: ethers.JsonRpcProvider;
+    let wallet: ethers.Wallet;
+
+    beforeAll(async () => {
+      rpcManager = await getRpcProviderFromUrls(
+        DEAD_PRIMARY_URL,
+        ANVIL_URL,
+        CHAIN_ID,
+        "anvil-test"
+      );
+      // Wallet stays connected to the healthy fallback so the unrelated
+      // populateTransaction-time chainId/network lookups never hit the
+      // dead primary; the broadcast itself still goes through rpcManager.
+      fallbackProvider = new ethers.JsonRpcProvider(ANVIL_URL, CHAIN_ID, {
+        staticNetwork: true,
+      });
+      wallet = new ethers.Wallet(ANVIL_PRIV_0, fallbackProvider);
+    });
+
+    afterAll(() => {
+      fallbackProvider.destroy();
+    });
+
+    async function buildFundedTxRequest(
+      value: bigint,
+      nonceOverride?: number
+    ): Promise<ethers.TransactionRequest> {
+      const nonce =
+        nonceOverride ??
+        (await fallbackProvider.getTransactionCount(wallet.address, "pending"));
+      return {
+        to: ANVIL_ADDR_1,
+        value,
+        nonce,
+        gasLimit: BigInt(21_000),
+        maxFeePerGas: ethers.parseUnits("2", "gwei"),
+        maxPriorityFeePerGas: ethers.parseUnits("1", "gwei"),
+        chainId: CHAIN_ID,
+        type: 2,
+      };
+    }
+
+    it("falls over from a dead primary to a healthy fallback and lands the tx on-chain", {
+      timeout: 30_000,
+    }, async () => {
+      const txRequest = await buildFundedTxRequest(ethers.parseEther("0.001"));
+      // Capture the hash we expect *before* the helper runs, so we can
+      // assert the signed bytes are byte-identical to what reached chain.
+      const expectedHash = ethers.Transaction.from(
+        await wallet.signTransaction(txRequest)
+      ).hash;
+
+      const result = await submitSignedTransactionWithFailover(
+        wallet,
+        txRequest,
+        rpcManager
+      );
+
+      expect(result.hash).toBe(expectedHash);
+      expect(result.preExistingReceipt).toBeUndefined();
+
+      const receipt = await fallbackProvider.waitForTransaction(result.hash);
+      expect(receipt).toBeTruthy();
+      expect(receipt?.status).toBe(1);
+      expect(receipt?.to?.toLowerCase()).toBe(ANVIL_ADDR_1.toLowerCase());
+    });
+
+    // Three failover rounds against the dead primary (broadcast + two
+    // reconcile probes) burn the default retry budget before each falls
+    // over to the live fallback, so this test needs a longer timeout
+    // than the vitest default.
+    it("throws NonceConflictError when re-using a consumed nonce with different bytes", {
+      timeout: 90_000,
+    }, async () => {
+      // First broadcast at nonce N. After this lands, nonce N is consumed.
+      const consumedNonce = await fallbackProvider.getTransactionCount(
+        wallet.address,
+        "pending"
+      );
+      const firstTx = await buildFundedTxRequest(
+        ethers.parseEther("0.0005"),
+        consumedNonce
+      );
+      const firstResult = await submitSignedTransactionWithFailover(
+        wallet,
+        firstTx,
+        rpcManager
+      );
+      const firstReceipt = await fallbackProvider.waitForTransaction(
+        firstResult.hash
+      );
+      expect(firstReceipt?.status).toBe(1);
+
+      // Second broadcast at the SAME nonce but DIFFERENT value -> different
+      // signature -> different hash. Anvil rejects with "nonce too low".
+      // The helper's reconcile probes for OUR hash (not the first tx's),
+      // finds neither receipt nor mempool entry, and throws.
+      const secondTx = await buildFundedTxRequest(
+        ethers.parseEther("0.0007"),
+        consumedNonce
+      );
+
+      await expect(
+        submitSignedTransactionWithFailover(wallet, secondTx, rpcManager)
+      ).rejects.toBeInstanceOf(NonceConflictError);
+    });
+  }
+);

--- a/tests/unit/submit-signed.test.ts
+++ b/tests/unit/submit-signed.test.ts
@@ -347,19 +347,17 @@ describe("isNonceConflictError", () => {
     "Already known",
     "RPC error: ALREADY KNOWN",
     "known transaction",
-  ])("matches geth 'already known' family by message: %s", (msg) => {
-    expect(isNonceConflictError(new Error(msg))).toBe(true);
-  });
-
-  it.each([
     "nonce too low",
+    "nonce is too low",
     "nonce has already been used",
     "replacement transaction underpriced",
-  ])("does NOT match bare Error with conflict-y message (no ethers code): %s", (msg) => {
-    // These strings come from nodes but ethers translates them to typed codes.
-    // A bare `Error` without a code should not pretend to be a typed ethers
-    // error - this guards against accidentally classifying user-thrown errors.
-    expect(isNonceConflictError(new Error(msg))).toBe(false);
+    "replacement underpriced",
+    "replacement fee too low",
+    // executeWithFailover-style wrapped messages (both endpoints failed)
+    "RPC failed on both endpoints. Primary: connection refused. Fallback: nonce has already been used",
+    "RPC failed on both endpoints. Primary: timeout. Fallback: replacement fee too low",
+  ])("matches conflict-message by substring: %s", (msg) => {
+    expect(isNonceConflictError(new Error(msg))).toBe(true);
   });
 
   it.each([

--- a/tests/unit/write-failover.test.ts
+++ b/tests/unit/write-failover.test.ts
@@ -1,3 +1,4 @@
+import type { ethers } from "ethers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -64,11 +65,24 @@ vi.mock("@/lib/web3/gas-strategy", () => ({
   getGasStrategy: vi.fn(),
 }));
 
+const mockSubmitSigned = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/web3/submit-signed", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/web3/submit-signed")
+  >("@/lib/web3/submit-signed");
+  return {
+    ...actual,
+    submitSignedTransactionWithFailover: mockSubmitSigned,
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Import module under test AFTER mocks
 // ---------------------------------------------------------------------------
 
 import type { NonceSession } from "@/lib/web3/nonce-manager";
+import { NonceConflictError } from "@/lib/web3/submit-signed";
 import {
   type SubmitAndConfirmOptions,
   submitAndConfirm,
@@ -79,19 +93,16 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeMockReceipt(hash: string): {
-  hash: string;
-  gasUsed: bigint;
-  gasPrice: bigint;
-} {
-  return { hash, gasUsed: BigInt(21_000), gasPrice: BigInt(10_000_000_000) };
+function makeMockReceipt(hash: string): ethers.TransactionReceipt {
+  return {
+    hash,
+    gasUsed: BigInt(21_000),
+    gasPrice: BigInt(10_000_000_000),
+  } as unknown as ethers.TransactionReceipt;
 }
 
-function makeMockTxResponse(hash: string): {
-  hash: string;
-  wait: ReturnType<typeof vi.fn>;
-} {
-  return { hash, wait: vi.fn().mockResolvedValue(makeMockReceipt(hash)) };
+function makeMockTxResponse(hash: string): ethers.TransactionResponse {
+  return { hash } as unknown as ethers.TransactionResponse;
 }
 
 function makeSession(): NonceSession {
@@ -104,27 +115,36 @@ function makeSession(): NonceSession {
   };
 }
 
+function makeRpcManager(waitReceipt?: ethers.TransactionReceipt | null) {
+  const executeWithFailover = vi
+    .fn()
+    .mockImplementation(
+      async (
+        op: (p: ethers.JsonRpcProvider) => Promise<unknown>,
+        _opType: string
+      ) => {
+        const provider = {
+          waitForTransaction: vi
+            .fn()
+            .mockImplementation((hash: string) =>
+              Promise.resolve(
+                waitReceipt === undefined ? makeMockReceipt(hash) : waitReceipt
+              )
+            ),
+        } as unknown as ethers.JsonRpcProvider;
+        return await op(provider);
+      }
+    );
+  return {
+    executeWithFailover,
+  } as unknown as SubmitAndConfirmOptions["rpcManager"];
+}
+
 function makeOptions(
   overrides?: Partial<SubmitAndConfirmOptions>
 ): SubmitAndConfirmOptions {
   return {
-    rpcManager: {
-      getFallbackProvider: vi.fn().mockReturnValue(null),
-      getChainName: vi.fn().mockReturnValue("ethereum"),
-      getCurrentProviderType: vi.fn().mockReturnValue("primary"),
-      getMetricsCollector: vi.fn().mockReturnValue({
-        recordPrimaryAttempt: vi.fn(),
-        recordPrimaryFailure: vi.fn(),
-        recordFallbackAttempt: vi.fn(),
-        recordFallbackFailure: vi.fn(),
-        recordFailoverEvent: vi.fn(),
-        recordRecoveryEvent: vi.fn(),
-        recordBothFailed: vi.fn(),
-        recordSuccess: vi.fn(),
-        recordLatency: vi.fn(),
-        recordErrorType: vi.fn(),
-      }),
-    } as unknown as SubmitAndConfirmOptions["rpcManager"],
+    rpcManager: makeRpcManager(),
     session: makeSession(),
     nonce: 42,
     workflowId: "wf-1",
@@ -143,113 +163,92 @@ describe("submitAndConfirm", () => {
     vi.clearAllMocks();
   });
 
-  it("sends on primary and returns result on success", async () => {
-    const txResponse = makeMockTxResponse("0xhash1");
-    const signer = {
-      sendTransaction: vi.fn().mockResolvedValue(txResponse),
-      connect: vi.fn(),
-    };
+  it("routes broadcast through submitSignedTransactionWithFailover and returns built result", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xhash1",
+      response: makeMockTxResponse("0xhash1"),
+    });
+    const signer = {} as ethers.Signer;
+    const options = makeOptions();
 
     const result = await submitAndConfirm(
       signer as never,
       { to: "0xrecipient", value: BigInt(1000), nonce: 42 },
-      makeOptions()
+      options
     );
 
+    expect(mockSubmitSigned).toHaveBeenCalledWith(
+      signer,
+      { to: "0xrecipient", value: BigInt(1000), nonce: 42 },
+      options.rpcManager
+    );
     expect(result.txHash).toBe("0xhash1");
     expect(result.gasCostWei).toBe(
       (BigInt(21_000) * BigInt(10_000_000_000)).toString()
     );
     expect(result.transactionLink).toContain("0xhash1");
-    expect(signer.connect).not.toHaveBeenCalled();
     expect(mockRecordTransaction).toHaveBeenCalledOnce();
     expect(mockConfirmTransaction).toHaveBeenCalledOnce();
   });
 
-  it("throws immediately for non-retryable errors without trying fallback", async () => {
-    const error = Object.assign(new Error("revert"), {
-      code: "CALL_EXCEPTION",
+  it("uses preExistingReceipt and skips waitForTransaction when helper found tx already mined", async () => {
+    const preReceipt = makeMockReceipt("0xhash-mined");
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xhash-mined",
+      response: makeMockTxResponse("0xhash-mined"),
+      preExistingReceipt: preReceipt,
     });
-    const signer = {
-      sendTransaction: vi.fn().mockRejectedValue(error),
-      connect: vi.fn(),
-    };
-
-    await expect(
-      submitAndConfirm(
-        signer as never,
-        { to: "0xrecipient", value: BigInt(1000), nonce: 42 },
-        makeOptions()
-      )
-    ).rejects.toThrow("revert");
-
-    expect(signer.connect).not.toHaveBeenCalled();
-  });
-
-  it("retries on fallback for retryable errors when fallback exists", async () => {
-    const error = Object.assign(new Error("timeout"), {
-      code: "NETWORK_ERROR",
-    });
-    const fallbackTx = makeMockTxResponse("0xfallback");
-    const reconnectedSigner = {
-      sendTransaction: vi.fn().mockResolvedValue(fallbackTx),
-    };
-    const signer = {
-      sendTransaction: vi.fn().mockRejectedValue(error),
-      connect: vi.fn().mockReturnValue(reconnectedSigner),
-    };
-
-    const fallbackProvider = { _isFallback: true };
-    const rpcManager = {
-      getFallbackProvider: vi.fn().mockReturnValue(fallbackProvider),
-      getChainName: vi.fn().mockReturnValue("ethereum"),
-      getCurrentProviderType: vi.fn().mockReturnValue("primary"),
-      getMetricsCollector: vi.fn().mockReturnValue({
-        recordPrimaryAttempt: vi.fn(),
-        recordPrimaryFailure: vi.fn(),
-        recordFallbackAttempt: vi.fn(),
-        recordFallbackFailure: vi.fn(),
-        recordFailoverEvent: vi.fn(),
-        recordRecoveryEvent: vi.fn(),
-        recordBothFailed: vi.fn(),
-        recordSuccess: vi.fn(),
-        recordLatency: vi.fn(),
-        recordErrorType: vi.fn(),
-      }),
-    };
+    const options = makeOptions();
+    const waitSpy = options.rpcManager.executeWithFailover as ReturnType<
+      typeof vi.fn
+    >;
 
     const result = await submitAndConfirm(
-      signer as never,
-      { to: "0xrecipient", value: BigInt(1000), nonce: 42 },
-      makeOptions({
-        rpcManager:
-          rpcManager as unknown as SubmitAndConfirmOptions["rpcManager"],
-      })
+      {} as never,
+      { to: "0xrecipient", value: BigInt(0), nonce: 42 },
+      options
     );
 
-    expect(result.txHash).toBe("0xfallback");
-    expect(signer.connect).toHaveBeenCalledWith(fallbackProvider);
-    expect(reconnectedSigner.sendTransaction).toHaveBeenCalledOnce();
+    expect(result.txHash).toBe("0xhash-mined");
+    expect(waitSpy).not.toHaveBeenCalled();
+    expect(mockConfirmTransaction).toHaveBeenCalledWith("0xhash-mined");
   });
 
-  it("throws retryable error when no fallback provider exists", async () => {
-    const error = Object.assign(new Error("timeout"), {
-      code: "NETWORK_ERROR",
-    });
-    const signer = {
-      sendTransaction: vi.fn().mockRejectedValue(error),
-      connect: vi.fn(),
-    };
+  it("propagates NonceConflictError from the helper without recording", async () => {
+    const conflictErr = new NonceConflictError(
+      "0xhashlost",
+      42,
+      new Error("nonce too low")
+    );
+    mockSubmitSigned.mockRejectedValue(conflictErr);
 
     await expect(
       submitAndConfirm(
-        signer as never,
-        { to: "0xrecipient", value: BigInt(1000), nonce: 42 },
+        {} as never,
+        { to: "0xrecipient", value: BigInt(0), nonce: 42 },
         makeOptions()
       )
-    ).rejects.toThrow("timeout");
+    ).rejects.toBe(conflictErr);
 
-    expect(signer.connect).not.toHaveBeenCalled();
+    expect(mockRecordTransaction).not.toHaveBeenCalled();
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+  });
+
+  it("throws when waitForTransaction resolves null (receipt unavailable)", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xhash1",
+      response: makeMockTxResponse("0xhash1"),
+    });
+    const options = makeOptions(undefined);
+    options.rpcManager = makeRpcManager(null);
+
+    await expect(
+      submitAndConfirm(
+        {} as never,
+        { to: "0xrecipient", value: BigInt(0), nonce: 42 },
+        options
+      )
+    ).rejects.toThrow("receipt not available");
   });
 });
 
@@ -258,130 +257,65 @@ describe("submitContractCallAndConfirm", () => {
     vi.clearAllMocks();
   });
 
-  it("sends contract call on primary and returns result on success", async () => {
-    const txResponse = makeMockTxResponse("0xcontract1");
-    const transferFn = vi.fn().mockResolvedValue(txResponse);
+  it("encodes calldata and forwards a fully-populated txRequest to the helper", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xhash-c1",
+      response: makeMockTxResponse("0xhash-c1"),
+    });
+    const encodeFunctionData = vi.fn().mockReturnValue("0xencodeddata");
+    const getAddress = vi.fn().mockResolvedValue("0xcontract");
     const contract = {
-      transfer: transferFn,
-      connect: vi.fn(),
-      getFunction: (name: string): unknown => {
-        if (name === "transfer") {
-          return transferFn;
-        }
-        throw new Error(`unknown function: ${name}`);
-      },
-    };
-    const signer = { connect: vi.fn() };
+      interface: { encodeFunctionData },
+      getAddress,
+    } as unknown as ethers.Contract;
+    const signer = {} as ethers.Signer;
+    const options = makeOptions();
 
     const result = await submitContractCallAndConfirm(
-      contract as never,
+      contract,
       "transfer",
       ["0xrecipient", BigInt(1000)],
-      { nonce: 42, gasLimit: BigInt(100_000) },
+      { nonce: 42, gasLimit: BigInt(50_000) },
       signer as never,
-      makeOptions()
+      options
     );
 
-    expect(result.txHash).toBe("0xcontract1");
-    expect(contract.connect).not.toHaveBeenCalled();
-  });
-
-  it("retries contract call on fallback for retryable errors", async () => {
-    const error = Object.assign(new Error("timeout"), {
-      code: "SERVER_ERROR",
-    });
-    const fallbackTx = makeMockTxResponse("0xfallbackContract");
-    const fallbackTransferFn = vi.fn().mockResolvedValue(fallbackTx);
-    const reconnectedContract = {
-      transfer: fallbackTransferFn,
-      getFunction: (name: string): unknown => {
-        if (name === "transfer") {
-          return fallbackTransferFn;
-        }
-        throw new Error(`unknown function: ${name}`);
+    expect(encodeFunctionData).toHaveBeenCalledWith("transfer", [
+      "0xrecipient",
+      BigInt(1000),
+    ]);
+    expect(getAddress).toHaveBeenCalledOnce();
+    expect(mockSubmitSigned).toHaveBeenCalledWith(
+      signer,
+      {
+        to: "0xcontract",
+        data: "0xencodeddata",
+        nonce: 42,
+        gasLimit: BigInt(50_000),
       },
-    };
-    const reconnectedSigner = {};
-    const primaryTransferFn = vi.fn().mockRejectedValue(error);
-    const contract = {
-      transfer: primaryTransferFn,
-      connect: vi.fn().mockReturnValue(reconnectedContract),
-      getFunction: (name: string): unknown => {
-        if (name === "transfer") {
-          return primaryTransferFn;
-        }
-        throw new Error(`unknown function: ${name}`);
-      },
-    };
-    const signer = {
-      connect: vi.fn().mockReturnValue(reconnectedSigner),
-    };
-
-    const fallbackProvider = { _isFallback: true };
-    const rpcManager = {
-      getFallbackProvider: vi.fn().mockReturnValue(fallbackProvider),
-      getChainName: vi.fn().mockReturnValue("ethereum"),
-      getCurrentProviderType: vi.fn().mockReturnValue("primary"),
-      getMetricsCollector: vi.fn().mockReturnValue({
-        recordPrimaryAttempt: vi.fn(),
-        recordPrimaryFailure: vi.fn(),
-        recordFallbackAttempt: vi.fn(),
-        recordFallbackFailure: vi.fn(),
-        recordFailoverEvent: vi.fn(),
-        recordRecoveryEvent: vi.fn(),
-        recordBothFailed: vi.fn(),
-        recordSuccess: vi.fn(),
-        recordLatency: vi.fn(),
-        recordErrorType: vi.fn(),
-      }),
-    };
-
-    const result = await submitContractCallAndConfirm(
-      contract as never,
-      "transfer",
-      ["0xrecipient", BigInt(1000)],
-      { nonce: 42, gasLimit: BigInt(100_000) },
-      signer as never,
-      makeOptions({
-        rpcManager:
-          rpcManager as unknown as SubmitAndConfirmOptions["rpcManager"],
-      })
+      options.rpcManager
     );
-
-    expect(result.txHash).toBe("0xfallbackContract");
-    expect(signer.connect).toHaveBeenCalledWith(fallbackProvider);
-    expect(contract.connect).toHaveBeenCalledWith(reconnectedSigner);
-    expect(reconnectedContract.transfer).toHaveBeenCalledOnce();
+    expect(result.txHash).toBe("0xhash-c1");
   });
 
-  it("throws immediately for non-retryable contract errors", async () => {
-    const error = Object.assign(new Error("invalid args"), {
-      code: "INVALID_ARGUMENT",
-    });
-    const approveFn = vi.fn().mockRejectedValue(error);
+  it("propagates NonceConflictError from helper", async () => {
+    mockSubmitSigned.mockRejectedValue(
+      new NonceConflictError("0xhashlost", 42, new Error("nonce too low"))
+    );
     const contract = {
-      approve: approveFn,
-      connect: vi.fn(),
-      getFunction: (name: string): unknown => {
-        if (name === "approve") {
-          return approveFn;
-        }
-        throw new Error(`unknown function: ${name}`);
-      },
-    };
-    const signer = { connect: vi.fn() };
+      interface: { encodeFunctionData: vi.fn().mockReturnValue("0xdata") },
+      getAddress: vi.fn().mockResolvedValue("0xcontract"),
+    } as unknown as ethers.Contract;
 
     await expect(
       submitContractCallAndConfirm(
-        contract as never,
+        contract,
         "approve",
-        ["0xspender", BigInt(1000)],
+        [],
         { nonce: 42 },
-        signer as never,
+        {} as never,
         makeOptions()
       )
-    ).rejects.toThrow("invalid args");
-
-    expect(signer.connect).not.toHaveBeenCalled();
+    ).rejects.toBeInstanceOf(NonceConflictError);
   });
 });


### PR DESCRIPTION
## Summary

Routes every existing EVM write path through `submitSignedTransactionWithFailover` (the helper landed in KEEP-546). Broadcasts now sign once and reconcile errors via on-chain lookup instead of the buggy "naive two-attempt failover" that re-signed on the fallback.

This PR targets `feat/keep-177-safe-wallet-integration` (not `staging`) because the helper itself lives on that branch and the local KEEP-177 commits (tx.wait failover, gas-strategy failover, signer-resolver probe failover) need to stay coherent with this work. KEEP-177 absorbs this when ready, or merges it first before merging itself.

## What changed

**Safe write paths** (`lib/safe/execute-as-safe.ts`) — all four sites now use the helper:
- `executeContractCallAsSafe`
- `executeContractCallAsRole`
- `executeNativeTransferAsRole`
- `executeNativeTransferAsSafe`

**EOA write paths** (`lib/web3/transaction-manager.ts`):
- `submitAndConfirm` — thin wrapper around the helper
- `submitContractCallAndConfirm` — encodes calldata, defers to `submitAndConfirm`
- `executeTransaction` — used by `lib/safe/deployment.ts` and `lib/safe/roles-orchestrator.ts`
- `executeContractTransaction` — symmetric

**Surface changes**:
- `ExecuteAsSafeOptions.rpcManager`: optional → **required**
- `TransactionContext.rpcManager`: optional → **required**
- Withdraw route now constructs its own single-armed `RpcProviderManager` via `getRpcProviderFromUrls(rpcUrl, undefined, chainId)` to satisfy the mandatory contract
- `withNonceSession`'s lazy `rpcManager ?? construct()` fallback removed
- `startSafeTxMetrics` outcome union widened: `"success" | "failure" | "nonce-conflict"` — Safe sites catch `NonceConflictError` and emit the distinct label

## Commits (7)

```
102c2e0c chore: KEEP-551 widen safe-tx metrics with nonce-conflict outcome
5fc6ad59 refactor: KEEP-551 route EOA write paths through sign-once failover helper
65aace58 refactor: KEEP-551 route Safe write paths through sign-once failover helper
6c985278 fix: KEEP-551 construct RpcProviderManager in withdraw route
02a214c7 test: KEEP-551 rewrite write-failover tests against helper-based impl
5c12f09a fix: KEEP-551 broaden NonceConflictError matcher to handle wrapped errors
45b9af63 test: KEEP-551 add anvil integration test for sign-once failover + reconcile
```

Each commit is self-contained and reviewable independently.

## What this fixes

Without this migration, every production EVM write still ran through `signer.sendTransaction(...)` — the exact "naive wrap" pattern KEEP-546 was written to replace. The local fixes on KEEP-177 (`tx.wait()` failover, gas-strategy failover, signer-resolver probe failover) closed adjacent gaps but left the broadcast itself vulnerable to:

- Primary-RPC failure between broadcast and confirmation reporting (silent loss),
- ethers re-signing on retry (different signed bytes, stuck nonces),
- "already known" / "nonce too low" reported as failure when the tx in fact landed.

The migration plugs the broadcast itself into the failover + on-chain reconcile loop.

## Matcher broadening

`isNonceConflictError` originally checked only ethers' typed codes (`NONCE_EXPIRED`, `REPLACEMENT_UNDERPRICED`) and the geth-untranslated `"already known"` substring. The integration test surfaced that `rpcManager.executeWithFailover` wraps both-endpoint failures in a plain `Error` whose message *interpolates* the inner error text — dropping the typed code. Since every helper call now goes through executeWithFailover, the wrapped-error case is the common path, not the edge case.

The matcher's substring list now covers raw node phrasings AND ethers' typed-error message text (e.g. `"nonce has already been used"` is ethers' NONCE_EXPIRED wrap text):

```
"already known", "known transaction",
"nonce too low", "nonce is too low", "nonce has already been used",
"replacement transaction underpriced", "replacement underpriced", "replacement fee too low"
```

Tradeoff documented in the commit message. The on-chain hash probe above the matcher remains source of truth; the matcher only decides which typed error to throw when on-chain shows no trace.

## Tests

**Unit** (passing locally):
- `tests/unit/submit-signed.test.ts` — 38 tests covering the helper + matcher
- `tests/unit/write-failover.test.ts` — rewritten against the helper-based implementation (no more `signer.sendTransaction`/`signer.connect` mocking)
- `tests/unit/approve-token.test.ts` — unchanged, still passes

**Integration** (anvil-backed, passing locally):
- `tests/e2e/vitest/submit-signed-anvil.test.ts` — two scenarios:
  - **Failover happy path**: dead primary (`127.0.0.1:1` connection-refused) + live anvil fallback. Helper signs once, broadcast on fallback lands, mined hash equals signed hash. Proves the sign-once invariant end-to-end.
  - **Nonce-conflict reconcile**: send tx with nonce N, then send a different tx with the SAME nonce. Fallback rejects with `"nonce has already been used"`, helper probes for our hash, finds nothing on-chain, throws `NonceConflictError`. Proves the reconcile path against a real EVM.

Skipped when `SKIP_INFRA_TESTS=true` or anvil isn't reachable, matching the existing pattern in `tests/e2e/vitest/`. Run locally with:
```
docker compose --profile test up -d test-anvil
pnpm vitest run tests/e2e/vitest/submit-signed-anvil.test.ts
```

## Out of scope

- Adding fallback RPC URLs to chain rows for `lib/safe/deployment.ts` and `lib/safe/roles-orchestrator.ts` (they still construct single-armed `RpcProviderManager`s). Improving that plumbing is a separate concern.
- `getCurrentNonce` mislabel of `"write"` op type → KEEP-549.
- `tx.wait()`, gas-strategy, and signer-resolver probe failover — already done on KEEP-177's previous commits.
- Future: `IdempotentTransaction` class wrapping the helper → KEEP-550.

## Related

- KEEP-546 — the helper this PR consumes
- KEEP-547 — transaction outbox for crash-recovery (separate concern)
- KEEP-549 — getCurrentNonce mislabel cleanup
- KEEP-550 — speculative IdempotentTransaction class

## Test plan

- [x] CI green
- [x] Reviewer agrees the matcher broadening is the right tradeoff (vs alternative: preserve `cause` in `rpcManager.executeWithFailover`'s wrapped error)
- [x] Reviewer agrees mandatory `rpcManager` is the right contract
- [x] Reviewer confirms the withdraw route's single-armed manager is appropriate (or asks for fallback URL plumbing)