### PR TITLE
feat(block-dispatcher): KEEP-557 Prometheus metrics for chain monitor liveness, reconnects, and SQS enqueue

### DIFF
--- a/deploy/scheduler/prod/block-dispatcher-values.yaml
+++ b/deploy/scheduler/prod/block-dispatcher-values.yaml
@@ -35,6 +35,9 @@ serviceAccount:
 
 podAnnotations:
   reloader.stakater.com/auto: "true"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "3000"
+  prometheus.io/path: "/metrics"
 
 resources:
   limits:

--- a/deploy/scheduler/staging/block-dispatcher-values.yaml
+++ b/deploy/scheduler/staging/block-dispatcher-values.yaml
@@ -35,6 +35,9 @@ serviceAccount:
 
 podAnnotations:
   reloader.stakater.com/auto: "true"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "3000"
+  prometheus.io/path: "/metrics"
 
 resources:
   limits:

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -220,11 +220,10 @@ export class ChainMonitor {
     this.silentReconnects = 0;
     this.stopTimers();
     await this.destroyProvider();
-    metrics.setIsAlive(this.chainName, false);
-    metrics.setIsReconnecting(this.chainName, false);
-    metrics.setHasActiveSubscription(this.chainName, false);
-    metrics.setSilentReconnectsCurrent(this.chainName, 0);
-    metrics.setWorkflowsTracked(this.chainName, 0);
+    // forgetChain() removes every per-chain gauge labelset, so the chain
+    // disappears entirely from /metrics output. No need to flip individual
+    // gauges to 0 first — that would leave residual labels behind. Counters
+    // and histograms keep their cumulative history.
     metrics.forgetChain(this.chainName);
   }
 

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -12,6 +12,7 @@
  */
 
 import { ethers } from "ethers";
+import { metrics } from "../lib/metrics.js";
 import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
 import { enqueueBlockTrigger } from "./sqs-enqueue.js";
 
@@ -195,6 +196,8 @@ export class ChainMonitor {
     }
     this.isRunning = true;
     this.silentReconnects = 0;
+    metrics.setSilentReconnectsCurrent(this.chainName, 0);
+    metrics.setWorkflowsTracked(this.chainName, this.workflows.length);
 
     try {
       await this.connect();
@@ -202,8 +205,10 @@ export class ChainMonitor {
       this.startPingPong();
       this.resetNoBlockTimer();
       this.startPrimaryProbe();
+      metrics.setIsAlive(this.chainName, true);
     } catch (error) {
       this.isRunning = false;
+      metrics.setIsAlive(this.chainName, false);
       throw error;
     }
   }
