### PR TITLE
fix: require active org membership for workflow access

### DIFF
--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -14,6 +14,7 @@ import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
@@ -125,6 +126,19 @@ export async function POST(
       }
 
       userId = workflow.userId;
+
+      const access = await getWorkflowAccess(workflow, {
+        userId,
+        organizationId: null,
+        authMethod: "internal",
+      });
+
+      if (!access.hasFullAccess) {
+        return NextResponse.json(
+          { error: "Workflow not found" },
+          { status: 404 }
+        );
+      }
     } else {
       const authContext = await getDualAuthContext(request);
       if ("error" in authContext) {
@@ -145,14 +159,17 @@ export async function POST(
         );
       }
 
-      const isOwner = authContext.authMethod === "session" && workflow.userId === authContext.userId;
-      const isSameOrg =
-        !workflow.isAnonymous &&
-        workflow.organizationId &&
-        authContext.organizationId === workflow.organizationId;
+      const access = await getWorkflowAccess(workflow, {
+        userId: authContext.userId,
+        organizationId: authContext.organizationId,
+        authMethod: authContext.authMethod,
+      });
 
-      if (!(isOwner || isSameOrg)) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      if (!access.hasFullAccess) {
+        return NextResponse.json(
+          { error: "Workflow not found" },
+          { status: 404 }
+        );
       }
 
       userId = authContext.userId ?? workflow.userId;

--- a/app/api/workflows/[workflowId]/code/route.ts
+++ b/app/api/workflows/[workflowId]/code/route.ts
@@ -8,6 +8,7 @@ import {
   auditFromAuth,
   getDualAuthContext,
 } from "@/lib/middleware/auth-helpers";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 import { generateWorkflowSDKCode } from "@/lib/workflow/codegen/sdk";
 
 export async function GET(
@@ -38,13 +39,13 @@ export async function GET(
       );
     }
 
-    const isOwner = userId !== null && userId === workflow.userId;
-    const isSameOrg =
-      !workflow.isAnonymous &&
-      workflow.organizationId !== null &&
-      workflow.organizationId === organizationId;
+    const access = await getWorkflowAccess(workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
-    if (!(isOwner || isSameOrg)) {
+    if (!access.hasFullAccess) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/download/route.ts
+++ b/app/api/workflows/[workflowId]/download/route.ts
@@ -10,6 +10,7 @@ import {
   auditFromAuth,
   getDualAuthContext,
 } from "@/lib/middleware/auth-helpers";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 import { buildWorkflowExportV1 } from "@/lib/workflow/export-schema";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
@@ -52,13 +53,13 @@ export async function GET(
       );
     }
 
-    const isOwner = userId !== null && userId === workflow.userId;
-    const isSameOrg =
-      !workflow.isAnonymous &&
-      workflow.organizationId !== null &&
-      workflow.organizationId === organizationId;
+    const access = await getWorkflowAccess(workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
-    if (!(isOwner || isSameOrg)) {
+    if (!access.hasFullAccess) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -7,6 +7,7 @@ import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 import { remapTemplateRefsInString } from "@/lib/utils/template";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
 // Node type for type-safe node manipulation
 type WorkflowNodeLike = {
@@ -139,10 +140,14 @@ export async function POST(
       );
     }
 
-    const isOwner = userId === sourceWorkflow.userId;
+    const access = await getWorkflowAccess(sourceWorkflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
     // If not owner, check if workflow is public
-    if (!isOwner && sourceWorkflow.visibility !== "public") {
+    if (!access.hasFullAccess && sourceWorkflow.visibility !== "public") {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
@@ -220,7 +225,11 @@ export async function POST(
 
     // If moving an anonymous workflow to an org, delete the original
     // This prevents the old anonymous workflow from being accessible after sign out
-    if (sourceWorkflow.isAnonymous && isOwner && !isAnonymous) {
+    if (
+      sourceWorkflow.isAnonymous &&
+      access.isCreatorWithCurrentAccess &&
+      !isAnonymous
+    ) {
       await db.delete(workflows).where(eq(workflows.id, workflowId));
     }
 

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -4,6 +4,7 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 
 export async function GET(
   request: Request,
@@ -33,13 +34,13 @@ export async function GET(
       );
     }
 
-    const isOwner = userId !== null && userId === workflow.userId;
-    const isSameOrg =
-      !workflow.isAnonymous &&
-      workflow.organizationId &&
-      organizationId === workflow.organizationId;
+    const access = await getWorkflowAccess(workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
-    if (!(isOwner || isSameOrg)) {
+    if (!access.hasFullAccess) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
@@ -97,13 +98,13 @@ export async function DELETE(
       );
     }
 
-    const isOwner = userId !== null && userId === workflow.userId;
-    const isSameOrg =
-      !workflow.isAnonymous &&
-      workflow.organizationId &&
-      organizationId === workflow.organizationId;
+    const access = await getWorkflowAccess(workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
-    if (!(isOwner || isSameOrg)) {
+    if (!access.hasFullAccess) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/go-live/route.ts
+++ b/app/api/workflows/[workflowId]/go-live/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { workflowPublicTags, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getOrgContext } from "@/lib/middleware/org-context";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 
 export async function PUT(
   request: Request,
@@ -30,13 +31,13 @@ export async function PUT(
       );
     }
 
-    const isOwner = workflow.userId === orgContext.user.id;
-    const isSameOrg =
-      !workflow.isAnonymous &&
-      workflow.organizationId &&
-      orgContext.organization?.id === workflow.organizationId;
+    const access = await getWorkflowAccess(workflow, {
+      userId: orgContext.user.id,
+      organizationId: orgContext.organization?.id ?? null,
+      authMethod: "session",
+    });
 
-    if (!(isOwner || isSameOrg)) {
+    if (!access.hasFullAccess) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/mcp/listing-validators";
 import { syncWorkflowSchedule } from "@/lib/schedule-service";
 import { sanitizeDescription } from "@/lib/sanitize-description";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
 import { isReservedSlug } from "@/lib/workflow/reserved-slugs";
 import { findInvalidTemplateTokens } from "@/lib/workflow/validation/template-syntax";
@@ -87,26 +88,24 @@ export async function GET(
       );
     }
 
-    const isOwner = userId === workflow.userId;
-
-    // Check organization membership for private workflows
-    const isSameOrg =
-      !workflow.isAnonymous &&
-      workflow.organizationId &&
-      organizationId === workflow.organizationId;
+    const access = await getWorkflowAccess(workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
     // Access control:
     // - Public workflows: anyone can view (sanitized)
     // - Private workflows: owner or org member can view
     // - Anonymous workflows: only owner can view
-    if (!isOwner && workflow.visibility !== "public" && !isSameOrg) {
+    if (!access.hasFullAccess && workflow.visibility !== "public") {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
       );
     }
 
-    const hasFullAccess = isOwner || isSameOrg;
+    const hasFullAccess = access.hasFullAccess;
 
     const workflowTags = await fetchWorkflowPublicTags(workflowId);
 
@@ -206,7 +205,8 @@ function isValidVisibility(visibility: unknown): boolean {
 async function validateWorkflowAccess(
   workflowId: string,
   userId: string | null,
-  organizationId: string | null
+  organizationId: string | null,
+  authMethod: "api-key" | "oauth" | "session"
 ): Promise<{
   workflow: typeof workflows.$inferSelect | null;
   hasAccess: boolean;
@@ -219,15 +219,15 @@ async function validateWorkflowAccess(
     return { workflow: null, hasAccess: false };
   }
 
-  const isOwner = userId ? existingWorkflow.userId === userId : false;
-  const isSameOrg =
-    !existingWorkflow.isAnonymous &&
-    existingWorkflow.organizationId &&
-    organizationId === existingWorkflow.organizationId;
+  const access = await getWorkflowAccess(existingWorkflow, {
+    userId,
+    organizationId,
+    authMethod,
+  });
 
   return {
     workflow: existingWorkflow,
-    hasAccess: isOwner || Boolean(isSameOrg),
+    hasAccess: access.hasFullAccess,
   };
 }
 
@@ -283,7 +283,12 @@ export async function PATCH(
 
     const { userId, organizationId } = authContext;
     const { workflow: existingWorkflow, hasAccess } =
-      await validateWorkflowAccess(workflowId, userId, organizationId);
+      await validateWorkflowAccess(
+        workflowId,
+        userId,
+        organizationId,
+        authContext.authMethod
+      );
 
     if (!(existingWorkflow && hasAccess)) {
       return NextResponse.json(
@@ -589,7 +594,8 @@ export async function DELETE(
     const { hasAccess } = await validateWorkflowAccess(
       workflowId,
       userId,
-      organizationId
+      organizationId,
+      authContext.authMethod
     );
 
     if (!hasAccess) {

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -20,10 +20,12 @@ import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { apiKeys, workflowExecutions, workflows } from "@/lib/db/schema";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 type ValidateApiKeyResult = {
   valid: boolean;
+  userId?: string;
   error?: string;
   statusCode?: number;
   errorBody?: Record<string, unknown>;
@@ -107,7 +109,7 @@ async function validateApiKey(
       // Fire and forget - ignore errors
     });
 
-  return { valid: true };
+  return { valid: true, userId: apiKey.userId };
 }
 
 const corsHeaders = {
@@ -251,6 +253,16 @@ export async function POST(
         apiKeyValidation.error ?? "Invalid API key",
         apiKeyValidation.errorBody
       );
+    }
+
+    const access = await getWorkflowAccess(workflow, {
+      userId: apiKeyValidation.userId ?? null,
+      organizationId: null,
+      authMethod: "webhook",
+    });
+
+    if (!access.hasFullAccess) {
+      return failResponse(workflowId, timer, 404, "Workflow not found");
     }
 
     // Verify this is a webhook-triggered workflow

--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { redactSensitiveData } from "@/lib/utils/redact";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 
 export async function GET(
   request: Request,
@@ -45,14 +46,17 @@ export async function GET(
     }
 
     // Verify access: owner or org member
-    const isOwner = userId !== null && execution.workflow.userId === userId;
-    const isSameOrg =
-      !execution.workflow.isAnonymous &&
-      execution.workflow.organizationId &&
-      organizationId === execution.workflow.organizationId;
+    const access = await getWorkflowAccess(execution.workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
-    if (!(isOwner || isSameOrg)) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    if (!access.hasFullAccess) {
+      return NextResponse.json(
+        { error: "Execution not found" },
+        { status: 404 }
+      );
     }
 
     // Get logs

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -6,6 +6,7 @@ import { recordStatusPollMetrics } from "@/lib/metrics/instrumentation/api";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+import { getWorkflowAccess } from "@/lib/workflow/access";
 
 type NodeStatus = {
   nodeId: string;
@@ -68,19 +69,22 @@ export async function GET(
     }
 
     // Verify access: owner or org member
-    const isOwner = userId !== null && execution.workflow.userId === userId;
-    const isSameOrg =
-      !execution.workflow.isAnonymous &&
-      execution.workflow.organizationId &&
-      organizationId === execution.workflow.organizationId;
+    const access = await getWorkflowAccess(execution.workflow, {
+      userId,
+      organizationId,
+      authMethod: authContext.authMethod,
+    });
 
-    if (!(isOwner || isSameOrg)) {
+    if (!access.hasFullAccess) {
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),
-        statusCode: 403,
+        statusCode: 404,
       });
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Execution not found" },
+        { status: 404 }
+      );
     }
 
     // Get logs for all nodes

--- a/lib/api-key-auth.ts
+++ b/lib/api-key-auth.ts
@@ -20,7 +20,7 @@
 import { createHash } from "node:crypto";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { organizationApiKeys, users } from "@/lib/db/schema";
+import { member, organizationApiKeys, users } from "@/lib/db/schema";
 
 export type ApiKeyAuthResult = {
   authenticated: boolean;
@@ -90,9 +90,17 @@ export async function authenticateApiKey(
         organizationId: organizationApiKeys.organizationId,
         createdBy: organizationApiKeys.createdBy,
         creatorDeactivatedAt: users.deactivatedAt,
+        creatorMemberId: member.id,
       })
       .from(organizationApiKeys)
       .leftJoin(users, eq(users.id, organizationApiKeys.createdBy))
+      .leftJoin(
+        member,
+        and(
+          eq(member.userId, organizationApiKeys.createdBy),
+          eq(member.organizationId, organizationApiKeys.organizationId)
+        )
+      )
       .where(
         and(
           eq(organizationApiKeys.keyHash, keyHash),
@@ -126,6 +134,14 @@ export async function authenticateApiKey(
       return {
         authenticated: false,
         error: "API key creator account is deactivated",
+        statusCode: 401,
+      };
+    }
+
+    if (apiKey.createdBy && !apiKey.creatorMemberId) {
+      return {
+        authenticated: false,
+        error: "API key creator is no longer a member of this organization",
         statusCode: 401,
       };
     }

--- a/lib/workflow/access.ts
+++ b/lib/workflow/access.ts
@@ -65,10 +65,7 @@ export async function getWorkflowAccess(
   };
 
   const isSameOrg =
-    hasSameOrgContext &&
-    (subject.authMethod === "api-key" && userId !== null
-      ? await hasCurrentMembership()
-      : true);
+    hasSameOrgContext && userId !== null && (await hasCurrentMembership());
   const isOrgWorkflowCreatorWithMembership =
     !workflow.isAnonymous &&
     isCreator &&

--- a/lib/workflow/access.ts
+++ b/lib/workflow/access.ts
@@ -1,0 +1,90 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { member } from "@/lib/db/schema";
+
+type WorkflowAccessSubject = {
+  userId: string | null;
+  organizationId: string | null;
+  authMethod?: "api-key" | "internal" | "oauth" | "session" | "webhook";
+};
+
+type WorkflowAccessWorkflow = {
+  id?: string;
+  userId: string;
+  organizationId: string | null;
+  isAnonymous: boolean;
+};
+
+export type WorkflowAccess = {
+  isCreatorWithCurrentAccess: boolean;
+  isSameOrg: boolean;
+  hasFullAccess: boolean;
+};
+
+async function isUserMemberOfOrganization(
+  userId: string,
+  organizationId: string
+): Promise<boolean> {
+  const [membership] = await db
+    .select({ id: member.id })
+    .from(member)
+    .where(
+      and(eq(member.userId, userId), eq(member.organizationId, organizationId))
+    )
+    .limit(1);
+
+  return membership !== undefined && membership !== null;
+}
+
+export async function getWorkflowAccess(
+  workflow: WorkflowAccessWorkflow,
+  subject: WorkflowAccessSubject
+): Promise<WorkflowAccess> {
+  const userId = subject.userId;
+  const isCreator = userId !== null && userId === workflow.userId;
+  const hasSameOrgContext =
+    !workflow.isAnonymous &&
+    workflow.organizationId !== null &&
+    subject.organizationId === workflow.organizationId;
+  const isAnonymousCreator = workflow.isAnonymous && isCreator;
+
+  let currentMembership: boolean | null = null;
+  const hasCurrentMembership = async (): Promise<boolean> => {
+    if (
+      workflow.isAnonymous ||
+      workflow.organizationId === null ||
+      userId === null
+    ) {
+      return false;
+    }
+    currentMembership ??= await isUserMemberOfOrganization(
+      userId,
+      workflow.organizationId
+    );
+    return currentMembership;
+  };
+
+  const isSameOrg =
+    hasSameOrgContext &&
+    (subject.authMethod === "api-key" && userId !== null
+      ? await hasCurrentMembership()
+      : true);
+  const isOrgWorkflowCreatorWithMembership =
+    !workflow.isAnonymous &&
+    isCreator &&
+    !isSameOrg &&
+    workflow.organizationId !== null &&
+    userId !== null &&
+    (await hasCurrentMembership());
+
+  const isCreatorWithCurrentAccess =
+    isAnonymousCreator ||
+    (isCreator && isSameOrg) ||
+    isOrgWorkflowCreatorWithMembership;
+
+  return {
+    isCreatorWithCurrentAccess,
+    isSameOrg,
+    hasFullAccess: isCreatorWithCurrentAccess || isSameOrg,
+  };
+}

--- a/tests/e2e/vitest/api-key-auth.test.ts
+++ b/tests/e2e/vitest/api-key-auth.test.ts
@@ -415,7 +415,7 @@ describe.skipIf(shouldSkip)("API Key Authentication", () => {
       expect(result.status).toBe("running");
     });
 
-    it("should reject execution from different org", async ({ skip }) => {
+    it("should mask execution from different org", async ({ skip }) => {
       if (!setupSucceeded) {
         skip();
       }
@@ -448,7 +448,7 @@ describe.skipIf(shouldSkip)("API Key Authentication", () => {
           body: JSON.stringify({ input: { test: "data" } }),
         }
       );
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(404);
     });
   });
 

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -67,6 +67,7 @@ const manualWorkflow = {
 const {
   mockWorkflowsFindFirst,
   mockApiKeysFindFirst,
+  mockMemberLimit,
   mockInsertReturning,
   mockValidateIntegrations,
   mockEnforceExecutionLimit,
@@ -74,6 +75,7 @@ const {
 } = vi.hoisted(() => ({
   mockWorkflowsFindFirst: vi.fn(),
   mockApiKeysFindFirst: vi.fn(),
+  mockMemberLimit: vi.fn(),
   mockInsertReturning: vi.fn(),
   mockValidateIntegrations: vi.fn(),
   mockEnforceExecutionLimit: vi.fn(),
@@ -82,6 +84,13 @@ const {
 
 vi.mock("@/lib/db", () => ({
   db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
+      })),
+    })),
     query: {
       workflows: { findFirst: mockWorkflowsFindFirst },
       apiKeys: { findFirst: mockApiKeysFindFirst },
@@ -103,6 +112,7 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/db/schema", () => ({
   apiKeys: { keyHash: "key_hash", id: "id", lastUsedAt: "last_used_at" },
+  member: { id: "id", organizationId: "organizationId", userId: "userId" },
   workflows: { id: "id" },
   workflowExecutions: { id: "id" },
 }));
@@ -180,6 +190,7 @@ function setupHappyPath(): void {
     userId: OWNER_USER_ID,
     keyHash: VALID_KEY_HASH,
   });
+  mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   mockValidateIntegrations.mockResolvedValue({ valid: true });
   mockEnforceExecutionLimit.mockResolvedValue({ blocked: false });
   mockCheckConcurrency.mockResolvedValue({ allowed: true });
@@ -191,6 +202,7 @@ function setupHappyPath(): void {
 describe("POST /api/workflows/:workflowId/webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   describe("workflow lookup", () => {
@@ -306,6 +318,24 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
       expect(data.error).toBe(
         "You do not have permission to run this workflow"
       );
+    });
+
+    it("should return 404 when the owner key belongs to a removed org member", async () => {
+      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+      mockApiKeysFindFirst.mockResolvedValue({
+        id: "key-1",
+        userId: OWNER_USER_ID,
+        keyHash: VALID_KEY_HASH,
+      });
+      mockMemberLimit.mockResolvedValue([]);
+
+      const response = await POST(
+        createWebhookRequest(VALID_API_KEY),
+        createContext(WORKFLOW_ID)
+      );
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe("Workflow not found");
     });
   });
 

--- a/tests/integration/workflow-code-route.test.ts
+++ b/tests/integration/workflow-code-route.test.ts
@@ -142,6 +142,7 @@ describe("GET /api/workflows/[id]/code", () => {
       organizationId: ORG_ID,
       authMethod: "session",
     });
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
     mockWorkflowsFindFirst.mockResolvedValue({
       id: WORKFLOW_ID,
       userId: OWNER_USER_ID,
@@ -158,10 +159,11 @@ describe("GET /api/workflows/[id]/code", () => {
 
   it("permits an API-key caller whose org matches the workflow's org", async () => {
     mockGetDualAuthContext.mockResolvedValue({
-      userId: null,
+      userId: OWNER_USER_ID,
       organizationId: ORG_ID,
       authMethod: "api-key",
     });
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
     mockWorkflowsFindFirst.mockResolvedValue({
       id: WORKFLOW_ID,
       userId: OWNER_USER_ID,

--- a/tests/integration/workflow-code-route.test.ts
+++ b/tests/integration/workflow-code-route.test.ts
@@ -8,10 +8,12 @@ const STRANGER_USER_ID = "user-stranger";
 const ORG_ID = "org-1";
 const OTHER_ORG_ID = "org-2";
 
-const { mockGetDualAuthContext, mockWorkflowsFindFirst } = vi.hoisted(() => ({
-  mockGetDualAuthContext: vi.fn(),
-  mockWorkflowsFindFirst: vi.fn(),
-}));
+const { mockGetDualAuthContext, mockMemberLimit, mockWorkflowsFindFirst } =
+  vi.hoisted(() => ({
+    mockGetDualAuthContext: vi.fn(),
+    mockMemberLimit: vi.fn(),
+    mockWorkflowsFindFirst: vi.fn(),
+  }));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
   getDualAuthContext: mockGetDualAuthContext,
@@ -29,6 +31,13 @@ vi.mock("@/lib/middleware/auth-helpers", () => ({
 
 vi.mock("@/lib/db", () => ({
   db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
+      })),
+    })),
     query: {
       workflows: { findFirst: mockWorkflowsFindFirst },
     },
@@ -36,6 +45,7 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/db/schema", () => ({
+  member: { id: "id", organizationId: "organizationId", userId: "userId" },
   workflows: { id: "id" },
 }));
 
@@ -60,6 +70,7 @@ function buildContext(): { params: Promise<{ workflowId: string }> } {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockMemberLimit.mockResolvedValue([]);
 });
 
 describe("GET /api/workflows/[id]/code", () => {
@@ -103,6 +114,26 @@ describe("GET /api/workflows/[id]/code", () => {
 
     const response = await GET(buildRequest(), buildContext());
     expect(response.status).toBe(200);
+  });
+
+  it("returns 404 when an org workflow creator is no longer a member of that org", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: OWNER_USER_ID,
+      organizationId: OTHER_ORG_ID,
+      authMethod: "session",
+    });
+    mockWorkflowsFindFirst.mockResolvedValue({
+      id: WORKFLOW_ID,
+      userId: OWNER_USER_ID,
+      organizationId: ORG_ID,
+      isAnonymous: false,
+      name: "wf",
+      nodes: [],
+      edges: [],
+    });
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(404);
   });
 
   it("permits a session user in the workflow's org even if not the owner", async () => {

--- a/tests/integration/workflow-duplicate.test.ts
+++ b/tests/integration/workflow-duplicate.test.ts
@@ -52,10 +52,18 @@ const mockDbQuery = {
 };
 
 const mockDbDelete = vi.fn().mockResolvedValue(undefined);
+const mockMemberLimit = vi.fn();
 
 vi.mock("@/lib/db", () => ({
   db: {
     query: mockDbQuery,
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
+      })),
+    })),
     insert: vi.fn().mockReturnValue({
       values: vi.fn().mockImplementation((v: unknown) => ({
         returning: vi.fn().mockResolvedValue([
@@ -131,6 +139,7 @@ describe("Workflow duplicate API", () => {
     vi.clearAllMocks();
     mockDbQuery.workflows.findFirst.mockResolvedValue(sourceWorkflow);
     mockDbQuery.workflows.findMany.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   it("duplicates workflow and remaps template references to new node IDs", async () => {

--- a/tests/integration/workflow-export-import-route.test.ts
+++ b/tests/integration/workflow-export-import-route.test.ts
@@ -80,11 +80,19 @@ const mockDbQuery = {
   },
 };
 
+const mockMemberLimit = vi.fn();
 const mockIncrementCounter = vi.fn();
 
 vi.mock("@/lib/db", () => ({
   db: {
     query: mockDbQuery,
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
+      })),
+    })),
     insert: vi.fn().mockReturnValue({
       values: vi.fn().mockImplementation((v: Record<string, unknown>) => ({
         returning: vi.fn().mockImplementation(() => {
@@ -145,6 +153,7 @@ describe("GET /api/workflows/[workflowId]/download", () => {
     vi.clearAllMocks();
     insertedRows.length = 0;
     mockDbQuery.workflows.findFirst.mockResolvedValue(storedWorkflow);
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   it("returns a v1 JSON export attachment for the owner", async () => {
@@ -261,6 +270,7 @@ describe("POST /api/workflows/import", () => {
     vi.clearAllMocks();
     insertedRows.length = 0;
     mockDbQuery.workflows.findFirst.mockResolvedValue(storedWorkflow);
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   it("creates a new workflow row owned by the caller", async () => {

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -4,11 +4,13 @@ const {
   mockGetDualAuthContext,
   mockWorkflowsFindFirst,
   mockUpdateReturning,
+  mockMemberLimit,
   mockSelectFrom,
 } = vi.hoisted(() => ({
   mockGetDualAuthContext: vi.fn(),
   mockWorkflowsFindFirst: vi.fn(),
   mockUpdateReturning: vi.fn(),
+  mockMemberLimit: vi.fn(),
   mockSelectFrom: vi.fn(),
 }));
 
@@ -35,6 +37,9 @@ vi.mock("@/lib/db", () => ({
         innerJoin: vi.fn(() => ({
           where: mockSelectFrom,
         })),
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
       })),
     })),
   },
@@ -47,6 +52,7 @@ vi.mock("@/lib/db/schema", () => ({
     publicTagId: "public_tag_id",
   },
   publicTags: { id: "id", name: "name", slug: "slug" },
+  member: { id: "id", organizationId: "organization_id", userId: "user_id" },
   projects: { id: "id", organizationId: "organization_id" },
   tags: { id: "id", organizationId: "organization_id" },
   workflowExecutions: { workflowId: "workflow_id" },
@@ -135,6 +141,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     });
     // Default: no public tags
     mockSelectFrom.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   it("LIST-01: PATCH with isListed=true sets listedAt server-side when listedAt is null", async () => {
@@ -647,6 +654,7 @@ describe("GET /api/workflows/[workflowId] — description sanitization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSelectFrom.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   it("LIST-06 + INFRA-05: non-owner GET on listed workflow receives sanitized description", async () => {

--- a/tests/unit/api-key-auth-deactivated.test.ts
+++ b/tests/unit/api-key-auth-deactivated.test.ts
@@ -16,11 +16,14 @@ vi.mock("@/lib/db", () => ({
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        leftJoin: vi.fn(() => ({
-          where: vi.fn(() => ({
-            limit: mockSelectLimit,
-          })),
-        })),
+        leftJoin: vi.fn(function leftJoin() {
+          return {
+            leftJoin,
+            where: vi.fn(() => ({
+              limit: mockSelectLimit,
+            })),
+          };
+        }),
       })),
     })),
     update: mockUpdate,
@@ -28,13 +31,20 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/db/schema", () => ({
+  member: {
+    id: "id",
+    organizationId: "organization_id",
+    userId: "user_id",
+  },
   organizationApiKeys: {
     id: "id",
+    organizationId: "organization_id",
     keyHash: "key_hash",
     revokedAt: "revoked_at",
     expiresAt: "expires_at",
+    createdBy: "created_by",
   },
-  users: { id: "id" },
+  users: { id: "id", deactivatedAt: "deactivated_at" },
 }));
 
 import { authenticateApiKey } from "@/lib/api-key-auth";
@@ -61,6 +71,7 @@ describe("authenticateApiKey -- deactivated creator handling", () => {
         organizationId: "org-1",
         createdBy: "user-1",
         creatorDeactivatedAt: null,
+        creatorMemberId: "member-1",
       },
     ]);
 
@@ -79,6 +90,7 @@ describe("authenticateApiKey -- deactivated creator handling", () => {
         organizationId: "org-1",
         createdBy: "user-1",
         creatorDeactivatedAt: new Date("2026-01-01T00:00:00Z"),
+        creatorMemberId: "member-1",
       },
     ]);
 
@@ -89,6 +101,26 @@ describe("authenticateApiKey -- deactivated creator handling", () => {
     expect(result.error).toBe("API key creator account is deactivated");
   });
 
+  it("rejects a key whose creator is no longer an organization member", async () => {
+    mockSelectLimit.mockResolvedValue([
+      {
+        id: "key-1",
+        organizationId: "org-1",
+        createdBy: "user-1",
+        creatorDeactivatedAt: null,
+        creatorMemberId: null,
+      },
+    ]);
+
+    const result = await authenticateApiKey(buildRequest());
+
+    expect(result.authenticated).toBe(false);
+    expect(result.statusCode).toBe(401);
+    expect(result.error).toBe(
+      "API key creator is no longer a member of this organization"
+    );
+  });
+
   it("authenticates a key with no recorded creator (legacy compat)", async () => {
     mockSelectLimit.mockResolvedValue([
       {
@@ -96,6 +128,7 @@ describe("authenticateApiKey -- deactivated creator handling", () => {
         organizationId: "org-1",
         createdBy: null,
         creatorDeactivatedAt: null,
+        creatorMemberId: null,
       },
     ]);
 
@@ -122,6 +155,7 @@ describe("authenticateApiKey -- deactivated creator handling", () => {
         organizationId: "org-1",
         createdBy: "user-1",
         creatorDeactivatedAt: null,
+        creatorMemberId: "member-1",
       },
     ]);
 

--- a/tests/unit/workflow-access.test.ts
+++ b/tests/unit/workflow-access.test.ts
@@ -91,6 +91,33 @@ describe("getWorkflowAccess", () => {
     expect(access.isSameOrg).toBe(true);
   });
 
+  it("does not grant session same-org access when the active org context is stale", async () => {
+    mockMemberLimit.mockResolvedValue([]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "member-user",
+      organizationId: "org-1",
+      authMethod: "session",
+    });
+
+    expect(access.hasFullAccess).toBe(false);
+    expect(access.isSameOrg).toBe(false);
+    expect(mockMemberLimit).toHaveBeenCalledOnce();
+  });
+
+  it("grants session same-org access when the user is still an org member", async () => {
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "member-user",
+      organizationId: "org-1",
+      authMethod: "session",
+    });
+
+    expect(access.hasFullAccess).toBe(true);
+    expect(access.isSameOrg).toBe(true);
+  });
+
   it("does not grant internal execution access when the org workflow creator is no longer an org member", async () => {
     mockMemberLimit.mockResolvedValue([]);
 

--- a/tests/unit/workflow-access.test.ts
+++ b/tests/unit/workflow-access.test.ts
@@ -105,6 +105,20 @@ describe("getWorkflowAccess", () => {
     expect(mockMemberLimit).toHaveBeenCalledOnce();
   });
 
+  it("does not grant OAuth same-org access when the token org context is stale", async () => {
+    mockMemberLimit.mockResolvedValue([]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "member-user",
+      organizationId: "org-1",
+      authMethod: "oauth",
+    });
+
+    expect(access.hasFullAccess).toBe(false);
+    expect(access.isSameOrg).toBe(false);
+    expect(mockMemberLimit).toHaveBeenCalledOnce();
+  });
+
   it("grants session same-org access when the user is still an org member", async () => {
     mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
 
@@ -116,6 +130,18 @@ describe("getWorkflowAccess", () => {
 
     expect(access.hasFullAccess).toBe(true);
     expect(access.isSameOrg).toBe(true);
+  });
+
+  it("does not grant legacy creatorless API-key access without a user to prove membership", async () => {
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: null,
+      organizationId: "org-1",
+      authMethod: "api-key",
+    });
+
+    expect(access.hasFullAccess).toBe(false);
+    expect(access.isSameOrg).toBe(false);
+    expect(mockMemberLimit).not.toHaveBeenCalled();
   });
 
   it("does not grant internal execution access when the org workflow creator is no longer an org member", async () => {

--- a/tests/unit/workflow-access.test.ts
+++ b/tests/unit/workflow-access.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockMemberLimit } = vi.hoisted(() => ({
+  mockMemberLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  member: {
+    id: "id",
+    organizationId: "organizationId",
+    userId: "userId",
+  },
+}));
+
+import { getWorkflowAccess } from "@/lib/workflow/access";
+
+const ORG_WORKFLOW = {
+  id: "wf-org",
+  userId: "creator",
+  organizationId: "org-1",
+  isAnonymous: false,
+  visibility: "private",
+};
+
+describe("getWorkflowAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not grant full access to an org workflow creator who is no longer an org member", async () => {
+    mockMemberLimit.mockResolvedValue([]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "creator",
+      organizationId: null,
+    });
+
+    expect(access.hasFullAccess).toBe(false);
+    expect(access.isCreatorWithCurrentAccess).toBe(false);
+    expect(mockMemberLimit).toHaveBeenCalledOnce();
+  });
+
+  it("grants full access to an org workflow creator who is still an org member", async () => {
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "creator",
+      organizationId: null,
+    });
+
+    expect(access.hasFullAccess).toBe(true);
+    expect(access.isCreatorWithCurrentAccess).toBe(true);
+  });
+
+  it("does not grant API-key same-org access when the key creator is no longer an org member", async () => {
+    mockMemberLimit.mockResolvedValue([]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "creator",
+      organizationId: "org-1",
+      authMethod: "api-key",
+    });
+
+    expect(access.hasFullAccess).toBe(false);
+    expect(access.isSameOrg).toBe(false);
+    expect(mockMemberLimit).toHaveBeenCalledOnce();
+  });
+
+  it("grants API-key same-org access when the key creator is still an org member", async () => {
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "creator",
+      organizationId: "org-1",
+      authMethod: "api-key",
+    });
+
+    expect(access.hasFullAccess).toBe(true);
+    expect(access.isSameOrg).toBe(true);
+  });
+
+  it("does not grant internal execution access when the org workflow creator is no longer an org member", async () => {
+    mockMemberLimit.mockResolvedValue([]);
+
+    const access = await getWorkflowAccess(ORG_WORKFLOW, {
+      userId: "creator",
+      organizationId: null,
+      authMethod: "internal",
+    });
+
+    expect(access.hasFullAccess).toBe(false);
+    expect(access.isCreatorWithCurrentAccess).toBe(false);
+    expect(mockMemberLimit).toHaveBeenCalledOnce();
+  });
+
+  it("preserves anonymous workflow ownership for the creator", async () => {
+    const access = await getWorkflowAccess(
+      {
+        ...ORG_WORKFLOW,
+        id: "wf-anon",
+        organizationId: null,
+        isAnonymous: true,
+      },
+      {
+        userId: "creator",
+        organizationId: null,
+      }
+    );
+
+    expect(access.hasFullAccess).toBe(true);
+    expect(access.isCreatorWithCurrentAccess).toBe(true);
+    expect(mockMemberLimit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Centralizes workflow access checks so org workflow ownership requires current organization membership.
- Applies the non-leaky access behavior across workflow read/update/delete, duplicate, code/download, executions, go-live, webhook, logs/status, and API-key/internal execution paths.
- Preserves personal and anonymous workflow behavior.

Linear: https://linear.app/keeperhubapp/issue/KEEP-437

## Repro / Evidence
- Linear described removed org members retaining workflow access after membership removal.
- Regression coverage exercises removed-member access paths and expects 404-style non-leaky denial where appropriate.

## Test Plan
- Targeted workflow access regression tests passed.
- Relevant broader unit/integration tests passed.
- pnpm type-check passed.
- pnpm fix ran; it exits 0 but reports the existing repo-wide Ultracite/Biome parse diagnostics. Unrelated formatter churn was reverted.

## Notes
- Labels added: deploy-pr-environment, run-e2e-tests-ephemeral.