### PR TITLE
feat: add x402 + SIWX security schemes to OpenAPI discovery doc

### DIFF
--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -71,9 +71,6 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
   }
 
   if (isPaid) {
-    operation["x-x402-price"] = workflow.priceUsdcPerCall;
-    operation["x-x402-protocol"] = "x402";
-    operation["x-x402-network"] = "eip155:8453";
     operation["x-payment-info"] = {
       price: {
         mode: "fixed",
@@ -211,20 +208,23 @@ export async function GET(request: Request): Promise<Response> {
     },
     servers: [{ url: baseUrl }],
     components: {
+      // Declared for discovery only. Paid operations deliberately leave
+      // `security` unset — the HTTP 402 challenge-response conveys auth (see
+      // x-payment-info). These schemes document the supported payment/identity
+      // mechanisms for scanners; they are not referenced per-operation.
       securitySchemes: {
         x402: {
-          type: "apiKey",
-          in: "header",
-          name: "PAYMENT-SIGNATURE",
+          type: "http",
+          scheme: "Payment",
           description:
-            "x402 payment signature header for paid workflow calls. Unpaid first calls receive HTTP 402 with payment requirements.",
+            "x402 challenge-response payment. The first unpaid call returns HTTP 402 with payment requirements; the client signs that payment and replays the request.",
         },
         siwx: {
           type: "http",
           scheme: "bearer",
-          bearerFormat: "CAIP-122 SIWX",
+          bearerFormat: "CAIP-122",
           description:
-            "Sign-In with X identity proof for compatible agent clients. KeeperHub workflow calls primarily use x402 payment discovery today.",
+            "Sign-In with X identity proof (CAIP-122) for compatible agent clients. KeeperHub workflow calls primarily use x402 payment discovery today.",
         },
       },
     },

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -71,6 +71,9 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
   }
 
   if (isPaid) {
+    operation["x-x402-price"] = workflow.priceUsdcPerCall;
+    operation["x-x402-protocol"] = "x402";
+    operation["x-x402-network"] = "eip155:8453";
     operation["x-payment-info"] = {
       price: {
         mode: "fixed",
@@ -207,6 +210,24 @@ export async function GET(request: Request): Promise<Response> {
       docs: { homepage: "https://docs.keeperhub.com" },
     },
     servers: [{ url: baseUrl }],
+    components: {
+      securitySchemes: {
+        x402: {
+          type: "apiKey",
+          in: "header",
+          name: "PAYMENT-SIGNATURE",
+          description:
+            "x402 payment signature header for paid workflow calls. Unpaid first calls receive HTTP 402 with payment requirements.",
+        },
+        siwx: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "CAIP-122 SIWX",
+          description:
+            "Sign-In with X identity proof for compatible agent clients. KeeperHub workflow calls primarily use x402 payment discovery today.",
+        },
+      },
+    },
     paths,
   };
 

--- a/app/openapi.json/route.ts
+++ b/app/openapi.json/route.ts
@@ -1,3 +1,0 @@
-export const dynamic = "force-dynamic";
-
-export { GET } from "@/app/api/openapi/route";

--- a/app/openapi.json/route.ts
+++ b/app/openapi.json/route.ts
@@ -1,1 +1,3 @@
-export { dynamic, GET } from "@/app/api/openapi/route";
+export const dynamic = "force-dynamic";
+
+export { GET } from "@/app/api/openapi/route";

--- a/app/openapi.json/route.ts
+++ b/app/openapi.json/route.ts
@@ -1,0 +1,1 @@
+export { dynamic, GET } from "@/app/api/openapi/route";

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -80,9 +80,6 @@ describe("GET /api/openapi", () => {
     expect(path).toBeDefined();
     expect(path.post["x-payment-info"]).toBeDefined();
     expect(path.post["x-payment-info"].price.amount).toBe("0.05");
-    expect(path.post["x-x402-price"]).toBe("0.05");
-    expect(path.post["x-x402-protocol"]).toBe("x402");
-    expect(path.post["x-x402-network"]).toBe("eip155:8453");
     expect(path.post.responses["402"]).toBeDefined();
   });
 
@@ -99,14 +96,13 @@ describe("GET /api/openapi", () => {
     const body = await response.json();
 
     expect(body.components.securitySchemes.x402).toMatchObject({
-      type: "apiKey",
-      in: "header",
-      name: "PAYMENT-SIGNATURE",
+      type: "http",
+      scheme: "Payment",
     });
     expect(body.components.securitySchemes.siwx).toMatchObject({
       type: "http",
       scheme: "bearer",
-      bearerFormat: "CAIP-122 SIWX",
+      bearerFormat: "CAIP-122",
     });
   });
 
@@ -330,22 +326,5 @@ describe("GET /api/openapi", () => {
     expect(path.post["x-payment-info"]).toBeUndefined();
     expect(path.post["x-workflow-type"]).toBe("write");
     expect(path.post.responses["402"]).toBeUndefined();
-  });
-
-  it("/openapi.json reuses the OpenAPI emitter", async () => {
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([]),
-      }),
-    });
-
-    const { GET } = await import("@/app/openapi.json/route");
-    const request = new Request("https://app.keeperhub.com/openapi.json");
-    const response = await GET(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body.openapi).toBe("3.1.0");
-    expect(body.servers[0].url).toBe("https://app.keeperhub.com");
   });
 });

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -80,7 +80,34 @@ describe("GET /api/openapi", () => {
     expect(path).toBeDefined();
     expect(path.post["x-payment-info"]).toBeDefined();
     expect(path.post["x-payment-info"].price.amount).toBe("0.05");
+    expect(path.post["x-x402-price"]).toBe("0.05");
+    expect(path.post["x-x402-protocol"]).toBe("x402");
+    expect(path.post["x-x402-network"]).toBe("eip155:8453");
     expect(path.post.responses["402"]).toBeDefined();
+  });
+
+  it("declares OpenAPI security schemes for x402 and SIWX discovery clients", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body.components.securitySchemes.x402).toMatchObject({
+      type: "apiKey",
+      in: "header",
+      name: "PAYMENT-SIGNATURE",
+    });
+    expect(body.components.securitySchemes.siwx).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "CAIP-122 SIWX",
+    });
   });
 
   it("paid read workflows: no `security` (paid auth via x-payment-info → 402) + open-object fallback requestBody", async () => {
@@ -303,5 +330,22 @@ describe("GET /api/openapi", () => {
     expect(path.post["x-payment-info"]).toBeUndefined();
     expect(path.post["x-workflow-type"]).toBe("write");
     expect(path.post.responses["402"]).toBeUndefined();
+  });
+
+  it("/openapi.json reuses the OpenAPI emitter", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const request = new Request("https://app.keeperhub.com/openapi.json");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.openapi).toBe("3.1.0");
+    expect(body.servers[0].url).toBe("https://app.keeperhub.com");
   });
 });


