### PR TITLE
fix: validate workflow action configs

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -15,6 +15,10 @@ import { syncWorkflowSchedule } from "@/lib/schedule-service";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
 import { isReservedSlug } from "@/lib/workflow/reserved-slugs";
+import {
+  formatActionConfigValidationResponse,
+  validateWorkflowActionConfigs,
+} from "@/lib/workflow/validation/action-config";
 import { findInvalidTemplateTokens } from "@/lib/workflow/validation/template-syntax";
 async function fetchWorkflowPublicTags(
   workflowId: string
@@ -294,20 +298,7 @@ export async function PATCH(
 
     const body = await request.json();
 
-    // Validate that all integrationIds in nodes belong to the current user
     if (Array.isArray(body.nodes)) {
-      const validation = await validateWorkflowIntegrations(
-        body.nodes,
-        userId || existingWorkflow.userId,
-        organizationId
-      );
-      if (!validation.valid) {
-        return NextResponse.json(
-          { error: "Invalid integration references in workflow" },
-          { status: 403 }
-        );
-      }
-
       // KEEP-468: parse every `{{...}}` token at save time so grammar typos
       // (the n8n-style `{{$trigger.input.ts}}`-shaped errors that produced
       // on-chain corruption during the hackathon) are rejected with line/path
@@ -403,6 +394,32 @@ export async function PATCH(
     }
 
     const updateData = buildUpdateData(body);
+
+    if (Array.isArray(updateData.nodes)) {
+      // Validate the exact shape that will be persisted. The sanitizer moves
+      // misplaced root fields into data.config, including integrationId.
+      const validation = await validateWorkflowIntegrations(
+        updateData.nodes,
+        userId || existingWorkflow.userId,
+        organizationId
+      );
+      if (!validation.valid) {
+        return NextResponse.json(
+          { error: "Invalid integration references in workflow" },
+          { status: 403 }
+        );
+      }
+
+      const actionConfigValidation = validateWorkflowActionConfigs(
+        updateData.nodes
+      );
+      if (!actionConfigValidation.valid) {
+        return NextResponse.json(
+          formatActionConfigValidationResponse(actionConfigValidation),
+          { status: 422 }
+        );
+      }
+    }
 
     // Set listedAt server-side on first listing (never from client, never cleared on unlist)
     if (body.isListed === true && existingWorkflow.listedAt === null) {

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -8,6 +8,10 @@ import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, tags, workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
+import {
+  formatActionConfigValidationResponse,
+  validateWorkflowActionConfigs,
+} from "@/lib/workflow/validation/action-config";
 function createDefaultNodes() {
   const triggerId = nanoid();
   const actionId = nanoid();
@@ -102,19 +106,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // Validate that all integrationIds in nodes belong to the current user
-    const validation = await validateWorkflowIntegrations(
-      body.nodes,
-      userId,
-      organizationId
-    );
-    if (!validation.valid) {
-      return NextResponse.json(
-        { error: "Invalid integration references in workflow" },
-        { status: 403 }
-      );
-    }
-
     // Ensure there are always default nodes (trigger + action) if nodes array is empty
     let nodes = body.nodes;
     let edges = body.edges;
@@ -128,6 +119,28 @@ export async function POST(request: Request) {
     const sanitized = sanitizeWorkflowData(nodes, edges);
     nodes = sanitized.nodes;
     edges = sanitized.edges;
+
+    // Validate the exact shape that will be persisted. The sanitizer moves
+    // misplaced root fields into data.config, including integrationId.
+    const validation = await validateWorkflowIntegrations(
+      nodes,
+      userId,
+      organizationId
+    );
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: "Invalid integration references in workflow" },
+        { status: 403 }
+      );
+    }
+
+    const actionConfigValidation = validateWorkflowActionConfigs(nodes);
+    if (!actionConfigValidation.valid) {
+      return NextResponse.json(
+        formatActionConfigValidationResponse(actionConfigValidation),
+        { status: 422 }
+      );
+    }
 
     const isAnonymous = !organizationId;
     const workflowName = await generateWorkflowName(

--- a/app/api/workflows/current/route.ts
+++ b/app/api/workflows/current/route.ts
@@ -5,6 +5,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { workflows } from "@/lib/db/schema";
+import { getOrgContext } from "@/lib/middleware/org-context";
 import { generateId } from "@/lib/utils/id";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
 import {
@@ -94,11 +95,12 @@ export async function POST(request: Request) {
     // Sanitize nodes/edges: strip React Flow UI state and normalize formats
     const sanitized = sanitizeWorkflowData(rawNodes, rawEdges);
     const { nodes, edges } = sanitized;
+    const orgContext = await getOrgContext();
 
     const integrationValidation = await validateWorkflowIntegrations(
       nodes,
       session.user.id,
-      null
+      orgContext.organization?.id ?? null
     );
     if (!integrationValidation.valid) {
       return NextResponse.json(

--- a/app/api/workflows/current/route.ts
+++ b/app/api/workflows/current/route.ts
@@ -3,9 +3,14 @@ import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
+import {
+  formatActionConfigValidationResponse,
+  validateWorkflowActionConfigs,
+} from "@/lib/workflow/validation/action-config";
 
 const CURRENT_WORKFLOW_NAME = "~~__CURRENT__~~";
 
@@ -89,6 +94,26 @@ export async function POST(request: Request) {
     // Sanitize nodes/edges: strip React Flow UI state and normalize formats
     const sanitized = sanitizeWorkflowData(rawNodes, rawEdges);
     const { nodes, edges } = sanitized;
+
+    const integrationValidation = await validateWorkflowIntegrations(
+      nodes,
+      session.user.id,
+      null
+    );
+    if (!integrationValidation.valid) {
+      return NextResponse.json(
+        { error: "Invalid integration references in workflow" },
+        { status: 403 }
+      );
+    }
+
+    const actionConfigValidation = validateWorkflowActionConfigs(nodes);
+    if (!actionConfigValidation.valid) {
+      return NextResponse.json(
+        formatActionConfigValidationResponse(actionConfigValidation),
+        { status: 422 }
+      );
+    }
 
     // Check if current workflow exists
     const [existingWorkflow] = await db

--- a/app/api/workflows/import/route.ts
+++ b/app/api/workflows/import/route.ts
@@ -20,6 +20,10 @@ import {
   workflowExportV1Schema,
 } from "@/lib/workflow/export-schema";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
+import {
+  formatActionConfigValidationResponse,
+  validateWorkflowActionConfigs,
+} from "@/lib/workflow/validation/action-config";
 
 const versionedBodySchema = z
   .object({ version: z.unknown() })
@@ -121,6 +125,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json(
         { error: "Invalid integration references in workflow" },
         { status: 403 }
+      );
+    }
+
+    const actionConfigValidation = validateWorkflowActionConfigs(
+      sanitized.nodes
+    );
+    if (!actionConfigValidation.valid) {
+      return NextResponse.json(
+        formatActionConfigValidationResponse(actionConfigValidation),
+        { status: 422 }
       );
     }
 

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -95,6 +95,17 @@ function valueContainsTemplate(value: unknown): boolean {
   return typeof value === "string" && TEMPLATE_VALUE_PATTERN.test(value);
 }
 
+function isJsonArrayString(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  try {
+    return Array.isArray(JSON.parse(value));
+  } catch {
+    return false;
+  }
+}
+
 function validateStringLike(value: unknown): boolean {
   return typeof value === "string" || typeof value === "number";
 }
@@ -146,12 +157,12 @@ function validateFieldValue(
       return { valid: true };
     case "protocol-address":
       return typeof value === "string" &&
-        !valueContainsTemplate(value) &&
-        ETH_ADDRESS_PATTERN.test(value)
+        (valueContainsTemplate(value) || ETH_ADDRESS_PATTERN.test(value))
         ? { valid: true }
         : { valid: false, expected: "address", received: value };
     case "protocol-uint":
-      return typeof value === "string" && UNSIGNED_INTEGER_PATTERN.test(value)
+      return typeof value === "string" &&
+        (valueContainsTemplate(value) || UNSIGNED_INTEGER_PATTERN.test(value))
         ? { valid: true }
         : {
             valid: false,
@@ -159,7 +170,8 @@ function validateFieldValue(
             received: value,
           };
     case "protocol-int":
-      return typeof value === "string" && INTEGER_PATTERN.test(value)
+      return typeof value === "string" &&
+        (valueContainsTemplate(value) || INTEGER_PATTERN.test(value))
         ? { valid: true }
         : {
             valid: false,
@@ -167,6 +179,9 @@ function validateFieldValue(
             received: value,
           };
     case "protocol-bool":
+      if (valueContainsTemplate(value)) {
+        return { valid: true };
+      }
       return value === true ||
         value === false ||
         value === "true" ||
@@ -175,8 +190,7 @@ function validateFieldValue(
         : { valid: false, expected: "boolean", received: value };
     case "protocol-bytes":
       return typeof value === "string" &&
-        !valueContainsTemplate(value) &&
-        HEX_BYTES_PATTERN.test(value)
+        (valueContainsTemplate(value) || HEX_BYTES_PATTERN.test(value))
         ? { valid: true }
         : {
             valid: false,
@@ -184,11 +198,14 @@ function validateFieldValue(
             received: value,
           };
     case "protocol-eth-value":
-      return typeof value === "string" && DECIMAL_PATTERN.test(value)
+      return typeof value === "string" &&
+        (valueContainsTemplate(value) || DECIMAL_PATTERN.test(value))
         ? { valid: true }
         : { valid: false, expected: "decimal ETH amount", received: value };
     case "protocol-tuple-array":
-      return Array.isArray(value)
+      return Array.isArray(value) ||
+        valueContainsTemplate(value) ||
+        isJsonArrayString(value)
         ? { valid: true }
         : {
             valid: false,

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -1,0 +1,316 @@
+import { ADDRESS_BOOK_SELECTION_KEY } from "@/lib/address-book-selection";
+import { evaluateShowWhen } from "@/lib/workflow/editor/show-when";
+import {
+  type ActionConfigField,
+  type ActionConfigFieldBase,
+  findActionById,
+} from "@/plugins/registry";
+
+const SYSTEM_ACTION_TYPES = new Set([
+  "Database Query",
+  "HTTP Request",
+  "Condition",
+  "For Each",
+  "Collect",
+]);
+
+const RESERVED_CONFIG_KEYS = new Set([
+  "actionType",
+  "integrationId",
+  ADDRESS_BOOK_SELECTION_KEY,
+  "usePrivateMempool",
+  "strict",
+]);
+
+const TEMPLATE_VALUE_PATTERN = /\{\{[^}]+}}/;
+const ETH_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const HEX_BYTES_PATTERN = /^0x(?:[0-9a-fA-F]{2})*$/;
+const INTEGER_PATTERN = /^-?\d+$/;
+const UNSIGNED_INTEGER_PATTERN = /^\d+$/;
+const DECIMAL_PATTERN = /^\d+(?:\.\d+)?$/;
+
+export type ActionConfigValidationIssueCode =
+  | "UNKNOWN_ACTION_TYPE"
+  | "UNKNOWN_FIELD"
+  | "MISSING_REQUIRED_FIELD"
+  | "INVALID_FIELD_TYPE";
+
+export type ActionConfigValidationIssue = {
+  code: ActionConfigValidationIssueCode;
+  path: string;
+  message: string;
+  actionType?: string;
+  field?: string;
+  expected?: string;
+  received?: unknown;
+};
+
+export type ActionConfigValidationResult = {
+  valid: boolean;
+  issues: ActionConfigValidationIssue[];
+};
+
+type WorkflowNodeForValidation = {
+  id?: string;
+  type?: unknown;
+  data?: {
+    type?: unknown;
+    config?: Record<string, unknown>;
+  };
+};
+
+type FieldCheckResult =
+  | { valid: true }
+  | { valid: false; expected: string; received: unknown };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isActionNode(node: WorkflowNodeForValidation): boolean {
+  return node.type === "action" || node.data?.type === "action";
+}
+
+function isMissingRequiredValue(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
+function flattenConfigFields(
+  fields: ActionConfigField[]
+): ActionConfigFieldBase[] {
+  const flattened: ActionConfigFieldBase[] = [];
+
+  for (const field of fields) {
+    if (field.type === "group") {
+      flattened.push(...flattenConfigFields(field.fields));
+      continue;
+    }
+    flattened.push(field);
+  }
+
+  return flattened;
+}
+
+function valueContainsTemplate(value: unknown): boolean {
+  return typeof value === "string" && TEMPLATE_VALUE_PATTERN.test(value);
+}
+
+function validateStringLike(value: unknown): boolean {
+  return typeof value === "string" || typeof value === "number";
+}
+
+function validateFieldValue(
+  field: ActionConfigFieldBase,
+  value: unknown
+): FieldCheckResult {
+  if (isMissingRequiredValue(value)) {
+    return { valid: true };
+  }
+
+  switch (field.type) {
+    case "number":
+      return typeof value === "number" || DECIMAL_PATTERN.test(String(value))
+        ? { valid: true }
+        : { valid: false, expected: "number", received: value };
+    case "select":
+      if (!validateStringLike(value)) {
+        return { valid: false, expected: "select option", received: value };
+      }
+      if (
+        field.options &&
+        field.options.length > 0 &&
+        !field.options.some((option) => option.value === String(value))
+      ) {
+        return {
+          valid: false,
+          expected: field.options.map((option) => option.value).join(" | "),
+          received: value,
+        };
+      }
+      return { valid: true };
+    case "chain-select":
+      if (!validateStringLike(value)) {
+        return { valid: false, expected: "chain id", received: value };
+      }
+      if (
+        field.allowedChainIds &&
+        field.allowedChainIds.length > 0 &&
+        !field.allowedChainIds.includes(String(value))
+      ) {
+        return {
+          valid: false,
+          expected: field.allowedChainIds.join(" | "),
+          received: value,
+        };
+      }
+      return { valid: true };
+    case "protocol-address":
+      return typeof value === "string" &&
+        !valueContainsTemplate(value) &&
+        ETH_ADDRESS_PATTERN.test(value)
+        ? { valid: true }
+        : { valid: false, expected: "address", received: value };
+    case "protocol-uint":
+      return typeof value === "string" && UNSIGNED_INTEGER_PATTERN.test(value)
+        ? { valid: true }
+        : {
+            valid: false,
+            expected: field.solidityType ?? "uint",
+            received: value,
+          };
+    case "protocol-int":
+      return typeof value === "string" && INTEGER_PATTERN.test(value)
+        ? { valid: true }
+        : {
+            valid: false,
+            expected: field.solidityType ?? "int",
+            received: value,
+          };
+    case "protocol-bool":
+      return value === true ||
+        value === false ||
+        value === "true" ||
+        value === "false"
+        ? { valid: true }
+        : { valid: false, expected: "boolean", received: value };
+    case "protocol-bytes":
+      return typeof value === "string" &&
+        !valueContainsTemplate(value) &&
+        HEX_BYTES_PATTERN.test(value)
+        ? { valid: true }
+        : {
+            valid: false,
+            expected: field.solidityType ?? "bytes",
+            received: value,
+          };
+    case "protocol-eth-value":
+      return typeof value === "string" && DECIMAL_PATTERN.test(value)
+        ? { valid: true }
+        : { valid: false, expected: "decimal ETH amount", received: value };
+    case "protocol-tuple-array":
+      return Array.isArray(value)
+        ? { valid: true }
+        : {
+            valid: false,
+            expected: field.solidityType ?? "tuple[]",
+            received: value,
+          };
+    case "json-editor":
+    case "schema-builder":
+    case "abi-function-args":
+    case "call-list-builder":
+    case "args-list-builder":
+      return isRecord(value) || Array.isArray(value)
+        ? { valid: true }
+        : { valid: false, expected: "object or array", received: value };
+    default:
+      if (field.isAddressField && valueContainsTemplate(value)) {
+        return { valid: false, expected: "address", received: value };
+      }
+      return validateStringLike(value) || typeof value === "boolean"
+        ? { valid: true }
+        : { valid: false, expected: "string", received: value };
+  }
+}
+
+export function validateWorkflowActionConfigs(
+  nodes: WorkflowNodeForValidation[]
+): ActionConfigValidationResult {
+  const issues: ActionConfigValidationIssue[] = [];
+
+  for (const [nodeIndex, node] of nodes.entries()) {
+    if (!isActionNode(node)) {
+      continue;
+    }
+
+    const config = node.data?.config;
+    if (!isRecord(config)) {
+      continue;
+    }
+
+    const actionType = config.actionType;
+    if (typeof actionType !== "string" || actionType.trim() === "") {
+      continue;
+    }
+
+    if (SYSTEM_ACTION_TYPES.has(actionType)) {
+      continue;
+    }
+
+    const action = findActionById(actionType);
+    if (!action) {
+      issues.push({
+        code: "UNKNOWN_ACTION_TYPE",
+        path: `nodes[${nodeIndex}].data.config.actionType`,
+        actionType,
+        received: actionType,
+        message: `Unknown action type "${actionType}".`,
+      });
+      continue;
+    }
+
+    const fields = flattenConfigFields(action.configFields);
+    const fieldsByKey = new Map(fields.map((field) => [field.key, field]));
+
+    for (const [key, value] of Object.entries(config)) {
+      if (RESERVED_CONFIG_KEYS.has(key)) {
+        continue;
+      }
+      if (!fieldsByKey.has(key)) {
+        issues.push({
+          code: "UNKNOWN_FIELD",
+          path: `nodes[${nodeIndex}].data.config.${key}`,
+          actionType,
+          field: key,
+          received: value,
+          message: `Unknown field "${key}" for action "${actionType}".`,
+        });
+      }
+    }
+
+    for (const field of fields) {
+      if (!evaluateShowWhen(field.showWhen, config)) {
+        continue;
+      }
+
+      const value = config[field.key];
+      if (field.required && isMissingRequiredValue(value)) {
+        issues.push({
+          code: "MISSING_REQUIRED_FIELD",
+          path: `nodes[${nodeIndex}].data.config.${field.key}`,
+          actionType,
+          field: field.key,
+          expected: field.label,
+          message: `Missing required field "${field.key}" for action "${actionType}".`,
+        });
+        continue;
+      }
+
+      const fieldCheck = validateFieldValue(field, value);
+      if (!fieldCheck.valid) {
+        issues.push({
+          code: "INVALID_FIELD_TYPE",
+          path: `nodes[${nodeIndex}].data.config.${field.key}`,
+          actionType,
+          field: field.key,
+          expected: fieldCheck.expected,
+          received: fieldCheck.received,
+          message: `Invalid value for field "${field.key}" on action "${actionType}".`,
+        });
+      }
+    }
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+export function formatActionConfigValidationResponse(
+  validation: ActionConfigValidationResult
+) {
+  return {
+    error: "INVALID_ACTION_CONFIG",
+    message:
+      "Workflow contains invalid action configuration. Fix the listed fields and save again.",
+    invalidFields: validation.issues,
+  };
+}

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -221,8 +221,11 @@ function validateFieldValue(
         ? { valid: true }
         : { valid: false, expected: "object or array", received: value };
     default:
-      if (field.isAddressField && valueContainsTemplate(value)) {
-        return { valid: false, expected: "address", received: value };
+      if (field.isAddressField) {
+        return typeof value === "string" &&
+          (valueContainsTemplate(value) || ETH_ADDRESS_PATTERN.test(value))
+          ? { valid: true }
+          : { valid: false, expected: "address", received: value };
       }
       return validateStringLike(value) || typeof value === "boolean"
         ? { valid: true }

--- a/tests/integration/workflow-create-route.test.ts
+++ b/tests/integration/workflow-create-route.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetDualAuthContext, mockInsert, mockValidateWorkflowIntegrations } =
+  vi.hoisted(() => ({
+    mockGetDualAuthContext: vi.fn(),
+    mockInsert: vi.fn(),
+    mockValidateWorkflowIntegrations: vi.fn(),
+  }));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: mockInsert,
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  projects: { id: "id", organizationId: "organization_id" },
+  tags: { id: "id", organizationId: "organization_id" },
+  workflows: {},
+}));
+
+vi.mock("@/lib/db/integrations", () => ({
+  validateWorkflowIntegrations: mockValidateWorkflowIntegrations,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+import { POST } from "@/app/api/workflows/create/route";
+
+function request(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/workflows/create", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function workflowBody(nodes: unknown[]) {
+  return {
+    name: "Invalid workflow",
+    nodes,
+    edges: [],
+  };
+}
+
+function baseActionNode(config: Record<string, unknown>) {
+  return {
+    id: "node-1",
+    type: "action",
+    data: {
+      type: "action",
+      config,
+    },
+  };
+}
+
+describe("POST /api/workflows/create action config validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-123",
+      organizationId: "org-123",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+  });
+
+  it("rejects invalid action config before inserting workflow", async () => {
+    const response = await POST(
+      request(
+        workflowBody([
+          baseActionNode({
+            actionType: "discord/send-message",
+            Message: "hello",
+          }),
+        ])
+      )
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error).toBe("INVALID_ACTION_CONFIG");
+    expect(body.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "UNKNOWN_FIELD", field: "Message" }),
+        expect.objectContaining({
+          code: "MISSING_REQUIRED_FIELD",
+          field: "discordMessage",
+        }),
+      ])
+    );
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown action types before inserting workflow", async () => {
+    const response = await POST(
+      request(
+        workflowBody([
+          baseActionNode({
+            actionType: "webhook/send",
+            webhookUrl: "https://example.com",
+          }),
+        ])
+      )
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "UNKNOWN_ACTION_TYPE" }),
+      ])
+    );
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid typed protocol fields before inserting workflow", async () => {
+    const response = await POST(
+      request(
+        workflowBody([
+          baseActionNode({
+            actionType: "aave-v3/supply",
+            network: "1",
+            asset: "{{trigger.walletAddress}}",
+            amount: "1000000000000000000",
+            onBehalfOf: "0x0000000000000000000000000000000000000001",
+          }),
+        ])
+      )
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          field: "asset",
+        }),
+      ])
+    );
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("validates integration ownership after sanitizer moves misplaced config fields", async () => {
+    mockValidateWorkflowIntegrations.mockResolvedValue({
+      valid: false,
+      invalidIds: ["foreign-integration"],
+    });
+
+    const response = await POST(
+      request(
+        workflowBody([
+          {
+            id: "node-1",
+            type: "action",
+            data: {
+              type: "action",
+              actionType: "discord/send-message",
+              integrationId: "foreign-integration",
+              discordMessage: "hello",
+            },
+          },
+        ])
+      )
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockValidateWorkflowIntegrations).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            config: expect.objectContaining({
+              integrationId: "foreign-integration",
+            }),
+          }),
+        }),
+      ],
+      "user-123",
+      "org-123"
+    );
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/workflow-create-route.test.ts
+++ b/tests/integration/workflow-create-route.test.ts
@@ -130,7 +130,7 @@ describe("POST /api/workflows/create action config validation", () => {
           baseActionNode({
             actionType: "aave-v3/supply",
             network: "1",
-            asset: "{{trigger.walletAddress}}",
+            asset: "not-an-address",
             amount: "1000000000000000000",
             onBehalfOf: "0x0000000000000000000000000000000000000001",
           }),

--- a/tests/integration/workflow-current-route.test.ts
+++ b/tests/integration/workflow-current-route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetSession, mockValidateWorkflowIntegrations, mockSelect } =
+  vi.hoisted(() => ({
+    mockGetSession: vi.fn(),
+    mockValidateWorkflowIntegrations: vi.fn(),
+    mockSelect: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: mockGetSession,
+    },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: mockSelect,
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflows: {
+    id: "id",
+    name: "name",
+    userId: "user_id",
+    updatedAt: "updated_at",
+  },
+}));
+
+vi.mock("@/lib/db/integrations", () => ({
+  validateWorkflowIntegrations: mockValidateWorkflowIntegrations,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+import { POST } from "@/app/api/workflows/current/route";
+
+function request(nodes: unknown[]): Request {
+  return new Request("http://localhost:3000/api/workflows/current", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ nodes, edges: [] }),
+  });
+}
+
+describe("POST /api/workflows/current action config validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      user: { id: "user-123", email: "user@example.com" },
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+  });
+
+  it("rejects invalid action config before autosaving current workflow", async () => {
+    const response = await POST(
+      request([
+        {
+          id: "node-1",
+          type: "action",
+          data: {
+            type: "action",
+            config: {
+              actionType: "discord/send-message",
+              Message: "hello",
+            },
+          },
+        },
+      ])
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error).toBe("INVALID_ACTION_CONFIG");
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("validates integration ownership after sanitizer moves misplaced config fields", async () => {
+    mockValidateWorkflowIntegrations.mockResolvedValue({
+      valid: false,
+      invalidIds: ["foreign-integration"],
+    });
+
+    const response = await POST(
+      request([
+        {
+          id: "node-1",
+          type: "action",
+          data: {
+            type: "action",
+            actionType: "discord/send-message",
+            integrationId: "foreign-integration",
+            discordMessage: "hello",
+          },
+        },
+      ])
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockValidateWorkflowIntegrations).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            config: expect.objectContaining({
+              integrationId: "foreign-integration",
+            }),
+          }),
+        }),
+      ],
+      "user-123",
+      null
+    );
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/workflow-current-route.test.ts
+++ b/tests/integration/workflow-current-route.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetSession, mockValidateWorkflowIntegrations, mockSelect } =
-  vi.hoisted(() => ({
-    mockGetSession: vi.fn(),
-    mockValidateWorkflowIntegrations: vi.fn(),
-    mockSelect: vi.fn(),
-  }));
+const {
+  mockGetSession,
+  mockGetOrgContext,
+  mockValidateWorkflowIntegrations,
+  mockSelect,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetOrgContext: vi.fn(),
+  mockValidateWorkflowIntegrations: vi.fn(),
+  mockSelect: vi.fn(),
+}));
 
 vi.mock("@/lib/auth", () => ({
   auth: {
@@ -36,6 +41,10 @@ vi.mock("@/lib/db/integrations", () => ({
   validateWorkflowIntegrations: mockValidateWorkflowIntegrations,
 }));
 
+vi.mock("@/lib/middleware/org-context", () => ({
+  getOrgContext: mockGetOrgContext,
+}));
+
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { DATABASE: "DATABASE" },
   logSystemError: vi.fn(),
@@ -56,6 +65,9 @@ describe("POST /api/workflows/current action config validation", () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue({
       user: { id: "user-123", email: "user@example.com" },
+    });
+    mockGetOrgContext.mockResolvedValue({
+      organization: { id: "org-123" },
     });
     mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
   });
@@ -117,8 +129,40 @@ describe("POST /api/workflows/current action config validation", () => {
         }),
       ],
       "user-123",
-      null
+      "org-123"
     );
     expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("falls back to user-scoped integration validation when there is no active org", async () => {
+    mockGetOrgContext.mockResolvedValue({ organization: null });
+    mockValidateWorkflowIntegrations.mockResolvedValue({
+      valid: false,
+      invalidIds: ["foreign-integration"],
+    });
+
+    const response = await POST(
+      request([
+        {
+          id: "node-1",
+          type: "action",
+          data: {
+            type: "action",
+            config: {
+              actionType: "discord/send-message",
+              integrationId: "foreign-integration",
+              discordMessage: "hello",
+            },
+          },
+        },
+      ])
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockValidateWorkflowIntegrations).toHaveBeenCalledWith(
+      expect.any(Array),
+      "user-123",
+      null
+    );
   });
 });

