### PR TITLE
fix: TECH-6417 Show org name in the log

### DIFF
--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -17,7 +17,11 @@ import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
-import { getOrgName, getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
+import {
+  getOrgIdentity,
+  getOrgPlanLabel,
+  getOrgSlug,
+} from "@/lib/db/org-helpers";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 type ValidateApiKeyResult = {
@@ -268,18 +272,15 @@ export async function POST(
 
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
-      const [blockedOrgSlug, blockedOrgName] = await Promise.all([
-        getOrgSlug(workflow.organizationId),
-        getOrgName(workflow.organizationId),
-      ]);
+      const blockedOrg = await getOrgIdentity(workflow.organizationId);
       recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 429,
         error: EXECUTION_LIMIT_ERROR,
         orgId: workflow.organizationId,
-        orgSlug: blockedOrgSlug,
-        orgName: blockedOrgName,
+        orgSlug: blockedOrg.slug,
+        orgName: blockedOrg.name,
       });
       const body = await executionGuard.response.json();
       return NextResponse.json(body, {

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -17,7 +17,7 @@ import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
-import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
+import { getOrgName, getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 type ValidateApiKeyResult = {
@@ -268,11 +268,18 @@ export async function POST(
 
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
+      const [blockedOrgSlug, blockedOrgName] = await Promise.all([
+        getOrgSlug(workflow.organizationId),
+        getOrgName(workflow.organizationId),
+      ]);
       recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 429,
         error: EXECUTION_LIMIT_ERROR,
+        orgId: workflow.organizationId,
+        orgSlug: blockedOrgSlug,
+        orgName: blockedOrgName,
       });
       const body = await executionGuard.response.json();
       return NextResponse.json(body, {

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -17,11 +17,7 @@ import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
-import {
-  getOrgIdentity,
-  getOrgPlanLabel,
-  getOrgSlug,
-} from "@/lib/db/org-helpers";
+import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 type ValidateApiKeyResult = {
@@ -123,14 +119,14 @@ const corsHeaders = {
  * metric in one call. Covers the simple-error gates (404, 410, 401, 403, 400,
  * 500). The two 429 variants have custom response bodies and stay inline.
  */
-function failResponse(
+async function failResponse(
   workflowId: string,
   timer: () => number,
   statusCode: number,
   message: string,
   extraBody?: Record<string, unknown>
-): NextResponse {
-  recordWebhookMetrics({
+): Promise<NextResponse> {
+  await recordWebhookMetrics({
     workflowId,
     durationMs: timer(),
     statusCode,
@@ -272,15 +268,12 @@ export async function POST(
 
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
-      const blockedOrg = await getOrgIdentity(workflow.organizationId);
-      recordWebhookMetrics({
+      await recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 429,
         error: EXECUTION_LIMIT_ERROR,
-        orgId: workflow.organizationId,
-        orgSlug: blockedOrg.slug,
-        orgName: blockedOrg.name,
+        organizationId: workflow.organizationId,
       });
       const body = await executionGuard.response.json();
       return NextResponse.json(body, {
@@ -291,11 +284,12 @@ export async function POST(
 
     const concurrencyCheck = await checkConcurrencyLimit();
     if (!concurrencyCheck.allowed) {
-      recordWebhookMetrics({
+      await recordWebhookMetrics({
         workflowId,
         durationMs: timer(),
         statusCode: 429,
         error: "Too many concurrent workflow executions",
+        organizationId: workflow.organizationId,
       });
       return NextResponse.json(
         {
@@ -349,7 +343,7 @@ export async function POST(
       organizationPlan
     );
 
-    recordWebhookMetrics({
+    await recordWebhookMetrics({
       workflowId,
       executionId: execution.id,
       durationMs: timer(),

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -32,6 +32,29 @@ export const getOrgSlug = cache(
 );
 
 /**
+ * Resolve an organization's display name by id. Cached per request. Same
+ * best-effort semantics as `getOrgSlug` - used as a human-readable identifier
+ * in error logs alongside `org_id`.
+ */
+export const getOrgName = cache(
+  async (orgId: string | null | undefined): Promise<string | undefined> => {
+    if (!orgId) {
+      return undefined;
+    }
+    try {
+      const rows = await db
+        .select({ name: organization.name })
+        .from(organization)
+        .where(eq(organization.id, orgId))
+        .limit(1);
+      return rows[0]?.name ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }
+);
+
+/**
  * Resolve an organization's plan by id. Cached per request. Returns "free"
  * when the org has no subscription row, undefined when the lookup fails or
  * orgId is missing. Used as a low-cardinality label on error metrics so

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -32,24 +32,34 @@ export const getOrgSlug = cache(
 );
 
 /**
- * Resolve an organization's display name by id. Cached per request. Same
- * best-effort semantics as `getOrgSlug` - used as a human-readable identifier
- * in error logs alongside `org_id`.
+ * Resolve an organization's slug and display name in a single round-trip.
+ * Cached per request via React `cache()`. Same best-effort semantics as
+ * `getOrgSlug` - a failed lookup yields `{}` rather than throwing, so a
+ * metric label resolution can never break the calling request.
  */
-export const getOrgName = cache(
-  async (orgId: string | null | undefined): Promise<string | undefined> => {
+export const getOrgIdentity = cache(
+  async (
+    orgId: string | null | undefined
+  ): Promise<{ slug?: string; name?: string }> => {
     if (!orgId) {
-      return undefined;
+      return {};
     }
     try {
       const rows = await db
-        .select({ name: organization.name })
+        .select({ slug: organization.slug, name: organization.name })
         .from(organization)
         .where(eq(organization.id, orgId))
         .limit(1);
-      return rows[0]?.name ?? undefined;
+      const row = rows[0];
+      if (!row) {
+        return {};
+      }
+      return {
+        slug: row.slug ?? undefined,
+        name: row.name ?? undefined,
+      };
     } catch {
-      return undefined;
+      return {};
     }
   }
 );

--- a/lib/metrics/instrumentation/api.ts
+++ b/lib/metrics/instrumentation/api.ts
@@ -4,29 +4,33 @@
  * Helper functions to instrument API routes with golden signal metrics.
  */
 
+import { getOrgIdentity } from "@/lib/db/org-helpers";
 import { getMetricsCollector } from "../index";
 import { LabelKeys, MetricNames } from "../types";
 
 /**
  * Record webhook trigger metrics.
  *
- * Optional org identifiers (`orgId`, `orgSlug`, `orgName`) are attached as
+ * When `organizationId` is supplied and the request is a failure, the org's
+ * slug and display name are resolved via `getOrgIdentity` and attached as
  * labels on the emitted `api.errors.total` event. They show up in the console
  * JSON log (shipped to Loki) so operators can identify which organization
  * triggered a failure response. `org_id` and `org_name` are dropped from the
  * Prometheus counter via the metric allowlist to keep cardinality bounded;
  * `org_slug` is allowlisted and becomes a Prometheus label.
+ *
+ * The org lookup runs only on the failure path (after the latency metric is
+ * already recorded) and only when an `organizationId` is supplied, so success
+ * and pre-auth failure call sites pay no DB cost.
  */
-export function recordWebhookMetrics(options: {
+export async function recordWebhookMetrics(options: {
   workflowId: string;
   executionId?: string;
   durationMs: number;
   statusCode: number;
   error?: string;
-  orgId?: string | null;
-  orgSlug?: string;
-  orgName?: string;
-}): void {
+  organizationId?: string | null;
+}): Promise<void> {
   const metrics = getMetricsCollector();
   const success = options.statusCode < 400;
 
@@ -46,14 +50,16 @@ export function recordWebhookMetrics(options: {
       [LabelKeys.ENDPOINT]: "webhook",
       [LabelKeys.STATUS_CODE]: String(options.statusCode),
     };
-    if (options.orgId) {
-      errorLabels[LabelKeys.ORG_ID] = options.orgId;
-    }
-    if (options.orgSlug) {
-      errorLabels[LabelKeys.ORG_SLUG] = options.orgSlug;
-    }
-    if (options.orgName) {
-      errorLabels[LabelKeys.ORG_NAME] = options.orgName;
+
+    if (options.organizationId) {
+      errorLabels[LabelKeys.ORG_ID] = options.organizationId;
+      const { slug, name } = await getOrgIdentity(options.organizationId);
+      if (slug) {
+        errorLabels[LabelKeys.ORG_SLUG] = slug;
+      }
+      if (name) {
+        errorLabels[LabelKeys.ORG_NAME] = name;
+      }
     }
 
     metrics.recordError(

--- a/lib/metrics/instrumentation/api.ts
+++ b/lib/metrics/instrumentation/api.ts
@@ -8,7 +8,14 @@ import { getMetricsCollector } from "../index";
 import { LabelKeys, MetricNames } from "../types";
 
 /**
- * Record webhook trigger metrics
+ * Record webhook trigger metrics.
+ *
+ * Optional org identifiers (`orgId`, `orgSlug`, `orgName`) are attached as
+ * labels on the emitted `api.errors.total` event. They show up in the console
+ * JSON log (shipped to Loki) so operators can identify which organization
+ * triggered a failure response. `org_id` and `org_name` are dropped from the
+ * Prometheus counter via the metric allowlist to keep cardinality bounded;
+ * `org_slug` is allowlisted and becomes a Prometheus label.
  */
 export function recordWebhookMetrics(options: {
   workflowId: string;
@@ -16,6 +23,9 @@ export function recordWebhookMetrics(options: {
   durationMs: number;
   statusCode: number;
   error?: string;
+  orgId?: string | null;
+  orgSlug?: string;
+  orgName?: string;
 }): void {
   const metrics = getMetricsCollector();
   const success = options.statusCode < 400;
@@ -32,13 +42,24 @@ export function recordWebhookMetrics(options: {
   );
 
   if (!success && options.error) {
+    const errorLabels: Record<string, string> = {
+      [LabelKeys.ENDPOINT]: "webhook",
+      [LabelKeys.STATUS_CODE]: String(options.statusCode),
+    };
+    if (options.orgId) {
+      errorLabels[LabelKeys.ORG_ID] = options.orgId;
+    }
+    if (options.orgSlug) {
+      errorLabels[LabelKeys.ORG_SLUG] = options.orgSlug;
+    }
+    if (options.orgName) {
+      errorLabels[LabelKeys.ORG_NAME] = options.orgName;
+    }
+
     metrics.recordError(
       MetricNames.API_ERRORS_TOTAL,
       { message: options.error },
-      {
-        [LabelKeys.ENDPOINT]: "webhook",
-        [LabelKeys.STATUS_CODE]: String(options.statusCode),
-      }
+      errorLabels
     );
   }
 }

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -164,6 +164,7 @@ export const LabelKeys = {
   EXECUTION_ID: "execution_id",
   ORG_ID: "org_id",
   ORG_SLUG: "org_slug",
+  ORG_NAME: "org_name",
   PLAN: "plan",
   OWNER_ID: "owner_id",
   PLUGIN_ID: "plugin_id",

--- a/tests/unit/api-metrics.test.ts
+++ b/tests/unit/api-metrics.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetMetricsCollector, setMetricsCollector } from "@/lib/metrics";
 import { getOrgIdentity } from "@/lib/db/org-helpers";
+import { resetMetricsCollector, setMetricsCollector } from "@/lib/metrics";
 import {
   recordStatusPollMetrics,
   recordWebhookMetrics,

--- a/tests/unit/api-metrics.test.ts
+++ b/tests/unit/api-metrics.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetMetricsCollector, setMetricsCollector } from "@/lib/metrics";
+import { getOrgIdentity } from "@/lib/db/org-helpers";
 import {
   recordStatusPollMetrics,
   recordWebhookMetrics,
 } from "@/lib/metrics/instrumentation/api";
 import { MetricNames, type MetricsCollector } from "@/lib/metrics/types";
 import { createMockMetricsCollector } from "../mocks/metrics";
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  getOrgIdentity: vi.fn(),
+}));
 
 describe("API Metrics Instrumentation", () => {
   let mockCollector: MetricsCollector;
@@ -16,6 +21,8 @@ describe("API Metrics Instrumentation", () => {
 
     mockCollector = createMockMetricsCollector();
     setMetricsCollector(mockCollector);
+
+    vi.mocked(getOrgIdentity).mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -24,8 +31,8 @@ describe("API Metrics Instrumentation", () => {
   });
 
   describe("recordWebhookMetrics", () => {
-    it("should record successful webhook trigger", () => {
-      recordWebhookMetrics({
+    it("should record successful webhook trigger", async () => {
+      await recordWebhookMetrics({
         workflowId: "wf_123",
         executionId: "exec_456",
         durationMs: 45,
@@ -44,8 +51,8 @@ describe("API Metrics Instrumentation", () => {
       expect(mockCollector.recordError).not.toHaveBeenCalled();
     });
 
-    it("should record failed webhook trigger with error", () => {
-      recordWebhookMetrics({
+    it("should record failed webhook trigger with error", async () => {
+      await recordWebhookMetrics({
         workflowId: "wf_123",
         durationMs: 100,
         statusCode: 401,
@@ -71,17 +78,21 @@ describe("API Metrics Instrumentation", () => {
       );
     });
 
-    it("should include org labels on failure when provided", () => {
-      recordWebhookMetrics({
+    it("should resolve and attach org labels when organizationId provided", async () => {
+      vi.mocked(getOrgIdentity).mockResolvedValueOnce({
+        slug: "acme-corp",
+        name: "Acme Corp",
+      });
+
+      await recordWebhookMetrics({
         workflowId: "wf_123",
         durationMs: 100,
         statusCode: 429,
         error: "Execution limit reached",
-        orgId: "org_abc",
-        orgSlug: "acme-corp",
-        orgName: "Acme Corp",
+        organizationId: "org_abc",
       });
 
+      expect(getOrgIdentity).toHaveBeenCalledWith("org_abc");
       expect(mockCollector.recordError).toHaveBeenCalledWith(
         MetricNames.API_ERRORS_TOTAL,
         { message: "Execution limit reached" },
@@ -95,17 +106,40 @@ describe("API Metrics Instrumentation", () => {
       );
     });
 
-    it("should omit org labels on failure when not provided", () => {
-      recordWebhookMetrics({
+    it("should omit org labels and skip lookup when organizationId not provided", async () => {
+      await recordWebhookMetrics({
         workflowId: "wf_123",
         durationMs: 100,
         statusCode: 401,
         error: "Invalid API key",
       });
 
+      expect(getOrgIdentity).not.toHaveBeenCalled();
       const labels = (mockCollector.recordError as ReturnType<typeof vi.fn>)
         .mock.calls[0][2];
       expect(labels).not.toHaveProperty("org_id");
+      expect(labels).not.toHaveProperty("org_slug");
+      expect(labels).not.toHaveProperty("org_name");
+    });
+
+    it("should attach only org_id when identity lookup yields nothing", async () => {
+      vi.mocked(getOrgIdentity).mockResolvedValueOnce({});
+
+      await recordWebhookMetrics({
+        workflowId: "wf_123",
+        durationMs: 100,
+        statusCode: 429,
+        error: "Execution limit reached",
+        organizationId: "org_abc",
+      });
+
+      const labels = (mockCollector.recordError as ReturnType<typeof vi.fn>)
+        .mock.calls[0][2];
+      expect(labels).toMatchObject({
+        endpoint: "webhook",
+        status_code: "429",
+        org_id: "org_abc",
+      });
       expect(labels).not.toHaveProperty("org_slug");
       expect(labels).not.toHaveProperty("org_name");
     });

--- a/tests/unit/api-metrics.test.ts
+++ b/tests/unit/api-metrics.test.ts
@@ -70,6 +70,45 @@ describe("API Metrics Instrumentation", () => {
         })
       );
     });
+
+    it("should include org labels on failure when provided", () => {
+      recordWebhookMetrics({
+        workflowId: "wf_123",
+        durationMs: 100,
+        statusCode: 429,
+        error: "Execution limit reached",
+        orgId: "org_abc",
+        orgSlug: "acme-corp",
+        orgName: "Acme Corp",
+      });
+
+      expect(mockCollector.recordError).toHaveBeenCalledWith(
+        MetricNames.API_ERRORS_TOTAL,
+        { message: "Execution limit reached" },
+        expect.objectContaining({
+          endpoint: "webhook",
+          status_code: "429",
+          org_id: "org_abc",
+          org_slug: "acme-corp",
+          org_name: "Acme Corp",
+        })
+      );
+    });
+
+    it("should omit org labels on failure when not provided", () => {
+      recordWebhookMetrics({
+        workflowId: "wf_123",
+        durationMs: 100,
+        statusCode: 401,
+        error: "Invalid API key",
+      });
+
+      const labels = (mockCollector.recordError as ReturnType<typeof vi.fn>)
+        .mock.calls[0][2];
+      expect(labels).not.toHaveProperty("org_id");
+      expect(labels).not.toHaveProperty("org_slug");
+      expect(labels).not.toHaveProperty("org_name");
+    });
   });
 
   describe("recordStatusPollMetrics", () => {


### PR DESCRIPTION
## Summary

Adds `org_id`, `org_slug`, and `org_name` labels to the `api.errors.total` event emitted when a webhook trigger is rejected by the monthly execution limit. Previously the log only carried `endpoint`, `status_code`, and `error_message`, leaving infra unable to identify which organization hit the quota when an alert fired. The new labels appear in the Loki log for human drill-down while keeping Prometheus cardinality bounded (only `org_slug` is allowlisted into the Prometheus counter; `org_id` and `org_name` stay log-only).

## What Changed

- **Metrics instrumentation** (`lib/metrics/instrumentation/api.ts`): `recordWebhookMetrics` now accepts optional `orgId`, `orgSlug`, `orgName` and attaches them as labels on the emitted `api.errors.total` counter. Signature change is backward-compatible — all new fields are optional.
- **Label registry** (`lib/metrics/types.ts`): added `ORG_NAME: "org_name"` to `LabelKeys` so the new label has a canonical constant.
- **Org helpers** (`lib/db/org-helpers.ts`): added a `getOrgName` helper, mirroring the existing `getOrgSlug` (per-request `cache()`, best-effort, returns `undefined` on lookup failure so a metric never breaks the calling request).
- **Webhook route** (`app/api/workflows/[workflowId]/webhook/route.ts`): on the `EXECUTION_LIMIT_ERROR` 429 branch, fetches slug + name in parallel and forwards `orgId`, `orgSlug`, `orgName` into `recordWebhookMetrics`. The lookup runs only on the failure path, so the happy path is unaffected.


## Notes

- Cardinality: `org_id` and `org_name` are intentionally not in the `api.errors.total` Prometheus allowlist
(`lib/metrics/collectors/prometheus.ts`), so the counter remains low-cardinality. Both fields are visible in the console JSON log (Loki). `org_slug` is allowlisted and does become a Prometheus label — same as elsewhere in the codebase.
- Scope: this PR only updates the `EXECUTION_LIMIT_ERROR` call site. The other three `recordWebhookMetrics` call sites in the same file (`failResponse` helper, concurrency-limit branch, success branch) still pass no org info. Easy follow-up if we want consistent labels across all webhook events — left out here to keep the change focused.
- Tests in `tests/unit/api-metrics.test.ts` and `tests/integration/webhook-route.test.ts` reference `recordWebhookMetrics`. Existing assertions should continue to pass since new params are optional; worth a quick eyeball during review.

## Test Plan

- [x] CI Green