### PR TITLE
feat: add per-(trigger_type, chain) execution counter and X-Trigger-Type plumbing

### DIFF
--- a/.github/workflows/db-prep-check.yml
+++ b/.github/workflows/db-prep-check.yml
@@ -1,0 +1,94 @@
+name: DB Prep Check
+
+# Blocks merge of PRs that introduce a migration containing the
+# `-- @requires-db-prep` directive until the matching
+# `db-prepped-<base-branch>` label is set.
+#
+# Use case: a migration whose SQL is safe to run on a fresh / small DB
+# (dev, PR environments, CI) but requires a manual pre-step on the real
+# target DB - typically `CREATE INDEX CONCURRENTLY` against a large hot
+# table, which drizzle-kit cannot run because it wraps each migration in
+# a transaction.
+#
+# Workflow:
+#   1. PR author writes the migration with plain CREATE INDEX IF NOT
+#      EXISTS and adds `-- @requires-db-prep` on line 1.
+#   2. This workflow detects the directive in any newly-added migration
+#      and fails until the right label is present.
+#   3. An operator (DBA / on-call) applies the CONCURRENTLY-equivalent
+#      statements to the target DB via psql, then adds the label.
+#   4. Merge unblocks. The deploy's drizzle-kit migrate runs the plain
+#      CREATE INDEX which becomes a no-op via IF NOT EXISTS.
+#
+# Triggers on `labeled` / `unlabeled` so the status check updates the
+# instant the operator flips the label.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - staging
+      - prod
+      - main
+
+jobs:
+  db-prep-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect @requires-db-prep migrations added in this PR
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          REQUIRES_PREP=false
+          REPORTED_FILES=""
+
+          # Only inspect files added or modified in this PR under drizzle/
+          # whose name matches a migration (NNNN_*.sql).
+          while IFS= read -r f; do
+            if [ -z "$f" ]; then
+              continue
+            fi
+            if [ ! -f "$f" ]; then
+              continue
+            fi
+            # Match on the directive anywhere in the first 5 lines so the
+            # check survives a top-of-file comment block above it.
+            if head -n 5 "$f" | grep -qE '^[[:space:]]*--[[:space:]]*@requires-db-prep([[:space:]]|$)'; then
+              REQUIRES_PREP=true
+              REPORTED_FILES="$REPORTED_FILES $f"
+            fi
+          done < <(git diff --name-only --diff-filter=AM "$BASE_SHA...$HEAD_SHA" -- 'drizzle/*.sql')
+
+          echo "requires_prep=$REQUIRES_PREP" >> "$GITHUB_OUTPUT"
+          echo "files=$REPORTED_FILES" >> "$GITHUB_OUTPUT"
+
+      - name: Verify db-prepped-<branch> label is present
+        if: steps.detect.outputs.requires_prep == 'true'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          FILES: ${{ steps.detect.outputs.files }}
+        run: |
+          set -euo pipefail
+          REQUIRED_LABEL="db-prepped-$BASE_REF"
+          if printf '%s' "$LABELS_JSON" | jq -e --arg L "$REQUIRED_LABEL" 'any(. == $L)' >/dev/null; then
+            echo "Label '$REQUIRED_LABEL' is set. Migration prep confirmed."
+            exit 0
+          fi
+
+          echo "::error::Migration(s) with the '@requires-db-prep' directive are in this PR:$FILES"
+          echo "::error::Required label '$REQUIRED_LABEL' is NOT set."
+          echo "::error::Operator runbook: apply each statement in the affected migration(s) against the '$BASE_REF' database with CREATE INDEX CONCURRENTLY (or the equivalent lock-free form), verify no INVALID indexes were left behind, then add the '$REQUIRED_LABEL' label to this PR."
+          exit 1
+
+      - name: No DB prep required
+        if: steps.detect.outputs.requires_prep != 'true'
+        run: echo "No '@requires-db-prep' migrations in this PR; check passes."

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -14,6 +14,7 @@ jobs:
       should-test: ${{ steps.check.outputs.should-test }}
       should-deploy-events: ${{ steps.check.outputs.should-deploy-events }}
       should-deploy-events-only: ${{ steps.check.outputs.should-deploy-events-only }}
+      should-build-executor: ${{ steps.check.outputs.should-build-executor }}
     steps:
       - name: Checkout code (for change detection)
         if: github.event.action == 'synchronize'
@@ -28,6 +29,7 @@ jobs:
           echo "should-test=false" >> $GITHUB_OUTPUT
           echo "should-deploy-events=false" >> $GITHUB_OUTPUT
           echo "should-deploy-events-only=false" >> $GITHUB_OUTPUT