--- a/tests/integration/workflow-export-import-route.test.ts
+++ b/tests/integration/workflow-export-import-route.test.ts
@@ -72,6 +72,22 @@ const storedWorkflow = {
   updatedAt: new Date(),
 };
 
+const validImportActionNode = {
+  id: "action-1",
+  type: "action",
+  position: { x: 200, y: 0 },
+  data: {
+    label: "Send Webhook",
+    type: "action",
+    config: {
+      actionType: "webhook/send-webhook",
+      webhookUrl: "https://example.com/webhook",
+      webhookMethod: "POST",
+    },
+    status: "idle",
+  },
+};
+
 const insertedRows: Record<string, unknown>[] = [];
 
 const mockDbQuery = {
@@ -267,9 +283,10 @@ describe("POST /api/workflows/import", () => {
     const exportPayload = buildWorkflowExportV1({
       name: "imported wf",
       description: "imported description",
-      nodes: storedWorkflow.nodes.filter(
-        (n) => n.data.type !== "add"
-      ) as WorkflowNode[],
+      nodes: [
+        storedWorkflow.nodes[0] as unknown as WorkflowNode,
+        validImportActionNode as unknown as WorkflowNode,
+      ],
       edges: storedWorkflow.edges.slice(0, 1) as WorkflowEdge[],
     });
 
@@ -293,6 +310,43 @@ describe("POST /api/workflows/import", () => {
     expect(insertedRows[0].organizationId).toBe(orgId);
 
     expect(mockIncrementCounter).toHaveBeenCalledWith("workflow.imports.total");
+  });
+
+  it("rejects invalid action configs before importing workflow", async () => {
+    const exportPayload = buildWorkflowExportV1({
+      name: "invalid import",
+      description: null,
+      nodes: [
+        storedWorkflow.nodes[0],
+        {
+          ...validImportActionNode,
+          data: {
+            ...validImportActionNode.data,
+            config: {
+              actionType: "discord/send-message",
+              Message: "hello",
+            },
+          },
+        },
+      ] as WorkflowNode[],
+      edges: storedWorkflow.edges.slice(0, 1) as WorkflowEdge[],
+    });
+
+    const { POST } = await import("@/app/api/workflows/import/route");
+    const request = new Request("http://localhost/api/workflows/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(exportPayload),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error).toBe("INVALID_ACTION_CONFIG");
+    expect(insertedRows).toHaveLength(0);
+    expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+      "workflow.imports.total"
+    );
   });
 
   it("rejects an unsupported version", async () => {

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -416,7 +416,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
               config: {
                 actionType: "aave-v3/supply",
                 network: "1",
-                asset: "{{trigger.walletAddress}}",
+                asset: "not-an-address",
                 amount: "1000000000000000000",
                 onBehalfOf: "0x0000000000000000000000000000000000000001",
               },

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -5,11 +5,13 @@ const {
   mockWorkflowsFindFirst,
   mockUpdateReturning,
   mockSelectFrom,
+  mockValidateWorkflowIntegrations,
 } = vi.hoisted(() => ({
   mockGetDualAuthContext: vi.fn(),
   mockWorkflowsFindFirst: vi.fn(),
   mockUpdateReturning: vi.fn(),
   mockSelectFrom: vi.fn(),
+  mockValidateWorkflowIntegrations: vi.fn(),
 }));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
@@ -58,7 +60,7 @@ vi.mock("@/lib/logging", () => ({
 }));
 
 vi.mock("@/lib/db/integrations", () => ({
-  validateWorkflowIntegrations: vi.fn().mockResolvedValue({ valid: true }),
+  validateWorkflowIntegrations: mockValidateWorkflowIntegrations,
 }));
 
 vi.mock("@/lib/schedule-service", () => ({
@@ -133,6 +135,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
       organizationId: "org-123",
       authMethod: "session",
     });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
     // Default: no public tags
     mockSelectFrom.mockResolvedValue([]);
   });
@@ -279,19 +282,28 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
   // ──────────────────────────────────────────────────────────────────────
 
   const badNode = {
-    id: "read-1",
+    id: "webhook-1",
     type: "action",
     data: {
       type: "action",
-      config: { actionType: "web3/read-contract", address: "@40" },
+      config: {
+        actionType: "webhook/send-webhook",
+        webhookUrl: "https://example.com",
+        webhookMethod: "POST",
+        webhookPayload: "@40",
+      },
     },
   };
   const goodNode = {
-    id: "read-1",
+    id: "webhook-1",
     type: "action",
     data: {
       type: "action",
-      config: { actionType: "web3/read-contract", address: "0xabc" },
+      config: {
+        actionType: "webhook/send-webhook",
+        webhookUrl: "https://example.com",
+        webhookMethod: "POST",
+      },
     },
   };
 
@@ -314,6 +326,162 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     const data = await response.json();
     expect(data.error).toBe("INVALID_TEMPLATE_LITERALS");
     expect(data.literals).toContain("@40");
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("KEEP-467: PATCH rejects invalid action config before updating workflow", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "node-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "discord/send-message",
+                Message: "hello",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    const data = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(data.error).toBe("INVALID_ACTION_CONFIG");
+    expect(data.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "UNKNOWN_FIELD", field: "Message" }),
+        expect.objectContaining({
+          code: "MISSING_REQUIRED_FIELD",
+          field: "discordMessage",
+        }),
+      ])
+    );
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("KEEP-467: PATCH rejects unknown action types before updating workflow", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "node-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "webhook/send",
+                webhookUrl: "https://example.com",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    const data = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(data.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "UNKNOWN_ACTION_TYPE" }),
+      ])
+    );
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("KEEP-467: PATCH rejects invalid typed protocol fields before updating workflow", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "node-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "aave-v3/supply",
+                network: "1",
+                asset: "{{trigger.walletAddress}}",
+                amount: "1000000000000000000",
+                onBehalfOf: "0x0000000000000000000000000000000000000001",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    const data = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(data.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          field: "asset",
+        }),
+      ])
+    );
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("KEEP-467: PATCH validates integration ownership after sanitizer moves misplaced config fields", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockValidateWorkflowIntegrations.mockResolvedValue({
+      valid: false,
+      invalidIds: ["foreign-integration"],
+    });
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "node-1",
+            type: "action",
+            data: {
+              type: "action",
+              actionType: "discord/send-message",
+              integrationId: "foreign-integration",
+              discordMessage: "hello",
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockValidateWorkflowIntegrations).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            config: expect.objectContaining({
+              integrationId: "foreign-integration",
+            }),
+          }),
+        }),
+      ],
+      "user-123",
+      "org-123"
+    );
     expect(mockUpdateReturning).not.toHaveBeenCalled();
   });
 
