### PR TITLE
feat(metrics): KEEP-545 classify workflow execution errors, replace gauge with counter

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { walletLocks } from "@/lib/db/schema-extensions";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
@@ -87,18 +89,38 @@ export async function GET(request: Request): Promise<NextResponse> {
       )
     );
 
+    // KEEP-545: reaped executions are by definition stuck/timed-out, which
+    // classifies as WORKFLOW_ENGINE / system-side. Write the classification
+    // columns and increment the per-org counter per reaped row.
+    const reaperErrorMessage = `Execution timed out: no progress for ${thresholdMinutes} minutes`;
+    const reaperClassification = classifyExecutionError(reaperErrorMessage);
+
     const reaped = await db
       .update(workflowExecutions)
       .set({
         status: "error",
-        error: `Execution timed out: no progress for ${thresholdMinutes} minutes`,
+        error: reaperErrorMessage,
+        errorCategory: reaperClassification.errorCategory,
+        isUserError: reaperClassification.isUserError,
         completedAt: new Date(),
         duration: sql`ROUND(EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000)`,
       })
       .where(staleConditions)
-      .returning({ id: workflowExecutions.id });
+      .returning({
+        id: workflowExecutions.id,
+        workflowId: workflowExecutions.workflowId,
+      });
 
     const reapedIds = reaped.map((row) => row.id);
+
+    // KEEP-545: emit one counter increment per reaped row so the timeout
+    // family shows up in the new classified counter the SLA alert watches.
+    for (const row of reaped) {
+      await recordExecutionErrorFinalized({
+        workflowId: row.workflowId,
+        errorMessage: reaperErrorMessage,
+      });
+    }
 
     // KEEP-333: Close orphaned 'running' step logs for reaped executions so
     // the UI doesn't show stuck spinners after the workflow has been marked

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -7,6 +7,8 @@ import { priceQualifiesForMarketplaceExemption } from "@/lib/billing/marketplace
 import { db } from "@/lib/db";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { tags, workflowExecutions, workflows } from "@/lib/db/schema";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { hashMppCredential } from "@/lib/payments/mpp/server";
@@ -359,16 +361,30 @@ async function handlePaidWorkflow(
             }
           });
         } catch (err) {
-          await db
+          // KEEP-545: classify and record per-execution counter increment.
+          const errorMessage =
+            err instanceof Error
+              ? `recordPayment failed: ${err.message}`
+              : "recordPayment failed";
+          const classification = classifyExecutionError(errorMessage);
+
+          const updated = await db
             .update(workflowExecutions)
             .set({
               status: "error",
-              error:
-                err instanceof Error
-                  ? `recordPayment failed: ${err.message}`
-                  : "recordPayment failed",
+              error: errorMessage,
+              errorCategory: classification.errorCategory,
+              isUserError: classification.isUserError,
             })
-            .where(eq(workflowExecutions.id, executionId));
+            .where(eq(workflowExecutions.id, executionId))
+            .returning({ workflowId: workflowExecutions.workflowId });
+
+          if (updated.length > 0) {
+            await recordExecutionErrorFinalized({
+              workflowId: updated[0].workflowId,
+              errorMessage,
+            });
+          }
           throw err;
         }
 

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -2,6 +2,8 @@ import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { start } from "workflow/api";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { getMetricsCollector } from "@/lib/metrics";
@@ -63,15 +65,30 @@ async function executeWorkflowBackground(
   } catch (error) {
     logSystemError(ErrorCategory.WORKFLOW_ENGINE, "[Workflow Execute] Error during execution", error, { endpoint: "/api/workflow/[workflowId]/execute", operation: "executeWorkflow" });
 
-    // Update execution record with error
-    await db
+    // KEEP-545: classify the error so the row carries error_category and
+    // is_user_error and so the per-execution counter is incremented post-update.
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    const classification = classifyExecutionError(errorMessage);
+
+    const updated = await db
       .update(workflowExecutions)
       .set({
         status: "error",
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: errorMessage,
+        errorCategory: classification.errorCategory,
+        isUserError: classification.isUserError,
         completedAt: new Date(),
       })
-      .where(eq(workflowExecutions.id, executionId));
+      .where(eq(workflowExecutions.id, executionId))
+      .returning({ workflowId: workflowExecutions.workflowId });
+
+    if (updated.length > 0) {
+      await recordExecutionErrorFinalized({
+        workflowId: updated[0].workflowId,
+        errorMessage,
+      });
+    }
   }
 }
 

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -12,6 +12,8 @@ import {
   enforceExecutionLimit,
 } from "@/lib/billing/execution-guard";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { recordWebhookMetrics } from "@/lib/metrics/instrumentation/api";
 import { db } from "@/lib/db";
@@ -182,14 +184,29 @@ async function executeWorkflowBackground(
   } catch (error) {
     logSystemError(ErrorCategory.WORKFLOW_ENGINE, "[Webhook] Error during execution", error, { endpoint: "/api/workflows/[workflowId]/webhook", operation: "executeWorkflow" });
 
-    await db
+    // KEEP-545: classify and increment per-execution counter.
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    const classification = classifyExecutionError(errorMessage);
+
+    const updated = await db
       .update(workflowExecutions)
       .set({
         status: "error",
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: errorMessage,
+        errorCategory: classification.errorCategory,
+        isUserError: classification.isUserError,
         completedAt: new Date(),
       })
-      .where(eq(workflowExecutions.id, executionId));
+      .where(eq(workflowExecutions.id, executionId))
+      .returning({ workflowId: workflowExecutions.workflowId });
+
+    if (updated.length > 0) {
+      await recordExecutionErrorFinalized({
+        workflowId: updated[0].workflowId,
+        errorMessage,
+      });
+    }
   }
 }
 

--- a/drizzle/0073_keep545_workflow_executions_error_classification.sql
+++ b/drizzle/0073_keep545_workflow_executions_error_classification.sql
@@ -1,0 +1,17 @@
+-- KEEP-545: classification columns on workflow_executions so the SLA alert
+-- (`keeperhub_workflow_execution_errors_created_total{is_user_error="false"}`)
+-- can separate real DB/infra/engine failures from user-config noise without
+-- depending on log-line text matching.
+--
+-- Nullable on purpose: existing rows stay null; new rows get classified at
+-- finalization time by lib/errors/classify.ts. A separate backfill script
+-- (scripts/backfill-error-classification.ts) populates managed-client rows
+-- in last 90 days.
+--
+-- No partial index in this migration. A `CREATE INDEX CONCURRENTLY ON
+-- workflow_executions (error_category) WHERE error_category IS NOT NULL`
+-- is planned as a follow-up once the project's concurrent-index migrator
+-- helper lands; the alert query filters on a Prometheus label, not the DB
+-- column, so this PR does not need the index.
+ALTER TABLE "workflow_executions" ADD COLUMN "error_category" text;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD COLUMN "is_user_error" boolean;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1777760000006,
       "tag": "0072_keep458_workflows_seeded_at",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1777760000007,