+          echo "should-build-executor=false" >> $GITHUB_OUTPUT
 
           HAS_DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-environment') }}"
           HAS_TEST_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-pr-deploy') }}"
@@ -36,6 +38,12 @@ jobs:
           # namespace created by deploy-pr-environment, so it has no meaning
           # without that label. See KEEP-325.
           HAS_EVENTS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-events') }}"
+          # Executor PR build is opt-in alongside deploy-pr-environment, same
+          # pattern as deploy-pr-events. The PR env always deploys an executor
+          # (using executor-latest by default) so SQS messages from the PR's
+          # dispatchers are consumed; this label adds a PR-specific build for
+          # ticket-driven validation. See KEEP-556.
+          HAS_EXECUTOR_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-executor') }}"
           ACTION="${{ github.event.action }}"
           ADDED_LABEL="${{ github.event.label.name }}"
 
@@ -48,8 +56,25 @@ jobs:
               if [[ "$HAS_EVENTS_LABEL" == "true" ]]; then
                 echo "should-deploy-events=true" >> $GITHUB_OUTPUT
               fi
+              if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
+                echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
             elif [[ "$ADDED_LABEL" == "run-e2e-tests-pr-deploy" ]]; then
               echo "should-test=true" >> $GITHUB_OUTPUT
+            elif [[ "$ADDED_LABEL" == "deploy-pr-executor" ]]; then
+              # Executor-only path: PR env is already deployed. Build a PR
+              # executor image and redeploy just that satellite. Cheaper than
+              # re-running the full app+migrator deploy.
+              if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-build-executor=true" >> $GITHUB_OUTPUT
+                echo "should-deploy=true" >> $GITHUB_OUTPUT
+                if [[ "$HAS_EVENTS_LABEL" == "true" ]]; then
+                  echo "should-deploy-events=true" >> $GITHUB_OUTPUT
+                fi
+                if [[ "$HAS_TEST_LABEL" == "true" ]]; then
+                  echo "should-test=true" >> $GITHUB_OUTPUT
+                fi
+              fi
             elif [[ "$ADDED_LABEL" == "deploy-pr-events" ]]; then
               # Events-only path: PR env is already deployed (HAS_DEPLOY_LABEL).
               # Build a PR-specific events image and only re-run the events
@@ -93,6 +118,9 @@ jobs:
               echo "should-deploy=true" >> $GITHUB_OUTPUT
               if [[ "$HAS_EVENTS_LABEL" == "true" ]]; then
                 echo "should-deploy-events=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
+                echo "should-build-executor=true" >> $GITHUB_OUTPUT
               fi
             fi
             # Run tests if both labels present (even without deploy)
@@ -247,8 +275,81 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EVENTS_ECR_NAME }}:cache-pr
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EVENTS_ECR_NAME }}:cache-pr,mode=max
 
+  # Builds a PR-specific executor image when the deploy-pr-executor label is
+  # present alongside deploy-pr-environment. Without it, the PR environment
+  # always deploys an executor anyway (using the executor-latest staging tag),
+  # so the PR's SQS messages get consumed; this job only builds a sha-tagged
+  # image so the executor running in the PR env is bit-identical to the PR
+  # commit (needed for end-to-end validation of executor-side changes, e.g.
+  # the KEEP-556 counter increment).
+  # Pushes only executor-${sha_short} - never executor-latest, so concurrent
+  # staging deploys are unaffected.
+  build-executor-image:
+    needs: check-labels
+    if: needs.check-labels.outputs.should-build-executor == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      EXECUTOR_ECR_NAME: keeperhub-executor-staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if executor image exists
+        id: check-image
+        run: |
+          IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
+          if aws ecr describe-images \
+            --repository-name ${{ env.EXECUTOR_ECR_NAME }} \
+            --image-ids imageTag=executor-${IMAGE_TAG} \
+            --region ${{ env.REGION }} >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push executor image
+        if: steps.check-image.outputs.exists != 'true'
+        # Read from staging cache (warm start) and PR cache, but only write to
+        # :cache-pr. Prevents PR builds from poisoning the staging :cache layer
+        # used by deploy-executor.yaml.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: executor
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:executor-${{ steps.vars.outputs.sha_short }}
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr,mode=max
+
   deploy:
-    needs: [check-labels, build-images, build-events-image]
+    needs: [check-labels, build-images, build-events-image, build-executor-image]
     # Cannot use the `success()` shorthand here because GHA evaluates it
     # as false whenever ANY needed job is skipped. build-events-image is
     # skipped on purpose for PRs without the deploy-pr-events label, so
