### PR TITLE
fix(deploy): add ServiceMonitor to block-dispatcher so Alloy scrapes /metrics

### DIFF
--- a/deploy/scheduler/prod/block-dispatcher-values.yaml
+++ b/deploy/scheduler/prod/block-dispatcher-values.yaml
@@ -35,9 +35,19 @@ serviceAccount:
 
 podAnnotations:
   reloader.stakater.com/auto: "true"
-  prometheus.io/scrape: "true"
-  prometheus.io/port: "3000"
-  prometheus.io/path: "/metrics"
+
+# Prod Alloy scrapes via ServiceMonitor CRDs, not prometheus.io/* annotations.
+# Same pattern the executor uses (deploy/executor/prod/values.yaml). Without
+# this block, the block-dispatcher /metrics endpoint is unreachable to Alloy
+# even with annotations set, so Grafana panels stay empty.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: block-dispatcher-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
 
 resources:
   limits:

--- a/deploy/scheduler/staging/block-dispatcher-values.yaml
+++ b/deploy/scheduler/staging/block-dispatcher-values.yaml
@@ -35,9 +35,19 @@ serviceAccount:
 
 podAnnotations:
   reloader.stakater.com/auto: "true"
-  prometheus.io/scrape: "true"
-  prometheus.io/port: "3000"
-  prometheus.io/path: "/metrics"
+
+# Staging Alloy scrapes via ServiceMonitor CRDs, not prometheus.io/* annotations.
+# Same pattern the executor uses (deploy/executor/staging/values.yaml). Without
+# this block, the block-dispatcher /metrics endpoint is unreachable to Alloy
+# even with annotations set, so Grafana panels stay empty.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: block-dispatcher-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
 
 resources:
   limits:


### PR DESCRIPTION
## Summary

Block-dispatcher pod has exposed `/metrics` on `:3000` since KEEP-557 (#1256) but prod Grafana panels are still empty. Root cause: Alloy in the prod and staging clusters discovers scrape targets via **ServiceMonitor CRDs**, not `prometheus.io/*` pod annotations — so the annotations on the pod were dead weight. Without a ServiceMonitor resource, Alloy never reaches `/metrics` and nothing lands in Grafana Cloud Prometheus.

Evidence collected against prod:

- `kubectl exec` into the running block pod → `wget /metrics` returns real `keeperhub_block_dispatcher_*` data.
- Grafana Explore: `up{namespace="keeperhub"}` returns only `job="keeperhub-common"` and `job="keeperhub-executor-common"` (executor uses the same pattern this PR adds).
- `count(keeperhub_block_dispatcher_seconds_since_last_block)` returns no data.
- `kubectl get svc -n keeperhub` shows `keeperhub-block-common` Service exists, just no ServiceMonitor pointing at it.

## Fix

Mirror the executor pattern at [`deploy/executor/{prod,staging}/values.yaml`](../tree/staging/deploy/executor). The `common` Helm chart turns a `serviceMonitors:` block into a ServiceMonitor that Alloy picks up automatically:

```yaml
serviceMonitors:
  enabled: true
  monitors:
    - name: block-dispatcher-metrics
      port: http
      path: /metrics
      interval: 30s
      scrapeTimeout: 10s
```

Applied to both `prod` and `staging` values files. Stale `prometheus.io/*` pod annotations dropped at the same time so the deploy values reflect what's actually wired.

## After deploy

Within ~60s of the helm release applying:

- Grafana Cloud Prom starts ingesting `keeperhub_block_dispatcher_*` series tagged with `job=keeperhub-block-common`.
- `KeeperHub - Block Dispatcher` dashboard panels populate.
- The two alerts from [techops-infrastructure#196](https://github.com/techops-services/infrastructure/pull/196) — `Block Dispatcher Chain Silent` and `Block Dispatcher URL Flipped` — start evaluating against real data instead of NoData.