### PR TITLE
ci: target keeperhub-common service in deploy health check

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -104,9 +104,7 @@ jobs:
       - name: Wait for deployment health check
         if: steps.skip.outputs.skip_deploy != 'true'
         run: |
-          SVC_NAME=$(yq '.service.name' "$HELM_FILE")
-          SVC_PORT=$(yq '.service.port' "$HELM_FILE")
-          HEALTH_URL="http://${SVC_NAME}.${NAMESPACE}.svc.cluster.local:${SVC_PORT}/api/health"
+          HEALTH_URL="http://${SERVICE_NAME}-common.${NAMESPACE}.svc.cluster.local:3000/api/health"
           echo "Checking ${HEALTH_URL} from inside the cluster..."
           kubectl run "health-check-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --namespace "${NAMESPACE}" \


### PR DESCRIPTION
## Summary

Follow-up to #1254. The in-cluster health check built the service URL from the helm values file's `service.name` (`keeperhub-staging`), but the `techops-services/common` chart names the Service `<release>-common`. The curl pod could not connect and the staging deploy failed with `HTTP 000` on every attempt.

Build the URL as `${SERVICE_NAME}-common.${NAMESPACE}.svc.cluster.local:3000` instead. This matches how every other component in `deploy/` reaches the app (`event-tracker`, `scheduler` dispatchers, the `reaper` cronjob in the staging values file itself, and the local-dev ingress) -- all use `keeperhub-common:3000`. Release name and chart are identical for staging and prod, so the derived name is correct for both.

## Test plan

- [ ] Merge triggers a push-event CI Pipeline on `staging`; `deploy / deploy` health check connects and returns 200
- [ ] `health-check-*` pod created and cleaned up in the `keeperhub` namespace