@@ -260,7 +361,8 @@ jobs:
       !cancelled() &&
       needs.check-labels.outputs.should-deploy == 'true' &&
       needs.build-images.result == 'success' &&
-      (needs.build-events-image.result == 'success' || needs.build-events-image.result == 'skipped')
+      (needs.build-events-image.result == 'success' || needs.build-events-image.result == 'skipped') &&
+      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped')
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -398,6 +500,12 @@ jobs:
           # (build-events-image job ran). Otherwise stays on the staging
           # event-latest tag.
           EVENTS_IMAGE_TAG: ${{ needs.check-labels.outputs.should-deploy-events == 'true' && format('event-{0}', steps.vars.outputs.sha_short) || 'event-latest' }}
+          # PR-specific executor image tag if deploy-pr-executor label was set
+          # (build-executor-image job ran). Otherwise stays on executor-latest
+          # so the PR env still has a working SQS consumer for schedule / block
+          # / event triggers. The template prepends "executor-" itself, so we
+          # set only the bare tag here (matches the {{IMAGE_TAG}} pattern).
+          EXECUTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-build-executor == 'true' && steps.vars.outputs.sha_short || 'latest' }}
         run: |
           # Percent-encode DB_PASSWORD so base64 characters (+/=) don't break URL parsing
           # in the pod. Init containers previously encoded at runtime but that path was
@@ -409,6 +517,7 @@ jobs:
           envsubst < deploy/pr-environment/scheduler-dispatcher.template.yaml > ${{ github.workspace }}/schedule-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/block-dispatcher.template.yaml > ${{ github.workspace }}/block-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/event-tracker.template.yaml > ${{ github.workspace }}/event-pr-${{ env.PR_NUMBER }}.yaml
+          envsubst < deploy/pr-environment/executor.template.yaml > ${{ github.workspace }}/executor-pr-${{ env.PR_NUMBER }}.yaml
 
       - name: Clean up stale Helm releases
         run: |
@@ -460,8 +569,16 @@ jobs:
           ) > "${LOGDIR}/event.log" 2>&1 &
           PID3=$!
 
+          (
+            helm upgrade --install executor-pr-${PR_NUMBER} \
+              techops-services/common \
+              -f ${GITHUB_WORKSPACE}/executor-pr-${PR_NUMBER}.yaml \
+              "${COMMON_ARGS[@]}"
+          ) > "${LOGDIR}/executor.log" 2>&1 &
+          PID4=$!
+
           FAILED=0
-          for COMPONENT in schedule:$PID1 block:$PID2 event:$PID3; do
+          for COMPONENT in schedule:$PID1 block:$PID2 event:$PID3 executor:$PID4; do
             NAME="${COMPONENT%%:*}"
             PID="${COMPONENT##*:}"
             if wait "$PID"; then

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -5,7 +5,7 @@ import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { getMetricsCollector } from "@/lib/metrics";
-import { LabelKeys, MetricNames } from "@/lib/metrics/types";
+import { isTriggerType, LabelKeys, MetricNames, type TriggerType } from "@/lib/metrics/types";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { db } from "@/lib/db";
@@ -216,12 +216,22 @@ export async function POST(
       console.log("[API] Created execution:", executionId);
     }
 
-    // Record workflow execution metric in API process (workflow runs in separate context)
-    const triggerType = isInternalExecution ? "scheduled" : "manual";
+    // Record per-(trigger_type, chain) start of a workflow execution. Drives the
+    // Grafana "zero executions in N min" alert family (see KEEP-556). The trigger
+    // type is carried by the caller via the X-Trigger-Type header so we can tell
+    // block vs schedule vs event apart on internal calls; we fall back to the
+    // legacy "scheduled" / "manual" defaults if the header is absent or invalid.
+    const headerTrigger = request.headers.get("x-trigger-type");
+    const triggerType: TriggerType = isTriggerType(headerTrigger)
+      ? headerTrigger
+      : isInternalExecution
+        ? "scheduled"
+        : "manual";
+    const chainLabel = workflow.chain ?? "_unknown";
     const metrics = getMetricsCollector();
