### PR TITLE
feat: KEEP-554 enrich ERC-8004 agent card with skills, keywords, payment metadata

### DIFF
--- a/app/.well-known/agent-card.json/route.ts
+++ b/app/.well-known/agent-card.json/route.ts
@@ -18,7 +18,7 @@ export function GET(request: Request): Response {
   const card = {
     name: "KeeperHub",
     description:
-      "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP and x402 micropayments.",
+      "Execution layer for AI agents operating onchain. Discover and call DeFi workflows via MCP and ERC-8004, pay per execution in USDC over x402 on Base or MPP on Tempo. Managed DeFi 24/7 with onchain audit trail.",
     url: baseUrl,
     version: "1.0.0",
     provider: {
@@ -38,50 +38,57 @@ export function GET(request: Request): Response {
         id: "workflow_discovery",
         name: "Workflow Discovery",
         description:
-          "Search and list agent-callable workflows in the KeeperHub catalog by keyword, plugin, or chain.",
-        tags: ["discovery", "workflow", "catalog", "search"],
+          "Search and list KeeperHub-listed DeFi workflows by keyword, protocol, asset, chain, or pricing. Returns name, price, input schema, and supported payment rails (x402, MPP).",
+        tags: ["discovery", "search", "workflow", "marketplace", "defi"],
       },
       {
         id: "workflow_invocation",
         name: "Workflow Invocation",
         description:
-          "Invoke a listed workflow with structured inputs. Paid workflows settle via x402 micropayments on Base.",
-        tags: ["execution", "x402", "payments", "workflow"],
+          "Pay per execution and invoke a listed DeFi workflow with structured inputs. Paid workflows settle via x402 USDC on Base or MPP USDC.e on Tempo. Returns transaction hashes and a structured payment receipt.",
+        tags: ["execution", "x402", "mpp", "usdc", "base", "tempo", "payments"],
       },
       {
         id: "ai_workflow_generation",
         name: "AI Workflow Generation",
         description:
-          "Generate a new workflow from a natural-language description, including triggers, actions, and parameters.",
-        tags: ["generation", "ai", "workflow", "automation"],
+          "Generate a new automation workflow from a natural-language goal, including triggers, conditional logic, and multi-step protocol actions across chains.",
+        tags: ["ai", "generation", "natural-language", "workflow", "automation"],
       },
       {
         id: "protocol_actions",
         name: "Protocol Actions",
         description:
-          "Search and execute Web3 protocol actions (DeFi, governance, NFT, bridging) across supported chains.",
-        tags: ["defi", "web3", "protocol", "onchain"],
+          "Search and execute Web3 protocol actions (DeFi, governance, NFT, bridging, lending) across supported chains. Aave, Safe, swap routers, lending markets and more.",
+        tags: ["defi", "web3", "protocol", "onchain", "aave", "safe", "lending", "governance"],
       },
       {
         id: "onchain_execution",
-        name: "On-chain Execution",
+        name: "Onchain Execution",
         description:
-          "Execute token transfers, contract calls, and conditional check-and-execute transactions across supported chains.",
-        tags: ["transfer", "contract", "execution", "onchain"],
+          "Execute token transfers, swaps, bridges, stakes, contract calls, and conditional check-and-execute transactions across Base, Ethereum, Tempo and other supported chains.",
+        tags: ["transfer", "swap", "bridge", "stake", "contract", "execution", "onchain"],
       },
       {
         id: "templates",
         name: "Workflow Templates",
         description:
-          "Browse the template gallery and deploy pre-built workflows with parameter overrides.",
-        tags: ["templates", "deploy", "workflow"],
+          "Browse curated workflow templates (multisig automation, treasury management, DeFi position management) and deploy them with one call.",
+        tags: ["template", "deploy", "marketplace", "treasury", "multisig"],
       },
       {
         id: "execution_monitoring",
         name: "Execution Monitoring",
         description:
-          "Inspect workflow run status and logs for debugging and audit trails.",
-        tags: ["observability", "logs", "monitoring"],
+          "Stream or poll workflow execution status, transaction hashes, gas spent, and per-step logs for debugging and audit. Full onchain audit trail per execution.",
+        tags: ["monitoring", "status", "logs", "audit", "observability"],
+      },
+      {
+        id: "reputation_feedback",
+        name: "Reputation Feedback",
+        description:
+          "Record ERC-8004 ReputationRegistry feedback for a workflow execution. Wallet-signed and broadcast onchain. Feeds external scorers (Valiron, AgentScore, AgentSign).",
+        tags: ["reputation", "feedback", "erc-8004", "audit", "trust"],
       },
     ],
   };

--- a/data/agent-registry.json
+++ b/data/agent-registry.json
@@ -140,18 +140,26 @@
       "endpoint": "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51"
     }
   ],
