### PR TITLE
fix(web3): KEEP-371 reject missing abiFunction with descriptive error

### DIFF
--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -280,7 +280,7 @@ Conditions reference previous node outputs using template syntax: `{{@nodeId:Lab
 |--------|----------------|
 | `web3/check-balance` | `network`, `address` |
 | `web3/check-token-balance` | `network`, `address`, `tokenAddress` |
-| `web3/read-contract` | `network`, `contractAddress`, `functionName` |
+| `web3/read-contract` | `network`, `contractAddress`, `abiFunction` |
 
 ### Write Actions (require wallet integration)
 
@@ -288,11 +288,15 @@ Conditions reference previous node outputs using template syntax: `{{@nodeId:Lab
 |--------|----------------|
 | `web3/transfer-funds` | `network`, `toAddress`, `amount`, `walletId` |
 | `web3/transfer-token` | `network`, `toAddress`, `tokenAddress`, `amount`, `walletId` |
-| `web3/write-contract` | `network`, `contractAddress`, `functionName`, `walletId` |
+| `web3/write-contract` | `network`, `contractAddress`, `abiFunction`, `walletId` |
 
 Get the `walletId` by calling `get_wallet_integration`.
 
 The `network` field accepts chain IDs as strings: `"1"` (Ethereum mainnet), `"11155111"` (Sepolia), `"8453"` (Base), `"42161"` (Arbitrum), `"137"` (Polygon).
+
+### `abiFunction` field
+
+For `web3/read-contract` and `web3/write-contract`, the `abiFunction` field is the function as it appears in the contract's ABI. Pass the plain name for unique functions (`"balanceOf"`) or the full signature for overloaded ones (`"transfer(address,uint256)"`).
 
 ## Error Handling
 

--- a/lib/abi/utils.ts
+++ b/lib/abi/utils.ts
@@ -69,8 +69,11 @@ export type AbiFunctionItem = AbiItem & { name: string };
  */
 export function findAbiFunction(
   abi: AbiItem[],
-  key: string
+  key: string | undefined | null
 ): AbiFunctionItem | undefined {
+  if (!key) {
+    return;
+  }
   const parenIdx = key.indexOf("(");
   if (parenIdx === -1) {
     return abi.find(

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -63,6 +63,19 @@ export async function readContractCore(
   const { contractAddress, network, abi, abiFunction, functionArgs, _context } =
     input;
 
+  if (!abiFunction || abiFunction.trim() === "") {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Read Contract] Missing abiFunction",
+      { abiFunction },
+      { plugin_name: "web3", action_name: "read-contract" }
+    );
+    return {
+      success: false,
+      error: "Missing `abiFunction` in the step config",
+    };
+  }
+
   const userId = _context?.organizationId
     ? undefined
     : await getUserIdFromExecution(_context?.executionId);

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -99,6 +99,19 @@ export async function writeContractCore(
     _context,
   } = input;
 
+  if (!abiFunction || abiFunction.trim() === "") {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Write Contract] Missing abiFunction",
+      { abiFunction },
+      { plugin_name: "web3", action_name: "write-contract" }
+    );
+    return {
+      success: false,
+      error: "Missing `abiFunction` in the step config",
+    };
+  }
+
   const { multiplierOverride, gasLimitOverride } =
     resolveGasLimitOverrides(gasLimitMultiplier);
   const priorityFeeOverride = parsePriorityFeeGwei(priorityFeeGwei);

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -364,3 +364,37 @@ describe("read-contract-core - tuple output decoding", () => {
     expect(tuple[14]).toBe("0");
   });
 });
+
+describe("read-contract-core - missing abiFunction (KEEP-371)", () => {
+  it("returns a descriptive error when abiFunction is missing", async () => {
+    const result = await readContractCore({
+      contractAddress: VALID_ADDRESS,
+      network: "ethereum",
+      abi: JSON.stringify(VIEW_ABI),
+      abiFunction: "",
+      functionArgs: JSON.stringify([VALID_ADDRESS]),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("abiFunction");
+    }
+  });
+
+  it("does not crash with TypeError when abiFunction is undefined", async () => {
+    // Regression: before the fix, `findAbiFunction(parsedAbi, undefined)`
+    // threw `Cannot read properties of undefined (reading 'indexOf')`.
+    const result = await readContractCore({
+      contractAddress: VALID_ADDRESS,
+      network: "ethereum",
+      abi: JSON.stringify(VIEW_ABI),
+      abiFunction: undefined as unknown as string,
+      functionArgs: JSON.stringify([VALID_ADDRESS]),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toContain("indexOf");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Workflow nodes for `web3/read-contract` and `web3/write-contract` read the function name from `config.abiFunction`. AI-authored workflow JSON that followed the AI-tools docs put `functionName` in the config and crashed inside `findAbiFunction(parsedAbi, undefined)` with `Cannot read properties of undefined (reading 'indexOf')` (KEEP-371).

## Changes

- [plugins/web3/steps/read-contract-core.ts](plugins/web3/steps/read-contract-core.ts), [plugins/web3/steps/write-contract-core.ts](plugins/web3/steps/write-contract-core.ts): early-return with `"Missing \`abiFunction\` in the step config"` when the field is empty/missing.
- [lib/abi/utils.ts](lib/abi/utils.ts): `findAbiFunction` accepts `string | undefined | null` and short-circuits to `undefined` for falsy keys, so any future callsite that drifts hits the caller's existing "Function not found in ABI" branch instead of a TypeError.
- [docs/ai-tools/mcp-server.md](docs/ai-tools/mcp-server.md): workflow-node tables now list `abiFunction` (the actual step field). Added a short note describing what the field accepts.
- [tests/unit/read-contract-core.test.ts](tests/unit/read-contract-core.test.ts): two regression tests covering the missing-field error and the no-TypeError-on-undefined invariant.

## Out of scope

- The Direct Execution API (`POST /api/execute/contract-call`) still accepts `functionName` in the request body and maps it to `abiFunction` at the route boundary. External API callers and the `execute_contract_call` MCP tool are unaffected.

## Effect on existing workflows

- UI-authored workflows: unchanged (the editor's `abi-function-select` field has always produced `abiFunction`).
- AI-authored workflows already using `abiFunction`: unchanged.
- AI-authored workflows that picked up the wrong field name from the old docs: now fail with a readable error at execution time instead of a TypeError. They still need to be re-saved or hand-edited to use `abiFunction`.

Closes KEEP-371.