### PR TITLE
fix(block-dispatcher): tighten failover thresholds to match dashboard red

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -61,11 +61,22 @@ const LIVENESS_DEFAULTS = {
   // Subscription-level liveness. If lastProcessedBlock has not *advanced* in
   // this window, force a reconnect. Was NO_BLOCK_TIMEOUT_MS. Renamed to make
   // the rule explicit: it is about new-height delivery, not callback fire.
-  BLOCK_ADVANCE_TIMEOUT_MS: 5 * 60_000,
+  // 60s is the floor that still tolerates Ethereum's 12s block time during
+  // testnet variance (~5 missed blocks) while detecting silent subscriptions
+  // on sub-2s chains (Polygon, Base, Avalanche, BSC) within tens of expected
+  // blocks. Combined with SILENT_FAILOVER_THRESHOLD=2, this flips a chain
+  // to fallback at 120s — the same moment the dashboard cell turns red and
+  // the Block Dispatcher Chain Silent alert finishes its for=2m debounce.
+  BLOCK_ADVANCE_TIMEOUT_MS: 60_000,
   // Reconciler-level recreate threshold. If a monitor reports not-alive for
   // longer than this gap of dead subscription, BlockMonitorService destroys
   // and recreates it. Was STALE_SUBSCRIPTION_MS. Same purpose.
-  MONITOR_RECREATE_TIMEOUT_MS: 10 * 60_000,
+  // Aligned with the dashboard red threshold (120s) so the reconciler's
+  // backstop kicks in at the same moment the alert fires. By that point the
+  // chain has already had its first 60s reconnect attempt and is about to
+  // hit the SILENT_FAILOVER_THRESHOLD flip; the recreate is the next-tier
+  // safety net for monitors that wedge during the flip itself.
+  MONITOR_RECREATE_TIMEOUT_MS: 120_000,
   // Cap on how long isReconnecting=true is acceptable before the reconciler
   // treats the monitor as dead. The normal reconnect-with-backoff path (max
   // 10 attempts, max 30s each) completes well under this; only a hung

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -477,7 +477,7 @@ describe("ChainMonitor", () => {
       expect(monitor.isAlive()).toBe(false);
     });
 
-    it("returns false when subscription has gone silent for >10 minutes", async () => {
+    it("returns false when subscription has gone silent past MONITOR_RECREATE_TIMEOUT_MS", async () => {
       // Reproduces the prod zombie state: subscription is set up but the
       // upstream WSS never delivers blocks. The in-monitor no-block timer
       // failed to fire; the reconciler must catch this via isAlive() so it
@@ -487,7 +487,12 @@ describe("ChainMonitor", () => {
       // reconciler-level staleness path is exercised on its own. (In prod,
       // the in-monitor timer was demonstrably not firing — that is the
       // failure mode this fallback exists for.)
+      //
+      // Pin the reconciler threshold so the test stays decoupled from the
+      // production default (which has been tuned tighter alongside
+      // BLOCK_ADVANCE_TIMEOUT_MS to match the dashboard red threshold).
       vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", String(60 * 60_000));
+      vi.stubEnv("MONITOR_RECREATE_TIMEOUT_MS", String(10 * 60_000));
 
       const monitor = new ChainMonitor({
         chain: makeChain(),


### PR DESCRIPTION
## Summary

Previous defaults left a **10-minute gap** between a chain going silent and the dispatcher flipping to fallback. Dashboard cell turned red at 120s and the `Block Dispatcher Chain Silent` alert finished its `for: 2m` debounce at the same point, but the dispatcher itself sat on the broken primary for another 8 minutes.

After this PR:

| | Before | After |
|---|---|---|
| First reconnect attempt | 5 min | **60s** |
| Flip to fallback (2x threshold) | 10 min | **120s** |
| Reconciler recreate backstop | 10 min | **120s** |

Aligned end-to-end: dashboard red at 120s, alert firing at 120s, dispatcher flipped at 120s.

## Why 60s and not tighter

60s is the floor that keeps Ethereum's 12s block time tolerable during testnet variance — 5 missed blocks is noisy but not unusual. Anything tighter would false-positive Ethereum during normal congestion.

For sub-2s chains (Polygon, Polygon Amoy, Base, Avalanche, BSC, Plasma, Tempo, 0G) that the canary fleet exercised today, 60s = 30+ expected blocks missed — clearly broken, no false-positive risk.

Per-chain tuning (e.g., 30s for sub-second chains) is a separate refactor that would need a `block_advance_timeout_ms` column on the `chains` table; out of scope here.

## Tests

`tests/unit/chain-monitor.test.ts` had one assertion ("stays alive for 10 minutes" reaper test) that hardcoded the old 10-min threshold in its wall-clock advance. Pinned the test via `vi.stubEnv("MONITOR_RECREATE_TIMEOUT_MS", String(10 * 60_000))` so the test stays decoupled from the prod default. All 80 unit tests pass.

```
Test Files  3 passed (3)
     Tests  80 passed (80)
```

## Safety

Both thresholds are env-overridable via the existing `liveness()` helper. If the new defaults cause unexpected reconnect churn on a specific chain in prod, set `BLOCK_ADVANCE_TIMEOUT_MS=180000` in the block-dispatcher deployment env to bump back without a code change.

The actual flip only happens after **two consecutive** 60s windows of nothing arriving on the same URL — `silentReconnects` resets on every real block advance. A single transient blip won't trigger a flip.