### PR TITLE
test: KEEP-459 harden on-chain dispatch assertions against routing regressions

### DIFF
--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -481,7 +481,7 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
       action: "estimateGas",
       data: "0x",
       reason: null,
-      transaction: { to: TEST_ADDRESS },
+      transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
       invocation: null,
       revert: null,
     });
@@ -498,7 +498,7 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
         action: "estimateGas",
         data: "0x08c379a0deadbeef",
         reason: "X",
-        transaction: { to: TEST_ADDRESS },
+        transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
         invocation: null,
         revert: { args: ["X"], name: "Error", signature: "Error(string)" },
       }
@@ -550,7 +550,7 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
         action: "estimateGas",
         data: "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a43616c6c5574696c733a20746172676574207265766572742829000000000000",
         reason: "CallUtils: target revert()",
-        transaction: { to: TEST_ADDRESS },
+        transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
         invocation: null,
         revert: {
           args: ["CallUtils: target revert()"],

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -328,13 +328,15 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
   }, 15_000);
 
   it("connect-pool: encodes against gdaForwarder.connectPool", async () => {
-    // Not convertible to toBe(""): the GDA host calls into the pool
-    // address during connectPool, and TEST_ADDRESS has no contract code,
-    // so estimateGas reverts with `CallUtils: target revert()`. That is
-    // not a routing/ABI failure (revert data is non-empty), so it does
-    // not match DISPATCH_FAILURE_RE -- which is the assertion we want.
-    // Strengthening to toBe("") would need a real Superfluid pool address
-    // on Sepolia, out of scope for "no on-chain state dependency" tests.
+    // Not convertible to toBe(""): the GDA host dispatches into the pool
+    // address as a contract call during connectPool, and TEST_ADDRESS has
+    // no deployed code -- so estimateGas reverts with `CallUtils: target
+    // revert()`. That is not a routing/ABI failure (the revert *does*
+    // have data, just from a different source), so it correctly does not
+    // match DISPATCH_FAILURE_RE. Strengthening to toBe("") would need a
+    // deployed contract at the pool address that implements the expected
+    // pool interface (any Superfluid pool would do); out of scope for
+    // "no on-chain state dependency" tests.
     const msg = await estimateGasError("connect-pool", {
       pool: TEST_ADDRESS,
       userData: DUMMY_BYTES,

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -387,6 +387,40 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     expect(msg).toBe("");
   }, 15_000);
 
+  // -- Reroute regression --------------------------------------------------
+
+  it("reroute regression: misdispatched calldata triggers DISPATCH_FAILURE_RE", async () => {
+    // Acceptance criterion #2 of KEEP-459: "no test passes when its
+    // action is silently re-routed to a non-existent contract method."
+    //
+    // Reproduces the KEEP-456 failure mode end-to-end against the live
+    // Sepolia RPC: take a currently-passing action (grant-flow-operator,
+    // which routes correctly to the CFAv1Forwarder), then override its
+    // destination to SEPOLIA_FUSDC -- a real ERC20 contract that exists
+    // on chain but has no Superfluid methods. The EVM returns from the
+    // dispatch with empty revert data (no fallback, no matching selector),
+    // and ethers surfaces it as `missing revert data ... code=CALL_EXCEPTION`.
+    //
+    // If DISPATCH_FAILURE_RE is ever weakened or removed, this test fails
+    // -- which is the whole point. This is the load-bearing assertion of
+    // the hardening, validated against a real RPC rather than a regex
+    // shape sample.
+    const msg = await estimateGasError(
+      "grant-flow-operator",
+      {
+        token: SEPOLIA_FUSDCX,
+        flowOperator: TEST_OPERATOR,
+        permissions: DUMMY_PERMISSIONS_ALL,
+        flowRateAllowance: DUMMY_FLOW_RATE,
+      },
+      SEPOLIA_FUSDC
+    );
+    // Sanity: must not be the empty-string "simulated" case.
+    expect(msg).not.toBe("");
+    // The actual guard: a real misroute must surface as a dispatch failure.
+    expect(msg).toMatch(DISPATCH_FAILURE_RE);
+  }, 15_000);
+
   // -- Coverage check ------------------------------------------------------
 
   it("every declared action has at least one dispatch test in this file", () => {

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -69,11 +69,14 @@ const DUMMY_BYTES = "0x";
 // balance, CFA_*/GDA_* business reverts, etc.) is fine: writes are called
 // from an unfunded TEST_ADDRESS and naturally revert at the contract layer.
 //
-// `data="0x"` (with the closing quote) is the precise KEEP-456 signature:
-// real reverts have hex content between the quotes (`data="0x08c..."`),
-// so the literal `0x"` only appears when the revert data is empty.
+// `,\s*data="0x"` anchors on the top-level CALL_EXCEPTION field separator,
+// so the pattern only matches the precise empty-revert-data field at the
+// top of the error -- not e.g. a nested transaction's `"data": "0x..."`
+// (which uses JSON `"key": value` with a colon, not `key=value` with =).
+// The closing quote immediately after `0x` is the precise signature:
+// real reverts have hex content between the quotes (`data="0x08c..."`).
 const DISPATCH_FAILURE_RE =
-  /INVALID_ARGUMENT|could not decode|invalid function|missing revert data|data="0x"/;
+  /INVALID_ARGUMENT|could not decode|invalid function|missing revert data|,\s*data="0x"/;
 
 function buildCalldata(
   protocol: ProtocolDefinition,
@@ -476,6 +479,29 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
       { argument: "value", value: "abc" }
     );
     expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
+  });
+
+  it('does NOT misfire when only the nested transaction.data is "0x"', () => {
+    // Defense-in-depth: confirms the `,\s*data="0x"` anchor distinguishes
+    // top-level CALL_EXCEPTION fields (key=value) from nested JSON
+    // (`"key": value`). If a future ethers version (or a quirky calldata)
+    // ever produced a transaction object whose data was literally "0x"
+    // while the top-level data was populated, the old `data="0x"` pattern
+    // would have false-positived. The anchor prevents that.
+    const err = ethers.makeError(
+      'execution reverted: "X"',
+      "CALL_EXCEPTION",
+      {
+        action: "estimateGas",
+        data: "0x08c379a0deadbeef",
+        reason: "X",
+        // Nested transaction with empty data (hypothetical fallback call):
+        transaction: { data: "0x", to: TEST_ADDRESS },
+        invocation: null,
+        revert: { args: ["X"], name: "Error", signature: "Error(string)" },
+      }
+    );
+    expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
   });
 
   it("does NOT match a normal business revert with populated revert data", () => {

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -415,44 +415,90 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
 
 // Not gated on RPC: validates the regex shape that the on-chain block above
 // relies on to catch routing regressions like KEEP-456 (calling into a
-// non-existent proxy returns no revert data). If someone tightens or relaxes
-// DISPATCH_FAILURE_RE without updating these samples, this fails -- the
-// regex itself is the load-bearing piece of the hardening; the on-chain
-// block can't exercise it without an actual routing bug to reproduce.
-describe("DISPATCH_FAILURE_RE shape", () => {
-  it("matches the `missing revert data` ethers v6 error shape", () => {
-    const sample =
-      'Error: missing revert data (action="estimateGas", data=null, reason=null, transaction={ "data": "0x...", "from": "0x...", "to": "0x..." }, invocation=null, revert=null, code=CALL_EXCEPTION, version=6.16.0)';
-    expect(sample).toMatch(DISPATCH_FAILURE_RE);
+// non-existent proxy returns no revert data). Each case synthesizes a real
+// ethers error via `ethers.makeError` rather than pinning a hardcoded
+// string -- if ethers changes its error formatting in a future major,
+// these tests fail loudly instead of silently validating a stale shape.
+describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
+  // estimateGasError wraps caught errors with `String(error)`, so the
+  // assertion target is the .toString() of the ethers error, prefixed
+  // with the constructor name (e.g. "Error: ..." or "TypeError: ...").
+  function asMessage(err: Error): string {
+    return String(err);
+  }
+
+  it("matches `missing revert data` (revert: null branch)", () => {
+    const err = ethers.makeError("missing revert data", "CALL_EXCEPTION", {
+      action: "estimateGas",
+      data: null,
+      reason: null,
+      transaction: { data: "0xdeadbeef", from: TEST_ADDRESS, to: TEST_ADDRESS },
+      invocation: null,
+      revert: null,
+    });
+    expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
   });
 
-  it('matches CALL_EXCEPTION with empty data="0x" (proxy returned no revert data)', () => {
-    const sample =
-      'Error: execution reverted (action="estimateGas", data="0x", reason=null, transaction={ "to": "0x..." }, code=CALL_EXCEPTION, version=6.16.0)';
-    expect(sample).toMatch(DISPATCH_FAILURE_RE);
+  it('matches empty revert data="0x" (proxy returned no revert data)', () => {
+    const err = ethers.makeError("execution reverted", "CALL_EXCEPTION", {
+      action: "estimateGas",
+      data: "0x",
+      reason: null,
+      transaction: { to: TEST_ADDRESS },
+      invocation: null,
+      revert: null,
+    });
+    expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
   });
 
-  it('does NOT misfire on `data="0x..."` with actual revert data', () => {
-    // Guards against the obvious regression of writing
-    // `/data="0x/` (no closing quote) which would match every revert.
-    const sample =
-      'Error: execution reverted: "X" (action="estimateGas", data="0x08c379a0deadbeef", code=CALL_EXCEPTION, version=6.16.0)';
-    expect(sample).not.toMatch(DISPATCH_FAILURE_RE);
+  it('does NOT misfire on data="0x..." with actual revert payload', () => {
+    // Guards against the obvious regression of writing `/data="0x/`
+    // (no closing quote), which would match every revert.
+    const err = ethers.makeError(
+      'execution reverted: "X"',
+      "CALL_EXCEPTION",
+      {
+        action: "estimateGas",
+        data: "0x08c379a0deadbeef",
+        reason: "X",
+        transaction: { to: TEST_ADDRESS },
+        invocation: null,
+        revert: { args: ["X"], name: "Error", signature: "Error(string)" },
+      }
+    );
+    expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
   });
 
   it("matches ABI encoding errors (INVALID_ARGUMENT)", () => {
-    const sample =
-      'Error: invalid BigNumberish value (argument="value", value="abc", code=INVALID_ARGUMENT, version=6.16.0)';
-    expect(sample).toMatch(DISPATCH_FAILURE_RE);
+    const err = ethers.makeError(
+      "invalid BigNumberish value",
+      "INVALID_ARGUMENT",
+      { argument: "value", value: "abc" }
+    );
+    expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
   });
 
   it("does NOT match a normal business revert with populated revert data", () => {
-    // Real Sepolia revert from connect-pool against TEST_ADDRESS: the GDA
-    // calls into the "pool" address and gets a real revert string back.
-    // This is the failure mode we want to tolerate -- contract reached,
-    // protocol-level revert with data, not a routing/dispatch bug.
-    const sample =
-      'Error: execution reverted: "CallUtils: target revert()" (action="estimateGas", data="0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a43616c6c5574696c733a20746172676574207265766572742829000000000000", reason="CallUtils: target revert()", code=CALL_EXCEPTION, version=6.16.0)';
-    expect(sample).not.toMatch(DISPATCH_FAILURE_RE);
+    // Models the real connect-pool revert against an EOA "pool": the GDA
+    // dispatches into the address and gets `CallUtils: target revert()`.
+    // Contract was reached, revert has data -- tolerate, do not flag as
+    // a routing/dispatch bug.
+    const err = ethers.makeError(
+      'execution reverted: "CallUtils: target revert()"',
+      "CALL_EXCEPTION",
+      {
+        action: "estimateGas",
+        data: "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a43616c6c5574696c733a20746172676574207265766572742829000000000000",
+        reason: "CallUtils: target revert()",
+        transaction: { to: TEST_ADDRESS },
+        invocation: null,
+        revert: {
+          args: ["CallUtils: target revert()"],
+          name: "Error",
+          signature: "Error(string)",
+        },
+      }
+    );
+    expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
   });
 });

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -61,10 +61,19 @@ const DUMMY_UNITS = "1";
 const DUMMY_PERMISSIONS_ALL = "7"; // create+update+delete bitmap
 const DUMMY_BYTES = "0x";
 
-// Markers we treat as failures: ABI/calldata mistakes the test should catch.
-// Anything else (require(false), insufficient balance, etc.) is a business
-// revert -- expected when calling write ops from an unfunded test address.
-const ENCODING_ERROR_RE = /INVALID_ARGUMENT|could not decode|invalid function/;
+// Markers we treat as failures: ABI/calldata mistakes plus the
+// "contract reverted with no data" pattern. The latter is the KEEP-456
+// failure mode -- routing into a non-existent SuperToken proxy returned a
+// CALL_EXCEPTION with empty revert data, and the previous loose guard
+// silently tolerated it. Anything else (require(false), insufficient
+// balance, CFA_*/GDA_* business reverts, etc.) is fine: writes are called
+// from an unfunded TEST_ADDRESS and naturally revert at the contract layer.
+//
+// `data="0x"` (with the closing quote) is the precise KEEP-456 signature:
+// real reverts have hex content between the quotes (`data="0x08c..."`),
+// so the literal `0x"` only appears when the revert data is empty.
+const DISPATCH_FAILURE_RE =
+  /INVALID_ARGUMENT|could not decode|invalid function|missing revert data|data="0x"/;
 
 function buildCalldata(
   protocol: ProtocolDefinition,
@@ -157,8 +166,10 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     return { decoded, contract, action, to };
   }
 
-  // Returns the error message from estimateGas, or "" if it succeeded. The
-  // test then asserts the message doesn't contain ABI-error markers.
+  // Returns the error message from estimateGas, or "" if it succeeded.
+  // Callers either assert the empty string (positive simulation) or assert
+  // the message does not match DISPATCH_FAILURE_RE (any non-routing-error
+  // revert is acceptable).
   async function estimateGasError(
     slug: string,
     inputs: Record<string, string>,
@@ -244,7 +255,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       flowRate: DUMMY_FLOW_RATE,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("update-flow: encodes against cfaForwarder.updateFlow", async () => {
@@ -255,7 +266,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       flowRate: DUMMY_FLOW_RATE,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("delete-flow: encodes against cfaForwarder.deleteFlow", async () => {
@@ -265,19 +276,23 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       receiver: TEST_ADDRESS,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   // -- GDA writes ----------------------------------------------------------
 
-  it("create-pool: flat bool inputs reshape into the (bool,bool) PoolConfig tuple", async () => {
+  it("create-pool: simulates successfully against gdaForwarder.createPool", async () => {
+    // GDA createPool only writes pool metadata -- no sender balance, no
+    // pre-existing state required. We can assert positive simulation
+    // success, which (unlike the loose .not.toMatch guard) catches the
+    // class of routing bug KEEP-456 surfaced.
     const msg = await estimateGasError("create-pool", {
       token: SEPOLIA_FUSDCX,
       admin: TEST_ADDRESS,
       transferabilityForUnitsOwner: "false",
       distributionFromAnyAddress: "false",
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).toBe("");
   }, 15_000);
 
   it("update-member-units: encodes against gdaForwarder.updateMemberUnits", async () => {
@@ -287,7 +302,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       units: DUMMY_UNITS,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("distribute: encodes against gdaForwarder.distribute", async () => {
@@ -298,7 +313,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       amount: DUMMY_AMOUNT_WEI,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("distribute-flow: encodes int96 flowRate against gdaForwarder.distributeFlow", async () => {
@@ -309,15 +324,22 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       flowRate: DUMMY_FLOW_RATE,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("connect-pool: encodes against gdaForwarder.connectPool", async () => {
+    // Not convertible to toBe(""): the GDA host calls into the pool
+    // address during connectPool, and TEST_ADDRESS has no contract code,
+    // so estimateGas reverts with `CallUtils: target revert()`. That is
+    // not a routing/ABI failure (revert data is non-empty), so it does
+    // not match DISPATCH_FAILURE_RE -- which is the assertion we want.
+    // Strengthening to toBe("") would need a real Superfluid pool address
+    // on Sepolia, out of scope for "no on-chain state dependency" tests.
     const msg = await estimateGasError("connect-pool", {
       pool: TEST_ADDRESS,
       userData: DUMMY_BYTES,
     });
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   // -- SuperToken writes (userSpecifiedAddress) ----------------------------
@@ -328,7 +350,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       { amount: DUMMY_AMOUNT_WEI },
       SEPOLIA_FUSDCX
     );
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("unwrap: encodes uint256 amount against superToken.downgrade", async () => {
@@ -337,7 +359,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       { amount: DUMMY_AMOUNT_WEI },
       SEPOLIA_FUSDCX
     );
-    expect(msg).not.toMatch(ENCODING_ERROR_RE);
+    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
   }, 15_000);
 
   it("grant-flow-operator: simulates successfully against cfaForwarder.updateFlowOperatorPermissions", async () => {
@@ -386,5 +408,49 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     const stale = [...tested].filter((s) => !declared.has(s));
     expect(missing).toEqual([]);
     expect(stale).toEqual([]);
+  });
+});
+
+// Not gated on RPC: validates the regex shape that the on-chain block above
+// relies on to catch routing regressions like KEEP-456 (calling into a
+// non-existent proxy returns no revert data). If someone tightens or relaxes
+// DISPATCH_FAILURE_RE without updating these samples, this fails -- the
+// regex itself is the load-bearing piece of the hardening; the on-chain
+// block can't exercise it without an actual routing bug to reproduce.
+describe("DISPATCH_FAILURE_RE shape", () => {
+  it("matches the `missing revert data` ethers v6 error shape", () => {
+    const sample =
+      'Error: missing revert data (action="estimateGas", data=null, reason=null, transaction={ "data": "0x...", "from": "0x...", "to": "0x..." }, invocation=null, revert=null, code=CALL_EXCEPTION, version=6.16.0)';
+    expect(sample).toMatch(DISPATCH_FAILURE_RE);
+  });
+
+  it('matches CALL_EXCEPTION with empty data="0x" (proxy returned no revert data)', () => {
+    const sample =
+      'Error: execution reverted (action="estimateGas", data="0x", reason=null, transaction={ "to": "0x..." }, code=CALL_EXCEPTION, version=6.16.0)';
+    expect(sample).toMatch(DISPATCH_FAILURE_RE);
+  });
+
+  it('does NOT misfire on `data="0x..."` with actual revert data', () => {
+    // Guards against the obvious regression of writing
+    // `/data="0x/` (no closing quote) which would match every revert.
+    const sample =
+      'Error: execution reverted: "X" (action="estimateGas", data="0x08c379a0deadbeef", code=CALL_EXCEPTION, version=6.16.0)';
+    expect(sample).not.toMatch(DISPATCH_FAILURE_RE);
+  });
+
+  it("matches ABI encoding errors (INVALID_ARGUMENT)", () => {
+    const sample =
+      'Error: invalid BigNumberish value (argument="value", value="abc", code=INVALID_ARGUMENT, version=6.16.0)';
+    expect(sample).toMatch(DISPATCH_FAILURE_RE);
+  });
+
+  it("does NOT match a normal business revert with populated revert data", () => {
+    // Real Sepolia revert from connect-pool against TEST_ADDRESS: the GDA
+    // calls into the "pool" address and gets a real revert string back.
+    // This is the failure mode we want to tolerate -- contract reached,
+    // protocol-level revert with data, not a routing/dispatch bug.
+    const sample =
+      'Error: execution reverted: "CallUtils: target revert()" (action="estimateGas", data="0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a43616c6c5574696c733a20746172676574207265766572742829000000000000", reason="CallUtils: target revert()", code=CALL_EXCEPTION, version=6.16.0)';
+    expect(sample).not.toMatch(DISPATCH_FAILURE_RE);
   });
 });


### PR DESCRIPTION
## Summary

Hardens `tests/integration/protocol-superfluid-onchain.test.ts` so the dispatch tests catch the class of routing bug KEEP-456 surfaced (calling into a non-existent SuperToken proxy returned a `CALL_EXCEPTION` with empty revert data, which the previous loose `.not.toMatch(ENCODING_ERROR_RE)` guard silently tolerated).

## Layered protection

Three layers of guard, each catching a different class of regression:

1. **Per-action assertions** (existing, tightened): `expect(msg).toBe("")` for actions that can simulate from `TEST_ADDRESS`, `expect(msg).not.toMatch(DISPATCH_FAILURE_RE)` for those that cannot.
2. **Regex shape tests** (new, always-on): synthesize real ethers errors via `ethers.makeError(...)` and assert `DISPATCH_FAILURE_RE` matches the dispatch-failure shapes and does not misfire on legitimate business reverts. Runs in CI without an RPC URL -- catches silent strengthening (someone tightening the regex past what real ethers errors look like).
3. **System-level reroute regression test** (new, RPC-gated): takes a currently-passing action (`grant-flow-operator`), overrides its destination to `SEPOLIA_FUSDC` (a real ERC20 with no Superfluid methods), and asserts the dispatch test catches it. Empirically verified to produce the KEEP-456 error shape on Sepolia. Catches silent weakening (someone removing `missing revert data` from the regex would let KEEP-456 through again).

Directly satisfies acceptance criterion #2 of KEEP-459: "no test passes when its action is silently re-routed to a non-existent contract method."

## Per-action assertion changes

- **`create-pool`**: converted to `expect(msg).toBe("")` -- verified to simulate successfully on Sepolia. GDA `createPool` only writes pool metadata, no sender balance required.
- **`connect-pool`**: kept on `.not.toMatch(DISPATCH_FAILURE_RE)`. Experimentally converting it to `toBe("")` failed: the GDA dispatches into the pool address as a contract call, and `TEST_ADDRESS` has no deployed code, so estimateGas reverts with `CallUtils: target revert()` (a real revert with data -- not a routing failure). Strengthening would need a deployed pool contract.
- **`wrap`, `unwrap`, `create-flow`, `update-flow`, `delete-flow`, `distribute`, `distribute-flow`, `update-member-units`**: tightened to `.not.toMatch(DISPATCH_FAILURE_RE)`. These cannot be converted to `toBe("")` -- they need real on-chain state (token balance, existing flow, real pool, pool admin) that `TEST_ADDRESS` does not have.
- **`grant-flow-operator`**: unchanged (`toBe("")` from KEEP-456).

## Regex design

The final regex:

```ts
const DISPATCH_FAILURE_RE =
  /INVALID_ARGUMENT|could not decode|invalid function|missing revert data|,\s*data="0x"/;
```

The `,\s*data="0x"` alternation requires the top-level CALL_EXCEPTION field separator, so the pattern matches only the precise empty-revert-data field at the top of the error -- not a nested transaction's `"data": "0x..."` (JSON uses `"key": value`, not `key=value`).

## Deviation from the ticket

The ticket's suggested middle-ground `/missing revert data|CALL_EXCEPTION.*data="0x"/` is **order-dependent** and does not match real ethers v6 error strings, where `data=` comes before `code=CALL_EXCEPTION`. Caught by the regex shape tests during development. Replaced with the order-independent anchor above.

## Test plan

- [x] With RPC (`INTEGRATION_TEST_RPC_URL=<sepolia>`): **24/24** pass (17 on-chain action tests + 6 regex shape tests + 1 system-level reroute regression).
- [x] Without RPC (CI scenario): 6 regex shape tests run and pass, 18 on-chain skipped.
- [x] Coverage assertion ("every declared action has at least one dispatch test") stays green.
- [x] No new type or lint errors in the modified file.
- [x] Empirically verified `create-pool` and `connect-pool` behavior on Sepolia (the ticket's "likely yes / verify" hedges).
- [x] Empirically verified the reroute regression test produces the KEEP-456 error shape on Sepolia.

## Out of scope

- Equivalent audit for Aave / Uniswap / CCIP dispatch tests (separate tickets per ticket's "Out of scope").
- Per-action revert allowlists -- the universal "non-empty revert" guard satisfies the ticket's minimum acceptance criterion and is robust to Superfluid version churn. Tightening to per-action allowlists can come later when someone owns the revert vocabulary.

## Commits

1. `test: harden on-chain dispatch assertions against routing regressions` -- initial hardening.
2. `docs: clarify connect-pool comment` -- review nit.
3. `test: synthesize real ethers errors for regex shape tests` -- replaces hardcoded ethers v6.16.0 sample strings with `ethers.makeError(...)` calls so the test stays valid across ethers upgrades.
4. `test: anchor data="0x" regex to top-level revert context` -- defense-in-depth against false-matches on nested JSON.
5. `test: add system-level reroute regression test` -- end-to-end proof against the KEEP-456 failure mode.