### PR TITLE
fix: KEEP-349 race connect against ws-error + timeout in openProvider

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -49,6 +49,15 @@ const MAX_RECONNECT_ATTEMPTS = 10;
  * same scale.
  */
 const PROBE_TIMEOUT_MS = 10_000;
+/**
+ * Cap on the WS handshake + first RPC round-trip during `openProvider`.
+ * `getBlockNumber()` internally calls ethers' `_waitUntilReady()`, which
+ * resolves on socket open but never rejects on socket failure - so a host
+ * that DNS-fails or refuses the TCP connect would otherwise hang the
+ * connect attempt indefinitely. Matches `PROBE_TIMEOUT_MS` so both
+ * connect-time reachability gates fail at the same scale.
+ */
+const CONNECT_TIMEOUT_MS = 10_000;
 
 export type LogHandler = (log: ethers.Log) => void | Promise<void>;
 export type Unsubscribe = () => void;
@@ -130,9 +139,10 @@ interface ChainEntry {
   wssUrl: string;
   /**
    * Configured fallback URL, immutable once the entry is created. Tried
-   * only when the primary attempt fails (factory throws, `provider.ready`
-   * rejects, or `eth_subscribe` probe rejects). Reconnects always start
-   * over from primary so a primary that recovers is preferred.
+   * only when the primary attempt fails (factory throws, the connect
+   * race in `openProvider` rejects, or the `eth_subscribe` probe
+   * rejects). Reconnects always start over from primary so a primary
+   * that recovers is preferred.
    */
   fallbackWssUrl: string | null;
   /**
@@ -175,11 +185,12 @@ interface ChainEntry {
  * exits the pod - which would crashloop the whole event-tracker on a
  * misconfigured WSS URL even when a healthy fallback is configured.
  *
- * The listener is a no-op: failures still reject `provider.ready` via
- * ethers' onerror (assigned shortly after we return), and that rejection
- * is what openProvider catches to walk to the fallback. We just need
- * *some* error listener to be on the ws by the time the connection
- * attempt resolves.
+ * The listener is a no-op: actual error propagation happens through
+ * `attachConnectErrorListener` (a second listener attached in
+ * `openProvider`), which rejects the connect race that walks to the
+ * fallback URL. We just need *some* error listener to be on the ws by
+ * the time the connection attempt resolves so the EventEmitter does not
+ * re-throw synchronously.
  */
 const defaultFactory: ProviderFactory = (wssUrl) =>
   new ethers.WebSocketProvider(() => {
@@ -195,6 +206,34 @@ const defaultOnPermanentFailure = (chainId: number): void => {
     `[ChainProviderManager] chain=${chainId} permanent failure after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts; exiting process for K8s restart`,
   );
   process.exit(1);
+};
+
+/**
+ * Returns a Promise<never> that rejects when the provider's underlying ws
+ * emits "error". The no-op listener in `defaultFactory` exists only to
+ * keep the EventEmitter happy and prevent uncaughtException; this listener
+ * does the actual error propagation that `openProvider`'s race needs to
+ * walk to the fallback URL instead of hanging on `getBlockNumber()`.
+ *
+ * Cast through unknown because ethers does not expose `.websocket` in its
+ * public type even though it is the documented hook for direct ws access.
+ * A factory that returns a provider without a usable `.websocket` (e.g. a
+ * test mock) leaves this promise pending, so the race falls back to the
+ * timeout - acceptable for tests, and the connect path is exercised by
+ * the integration tests in `provider-manager-bad-url.test.ts`.
+ */
+const attachConnectErrorListener = (
+  provider: ethers.WebSocketProvider,
+): Promise<never> => {
+  const ws = provider.websocket as unknown as {
+    on?: (event: string, cb: (err: Error) => void) => void;
+  };
+  return new Promise<never>((_, reject) => {
+    ws?.on?.("error", (err: Error) => {
+      const message = err?.message ?? String(err);
+      reject(new Error(`WebSocket error: ${message}`));
+    });
+  });
 };
 
 export class ChainProviderManager {
@@ -501,7 +540,35 @@ export class ChainProviderManager {
       let provider: ethers.WebSocketProvider | null = null;
       try {
         provider = this.factory(url);
-        await provider.ready;
+        // Confirm the ws upgrade actually completed. `provider.ready` in
+        // ethers v6 is a synchronous boolean getter, not a Promise, so
+        // awaiting it tells us nothing. `getBlockNumber()` internally
+        // calls `_waitUntilReady()` which waits for socket open but
+        // never rejects on socket failure - so race it against an
+        // explicit ws-error listener and a connect timeout, matching
+        // PR #988 in keeperhub-scheduler/block-dispatcher/chain-monitor.ts.
+        const wsErrorPromise = attachConnectErrorListener(provider);
+        let timeoutHandle: NodeJS.Timeout | null = null;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () =>
+              reject(
+                new Error(`connect timed out after ${CONNECT_TIMEOUT_MS}ms`),
+              ),
+            CONNECT_TIMEOUT_MS,
+          );
+        });
+        try {
+          await Promise.race([
+            provider.getBlockNumber(),
+            wsErrorPromise,
+            timeoutPromise,
+          ]);
+        } finally {
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+        }
         await this.probeSubscriptionSupport(provider, entry, url);
         return { provider, urlUsed: url };
       } catch (err) {

--- a/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
@@ -12,13 +12,15 @@ import {
 } from "../../src/health/health-server";
 
 class MockProvider {
-  ready: Promise<void> = Promise.resolve();
   destroyed = false;
   on(): void {
     /* noop */
   }
   off(): void {
     /* noop */
+  }
+  async getBlockNumber(): Promise<number> {
+    return 0;
   }
   async send(): Promise<unknown> {
     return 0;

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -14,9 +14,6 @@ interface SendCall {
 }
 
 class MockProvider {
-  // Vitest's vi.fn provides better assertions (toHaveBeenCalledWith) than a plain
-  // Promise.resolve would, and the field is still awaitable.
-  ready: Promise<void> = Promise.resolve();
   public sendCalls: SendCall[] = [];
   public sendResponses: unknown[] = [];
   public blockNumberResponses: Array<number | Error> = [];
@@ -46,6 +43,10 @@ class MockProvider {
     } else if (event === "error" && this.errorHandler === handler) {
       this.errorHandler = null;
     }
+  }
+
+  async getBlockNumber(): Promise<number> {
+    return (await this.send("eth_blockNumber", [])) as number;
   }
 
   async send(method: string, params: unknown[]): Promise<unknown> {
@@ -1229,15 +1230,20 @@ describe("ChainProviderManager", () => {
       // Heartbeat is subscriber-scoped: creating a provider without
       // subscribing leaves it silent. Previously the heartbeat started
       // on provider creation, wasting RPC calls on idle providers.
+      // Baseline after connect so the initial connect probe (a single
+      // getBlockNumber call inside openProvider) is not counted as a ping.
       await manager.getOrCreateProvider(CHAIN_A, "ws://a");
       const provider = factoryBundle.created[0];
+      const pingsBefore = provider.sendCalls.filter(
+        (c) => c.method === "eth_blockNumber",
+      ).length;
 
       await vi.advanceTimersByTimeAsync(60_000);
 
-      const pings = provider.sendCalls.filter(
+      const pingsAfter = provider.sendCalls.filter(
         (c) => c.method === "eth_blockNumber",
       ).length;
-      expect(pings).toBe(0);
+      expect(pingsAfter).toBe(pingsBefore);
     });
 
     it("pings eth_blockNumber periodically once a subscriber is added", async () => {


### PR DESCRIPTION
## Summary

Same `provider.ready` misuse pattern that PR #988 fixed in the block dispatcher (KEEP-347) was still present in `keeperhub-events`. `ethers.WebSocketProvider.ready` is a **synchronous boolean getter** on `JsonRpcApiProvider`, not a Promise - `await`ing it resolves immediately and lets `openProvider` proceed before the ws upgrade completes. Subsequent calls then race against an unconnected socket.

Plain replacement with `await provider.getBlockNumber()` is necessary but not sufficient: `_waitUntilReady()` waits for socket `open` but never rejects on socket failure, so DNS/TCP failures would hang the connect attempt indefinitely instead of walking to the fallback URL. The full fix mirrors PR #988's three-way `Promise.race`:

- `provider.getBlockNumber()` - actual readiness signal (resolves once the ws is open and the RPC round-trips)
- `attachConnectErrorListener(provider)` - rejects on the underlying ws `"error"` event (catches DNS NXDOMAIN, ECONNREFUSED)
- 10s `CONNECT_TIMEOUT_MS` - guards against accept-but-silent upstreams that take the ws handshake and never answer

## Scope discrepancy from the ticket

The ticket pointed at four call sites (two in `ws-connection.ts`, two in `provider-manager.ts`). Those line numbers are stale - subsequent refactors (KEEP-1587 monorepo move, KEEP-328 fork-mode delete, KEEP-295/418/434 provider-manager rewrites) collapsed the read path to a single `await provider.ready` in `openProvider`, which is the shared code path for both initial connect and reconnect. The single fix covers all four original sites in spirit.

Two misleading comments in `provider-manager.ts` (ChainEntry JSDoc, defaultFactory JSDoc) referenced `provider.ready` "rejecting" via ethers' onerror - that never happened (it is not a Promise). Updated both to describe the actual rejection path through `attachConnectErrorListener`.

## Test plan

- [x] `provider-manager.test.ts` unit tests pass (132 passing, including updated heartbeat baseline)
- [x] `health-server.test.ts` unit tests pass (MockProvider now exposes `getBlockNumber`)
- [x] `provider-manager-bad-url.test.ts` integration tests pass in 2.6s (previously timing out at 60s per test against ECONNREFUSED + NXDOMAIN URLs)
- [x] `pnpm typecheck` passes for `@techops/events-tracker`
- [ ] Verify in staging that event-tracker reconnects cleanly when WSS endpoints fail-and-recover