+  "marketplace": {
+    "model": "multi-creator",
+    "description": "KeeperHub-listed workflows are published by independent creators. Each workflow advertises its own payTo address and per-call price in its 402 PAYMENT-REQUIRED response and at /api/mcp/workflows/<slug>. Per-execution settlement splits between the creator and the platform.",
+    "platformFeePercent": 30,
+    "creatorSharePercent": 70,
+    "platformFeeRecipient": {
+      "base": "eip155:8453:0xc300b53616532fdb0116bce916c9307377362b51",
+      "tempo": "eip155:4217:0xc300b53616532fdb0116bce916c9307377362b51"
+    }
+  },
   "payment": {
     "x402": {
       "supported": true,
       "networks": ["base"],
-      "assets": ["USDC"],
-      "payTo": "eip155:8453:0xc300b53616532fdb0116bce916c9307377362b51"
+      "assets": ["USDC"]
     },
     "mpp": {
       "supported": true,
       "networks": ["tempo"],
-      "assets": ["USDC.e"],
-      "payTo": "eip155:4217:0xc300b53616532fdb0116bce916c9307377362b51"
+      "assets": ["USDC.e"]
     }
   },
   "supportedTrust": ["reputation"],

--- a/data/agent-registry.json
+++ b/data/agent-registry.json
@@ -1,8 +1,90 @@
 {
   "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
   "name": "KeeperHub",
-  "description": "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP.",
+  "description": "Execution layer for AI agents operating onchain. Discover and call DeFi workflows via MCP and ERC-8004, pay per execution in USDC over x402 on Base or MPP on Tempo. Managed DeFi 24/7 with onchain audit trail.",
   "image": "https://app.keeperhub.com/keeperhub_logo.png",
+  "keywords": [
+    "keeperhub",
+    "execution",
+    "automation",
+    "workflow",
+    "defi",
+    "agent",
+    "ai-agent",
+    "x402",
+    "mpp",
+    "usdc",
+    "base",
+    "tempo",
+    "stablecoin",
+    "managed-defi",
+    "onchain",
+    "web3",
+    "trading",
+    "rebalance",
+    "swap",
+    "bridge",
+    "stake",
+    "lending",
+    "aave",
+    "safe",
+    "sky-protocol",
+    "audit-trail",
+    "reliability",
+    "erc-8004",
+    "mcp",
+    "a2a"
+  ],
+  "skills": [
+    {
+      "id": "workflow_discovery",
+      "name": "Workflow Discovery",
+      "description": "Search and list KeeperHub-listed DeFi workflows by keyword, protocol, asset, chain, or pricing. Returns name, price, input schema, and supported payment rails (x402, MPP).",
+      "tags": ["discovery", "search", "workflow", "marketplace", "defi"]
+    },
+    {
+      "id": "workflow_invocation",
+      "name": "Workflow Invocation",
+      "description": "Pay per execution and invoke a listed DeFi workflow with structured inputs. Paid workflows settle via x402 USDC on Base or MPP USDC.e on Tempo. Returns transaction hashes and a structured payment receipt.",
+      "tags": ["execution", "x402", "mpp", "usdc", "base", "tempo", "payments"]
+    },
+    {
+      "id": "ai_workflow_generation",
+      "name": "AI Workflow Generation",
+      "description": "Generate a new automation workflow from a natural-language goal, including triggers, conditional logic, and multi-step protocol actions across chains.",
+      "tags": ["ai", "generation", "natural-language", "workflow", "automation"]
+    },
+    {
+      "id": "protocol_actions",
+      "name": "Protocol Actions",
+      "description": "Search and execute Web3 protocol actions (DeFi, governance, NFT, bridging, lending) across supported chains. Aave, Safe, swap routers, lending markets and more.",
+      "tags": ["defi", "web3", "protocol", "onchain", "aave", "safe", "lending", "governance"]
+    },
+    {
+      "id": "onchain_execution",
+      "name": "Onchain Execution",
+      "description": "Execute token transfers, swaps, bridges, stakes, contract calls, and conditional check-and-execute transactions across Base, Ethereum, Tempo and other supported chains.",
+      "tags": ["transfer", "swap", "bridge", "stake", "contract", "execution", "onchain"]
+    },
+    {
+      "id": "templates",
+      "name": "Workflow Templates",
+      "description": "Browse curated workflow templates (multisig automation, treasury management, DeFi position management) and deploy them with one call.",
+      "tags": ["template", "deploy", "marketplace", "treasury", "multisig"]
+    },
+    {
+      "id": "execution_monitoring",
+      "name": "Execution Monitoring",
+      "description": "Stream or poll workflow execution status, transaction hashes, gas spent, and per-step logs for debugging and audit. Full onchain audit trail per execution.",
+      "tags": ["monitoring", "status", "logs", "audit", "observability"]
+    },
+    {
+      "id": "reputation_feedback",
+      "name": "Reputation Feedback",
+      "description": "Record ERC-8004 ReputationRegistry feedback for a workflow execution. Wallet-signed and broadcast onchain. Feeds external scorers (Valiron, AgentScore, AgentSign).",
+      "tags": ["reputation", "feedback", "erc-8004", "audit", "trust"]
+    }
+  ],
   "services": [
     {
       "name": "MCP",
@@ -51,12 +133,27 @@
       "endpoint": "https://app.keeperhub.com/api/mcp/workflows"
     },
     { "name": "web", "endpoint": "https://app.keeperhub.com" },
+    { "name": "docs", "endpoint": "https://docs.keeperhub.com" },
     { "name": "ens", "endpoint": "keeperhub.eth" },
     {
       "name": "agentWallet",
       "endpoint": "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51"
     }
   ],
+  "payment": {
+    "x402": {
+      "supported": true,
+      "networks": ["base"],
+      "assets": ["USDC"],
+      "payTo": "eip155:8453:0xc300b53616532fdb0116bce916c9307377362b51"
+    },
+    "mpp": {
+      "supported": true,
+      "networks": ["tempo"],
+      "assets": ["USDC.e"],
+      "payTo": "eip155:4217:0xc300b53616532fdb0116bce916c9307377362b51"
+    }
+  },
   "supportedTrust": ["reputation"],
   "x402Support": true,
   "active": true,


### PR DESCRIPTION
## Summary

Enriches both surfaces of the KeeperHub agent identity:

- \`data/agent-registry.json\` — the JSON pinned to IPFS and referenced by the ERC-8004 IdentityRegistry tokenURI for agent #31875
- \`app/.well-known/agent-card.json/route.ts\` — the live A2A endpoint

The card previously shipped with a generic description ("Web3 workflow automation platform...") and no inline \`skills\` array, no \`keywords\`, no structured payment fields. Keyword search against 8004scan for \"keeperhub\" returned zero results; downstream indexers (agentcash search, x402scan) had no searchable surface to match against.

## Changes

- **Description** rewritten to match the D-066 wedge wording: execution layer, x402 on Base, MPP on Tempo, Managed DeFi, onchain audit trail.
- **Inline \`skills\` array** (8 entries) on both surfaces with matching IDs:
  - \`workflow_discovery\`, \`workflow_invocation\`, \`ai_workflow_generation\`, \`protocol_actions\`, \`onchain_execution\`, \`templates\`, \`execution_monitoring\`, and **\`reputation_feedback\`** (new — completes the ERC-8004 feedback read/write symmetry against the \`feedback\` write path the wallet already ships).
- **Per-skill descriptions and tags** include searchable terms agents query for: \`x402\`, \`mpp\`, \`usdc\`, \`base\`, \`tempo\`, \`aave\`, \`safe\`, \`defi\`, \`swap\`, \`bridge\`, \`stake\`, \`contract\`, etc.
- **\`keywords\` array** (30 tags) added to \`data/agent-registry.json\`.
- **Structured \`payment\` block** (x402 on Base + MPP on Tempo with payTo addresses) added to \`data/agent-registry.json\`.
- **New service entries**: \`/api/openapi.json\` (forthcoming) and \`docs.keeperhub.com\`.

## Deploy steps after merge

```bash
PINATA_JWT=<jwt> pnpm tsx scripts/pin-agent-card.ts
# script prints the new ipfs://<cid>

REGISTRATION_PRIVATE_KEY=<owner-key> NEW_AGENT_URI=\"ipfs://<cid>\" \\
  pnpm tsx scripts/update-agent-uri.ts
```

Cost: ~\$1-3 in ETH gas. 8004scan typically re-indexes within hours of the onchain \`setAgentURI\` event.

## Pairs with

- techops-services/infrastructure PR #194 — Cloudflare bypass for AI-vendor UAs on \`/.well-known/*\`, \`/api/openapi.json\`, \`/llms.txt\` on \`app.keeperhub.com\`. Required for Claude / ChatGPT / Perplexity browse-on-behalf-of-user to reach the A2A endpoint.

## Test plan

- [ ] CI / lint / type-check green
- [ ] After merge + deploy: \`curl -H 'User-Agent: Mozilla/5.0' https://app.keeperhub.com/.well-known/agent-card.json | jq '.skills | length'\` returns \`8\`
- [ ] After IPFS pin + onchain update: \`https://8004scan.io/api/v1/public/agents/1/31875\` shows the new description and rich service list
- [ ] After 8004scan re-index (allow several hours): \`https://8004scan.io/api/v1/public/agents/search?q=keeperhub\` returns agent #31875 as a result (currently returns zero)