+      "tag": "0073_keep545_workflow_executions_error_classification",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -320,6 +320,19 @@ export const workflowExecutions = pgTable(
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     output: jsonb("output").$type<any>(),
     error: text("error"),
+    errorCategory: text("error_category").$type<
+      | "validation"
+      | "configuration"
+      | "external_service"
+      | "network_rpc"
+      | "transaction"
+      | "database"
+      | "auth"
+      | "infrastructure"
+      | "workflow_engine"
+      | "unknown"
+    >(),
+    isUserError: boolean("is_user_error"),
     startedAt: timestamp("started_at").notNull().defaultNow(),
     completedAt: timestamp("completed_at"),
     duration: numeric("duration"), // Duration in milliseconds

--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { ErrorCategory } from "@/lib/logging";
+
+describe("classifyExecutionError", () => {
+  describe("empty / null / unknown inputs default to system workflow_engine", () => {
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["empty string", ""],
+      ["whitespace only", "   \n\t  "],
+      [
+        "totally unmatched message",
+        "something completely novel that no rule matches",
+      ],
+    ])("returns workflow_engine + system for %s", (_label, input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.isUserError).toBe(false);
+    });
+  });
+
+  describe("user-config: template and variable failures", () => {
+    it.each([
+      "Unresolved template reference(s): {{@nodeId:Foo.bar}} (Reference left in render)",
+      "Missing template variable(s) in URL: address",
+      "HTTP request failed: Missing template variable(s) in URL: address",
+    ])("classifies %s as configuration + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.isUserError).toBe(true);
+    });
+  });
+
+  describe("user-config: safe-fetch validation", () => {
+    it.each([
+      "safe-fetch: invalid URL",
+      "safe-fetch: scheme file: not allowed",
+      "blocked by SSRF policy",
+      "URL is required",
+    ])("classifies %s as validation + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.isUserError).toBe(true);
+    });
+  });
+
+  describe("user-config: workflow authoring mistakes", () => {
+    it("Code execution failed: validation + user", () => {
+      const r = classifyExecutionError(
+        "Code execution failed: require is not defined"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.isUserError).toBe(true);
+    });
+
+    it("Invalid contract address: validation + user", () => {
+      const r = classifyExecutionError("Invalid contract address: ");
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.isUserError).toBe(true);
+    });
+
+    it("Invalid function arguments: validation + user", () => {
+      const r = classifyExecutionError(
+        "Invalid function arguments: _fee.nativeFee: uint256 cannot be empty"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.isUserError).toBe(true);
+    });
+
+    it("For Each: arraySource is required: configuration + user", () => {
+      const r = classifyExecutionError(
+        "For Each: arraySource is required. Configure a template reference to an array"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.isUserError).toBe(true);
+    });
+
+    it("Condition references field: configuration + user", () => {
+      const r = classifyExecutionError(
+        'Condition references field "logs" but "logs" does not exist on the data'
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.isUserError).toBe(true);
+    });
+
+    it("No token selected: configuration + user", () => {
+      const r = classifyExecutionError("No token selected to check");
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.isUserError).toBe(true);
+    });
+
+    it("Contract call failed: transaction + user", () => {
+      const r = classifyExecutionError(
+        "Contract call failed: Error(This spell has already been scheduled)"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.isUserError).toBe(true);
+    });
+  });
+
+  describe("network / RPC: external dependencies", () => {
+    it("RPC failed on both endpoints: network_rpc + system", () => {
+      const r = classifyExecutionError(
+        "RPC failed on both endpoints. Primary: request timeout. Fallback: request timeout"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Failed to check balance: RPC failed: network_rpc + system", () => {
+      const r = classifyExecutionError(
+        "Failed to check balance: RPC failed on both endpoints. Primary: request timeout"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Failed to send webhook DNS failure: external_service + user (likely bad URL)", () => {
+      const r = classifyExecutionError(
+        "Failed to send webhook: fetch failed: getaddrinfo EAI_AGAIN events.pagerduty.com"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.EXTERNAL_SERVICE);
+      expect(r.isUserError).toBe(true);
+    });
+  });
+
+  describe("system: database / persistence", () => {
+    it.each([
+      "Database query failed: Database connection failed. Please verify your connection settings.",
+      'Failed query: update "workflow_executions" set "status" = $1 where "workflow_executions"."id" = $2',
+      "getaddrinfo EAI_AGAIN keeperhub-prod.cwmewmwvrqii.us-east-2.rds.amazonaws.com",
+    ])("classifies %s as database + system", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.DATABASE);
+      expect(r.isUserError).toBe(false);
+    });
+  });
+
+  describe("system: workflow engine internals", () => {
+    it("Execution timed out: workflow_engine + system", () => {
+      const r = classifyExecutionError(
+        "Execution timed out: no progress for 30 minutes"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Step exceeded max retries: workflow_engine + system", () => {
+      const r = classifyExecutionError(
+        'Step "step//./plugins/web3/steps/read-contract//readContractStep" exceeded max retries (1 retry)'
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Unknown action type: workflow_engine + system", () => {
+      const r = classifyExecutionError(
+        'Unknown action type: "condition". This action is not registered in the plugin system.'
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Failed to acquire nonce lock: workflow_engine + system", () => {
+      const r = classifyExecutionError(
+        "Failed to acquire nonce lock for 0xae36bc35098e24bbaed3dee86ec4653eb88a71a9:1 after 50 attempts"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.isUserError).toBe(false);
+    });
+  });
+
+  describe("system: infra / deploy / secrets", () => {
+    it("Workflow terminated by SIGTERM: infrastructure + system", () => {
+      const r = classifyExecutionError("Workflow terminated by SIGTERM signal");
+      expect(r.errorCategory).toBe(ErrorCategory.INFRASTRUCTURE);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Cannot find module: infrastructure + system", () => {
+      const r = classifyExecutionError(
+        "Cannot find module './credential-map'\nRequire stack:\n- /app/lib/credential-fetcher.ts"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.INFRASTRUCTURE);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it("Failed to initialize organization wallet (missing Turnkey key): infrastructure + system", () => {
+      const r = classifyExecutionError(
+        "Failed to initialize organization wallet: TURNKEY_API_PUBLIC_KEY and TURNKEY_API_PRIVATE_KEY must be set"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.INFRASTRUCTURE);
+      expect(r.isUserError).toBe(false);
+    });
+  });
+
+  describe("ErrorCategory enum exhaustiveness", () => {
+    it("returns values that all belong to the ErrorCategory enum", () => {
+      const allCategoryValues = new Set(Object.values(ErrorCategory));
+      const samples = [
+        "Unresolved template reference foo",
+        "Database query failed: x",
+        "Execution timed out",
+        "Contract call failed: x",
+        "Code execution failed: x",
+        "Cannot find module foo",
+        "RPC failed on both endpoints: x",
+        "Failed to send webhook: x",
+        "Workflow terminated by SIGTERM",
+        "novel unmatched error",
+      ];
+      for (const s of samples) {
+        const r = classifyExecutionError(s);
+        expect(allCategoryValues.has(r.errorCategory)).toBe(true);
+        expect(typeof r.isUserError).toBe("boolean");
+      }
+    });
+  });
+});

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -1,0 +1,247 @@
+import { ErrorCategory } from "@/lib/logging";
+
+/**
+ * Classification of a workflow execution failure into:
+ *   - errorCategory: one of the ErrorCategory enum values
+ *   - isUserError:   true if the failure was caused by the workflow author's
+ *                    configuration (template variables, contract args, code
+ *                    typos, missing tokens, etc.) and false if the failure
+ *                    was caused by KeeperHub itself (database, infra, plugin
+ *                    registry, missing secret, etc.).
+ *
+ * The classifier is intentionally pattern-driven against real production
+ * messages observed for managed clients (Sky/Ajna) so the resulting
+ * `is_user_error` label on `workflow_executions` lets the SLA alert filter
+ * out user-config noise.
+ *
+ * Default for unmatched messages is WORKFLOW_ENGINE / isUserError=false.
+ * That defaults to "treat unknown as system" so a real engine failure that
+ * doesn't match any known pattern still pages, and a new user-config family
+ * shows up in dashboards as engine-classified until a pattern is added.
+ */
+export type ExecutionErrorClassification = {
+  errorCategory: ErrorCategory;
+  isUserError: boolean;
+};
+
+type Rule = {
+  pattern: RegExp;
+  errorCategory: ErrorCategory;
+  isUserError: boolean;
+};
+
+/**
+ * Ordered list of rules. First match wins. Order matters when patterns
+ * overlap; more specific patterns should come before broader ones.
+ */
+const RULES: readonly Rule[] = [
+  // User-config: template / variable / safe-fetch input failures
+  {
+    pattern: /^Unresolved template reference/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /Missing template variable/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /safe-fetch:\s*invalid URL/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+  {
+    pattern: /safe-fetch:\s*scheme .* not allowed/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+  {
+    pattern: /blocked by SSRF policy/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^URL is required/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+
+  // User-config: code-step authoring mistakes
+  {
+    pattern: /^Code execution failed/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+
+  // User-config: contract / web3 inputs the author wired up
+  {
+    pattern: /^Contract call failed/i,
+    errorCategory: ErrorCategory.TRANSACTION,
+    isUserError: true,
+  },
+  {
+    pattern: /^Invalid contract address/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^Invalid (function arguments|ABI JSON|payable value)/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^For Each:\s*arraySource is required/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^Condition references field/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^Failed to evaluate condition expression/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^No token selected/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^HTTP request failed:\s*Missing template variable/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    isUserError: true,
+  },
+  {
+    pattern: /^HTTP request failed:\s*Request with GET\/HEAD method/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    isUserError: true,
+  },
+
+  // External-service / network: dependencies outside KeeperHub
+  {
+    pattern: /^Failed to check balance:\s*RPC failed/i,
+    errorCategory: ErrorCategory.NETWORK_RPC,
+    isUserError: false,
+  },
+  {
+    pattern: /RPC failed on both endpoints/i,
+    errorCategory: ErrorCategory.NETWORK_RPC,
+    isUserError: false,
+  },
+  {
+    pattern: /^Failed to send webhook:\s*fetch failed:\s*getaddrinfo/i,
+    errorCategory: ErrorCategory.EXTERNAL_SERVICE,
+    isUserError: true,
+  },
+  {
+    pattern: /^Failed to send webhook/i,
+    errorCategory: ErrorCategory.EXTERNAL_SERVICE,
+    isUserError: false,
+  },
+
+  // System: database / persistence layer
+  {
+    pattern: /^Database query failed/i,
+    errorCategory: ErrorCategory.DATABASE,
+    isUserError: false,
+  },
+  {
+    pattern: /^Failed query:/i,
+    errorCategory: ErrorCategory.DATABASE,
+    isUserError: false,
+  },
+  {
+    pattern: /^getaddrinfo .*\.rds\.amazonaws\.com/i,
+    errorCategory: ErrorCategory.DATABASE,
+    isUserError: false,
+  },
+
+  // System: workflow engine / executor
+  {
+    pattern: /^Execution timed out/i,
+    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+    isUserError: false,
+  },
+  {
+    pattern: /^Workflow terminated by SIGTERM/i,
+    errorCategory: ErrorCategory.INFRASTRUCTURE,
+    isUserError: false,
+  },
+  {
+    pattern: /^Step ".*" exceeded max retries/i,
+    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+    isUserError: false,
+  },
+  {
+    pattern: /^Unknown action type:/i,
+    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+    isUserError: false,
+  },
+  {
+    pattern: /^Failed to acquire nonce lock/i,
+    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+    isUserError: false,
+  },
+
+  // System: deploy bugs / missing modules / missing secrets
+  {
+    pattern: /^Cannot find module/i,
+    errorCategory: ErrorCategory.INFRASTRUCTURE,
+    isUserError: false,
+  },
+  {
+    pattern: /must be set\s*$/i,
+    errorCategory: ErrorCategory.INFRASTRUCTURE,
+    isUserError: false,
+  },
+  {
+    pattern: /^Failed to initialize organization wallet/i,
+    errorCategory: ErrorCategory.INFRASTRUCTURE,
+    isUserError: false,
+  },
+];
+
+/**
+ * Classify a workflow execution error message into an `ErrorCategory` and a
+ * user-vs-system flag.
+ *
+ * Returns `WORKFLOW_ENGINE` / `isUserError=false` for null, empty, or
+ * unmatched messages so unknown failures still surface to system-level
+ * alerting until a more specific rule is added.
+ */
+export function classifyExecutionError(
+  errorMessage: string | null | undefined
+): ExecutionErrorClassification {
+  if (!errorMessage) {
+    return {
+      errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+      isUserError: false,
+    };
+  }
+
+  const trimmed = errorMessage.trim();
+  if (trimmed.length === 0) {
+    return {
+      errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+      isUserError: false,
+    };
+  }
+
+  for (const rule of RULES) {
+    if (rule.pattern.test(trimmed)) {
+      return {
+        errorCategory: rule.errorCategory,
+        isUserError: rule.isUserError,
+      };
+    }
+  }
+
+  return {
+    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+    isUserError: false,
+  };
+}

--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { organization, workflows } from "@/lib/db/schema";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { recordWorkflowExecutionError } from "@/lib/metrics/collectors/prometheus";
+import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
+
+/**
+ * Increment `keeperhub_workflow_execution_errors_created_total` after a
+ * `workflow_executions` row has been written with status='error'.
+ *
+ * Resolves the org slug for the workflow so the counter series is scoped
+ * for the SLA alert (Sky/Ajna). Falls back to ANONYMOUS_ORG_SLUG for
+ * personal workflows so personal failures still emit a series.
+ *
+ * Safe to call after the DB write succeeded. Errors are caught and dropped
+ * because metric emission must never break an already-finalized execution.
+ */
+export async function recordExecutionErrorFinalized(args: {
+  workflowId: string;
+  errorMessage: string | null | undefined;
+}): Promise<void> {
+  try {
+    const { errorCategory, isUserError } = classifyExecutionError(
+      args.errorMessage
+    );
+
+    const row = await db
+      .select({ slug: organization.slug })
+      .from(workflows)
+      .leftJoin(organization, eq(workflows.organizationId, organization.id))
+      .where(eq(workflows.id, args.workflowId))
+      .limit(1);
+
+    const orgSlug = row[0]?.slug ?? ANONYMOUS_ORG_SLUG;
+
+    recordWorkflowExecutionError({
+      orgSlug,
+      errorCategory,
+      isUserError,
+    });
+  } catch {
+    // Counter emission must not break the execution finalize path.
+  }
+}

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -89,6 +89,64 @@ function buildLogTag(labels: Record<string, string>): string {
   return parts.length > 0 ? ` [${parts.join("][")}]` : "";
 }
 
+function buildErrPayload(
+  error: unknown
+): { message: string; name?: string; stack?: string } | undefined {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+  if (error === undefined || error === null || error === "") {
+    return;
+  }
+  return { message: String(error) };
+}
+
+/**
+ * KEEP-545: serialize an error/log event as a single-line JSON object so
+ * Grafana Cloud Loki can extract top-level keys via `| json`. Drilldown
+ * from the managed-client SLA alert to the failing execution requires
+ * `execution_id`, `is_user_error`, and `error_category` to be available as
+ * Loki labels, not just as text inside the message string.
+ *
+ * The human-readable `msg` field retains the original message and the
+ * `[org:Sky][exec:xyz]` tag so `kubectl logs` greps still work.
+ */
+function serializeStructuredLogLine(args: {
+  level: "warn" | "error";
+  message: string;
+  tag: string;
+  fullLabels: Record<string, string>;
+  category: ErrorCategory;
+  context: string;
+  isUserError: "true" | "false" | undefined;
+  error: unknown;
+}): string {
+  const errPayload = buildErrPayload(args.error);
+
+  const payload: Record<string, unknown> = {
+    level: args.level,
+    msg: `${args.message}${args.tag}`,
+    error_category: args.category,
+    error_context: args.context,
+  };
+  if (args.isUserError !== undefined) {
+    payload.is_user_error = args.isUserError;
+  }
+  for (const [k, v] of Object.entries(args.fullLabels)) {
+    if (v !== undefined && !(k in payload)) {
+      payload[k] = v;
+    }
+  }
+  if (errPayload) {
+    payload.err = errPayload;
+  }
+  return JSON.stringify(payload);
+}
+
 /**
  * Error/warning categories for metrics classification
  */
@@ -180,9 +238,22 @@ export function logUserError(
   // Merge async-local workflow context (org/owner/workflow ids).
   const fullLabels = mergeLabels(labels);
 
-  // Log as warning (user errors don't wake up DevOps)
+  // KEEP-545: emit structured JSON so Loki indexes is_user_error,
+  // error_category, execution_id, org_slug as queryable labels via `| json`.
+  // User errors are logged at warn level so they don't page on-call.
   const tag = buildLogTag(fullLabels);
-  console.warn(`${message}${tag}`, error ?? "");
+  console.warn(
+    serializeStructuredLogLine({
+      level: "warn",
+      message,
+      tag,
+      fullLabels,
+      category,
+      context,
+      isUserError: "true",
+      error,
+    })
+  );
 
   // Emit metric (high-cardinality labels stripped to protect Prometheus)
   const metricLabels = stripHighCardinality(fullLabels);
@@ -242,9 +313,21 @@ export function logSystemError(
   // Merge async-local workflow context (org/owner/workflow ids).
   const fullLabels = mergeLabels(labels);
 
-  // Log as error (system failures are critical)
+  // KEEP-545: emit structured JSON so Loki indexes is_user_error,
+  // error_category, execution_id, org_slug as queryable labels via `| json`.
   const tag = buildLogTag(fullLabels);
-  console.error(`${message}${tag}`, error);
+  console.error(
+    serializeStructuredLogLine({
+      level: "error",
+      message,
+      tag,
+      fullLabels,
+      category,
+      context,
+      isUserError: "false",
+      error,
+    })
+  );
 
   // Emit metric (high-cardinality labels stripped to protect Prometheus)
   const metricLabels = stripHighCardinality(fullLabels);
@@ -305,8 +388,25 @@ export function logSystemWarn(
   const context = extractContext(message);
   const fullLabels = mergeLabels(labels);
 
+  // KEEP-545: emit structured JSON so Loki indexes execution_id, org_slug,
+  // and error_category for the warn-level recovery/notice events. is_user_error
+  // is intentionally omitted on logSystemWarn (the call site does not yet
+  // know whether the underlying failure is user-caused or engine-caused);
+  // alerts that filter `is_user_error="false"` therefore won't re-trip on
+  // these events. See logSystemWarn jsdoc for full reasoning.
   const tag = buildLogTag(fullLabels);
-  console.warn(`${message}${tag}`, error);
+  console.warn(
+    serializeStructuredLogLine({
+      level: "warn",
+      message,
+      tag,
+      fullLabels,
+      category,
+      context,
+      isUserError: undefined,
+      error,
+    })
+  );
 
   const sentryError = error instanceof Error ? error : new Error(String(error));
   captureException(sentryError, {

--- a/lib/metrics/__tests__/error-labels.test.ts
+++ b/lib/metrics/__tests__/error-labels.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+// lib/metrics/collectors/prometheus.ts is server-only because it touches
+// prom-client's process-global registries. Stub server-only so this purely
+// data-snapshot test can load the module under vitest's node environment.
+vi.mock("server-only", () => ({}));
+
+const { ERROR_LABELS } = await import("@/lib/metrics/collectors/prometheus");
+
+/**
+ * KEEP-545 (closes KEEP-536): regression guard for the Prometheus error
+ * counter label set. The `specs/logging-and-metrics/keeperhub-errors-dashboard.json`
+ * and the managed-client alert PromQL both group by `error_category` and
+ * filter by `is_user_error`. Removing either of these labels from the shared
+ * `ERROR_LABELS` array would silently produce empty panels and a no-data
+ * alert without any test or type failure. This snapshot prevents that.
+ */
+describe("ERROR_LABELS regression guard (KEEP-545 / closes KEEP-536)", () => {
+  it("includes the labels required by the errors dashboard and SLA alert", () => {
+    expect(ERROR_LABELS).toContain("error_category");
+    expect(ERROR_LABELS).toContain("is_user_error");
+    expect(ERROR_LABELS).toContain("error_context");
+  });
+
+  it("matches the canonical snapshot", () => {
+    expect([...ERROR_LABELS].sort()).toEqual(
+      [
+        "action_name",
+        "chain_id",
+        "component",
+        "endpoint",
+        "error_category",
+        "error_context",
+        "error_type",
+        "execution_id",
+        "integration_id",
+        "is_user_error",
+        "org_slug",
+        "plan",
+        "plugin_name",
+        "service",
+        "status_code",
+        "table",
+        "workflow_id",
+      ].sort()
+    );
+  });
+});

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -104,16 +104,15 @@ const workflowExecutionsTotal = getOrCreateGauge(
   ["status", "org_slug"]
 );
 
-// Workflow errors total (convenience gauge for alerting). Labeled by org_slug
-// so alerts can scope to managed clients. Personal/anonymous workflows are
-// emitted under org_slug="_anonymous" so the sum across labels matches the
-// global error count.
-const workflowErrorsTotal = getOrCreateGauge(
-  dbRegistry,
-  "keeperhub_workflow_execution_errors_total",
-  "Total failed workflow executions (all-time), broken down by org_slug",
-  ["org_slug"]
-);
+// KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
+// has been removed. It was named with the `_total` counter suffix but was
+// actually a poll-driven gauge that overwrote itself on every scrape with the
+// all-time cumulative error count, which made every dashboard read it as a
+// huge static number instead of recent activity. The replacement is the
+// per-pod counter `keeperhub_workflow_execution_errors_created_total` below,
+// incremented at the workflow-execution finalization site (see
+// lib/workflow/finalize-error.ts) so it reflects actual new errors and
+// composes correctly with PromQL `rate()` / `increase()` over time ranges.
 
 // Workflow duration histogram as gauges (replaces histogram)
 const workflowDurationBucket = getOrCreateGauge(
@@ -854,6 +853,38 @@ const systemWorkflowEngineErrors = getOrCreateCounter(
   ERROR_LABELS
 );
 
+// KEEP-545: per-execution-row counter incremented exactly once when a
+// workflow execution is finalized with status='error'. Replaces the old
+// poll-driven `keeperhub_workflow_execution_errors_total` gauge that
+// overwrote itself with the all-time cumulative count on every scrape.
+//
+// Labels:
+//   org_slug       per-organization slug (or ANONYMOUS_ORG_SLUG for personal)
+//   error_category one of the ErrorCategory enum values (validation,
+//                  configuration, database, workflow_engine, etc.)
+//   is_user_error  "true" for workflow-author bugs, "false" for engine/infra
+//
+// Cardinality: ~200 active orgs * 10 categories * 2 = 4k worst case;
+// realistic ~1k (most orgs hit 1-2 categories).
+const workflowExecutionErrorsCreated = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_workflow_execution_errors_created_total",
+  "Workflow execution errors observed since pod start, by classification",
+  ["org_slug", "error_category", "is_user_error"]
+);
+
+export function recordWorkflowExecutionError(labels: {
+  orgSlug: string;
+  errorCategory: string;
+  isUserError: boolean;
+}): void {
+  workflowExecutionErrorsCreated.inc({
+    org_slug: labels.orgSlug,
+    error_category: labels.errorCategory,
+    is_user_error: labels.isUserError ? "true" : "false",
+  });
+}
+
 const slowQueries = getOrCreateCounter(
   apiRegistry,
   "keeperhub_db_query_slow_total",
@@ -1205,15 +1236,9 @@ export async function updateDbMetrics(): Promise<void> {
       );
     }
 
-    // Update workflow errors total per org_slug (convenience gauge for
-    // alerting). Reset before populating so series for orgs that no longer
-    // have errors clear out instead of going stale.
-    workflowErrorsTotal.reset();
-    for (const [orgSlug, errorCount] of Object.entries(
-      workflowStats.errorByOrgSlug
-    )) {
-      workflowErrorsTotal.set({ org_slug: orgSlug }, errorCount);
-    }
+    // KEEP-545: the per-org error gauge that used to live here was removed.
+    // See `keeperhub_workflow_execution_errors_created_total` (per-pod
+    // counter incremented at finalization time) for the replacement.
 
     // Update workflow duration histogram buckets
     for (let i = 0; i < WORKFLOW_DURATION_BUCKETS.length; i++) {

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -767,8 +767,10 @@ const apiErrors = getOrCreateCounter(
   ["endpoint", "status_code", "error_type", "org_slug", "plan"]
 );
 
-// Common labels for all error counters (allows any subset to be used)
-const ERROR_LABELS = [
+// Common labels for all error counters (allows any subset to be used).
+// Exported so the KEEP-545 regression test can snapshot the canonical set
+// and prevent any panel-affecting label from being removed silently.
+export const ERROR_LABELS = [
   "error_category",
   "error_context",
   "is_user_error",

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -38,9 +38,11 @@ import {
 import type { BillingStatus } from "./types";
 
 // Label value used for workflow executions whose workflow has no organization
-// (personal/anonymous workflows). Keeps the per-org error gauge total equal
-// to the global error count instead of silently dropping these executions.
-const ANONYMOUS_ORG_SLUG = "_anonymous";
+// (personal/anonymous workflows). Keeps the per-(status, org_slug) execution
+// gauge total equal to the global total instead of silently dropping these
+// rows. Also re-exported for the runtime finalization counter so personal
+// workflows still produce a series rather than silently dropping increments.
+export const ANONYMOUS_ORG_SLUG = "_anonymous";
 
 // Histogram bucket boundaries in milliseconds (must match prometheus.ts)
 const WORKFLOW_DURATION_BUCKETS = [
@@ -55,10 +57,6 @@ export type WorkflowStats = {
   totalRunning: number;
   totalPending: number;
   totalCancelled: number;
-
-  // Error count per org slug. Personal/anonymous workflows are bucketed
-  // under ANONYMOUS_ORG_SLUG so the sum across this map matches totalError.
-  errorByOrgSlug: Record<string, number>;
 
   // Per-(status, org_slug) execution counts. Personal/anonymous workflows
   // are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for a given
@@ -89,7 +87,6 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       totalRunning: 0,
       totalPending: 0,
       totalCancelled: 0,
-      errorByOrgSlug: {},
       executionsByStatusAndOrgSlug: [],
       durationBuckets: new Array(WORKFLOW_DURATION_BUCKETS.length + 1).fill(0),
       durationSum: 0,
@@ -128,7 +125,6 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
           break;
         case "error":
           stats.totalError += c;
-          stats.errorByOrgSlug[row.orgSlug] = c;
           break;
         case "running":
           stats.totalRunning += c;
@@ -196,7 +192,6 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       totalRunning: 0,
       totalPending: 0,
       totalCancelled: 0,
-      errorByOrgSlug: {},
       executionsByStatusAndOrgSlug: [],
       durationBuckets: new Array(WORKFLOW_DURATION_BUCKETS.length + 1).fill(0),
       durationSum: 0,

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -7,12 +7,17 @@ import "server-only";
 import { and, asc, eq, isNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
+  organization,
   type TransactionHashEntry,
   workflowExecutionLogs,
   workflowExecutions,
+  workflows,
 } from "@/lib/db/schema";
+import { classifyExecutionError } from "@/lib/errors/classify";
 import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
+import { recordWorkflowExecutionError } from "@/lib/metrics/collectors/prometheus";
+import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
   FAILED_AFTER_RETRIES_REGEX,
@@ -334,7 +339,7 @@ async function selfHealWorkflowAfterLateStepCommit(
       { outcome: "flipped" }
     );
 
-    logSystemError(
+    logSystemWarn(
       ErrorCategory.WORKFLOW_ENGINE,
       "[Workflow Logging] Self-healed workflow status from spurious error to success after late step commit",
       execution.error ?? "unknown",
@@ -611,12 +616,19 @@ export async function logWorkflowCompleteDb(
       ? await resolveTransactionHashesForSuccess(params.executionId)
       : [];
 
-  await db
+  // KEEP-545: classify the error so the row carries error_category and
+  // is_user_error at write time. Success rows get null for both columns.
+  const classification =
+    resolvedStatus === "error" ? classifyExecutionError(resolvedError) : null;
+
+  const updated = await db
     .update(workflowExecutions)
     .set({
       status: resolvedStatus,
       output: params.output,
       error: resolvedError,
+      errorCategory: classification?.errorCategory ?? null,
+      isUserError: classification?.isUserError ?? null,
       completedAt: new Date(),
       duration: duration.toString(),
       // Clear current step on completion
@@ -636,7 +648,41 @@ export async function logWorkflowCompleteDb(
         // a no-op once self-heal has won the race.
         ne(workflowExecutions.status, "success")
       )
-    );
+    )
+    .returning({ workflowId: workflowExecutions.workflowId });
+
+  // KEEP-545: increment the per-execution-error counter only when this
+  // UPDATE actually flipped a row to 'error'. The WHERE clause excludes
+  // already-cancelled/healed rows, so `updated` is empty in those races
+  // and we correctly skip the counter increment for the lost write.
+  if (resolvedStatus === "error" && updated.length > 0 && classification) {
+    const workflowId = updated[0].workflowId;
+    try {
+      const orgSlug = await resolveOrgSlugForCounter(workflowId);
+      recordWorkflowExecutionError({
+        orgSlug,
+        errorCategory: classification.errorCategory,
+        isUserError: classification.isUserError,
+      });
+    } catch {
+      // Counter emission must never break finalization.
+    }
+  }
+}
+
+/**
+ * Resolve the org slug that owns the workflow behind an execution, falling
+ * back to ANONYMOUS_ORG_SLUG for personal/anonymous workflows so the
+ * counter always emits a series (the SLA alert filters by `org_slug=~`).
+ */
+async function resolveOrgSlugForCounter(workflowId: string): Promise<string> {
+  const row = await db
+    .select({ slug: organization.slug })
+    .from(workflows)
+    .leftJoin(organization, eq(workflows.organizationId, organization.id))
+    .where(eq(workflows.id, workflowId))
+    .limit(1);
+  return row[0]?.slug ?? ANONYMOUS_ORG_SLUG;
 }
 
 // ============================================================================

--- a/scripts/backfill-error-classification.ts
+++ b/scripts/backfill-error-classification.ts
@@ -1,0 +1,211 @@
+/**
+ * KEEP-545: one-time backfill of `error_category` and `is_user_error`
+ * columns on `workflow_executions` rows for managed-client orgs (Sky and
+ * Ajna) over the last 90 days.
+ *
+ * The DB schema migration that added these columns leaves them null on
+ * historical rows. The SLA alert post-PR-2 watches the new counter, not
+ * the historical column, so backfill is not required for the alert. The
+ * reason to run this is to produce an immediate inventory of "real
+ * engineering failures vs user-config noise" inside the managed-client
+ * scope without writing one-off SQL.
+ *
+ * Idempotent: skips rows that already have both classification columns
+ * set. Safe to re-run.
+ *
+ * Usage:
+ *   pnpm tsx scripts/backfill-error-classification.ts --dry-run
+ *   pnpm tsx scripts/backfill-error-classification.ts
+ *   pnpm tsx scripts/backfill-error-classification.ts --orgs sky,ajna --days 30
+ *
+ * Output:
+ *   - Progress lines per batch (`processed=N updated=M skipped=K`)
+ *   - Final summary table by (org_slug, error_category, is_user_error)
+ */
+
+import { and, eq, gte, inArray, isNull, or, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { organization, workflowExecutions, workflows } from "@/lib/db/schema";
+import { classifyExecutionError } from "@/lib/errors/classify";
+
+const DEFAULT_ORGS = ["techops-services", "ajna"];
+const DEFAULT_DAYS = 90;
+const BATCH_SIZE = 500;
+
+type CliArgs = {
+  dryRun: boolean;
+  orgs: string[];
+  days: number;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    dryRun: false,
+    orgs: DEFAULT_ORGS,
+    days: DEFAULT_DAYS,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--orgs" && argv[i + 1]) {
+      args.orgs = argv[i + 1].split(",").map((s) => s.trim()).filter(Boolean);
+      i++;
+    } else if (a === "--days" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.days = parsed;
+      }
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: pnpm tsx scripts/backfill-error-classification.ts [--dry-run] [--orgs slug1,slug2] [--days N]"
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+type RowToClassify = {
+  id: string;
+  error: string | null;
+  orgSlug: string | null;
+};
+
+async function fetchUnclassifiedBatch(args: {
+  orgs: string[];
+  days: number;
+  afterId: string | null;
+}): Promise<RowToClassify[]> {
+  const startedAtCutoff = new Date(
+    Date.now() - args.days * 24 * 60 * 60 * 1000
+  );
+
+  return db
+    .select({
+      id: workflowExecutions.id,
+      error: workflowExecutions.error,
+      orgSlug: organization.slug,
+    })
+    .from(workflowExecutions)
+    .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+    .innerJoin(organization, eq(workflows.organizationId, organization.id))
+    .where(
+      and(
+        eq(workflowExecutions.status, "error"),
+        gte(workflowExecutions.startedAt, startedAtCutoff),
+        inArray(organization.slug, args.orgs),
+        or(
+          isNull(workflowExecutions.errorCategory),
+          isNull(workflowExecutions.isUserError)
+        ),
+        args.afterId ? sql`${workflowExecutions.id} > ${args.afterId}` : undefined
+      )
+    )
+    .orderBy(workflowExecutions.id)
+    .limit(BATCH_SIZE);
+}
+
+type Summary = Record<string, Record<string, { user: number; system: number }>>;
+
+function recordInSummary(
+  summary: Summary,
+  orgSlug: string,
+  errorCategory: string,
+  isUserError: boolean
+): void {
+  if (!summary[orgSlug]) {
+    summary[orgSlug] = {};
+  }
+  if (!summary[orgSlug][errorCategory]) {
+    summary[orgSlug][errorCategory] = { user: 0, system: 0 };
+  }
+  if (isUserError) {
+    summary[orgSlug][errorCategory].user += 1;
+  } else {
+    summary[orgSlug][errorCategory].system += 1;
+  }
+}
+
+function formatSummary(summary: Summary): string {
+  const lines: string[] = [];
+  lines.push(
+    "org_slug              | error_category       |   user |  system | total"
+  );
+  lines.push(
+    "----------------------+----------------------+--------+---------+-------"
+  );
+  for (const orgSlug of Object.keys(summary).sort()) {
+    for (const cat of Object.keys(summary[orgSlug]).sort()) {
+      const { user, system } = summary[orgSlug][cat];
+      lines.push(
+        `${orgSlug.padEnd(22)}| ${cat.padEnd(21)}| ${String(user).padStart(6)} | ${String(system).padStart(7)} | ${String(user + system).padStart(5)}`
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `[backfill-error-classification] mode=${args.dryRun ? "DRY-RUN" : "LIVE"} orgs=${args.orgs.join(",")} days=${args.days}`
+  );
+
+  const summary: Summary = {};
+  let totalProcessed = 0;
+  let totalUpdated = 0;
+  let afterId: string | null = null;
+
+  for (;;) {
+    const rows = await fetchUnclassifiedBatch({
+      orgs: args.orgs,
+      days: args.days,
+      afterId,
+    });
+    if (rows.length === 0) {
+      break;
+    }
+
+    let updatedInBatch = 0;
+    for (const row of rows) {
+      const orgSlug = row.orgSlug ?? "_anonymous";
+      const { errorCategory, isUserError } = classifyExecutionError(row.error);
+      recordInSummary(summary, orgSlug, errorCategory, isUserError);
+
+      if (!args.dryRun) {
+        await db
+          .update(workflowExecutions)
+          .set({ errorCategory, isUserError })
+          .where(eq(workflowExecutions.id, row.id));
+        updatedInBatch += 1;
+      }
+    }
+
+    totalProcessed += rows.length;
+    totalUpdated += updatedInBatch;
+    afterId = rows[rows.length - 1].id;
+
+    console.log(
+      `[backfill-error-classification] batch: processed=${rows.length} updated=${updatedInBatch} cumulative=${totalProcessed}`
+    );
+
+    if (rows.length < BATCH_SIZE) {
+      break;
+    }
+  }
+
+  console.log("");
+  console.log(
+    `[backfill-error-classification] done. total_processed=${totalProcessed} total_updated=${totalUpdated} mode=${args.dryRun ? "DRY-RUN" : "LIVE"}`
+  );
+  console.log("");
+  console.log("Breakdown:");
+  console.log(formatSummary(summary));
+}
+
+main().catch((err) => {
+  console.error("[backfill-error-classification] failed:", err);
+  process.exit(1);
+});

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -1,6 +1,20 @@
 import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// KEEP-545: route imports lib/errors/finalize-error which pulls in server-only
+// via the metrics collector. Stubbing server-only as an empty module lets the
+// test load the route without a Next runtime.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/errors/classify", () => ({
+  classifyExecutionError: () => ({
+    errorCategory: "workflow_engine",
+    isUserError: false,
+  }),
+}));
+vi.mock("@/lib/errors/finalize-error", () => ({
+  recordExecutionErrorFinalized: vi.fn().mockResolvedValue(undefined),
+}));
+
 const VALID_API_KEY = "wfb_test-key-abc123";
 const VALID_KEY_HASH = createHash("sha256").update(VALID_API_KEY).digest("hex");
 const OWNER_USER_ID = "user-owner-123";

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -18,39 +18,72 @@ vi.mock("@/lib/metrics", () => ({
 }));
 
 // Hoisted schema stubs so the vi.mock factory can reference them.
-const { workflowExecutionsMock, workflowExecutionLogsMock } = vi.hoisted(
-  () => ({
-    workflowExecutionsMock: {
-      id: "id",
-      status: "status",
-      output: "output",
-      error: "error",
-      completedAt: "completed_at",
-      duration: "duration",
-      currentNodeId: "current_node_id",
-      currentNodeName: "current_node_name",
-      // KEEP-470: column referenced by terminal UPDATE SET clauses
-      transactionHashes: "transaction_hashes",
-    },
-    workflowExecutionLogsMock: {
-      id: "id",
-      executionId: "execution_id",
-      nodeId: "node_id",
-      nodeName: "node_name",
-      status: "status",
-      error: "error",
-      completedAt: "completed_at",
-      // KEEP-470: columns referenced by loadHashesFromLogs SELECT
-      iterationIndex: "iteration_index",
-      outputRaw: "output_raw",
-      startedAt: "started_at",
-    },
-  })
-);
+const {
+  workflowExecutionsMock,
+  workflowExecutionLogsMock,
+  workflowsMock,
+  organizationMock,
+} = vi.hoisted(() => ({
+  workflowExecutionsMock: {
+    id: "id",
+    workflowId: "workflow_id",
+    status: "status",
+    output: "output",
+    error: "error",
+    errorCategory: "error_category",
+    isUserError: "is_user_error",
+    completedAt: "completed_at",
+    duration: "duration",
+    currentNodeId: "current_node_id",
+    currentNodeName: "current_node_name",
+    // KEEP-470: column referenced by terminal UPDATE SET clauses
+    transactionHashes: "transaction_hashes",
+  },
+  workflowExecutionLogsMock: {
+    id: "id",
+    executionId: "execution_id",
+    nodeId: "node_id",
+    nodeName: "node_name",
+    status: "status",
+    error: "error",
+    completedAt: "completed_at",
+    // KEEP-470: columns referenced by loadHashesFromLogs SELECT
+    iterationIndex: "iteration_index",
+    outputRaw: "output_raw",
+    startedAt: "started_at",
+  },
+  // KEEP-545: org_slug resolution joins workflows -> organization for the
+  // per-execution-error counter
+  workflowsMock: {
+    id: "id",
+    organizationId: "organization_id",
+  },
+  organizationMock: {
+    id: "id",
+    slug: "slug",
+  },
+}));
 
 vi.mock("@/lib/db/schema", () => ({
   workflowExecutions: workflowExecutionsMock,
   workflowExecutionLogs: workflowExecutionLogsMock,
+  workflows: workflowsMock,
+  organization: organizationMock,
+}));
+
+// KEEP-545: stub classifier + counter so the test doesn't load the
+// server-only metric collector module.
+vi.mock("@/lib/errors/classify", () => ({
+  classifyExecutionError: (msg: string | null | undefined) => ({
+    errorCategory: msg ? "workflow_engine" : "workflow_engine",
+    isUserError: false,
+  }),
+}));
+vi.mock("@/lib/metrics/collectors/prometheus", () => ({
+  recordWorkflowExecutionError: vi.fn(),
+}));
+vi.mock("@/lib/metrics/db-metrics", () => ({
+  ANONYMOUS_ORG_SLUG: "_anonymous",
 }));
 
 // State the tests mutate between runs.
@@ -70,21 +103,47 @@ let updateCalls: UpdateCall[] = [];
 let updateShouldThrow = false;
 let mockExecution: ExecutionRow | null = null;
 
-type WhereChain = Promise<void>;
+// KEEP-545: the workflow_executions UPDATE in logWorkflowCompleteDb now chains
+// `.returning({workflowId})` on the where() result so the per-execution error
+// counter knows which org to scope the increment to. The where() return value
+// must be BOTH awaitable (for callers that don't care about returning rows)
+// AND expose a `.returning()` method. We model it as a custom thenable
+// (NOT a native Promise -- V8 disallows assigning extra properties on those)
+// so awaiting it resolves and the new code-path can call .returning(), which
+// resolves to []. The counter-increment path treats empty returning() as
+// "no rows actually flipped" and skips, which is the right behavior for tests
+// that don't seed mockExecution.
+type WhereChain = {
+  then: <T>(
+    onFulfilled?: ((value: void) => T | PromiseLike<T>) | null,
+    onRejected?: ((reason: unknown) => T | PromiseLike<T>) | null
+  ) => Promise<T>;
+  catch: <T>(
+    onRejected: (reason: unknown) => T | PromiseLike<T>
+  ) => Promise<T | void>;
+  returning: (..._args: unknown[]) => Promise<Array<{ workflowId?: string }>>;
+};
 type SetChain = { where: () => WhereChain };
 type UpdateChain = { set: (values: Record<string, unknown>) => SetChain };
+
+function makeWhereChain(failure: Error | null): WhereChain {
+  const promise: Promise<void> = failure
+    ? Promise.reject(failure)
+    : Promise.resolve();
+  return {
+    then: (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected),
+    catch: (onRejected) => promise.catch(onRejected),
+    returning: () => Promise.resolve([]),
+  };
+}
 
 function buildUpdate(target: unknown): UpdateChain {
   return {
     set: (values: Record<string, unknown>): SetChain => {
       updateCalls.push({ target, set: values });
-      if (updateShouldThrow) {
-        return {
-          where: (): WhereChain => Promise.reject(new Error("db down")),
-        };
-      }
+      const failure = updateShouldThrow ? new Error("db down") : null;
       return {
-        where: (): WhereChain => Promise.resolve(),
+        where: (): WhereChain => makeWhereChain(failure),
       };
     },
   };
@@ -353,7 +412,9 @@ describe("logWorkflowCompleteDb", () => {
     updateShouldThrow = false;
 
     // Patch buildUpdate behavior per-call: first UPDATE (logs) throws,
-    // second UPDATE (executions) succeeds.
+    // second UPDATE (executions) succeeds. The where() return value must
+    // expose `.returning()` so the workflow_executions UPDATE chain works
+    // (KEEP-545 added a per-execution-error counter that reads it).
     const { db } = await import("@/lib/db");
     (
       db.update as unknown as {
@@ -367,12 +428,24 @@ describe("logWorkflowCompleteDb", () => {
         callIndex += 1;
         return {
           where: (): WhereChain =>
-            shouldThrow
-              ? Promise.reject(new Error("transient db failure"))
-              : Promise.resolve(),
+            makeWhereChain(
+              shouldThrow ? new Error("transient db failure") : null
+            ),
         };
       },
     }));
+
+    // Restore the base mock after this test so subsequent tests in the
+    // file (which rely on the base buildUpdate returning a chain with
+    // `.returning()`) aren't polluted by this inline override --
+    // vi.clearAllMocks() preserves implementations set via mockImplementation.
+    onTestFinished(() => {
+      (
+        db.update as unknown as {
+          mockImplementation: (fn: (t: unknown) => UpdateChain) => void;
+        }
+      ).mockImplementation((target: unknown) => buildUpdate(target));
+    });
 
     await logWorkflowCompleteDb({
       executionId: "exec_1",

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -39,8 +39,21 @@ describe("Unified Logging Helpers", () => {
     resetMetricsCollector();
   });
 
+  // KEEP-545: log helpers now emit a single structured JSON line so Grafana
+  // Cloud Loki can index `is_user_error`, `error_category`, `execution_id`,
+  // and `org_slug` via `| json`. This helper parses the JSON arg and returns
+  // the payload so per-test assertions can check fields without coupling to
+  // the on-the-wire serialization order.
+  function lastJsonLine(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+    const calls = spy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const last = calls[calls.length - 1];
+    expect(last.length).toBe(1);
+    return JSON.parse(last[0] as string) as Record<string, unknown>;
+  }
+
   describe("logUserError", () => {
-    it("should log as warning and emit metric", () => {
+    it("should log as warning JSON and emit metric", () => {
       logUserError(
         ErrorCategory.VALIDATION,
         "[Test] Invalid input",
@@ -48,10 +61,14 @@ describe("Unified Logging Helpers", () => {
         { foo: "bar" }
       );
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[Test] Invalid input",
-        "details"
-      );
+      const line = lastJsonLine(consoleWarnSpy);
+      expect(line.level).toBe("warn");
+      expect(line.msg).toBe("[Test] Invalid input");
+      expect(line.is_user_error).toBe("true");
+      expect(line.error_category).toBe(ErrorCategory.VALIDATION);
+      expect(line.error_context).toBe("Test");
+      expect(line.foo).toBe("bar");
+      expect(line.err).toEqual({ message: "details" });
       expect(consoleErrorSpy).not.toHaveBeenCalled();
 
       expect(mockCollector.recordError).toHaveBeenCalledWith(
@@ -66,14 +83,13 @@ describe("Unified Logging Helpers", () => {
       );
     });
 
-    it("should handle Error objects", () => {
+    it("should serialize Error objects to err.message and stack", () => {
       const error = new Error("Test error");
       logUserError(ErrorCategory.VALIDATION, "[Context] Error occurred", error);
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[Context] Error occurred",
-        error
-      );
+      const line = lastJsonLine(consoleWarnSpy);
+      expect(line.msg).toBe("[Context] Error occurred");
+      expect(line.err).toMatchObject({ message: "Test error", name: "Error" });
       expect(mockCollector.recordError).toHaveBeenCalledWith(
         MetricNames.USER_VALIDATION_ERRORS,
         error,
@@ -85,10 +101,12 @@ describe("Unified Logging Helpers", () => {
       );
     });
 
-    it("should handle undefined error details", () => {
+    it("should omit `err` when no error detail is passed", () => {
       logUserError(ErrorCategory.VALIDATION, "[Test] Simple warning");
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith("[Test] Simple warning", "");
+      const line = lastJsonLine(consoleWarnSpy);
+      expect(line.msg).toBe("[Test] Simple warning");
+      expect(line.err).toBeUndefined();
       expect(mockCollector.recordError).toHaveBeenCalledWith(
         MetricNames.USER_VALIDATION_ERRORS,
         { message: "[Test] Simple warning" },
@@ -160,16 +178,23 @@ describe("Unified Logging Helpers", () => {
   });
 
   describe("logSystemError", () => {
-    it("should log as error and emit metric", () => {
+    it("should log as structured error JSON and emit metric", () => {
       const error = new Error("System failure");
       logSystemError(ErrorCategory.DATABASE, "[DB] Connection failed", error, {
         table: "workflows",
       });
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[DB] Connection failed",
-        error
-      );
+      const line = lastJsonLine(consoleErrorSpy);
+      expect(line.level).toBe("error");
+      expect(line.msg).toBe("[DB] Connection failed");
+      expect(line.is_user_error).toBe("false");
+      expect(line.error_category).toBe(ErrorCategory.DATABASE);
+      expect(line.error_context).toBe("DB");
+      expect(line.table).toBe("workflows");
+      expect(line.err).toMatchObject({
+        message: "System failure",
+        name: "Error",
+      });
       expect(consoleWarnSpy).not.toHaveBeenCalled();
 
       expect(mockCollector.recordError).toHaveBeenCalledWith(
@@ -243,7 +268,7 @@ describe("Unified Logging Helpers", () => {
   });
 
   describe("logSystemWarn", () => {
-    it("should log as warn and NOT emit any metric", () => {
+    it("should log as warn JSON and NOT emit any metric", () => {
       const error = new Error("Spurious SDK error");
       logSystemWarn(
         ErrorCategory.WORKFLOW_ENGINE,
@@ -252,13 +277,20 @@ describe("Unified Logging Helpers", () => {
         { execution_id: "exec-123" }
       );
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[Workflow Logging] Pre-reconciliation"),
-        error
+      const line = lastJsonLine(consoleWarnSpy);
+      expect(line.level).toBe("warn");
+      expect(line.msg).toBe(
+        "[Workflow Logging] Pre-reconciliation [exec:exec-123]"
       );
+      expect(line.error_category).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(line.error_context).toBe("Workflow Logging");
+      // is_user_error intentionally not set on logSystemWarn so alerts
+      // filtering on is_user_error="false" don't match these events.
+      expect(line.is_user_error).toBeUndefined();
+      expect(line.execution_id).toBe("exec-123");
       expect(consoleErrorSpy).not.toHaveBeenCalled();
 
-      // The key invariant: warn helper does not increment ANY metric counter,
+      // Key invariant: warn helper does not increment ANY metric counter,
       // so it cannot trip system-error or user-error dashboards.
       expect(mockCollector.recordError).not.toHaveBeenCalled();
     });
@@ -270,10 +302,9 @@ describe("Unified Logging Helpers", () => {
         "string detail"
       );
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[Test] Warn"),
-        "string detail"
-      );
+      const line = lastJsonLine(consoleWarnSpy);
+      expect(line.msg).toBe("[Test] Warn");
+      expect(line.err).toEqual({ message: "string detail" });
       expect(mockCollector.recordError).not.toHaveBeenCalled();
     });
 
@@ -306,10 +337,11 @@ describe("Unified Logging Helpers", () => {
         }
       );
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[Check Balance] Invalid address:",
-        "0xINVALID"
-      );
+      const line = lastJsonLine(consoleWarnSpy);
+      expect(line.msg).toBe("[Check Balance] Invalid address:");
+      expect(line.err).toEqual({ message: "0xINVALID" });
+      expect(line.plugin_name).toBe("web3");
+      expect(line.action_name).toBe("check-balance");
 
       expect(mockCollector.recordError).toHaveBeenCalledWith(
         MetricNames.USER_VALIDATION_ERRORS,

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -940,6 +940,16 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
     generateCalldataForWorkflow: mockGenerateCalldata,
   }));
 
+  vi.mock("@/lib/errors/classify", () => ({
+    classifyExecutionError: () => ({
+      errorCategory: "workflow_engine",
+      isUserError: false,
+    }),
+  }));
+  vi.mock("@/lib/errors/finalize-error", () => ({
+    recordExecutionErrorFinalized: vi.fn().mockResolvedValue(undefined),
+  }));
+
   const WRITE_WORKFLOW = {
     id: "wf-write-1",
     name: "Write Workflow",

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -119,6 +119,21 @@ vi.mock("@/lib/payments/x402/execution-wait", () => ({
   buildCallCompletionResponse: mockBuildCallCompletionResponse,
 }));
 
+// KEEP-545: route now classifies errors and increments a per-execution counter
+// after writing status='error'. The classifier is pure (safe to import) but
+// the finalize-error helper transitively imports server-only modules; mock
+// both so the test doesn't try to load them.
+vi.mock("@/lib/errors/classify", () => ({
+  classifyExecutionError: (msg: unknown) => ({
+    errorCategory: "workflow_engine",
+    isUserError: false,
+    _msg: msg,
+  }),
+}));
+vi.mock("@/lib/errors/finalize-error", () => ({
+  recordExecutionErrorFinalized: vi.fn().mockResolvedValue(undefined),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes KEEP-545. Replaces the misleading `keeperhub_workflow_execution_errors_total` DB-sourced gauge with a real Prometheus counter and adds classification (`error_category`, `is_user_error`) at the source. Folds in the KEEP-391 L337 anomaly demotion.

## Why

Live evidence on 2026-05-12 (techops-prod, last 30 days):

| What | Value |
|---|---|
| Gauge value the dashboard shows for Sky + Ajna | **18,876** |
| Actual error rows in last 30 days | **1,554** |
| Real system-class failures (DB / executor / infra / plugin / secret) | **~720 (47%)** |
| User-config noise (template / contract args / code typos) | **~830 (53%)** |

Two problems shipped:

1. `keeperhub_workflow_execution_errors_total` was named with the counter `_total` suffix but is actually a gauge that gets overwritten on every scrape with the all-time cumulative count. Every dashboard reads it as a static 12x-inflated number ignoring the panel time range.
2. There is no classification on the `workflow_executions` row, so the SLA alert can't separate "real engineering failures we need to fix" from user-config noise.

## What changed

1. New Prometheus counter `keeperhub_workflow_execution_errors_created_total{org_slug, error_category, is_user_error}` incremented once per `status='error'` row write.
2. New nullable columns on `workflow_executions`: `error_category` (text), `is_user_error` (boolean).
3. New `lib/errors/classify.ts` with a pattern matrix covering every error family observed in 30 days of managed-client production errors.
4. Counter + classification wired into every callsite that finalizes a `workflow_executions` row as `status='error'`: `logWorkflowCompleteDb` (central chokepoint), reaper, three route handlers.
5. `logUserError`, `logSystemError`, `logSystemWarn` now emit a single structured JSON line per call so Grafana Cloud Loki indexes `is_user_error`, `error_category`, `execution_id`, `org_slug` as queryable labels via `| json`.
6. `lib/workflow/executor/logging.ts:337` `selfHealWorkflowAfterLateStepCommit` success-flip demoted from `logSystemError` to `logSystemWarn`.
7. `scripts/backfill-error-classification.ts` one-time idempotent backfill for managed-client error rows over the last 90 days.

## Test plan

- [x] `pnpm check` clean on my files
- [x] `pnpm type-check` clean on my files (0 new errors)
- [x] `pnpm test:unit` -- 4008 tests pass, 0 new failures vs baseline
- [x] 33 new tests for `classifyExecutionError`
- [x] 28 tests for restructured logging JSON output
- [ ] After deploy to staging:
  - [ ] New counter appears with `org_slug`, `error_category`, `is_user_error` labels
  - [ ] `absent(keeperhub_workflow_execution_errors_total{cluster="techops-staging"}) == 1`
  - [ ] Synthetic user-config failure classified `configuration` / `is_user_error=true`
  - [ ] Synthetic system failure classified `workflow_engine` / `is_user_error=false`; JSON log line queryable in Loki via `| json | execution_id="<id>"`
  - [ ] Run backfill `--dry-run` then real, verify idempotency

## Rollback

`git revert`. New columns stay nullable. New counter stops emitting; Prometheus series ages out per retention.

## Follow-up PRs

- Infrastructure PR: switch `workflow_high_error_count_alert` and dashboard panels from the removed gauge to the new counter (must wait ~30 min after this PR lands so the counter is emitting).
- Keeperhub PR: close KEEP-536 with a regression test snapshotting `ERROR_LABELS` and dashboard panel polish.

## Out of scope (follow-up engineering tickets, file after this lands)

30-day data already surfaced these as concrete system failures inside the managed-client scope -- to be filed as separate KEEP tickets once the classified dashboard confirms they're still active:

- 406 DB connection failures
- 225 stuck executions
- 72 `Cannot find module './credential-map'` deploy regressions
- 14 SIGTERM mid-execution kills
- 2 `Unknown action type: "condition"` plugin registry bugs
- 2 missing `TURNKEY_API_PUBLIC_KEY` env