@@ -520,7 +688,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
         type: "action",
         config: {
           actionType: "discord/send-message",
-          content: "Alert @here token spiked, @user1 please review",
+          discordMessage: "Alert @here token spiked, @user1 please review",
         },
       },
     };

--- a/tests/unit/fixtures/workflow-import-valid.json
+++ b/tests/unit/fixtures/workflow-import-valid.json
@@ -1,13 +1,43 @@
 {
   "version": 1,
   "exportedAt": "2026-04-30T00:00:00.000Z",
-  "workflow": { "name": "Valid Baseline", "description": "Positive case for SEC-06" },
+  "workflow": {
+    "name": "Valid Baseline",
+    "description": "Positive case for SEC-06"
+  },
   "nodes": [
-    { "id": "trigger-1", "type": "trigger", "position": { "x": 0, "y": 0 },
-      "data": { "label": "Manual Trigger", "type": "trigger", "config": { "triggerType": "Manual" } } },
-    { "id": "action-1", "type": "action", "position": { "x": 200, "y": 0 },
-      "data": { "label": "HTTP Request", "type": "action", "config": { "actionType": "http/request", "url": "https://example.com/api" } } }
+    {
+      "id": "trigger-1",
+      "type": "trigger",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Manual Trigger",
+        "type": "trigger",
+        "config": { "triggerType": "Manual" }
+      }
+    },
+    {
+      "id": "action-1",
+      "type": "action",
+      "position": { "x": 200, "y": 0 },
+      "data": {
+        "label": "HTTP Request",
+        "type": "action",
+        "config": {
+          "actionType": "HTTP Request",
+          "httpMethod": "GET",
+          "endpoint": "https://example.com/api"
+        }
+      }
+    }
   ],
