### PR TITLE
ci: replace public CF-gated deploy health check with in-cluster check

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -104,26 +104,31 @@ jobs:
       - name: Wait for deployment health check
         if: steps.skip.outputs.skip_deploy != 'true'
         run: |
-          HEALTH_URL="${{ vars.TO_HEALTH_URL }}/api/health"
-          echo "Waiting for ${HEALTH_URL} to return 200..."
-          CURL_ARGS=(-s -o /dev/null -w "%{http_code}" -L)
-          if [[ -n "$CF_ACCESS_CLIENT_ID" && -n "$CF_ACCESS_CLIENT_SECRET" ]]; then
-            CURL_ARGS+=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
-          fi
-          for i in {1..30}; do
-            STATUS=$(curl "${CURL_ARGS[@]}" "${HEALTH_URL}" || echo "000")
-            if [[ "$STATUS" == "200" ]]; then
-              echo "Deployment is ready!"
-              exit 0
-            fi
-            echo "Attempt $i/30: got HTTP $STATUS, waiting 10s..."
-            sleep 10
-          done
-          echo "Deployment did not become ready in time"
-          exit 1
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
+          SVC_NAME=$(yq '.service.name' "$HELM_FILE")
+          SVC_PORT=$(yq '.service.port' "$HELM_FILE")
+          HEALTH_URL="http://${SVC_NAME}.${NAMESPACE}.svc.cluster.local:${SVC_PORT}/api/health"
+          echo "Checking ${HEALTH_URL} from inside the cluster..."
+          kubectl run "health-check-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --namespace "${NAMESPACE}" \
+            --restart=Never \
+            --attach \
+            --rm \
+            --quiet \
+            --image=curlimages/curl:8.11.0 \
+            --env="HEALTH_URL=${HEALTH_URL}" \
+            --command -- sh -c '
+              for i in $(seq 1 30); do
+                STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" || echo "000")
+                if [ "$STATUS" = "200" ]; then
+                  echo "Deployment is ready!"
+                  exit 0
+                fi
+                echo "Attempt $i/30: got HTTP $STATUS, waiting 10s..."
+                sleep 10
+              done
+              echo "Deployment did not become ready in time"
+              exit 1
+            '
 
   # DISABLED: remote E2E tests temporarily disabled while KEEP-1351 stabilises auth/rate-limit infrastructure
   e2e-playwright-remote:


### PR DESCRIPTION
## Summary

The post-deploy health gate in `deploy-keeperhub.yaml` curled the public `app-staging.keeperhub.com/api/health` edge with CF-Access service-token headers. A Cloudflare edge rule started returning **403** to GitHub Actions runner IPs at ~`2026-05-14T00:06` (no repo changes in that window), failing every staging deploy even though the helm rollout itself succeeded (`--atomic`, `STATUS: deployed`).

Confirmed it is not a CF-Access token problem: a rejected service token returns `302 -> login`, not `403`. The token is valid (verified `200` from a non-datacenter IP). The `403` is a Cloudflare edge block on runner IPs.

This replaces the public-edge curl with an in-cluster check: a one-shot `kubectl run` curl pod polls `/api/health` on the ClusterIP service from inside the cluster, removing the dependency on the Cloudflare edge, public DNS, and the CF-Access service token. Service name/port are read from the helm values file so it works for staging and prod.

## Notes

- The disabled `e2e-playwright-remote` job still references `secrets.TO_CF_ACCESS_*` / `vars.TO_HEALTH_URL`; left untouched since it is gated off.
- The underlying Cloudflare edge rule blocking datacenter IPs is worth investigating separately (it may also affect external uptime monitoring).

## Test plan

- [ ] Merge triggers a push-event CI Pipeline on `staging`; `deploy / deploy` runs the in-cluster health check and passes
- [ ] Confirm the `health-check-*` pod is created and cleaned up (`--rm`) in the `keeperhub` namespace