@@ -215,10 +220,17 @@ export class ChainMonitor {
     this.silentReconnects = 0;
     this.stopTimers();
     await this.destroyProvider();
+    metrics.setIsAlive(this.chainName, false);
+    metrics.setIsReconnecting(this.chainName, false);
+    metrics.setHasActiveSubscription(this.chainName, false);
+    metrics.setSilentReconnectsCurrent(this.chainName, 0);
+    metrics.setWorkflowsTracked(this.chainName, 0);
+    metrics.forgetChain(this.chainName);
   }
 
   updateWorkflows(workflows: BlockWorkflow[]): void {
     this.workflows = workflows;
+    metrics.setWorkflowsTracked(this.chainName, workflows.length);
   }
 
   hasConfigChanged(chain: ChainConfig): boolean {
@@ -400,6 +412,7 @@ export class ChainMonitor {
 
         this.provider = provider;
         this.currentUrlIndex = candidate.index;
+        metrics.setCurrentUrlIndex(this.chainName, candidate.index);
         console.log(
           `[BlockMonitor:${this.chainName}] Connected to ${candidate.label} WSS (block: ${blockNumber})`,
         );
@@ -468,7 +481,11 @@ export class ChainMonitor {
     // Seed the staleness clock so a freshly-subscribed monitor isn't reaped
     // by isAlive() before the first block arrives. Real height advances
     // refresh this in processBlockRange().
-    this.lastBlockAdvanceAt = Date.now();
+    const subscribedAt = Date.now();
+    this.lastBlockAdvanceAt = subscribedAt;
+    metrics.setHasActiveSubscription(this.chainName, true);
+    metrics.setLastBlockAdvanceAt(this.chainName, subscribedAt);
+    metrics.setSubscribedAt(this.chainName, subscribedAt);
     // resetNoBlockTimer is called from start/reconnect, but seed it here too
     // for the same reason — the watchdog needs a baseline from the moment we
     // are subscribed, not from the previous run.
@@ -481,9 +498,11 @@ export class ChainMonitor {
       on?: (event: string, cb: () => void) => void;
     };
     if (ws?.on) {
-      this.wsCloseHandler = () => {
+      this.wsCloseHandler = (): void => {
         console.warn(`[BlockMonitor:${this.chainName}] WebSocket closed`);
         this.hasActiveSubscription = false;
+        metrics.setHasActiveSubscription(this.chainName, false);
+        metrics.recordWsClose(this.chainName, "upstream_close");
         this.handleDisconnect();
       };
       ws.on("close", this.wsCloseHandler);
@@ -570,13 +589,18 @@ export class ChainMonitor {
     await this.processBlockNumber(blockNumber);
     this.lastProcessedBlock = blockNumber;
     // Height genuinely advanced — refresh liveness AFTER the fact.
-    this.lastBlockAdvanceAt = Date.now();
+    const advancedAt = Date.now();
+    this.lastBlockAdvanceAt = advancedAt;
     // Trust the current URL again: a real height advance means the
     // subscription is delivering. Without this reset, an old streak of silent
     // reconnects would still trigger a URL flip on the next disconnect.
     this.silentReconnects = 0;
     this.resetNoBlockTimer();
     this.blocksReceived++;
+    metrics.recordBlockReceived(this.chainName);
+    metrics.setLastProcessedBlock(this.chainName, blockNumber);
+    metrics.setLastBlockAdvanceAt(this.chainName, advancedAt);
+    metrics.setSilentReconnectsCurrent(this.chainName, 0);
 
     // Heartbeat log
     const now = Date.now();
@@ -603,15 +627,18 @@ export class ChainMonitor {
       return;
     }
 
-    // Stale block warning
+    // Stale block warning + lag histogram
     const nowSeconds = Math.floor(Date.now() / 1000);
-    if (nowSeconds - block.timestamp > STALE_BLOCK_THRESHOLD_S) {
+    const lagSeconds = nowSeconds - block.timestamp;
+    metrics.observeBlockLag(this.chainName, lagSeconds);
+    if (lagSeconds > STALE_BLOCK_THRESHOLD_S) {
       console.warn(
-        `[BlockMonitor:${this.chainName}] Block ${blockNumber} timestamp is ${nowSeconds - block.timestamp}s behind wall clock`,
+        `[BlockMonitor:${this.chainName}] Block ${blockNumber} timestamp is ${lagSeconds}s behind wall clock`,
       );
     }
 
     this.blocksMatched++;
+    metrics.recordBlockMatched(this.chainName);
     console.log(
       `[BlockMonitor:${this.chainName}] Block ${blockNumber} matched ${matchingWorkflows.length} workflow(s): ${matchingWorkflows.map((wf) => `${wf.id}(interval=${wf.blockInterval})`).join(", ")}`,
     );
@@ -634,10 +661,13 @@ export class ChainMonitor {
 
     for (const [index, result] of results.entries()) {
       if (result.status === "rejected") {
+        metrics.recordSqsEnqueue(this.chainName, "error");
         console.error(
           `[BlockMonitor:${this.chainName}] Failed to enqueue workflow ${matchingWorkflows[index].id}:`,
           result.reason,
         );
+      } else {
+        metrics.recordSqsEnqueue(this.chainName, "success");
       }
     }
   }
@@ -716,6 +746,7 @@ export class ChainMonitor {
         console.warn(
           `[BlockMonitor:${this.chainName}] Failed to send ping, triggering reconnect`,
         );
+        metrics.recordWsClose(this.chainName, "ping_send_failure");
         this.handleDisconnect();
         return;
       }
@@ -730,6 +761,7 @@ export class ChainMonitor {
         console.warn(
           `[BlockMonitor:${this.chainName}] Pong timeout (${pongTimeoutMs}ms), triggering reconnect`,
         );
+        metrics.recordWsClose(this.chainName, "pong_timeout");
         this.handleDisconnect();
       }, pongTimeoutMs);
     }, pingIntervalMs);
@@ -759,6 +791,11 @@ export class ChainMonitor {
         // flip to the other URL is made by reconnectWithBackoff before its
         // next connect attempt, based on SILENT_FAILOVER_THRESHOLD.
         this.silentReconnects++;
+        metrics.setSilentReconnectsCurrent(
+          this.chainName,
+          this.silentReconnects,
+        );
+        metrics.recordWsClose(this.chainName, "block_advance_timeout");
         console.warn(
           `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s (silent reconnects=${this.silentReconnects}), triggering reconnect`,
         );
@@ -800,6 +837,7 @@ export class ChainMonitor {
       console.log(
         `[BlockMonitor:${this.chainName}] Socket age exceeded ${Math.floor(maxAgeMs / 1000)}s, recycling`,
       );
+      metrics.recordWsClose(this.chainName, "socket_age_recycle");
       this.handleDisconnect();
     }, maxAgeMs);
   }
@@ -880,6 +918,8 @@ export class ChainMonitor {
       await probeProvider.destroy().catch(() => {
         // ignore cleanup errors
       });
+      metrics.recordUrlFlip(this.chainName, "to_primary");
+      metrics.recordWsClose(this.chainName, "primary_probe_recovered");
       this.handleDisconnect();
     } catch (error) {
       const reason = summarizeProbeError(error);
@@ -906,6 +946,8 @@ export class ChainMonitor {
 
     this.isReconnecting = true;
     this.reconnectingStartedAt = Date.now();
+    metrics.setIsReconnecting(this.chainName, true);
+    metrics.setHasActiveSubscription(this.chainName, false);
     this.stopTimers();
 
     this.reconnectWithBackoff().catch((error: unknown) => {
@@ -915,10 +957,12 @@ export class ChainMonitor {
       );
       this.isReconnecting = false;
       this.reconnectingStartedAt = null;
+      metrics.setIsReconnecting(this.chainName, false);
     });
   }
 
   private async reconnectWithBackoff(): Promise<void> {
+    const reconnectStartedAt = this.reconnectingStartedAt ?? Date.now();
     await this.destroyProvider();
 
     while (this.isRunning) {
@@ -929,6 +973,9 @@ export class ChainMonitor {
         this.isRunning = false;
         this.isReconnecting = false;
         this.reconnectingStartedAt = null;
+        metrics.recordReconnect(this.chainName, "exhausted");
+        metrics.setIsAlive(this.chainName, false);
+        metrics.setIsReconnecting(this.chainName, false);
         return;
       }
 
@@ -961,6 +1008,13 @@ export class ChainMonitor {
         this.startPingPong();
         this.resetNoBlockTimer();
         this.startPrimaryProbe();
+        metrics.recordReconnect(this.chainName, "success");
+        metrics.observeReconnectDuration(
+          this.chainName,
+          Date.now() - reconnectStartedAt,
+        );
+        metrics.setIsReconnecting(this.chainName, false);
+        metrics.setIsAlive(this.chainName, true);
         return;
       } catch (error) {
         console.warn(
@@ -998,8 +1052,15 @@ export class ChainMonitor {
     }
     const previousLabel = this.currentUrlIndex === 0 ? "primary" : "fallback";
     const nextLabel = this.currentUrlIndex === 0 ? "fallback" : "primary";
-    this.currentUrlIndex = this.currentUrlIndex === 0 ? 1 : 0;
+    const nextIndex: 0 | 1 = this.currentUrlIndex === 0 ? 1 : 0;
+    this.currentUrlIndex = nextIndex;
     this.silentReconnects = 0;
+    metrics.setSilentReconnectsCurrent(this.chainName, 0);
+    metrics.recordUrlFlip(
+      this.chainName,
+      nextIndex === 1 ? "to_fallback" : "to_primary",
+    );
+    metrics.recordWsClose(this.chainName, "silent_failover");
     console.warn(
       `[BlockMonitor:${this.chainName}] Silent-reconnect threshold (${threshold}) reached on ${previousLabel}, flipping URL preference to ${nextLabel}`,
     );

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -84,6 +84,14 @@ const LIVENESS_DEFAULTS = {
   // Primary recovery probe (used only while running on the fallback URL).
   PRIMARY_PROBE_INTERVAL_MS: 5 * 60_000,
   PRIMARY_PROBE_TIMEOUT_MS: 5_000,
+  // After this many consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on the same
+  // URL, flip the URL preference (primary <-> fallback) on the next reconnect.
+  // This catches half-open-subscription upstreams where the WSS connects and
+  // request/response works but eth_subscribe never delivers newHeads — a
+  // failure mode the existing connect-level fallback cannot detect because
+  // getBlockNumber() succeeds on the broken URL. Reset to 0 on a real block
+  // advance, so a recovered URL is fully trusted again.
+  SILENT_FAILOVER_THRESHOLD: 2,
 } as const;
 
 type LivenessKey = keyof typeof LIVENESS_DEFAULTS;
@@ -167,6 +175,11 @@ export class ChainMonitor {
   private currentUrlIndex = 0;
   private hasActiveSubscription = false;
   private wsCloseHandler: (() => void) | null = null;
+  // Consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on the same URL. Reset on a
+  // real height advance in processBlockRange. When this hits
+  // SILENT_FAILOVER_THRESHOLD, the next reconnect flips currentUrlIndex so the
+  // monitor tries the other configured URL (primary <-> fallback).
+  private silentReconnects = 0;
 
   constructor(config: ChainMonitorConfig) {
     this.chainId = config.chain.chainId;
@@ -181,6 +194,7 @@ export class ChainMonitor {
       return;
     }
     this.isRunning = true;
+    this.silentReconnects = 0;
 
     try {
       await this.connect();
@@ -198,6 +212,7 @@ export class ChainMonitor {
     this.isRunning = false;
     this.isReconnecting = false;
     this.reconnectingStartedAt = null;
+    this.silentReconnects = 0;
     this.stopTimers();
     await this.destroyProvider();
   }
@@ -322,21 +337,39 @@ export class ChainMonitor {
   }
 
   private async connect(): Promise<void> {
-    const urls = [this.primaryWss, this.fallbackWss].filter(
-      (url): url is string => url !== null && url !== "",
-    );
+    type Candidate = {
+      url: string;
+      index: 0 | 1;
+      label: "primary" | "fallback";
+    };
+    const candidates: Candidate[] = [];
+    if (this.primaryWss) {
+      candidates.push({ url: this.primaryWss, index: 0, label: "primary" });
+    }
+    if (this.fallbackWss) {
+      candidates.push({ url: this.fallbackWss, index: 1, label: "fallback" });
+    }
 
-    if (urls.length === 0) {
+    if (candidates.length === 0) {
       throw new Error(
         `No WSS URLs configured for chain ${this.chainName} (${this.chainId})`,
       );
     }
 
-    for (const [index, url] of urls.entries()) {
-      const label = index === 0 ? "primary" : "fallback";
+    // Honor currentUrlIndex as the starting preference. It is updated below
+    // when we successfully connect, and also explicitly flipped by
+    // maybeFlipUrlPreference() when SILENT_FAILOVER_THRESHOLD is reached on
+    // the previous URL. The labels "primary"/"fallback" stay stable across
+    // reorderings so logs always identify which physical URL is in use.
+    const ordered =
+      this.currentUrlIndex === 1 && candidates.length === 2
+        ? [candidates[1], candidates[0]]
+        : candidates;
+
+    for (const [iterIdx, candidate] of ordered.entries()) {
       let provider: ethers.WebSocketProvider | null = null;
       try {
-        provider = new ethers.WebSocketProvider(url);
+        provider = new ethers.WebSocketProvider(candidate.url);
 
         // ethers v6 WebSocketProvider does not attach an 'error' listener on
         // the underlying ws. Without one, an HTTP 429 (or any non-101 upgrade
@@ -366,9 +399,9 @@ export class ChainMonitor {
         ])) as number;
 
         this.provider = provider;
-        this.currentUrlIndex = index;
+        this.currentUrlIndex = candidate.index;
         console.log(
-          `[BlockMonitor:${this.chainName}] Connected to ${label} WSS (block: ${blockNumber})`,
+          `[BlockMonitor:${this.chainName}] Connected to ${candidate.label} WSS (block: ${blockNumber})`,
         );
         return;
       } catch (error) {
@@ -378,10 +411,10 @@ export class ChainMonitor {
           await provider.destroy().catch(() => {});
         }
         console.warn(
-          `[BlockMonitor:${this.chainName}] Failed to connect to ${label} WSS:`,
+          `[BlockMonitor:${this.chainName}] Failed to connect to ${candidate.label} WSS:`,
           error instanceof Error ? error.message : error,
         );
-        if (index === urls.length - 1) {
+        if (iterIdx === ordered.length - 1) {
           throw error;
         }
       }
@@ -538,6 +571,10 @@ export class ChainMonitor {
     this.lastProcessedBlock = blockNumber;
     // Height genuinely advanced — refresh liveness AFTER the fact.
     this.lastBlockAdvanceAt = Date.now();
+    // Trust the current URL again: a real height advance means the
+    // subscription is delivering. Without this reset, an old streak of silent
+    // reconnects would still trigger a URL flip on the next disconnect.
+    this.silentReconnects = 0;
     this.resetNoBlockTimer();
     this.blocksReceived++;
 
@@ -718,8 +755,12 @@ export class ChainMonitor {
     const timeoutMs = liveness("BLOCK_ADVANCE_TIMEOUT_MS");
     this.noBlockTimer = setTimeout(() => {
       if (this.isRunning) {
+        // Count this as a silent reconnect on the current URL. Decision to
+        // flip to the other URL is made by reconnectWithBackoff before its
+        // next connect attempt, based on SILENT_FAILOVER_THRESHOLD.
+        this.silentReconnects++;
         console.warn(
-          `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s, triggering reconnect`,
+          `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s (silent reconnects=${this.silentReconnects}), triggering reconnect`,
         );
         this.handleDisconnect();
       }
@@ -909,6 +950,8 @@ export class ChainMonitor {
         return;
       }
 
+      this.maybeFlipUrlPreference();
+
       try {
         await this.connect();
         await this.subscribeToBlocks();
@@ -928,5 +971,37 @@ export class ChainMonitor {
         await this.destroyProvider();
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // URL preference flip
+  //
+  // Catches the half-open-subscription failure mode: the primary WSS accepts
+  // the upgrade, getBlockNumber() returns, eth_subscribe is acknowledged, but
+  // no newHeads notifications ever arrive. From connect()'s point of view the
+  // URL is healthy, so the existing fallback path never fires. After
+  // SILENT_FAILOVER_THRESHOLD consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on
+  // the same URL, swap the URL preference so the next reconnect lands on the
+  // other configured endpoint. Reset the counter on flip; if the new URL is
+  // also silent, the counter will rebuild and the monitor will alternate
+  // until one of them recovers. The existing primaryProbeTimer handles
+  // swapping back to primary when it recovers.
+  // ---------------------------------------------------------------------------
+
+  private maybeFlipUrlPreference(): void {
+    const threshold = liveness("SILENT_FAILOVER_THRESHOLD");
+    if (this.silentReconnects < threshold) {
+      return;
+    }
+    if (!(this.primaryWss && this.fallbackWss)) {
+      return;
+    }
+    const previousLabel = this.currentUrlIndex === 0 ? "primary" : "fallback";
+    const nextLabel = this.currentUrlIndex === 0 ? "fallback" : "primary";
+    this.currentUrlIndex = this.currentUrlIndex === 0 ? 1 : 0;
+    this.silentReconnects = 0;
+    console.warn(
+      `[BlockMonitor:${this.chainName}] Silent-reconnect threshold (${threshold}) reached on ${previousLabel}, flipping URL preference to ${nextLabel}`,
+    );
   }
 }

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -23,6 +23,7 @@ import {
   RECONCILE_INTERVAL_MS,
   SQS_QUEUE_URL,
 } from "../lib/config.js";
+import { metrics, registry } from "../lib/metrics.js";
 import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
 import { fetchBlockWorkflows } from "./api-client.js";
 import { ChainMonitor } from "./chain-monitor.js";
@@ -102,6 +103,7 @@ class BlockMonitorService {
             `${chain.name}(${id}): ${workflows.length} wf`,
         )
         .join(", ");
+      metrics.setChainsMonitored(this.monitors.size);
       console.log(
         `[BlockMonitorService] Reconciled: ${this.monitors.size} chain(s) monitored [${chainNames}]`,
       );
@@ -180,6 +182,7 @@ class BlockMonitorService {
 process.on("unhandledRejection", (reason: unknown) => {
   const message = reason instanceof Error ? reason.message : String(reason);
   const stack = reason instanceof Error ? reason.stack : "";
+  metrics.recordUnhandledRejection();
   console.error(`[BlockDispatcher] Unhandled rejection: ${message}`, stack);
 });
 
@@ -256,6 +259,16 @@ async function main(): Promise<void> {
       timestamp: new Date().toISOString(),
       monitors: health.monitors,
     });
+  });
+
+  healthApp.get("/metrics", async (_req, res) => {
+    try {
+      res.set("Content-Type", registry.contentType);
+      res.end(await registry.metrics());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).send(`Error collecting metrics: ${message}`);
+    }
   });
 
   const healthServer = healthApp.listen(HEALTH_PORT, () => {

--- a/keeperhub-scheduler/lib/metrics.ts
+++ b/keeperhub-scheduler/lib/metrics.ts
@@ -1,0 +1,296 @@
+/**
+ * Block dispatcher metrics (Prometheus).
+ *
+ * One process-wide Registry, exposed by block-dispatcher/index.ts at /metrics.
+ * ChainMonitor calls the small `record*` / `set*` helpers in this file at
+ * each lifecycle point — no business logic depends on prom-client.
+ *
+ * Naming follows the repo convention `keeperhub_<area>_<thing>_<unit>` (see
+ * lib/metrics/METRICS_REFERENCE.md and lib/metrics/collectors/prometheus.ts).
+ *
+ * Two gauges are computed at scrape time via prom-client `collect()` callbacks
+ * so they always reflect the latest value without us emitting on every block:
+ *   - keeperhub_block_dispatcher_seconds_since_last_block
+ *   - keeperhub_block_dispatcher_socket_age_seconds
+ *
+ * The Registry intentionally does NOT include default Node.js process
+ * metrics. The block-dispatcher's interesting signals are chain-specific.
+ */
+
+import { Counter, Gauge, Histogram, Registry } from "prom-client";
+
+// One registry for the whole process. block-dispatcher/index.ts wires the
+// `/metrics` endpoint to this.
+export const registry = new Registry();
+
+const PREFIX = "keeperhub_block_dispatcher";
+
+// ---------------------------------------------------------------------------
+// Gauges — current state, may go up and down
+// ---------------------------------------------------------------------------
+
+// Tracked per chain via the callback functions registered through
+// registerChainLivenessCallbacks() below. Two values that change every second
+// (seconds_since_last_block, socket_age_seconds) are computed at scrape time
+// from the same data so they never go stale between ticks.
+type ChainLivenessSnapshot = {
+  lastBlockAdvanceAt: number | null;
+  subscribedAt: number | null;
+};
+
+const livenessSnapshotByChain = new Map<string, ChainLivenessSnapshot>();
+
+function readSnapshot(chain: string): ChainLivenessSnapshot {
+  let snap = livenessSnapshotByChain.get(chain);
+  if (!snap) {
+    snap = { lastBlockAdvanceAt: null, subscribedAt: null };
+    livenessSnapshotByChain.set(chain, snap);
+  }
+  return snap;
+}
+
+export const secondsSinceLastBlock = new Gauge({
+  name: `${PREFIX}_seconds_since_last_block`,
+  help: "Wall-clock seconds since lastProcessedBlock last advanced on this chain. THE primary alert signal — fires high when newHeads stops flowing even though the WSS appears alive. Computed at scrape time.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+  collect() {
+    for (const [chain, snap] of livenessSnapshotByChain) {
+      if (snap.lastBlockAdvanceAt === null) {
+        this.set({ chain }, 0);
+      } else {
+        this.set({ chain }, (Date.now() - snap.lastBlockAdvanceAt) / 1000);
+      }
+    }
+  },
+});
+
+export const socketAgeSeconds = new Gauge({
+  name: `${PREFIX}_socket_age_seconds`,
+  help: "Wall-clock seconds since the current WSS subscription was established on this chain. Resets to 0 on every reconnect. Used to verify SOCKET_MAX_AGE_MS recycle behaviour and to spot abnormally short-lived sockets. Computed at scrape time.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+  collect() {
+    for (const [chain, snap] of livenessSnapshotByChain) {
+      if (snap.subscribedAt === null) {
+        this.set({ chain }, 0);
+      } else {
+        this.set({ chain }, (Date.now() - snap.subscribedAt) / 1000);
+      }
+    }
+  },
+});
+
+export const isAlive = new Gauge({
+  name: `${PREFIX}_is_alive`,
+  help: "Per-chain alive flag (0 or 1) mirroring ChainMonitor.isAlive(). Reflects: isRunning && hasActiveSubscription && not stuck-reconnecting && not block-advance-stale.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const isReconnecting = new Gauge({
+  name: `${PREFIX}_is_reconnecting`,
+  help: "1 when the chain monitor is mid reconnect-with-backoff, 0 otherwise.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const hasActiveSubscription = new Gauge({
+  name: `${PREFIX}_has_active_subscription`,
+  help: "1 when eth_subscribe('newHeads') has completed and we are awaiting block callbacks. 0 during teardown, reconnect, or before initial subscribe.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const currentUrlIndex = new Gauge({
+  name: `${PREFIX}_current_url_index`,
+  help: "Which configured URL the chain monitor is connected to: 0=primary, 1=fallback. Useful for spotting silent failovers triggered by SILENT_FAILOVER_THRESHOLD.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const silentReconnectsCurrent = new Gauge({
+  name: `${PREFIX}_silent_reconnects_current`,
+  help: "Consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on the current URL with no block advance in between. Resets to 0 on a real height advance or on a URL flip. Early warning signal: >=1 means the upstream is flaky.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const lastProcessedBlock = new Gauge({
+  name: `${PREFIX}_last_processed_block`,
+  help: "The highest block number this monitor has processed on the chain. Combined with the block timestamp, this is the canonical 'how far behind chain tip are we' signal.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const workflowsTracked = new Gauge({
+  name: `${PREFIX}_workflows_tracked`,
+  help: "Number of block-trigger workflows the monitor is currently tracking on this chain.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const chainsMonitored = new Gauge({
+  name: `${PREFIX}_chains_monitored`,
+  help: "Total number of chains the pod is currently monitoring across all ChainMonitor instances.",
+  registers: [registry],
+});
+
+// ---------------------------------------------------------------------------
+// Counters — monotonic, only ever increase
+// ---------------------------------------------------------------------------
+
+export const blocksReceivedTotal = new Counter({
+  name: `${PREFIX}_blocks_received_total`,
+  help: "Total blocks processed (height-advance, after dedup) per chain. rate() gives the block delivery rate; flatline means the subscription went silent.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const blocksMatchedTotal = new Counter({
+  name: `${PREFIX}_blocks_matched_total`,
+  help: "Total blocks that matched at least one workflow's blockInterval per chain. workflow_id intentionally omitted to keep cardinality bounded — use enqueue logs for per-workflow breakdown.",
+  labelNames: ["chain"] as const,
+  registers: [registry],
+});
+
+export const wsClosesTotal = new Counter({
+  name: `${PREFIX}_ws_closes_total`,
+  help: "WebSocket connection closures per chain by trigger reason. reason: upstream_close (server-initiated), pong_timeout, block_advance_timeout, socket_age_recycle, silent_failover, ping_send_failure, primary_probe_recovered, config_changed.",
+  labelNames: ["chain", "reason"] as const,
+  registers: [registry],
+});
+
+export const reconnectsTotal = new Counter({
+  name: `${PREFIX}_reconnects_total`,
+  help: "Reconnect attempts that completed per chain. outcome: success (connect + subscribe both succeeded) or exhausted (hit MAX_RECONNECT_ATTEMPTS without recovery, monitor stopped).",
+  labelNames: ["chain", "outcome"] as const,
+  registers: [registry],
+});
+
+export const urlFlipsTotal = new Counter({
+  name: `${PREFIX}_url_flips_total`,
+  help: "Auto-failover URL flips per chain (KEEP-557). direction: to_fallback when silent reconnects trigger the swap, to_primary when the primary-recovery probe brings us back.",
+  labelNames: ["chain", "direction"] as const,
+  registers: [registry],
+});
+
+export const sqsEnqueueTotal = new Counter({
+  name: `${PREFIX}_sqs_enqueue_total`,
+  help: "Workflow trigger enqueue attempts per chain. outcome: success or error. error rate climbing indicates an SQS / IAM / network issue downstream of the dispatcher.",
+  labelNames: ["chain", "outcome"] as const,
+  registers: [registry],
+});
+
+export const unhandledRejectionsTotal = new Counter({
+  name: `${PREFIX}_unhandled_rejections_total`,
+  help: "Process-level unhandled promise rejections absorbed by the dispatcher's safety-net handler. The most common source is ethers v6 destroyProvider eth_unsubscribe cancellation during reconnect. A sustained increase is fine for those; anything else warrants log investigation.",
+  registers: [registry],
+});
+
+// ---------------------------------------------------------------------------
+// Histograms — distributions
+// ---------------------------------------------------------------------------
+
+export const reconnectDurationMs = new Histogram({
+  name: `${PREFIX}_reconnect_duration_ms`,
+  help: "Time from handleDisconnect() to next 'Block subscription active' per chain, in milliseconds. p50/p95/p99 tell you how fast recovery is in practice.",
+  labelNames: ["chain"] as const,
+  buckets: [100, 500, 1000, 2000, 5000, 10000, 30000, 60000, 120000],
+  registers: [registry],
+});
+
+export const blockLagSeconds = new Histogram({
+  name: `${PREFIX}_block_lag_seconds`,
+  help: "How old the block was when we received it (wall_clock - block.timestamp), per chain. p95 > 30s on a fast chain like Ethereum is a sign of upstream lag, even if blocks are technically arriving.",
+  labelNames: ["chain"] as const,
+  buckets: [1, 2, 5, 10, 30, 60, 120, 300],
+  registers: [registry],
+});
+
+// ---------------------------------------------------------------------------
+// API: small helpers ChainMonitor calls at lifecycle points
+//
+// All take a `chain` (human-readable chain name, e.g. "Ethereum Mainnet") so
+// each metric line is keyed by chain name. The reconciler logs already use
+// this naming.
+// ---------------------------------------------------------------------------
+
+export const metrics = {
+  // Liveness callbacks: ChainMonitor pokes these snapshots whenever the
+  // underlying ms values change; collect() in the gauges above reads them.
+  setLastBlockAdvanceAt(chain: string, atMs: number | null): void {
+    readSnapshot(chain).lastBlockAdvanceAt = atMs;
+  },
+  setSubscribedAt(chain: string, atMs: number | null): void {
+    readSnapshot(chain).subscribedAt = atMs;
+  },
+  forgetChain(chain: string): void {
+    livenessSnapshotByChain.delete(chain);
+  },
+
+  // Discrete gauges (called when ChainMonitor flips a boolean / counter).
+  setIsAlive(chain: string, value: boolean): void {
+    isAlive.set({ chain }, value ? 1 : 0);
+  },
+  setIsReconnecting(chain: string, value: boolean): void {
+    isReconnecting.set({ chain }, value ? 1 : 0);
+  },
+  setHasActiveSubscription(chain: string, value: boolean): void {
+    hasActiveSubscription.set({ chain }, value ? 1 : 0);
+  },
+  setCurrentUrlIndex(chain: string, index: 0 | 1): void {
+    currentUrlIndex.set({ chain }, index);
+  },
+  setSilentReconnectsCurrent(chain: string, value: number): void {
+    silentReconnectsCurrent.set({ chain }, value);
+  },
+  setLastProcessedBlock(chain: string, blockNumber: number): void {
+    lastProcessedBlock.set({ chain }, blockNumber);
+  },
+  setWorkflowsTracked(chain: string, value: number): void {
+    workflowsTracked.set({ chain }, value);
+  },
+  setChainsMonitored(value: number): void {
+    chainsMonitored.set(value);
+  },
+
+  // Counters
+  recordBlockReceived(chain: string): void {
+    blocksReceivedTotal.inc({ chain });
+  },
+  recordBlockMatched(chain: string): void {
+    blocksMatchedTotal.inc({ chain });
+  },
+  recordWsClose(chain: string, reason: string): void {
+    wsClosesTotal.inc({ chain, reason });
+  },
+  recordReconnect(chain: string, outcome: "success" | "exhausted"): void {
+    reconnectsTotal.inc({ chain, outcome });
+  },
+  recordUrlFlip(chain: string, direction: "to_fallback" | "to_primary"): void {
+    urlFlipsTotal.inc({ chain, direction });
+  },
+  recordSqsEnqueue(chain: string, outcome: "success" | "error"): void {
+    sqsEnqueueTotal.inc({ chain, outcome });
+  },
+  recordUnhandledRejection(): void {
+    unhandledRejectionsTotal.inc();
+  },
+
+  // Histograms
+  observeReconnectDuration(chain: string, durationMs: number): void {
+    reconnectDurationMs.observe({ chain }, durationMs);
+  },
+  observeBlockLag(chain: string, lagSeconds: number): void {
+    blockLagSeconds.observe({ chain }, lagSeconds);
+  },
+
+  // For tests: forget all state without resetting the Registry singleton.
+  // The Registry itself is process-global and cannot be replaced; tests use
+  // this to clear snapshots and zero out per-chain gauges between cases.
+  resetForTests(): void {
+    livenessSnapshotByChain.clear();
+    registry.resetMetrics();
+  },
+};

--- a/keeperhub-scheduler/lib/metrics.ts
+++ b/keeperhub-scheduler/lib/metrics.ts
@@ -225,8 +225,23 @@ export const metrics = {
   setSubscribedAt(chain: string, atMs: number | null): void {
     readSnapshot(chain).subscribedAt = atMs;
   },
+  // Remove every per-chain gauge labelset so a chain that is no longer
+  // monitored disappears entirely from /metrics output. Without this, the
+  // gauges would retain the last-set value of each label combination forever
+  // (prom-client's default behaviour), causing alerts to fire indefinitely
+  // for chains we are no longer monitoring. Counters and histograms are not
+  // reset — their cumulative history is more useful than empty post-stop.
   forgetChain(chain: string): void {
     livenessSnapshotByChain.delete(chain);
+    secondsSinceLastBlock.remove({ chain });
+    socketAgeSeconds.remove({ chain });
+    isAlive.remove({ chain });
+    isReconnecting.remove({ chain });
+    hasActiveSubscription.remove({ chain });
+    currentUrlIndex.remove({ chain });
+    silentReconnectsCurrent.remove({ chain });
+    lastProcessedBlock.remove({ chain });
+    workflowsTracked.remove({ chain });
   },
 
   // Discrete gauges (called when ChainMonitor flips a boolean / counter).

--- a/keeperhub-scheduler/package.json
+++ b/keeperhub-scheduler/package.json
@@ -19,7 +19,8 @@
     "@aws-sdk/client-sqs": "^3.1038.0",
     "cron-parser": "^5.4.0",
     "ethers": "^6.16.0",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/keeperhub-scheduler/pnpm-lock.yaml
+++ b/keeperhub-scheduler/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.1
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -41,7 +44,7 @@ importers:
         version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -199,24 +202,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -414,6 +421,10 @@ packages:
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -452,36 +463,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -772,6 +789,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -999,24 +1019,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1120,6 +1144,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1200,6 +1228,9 @@ packages:
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1873,6 +1904,8 @@ snapshots:
 
   '@nodable/entities@2.1.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.127.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
@@ -2315,6 +2348,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bintrees@1.0.2: {}
+
   body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
@@ -2669,6 +2704,11 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -2787,6 +2827,10 @@ snapshots:
 
   strnum@2.2.3: {}
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -2841,7 +2885,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.2(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
@@ -2864,6 +2908,7 @@ snapshots:
       vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
     transitivePeerDependencies:
       - msw

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChainMonitor } from "../../block-dispatcher/chain-monitor.js";
+import { metrics, registry } from "../../lib/metrics.js";
 import type { BlockWorkflow, ChainConfig } from "../../lib/types.js";
 
 // ---------------------------------------------------------------------------
@@ -157,6 +158,9 @@ describe("ChainMonitor", () => {
     // SILENT_FAILOVER_THRESHOLD, SOCKET_MAX_AGE_MS) do not leak into later
     // tests and trigger timers earlier than the test under test expects.
     vi.unstubAllEnvs();
+    // Metrics registry is process-global; reset between tests so per-chain
+    // counters and snapshots from one test don't leak into the next.
+    metrics.resetForTests();
   });
 
   function latestProvider(): MockProvider {
@@ -729,6 +733,58 @@ describe("ChainMonitor", () => {
       });
 
       await expect(monitor.start()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Metrics integration — verify the monitor actually drives the prom-client
+  // registry at the right lifecycle points. Detailed assertions on the
+  // metrics themselves live in metrics.test.ts; here we only confirm wiring.
+  // -------------------------------------------------------------------------
+
+  describe("metrics integration", () => {
+    it("increments blocks_received_total and updates last_processed_block on advance", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow({ blockInterval: 1 })],
+      });
+
+      await monitor.start();
+      latestProvider().emitBlock(123);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_blocks_received_total{chain="TestChain"} 1',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_last_processed_block{chain="TestChain"} 123',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_has_active_subscription{chain="TestChain"} 1',
+      );
+
+      await monitor.stop();
+    });
+
+    it("records ws_close with reason=upstream_close on a WebSocket close event", async () => {
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      latestProvider().websocket.emit("close");
+      // Let handleDisconnect run synchronously through the microtask queue
+      // but don't advance long enough for reconnect-with-backoff to land.
+      await vi.advanceTimersByTimeAsync(10);
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_ws_closes_total{chain="TestChain",reason="upstream_close"} 1',
+      );
+
+      await monitor.stop();
     });
   });
 

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -153,6 +153,10 @@ describe("ChainMonitor", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    // Reset env stubs so per-test overrides (BLOCK_ADVANCE_TIMEOUT_MS,
+    // SILENT_FAILOVER_THRESHOLD, SOCKET_MAX_AGE_MS) do not leak into later
+    // tests and trigger timers earlier than the test under test expects.
+    vi.unstubAllEnvs();
   });
 
   function latestProvider(): MockProvider {
@@ -629,6 +633,71 @@ describe("ChainMonitor", () => {
       expect(providerInstances).toHaveLength(2);
       expect(latestProvider().url).toBe("wss://fallback.test");
       expect(monitor.isAlive()).toBe(true);
+    });
+
+    it("flips to fallback after SILENT_FAILOVER_THRESHOLD silent reconnects on primary", async () => {
+      // Half-open-subscription scenario:
+      //  - primary connects fine (getBlockNumber resolves)
+      //  - eth_subscribe is accepted (provider.on resolves)
+      //  - but newHeads is silent forever (we never call emitBlock on it)
+      // After SILENT_FAILOVER_THRESHOLD BLOCK_ADVANCE_TIMEOUT_MS firings on
+      // primary, the monitor flips to fallback for the next reconnect.
+      vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", "200");
+      vi.stubEnv("SILENT_FAILOVER_THRESHOLD", "2");
+      // Disable the primary-recovery probe so it does not swap us back to
+      // primary mid-test once we are on fallback.
+      vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", "600000");
+
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(latestProvider().url).toBe("wss://primary.test");
+      expect(providerInstances).toHaveLength(1);
+
+      // First silent window: noBlockTimer fires (silentReconnects=1),
+      // reconnect waits 1s backoff, lands back on primary (below threshold).
+      await vi.advanceTimersByTimeAsync(1_400);
+      expect(latestProvider().url).toBe("wss://primary.test");
+      expect(providerInstances.length).toBeGreaterThanOrEqual(2);
+
+      // Second silent window: noBlockTimer fires (silentReconnects=2),
+      // reconnect waits 1s backoff, maybeFlipUrlPreference() flips to
+      // fallback, connect lands on fallback URL.
+      await vi.advanceTimersByTimeAsync(1_400);
+      expect(latestProvider().url).toBe("wss://fallback.test");
+      expect(monitor.isAlive()).toBe(true);
+
+      await monitor.stop();
+    });
+
+    it("does not flip when fallback URL is not configured", async () => {
+      // If only a primary URL is configured, there is nowhere to flip to.
+      // The monitor must keep reconnecting to the same URL without crashing.
+      vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", "200");
+      vi.stubEnv("SILENT_FAILOVER_THRESHOLD", "2");
+      vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", "600000");
+
+      const monitor = new ChainMonitor({
+        chain: makeChain({ defaultFallbackWss: null }),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+      expect(latestProvider().url).toBe("wss://primary.test");
+
+      // Two silent windows; even past the threshold, still primary.
+      await vi.advanceTimersByTimeAsync(1_400);
+      await vi.advanceTimersByTimeAsync(1_400);
+
+      const urls = providerInstances.map((p) => p.url);
+      for (const url of urls) {
+        expect(url).toBe("wss://primary.test");
+      }
+
+      await monitor.stop();
     });
 
     it("does not propagate ws 'error' as an uncaughtException", async () => {

--- a/keeperhub-scheduler/tests/unit/metrics.test.ts
+++ b/keeperhub-scheduler/tests/unit/metrics.test.ts
@@ -137,9 +137,7 @@ describe("block dispatcher metrics", () => {
       expect(text).toContain(
         'keeperhub_block_dispatcher_workflows_tracked{chain="Ethereum Mainnet"} 4',
       );
-      expect(text).toMatch(
-        /keeperhub_block_dispatcher_chains_monitored\s+3/,
-      );
+      expect(text).toMatch(/keeperhub_block_dispatcher_chains_monitored\s+3/);
     });
   });
 

--- a/keeperhub-scheduler/tests/unit/metrics.test.ts
+++ b/keeperhub-scheduler/tests/unit/metrics.test.ts
@@ -176,18 +176,48 @@ describe("block dispatcher metrics", () => {
       expect(value).toBeLessThan(10);
     });
 
-    it("forgetChain drops snapshots so closed chains no longer appear", async () => {
-      metrics.setLastBlockAdvanceAt("Ethereum Mainnet", Date.now());
-      metrics.setSubscribedAt("Ethereum Mainnet", Date.now());
-      metrics.forgetChain("Ethereum Mainnet");
+    it("forgetChain drops every per-chain gauge labelset so closed chains disappear from /metrics", async () => {
+      // Populate every per-chain gauge for two chains so we can confirm that
+      // forgetChain only wipes the one we asked for.
+      const now = Date.now();
+      for (const chain of ["Ethereum Mainnet", "Avalanche"]) {
+        metrics.setLastBlockAdvanceAt(chain, now);
+        metrics.setSubscribedAt(chain, now);
+        metrics.setIsAlive(chain, true);
+        metrics.setIsReconnecting(chain, false);
+        metrics.setHasActiveSubscription(chain, true);
+        metrics.setCurrentUrlIndex(chain, 0);
+        metrics.setSilentReconnectsCurrent(chain, 0);
+        metrics.setLastProcessedBlock(chain, 100);
+        metrics.setWorkflowsTracked(chain, 1);
+      }
 
+      metrics.forgetChain("Ethereum Mainnet");
       const text = await registry.metrics();
-      expect(text).not.toContain(
-        'keeperhub_block_dispatcher_seconds_since_last_block{chain="Ethereum Mainnet"}',
-      );
-      expect(text).not.toContain(
-        'keeperhub_block_dispatcher_socket_age_seconds{chain="Ethereum Mainnet"}',
-      );
+
+      // No labelset for the forgotten chain anywhere. Without forgetChain
+      // calling .remove() on each gauge, prom-client would keep emitting the
+      // last value of these labels forever — exactly the behaviour that
+      // would make the alert fire for chains we no longer monitor.
+      for (const gaugeName of [
+        "seconds_since_last_block",
+        "socket_age_seconds",
+        "is_alive",
+        "is_reconnecting",
+        "has_active_subscription",
+        "current_url_index",
+        "silent_reconnects_current",
+        "last_processed_block",
+        "workflows_tracked",
+      ]) {
+        expect(text).not.toContain(
+          `keeperhub_block_dispatcher_${gaugeName}{chain="Ethereum Mainnet"}`,
+        );
+        // The other chain stays.
+        expect(text).toContain(
+          `keeperhub_block_dispatcher_${gaugeName}{chain="Avalanche"}`,
+        );
+      }
     });
   });
 

--- a/keeperhub-scheduler/tests/unit/metrics.test.ts
+++ b/keeperhub-scheduler/tests/unit/metrics.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { metrics, registry } from "../../lib/metrics.js";
+
+describe("block dispatcher metrics", () => {
+  afterEach(() => {
+    metrics.resetForTests();
+  });
+
+  // -------------------------------------------------------------------------
+  // Counters
+  // -------------------------------------------------------------------------
+
+  describe("counters", () => {
+    it("records block received per chain", async () => {
+      metrics.recordBlockReceived("Ethereum Mainnet");
+      metrics.recordBlockReceived("Ethereum Mainnet");
+      metrics.recordBlockReceived("Avalanche");
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_blocks_received_total{chain="Ethereum Mainnet"} 2',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_blocks_received_total{chain="Avalanche"} 1',
+      );
+    });
+
+    it("records ws close with the reason label", async () => {
+      metrics.recordWsClose("Ethereum Mainnet", "block_advance_timeout");
+      metrics.recordWsClose("Ethereum Mainnet", "pong_timeout");
+      metrics.recordWsClose("Avalanche", "upstream_close");
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_ws_closes_total{chain="Ethereum Mainnet",reason="block_advance_timeout"} 1',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_ws_closes_total{chain="Ethereum Mainnet",reason="pong_timeout"} 1',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_ws_closes_total{chain="Avalanche",reason="upstream_close"} 1',
+      );
+    });
+
+    it("records reconnect outcomes", async () => {
+      metrics.recordReconnect("Ethereum Mainnet", "success");
+      metrics.recordReconnect("Ethereum Mainnet", "success");
+      metrics.recordReconnect("Avalanche", "exhausted");
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_reconnects_total{chain="Ethereum Mainnet",outcome="success"} 2',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_reconnects_total{chain="Avalanche",outcome="exhausted"} 1',
+      );
+    });
+
+    it("records url flips with direction", async () => {
+      metrics.recordUrlFlip("Ethereum Mainnet", "to_fallback");
+      metrics.recordUrlFlip("Ethereum Mainnet", "to_primary");
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_url_flips_total{chain="Ethereum Mainnet",direction="to_fallback"} 1',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_url_flips_total{chain="Ethereum Mainnet",direction="to_primary"} 1',
+      );
+    });
+
+    it("records sqs enqueue outcomes", async () => {
+      metrics.recordSqsEnqueue("Ethereum Mainnet", "success");
+      metrics.recordSqsEnqueue("Ethereum Mainnet", "success");
+      metrics.recordSqsEnqueue("Ethereum Mainnet", "error");
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_sqs_enqueue_total{chain="Ethereum Mainnet",outcome="success"} 2',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_sqs_enqueue_total{chain="Ethereum Mainnet",outcome="error"} 1',
+      );
+    });
+
+    it("records unhandled rejection without chain label", async () => {
+      metrics.recordUnhandledRejection();
+      metrics.recordUnhandledRejection();
+
+      const text = await registry.metrics();
+      expect(text).toMatch(
+        /keeperhub_block_dispatcher_unhandled_rejections_total\s+2/,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // State gauges (set / read back via /metrics output)
+  // -------------------------------------------------------------------------
+
+  describe("state gauges", () => {
+    it("reflects is_alive flips", async () => {
+      metrics.setIsAlive("Ethereum Mainnet", true);
+      metrics.setIsAlive("Avalanche", false);
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_is_alive{chain="Ethereum Mainnet"} 1',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_is_alive{chain="Avalanche"} 0',
+      );
+    });
+
+    it("reflects current_url_index", async () => {
+      metrics.setCurrentUrlIndex("Ethereum Mainnet", 1);
+      metrics.setCurrentUrlIndex("Avalanche", 0);
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_current_url_index{chain="Ethereum Mainnet"} 1',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_current_url_index{chain="Avalanche"} 0',
+      );
+    });
+
+    it("reflects last_processed_block, workflows_tracked, chains_monitored", async () => {
+      metrics.setLastProcessedBlock("Ethereum Mainnet", 25_088_123);
+      metrics.setWorkflowsTracked("Ethereum Mainnet", 4);
+      metrics.setChainsMonitored(3);
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_last_processed_block{chain="Ethereum Mainnet"} 25088123',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_workflows_tracked{chain="Ethereum Mainnet"} 4',
+      );
+      expect(text).toMatch(
+        /keeperhub_block_dispatcher_chains_monitored\s+3/,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scrape-time callbacks: seconds_since_last_block, socket_age_seconds
+  // -------------------------------------------------------------------------
+
+  describe("scrape-time gauges", () => {
+    it("emits seconds_since_last_block from snapshot at scrape time", async () => {
+      const tenSecondsAgo = Date.now() - 10_000;
+      metrics.setLastBlockAdvanceAt("Ethereum Mainnet", tenSecondsAgo);
+
+      const text = await registry.metrics();
+      const match = text.match(
+        /keeperhub_block_dispatcher_seconds_since_last_block\{chain="Ethereum Mainnet"\} (\S+)/,
+      );
+      expect(match).not.toBeNull();
+      const value = Number(match?.[1]);
+      // Wall-clock between setLastBlockAdvanceAt and the scrape: ~10s. Allow
+      // a generous window for CI jitter.
+      expect(value).toBeGreaterThanOrEqual(9.5);
+      expect(value).toBeLessThan(15);
+    });
+
+    it("emits socket_age_seconds from snapshot at scrape time", async () => {
+      const fiveSecondsAgo = Date.now() - 5_000;
+      metrics.setSubscribedAt("Ethereum Mainnet", fiveSecondsAgo);
+
+      const text = await registry.metrics();
+      const match = text.match(
+        /keeperhub_block_dispatcher_socket_age_seconds\{chain="Ethereum Mainnet"\} (\S+)/,
+      );
+      expect(match).not.toBeNull();
+      const value = Number(match?.[1]);
+      expect(value).toBeGreaterThanOrEqual(4.5);
+      expect(value).toBeLessThan(10);
+    });
+
+    it("forgetChain drops snapshots so closed chains no longer appear", async () => {
+      metrics.setLastBlockAdvanceAt("Ethereum Mainnet", Date.now());
+      metrics.setSubscribedAt("Ethereum Mainnet", Date.now());
+      metrics.forgetChain("Ethereum Mainnet");
+
+      const text = await registry.metrics();
+      expect(text).not.toContain(
+        'keeperhub_block_dispatcher_seconds_since_last_block{chain="Ethereum Mainnet"}',
+      );
+      expect(text).not.toContain(
+        'keeperhub_block_dispatcher_socket_age_seconds{chain="Ethereum Mainnet"}',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Histograms
+  // -------------------------------------------------------------------------
+
+  describe("histograms", () => {
+    it("observes reconnect duration into the right buckets", async () => {
+      metrics.observeReconnectDuration("Ethereum Mainnet", 500);
+      metrics.observeReconnectDuration("Ethereum Mainnet", 1500);
+      metrics.observeReconnectDuration("Ethereum Mainnet", 35_000);
+
+      const text = await registry.metrics();
+      // Count bucket totals for the three observations.
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_reconnect_duration_ms_count{chain="Ethereum Mainnet"} 3',
+      );
+      // The 500ms one falls in le=500; le=500 should be 1.
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_reconnect_duration_ms_bucket{le="500",chain="Ethereum Mainnet"} 1',
+      );
+      // 500 + 1500 are both <= 2000; le=2000 should be 2.
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_reconnect_duration_ms_bucket{le="2000",chain="Ethereum Mainnet"} 2',
+      );
+    });
+
+    it("observes block lag into the right buckets", async () => {
+      metrics.observeBlockLag("Ethereum Mainnet", 1);
+      metrics.observeBlockLag("Ethereum Mainnet", 4);
+      metrics.observeBlockLag("Ethereum Mainnet", 200);
+
+      const text = await registry.metrics();
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_block_lag_seconds_count{chain="Ethereum Mainnet"} 3',
+      );
+      expect(text).toContain(
+        'keeperhub_block_dispatcher_block_lag_seconds_bucket{le="5",chain="Ethereum Mainnet"} 2',
+      );
+    });
+  });
+});

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -189,6 +189,48 @@ Billing-aware observability layered onto the org model. Plan distribution, per-o
 
 ---
 
+## 6. BLOCK DISPATCHER
+
+Per-chain liveness, subscription health, and SQS enqueue signals from the block-dispatcher pod (`keeperhub-scheduler/block-dispatcher`). All metrics live in the dispatcher's own in-process Prometheus registry exposed at `:3000/metrics` (separate from the main app's `/api/metrics`). Source code: `keeperhub-scheduler/lib/metrics.ts`.
+
+The dashboard and alert rules for these metrics are defined in `techops-infrastructure/grafana/keeperhub-dashboards/` (separate Terraform PR).
+
+### Gauges
+
+| Metric Name | Description | Labels | Alert-worthy? |
+|-------------|-------------|--------|---------------|
+| `keeperhub_block_dispatcher_seconds_since_last_block` | Wall-clock seconds since this chain's lastProcessedBlock last advanced. THE primary alert signal — fires high when newHeads stops flowing even though the WSS appears alive. Computed at scrape time. | `chain` | YES — page if > 120s |
+| `keeperhub_block_dispatcher_socket_age_seconds` | Wall-clock seconds since the current WSS subscription was established. Resets to 0 on every reconnect. | `chain` | no (debug) |
+| `keeperhub_block_dispatcher_is_alive` | 0/1 mirroring `ChainMonitor.isAlive()`: running && hasSubscription && not stuck-reconnecting && not block-advance-stale. | `chain` | warn if 0 for >2 min |
+| `keeperhub_block_dispatcher_is_reconnecting` | 1 when mid reconnect-with-backoff, 0 otherwise. | `chain` | no (debug) |
+| `keeperhub_block_dispatcher_has_active_subscription` | 1 when eth_subscribe('newHeads') has completed and the callback is wired. | `chain` | no (debug) |
+| `keeperhub_block_dispatcher_current_url_index` | 0 = primary, 1 = fallback. Tracks KEEP-557 silent-subscription failovers and primary-probe recoveries. | `chain` | no (debug) |
+| `keeperhub_block_dispatcher_silent_reconnects_current` | Consecutive BLOCK_ADVANCE_TIMEOUT_MS firings on the current URL with no height advance in between. Resets to 0 on real height advance or URL flip. Early warning for upstream flakiness. | `chain` | warn if >= 1 for >5 min |
+| `keeperhub_block_dispatcher_last_processed_block` | Highest block number this monitor has processed on the chain. | `chain` | no (debug) |
+| `keeperhub_block_dispatcher_workflows_tracked` | Number of block-trigger workflows the monitor is tracking on this chain. | `chain` | no (debug) |
+| `keeperhub_block_dispatcher_chains_monitored` | Total chains the pod is monitoring. | - | warn if 0 |
+
+### Counters
+
+| Metric Name | Description | Labels |
+|-------------|-------------|--------|
+| `keeperhub_block_dispatcher_blocks_received_total` | Blocks processed after dedup (height-advance) per chain. `rate()` gives block delivery rate; flatline means subscription silent. | `chain` |
+| `keeperhub_block_dispatcher_blocks_matched_total` | Blocks that matched at least one workflow's `blockInterval`. `workflow_id` intentionally omitted to keep cardinality bounded. | `chain` |
+| `keeperhub_block_dispatcher_ws_closes_total` | WebSocket closures per chain by trigger reason. | `chain`, `reason` (`upstream_close`, `pong_timeout`, `block_advance_timeout`, `socket_age_recycle`, `silent_failover`, `ping_send_failure`, `primary_probe_recovered`) |
+| `keeperhub_block_dispatcher_reconnects_total` | Reconnect-with-backoff completions. | `chain`, `outcome` (`success`, `exhausted`) |
+| `keeperhub_block_dispatcher_url_flips_total` | Auto-failover URL flips (KEEP-557). | `chain`, `direction` (`to_fallback`, `to_primary`) |
+| `keeperhub_block_dispatcher_sqs_enqueue_total` | Workflow trigger enqueue attempts. Error rate climbing indicates an SQS/IAM/network issue downstream. | `chain`, `outcome` (`success`, `error`) |
+| `keeperhub_block_dispatcher_unhandled_rejections_total` | Process-level unhandled promise rejections absorbed by the safety-net handler. Most common source: ethers v6 destroyProvider eth_unsubscribe cancellation. | - |
+
+### Histograms
+
+| Metric Name | Description | Labels | Buckets (ms) |
+|-------------|-------------|--------|--------------|
+| `keeperhub_block_dispatcher_reconnect_duration_ms` | Time from `handleDisconnect()` to next `Block subscription active`. | `chain` | 100, 500, 1000, 2000, 5000, 10000, 30000, 60000, 120000 |
+| `keeperhub_block_dispatcher_block_lag_seconds` | `wall_clock - block.timestamp` when the block was received. p95 > 30s on a fast chain indicates upstream lag. | `chain` | 1, 2, 5, 10, 30, 60, 120, 300 |
+
+---
+
 ## Label Keys Reference
 
 | Label Key | Description | Example Values |


### PR DESCRIPTION
## Summary

Adds a per-chain Prometheus surface at `:3000/metrics` on the block-dispatcher pod so operators can alert on silent subscriptions and other failure modes without waiting for users to report stuck workflows. Today's prod incident only surfaced because a user noticed their block-triggered workflow stopped firing several hours later — the dispatcher had no observable signal exposed.

**Stacked on top of [PR #1244](https://github.com/KeeperHub/keeperhub/pull/1244) (KEEP-557 silent-failover fix)**. Merge #1244 first; this PR's diff will then narrow to metrics-only changes.

## What's added

`keeperhub-scheduler/lib/metrics.ts` — one process-wide prom-client Registry, named handles, and small `record*`/`set*` helpers. ChainMonitor calls these at lifecycle points; no business logic depends on prom-client.

**18 metrics**, all prefixed `keeperhub_block_dispatcher_*`:

- **Gauges (10):** `seconds_since_last_block` (THE primary alert signal — scrape-time callback), `socket_age_seconds` (scrape-time callback), `is_alive`, `is_reconnecting`, `has_active_subscription`, `current_url_index`, `silent_reconnects_current`, `last_processed_block`, `workflows_tracked`, `chains_monitored`
- **Counters (7):** `blocks_received_total`, `blocks_matched_total`, `ws_closes_total{reason}`, `reconnects_total{outcome}`, `url_flips_total{direction}`, `sqs_enqueue_total{outcome}`, `unhandled_rejections_total`
- **Histograms (2):** `reconnect_duration_ms`, `block_lag_seconds`

Cardinality: chain label only (no `workflow_id`), reason/outcome/direction with small fixed sets. With 3 chains × ~7 reasons = 21 series on the busiest counter.

`block-dispatcher/index.ts` — `/metrics` endpoint wired to the existing express server next to `/health`. No new container port.

`deploy/scheduler/{staging,prod}/block-dispatcher-values.yaml` — `prometheus.io/scrape`, `prometheus.io/port`, `prometheus.io/path` annotations so Prometheus auto-scrapes the pod.

`lib/metrics/METRICS_REFERENCE.md` — new section 6 documenting every metric with description, labels, and alert thresholds.

## Tests

80/80 vitest pass. New cases:
- `tests/unit/metrics.test.ts` — 12 cases across counters, state gauges, scrape-time gauges, histograms, plus `forgetChain` cleanup.
- `tests/unit/chain-monitor.test.ts` — 2 integration cases asserting metrics actually move when a block arrives and when a WebSocket closes.

## Pre-existing typecheck

The express-types resolution warning in `block-dispatcher/index.ts` (and `schedule-dispatcher/index.ts`) is pre-existing — same condition this repo accepted for #1224 and #1244. The new code in `lib/metrics.ts` and the new metric wiring in `chain-monitor.ts` are clean.

## Out of scope (separate PR in techops-infrastructure)

Grafana dashboard JSON, Terraform alert rules, and `ALERTS_REFERENCE.md` entries that consume these metrics. Filed alongside this PR.