### PR TITLE
fix: add ETH-balance gas preflight to agentic-wallet feedback route

### DIFF
--- a/app/api/agentic-wallet/feedback/route.ts
+++ b/app/api/agentic-wallet/feedback/route.ts
@@ -24,6 +24,7 @@
  *   200 { feedbackId, txHash, publicUrl }
  *   400 BAD_INPUT
  *   401 missing/invalid HMAC
+ *   402 INSUFFICIENT_GAS -- caller's wallet cannot cover mainnet gas
  *   403 NOT_PAYER  -- caller's wallet did not pay for the referenced execution
  *   404 EXECUTION_NOT_FOUND
  *   409 ALREADY_RATED -- caller already rated this execution
@@ -96,6 +97,25 @@ type ValidatedInput = {
 
 function badRequest(message: string, code = "BAD_INPUT"): NextResponse {
   return NextResponse.json({ error: message, code }, { status: 400 });
+}
+
+// Thrown by buildAndSignTx when the caller wallet cannot cover mainnet gas
+// for the giveFeedback() tx. Surfaced as a clean 402 INSUFFICIENT_GAS so the
+// caller can fund the wallet and retry the now-stranded feedback row
+// (KEEP-515), instead of estimateGas/broadcast failing opaquely.
+class InsufficientGasError extends Error {
+  readonly balanceWei: bigint;
+  readonly requiredWei: bigint | null;
+  constructor(balanceWei: bigint, requiredWei: bigint | null) {
+    const need =
+      requiredWei === null
+        ? "any mainnet gas"
+        : `the ~${requiredWei} wei needed for mainnet gas`;
+    super(`Wallet balance ${balanceWei} wei is below ${need}`);
+    this.name = "InsufficientGasError";
+    this.balanceWei = balanceWei;
+    this.requiredWei = requiredWei;
+  }
 }
 
 // Hoisted to module scope per useTopLevelRegex (avoids re-parsing the
@@ -331,14 +351,25 @@ async function buildAndSignTx(args: {
     transport: http(rpcUrl),
   });
 
-  // Live network reads -- nonce + gas estimate + fee estimate. Each one
-  // hits the upstream RPC; we await sequentially to keep error surfacing
-  // crisp (and Promise.all would still be sequential because of viem's
-  // single-connection transport in practice).
+  // Live network reads -- nonce + balance + gas estimate + fee estimate.
+  // Each one hits the upstream RPC; we await sequentially to keep error
+  // surfacing crisp (and Promise.all would still be sequential because of
+  // viem's single-connection transport in practice).
   const nonce = await publicClient.getTransactionCount({
     address: args.walletAddress,
     blockTag: "pending",
   });
+  // Gas preflight. The caller wallet pays mainnet gas natively, so a wallet
+  // with no ETH cannot complete this tx. Check the balance up front: a zero
+  // balance short-circuits before estimateGas, which on a 0-balance account
+  // can fail opaquely or stall on some RPC providers. A non-zero balance is
+  // re-checked against the real estimated cost once it is known.
+  const balanceWei = await publicClient.getBalance({
+    address: args.walletAddress,
+  });
+  if (balanceWei === BigInt(0)) {
+    throw new InsufficientGasError(balanceWei, null);
+  }
   const gas = await publicClient.estimateGas({
     account: args.walletAddress,
     to: ERC_8004_REPUTATION_REGISTRY_ADDRESS,
@@ -349,6 +380,11 @@ async function buildAndSignTx(args: {
   // bumps invalidating the broadcast. Cheap insurance on a $3-10 tx.
   const gasWithHeadroom = (gas * BigInt(12)) / BigInt(10);
   const fees = await publicClient.estimateFeesPerGas();
+  // Reject before signing if the balance cannot cover the estimated cost.
+  const requiredWei = gasWithHeadroom * fees.maxFeePerGas;
+  if (balanceWei < requiredWei) {
+    throw new InsufficientGasError(balanceWei, requiredWei);
+  }
 
   const unsignedTx = serializeTransaction({
     chainId: args.agentChainId,
@@ -531,6 +567,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         error: err instanceof Error ? err.message : String(err),
       })
       .where(eq(feedback.id, feedbackId));
+    if (err instanceof InsufficientGasError) {
+      return NextResponse.json(
+        {
+          error: err.message,
+          code: "INSUFFICIENT_GAS",
+          feedbackId,
+          balanceWei: err.balanceWei.toString(),
+          ...(err.requiredWei === null
+            ? {}
+            : { requiredWei: err.requiredWei.toString() }),
+        },
+        { status: 402 }
+      );
+    }
     if (err instanceof PolicyBlockedError) {
       return NextResponse.json(
         { error: err.message, code: "POLICY_BLOCKED", feedbackId },

--- a/tests/integration/agentic-wallet-feedback-route.test.ts
+++ b/tests/integration/agentic-wallet-feedback-route.test.ts
@@ -54,6 +54,7 @@ const {
   mockLookupSecret,
   mockSignEthereumTransaction,
   mockBroadcastSignedTransaction,
+  mockGetBalance,
 } = vi.hoisted(
   (): {
     mockSelectLimit: MockFn;
@@ -63,6 +64,7 @@ const {
     mockLookupSecret: MockFn;
     mockSignEthereumTransaction: MockFn;
     mockBroadcastSignedTransaction: MockFn;
+    mockGetBalance: MockFn;
   } => {
     const updateWhere = vi.fn();
     return {
@@ -75,6 +77,9 @@ const {
       mockLookupSecret: vi.fn(),
       mockSignEthereumTransaction: vi.fn(),
       mockBroadcastSignedTransaction: vi.fn(),
+      // buildAndSignTx's gas preflight reads the wallet balance; tests drive
+      // it per-case (default healthy balance set in beforeEach).
+      mockGetBalance: vi.fn(),
     };
   }
 );
@@ -160,16 +165,18 @@ vi.mock("@/lib/logging", () => ({
   logSystemError: vi.fn(),
 }));
 
-// buildAndSignTx does live RPC reads (getTransactionCount / estimateGas /
-// estimateFeesPerGas) via viem's createPublicClient. Stub the client so
-// those reads are canned; keep serializeTransaction + http real so the
-// route's RLP encoding path still executes for real.
+// buildAndSignTx does live RPC reads (getTransactionCount / getBalance /
+// estimateGas / estimateFeesPerGas) via viem's createPublicClient. Stub the
+// client so those reads are canned; keep serializeTransaction + http real so
+// the route's RLP encoding path still executes for real. getBalance is the
+// hoisted mock so tests can drive the gas preflight per-case.
 vi.mock("viem", async (importOriginal) => {
   const actual = await importOriginal<typeof import("viem")>();
   return {
     ...actual,
     createPublicClient: (): {
       getTransactionCount: () => Promise<number>;
+      getBalance: () => Promise<bigint>;
       estimateGas: () => Promise<bigint>;
       estimateFeesPerGas: () => Promise<{
         maxFeePerGas: bigint;
@@ -177,6 +184,9 @@ vi.mock("viem", async (importOriginal) => {
       }>;
     } => ({
       getTransactionCount: async (): Promise<number> => 7,
+      // vi.fn()'s loose Mock type is not assignable to the explicit
+      // () => Promise<bigint> signature; cast the hoisted mock through.
+      getBalance: mockGetBalance as unknown as () => Promise<bigint>,
       estimateGas: async (): Promise<bigint> => BigInt(120_000),
       estimateFeesPerGas: async (): Promise<{
         maxFeePerGas: bigint;
@@ -283,6 +293,7 @@ beforeEach(() => {
   mockLookupSecret.mockReset();
   mockSignEthereumTransaction.mockReset();
   mockBroadcastSignedTransaction.mockReset();
+  mockGetBalance.mockReset();
 
   mockLookupSecret.mockResolvedValue({
     secret: TEST_HMAC_SECRET,
@@ -301,6 +312,9 @@ beforeEach(() => {
   mockBroadcastSignedTransaction.mockResolvedValue({
     txHash: BROADCAST_TX_HASH,
   });
+  // Default healthy balance (1 ETH) -- comfortably covers the canned gas
+  // cost so the existing happy-path tests clear the preflight unchanged.
+  mockGetBalance.mockResolvedValue(BigInt("1000000000000000000"));
 });
 
 describe("POST /api/agentic-wallet/feedback -- KEEP-515 retry recovery", () => {
@@ -485,5 +499,57 @@ describe("POST /api/agentic-wallet/feedback -- KEEP-515 retry recovery", () => {
     }
     // The route never reached the success update that writes txHash.
     expect(mockBroadcastSignedTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /api/agentic-wallet/feedback -- gas preflight", () => {
+  it("returns 402 INSUFFICIENT_GAS and leaves the row stranded when the wallet holds zero ETH", async () => {
+    queueSelects([]); // fresh insert path
+    mockGetBalance.mockResolvedValueOnce(BigInt(0));
+
+    const res = await callFeedback(VALID_BODY);
+
+    expect(res.status).toBe(402);
+    const json = (await res.json()) as {
+      code: string;
+      feedbackId: string;
+      balanceWei: string;
+    };
+    expect(json.code).toBe("INSUFFICIENT_GAS");
+    expect(json.feedbackId).toBe(NEW_FEEDBACK_ID);
+    expect(json.balanceWei).toBe("0");
+
+    // The row was inserted then marked "failed" -- a stranded, retryable row
+    // (KEEP-515). estimateGas is never reached; nothing is signed or cast.
+    expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      status: "failed",
+      error: expect.stringContaining("below any mainnet gas"),
+    });
+    expect(mockSignEthereumTransaction).not.toHaveBeenCalled();
+    expect(mockBroadcastSignedTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 402 INSUFFICIENT_GAS with the required amount when the balance cannot cover the estimated cost", async () => {
+    queueSelects([]); // fresh insert path
+    // Non-zero, so it clears the zero short-circuit, but far below the canned
+    // cost: gasWithHeadroom (120_000 * 1.2) * maxFeePerGas (30 gwei).
+    mockGetBalance.mockResolvedValueOnce(BigInt(1));
+
+    const res = await callFeedback(VALID_BODY);
+
+    expect(res.status).toBe(402);
+    const json = (await res.json()) as {
+      code: string;
+      balanceWei: string;
+      requiredWei: string;
+    };
+    expect(json.code).toBe("INSUFFICIENT_GAS");
+    expect(json.balanceWei).toBe("1");
+    expect(json.requiredWei).toBe(
+      (BigInt(144_000) * BigInt(30_000_000_000)).toString()
+    );
+    expect(mockSignEthereumTransaction).not.toHaveBeenCalled();
+    expect(mockBroadcastSignedTransaction).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`POST /api/agentic-wallet/feedback` went straight from building calldata to `estimateGas` with **no check of the caller wallet's ETH balance**. The caller wallet pays mainnet gas natively, so a 0-ETH wallet cannot complete the `giveFeedback()` tx — but instead of a clean error, that case failed opaquely (observed in UAT as a Cloudflare 502 with no usable body), because `estimateGas` on a 0-balance `account` can stall or error unhelpfully on some RPC providers.

This was surfaced by KEEP-515 negative-path UAT: a wallet with USDC on Base but 0 ETH on mainnet could pay for a workflow but then could not leave feedback, and got no actionable error.

## Changes

`buildAndSignTx` now does a gas preflight:
- **Zero balance** short-circuits *before* `estimateGas` is ever called — sidesteps the opaque failure entirely.
- **Non-zero balance** is re-checked against the real estimated cost (`gasWithHeadroom * maxFeePerGas`) once known.

Either case throws a new `InsufficientGasError`, which the `POST` handler catches and surfaces as **`402 INSUFFICIENT_GAS`** with `balanceWei` (and `requiredWei` when known). The feedback row is still marked `failed` with a null `txHash` — so it stays a **stranded, retryable row**: the caller funds the wallet and retries, recovering through the existing KEEP-515 stranded-retry path.

Adds integration coverage for both the zero-balance and balance-too-low branches.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm check` (biome) clean
- [x] `pnpm vitest run tests/integration/agentic-wallet-feedback-route.test.ts` — 8/8 pass (6 existing + 2 new)
- [ ] After deploy: feedback from a 0-ETH wallet returns `402 INSUFFICIENT_GAS` (not a 502); fund the wallet, retry, and the stranded row recovers

## Related

The `@keeperhub/wallet` client has a separate body-double-read bug (`dist/mcp-server.js` — `.json()` then `.text()` in the catch) that masked this server response as `Body is unusable`. Fixed separately in the agentic-wallet repo. Once the server returns clean JSON here, that client path stops mis-firing regardless.