### PR TITLE
fix: update Aave V3 data provider addresses

### DIFF
--- a/protocols/aave-v3.ts
+++ b/protocols/aave-v3.ts
@@ -112,13 +112,13 @@ export default defineProtocol({
       label: "Aave V3 Pool Data Provider",
       addresses: {
         // Ethereum Mainnet
-        "1": "0x7B4EB56E7CD4b454BA8ff71E4518426c03584755",
+        "1": "0x0a16f2FCC0D44FaE41cc54e079281D84A363bECD",
         // Base
-        "8453": "0x2d8A3C5677189723C4cB8873CfC9C8976FDF38Ac",
+        "8453": "0x0F43731EB8d45A581f4a36DD74F5f358bc90C73A",
         // Arbitrum One
-        "42161": "0x69FA688f1Dc47d4B5d8029D5a35FB7a548310654",
+        "42161": "0x243Aa95cAC2a25651eda86e80bEe66114413c43b",
         // Optimism
-        "10": "0x69FA688f1Dc47d4B5d8029D5a35FB7a548310654",
+        "10": "0x243Aa95cAC2a25651eda86e80bEe66114413c43b",
         // Sepolia Testnet
         "11155111": "0x3e9708d80f7B3e43118013075F7e95CE3AB31F31",
       },

--- a/tests/unit/protocol-aave-v3.test.ts
+++ b/tests/unit/protocol-aave-v3.test.ts
@@ -105,6 +105,16 @@ describe("Aave V3 Protocol Definition", () => {
     expect(chains).toContain("10");
   });
 
+  it("uses current Aave V3 PoolDataProvider addresses", () => {
+    expect(aaveV3Def.contracts.poolDataProvider.addresses).toMatchObject({
+      "1": "0x0a16f2FCC0D44FaE41cc54e079281D84A363bECD",
+      "8453": "0x0F43731EB8d45A581f4a36DD74F5f358bc90C73A",
+      "42161": "0x243Aa95cAC2a25651eda86e80bEe66114413c43b",
+      "10": "0x243Aa95cAC2a25651eda86e80bEe66114413c43b",
+      "11155111": "0x3e9708d80f7B3e43118013075F7e95CE3AB31F31",
+    });
+  });
+
   it("getUserAccountData has 6 outputs matching Pool return values", () => {
     const action = aaveV3Def.actions.find(
       (a) => a.slug === "get-user-account-data"


### PR DESCRIPTION
## Summary
- Updates hardcoded Aave V3 PoolDataProvider addresses to current on-chain values for Ethereum, Base, Arbitrum, Optimism, and Sepolia.
- Adds a focused regression test pinning the supported PoolDataProvider address map.

Linear: https://linear.app/keeperhubapp/issue/KEEP-439

## Repro / Evidence
- Confirmed the old Ethereum mainnet PoolDataProvider returned empty data for a USDC reserve read.
- Confirmed the current mainnet provider via PoolAddressesProvider.getPoolDataProvider() and verified it returns non-empty reserve data.
- Also checked sibling chains via on-chain PoolAddressesProvider values; Base, Arbitrum, and Optimism were stale too, so this PR updates all stale configured PoolDataProvider addresses.

## Test Plan
- pnpm exec vitest run tests/unit/protocol-aave-v3.test.ts passed.
- pnpm test:unit passed.
- pnpm type-check passed.
- git diff --check passed.
- pnpm fix ran; it exits 0 but reports the existing repo-wide Ultracite/Biome parse diagnostics. Unrelated formatter churn was reverted.

## Notes
- No deploy label requested; this is a static protocol address fix.