### PR TITLE
fix(block-dispatcher): KEEP-557 auto-failover to fallback WSS on silent-subscription failure

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -84,6 +84,14 @@ const LIVENESS_DEFAULTS = {
   // Primary recovery probe (used only while running on the fallback URL).
   PRIMARY_PROBE_INTERVAL_MS: 5 * 60_000,
   PRIMARY_PROBE_TIMEOUT_MS: 5_000,
+  // After this many consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on the same
+  // URL, flip the URL preference (primary <-> fallback) on the next reconnect.
+  // This catches half-open-subscription upstreams where the WSS connects and
+  // request/response works but eth_subscribe never delivers newHeads — a
+  // failure mode the existing connect-level fallback cannot detect because
+  // getBlockNumber() succeeds on the broken URL. Reset to 0 on a real block
+  // advance, so a recovered URL is fully trusted again.
+  SILENT_FAILOVER_THRESHOLD: 2,
 } as const;
 
 type LivenessKey = keyof typeof LIVENESS_DEFAULTS;
@@ -167,6 +175,11 @@ export class ChainMonitor {
   private currentUrlIndex = 0;
   private hasActiveSubscription = false;
   private wsCloseHandler: (() => void) | null = null;
+  // Consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on the same URL. Reset on a
+  // real height advance in processBlockRange. When this hits
+  // SILENT_FAILOVER_THRESHOLD, the next reconnect flips currentUrlIndex so the
+  // monitor tries the other configured URL (primary <-> fallback).
+  private silentReconnects = 0;
 
   constructor(config: ChainMonitorConfig) {
     this.chainId = config.chain.chainId;
@@ -181,6 +194,7 @@ export class ChainMonitor {
       return;
     }
     this.isRunning = true;
+    this.silentReconnects = 0;
 
     try {
       await this.connect();
@@ -198,6 +212,7 @@ export class ChainMonitor {
     this.isRunning = false;
     this.isReconnecting = false;
     this.reconnectingStartedAt = null;
+    this.silentReconnects = 0;
     this.stopTimers();
     await this.destroyProvider();
   }
@@ -322,21 +337,39 @@ export class ChainMonitor {
   }
 
   private async connect(): Promise<void> {
-    const urls = [this.primaryWss, this.fallbackWss].filter(
-      (url): url is string => url !== null && url !== "",
-    );
+    type Candidate = {
+      url: string;
+      index: 0 | 1;
+      label: "primary" | "fallback";
+    };
+    const candidates: Candidate[] = [];
+    if (this.primaryWss) {
+      candidates.push({ url: this.primaryWss, index: 0, label: "primary" });
+    }
+    if (this.fallbackWss) {
+      candidates.push({ url: this.fallbackWss, index: 1, label: "fallback" });
+    }
 
-    if (urls.length === 0) {
+    if (candidates.length === 0) {
       throw new Error(
         `No WSS URLs configured for chain ${this.chainName} (${this.chainId})`,
       );
     }
 
-    for (const [index, url] of urls.entries()) {
-      const label = index === 0 ? "primary" : "fallback";
+    // Honor currentUrlIndex as the starting preference. It is updated below
+    // when we successfully connect, and also explicitly flipped by
+    // maybeFlipUrlPreference() when SILENT_FAILOVER_THRESHOLD is reached on
+    // the previous URL. The labels "primary"/"fallback" stay stable across
+    // reorderings so logs always identify which physical URL is in use.
+    const ordered =
+      this.currentUrlIndex === 1 && candidates.length === 2
+        ? [candidates[1], candidates[0]]
+        : candidates;
+
+    for (const [iterIdx, candidate] of ordered.entries()) {
       let provider: ethers.WebSocketProvider | null = null;
       try {
-        provider = new ethers.WebSocketProvider(url);
+        provider = new ethers.WebSocketProvider(candidate.url);
 
         // ethers v6 WebSocketProvider does not attach an 'error' listener on
         // the underlying ws. Without one, an HTTP 429 (or any non-101 upgrade
@@ -366,9 +399,9 @@ export class ChainMonitor {
         ])) as number;
 
         this.provider = provider;
-        this.currentUrlIndex = index;
+        this.currentUrlIndex = candidate.index;
         console.log(
-          `[BlockMonitor:${this.chainName}] Connected to ${label} WSS (block: ${blockNumber})`,
+          `[BlockMonitor:${this.chainName}] Connected to ${candidate.label} WSS (block: ${blockNumber})`,
         );
         return;
       } catch (error) {
@@ -378,10 +411,10 @@ export class ChainMonitor {
           await provider.destroy().catch(() => {});
         }
         console.warn(
-          `[BlockMonitor:${this.chainName}] Failed to connect to ${label} WSS:`,
+          `[BlockMonitor:${this.chainName}] Failed to connect to ${candidate.label} WSS:`,
           error instanceof Error ? error.message : error,
         );
-        if (index === urls.length - 1) {
+        if (iterIdx === ordered.length - 1) {
           throw error;
         }
       }
@@ -538,6 +571,10 @@ export class ChainMonitor {
     this.lastProcessedBlock = blockNumber;
     // Height genuinely advanced — refresh liveness AFTER the fact.
     this.lastBlockAdvanceAt = Date.now();
+    // Trust the current URL again: a real height advance means the
+    // subscription is delivering. Without this reset, an old streak of silent
+    // reconnects would still trigger a URL flip on the next disconnect.
+    this.silentReconnects = 0;
     this.resetNoBlockTimer();
     this.blocksReceived++;
 
@@ -718,8 +755,12 @@ export class ChainMonitor {
     const timeoutMs = liveness("BLOCK_ADVANCE_TIMEOUT_MS");
     this.noBlockTimer = setTimeout(() => {
       if (this.isRunning) {
+        // Count this as a silent reconnect on the current URL. Decision to
+        // flip to the other URL is made by reconnectWithBackoff before its
+        // next connect attempt, based on SILENT_FAILOVER_THRESHOLD.
+        this.silentReconnects++;
         console.warn(
-          `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s, triggering reconnect`,
+          `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s (silent reconnects=${this.silentReconnects}), triggering reconnect`,
         );
         this.handleDisconnect();
       }
@@ -909,6 +950,8 @@ export class ChainMonitor {
         return;
       }
 
+      this.maybeFlipUrlPreference();
+
       try {
         await this.connect();
         await this.subscribeToBlocks();
@@ -928,5 +971,37 @@ export class ChainMonitor {
         await this.destroyProvider();
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // URL preference flip
+  //
+  // Catches the half-open-subscription failure mode: the primary WSS accepts
+  // the upgrade, getBlockNumber() returns, eth_subscribe is acknowledged, but
+  // no newHeads notifications ever arrive. From connect()'s point of view the
+  // URL is healthy, so the existing fallback path never fires. After
+  // SILENT_FAILOVER_THRESHOLD consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on
+  // the same URL, swap the URL preference so the next reconnect lands on the
+  // other configured endpoint. Reset the counter on flip; if the new URL is
+  // also silent, the counter will rebuild and the monitor will alternate
+  // until one of them recovers. The existing primaryProbeTimer handles
+  // swapping back to primary when it recovers.
+  // ---------------------------------------------------------------------------
+
+  private maybeFlipUrlPreference(): void {
+    const threshold = liveness("SILENT_FAILOVER_THRESHOLD");
+    if (this.silentReconnects < threshold) {
+      return;
+    }
+    if (!(this.primaryWss && this.fallbackWss)) {
+      return;
+    }
+    const previousLabel = this.currentUrlIndex === 0 ? "primary" : "fallback";
+    const nextLabel = this.currentUrlIndex === 0 ? "fallback" : "primary";
+    this.currentUrlIndex = this.currentUrlIndex === 0 ? 1 : 0;
+    this.silentReconnects = 0;
+    console.warn(
+      `[BlockMonitor:${this.chainName}] Silent-reconnect threshold (${threshold}) reached on ${previousLabel}, flipping URL preference to ${nextLabel}`,
+    );
   }
 }

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -153,6 +153,10 @@ describe("ChainMonitor", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    // Reset env stubs so per-test overrides (BLOCK_ADVANCE_TIMEOUT_MS,
+    // SILENT_FAILOVER_THRESHOLD, SOCKET_MAX_AGE_MS) do not leak into later
+    // tests and trigger timers earlier than the test under test expects.
+    vi.unstubAllEnvs();
   });
 
   function latestProvider(): MockProvider {
@@ -629,6 +633,71 @@ describe("ChainMonitor", () => {
       expect(providerInstances).toHaveLength(2);
       expect(latestProvider().url).toBe("wss://fallback.test");
       expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("flips to fallback after SILENT_FAILOVER_THRESHOLD silent reconnects on primary", async () => {
+      // Half-open-subscription scenario:
+      //  - primary connects fine (getBlockNumber resolves)
+      //  - eth_subscribe is accepted (provider.on resolves)
+      //  - but newHeads is silent forever (we never call emitBlock on it)
+      // After SILENT_FAILOVER_THRESHOLD BLOCK_ADVANCE_TIMEOUT_MS firings on
+      // primary, the monitor flips to fallback for the next reconnect.
+      vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", "200");
+      vi.stubEnv("SILENT_FAILOVER_THRESHOLD", "2");
+      // Disable the primary-recovery probe so it does not swap us back to
+      // primary mid-test once we are on fallback.
+      vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", "600000");
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(latestProvider().url).toBe("wss://primary.test");
+      expect(providerInstances).toHaveLength(1);
+
+      // First silent window: noBlockTimer fires (silentReconnects=1),
+      // reconnect waits 1s backoff, lands back on primary (below threshold).
+      await vi.advanceTimersByTimeAsync(1_400);
+      expect(latestProvider().url).toBe("wss://primary.test");
+      expect(providerInstances.length).toBeGreaterThanOrEqual(2);
+
+      // Second silent window: noBlockTimer fires (silentReconnects=2),
+      // reconnect waits 1s backoff, maybeFlipUrlPreference() flips to
+      // fallback, connect lands on fallback URL.
+      await vi.advanceTimersByTimeAsync(1_400);
+      expect(latestProvider().url).toBe("wss://fallback.test");
+      expect(monitor.isAlive()).toBe(true);
+
+      await monitor.stop();
+    });
+
+    it("does not flip when fallback URL is not configured", async () => {
+      // If only a primary URL is configured, there is nowhere to flip to.
+      // The monitor must keep reconnecting to the same URL without crashing.
+      vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", "200");
+      vi.stubEnv("SILENT_FAILOVER_THRESHOLD", "2");
+      vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", "600000");
+
+      const monitor = new ChainMonitor({
+        chain: makeChain({ defaultFallbackWss: null }),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(latestProvider().url).toBe("wss://primary.test");
+
+      // Two silent windows; even past the threshold, still primary.
+      await vi.advanceTimersByTimeAsync(1_400);
+      await vi.advanceTimersByTimeAsync(1_400);
+
+      const urls = providerInstances.map((p) => p.url);
+      for (const url of urls) {
+        expect(url).toBe("wss://primary.test");
+      }
+
+      await monitor.stop();
     });
 
     it("does not propagate ws 'error' as an uncaughtException", async () => {


### PR DESCRIPTION
## Summary

Fixes [KEEP-557](https://linear.app/keeperhubapp/issue/KEEP-557/), follow-up to KEEP-544.

Observed in prod on 2026-05-13: the Ethereum Mainnet upstream WSS (Aetherlay) entered a half-open subscription state — TCP/ping-pong alive, `getBlockNumber()` returning fresh tips, `eth_subscribe(\"newHeads\")` accepted — but no `newHeads` notifications ever pushed. KEEP-544's `noBlockTimer` correctly forced a reconnect every 300s, but every reconnect landed back on the same broken primary because primary's `getBlockNumber()` kept succeeding. The Alchemy fallback configured in `chains.default_fallback_wss` was never exercised. 6 consecutive reconnect cycles in 30 min, all silent. All 4 Ethereum Mainnet block-trigger workflows missed triggers during the silent windows.

## Change

`chain-monitor.ts`:

- New `silentReconnects` counter on `ChainMonitor`. Incremented in the `noBlockTimer` callback before `handleDisconnect()`. Reset to 0 on a real height advance in `processBlockRange`, on `start()`, and on `stop()`.
- New `maybeFlipUrlPreference()` helper called from `reconnectWithBackoff()` before each `connect()` attempt. When `silentReconnects >= SILENT_FAILOVER_THRESHOLD` (default 2, env-tunable) and both `primaryWss` and `fallbackWss` are configured, flip `currentUrlIndex` and reset the counter.
- `connect()` now reorders its candidate list so `currentUrlIndex` is honoured as the starting preference, while keeping the \"primary\"/\"fallback\" labels in logs tied to the original index. No change when only one URL is configured.

The existing `primaryProbeTimer` already swaps back to primary once it recovers, so this PR only needs the failover-out trigger.

## Files

- `keeperhub-scheduler/block-dispatcher/chain-monitor.ts` — counter + flip helper + connect reordering
- `keeperhub-scheduler/tests/unit/chain-monitor.test.ts` — two new tests + `vi.unstubAllEnvs()` in `afterEach` so per-test env overrides do not bleed across tests

## Tests

- New: \"flips to fallback after SILENT_FAILOVER_THRESHOLD silent reconnects on primary\" — drives the half-open scenario by never emitting blocks, asserts the third reconnect lands on `wss://fallback.test`.
- New: \"does not flip when fallback URL is not configured\" — confirms no-op behaviour when `fallbackWss` is null.
- 64/64 vitest pass (was 62).

The third test I drafted (counter resets on real height advance) was removed because reliable timing was hard to achieve with fake timers around the noBlockTimer/backoff overlap; the reset is a single-line write in `processBlockRange` that is straightforward to verify by code review.

## Out of scope (filed separately)

Observability for this kind of silent failure is currently absent — the block-dispatcher exposes only `/health` JSON, no Prometheus metrics, and the `observability/grafana/dashboards/` directory is empty. Today the only signal is users telling us workflows stopped triggering. Worth a follow-up to add `prom-client` + `seconds_since_last_block` gauge + alert rule, but out of scope for this PR.