### PR TITLE
fix: KEEP-440 soft-delete workflows to close slug-squat-after-delete

### DIFF
--- a/app/.well-known/x402/route.ts
+++ b/app/.well-known/x402/route.ts
@@ -1,6 +1,7 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +13,7 @@ export async function GET(): Promise<Response> {
       workflowType: workflows.workflowType,
     })
     .from(workflows)
-    .where(eq(workflows.isListed, true));
+    .where(and(eq(workflows.isListed, true), workflowNotDeleted()));
 
   const resources: string[] = [];
   for (const row of rows) {

--- a/app/api/internal/block-workflows/route.ts
+++ b/app/api/internal/block-workflows/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { type Chain, chains, workflows } from "@/lib/db/schema";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 import type { WorkflowNode } from "@/lib/workflow/store";
 
 export async function GET(request: Request): Promise<NextResponse> {
@@ -21,9 +22,14 @@ export async function GET(request: Request): Promise<NextResponse> {
 
     const blockTriggerFilter = sql`${workflows.nodes} @> '[{"data":{"type":"trigger","config":{"triggerType":"Block"}}}]'::jsonb`;
 
+    // KEEP-440: never hand a soft-deleted workflow to the block watcher.
     const conditions = filterActive
-      ? and(eq(workflows.enabled, true), blockTriggerFilter)
-      : blockTriggerFilter;
+      ? and(
+          eq(workflows.enabled, true),
+          blockTriggerFilter,
+          workflowNotDeleted()
+        )
+      : and(blockTriggerFilter, workflowNotDeleted());
 
     const matchedWorkflows = await db
       .select({

--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -27,10 +27,11 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const workflow = await db.query.workflows.findFirst({
     where: eq(workflows.id, workflowId),
-    columns: { organizationId: true },
+    columns: { organizationId: true, deletedAt: true },
   });
 
-  if (!workflow) {
+  // KEEP-440: never create an execution for a soft-deleted workflow.
+  if (!workflow || workflow.deletedAt) {
     return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
   }
 

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -28,6 +28,7 @@ import {
   type CallRouteWorkflow,
 } from "@/lib/payments/x402/types";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 const corsHeaders = {
@@ -185,7 +186,13 @@ async function lookupWorkflow(slug: string): Promise<CallRouteWorkflow | null> {
     .select({ ...CALL_ROUTE_COLUMNS, tagName: tags.name })
     .from(workflows)
     .leftJoin(tags, eq(workflows.tagId, tags.id))
-    .where(and(eq(workflows.listedSlug, slug), eq(workflows.isListed, true)))
+    .where(
+      and(
+        eq(workflows.listedSlug, slug),
+        eq(workflows.isListed, true),
+        workflowNotDeleted()
+      )
+    )
     .limit(1);
   return rows[0] ?? null;
 }

--- a/app/api/mcp/workflows/route.ts
+++ b/app/api/mcp/workflows/route.ts
@@ -5,6 +5,7 @@ import { workflows } from "@/lib/db/schema";
 import { workflowPayments } from "@/lib/db/schema-payments";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { sanitizeDescription } from "@/lib/sanitize-description";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
@@ -100,7 +101,8 @@ export async function GET(request: Request): Promise<NextResponse> {
     const offset = (page - 1) * limit;
     const sort = readSort(searchParams.get("sort"));
 
-    const baseFilter = eq(workflows.isListed, true);
+    // KEEP-440: soft-deleted workflows must never surface in the public catalog.
+    const baseFilter = and(eq(workflows.isListed, true), workflowNotDeleted());
     const textFilter = q
       ? or(
           ilike(workflows.name, `%${escapeLikePattern(q)}%`),

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -1,7 +1,8 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { sanitizeDescription } from "@/lib/sanitize-description";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 export const dynamic = "force-dynamic";
 
@@ -159,7 +160,7 @@ export async function GET(request: Request): Promise<Response> {
   const rows = await db
     .select(DISCOVERY_COLUMNS)
     .from(workflows)
-    .where(eq(workflows.isListed, true));
+    .where(and(eq(workflows.isListed, true), workflowNotDeleted()));
 
   const paths: Record<string, Record<string, unknown>> = {};
 

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -133,7 +133,8 @@ export async function POST(
         authMethod: "internal",
       });
 
-      if (!access.hasFullAccess) {
+      // KEEP-440: a soft-deleted workflow can never be executed.
+      if (!access.hasFullAccess || access.isDeleted) {
         return NextResponse.json(
           { error: "Workflow not found" },
           { status: 404 }
@@ -165,7 +166,8 @@ export async function POST(
         authMethod: authContext.authMethod,
       });
 
-      if (!access.hasFullAccess) {
+      // KEEP-440: a soft-deleted workflow can never be executed.
+      if (!access.hasFullAccess || access.isDeleted) {
         return NextResponse.json(
           { error: "Workflow not found" },
           { status: 404 }

--- a/app/api/workflows/[workflowId]/claim/route.ts
+++ b/app/api/workflows/[workflowId]/claim/route.ts
@@ -43,6 +43,14 @@ export async function POST(
       );
     }
 
+    // KEEP-440: a soft-deleted workflow cannot be claimed into an org.
+    if (workflow.deletedAt) {
+      return NextResponse.json(
+        { error: "Workflow not found" },
+        { status: 404 }
+      );
+    }
+
     const [updatedWorkflow] = await db
       .update(workflows)
       .set({

--- a/app/api/workflows/[workflowId]/code/route.ts
+++ b/app/api/workflows/[workflowId]/code/route.ts
@@ -45,7 +45,8 @@ export async function GET(
       authMethod: authContext.authMethod,
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: code export is unavailable for a soft-deleted workflow.
+    if (!access.hasFullAccess || access.isDeleted) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/download/route.ts
+++ b/app/api/workflows/[workflowId]/download/route.ts
@@ -59,7 +59,8 @@ export async function GET(
       authMethod: authContext.authMethod,
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: download is unavailable for a soft-deleted workflow.
+    if (!access.hasFullAccess || access.isDeleted) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -9,6 +9,7 @@ import { generateId } from "@/lib/utils/id";
 import { remapTemplateRefsInString } from "@/lib/utils/template";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 // Node type for type-safe node manipulation
 type WorkflowNodeLike = {
   id: string;
@@ -154,6 +155,14 @@ export async function POST(
       );
     }
 
+    // KEEP-440: a soft-deleted workflow cannot be duplicated.
+    if (access.isDeleted) {
+      return NextResponse.json(
+        { error: "Workflow not found" },
+        { status: 404 }
+      );
+    }
+
     const isAnonymous = !organizationId;
 
     // Generate new IDs for nodes
@@ -182,13 +191,15 @@ export async function POST(
       ? await db.query.workflows.findMany({
           where: and(
             eq(workflows.userId, userId ?? ""),
-            eq(workflows.isAnonymous, true)
+            eq(workflows.isAnonymous, true),
+            workflowNotDeleted()
           ),
         })
       : await db.query.workflows.findMany({
           where: and(
             eq(workflows.organizationId, organizationId ?? ""),
-            eq(workflows.isAnonymous, false)
+            eq(workflows.isAnonymous, false),
+            workflowNotDeleted()
           ),
         });
 
@@ -223,14 +234,19 @@ export async function POST(
       })
       .returning();
 
-    // If moving an anonymous workflow to an org, delete the original
-    // This prevents the old anonymous workflow from being accessible after sign out
+    // If moving an anonymous workflow to an org, retire the original.
+    // This prevents the old anonymous workflow from being accessible after
+    // sign out. KEEP-440: soft-delete so all workflow removal goes through one
+    // path and the deletedAt filters cover it uniformly.
     if (
       sourceWorkflow.isAnonymous &&
       access.isCreatorWithCurrentAccess &&
       !isAnonymous
     ) {
-      await db.delete(workflows).where(eq(workflows.id, workflowId));
+      await db
+        .update(workflows)
+        .set({ deletedAt: new Date() })
+        .where(eq(workflows.id, workflowId));
     }
 
     return NextResponse.json({

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -9,7 +9,10 @@ import { generateId } from "@/lib/utils/id";
 import { remapTemplateRefsInString } from "@/lib/utils/template";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
-import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
+import {
+  softDeleteValues,
+  workflowNotDeleted,
+} from "@/lib/workflow/soft-delete";
 // Node type for type-safe node manipulation
 type WorkflowNodeLike = {
   id: string;
@@ -245,7 +248,7 @@ export async function POST(
     ) {
       await db
         .update(workflows)
-        .set({ deletedAt: new Date() })
+        .set(softDeleteValues())
         .where(eq(workflows.id, workflowId));
     }
 

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -40,7 +40,8 @@ export async function GET(
       authMethod: authContext.authMethod,
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: execution history is hidden once the workflow is soft-deleted.
+    if (!access.hasFullAccess || access.isDeleted) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
@@ -104,7 +105,8 @@ export async function DELETE(
       authMethod: authContext.authMethod,
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: execution history is hidden once the workflow is soft-deleted.
+    if (!access.hasFullAccess || access.isDeleted) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/go-live/route.ts
+++ b/app/api/workflows/[workflowId]/go-live/route.ts
@@ -37,7 +37,8 @@ export async function PUT(
       authMethod: "session",
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: a soft-deleted workflow cannot be taken live.
+    if (!access.hasFullAccess || access.isDeleted) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -15,6 +15,7 @@ import { syncWorkflowSchedule } from "@/lib/schedule-service";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
+import { softDeleteValues } from "@/lib/workflow/soft-delete";
 import { isReservedSlug } from "@/lib/workflow/reserved-slugs";
 import {
   formatActionConfigValidationResponse,
@@ -659,7 +660,7 @@ export async function DELETE(
     // is still hard-deleted on force (only the workflow row must persist), and
     // schedules are removed explicitly -- the ON DELETE CASCADE that used to
     // clean them up no longer fires now that the row is not actually deleted.
-    const softDelete = { deletedAt: new Date(), isListed: false };
+    const softDelete = softDeleteValues();
 
     if (hasExecutions && force) {
       const { workflowExecutionLogs } = await import("@/lib/db/schema");

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -5,7 +5,7 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
-import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflows } from "@/lib/db/schema";
+import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflowSchedules, workflows } from "@/lib/db/schema";
 import { findFirstWriteActionNode } from "@/lib/mcp/calldata";
 import {
   findBareAtLiterals,
@@ -103,6 +103,15 @@ export async function GET(
     // - Private workflows: owner or org member can view
     // - Anonymous workflows: only owner can view
     if (!access.hasFullAccess && workflow.visibility !== "public") {
+      return NextResponse.json(
+        { error: "Workflow not found" },
+        { status: 404 }
+      );
+    }
+
+    // KEEP-440: a soft-deleted workflow stays readable for its owner/org so the
+    // UI can render a deleted marker, but is gone for everyone else.
+    if (access.isDeleted && !access.hasFullAccess) {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
@@ -229,9 +238,11 @@ async function validateWorkflowAccess(
     authMethod,
   });
 
+  // KEEP-440: a soft-deleted workflow is not mutable. PATCH and DELETE both
+  // treat it as not-found rather than re-deleting or editing a tombstone.
   return {
     workflow: existingWorkflow,
-    hasAccess: access.hasFullAccess,
+    hasAccess: access.hasFullAccess && !access.isDeleted,
   };
 }
 
@@ -642,7 +653,14 @@ export async function DELETE(
       );
     }
 
-    // If force delete, cascade delete logs, executions, and workflow in a transaction
+    // KEEP-440: soft-delete the workflow row instead of hard-deleting it. The
+    // surviving row keeps its listedSlug bound in idx_workflows_listed_slug, so
+    // the slug can never be re-claimed by another workflow. Execution history
+    // is still hard-deleted on force (only the workflow row must persist), and
+    // schedules are removed explicitly -- the ON DELETE CASCADE that used to
+    // clean them up no longer fires now that the row is not actually deleted.
+    const softDelete = { deletedAt: new Date(), isListed: false };
+
     if (hasExecutions && force) {
       const { workflowExecutionLogs } = await import("@/lib/db/schema");
       const { inArray } = await import("drizzle-orm");
@@ -665,10 +683,26 @@ export async function DELETE(
             .where(eq(workflowExecutions.workflowId, workflowId));
         }
 
-        await tx.delete(workflows).where(eq(workflows.id, workflowId));
+        await tx
+          .delete(workflowSchedules)
+          .where(eq(workflowSchedules.workflowId, workflowId));
+
+        await tx
+          .update(workflows)
+          .set(softDelete)
+          .where(eq(workflows.id, workflowId));
       });
     } else {
-      await db.delete(workflows).where(eq(workflows.id, workflowId));
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(workflowSchedules)
+          .where(eq(workflowSchedules.workflowId, workflowId));
+
+        await tx
+          .update(workflows)
+          .set(softDelete)
+          .where(eq(workflows.id, workflowId));
+      });
     }
 
     return NextResponse.json({ success: true });

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -261,7 +261,8 @@ export async function POST(
       authMethod: "webhook",
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: a soft-deleted workflow must never execute via its webhook URL.
+    if (!access.hasFullAccess || access.isDeleted) {
       return failResponse(workflowId, timer, 404, "Workflow not found");
     }
 

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -8,6 +8,7 @@ import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, tags, workflows } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils/id";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 import {
   formatActionConfigValidationResponse,
   validateWorkflowActionConfigs,
@@ -68,13 +69,15 @@ async function generateWorkflowName(
     ? await db.query.workflows.findMany({
         where: and(
           eq(workflows.userId, userId),
-          eq(workflows.isAnonymous, true)
+          eq(workflows.isAnonymous, true),
+          workflowNotDeleted()
         ),
       })
     : await db.query.workflows.findMany({
         where: and(
           eq(workflows.organizationId, organizationId ?? ""),
-          eq(workflows.isAnonymous, false)
+          eq(workflows.isAnonymous, false),
+          workflowNotDeleted()
         ),
       });
 

--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getProtocol } from "@/lib/protocol-registry";
@@ -6,6 +6,7 @@ import { db } from "@/lib/db";
 import { type Chain, chains, workflows } from "@/lib/db/schema";
 import type { WorkflowNode } from "@/lib/workflow/store";
 import { WorkflowTriggerEnum } from "@/lib/workflow/store";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 /**
  * Internal endpoint for workers to fetch active Event-type workflows
@@ -56,9 +57,12 @@ export async function GET(request: Request) {
       })
       .from(workflows);
 
+    // KEEP-440: never hand a soft-deleted workflow to the events worker.
     const allWorkflows = filterActive
-      ? await query.where(eq(workflows.enabled, true))
-      : await query;
+      ? await query.where(
+          and(eq(workflows.enabled, true), workflowNotDeleted())
+        )
+      : await query.where(workflowNotDeleted());
 
     const eventWorkflows = allWorkflows
       .map((workflow) => {

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -75,7 +75,9 @@ export async function GET(
       authMethod: authContext.authMethod,
     });
 
-    if (!access.hasFullAccess) {
+    // KEEP-440: keep this consistent with the execution-history route -- once
+    // the workflow is soft-deleted its execution detail is hidden too.
+    if (!access.hasFullAccess || access.isDeleted) {
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),

--- a/app/api/workflows/public/route.ts
+++ b/app/api/workflows/public/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import type { VoteDirection } from "@/lib/workflow/editor/votes";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 type TagInfo = { id: string; name: string; slug: string };
 
 async function resolveTagFilter(tagSlug: string): Promise<string[] | "empty"> {
@@ -122,7 +123,12 @@ async function fetchDuplicateCounts(
       count: sql<string>`COUNT(*)`,
     })
     .from(workflows)
-    .where(inArray(workflows.sourceWorkflowId, workflowIds))
+    .where(
+      and(
+        inArray(workflows.sourceWorkflowId, workflowIds),
+        workflowNotDeleted()
+      )
+    )
     .groupBy(workflows.sourceWorkflowId);
 
   const result: Record<string, number> = {};
@@ -146,7 +152,8 @@ async function fetchUserDuplications(
     .where(
       and(
         eq(workflows.userId, userId),
-        inArray(workflows.sourceWorkflowId, workflowIds)
+        inArray(workflows.sourceWorkflowId, workflowIds),
+        workflowNotDeleted()
       )
     );
 
@@ -177,7 +184,11 @@ export async function GET(request: Request): Promise<NextResponse> {
 
     const isProtocolFeaturedRequest = Boolean(featuredProtocol);
 
-    const conditions = [eq(workflows.visibility, "public")];
+    // KEEP-440: soft-deleted workflows must never surface in the public feed.
+    const conditions = [
+      eq(workflows.visibility, "public"),
+      workflowNotDeleted(),
+    ];
 
     if (isProtocolFeaturedRequest) {
       conditions.push(

--- a/app/hub/_protocols-tab.tsx
+++ b/app/hub/_protocols-tab.tsx
@@ -7,6 +7,7 @@ import {
   getRegisteredProtocols,
   type ProtocolDefinition,
 } from "@/lib/protocol-registry";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 import { ProtocolDetailIsland } from "./_protocol-detail-island";
 import { ProtocolGridClient } from "./_protocols-grid-client";
 
@@ -23,7 +24,8 @@ async function fetchProtocolWorkflowCounts(): Promise<Record<string, number>> {
     .where(
       and(
         eq(workflows.visibility, "public"),
-        isNotNull(workflows.featuredProtocol)
+        isNotNull(workflows.featuredProtocol),
+        workflowNotDeleted()
       )
     )
     .groupBy(workflows.featuredProtocol);

--- a/app/workflows/[workflowId]/layout.tsx
+++ b/app/workflows/[workflowId]/layout.tsx
@@ -1,8 +1,9 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 type WorkflowLayoutProps = {
   children: ReactNode;
@@ -20,7 +21,7 @@ export async function generateMetadata({
 
   try {
     const workflow = await db.query.workflows.findFirst({
-      where: eq(workflows.id, workflowId),
+      where: and(eq(workflows.id, workflowId), workflowNotDeleted()),
       columns: {
         name: true,
         visibility: true,

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -50,6 +50,9 @@ type WorkflowEntry = {
   updatedAt: string;
   projectId?: string | null;
   tagId?: string | null;
+  // KEEP-440: set when the workflow has been soft-deleted. Deleted rows stay
+  // in the list with a marker so the user has an audit trail / recovery window.
+  deletedAt?: string | null;
 };
 
 function groupWorkflows(workflows: WorkflowEntry[]): {
@@ -81,6 +84,7 @@ function WorkflowItem({
   activeWorkflowId: string | undefined;
 }): React.ReactNode {
   const router = useRouter();
+  const isDeleted = Boolean(workflow.deletedAt);
   return (
     <button
       className={cn(
@@ -90,9 +94,22 @@ function WorkflowItem({
       onClick={() => router.push(`/workflows/${workflow.id}`)}
       type="button"
     >
-      <span className="truncate">{workflow.name}</span>
-      {workflow.id === activeWorkflowId && (
-        <Check className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
+      <span
+        className={cn(
+          "truncate",
+          isDeleted && "text-muted-foreground line-through"
+        )}
+      >
+        {workflow.name}
+      </span>
+      {isDeleted ? (
+        <span className="ml-2 shrink-0 text-muted-foreground text-xs">
+          Deleted
+        </span>
+      ) : (
+        workflow.id === activeWorkflowId && (
+          <Check className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
+        )
       )}
     </button>
   );

--- a/drizzle/0074_keep440_workflows_soft_delete.sql
+++ b/drizzle/0074_keep440_workflows_soft_delete.sql
@@ -1,0 +1,14 @@
+-- KEEP-440: soft-delete for workflows.
+--
+-- Hard-deleting a workflow row removed its `listed_slug` from the
+-- `idx_workflows_listed_slug` unique index, letting any other workflow
+-- immediately re-claim the freed slug (slug-squat-after-delete).
+--
+-- The delete handler now sets `deleted_at` instead of deleting the row, so
+-- the row keeps holding its slug in the unique index forever. The index is
+-- intentionally left unchanged -- the surviving row is what blocks re-claim.
+--
+-- Nullable, no default: existing rows stay null (not deleted). Read paths
+-- filter on `deleted_at IS NULL`; the owner-facing workflow list keeps
+-- showing soft-deleted rows so the UI can mark them as deleted.
+ALTER TABLE "workflows" ADD COLUMN "deleted_at" timestamp;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1777760000007,
       "tag": "0073_keep545_workflow_executions_error_classification",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1777760000008,
+      "tag": "0074_keep440_workflows_soft_delete",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub-executor/in-process.ts
+++ b/keeperhub-executor/in-process.ts
@@ -43,6 +43,16 @@ export async function executeInProcess(params: {
       throw new Error(`Workflow not found: ${workflowId}`);
     }
 
+    // KEEP-440: a soft-deleted workflow must never execute, even if a stale
+    // schedule or queued message still references it.
+    if (workflow.deletedAt) {
+      console.log(
+        `[Executor:InProcess] Workflow deleted, skipping: ${workflowId}`
+      );
+      await updateExecutionStatus(db, executionId, "cancelled");
+      return;
+    }
+
     if (workflow.enabled === false) {
       console.log(
         `[Executor:InProcess] Workflow disabled, skipping: ${workflowId}`

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -36,9 +36,9 @@ import {
   workflowSchedules,
   workflows,
 } from "../lib/db/schema";
-import { generateId } from "../lib/utils/id";
 import { getMetricsCollector } from "../lib/metrics";
 import { LabelKeys, MetricNames } from "../lib/metrics/types";
+import { generateId } from "../lib/utils/id";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { type ApiExecuteTriggerType, executeViaApi } from "./api-execute";
 import { checkExecutionLimitForExecutor } from "./billing-guard";
@@ -222,6 +222,13 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
 
   if (!workflow) {
     console.error(`[Executor] Workflow not found: ${workflowId}`);
+    return;
+  }
+
+  // KEEP-440: a soft-deleted workflow must never execute, even if a stale
+  // schedule or queued message still references it.
+  if (workflow.deletedAt) {
+    console.log(`[Executor] Workflow deleted, skipping: ${workflowId}`);
     return;
   }
 

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -183,6 +183,16 @@ async function main(): Promise<void> {
       throw new Error(`Workflow not found: ${workflowId}`);
     }
 
+    // KEEP-440: a soft-deleted workflow must never execute, even if a stale
+    // schedule or queued message still references it.
+    if (workflow.deletedAt) {
+      console.log(
+        `[Runner] Workflow deleted, skipping execution: ${workflowId}`
+      );
+      await updateExecutionStatus(db, executionId, "cancelled");
+      return;
+    }
+
     if (workflow.enabled === false) {
       console.log(
         `[Runner] Workflow disabled, skipping execution: ${workflowId}`

--- a/lib/agentic-wallet/workflow-binding.ts
+++ b/lib/agentic-wallet/workflow-binding.ts
@@ -65,6 +65,7 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organizationWallets, workflows } from "@/lib/db/schema";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 import {
   BASE_CHAIN_ID,
   TEMPO_MAINNET_CHAIN_ID,
@@ -199,7 +200,13 @@ export async function verifyWorkflowBinding(
       chain: workflows.chain,
     })
     .from(workflows)
-    .where(and(eq(workflows.listedSlug, slug), eq(workflows.isListed, true)))
+    .where(
+      and(
+        eq(workflows.listedSlug, slug),
+        eq(workflows.isListed, true),
+        workflowNotDeleted()
+      )
+    )
     .limit(1);
 
   const wf = rows[0];

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -54,6 +54,9 @@ export type SavedWorkflow = WorkflowData & {
   isListed?: boolean;
   listedSlug?: string | null;
   listedAt?: string | null;
+  // KEEP-440: set when the workflow has been soft-deleted. The owner-facing
+  // list keeps showing these rows with a deleted marker.
+  deletedAt?: string | null;
   inputSchema?: Record<string, unknown> | null;
   outputMapping?: Record<string, unknown> | null;
   priceUsdcPerCall?: string | null;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -245,6 +245,9 @@ export const workflows = pgTable(
     chain: text("chain"),
     // v1.11: per-workflow MCP server versioning (incremented on listing schema changes)
     listingVersion: integer("listing_version").notNull().default(1),
+    // KEEP-440: soft-delete. Set instead of hard-deleting the row so the listed
+    // slug stays bound to this row and cannot be re-claimed by another workflow.
+    deletedAt: timestamp("deleted_at"),
   },
   (table) => [
     // INFRA-02: globally unique listed slug so external callers can invoke by slug alone

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -6,6 +6,7 @@ import {
   findBareAtLiterals,
   isInputSchemaPresent,
 } from "@/lib/mcp/listing-validators";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 export type ListingErrorCode =
   | "NOT_FOUND"
@@ -97,7 +98,11 @@ export async function listWorkflow(
     .select()
     .from(workflows)
     .where(
-      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+      and(
+        eq(workflows.id, workflowId),
+        eq(workflows.organizationId, orgId),
+        workflowNotDeleted()
+      )
     )
     .limit(1);
 
@@ -218,7 +223,11 @@ export async function unlistWorkflow(
     .select()
     .from(workflows)
     .where(
-      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+      and(
+        eq(workflows.id, workflowId),
+        eq(workflows.organizationId, orgId),
+        workflowNotDeleted()
+      )
     )
     .limit(1);
 
@@ -230,7 +239,11 @@ export async function unlistWorkflow(
     .update(workflows)
     .set({ isListed: false, updatedAt: new Date() })
     .where(
-      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+      and(
+        eq(workflows.id, workflowId),
+        eq(workflows.organizationId, orgId),
+        workflowNotDeleted()
+      )
     )
     .returning();
 
@@ -250,7 +263,11 @@ export async function updateWorkflowListing(
     .select()
     .from(workflows)
     .where(
-      and(eq(workflows.id, workflowId), eq(workflows.organizationId, orgId))
+      and(
+        eq(workflows.id, workflowId),
+        eq(workflows.organizationId, orgId),
+        workflowNotDeleted()
+      )
     )
     .limit(1);
 
@@ -373,7 +390,13 @@ export async function getWorkflowListing(
   const rows = await db
     .select(LISTING_COLUMNS)
     .from(workflows)
-    .where(and(eq(workflows.listedSlug, slug), eq(workflows.isListed, true)))
+    .where(
+      and(
+        eq(workflows.listedSlug, slug),
+        eq(workflows.isListed, true),
+        workflowNotDeleted()
+      )
+    )
     .limit(1);
 
   if (rows.length === 0) {

--- a/lib/workflow/access.ts
+++ b/lib/workflow/access.ts
@@ -13,12 +13,19 @@ type WorkflowAccessWorkflow = {
   userId: string;
   organizationId: string | null;
   isAnonymous: boolean;
+  // KEEP-440: present on full workflow rows; absent on the trimmed shapes some
+  // callers pass. Treated as not-deleted when absent.
+  deletedAt?: Date | null;
 };
 
 export type WorkflowAccess = {
   isCreatorWithCurrentAccess: boolean;
   isSameOrg: boolean;
   hasFullAccess: boolean;
+  // KEEP-440: true when the workflow has been soft-deleted. Mutation, execution
+  // and export routes must reject deleted workflows; only the owner-facing read
+  // paths keep serving them so the UI can render a deleted marker.
+  isDeleted: boolean;
 };
 
 async function isUserMemberOfOrganization(
@@ -83,5 +90,6 @@ export async function getWorkflowAccess(
     isCreatorWithCurrentAccess,
     isSameOrg,
     hasFullAccess: isCreatorWithCurrentAccess || isSameOrg,
+    isDeleted: (workflow.deletedAt ?? null) !== null,
   };
 }

--- a/lib/workflow/soft-delete.ts
+++ b/lib/workflow/soft-delete.ts
@@ -21,3 +21,14 @@ export function isWorkflowDeleted(workflow: {
 }): boolean {
   return workflow.deletedAt !== null;
 }
+
+/**
+ * KEEP-440: the column writes that retire a workflow. `deletedAt` records the
+ * soft-delete; `isListed: false` drops it off every marketplace surface (and
+ * is the secondary guard a few read paths still lean on). Every retirement
+ * path -- the delete handler and the duplicate-route anonymous move -- writes
+ * this same shape so a workflow is never left half-retired.
+ */
+export function softDeleteValues(): { deletedAt: Date; isListed: boolean } {
+  return { deletedAt: new Date(), isListed: false };
+}

--- a/lib/workflow/soft-delete.ts
+++ b/lib/workflow/soft-delete.ts
@@ -1,0 +1,23 @@
+import { isNull, type SQL } from "drizzle-orm";
+import { workflows } from "@/lib/db/schema";
+
+/**
+ * KEEP-440: Drizzle predicate that excludes soft-deleted workflow rows.
+ *
+ * Workflows are soft-deleted (`deletedAt` set) instead of hard-deleted so the
+ * listed slug stays bound to the row and cannot be re-claimed by another
+ * workflow. Every read that should treat a deleted workflow as gone must
+ * compose this into its WHERE clause. The owner-facing workflow list is the
+ * deliberate exception -- it keeps showing deleted rows so the UI can mark
+ * them as deleted.
+ */
+export function workflowNotDeleted(): SQL {
+  return isNull(workflows.deletedAt);
+}
+
+/** KEEP-440: true when a fetched workflow row has been soft-deleted. */
+export function isWorkflowDeleted(workflow: {
+  deletedAt: Date | null;
+}): boolean {
+  return workflow.deletedAt !== null;
+}

--- a/tests/unit/mcp-catalog.test.ts
+++ b/tests/unit/mcp-catalog.test.ts
@@ -53,6 +53,7 @@ vi.mock("@/lib/db/schema", () => ({
     workflowType: "workflow_type",
     category: "category",
     chain: "chain",
+    deletedAt: "deleted_at",
   },
 }));
 
@@ -67,6 +68,7 @@ vi.mock("drizzle-orm", () => ({
     col,
     pattern,
   })),
+  isNull: vi.fn((col: unknown) => ({ type: "isNull", col })),
   or: vi.fn((...args: unknown[]) => ({ type: "or", args })),
   and: vi.fn((...args: unknown[]) => ({ type: "and", args })),
   desc: vi.fn((col: unknown) => ({ type: "desc", col })),

--- a/tests/unit/workflow-soft-delete.test.ts
+++ b/tests/unit/workflow-soft-delete.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// KEEP-440: workflows are soft-deleted (deletedAt set) instead of hard-deleted
+// so the listed slug stays bound to the row and cannot be re-claimed. These
+// tests cover the unit-level surface of that change: the soft-delete helpers
+// and the isDeleted signal getWorkflowAccess now exposes. The end-to-end
+// "deleted slug cannot be re-claimed" property is exercised against the dev
+// server via the kh CLI.
+
+const { mockMemberLimit } = vi.hoisted(() => ({
+  mockMemberLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockMemberLimit,
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  member: {
+    id: "id",
+    organizationId: "organizationId",
+    userId: "userId",
+  },
+  workflows: {
+    deletedAt: "deleted_at",
+  },
+}));
+
+import { getWorkflowAccess } from "@/lib/workflow/access";
+import {
+  isWorkflowDeleted,
+  workflowNotDeleted,
+} from "@/lib/workflow/soft-delete";
+
+const ANON_WORKFLOW = {
+  id: "wf-anon",
+  userId: "creator",
+  organizationId: null,
+  isAnonymous: true,
+};
+
+describe("isWorkflowDeleted", () => {
+  it("returns true when deletedAt is set", () => {
+    expect(isWorkflowDeleted({ deletedAt: new Date() })).toBe(true);
+  });
+
+  it("returns false when deletedAt is null", () => {
+    expect(isWorkflowDeleted({ deletedAt: null })).toBe(false);
+  });
+});
+
+describe("workflowNotDeleted", () => {
+  it("returns a SQL predicate", () => {
+    expect(workflowNotDeleted()).toBeDefined();
+  });
+
+  it("returns a fresh predicate instance per call (no shared mutable state)", () => {
+    expect(workflowNotDeleted()).not.toBe(workflowNotDeleted());
+  });
+});
+
+describe("getWorkflowAccess soft-delete signal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flags isDeleted when the workflow row has a deletedAt timestamp", async () => {
+    const access = await getWorkflowAccess(
+      { ...ANON_WORKFLOW, deletedAt: new Date() },
+      { userId: "creator", organizationId: null }
+    );
+
+    expect(access.isDeleted).toBe(true);
+    // The creator still has full access -- isDeleted is an orthogonal signal
+    // so owner-facing read paths can keep serving the row with a marker.
+    expect(access.hasFullAccess).toBe(true);
+  });
+
+  it("does not flag isDeleted when deletedAt is null", async () => {
+    const access = await getWorkflowAccess(
+      { ...ANON_WORKFLOW, deletedAt: null },
+      { userId: "creator", organizationId: null }
+    );
+
+    expect(access.isDeleted).toBe(false);
+  });
+
+  it("does not flag isDeleted when deletedAt is absent (trimmed workflow shape)", async () => {
+    const access = await getWorkflowAccess(ANON_WORKFLOW, {
+      userId: "creator",
+      organizationId: null,
+    });
+
+    expect(access.isDeleted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Hard-deleting a workflow removed its `listed_slug` from the `idx_workflows_listed_slug` unique index, letting any other workflow immediately re-claim the freed slug and inherit its traffic + x402 revenue.
- Workflows are now **soft-deleted**: the delete handler sets `deleted_at` (and `is_listed = false`) instead of deleting the row, so the row keeps its slug bound in the unique index forever. The index is intentionally unchanged -- the surviving row is what blocks re-claim.
- Execution history is still hard-deleted on `force`; `workflow_schedules` are removed explicitly since the `ON DELETE CASCADE` no longer fires on a soft-delete (a "deleted" workflow with an active schedule would otherwise keep running).
- All workflow reads audited to filter `deleted_at IS NULL`: public listing, payment binding, slug call route, catalog, x402 discovery, public feed, executor lookups. Mutation/execution/export routes reject deleted workflows.
- The owner-facing workflow list deliberately keeps showing soft-deleted rows, marked "Deleted" in the sidebar, so the user has an audit trail and recovery window.

Linear: https://linear.app/keeperhubapp/issue/KEEP-440

## Repro (now fixed)

Verified end-to-end against local dev via the `kh` CLI:

1. Create workflow W, then `kh workflow delete W`.
2. DB check: the `workflows` row **still exists** with `deleted_at` set and `is_listed = false` (previously the row was gone, freeing the slug). `workflow_schedules` for W: 0 rows.
3. `kh workflow delete W` again -> `not found`.
4. `kh workflow run W` -> `HTTP 404: Workflow not found`.

Because the row + its `listed_slug` survive in the unchanged unique index, no other workflow can re-claim the slug.

## Test plan

- [x] New unit tests: `tests/unit/workflow-soft-delete.test.ts` (helper predicates + `getWorkflowAccess.isDeleted` signal)
- [x] Updated `tests/unit/mcp-catalog.test.ts` mock for the new `isNull` dependency
- [x] Full unit suite: 4520 passed, 0 failed, 1 skipped
- [x] `pnpm type-check` clean
- [x] `pnpm check` clean on changed files
- [x] Dev-server end-to-end repro via `kh` CLI (soft-delete persists row, blocks re-delete/run, cleans schedules)
- [ ] Migration `0074_keep440_workflows_soft_delete.sql` applies on staging deploy

## Follow-up (out of scope)

Stat/analytics surfaces (metrics, leaderboard, earnings, billing limit counts) are not yet filtered on `deleted_at` -- these are correctness-of-stats, not a security boundary. Worth a separate ticket.