### PR TITLE
hotfix: pin pnpm@10 in event-tracker Dockerfile

### DIFF
--- a/keeperhub-events/event-tracker/Dockerfile
+++ b/keeperhub-events/event-tracker/Dockerfile
@@ -5,7 +5,7 @@
 # Base stage - common setup
 # ==============================================================================
 FROM node:22-alpine AS base
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 WORKDIR /app
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

- Pin `pnpm@10` in `keeperhub-events/event-tracker/Dockerfile`. The Dockerfile previously installed pnpm via `npm install -g pnpm` (unpinned), so it floated to `latest` and started pulling pnpm 11 once it was published, breaking the deploy.
- Matches the existing pinning convention used by the root, `sandbox/`, and scheduler Dockerfiles.

## Root cause

Failing run: https://github.com/KeeperHub/keeperhub/actions/runs/25880900594

`pnpm@11.1.2` was published 2026-05-14 11:44 UTC. The events deploy at 03:11 UTC succeeded; the next deploy at 19:28 UTC pulled pnpm 11.1.2 fresh, which uses a different lockfile schema and rejects the pnpm-10-generated `keeperhub-events/pnpm-lock.yaml` under `--frozen-lockfile`:

```
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

Concretely, diffing a pnpm-10 vs pnpm-11 generated lockfile for this workspace:
1. pnpm 11 stops writing the top-level `overrides:` block into the lockfile (override behavior is still enforced from `package.json`, just not recorded). That alone produces the mismatch on `--frozen-lockfile`.
2. pnpm 11 adds `libc: [glibc] / libc: [musl]` annotations on native packages.

## Why not just regenerate the lockfile with pnpm 11

Tried it. Regenerating with pnpm 11.1.2 resolves `fast-xml-parser` to `5.4.1`, which **does not satisfy the `^5.7.0` override** in `keeperhub-events/package.json`. That override was added by KEEP-528 specifically to keep us off the versions affected by CVE-2026-44665 (GHSA-5wm8-gmm8-39j9). Likely an interaction with the root `.npmrc` `minimum-release-age=3d` gate, but until that is sorted out, switching to pnpm 11 silently regresses a security pin.

Pinning pnpm 10 keeps the existing, correctly-resolved lockfile intact. A repo-wide bump to pnpm 11 can be a separate piece of work once the override / minimum-release-age interaction is understood.