### PR TITLE
fix(workflow): KEEP-487 stop remounting manual ABI textarea on every keystroke

### DIFF
--- a/components/workflow/config/abi-with-auto-fetch-field.tsx
+++ b/components/workflow/config/abi-with-auto-fetch-field.tsx
@@ -872,7 +872,11 @@ export function AbiWithAutoFetchField({
         className="max-h-40 overflow-y-auto"
         disabled={disabled || isLoading || !useManualAbi}
         id={field.key}
-        key={`${field.key}-${value?.length || 0}-${useProxyAbi ? "proxy" : "impl"}${isDiamond ? `-${useDiamondAbi ? "diamond" : "proxy"}` : ""}`}
+        // Do not include `value.length` in the key: it remounts the textarea
+        // on every keystroke and kills focus mid-word. Parent-driven value
+        // changes are already synced via TemplateBadgeTextarea's effect when
+        // the field is blurred.
+        key={`${field.key}-${useProxyAbi ? "proxy" : "impl"}${isDiamond ? `-${useDiamondAbi ? "diamond" : "proxy"}` : ""}`}
         maxRows={4}
         onChange={(val) => {
           onChange(val);


### PR DESCRIPTION
## Summary

Manual ABI textarea lost focus after 1-2 characters of typing because [components/workflow/config/abi-with-auto-fetch-field.tsx:875](components/workflow/config/abi-with-auto-fetch-field.tsx#L875) used \`value?.length || 0\` as part of the React \`key\` for \`TemplateBadgeTextarea\`. Every keystroke changed the value length, which changed the key, which forced React to unmount and remount the textarea, which killed focus. Pasting worked because that is a single change.

## Fix

Drop \`value.length\` from the key. The toggle-driven pieces (\`useProxyAbi\`, \`useDiamondAbi\`) stay in the key so proxy/diamond source switches still get the clean remount they need. Parent-driven value updates (auto-fetched ABI, ABI swapped on proxy detection, etc.) continue to flow through \`TemplateBadgeTextarea\`'s internal sync effect, which already syncs on blur.

## What it does NOT change

- Proxy detection toggling between implementation/proxy ABI: still remounts via \`useProxyAbi\` in the key.
- Diamond detection toggling between combined/read-as-proxy ABI: still remounts via \`useDiamondAbi\` in the key.
- Auto-fetch on contract address / network change: unchanged; doesn't run while \`useManualAbi\` is on anyway.

## Verification

Verified locally: in a workflow with a \`web3/read-contract\` action node, check Use manual ABI, click into the textarea, type a multi-character string. Focus is preserved.

Closes KEEP-487.