-    metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_TOTAL, {
+    metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL, {
       [LabelKeys.TRIGGER_TYPE]: triggerType,
-      [LabelKeys.WORKFLOW_ID]: workflowId,
+      [LabelKeys.CHAIN]: chainLabel,
     });
 
     // Resolve org slug + plan for log labels (cached per request)

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -179,6 +179,11 @@ export async function POST(
     // Check if executionId was provided (for scheduled executions)
     // This allows the executor to pre-create the execution record
     let executionId = body.executionId;
+    // Whether this request created the workflow_executions row itself, vs.
+    // reusing one that the executor pre-created. The KEEP-556 counter only
+    // increments here when we created the row, so the executor-side increment
+    // and this one never double-count.
+    let createdHere = false;
 
     if (executionId) {
       // Verify execution exists and is in running state
@@ -199,6 +204,7 @@ export async function POST(
           input,
         });
         console.log("[API] Created execution with provided ID:", executionId);
+        createdHere = true;
       }
     } else {
       // Create new execution record
@@ -214,25 +220,30 @@ export async function POST(
 
       executionId = execution.id;
       console.log("[API] Created execution:", executionId);
+      createdHere = true;
     }
 
     // Record per-(trigger_type, chain) start of a workflow execution. Drives the
-    // Grafana "zero executions in N min" alert family (see KEEP-556). The trigger
-    // type is carried by the caller via the X-Trigger-Type header so we can tell
-    // block vs schedule vs event apart on internal calls; we fall back to the
-    // legacy "scheduled" / "manual" defaults if the header is absent or invalid.
-    const headerTrigger = request.headers.get("x-trigger-type");
-    const triggerType: TriggerType = isTriggerType(headerTrigger)
-      ? headerTrigger
-      : isInternalExecution
-        ? "scheduled"
-        : "manual";
-    const chainLabel = workflow.chain ?? "_unknown";
-    const metrics = getMetricsCollector();
-    metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL, {
-      [LabelKeys.TRIGGER_TYPE]: triggerType,
-      [LabelKeys.CHAIN]: chainLabel,
-    });
+    // Grafana "zero executions in N min" alert family (see KEEP-556). The
+    // trigger type is carried by the caller via the X-Trigger-Type header so
+    // internal callers can mark precise sources (block / schedule / event); we
+    // fall back to the legacy "scheduled" / "manual" defaults if the header is
+    // absent or invalid. Skipped when the executor pre-created the row - it
+    // already incremented on its side in that case.
+    if (createdHere) {
+      const headerTrigger = request.headers.get("x-trigger-type");
+      const triggerType: TriggerType = isTriggerType(headerTrigger)
+        ? headerTrigger
+        : isInternalExecution
+          ? "scheduled"
+          : "manual";
+      const chainLabel = workflow.chain ?? "_unknown";
+      const metrics = getMetricsCollector();
+      metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL, {
+        [LabelKeys.TRIGGER_TYPE]: triggerType,
+        [LabelKeys.CHAIN]: chainLabel,
+      });
+    }
 
     // Resolve org slug + plan for log labels (cached per request)
     const [organizationSlug, organizationPlan] = await Promise.all([

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -317,11 +317,12 @@ export async function POST(
 
     console.log("[Webhook] Created execution:", execution.id);
 
-    // Record workflow execution metric in API process (workflow runs in separate context)
+    // Record per-(trigger_type, chain) start of a workflow execution. See KEEP-556.
+    const chainLabel = workflow.chain ?? "_unknown";
     const metrics = getMetricsCollector();
-    metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_TOTAL, {
+    metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL, {
       [LabelKeys.TRIGGER_TYPE]: "webhook",
-      [LabelKeys.WORKFLOW_ID]: workflowId,
+      [LabelKeys.CHAIN]: chainLabel,
     });
 
     // Resolve org slug + plan for log labels (cached per request)

--- a/deploy/pr-environment/executor.template.yaml
+++ b/deploy/pr-environment/executor.template.yaml
@@ -1,0 +1,162 @@
+# Workflow Executor for PR environments
+#
+# Polls the PR's LocalStack SQS for all trigger types (schedule, block, event)
+# and dispatches workflows into the PR namespace. By default uses the
+# staging-baseline executor image (executor-latest), but when the PR carries
+# the deploy-pr-executor label the CI builds a PR-specific image and the
+# template is rendered with EXECUTOR_IMAGE_TAG=${sha_short} (see
+# .github/workflows/deploy-pr-environment.yaml).
+#
+# Variables substituted by envsubst at deploy time:
+#   ${PR_NUMBER}, ${ECR_REGISTRY}, ${IMAGE_TAG}, ${EXECUTOR_IMAGE_TAG}
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-executor-pr-${PR_NUMBER}
+  type: ClusterIP
+  port: 3080
+  containerPort: 3080
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-executor-staging
+  tag: executor-${EXECUTOR_IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-pr-${PR_NUMBER}
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+serviceMonitors:
+  enabled: false
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 300m
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [Executor] Starting..."
+    tsx keeperhub-executor/index.ts
+
+env:
+  DATABASE_URL:
+    type: kv
+    value: "postgresql://keeperhub:${ENCODED_DB_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.pr-${PR_NUMBER}.svc.cluster.local:5432/keeperhub"
+  INTEGRATION_ENCRYPTION_KEY:
+    type: parameterStore
+    name: integration-encryption-key
+    parameter_name: /eks/techops-staging/keeperhub/integration-encryption-key
+  KEEPERHUB_API_URL:
+    type: kv
+    value: "http://keeperhub-pr-${PR_NUMBER}-common:3000"
+  KEEPERHUB_API_KEY:
+    type: parameterStore
+    name: scheduler-service-api-key
+    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
+  AWS_REGION:
+    type: kv
+    value: "us-east-1"
+  AWS_ENDPOINT_URL:
+    type: kv
+    value: "http://localstack.pr-${PR_NUMBER}.svc.cluster.local:4566"
+  SQS_QUEUE_URL:
+    type: kv
+    value: "http://localstack.pr-${PR_NUMBER}.svc.cluster.local:4566/000000000000/keeperhub-workflow-queue"
+  RUNNER_IMAGE:
+    type: kv
+    value: "${ECR_REGISTRY}/keeperhub-staging:workflow-runner-${IMAGE_TAG}"
+  IMAGE_PULL_POLICY:
+    type: kv
+    value: "Always"
+  K8S_NAMESPACE:
+    type: kv
+    value: "pr-${PR_NUMBER}"
+  HEALTH_PORT:
+    type: kv
+    value: "3080"
+  JOB_TTL_SECONDS:
+    type: kv
+    value: "120"
+  JOB_ACTIVE_DEADLINE:
+    type: kv
+    value: "300"
+  EXECUTION_MODE:
+    type: kv
+    value: "isolated"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  WORKFLOW_RUNNER_COLLECT_MONITORING:
+    type: kv
+    value: "false"
+  PARA_API_KEY:
+    type: parameterStore
+    name: para-api-key
+    parameter_name: /eks/techops-staging/keeperhub/para-api-key
+  PARA_ENVIRONMENT:
+    type: kv
+    value: "beta"
+  WALLET_ENCRYPTION_KEY:
+    type: parameterStore
+    name: wallet-encryption-key
+    parameter_name: /eks/techops-staging/keeperhub/wallet-encryption-key
+  CHAIN_RPC_CONFIG:
+    type: parameterStore
+    name: chain-rpc-config
+    parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+  ETHERSCAN_API_KEY:
+    type: parameterStore
+    name: etherscan-api-key
+    parameter_name: /eks/techops-staging/keeperhub/etherscan-api-key
+  NEXT_PUBLIC_BILLING_ENABLED:
+    type: kv
+    value: "true"
+  GAS_CREDITS_FREE_CENTS:
+    type: kv
+    value: "100"
+  GAS_CREDITS_PRO_CENTS:
+    type: kv
+    value: "500"
+  GAS_CREDITS_BUSINESS_CENTS:
+    type: kv
+    value: "2500"
+  GAS_CREDITS_ENTERPRISE_CENTS:
+    type: kv
+    value: "10000"
+
+externalSecrets:
+  clusterSecretStoreName: techops-staging
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3080
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 3080
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/pr-environment/executor.template.yaml
+++ b/deploy/pr-environment/executor.template.yaml
@@ -119,6 +119,16 @@ env:
     type: parameterStore
     name: wallet-encryption-key
     parameter_name: /eks/techops-staging/keeperhub/wallet-encryption-key
+  # Required by assertTurnkeyEnvForActiveWallets at startup when the DB has
+  # any active turnkey wallets; missing these would crash-loop the executor.
+  TURNKEY_API_PUBLIC_KEY:
+    type: parameterStore
+    name: turnkey-api-public-key
+    parameter_name: /eks/techops-staging/keeperhub/turnkey-api-public-key
+  TURNKEY_API_PRIVATE_KEY:
+    type: parameterStore
+    name: turnkey-api-private-key
+    parameter_name: /eks/techops-staging/keeperhub/turnkey-api-private-key
   CHAIN_RPC_CONFIG:
     type: parameterStore
     name: chain-rpc-config

--- a/keeperhub-executor/api-execute.test.ts
+++ b/keeperhub-executor/api-execute.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./config", () => ({
+  CONFIG: {
+    keeperhubApiUrl: "https://api.test.local",
+    keeperhubApiKey: "test-service-key",
+  },
+}));
+
+const { executeViaApi } = await import("./api-execute");
+
+const API_CALL_FAILED_500 = /API call failed: 500/;
+
+describe("executeViaApi", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ executionId: "exec-1" }),
+      } as Response)
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function getFetchInit(): RequestInit {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const call = fetchMock.mock.calls[0];
+    return call[1] as RequestInit;
+  }
+
+  function getHeader(
+    headers: HeadersInit | undefined,
+    name: string
+  ): string | undefined {
+    if (!headers) {
+      return undefined;
+    }
+    // The implementation passes a plain Record<string, string>, so simple lookup is sufficient.
+    return (headers as Record<string, string>)[name];
+  }
+
+  it("sends X-Trigger-Type=block when triggerType is block", async () => {
+    await executeViaApi({
+      workflowId: "wf-1",
+      executionId: "exec-1",
+      input: {},
+      triggerType: "block",
+    });
+
+    const init = getFetchInit();
+    expect(getHeader(init.headers, "X-Trigger-Type")).toBe("block");
+    expect(getHeader(init.headers, "X-Service-Key")).toBe("test-service-key");
+  });
+
+  it("sends X-Trigger-Type=schedule when triggerType is schedule", async () => {
+    await executeViaApi({
+      workflowId: "wf-2",
+      executionId: "exec-2",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    expect(getHeader(getFetchInit().headers, "X-Trigger-Type")).toBe(
+      "schedule"
+    );
+  });
+
+  it("sends X-Trigger-Type=event when triggerType is event", async () => {
+    await executeViaApi({
+      workflowId: "wf-3",
+      executionId: "exec-3",
+      input: { foo: "bar" },
+      triggerType: "event",
+    });
+
+    expect(getHeader(getFetchInit().headers, "X-Trigger-Type")).toBe("event");
+  });
+
+  it("throws if the API responds non-ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("boom"),
+      } as Response)
+    );
+
+    await expect(
+      executeViaApi({
+        workflowId: "wf-4",
+        executionId: "exec-4",
+        input: {},
+        triggerType: "block",
+      })
+    ).rejects.toThrow(API_CALL_FAILED_500);
+  });
+});