-  "edges": [ { "id": "edge-1", "source": "trigger-1", "target": "action-1", "type": "animated" } ],
+  "edges": [
+    {
+      "id": "edge-1",
+      "source": "trigger-1",
+      "target": "action-1",
+      "type": "animated"
+    }
+  ],
   "integrationBindings": []
 }

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -115,6 +115,42 @@ describe("validateWorkflowActionConfigs", () => {
     );
   });
 
+  it("allows template values in isAddressField template-input fields", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("chainlink/ccip-check-bridge-allowance", {
+        network: "1",
+        contractAddress: "{{trigger.tokenAddress}}",
+        owner: "{{trigger.walletAddress}}",
+        spender: "{{@node-1:Previous.router}}",
+      }),
+    ]);
+
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  it("rejects non-address non-template literals in isAddressField fields", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("chainlink/ccip-check-bridge-allowance", {
+        network: "1",
+        contractAddress: "not-an-address",
+        owner: "{{trigger.walletAddress}}",
+        spender: "{{@node-1:Previous.router}}",
+      }),
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          path: "nodes[0].data.config.contractAddress",
+          field: "contractAddress",
+          expected: "address",
+        }),
+      ])
+    );
+  });
+
   it("accepts JSON-string tuple array protocol fields from the editor", () => {
     const result = validateWorkflowActionConfigs([
       actionNode("chainlink/ccip-send", {

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatActionConfigValidationResponse,
+  validateWorkflowActionConfigs,
+} from "@/lib/workflow/validation/action-config";
+
+function actionNode(
+  actionType: string,
+  config: Record<string, unknown>,
+  id = "node-1"
+) {
+  return {
+    id,
+    type: "action",
+    data: {
+      label: actionType,
+      type: "action",
+      config: {
+        actionType,
+        ...config,
+      },
+    },
+  };
+}
+
+describe("validateWorkflowActionConfigs", () => {
+  it("rejects unknown namespaced action types before persistence", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("webhook/send", { webhookUrl: "https://example.com" }),
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: "UNKNOWN_ACTION_TYPE",
+        path: "nodes[0].data.config.actionType",
+        actionType: "webhook/send",
+      }),
+    ]);
+  });
+
+  it("rejects wrong config keys and missing required fields", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("discord/send-message", { Message: "hello" }),
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.Message",
+          field: "Message",
+          actionType: "discord/send-message",
+        }),
+        expect.objectContaining({
+          code: "MISSING_REQUIRED_FIELD",
+          path: "nodes[0].data.config.discordMessage",
+          field: "discordMessage",
+          actionType: "discord/send-message",
+        }),
+      ])
+    );
+  });
+
+  it("rejects template values in typed protocol address fields", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("aave-v3/supply", {
+        network: "1",
+        asset: "{{trigger.walletAddress}}",
+        amount: "1000000000000000000",
+        onBehalfOf: "0x0000000000000000000000000000000000000001",
+      }),
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          path: "nodes[0].data.config.asset",
+          field: "asset",
+          expected: "address",
+        }),
+      ])
+    );
+  });
+
+  it("accepts registered actions with valid config", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("discord/send-message", { discordMessage: "hello" }),
+      actionNode("webhook/send-webhook", {
+        webhookUrl: "https://example.com",
+        webhookMethod: "POST",
+      }),
+    ]);
+
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  it.each([
+    "Database Query",
+    "HTTP Request",
+    "Condition",
+    "For Each",
+    "Collect",
+  ])("keeps legacy system action %s compatible", (actionType) => {
+    const result = validateWorkflowActionConfigs([
+      actionNode(actionType, {
+        url: "https://example.com",
+        method: "GET",
+        arbitraryLegacyField: true,
+      }),
+    ]);
+
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+});
+
+describe("formatActionConfigValidationResponse", () => {
+  it("returns a structured 422 body shape for route handlers", () => {
+    const validation = validateWorkflowActionConfigs([
+      actionNode("webhook/send", {}),
+    ]);
+
+    expect(formatActionConfigValidationResponse(validation)).toEqual({
+      error: "INVALID_ACTION_CONFIG",
+      message:
+        "Workflow contains invalid action configuration. Fix the listed fields and save again.",
+      invalidFields: validation.issues,
+    });
+  });
+});

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   formatActionConfigValidationResponse,
@@ -24,6 +26,20 @@ function actionNode(
 }
 
 describe("validateWorkflowActionConfigs", () => {
+  it("accepts the valid workflow import fixture", () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        join(import.meta.dirname, "fixtures/workflow-import-valid.json"),
+        "utf8"
+      )
+    ) as { nodes: Parameters<typeof validateWorkflowActionConfigs>[0] };
+
+    expect(validateWorkflowActionConfigs(fixture.nodes)).toEqual({
+      valid: true,
+      issues: [],
+    });
+  });
+
   it("rejects unknown namespaced action types before persistence", () => {
     const result = validateWorkflowActionConfigs([
       actionNode("webhook/send", { webhookUrl: "https://example.com" }),

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -63,11 +63,24 @@ describe("validateWorkflowActionConfigs", () => {
     );
   });
 
-  it("rejects template values in typed protocol address fields", () => {
+  it("allows template values in typed protocol fields", () => {
     const result = validateWorkflowActionConfigs([
       actionNode("aave-v3/supply", {
         network: "1",
         asset: "{{trigger.walletAddress}}",
+        amount: "{{@node-1:Previous.amount}}",
+        onBehalfOf: "{{@node-1:Previous.recipient}}",
+      }),
+    ]);
+
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  it("rejects invalid literal values in typed protocol address fields", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("aave-v3/supply", {
+        network: "1",
+        asset: "not-an-address",
         amount: "1000000000000000000",
         onBehalfOf: "0x0000000000000000000000000000000000000001",
       }),
@@ -84,6 +97,23 @@ describe("validateWorkflowActionConfigs", () => {
         }),
       ])
     );
+  });
+
+  it("accepts JSON-string tuple array protocol fields from the editor", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode("chainlink/ccip-send", {
+        network: "8453",
+        destinationChainSelector: "16015286601757825753",
+        receiver: "0x0000000000000000000000000000000000000001",
+        data: "0x",
+        tokenAmounts:
+          '[{"token":"0x0000000000000000000000000000000000000002","amount":"1"}]',
+        feeToken: "0x0000000000000000000000000000000000000000",
+        extraArgs: "0x",
+      }),
+    ]);
+
+    expect(result).toEqual({ valid: true, issues: [] });
   });
 
   it("accepts registered actions with valid config", () => {


### PR DESCRIPTION
## Summary
- Validates workflow action node configs against registered plugin action schemas before persistence.
- Rejects unknown action types, unknown config keys, missing required fields, and invalid typed fields with structured 422 errors.
- Wires validation into create, update, current autosave, and import paths after config sanitization.

Linear: https://linear.app/keeperhubapp/issue/KEEP-467

## Repro / Evidence
- Linear described invalid workflow configs being accepted and persisted.
- Added regression coverage for invalid actionType, bad fields, missing required values, sanitizer-moved integrationId behavior, and route-level create/current/import/update paths.

## Test Plan
- pnpm exec vitest run tests/unit/workflow-action-config-validation.test.ts tests/integration/workflow-create-route.test.ts tests/integration/workflow-current-route.test.ts tests/integration/workflow-listing-route.test.ts tests/integration/workflow-export-import-route.test.ts passed.
- pnpm test:unit passed.
- pnpm type-check passed.
- git diff --check passed.
- pnpm fix ran; it exits 0 but reports the existing repo-wide Ultracite/Biome parse diagnostics. Unrelated formatter churn was reverted.

## Notes
- Labels added: deploy-pr-environment, run-e2e-tests-ephemeral.