### PR DESCRIPTION
## Summary
Adds `components.securitySchemes` to the existing `/api/openapi` discovery document, declaring the two auth mechanisms KeeperHub supports for agent clients:
- `x402` — modeled as `type: http, scheme: "Payment"` (the IETF payment-discovery draft's registered HTTP auth scheme for x402 challenge-response payments).
- `siwx` — `type: http, scheme: bearer, bearerFormat: "CAIP-122"` for Sign-In-with-X identity proofs.

The schemes are declared for discovery only — paid operations deliberately leave `security` unset because the HTTP 402 challenge-response (already emitted via `x-payment-info`) conveys auth.

Linear: https://linear.app/keeperhubapp/issue/KEEP-554

## Scope notes
This is the "SIWX securityScheme" line-item of KEEP-554 slice #1. The rest of slice #1 was already shipped on `staging`:
- The OpenAPI 3.1 emitter and per-operation x402 pricing metadata already exist via `x-payment-info` / `x-service-info`.
- The ticket's `x-x402-price` / `-protocol` / `-network` keys were dropped: they are not part of any x402 or agentcash discovery spec, and they duplicate `x-payment-info`, which is the spec-canonical equivalent already emitted (per IETF draft-payment-discovery-00).
- `/openapi.json` is already served — `next.config.ts` rewrites it to `/api/openapi`. No app-route alias is needed, so the one added earlier in this branch was removed.

## Test Plan
- `pnpm exec vitest run tests/unit/openapi-route.test.ts` — 10 passed.
- `pnpm type-check` — passed.
- `pnpm exec ultracite check` on changed files — passed.

## Follow-up (not in this PR)
- KEEP-554 slice #1 asks for an end-to-end `agentcash discover_api_endpoints` round-trip against the deployed origin. Not yet run.