--- a/keeperhub-executor/api-execute.ts
+++ b/keeperhub-executor/api-execute.ts
@@ -1,16 +1,26 @@
 import { CONFIG } from "./config";
+import type { ExecutorMessage } from "./types";
+
+export type ApiExecuteTriggerType = ExecutorMessage["triggerType"];
 
 /**
  * Execute a workflow via the KeeperHub API endpoint.
  * Used in "process" execution mode where the API handles execution
  * directly without K8s Job isolation.
+ *
+ * Sends the precise trigger source (schedule | block | event) in the
+ * X-Trigger-Type header so the API can label the per-execution Prometheus
+ * counter accurately (see KEEP-556). Without this header, the API falls
+ * back to its legacy "scheduled" default for any internal call and the
+ * "zero executions in N min" alert family cannot tell trigger sources apart.
  */
 export async function executeViaApi(params: {
   workflowId: string;
   executionId: string;
   input: Record<string, unknown>;
+  triggerType: ApiExecuteTriggerType;
 }): Promise<void> {
-  const { workflowId, executionId, input } = params;
+  const { workflowId, executionId, input, triggerType } = params;
 
   const response = await fetch(
     `${CONFIG.keeperhubApiUrl}/api/workflow/${workflowId}/execute`,
@@ -19,6 +29,7 @@ export async function executeViaApi(params: {
       headers: {
         "Content-Type": "application/json",
         "X-Service-Key": CONFIG.keeperhubApiKey,
+        "X-Trigger-Type": triggerType,
       },
       body: JSON.stringify({ executionId, input }),
     }

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -365,6 +365,26 @@ async function listen(): Promise<void> {
   console.log(`[Executor] Runner image: ${CONFIG.runnerImage}`);
   console.log(`[Executor] K8s namespace: ${CONFIG.namespace}`);
 
+  // Wire up Prometheus dual-write. The Next.js app does this in
+  // instrumentation.ts; the executor is a separate tsx-launched process and
+  // never runs Next.js's instrumentation hook, so without this its
+  // getMetricsCollector() calls would only hit the console collector and the
+  // executor's /metrics endpoint would never see the counter series. See
+  // KEEP-556 for the missing-counter symptom this fixes.
+  if (process.env.METRICS_COLLECTOR === "prometheus") {
+    const { prometheusMetricsCollector } = await import(
+      "../lib/metrics/collectors/prometheus"
+    );
+    const { createDualWriteCollector } = await import(
+      "../lib/metrics/collectors/dual"
+    );
+    const { setMetricsCollector } = await import("../lib/metrics");
+    setMetricsCollector(createDualWriteCollector(prometheusMetricsCollector));
+    console.log(
+      "[Executor] Prometheus dual-write metrics collector initialized"
+    );
+  }
+
   await assertTurnkeyEnvForActiveWallets(db);
 
   // Health check + metrics server

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -38,7 +38,7 @@ import {
 } from "../lib/db/schema";
 import { generateId } from "../lib/utils/id";
 import type { WorkflowNode } from "../lib/workflow/store";
-import { executeViaApi } from "./api-execute";
+import { type ApiExecuteTriggerType, executeViaApi } from "./api-execute";
 import { checkExecutionLimitForExecutor } from "./billing-guard";
 import { CONFIG } from "./config";
 import { resolveDispatchTarget } from "./execution-mode";
@@ -149,7 +149,7 @@ async function dispatchExecution(params: {
   workflowId: string;
   executionId: string;
   input: Record<string, unknown>;
-  triggerType: string;
+  triggerType: ApiExecuteTriggerType;
   scheduleId?: string;
 }): Promise<void> {
   const { target, workflowId, executionId, input, triggerType, scheduleId } =
@@ -189,7 +189,7 @@ async function dispatchExecution(params: {
       break;
     }
     case "api": {
-      await executeViaApi({ workflowId, executionId, input });
+      await executeViaApi({ workflowId, executionId, input, triggerType });
       break;
     }
     case "in-process": {

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -37,6 +37,8 @@ import {
   workflows,
 } from "../lib/db/schema";
 import { generateId } from "../lib/utils/id";
+import { getMetricsCollector } from "../lib/metrics";
+import { LabelKeys, MetricNames } from "../lib/metrics/types";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { type ApiExecuteTriggerType, executeViaApi } from "./api-execute";
 import { checkExecutionLimitForExecutor } from "./billing-guard";
@@ -261,6 +263,20 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   });
 
   console.log(`[Executor] Created execution record: ${executionId}`);
+
+  // Counter for the "zero executions in N min" alert family (KEEP-556).
+  // Increments here for every SQS-triggered run regardless of dispatch target
+  // (k8s-job / in-process / api). The route.ts handler only increments when it
+  // creates the row itself - so manual and webhook flows go through there, and
+  // schedule / block / event go through here, with no double-count when the
+  // executor hands off via process mode and the API uses our pre-existing row.
+  getMetricsCollector().incrementCounter(
+    MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL,
+    {
+      [LabelKeys.TRIGGER_TYPE]: triggerType,
+      [LabelKeys.CHAIN]: workflow.chain ?? "_unknown",
+    }
+  );
 
   const nodes = workflow.nodes as WorkflowNode[];
   const target = resolveDispatchTarget(nodes);

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -738,6 +738,21 @@ const pluginInvocations = getOrCreateCounter(
   ["plugin_name", "action_name", "org_slug", "plan"]
 );
 
+// Runtime counter incremented exactly once per workflow_executions row creation,
+// labelled by trigger_type (block | schedule | event | manual | webhook | scheduled)
+// and chain (the workflows.chain column; "_unknown" when null). Used by the
+// Grafana "zero executions in N min" alert family - increase()[window] == 0 with
+// no_data_state="Alerting" fires when a (trigger_type, chain) pair stalls.
+//
+// Distinct from "workflow.executions.total" (a DB-sourced gauge of all-time counts
+// by status+org_slug) - that metric is computed via SQL in updateDbMetrics().
+const workflowExecutionsStartedTotal = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_workflow_executions_started_total",
+  "Workflow executions started (counter), labelled by trigger_type and chain",
+  ["trigger_type", "chain"]
+);
+
 // Error counters
 const pluginErrors = getOrCreateCounter(
   apiRegistry,
@@ -940,6 +955,7 @@ const histogramMap: Record<string, Histogram> = {
 
 const counterMap: Record<string, Counter> = {
   "plugin.invocations.total": pluginInvocations,
+  "workflow.executions.started.total": workflowExecutionsStartedTotal,
   "db.query.slow_count": slowQueries,
   "sponsorship.transactions.total": sponsorshipTransactions,
   "sponsorship.gas_used.total": sponsorshipGasUsed,
@@ -1335,7 +1351,10 @@ export async function updateDbMetrics(): Promise<void> {
 
     mrrUsdCents.reset();
     for (const entry of billingStats.mrrCentsByPlan) {
-      mrrUsdCents.set({ plan: entry.plan, tier: entry.tier ?? "" }, entry.cents);
+      mrrUsdCents.set(
+        { plan: entry.plan, tier: entry.tier ?? "" },
+        entry.cents
+      );
     }
     mrrUsdCentsTotal.set(billingStats.mrrCentsTotal);
 

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -111,6 +111,7 @@ export const MetricNames = {
 
   // Traffic metrics
   WORKFLOW_EXECUTIONS_TOTAL: "workflow.executions.total",
+  WORKFLOW_EXECUTIONS_STARTED_TOTAL: "workflow.executions.started.total",
   WORKFLOW_EXPORTS_TOTAL: "workflow.exports.total",
   WORKFLOW_IMPORTS_TOTAL: "workflow.imports.total",
   PLUGIN_INVOCATIONS_TOTAL: "plugin.invocations.total",
@@ -173,6 +174,7 @@ export const LabelKeys = {
   PLUGIN_NAME: "plugin_name",
   ACTION_NAME: "action_name",
   TRIGGER_TYPE: "trigger_type",
+  CHAIN: "chain",
   STATUS: "status",
   STATUS_CODE: "status_code",
   ERROR_TYPE: "error_type",
@@ -186,9 +188,34 @@ export const LabelKeys = {
 } as const;
 
 /**
- * Trigger types for workflow executions
+ * Trigger types for workflow executions.
+ *
+ * "scheduled" is the legacy label used for any internal call before the per-source
+ * discriminator was introduced. New code should prefer the precise values
+ * "schedule" (cron-based), "block" (block-interval), or "event" (smart contract
+ * event). Both "scheduled" and "schedule" are kept here so historical metric
+ * series remain valid.
  */
-export type TriggerType = "manual" | "webhook" | "scheduled";
+export type TriggerType =
+  | "manual"
+  | "webhook"
+  | "scheduled"
+  | "schedule"
+  | "block"
+  | "event";
+
+const TRIGGER_TYPES: ReadonlySet<TriggerType> = new Set<TriggerType>([
+  "manual",
+  "webhook",
+  "scheduled",
+  "schedule",
+  "block",
+  "event",
+]);
+
+export function isTriggerType(value: unknown): value is TriggerType {
+  return typeof value === "string" && TRIGGER_TYPES.has(value as TriggerType);
+}
 
 /**
  * Execution status values


### PR DESCRIPTION
## Summary

- New per-pod Prometheus counter `keeperhub_workflow_executions_started_total{trigger_type, chain}`, incremented once per `workflow_executions` row creation.
- `X-Trigger-Type` header plumbing from the executor through `executeViaApi()` to the `/api/workflow/:id/execute` route, so block / schedule / event are distinguishable on internal calls instead of all collapsing to "scheduled".
- `chain` label sourced from `workflows.chain` (with `_unknown` fallback for null).

Drives the new "Zero Executions in N min" Grafana alert family in the companion infrastructure PR.

## Why a new metric (not extending the existing one)

The existing `keeperhub_workflow_executions_total` is a DB-sourced gauge populated by `updateDbMetrics()`. Runtime `incrementCounter()` calls against it were silently dropped by the `dbSourcedMetrics` guard in `lib/metrics/collectors/prometheus.ts`. The new metric is a per-pod runtime counter on the API registry; the legacy gauge stays for historical visibility.

## Context

Follow-up to the 2026-05-12 incident: the Ethereum Mainnet WSS subscription in the block dispatcher went silent for ~7h40m; Avalanche and Base Sepolia block keepers kept running. A global `block executions == 0` alert would not have fired - the chain dimension is mandatory.

## Test plan

- [x] `pnpm type-check` clean.
- [x] `pnpm exec biome lint` clean on the seven touched files.
- [x] `pnpm exec vitest run keeperhub-executor/` - 42/42 pass, including the new `api-execute.test.ts` (4 cases covering block / schedule / event header propagation and non-OK error path).
- [ ] Post-deploy: `/api/metrics/api` on a prod pod returns `keeperhub_workflow_executions_started_total{trigger_type="block",chain="ethereum"} > 0` within 30s of a real execution.
- [ ] Synthetic outage test in staging (NetworkPolicy egress-blocks Ethereum Mainnet WSS for 35min, alert fires within ~35min, resolves within 5min after lift).

## Backwards compatibility

- `TriggerType` is extended additively (`"scheduled"` stays alongside the new precise `"schedule"`).
- During rolling deploy: pods on the old executor build will not send `X-Trigger-Type`; the route handler falls back to the legacy `"scheduled"` / `"manual"` defaults. The schedule alert in the infra PR matches both via regex.

Linear: KEEP-556