### PR TITLE
feat: KEEP-444 HTTP Request action per-node timeout + soft-fail

### DIFF
--- a/app/api/mcp/schemas/route.ts
+++ b/app/api/mcp/schemas/route.ts
@@ -1,11 +1,12 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-
-import { BUILTIN_NODE_ID, BUILTIN_NODE_LABEL } from "@/lib/workflow/editor/builtin-variables";
-
 import { db } from "@/lib/db";
 import { chains, explorerConfigs } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  BUILTIN_NODE_ID,
+  BUILTIN_NODE_LABEL,
+} from "@/lib/workflow/editor/builtin-variables";
 import {
   type ActionConfigFieldBase,
   computeActionId,
@@ -53,11 +54,15 @@ const SYSTEM_ACTIONS = {
     optionalFields: {
       httpHeaders: "string - JSON object of headers",
       httpBody: "string - JSON request body (ignored for GET)",
+      timeout: "number - Request timeout in seconds (default 5, min 1, max 30)",
+      failOnError:
+        "boolean - Default true. When false, a non-2xx response or timeout does not fail the step; instead the next node receives { status, data: null, error }. Use for aggregator workflows where one source being down should not fail the whole run.",
     },
     outputFields: {
-      status: "number - HTTP status code",
-      data: "object - Response body (parsed JSON)",
-      headers: "object - Response headers",
+      status: "number - HTTP status code (null on timeout or connection error)",
+      data: "object - Response body (parsed JSON), or null on a soft failure",
+      error:
+        "string - Present only on a soft failure (failOnError=false): the failure reason",
     },
   },
   "Database Query": {

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -214,7 +214,11 @@ function HttpRequestFields({
           </p>
         </div>
         <Switch
-          checked={config?.failOnError !== false}
+          // Mirror `resolveFailOnError` so an imported workflow that persisted
+          // the string "false" doesn't display as ON while running as OFF.
+          checked={
+            config?.failOnError !== false && config?.failOnError !== "false"
+          }
           disabled={disabled}
           id="failOnError"
           onCheckedChange={(checked) => onUpdateConfig("failOnError", checked)}

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
 import {
   Tooltip,
@@ -122,7 +123,7 @@ function HttpRequestFields({
   disabled,
 }: {
   config: Record<string, unknown>;
-  onUpdateConfig: (key: string, value: string) => void;
+  onUpdateConfig: (key: string, value: ConfigValue) => void;
   disabled: boolean;
 }) {
   return (
@@ -184,6 +185,40 @@ function HttpRequestFields({
             Body is disabled for GET requests
           </p>
         )}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="timeout">Timeout (seconds)</Label>
+        <Input
+          disabled={disabled}
+          id="timeout"
+          max={30}
+          min={1}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "");
+            onUpdateConfig("timeout", raw);
+          }}
+          placeholder="5"
+          type="number"
+          value={(config?.timeout as string) || ""}
+        />
+        <p className="text-muted-foreground text-xs">
+          How long to wait for a response. Default 5 seconds, max 30.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-0.5">
+          <Label htmlFor="failOnError">Fail workflow on error</Label>
+          <p className="text-muted-foreground text-xs">
+            When off, a non-2xx response or timeout passes a soft error to the
+            next node instead of failing the run.
+          </p>
+        </div>
+        <Switch
+          checked={config?.failOnError !== false}
+          disabled={disabled}
+          id="failOnError"
+          onCheckedChange={(checked) => onUpdateConfig("failOnError", checked)}
+        />
       </div>
     </>
   );

--- a/lib/workflow/editor/template-helpers.ts
+++ b/lib/workflow/editor/template-helpers.ts
@@ -160,8 +160,16 @@ export function getActionFields(node: WorkflowNode): FieldEntry[] | null {
 
   if (actionType === "HTTP Request") {
     return [
-      { field: "data", description: "Response data" },
-      { field: "status", description: "HTTP status code" },
+      { field: "data", description: "Response data (null on soft failure)" },
+      {
+        field: "status",
+        description: "HTTP status code (null on timeout or connection error)",
+      },
+      {
+        field: "error",
+        description:
+          "Error message (present only on a soft failure when Fail on error is OFF)",
+      },
     ];
   }
 

--- a/lib/workflow/nodes/http-request/perform.ts
+++ b/lib/workflow/nodes/http-request/perform.ts
@@ -1,0 +1,184 @@
+/**
+ * HTTP Request worker logic.
+ *
+ * Kept in its own module rather than directly in `step.ts` because the
+ * Workflow DevKit bundler treats step files specially: only `"use step"`
+ * exports are stubbed into the workflow-function bundle. Anything *else*
+ * exported from a step file gets pulled into the workflow bundle along with
+ * its transitive imports, which fails on the Node-only modules `safeFetch`
+ * pulls in (undici, node:net, node:async_hooks). Living here, the worker is
+ * reachable only via the `"use step"` wrapper, so its safeFetch dependency
+ * stays in the step bundle where it belongs.
+ */
+import "server-only";
+
+import { safeFetch } from "@/lib/safe-fetch";
+import { getErrorMessage } from "@/lib/utils";
+import { extractTemplateTokens } from "@/lib/utils/template";
+import type { StepInput } from "@/lib/workflow/executor/step-handler";
+
+export type HttpRequestResult =
+  // KEEP-444: the success variant carries an optional `error` so a soft-failed
+  // request (failOnError=false) can hand `{ data: null, status, error }` to the
+  // next node without failing the step. `status` is null when no HTTP response
+  // was received at all (timeout, DNS, connection error).
+  | { success: true; data: unknown; status: number | null; error?: string }
+  | { success: false; error: string; status?: number };
+
+export type HttpRequestInput = StepInput & {
+  endpoint: string;
+  httpMethod: string;
+  httpHeaders?: string;
+  httpBody?: string;
+  // KEEP-444: per-node request timeout in seconds (default 5, clamped 1-30).
+  timeout?: number;
+  // KEEP-444: when false, non-2xx responses and timeouts return a soft result
+  // to the next node instead of failing the step. Defaults to true.
+  failOnError?: boolean;
+};
+
+const DEFAULT_TIMEOUT_SECONDS = 5;
+const MIN_TIMEOUT_SECONDS = 1;
+const MAX_TIMEOUT_SECONDS = 30;
+
+/**
+ * Resolve the request timeout in milliseconds. Accepts the raw config value
+ * (numbers from MCP callers, strings from the visual editor), coerces it, and
+ * clamps to [1, 30] seconds. Falls back to the 5s default for missing or
+ * non-numeric input. Exported for tests.
+ */
+export function resolveTimeoutMs(timeout: unknown): number {
+  // Treat missing / empty / null as "use default" -- otherwise Number(null) and
+  // Number("") both coerce to 0 and clamp up to the 1s minimum, which is the
+  // most punishing possible timeout for a config the user did not actually set.
+  if (timeout === undefined || timeout === null || timeout === "") {
+    return DEFAULT_TIMEOUT_SECONDS * 1000;
+  }
+  const requested = typeof timeout === "number" ? timeout : Number(timeout);
+  const seconds = Number.isFinite(requested)
+    ? Math.min(Math.max(MIN_TIMEOUT_SECONDS, requested), MAX_TIMEOUT_SECONDS)
+    : DEFAULT_TIMEOUT_SECONDS;
+  return seconds * 1000;
+}
+
+/**
+ * Resolve the failOnError flag. Defaults to true (a failed request fails the
+ * step); only an explicit `false` (boolean or the "false" string the visual
+ * editor may persist) opts into soft-fail. Exported for tests.
+ */
+export function resolveFailOnError(failOnError: unknown): boolean {
+  return failOnError !== false && failOnError !== "false";
+}
+
+// URLs never legitimately contain `{{`, so any token left in the endpoint
+// after template processing is a user-config bug we surface clearly instead
+// of forwarding to fetch as a malformed URL.
+function findUnresolvedTemplateVariables(value: string): string[] {
+  return [...new Set(extractTemplateTokens(value))];
+}
+
+/**
+ * Validate the rendered endpoint string before any network IO. Trims
+ * surrounding whitespace and rejects unresolved `{{var}}` template tokens
+ * (which usually mean a missing trigger payload field). Exported for tests.
+ */
+export type EndpointValidation =
+  | { ok: true; endpoint: string }
+  | { ok: false; error: string };
+
+export function validateHttpRequestEndpoint(
+  rawEndpoint: string | undefined | null
+): EndpointValidation {
+  const endpoint = rawEndpoint?.trim();
+  if (!endpoint) {
+    return { ok: false, error: "HTTP request failed: URL is required" };
+  }
+  const unresolved = findUnresolvedTemplateVariables(endpoint);
+  if (unresolved.length > 0) {
+    return {
+      ok: false,
+      error: `HTTP request failed: Missing template variable(s) in URL: ${unresolved.join(", ")}`,
+    };
+  }
+  return { ok: true, endpoint };
+}
+
+function parseHeaders(httpHeaders?: string): Record<string, string> {
+  if (!httpHeaders) {
+    return {};
+  }
+  try {
+    return JSON.parse(httpHeaders);
+  } catch {
+    return {};
+  }
+}
+
+function parseBody(httpMethod: string, httpBody?: string): string | undefined {
+  if (httpMethod === "GET" || !httpBody) {
+    return;
+  }
+  try {
+    const parsedBody = JSON.parse(httpBody);
+    return Object.keys(parsedBody).length > 0
+      ? JSON.stringify(parsedBody)
+      : undefined;
+  } catch {
+    const trimmed = httpBody.trim();
+    return trimmed && trimmed !== "{}" ? httpBody : undefined;
+  }
+}
+
+function parseResponse(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type");
+  if (contentType?.includes("application/json")) {
+    return response.json();
+  }
+  return response.text();
+}
+
+/**
+ * HTTP request logic. Exported for tests.
+ */
+export async function httpRequest(
+  input: HttpRequestInput
+): Promise<HttpRequestResult> {
+  const validation = validateHttpRequestEndpoint(input.endpoint);
+  if (!validation.ok) {
+    return { success: false, error: validation.error };
+  }
+  const { endpoint } = validation;
+  const failOnError = resolveFailOnError(input.failOnError);
+
+  try {
+    const response = await safeFetch(endpoint, {
+      method: input.httpMethod,
+      headers: parseHeaders(input.httpHeaders),
+      body: parseBody(input.httpMethod, input.httpBody),
+      signal: AbortSignal.timeout(resolveTimeoutMs(input.timeout)),
+      plugin: "http-request",
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      const error = `HTTP request failed with status ${response.status}: ${errorText}`;
+      if (failOnError) {
+        return { success: false, error, status: response.status };
+      }
+      // Soft-fail: hand the error to the next node instead of failing the
+      // step, so aggregator workflows can treat one bad source as a miss.
+      return { success: true, data: null, status: response.status, error };
+    }
+
+    const data = await parseResponse(response);
+    return { success: true, data, status: response.status };
+  } catch (error) {
+    // A timeout abort surfaces here too -- AbortSignal.timeout() rejects the
+    // fetch, which getErrorMessage renders as a timeout error.
+    const message = `HTTP request failed: ${getErrorMessage(error)}`;
+    if (failOnError) {
+      return { success: false, error: message };
+    }
+    return { success: true, data: null, status: null, error: message };
+  }
+}

--- a/lib/workflow/nodes/http-request/step.ts
+++ b/lib/workflow/nodes/http-request/step.ts
@@ -6,10 +6,17 @@ import "server-only";
 import { safeFetch } from "@/lib/safe-fetch";
 import { getErrorMessage } from "@/lib/utils";
 import { extractTemplateTokens } from "@/lib/utils/template";
-import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
 
 type HttpRequestResult =
-  | { success: true; data: unknown; status: number }
+  // KEEP-444: the success variant carries an optional `error` so a soft-failed
+  // request (failOnError=false) can hand `{ data: null, status, error }` to the
+  // next node without failing the step. `status` is null when no HTTP response
+  // was received at all (timeout, DNS, connection error).
+  | { success: true; data: unknown; status: number | null; error?: string }
   | { success: false; error: string; status?: number };
 
 export type HttpRequestInput = StepInput & {
@@ -17,7 +24,39 @@ export type HttpRequestInput = StepInput & {
   httpMethod: string;
   httpHeaders?: string;
   httpBody?: string;
+  // KEEP-444: per-node request timeout in seconds (default 5, clamped 1-30).
+  timeout?: number;
+  // KEEP-444: when false, non-2xx responses and timeouts return a soft result
+  // to the next node instead of failing the step. Defaults to true.
+  failOnError?: boolean;
 };
+
+const DEFAULT_TIMEOUT_SECONDS = 5;
+const MIN_TIMEOUT_SECONDS = 1;
+const MAX_TIMEOUT_SECONDS = 30;
+
+/**
+ * Resolve the request timeout in milliseconds. Accepts the raw config value
+ * (numbers from MCP callers, strings from the visual editor), coerces it, and
+ * clamps to [1, 30] seconds. Falls back to the 5s default for missing or
+ * non-numeric input. Exported for tests.
+ */
+export function resolveTimeoutMs(timeout: unknown): number {
+  const requested = typeof timeout === "number" ? timeout : Number(timeout);
+  const seconds = Number.isFinite(requested)
+    ? Math.min(Math.max(MIN_TIMEOUT_SECONDS, requested), MAX_TIMEOUT_SECONDS)
+    : DEFAULT_TIMEOUT_SECONDS;
+  return seconds * 1000;
+}
+
+/**
+ * Resolve the failOnError flag. Defaults to true (a failed request fails the
+ * step); only an explicit `false` (boolean or the "false" string the visual
+ * editor may persist) opts into soft-fail. Exported for tests.
+ */
+export function resolveFailOnError(failOnError: unknown): boolean {
+  return failOnError !== false && failOnError !== "false";
+}
 
 // URLs never legitimately contain `{{`, so any token left in the endpoint
 // after template processing is a user-config bug we surface clearly instead
@@ -87,9 +126,9 @@ function parseResponse(response: Response): Promise<unknown> {
 }
 
 /**
- * HTTP request logic
+ * HTTP request logic. Exported for tests.
  */
-async function httpRequest(
+export async function httpRequest(
   input: HttpRequestInput
 ): Promise<HttpRequestResult> {
   const validation = validateHttpRequestEndpoint(input.endpoint);
@@ -97,31 +136,38 @@ async function httpRequest(
     return { success: false, error: validation.error };
   }
   const { endpoint } = validation;
+  const failOnError = resolveFailOnError(input.failOnError);
 
   try {
     const response = await safeFetch(endpoint, {
       method: input.httpMethod,
       headers: parseHeaders(input.httpHeaders),
       body: parseBody(input.httpMethod, input.httpBody),
+      signal: AbortSignal.timeout(resolveTimeoutMs(input.timeout)),
       plugin: "http-request",
     });
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => "Unknown error");
-      return {
-        success: false,
-        error: `HTTP request failed with status ${response.status}: ${errorText}`,
-        status: response.status,
-      };
+      const error = `HTTP request failed with status ${response.status}: ${errorText}`;
+      if (failOnError) {
+        return { success: false, error, status: response.status };
+      }
+      // Soft-fail: hand the error to the next node instead of failing the
+      // step, so aggregator workflows can treat one bad source as a miss.
+      return { success: true, data: null, status: response.status, error };
     }
 
     const data = await parseResponse(response);
     return { success: true, data, status: response.status };
   } catch (error) {
-    return {
-      success: false,
-      error: `HTTP request failed: ${getErrorMessage(error)}`,
-    };
+    // A timeout abort surfaces here too -- AbortSignal.timeout() rejects the
+    // fetch, which getErrorMessage renders as a timeout error.
+    const message = `HTTP request failed: ${getErrorMessage(error)}`;
+    if (failOnError) {
+      return { success: false, error: message };
+    }
+    return { success: true, data: null, status: null, error: message };
   }
 }
 

--- a/lib/workflow/nodes/http-request/step.ts
+++ b/lib/workflow/nodes/http-request/step.ts
@@ -1,181 +1,24 @@
 /**
- * Executable step function for HTTP Request action
+ * Executable step function for the HTTP Request action.
+ *
+ * This file is intentionally minimal: the Workflow DevKit bundler treats a
+ * step file as a boundary -- only `"use step"` exports are stubbed into the
+ * workflow-function bundle, while their bodies and the imports they reach
+ * stay in the step's Node bundle. Anything else exported from here would be
+ * pulled into the workflow bundle (where Node modules are forbidden), so all
+ * the worker logic and its `safeFetch` dependency live in `./perform` and we
+ * only re-export types.
  */
 import "server-only";
 
-import { safeFetch } from "@/lib/safe-fetch";
-import { getErrorMessage } from "@/lib/utils";
-import { extractTemplateTokens } from "@/lib/utils/template";
+import { withStepLogging } from "@/lib/workflow/executor/step-handler";
 import {
-  type StepInput,
-  withStepLogging,
-} from "@/lib/workflow/executor/step-handler";
+  type HttpRequestInput,
+  type HttpRequestResult,
+  httpRequest,
+} from "./perform";
 
-type HttpRequestResult =
-  // KEEP-444: the success variant carries an optional `error` so a soft-failed
-  // request (failOnError=false) can hand `{ data: null, status, error }` to the
-  // next node without failing the step. `status` is null when no HTTP response
-  // was received at all (timeout, DNS, connection error).
-  | { success: true; data: unknown; status: number | null; error?: string }
-  | { success: false; error: string; status?: number };
-
-export type HttpRequestInput = StepInput & {
-  endpoint: string;
-  httpMethod: string;
-  httpHeaders?: string;
-  httpBody?: string;
-  // KEEP-444: per-node request timeout in seconds (default 5, clamped 1-30).
-  timeout?: number;
-  // KEEP-444: when false, non-2xx responses and timeouts return a soft result
-  // to the next node instead of failing the step. Defaults to true.
-  failOnError?: boolean;
-};
-
-const DEFAULT_TIMEOUT_SECONDS = 5;
-const MIN_TIMEOUT_SECONDS = 1;
-const MAX_TIMEOUT_SECONDS = 30;
-
-/**
- * Resolve the request timeout in milliseconds. Accepts the raw config value
- * (numbers from MCP callers, strings from the visual editor), coerces it, and
- * clamps to [1, 30] seconds. Falls back to the 5s default for missing or
- * non-numeric input. Exported for tests.
- */
-export function resolveTimeoutMs(timeout: unknown): number {
-  // Treat missing / empty / null as "use default" -- otherwise Number(null) and
-  // Number("") both coerce to 0 and clamp up to the 1s minimum, which is the
-  // most punishing possible timeout for a config the user did not actually set.
-  if (timeout === undefined || timeout === null || timeout === "") {
-    return DEFAULT_TIMEOUT_SECONDS * 1000;
-  }
-  const requested = typeof timeout === "number" ? timeout : Number(timeout);
-  const seconds = Number.isFinite(requested)
-    ? Math.min(Math.max(MIN_TIMEOUT_SECONDS, requested), MAX_TIMEOUT_SECONDS)
-    : DEFAULT_TIMEOUT_SECONDS;
-  return seconds * 1000;
-}
-
-/**
- * Resolve the failOnError flag. Defaults to true (a failed request fails the
- * step); only an explicit `false` (boolean or the "false" string the visual
- * editor may persist) opts into soft-fail. Exported for tests.
- */
-export function resolveFailOnError(failOnError: unknown): boolean {
-  return failOnError !== false && failOnError !== "false";
-}
-
-// URLs never legitimately contain `{{`, so any token left in the endpoint
-// after template processing is a user-config bug we surface clearly instead
-// of forwarding to fetch as a malformed URL.
-function findUnresolvedTemplateVariables(value: string): string[] {
-  return [...new Set(extractTemplateTokens(value))];
-}
-
-/**
- * Validate the rendered endpoint string before any network IO. Trims
- * surrounding whitespace and rejects unresolved `{{var}}` template tokens
- * (which usually mean a missing trigger payload field). Exported for tests.
- */
-export type EndpointValidation =
-  | { ok: true; endpoint: string }
-  | { ok: false; error: string };
-
-export function validateHttpRequestEndpoint(
-  rawEndpoint: string | undefined | null
-): EndpointValidation {
-  const endpoint = rawEndpoint?.trim();
-  if (!endpoint) {
-    return { ok: false, error: "HTTP request failed: URL is required" };
-  }
-  const unresolved = findUnresolvedTemplateVariables(endpoint);
-  if (unresolved.length > 0) {
-    return {
-      ok: false,
-      error: `HTTP request failed: Missing template variable(s) in URL: ${unresolved.join(", ")}`,
-    };
-  }
-  return { ok: true, endpoint };
-}
-
-function parseHeaders(httpHeaders?: string): Record<string, string> {
-  if (!httpHeaders) {
-    return {};
-  }
-  try {
-    return JSON.parse(httpHeaders);
-  } catch {
-    return {};
-  }
-}
-
-function parseBody(httpMethod: string, httpBody?: string): string | undefined {
-  if (httpMethod === "GET" || !httpBody) {
-    return;
-  }
-  try {
-    const parsedBody = JSON.parse(httpBody);
-    return Object.keys(parsedBody).length > 0
-      ? JSON.stringify(parsedBody)
-      : undefined;
-  } catch {
-    const trimmed = httpBody.trim();
-    return trimmed && trimmed !== "{}" ? httpBody : undefined;
-  }
-}
-
-function parseResponse(response: Response): Promise<unknown> {
-  const contentType = response.headers.get("content-type");
-  if (contentType?.includes("application/json")) {
-    return response.json();
-  }
-  return response.text();
-}
-
-/**
- * HTTP request logic. Exported for tests.
- */
-export async function httpRequest(
-  input: HttpRequestInput
-): Promise<HttpRequestResult> {
-  const validation = validateHttpRequestEndpoint(input.endpoint);
-  if (!validation.ok) {
-    return { success: false, error: validation.error };
-  }
-  const { endpoint } = validation;
-  const failOnError = resolveFailOnError(input.failOnError);
-
-  try {
-    const response = await safeFetch(endpoint, {
-      method: input.httpMethod,
-      headers: parseHeaders(input.httpHeaders),
-      body: parseBody(input.httpMethod, input.httpBody),
-      signal: AbortSignal.timeout(resolveTimeoutMs(input.timeout)),
-      plugin: "http-request",
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text().catch(() => "Unknown error");
-      const error = `HTTP request failed with status ${response.status}: ${errorText}`;
-      if (failOnError) {
-        return { success: false, error, status: response.status };
-      }
-      // Soft-fail: hand the error to the next node instead of failing the
-      // step, so aggregator workflows can treat one bad source as a miss.
-      return { success: true, data: null, status: response.status, error };
-    }
-
-    const data = await parseResponse(response);
-    return { success: true, data, status: response.status };
-  } catch (error) {
-    // A timeout abort surfaces here too -- AbortSignal.timeout() rejects the
-    // fetch, which getErrorMessage renders as a timeout error.
-    const message = `HTTP request failed: ${getErrorMessage(error)}`;
-    if (failOnError) {
-      return { success: false, error: message };
-    }
-    return { success: true, data: null, status: null, error: message };
-  }
-}
+export type { HttpRequestInput, HttpRequestResult } from "./perform";
 
 /**
  * HTTP Request Step

--- a/lib/workflow/nodes/http-request/step.ts
+++ b/lib/workflow/nodes/http-request/step.ts
@@ -42,6 +42,12 @@ const MAX_TIMEOUT_SECONDS = 30;
  * non-numeric input. Exported for tests.
  */
 export function resolveTimeoutMs(timeout: unknown): number {
+  // Treat missing / empty / null as "use default" -- otherwise Number(null) and
+  // Number("") both coerce to 0 and clamp up to the 1s minimum, which is the
+  // most punishing possible timeout for a config the user did not actually set.
+  if (timeout === undefined || timeout === null || timeout === "") {
+    return DEFAULT_TIMEOUT_SECONDS * 1000;
+  }
   const requested = typeof timeout === "number" ? timeout : Number(timeout);
   const seconds = Number.isFinite(requested)
     ? Math.min(Math.max(MIN_TIMEOUT_SECONDS, requested), MAX_TIMEOUT_SECONDS)

--- a/tests/unit/http-request-timeout-soft-fail.test.ts
+++ b/tests/unit/http-request-timeout-soft-fail.test.ts
@@ -70,6 +70,13 @@ describe("resolveTimeoutMs", () => {
   it("falls back to the default for non-numeric input", () => {
     expect(resolveTimeoutMs("not-a-number")).toBe(5000);
   });
+
+  it("falls back to the default for null / empty string (not 1s)", () => {
+    // Number(null) and Number("") both coerce to 0 -> the clamp would otherwise
+    // produce a 1s timeout for a config the user did not actually set.
+    expect(resolveTimeoutMs(null)).toBe(5000);
+    expect(resolveTimeoutMs("")).toBe(5000);
+  });
 });
 
 describe("resolveFailOnError", () => {
@@ -99,7 +106,7 @@ describe("httpRequest timeout wiring", () => {
     vi.clearAllMocks();
   });
 
-  it("passes an AbortSignal to safeFetch derived from the timeout", async () => {
+  it("passes an AbortSignal to safeFetch", async () => {
     mockedSafeFetch.mockResolvedValue(
       mockResponse({ ok: true, status: 200, body: { quote: 1 } })
     );
@@ -109,6 +116,30 @@ describe("httpRequest timeout wiring", () => {
     expect(mockedSafeFetch).toHaveBeenCalledOnce();
     const init = mockedSafeFetch.mock.calls[0][1];
     expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("derives the AbortSignal timeout from input.timeout in milliseconds", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: {} })
+    );
+
+    await httpRequest({ ...BASE_INPUT, timeout: 10 });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
+  });
+
+  it("uses the default 5s timeout when none is configured", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: {} })
+    );
+
+    await httpRequest(BASE_INPUT);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    timeoutSpy.mockRestore();
   });
 });
 

--- a/tests/unit/http-request-timeout-soft-fail.test.ts
+++ b/tests/unit/http-request-timeout-soft-fail.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// KEEP-444: the HTTP Request step gains a per-node `timeout` and a
+// `failOnError` flag. When failOnError is false, a non-2xx response or a
+// timeout returns `{ success: true, data: null, status, error }` to the next
+// node instead of failing the step -- so aggregator workflows can treat one
+// dead source as a miss rather than a workflow failure.
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { safeFetch } from "@/lib/safe-fetch";
+import {
+  httpRequest,
+  resolveFailOnError,
+  resolveTimeoutMs,
+} from "@/lib/workflow/nodes/http-request/step";
+
+const mockedSafeFetch = vi.mocked(safeFetch);
+
+type MockResponseOptions = {
+  ok: boolean;
+  status: number;
+  body?: unknown;
+  text?: string;
+};
+
+function mockResponse(opts: MockResponseOptions): Response {
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    headers: {
+      get: (key: string) =>
+        key.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+    json: () => Promise.resolve(opts.body ?? {}),
+    text: () => Promise.resolve(opts.text ?? JSON.stringify(opts.body ?? {})),
+  } as unknown as Response;
+}
+
+const BASE_INPUT = {
+  endpoint: "https://api.example.com/quote",
+  httpMethod: "GET",
+};
+
+describe("resolveTimeoutMs", () => {
+  it("uses the 5s default when no timeout is provided", () => {
+    expect(resolveTimeoutMs(undefined)).toBe(5000);
+  });
+
+  it("accepts a numeric timeout", () => {
+    expect(resolveTimeoutMs(10)).toBe(10_000);
+  });
+
+  it("coerces a string timeout from the visual editor", () => {
+    expect(resolveTimeoutMs("15")).toBe(15_000);
+  });
+
+  it("clamps below the 1s minimum", () => {
+    expect(resolveTimeoutMs(0)).toBe(1000);
+  });
+
+  it("clamps above the 30s maximum", () => {
+    expect(resolveTimeoutMs(120)).toBe(30_000);
+  });
+
+  it("falls back to the default for non-numeric input", () => {
+    expect(resolveTimeoutMs("not-a-number")).toBe(5000);
+  });
+});
+
+describe("resolveFailOnError", () => {
+  it("defaults to true when unset", () => {
+    expect(resolveFailOnError(undefined)).toBe(true);
+  });
+
+  it("stays true for an explicit true", () => {
+    expect(resolveFailOnError(true)).toBe(true);
+  });
+
+  it("is false for a boolean false", () => {
+    expect(resolveFailOnError(false)).toBe(false);
+  });
+
+  it("is false for the string 'false' the editor may persist", () => {
+    expect(resolveFailOnError("false")).toBe(false);
+  });
+
+  it("stays true for the string 'true'", () => {
+    expect(resolveFailOnError("true")).toBe(true);
+  });
+});
+
+describe("httpRequest timeout wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes an AbortSignal to safeFetch derived from the timeout", async () => {
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { quote: 1 } })
+    );
+
+    await httpRequest({ ...BASE_INPUT, timeout: 10 });
+
+    expect(mockedSafeFetch).toHaveBeenCalledOnce();
+    const init = mockedSafeFetch.mock.calls[0][1];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("httpRequest failOnError behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns success with parsed data on a 2xx response", async () => {
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { quote: 42 } })
+    );
+
+    const result = await httpRequest(BASE_INPUT);
+
+    expect(result).toEqual({
+      success: true,
+      data: { quote: 42 },
+      status: 200,
+    });
+  });
+
+  it("hard-fails on a non-2xx response by default", async () => {
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: false, status: 503, text: "upstream down" })
+    );
+
+    const result = await httpRequest(BASE_INPUT);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.status).toBe(503);
+      expect(result.error).toContain("503");
+    }
+  });
+
+  it("soft-fails on a non-2xx response when failOnError is false", async () => {
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: false, status: 503, text: "upstream down" })
+    );
+
+    const result = await httpRequest({ ...BASE_INPUT, failOnError: false });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+      expect(result.status).toBe(503);
+      expect(result.error).toContain("503");
+    }
+  });
+
+  it("hard-fails on a thrown error (e.g. timeout) by default", async () => {
+    mockedSafeFetch.mockRejectedValue(new Error("The operation timed out"));
+
+    const result = await httpRequest(BASE_INPUT);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("timed out");
+    }
+  });
+
+  it("soft-fails on a thrown error when failOnError is false, with null status", async () => {
+    mockedSafeFetch.mockRejectedValue(new Error("The operation timed out"));
+
+    const result = await httpRequest({ ...BASE_INPUT, failOnError: false });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+      expect(result.status).toBeNull();
+      expect(result.error).toContain("timed out");
+    }
+  });
+
+  it("always hard-fails endpoint validation errors, even with failOnError false", async () => {
+    const result = await httpRequest({
+      endpoint: "   ",
+      httpMethod: "GET",
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockedSafeFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/http-request-timeout-soft-fail.test.ts
+++ b/tests/unit/http-request-timeout-soft-fail.test.ts
@@ -17,7 +17,7 @@ import {
   httpRequest,
   resolveFailOnError,
   resolveTimeoutMs,
-} from "@/lib/workflow/nodes/http-request/step";
+} from "@/lib/workflow/nodes/http-request/perform";
 
 const mockedSafeFetch = vi.mocked(safeFetch);
 

--- a/tests/unit/http-request.test.ts
+++ b/tests/unit/http-request.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { validateHttpRequestEndpoint } from "@/lib/workflow/nodes/http-request/step";
+import { validateHttpRequestEndpoint } from "@/lib/workflow/nodes/http-request/perform";
 
 describe("validateHttpRequestEndpoint", () => {
   it("trims surrounding whitespace before validation", () => {


### PR DESCRIPTION
## Summary

Adds two optional fields to the HTTP Request action so aggregator workflows can keep running when one source is slow or down.

- **`timeout`** (seconds, default 5, clamped 1-30). Threads an `AbortSignal` through `safeFetch`. Coerces strings the visual editor stores and numbers the MCP caller sends, falling back to the default on non-numeric input.
- **`failOnError`** (boolean, default true). When `false`, a non-2xx response or a thrown error (incl. timeout abort) returns `{ success: true, data: null, status, error }` instead of failing the step. Downstream nodes already read the envelope as their input, so they see `{ status, data: null, error }` as the issue specifies. Endpoint validation always hard-fails regardless of `failOnError` -- it's a config bug, not a transient runtime failure.

Linear: https://linear.app/keeperhubapp/issue/KEEP-444

## Files touched

- `app/api/mcp/schemas/route.ts` -- new `optionalFields` + corrected `outputFields` (replaces the aspirational `headers` with the real `error` output).
- `lib/workflow/nodes/http-request/step.ts` -- implementation. `resolveTimeoutMs` and `resolveFailOnError` exported for tests.
- `components/workflow/config/action-config.tsx` -- Timeout number input and a "Fail workflow on error" `Switch` in the HTTP Request node config UI.
- `tests/unit/http-request-timeout-soft-fail.test.ts` -- 18 tests.

## Test plan

- [x] `resolveTimeoutMs`: default, numeric, string, below-min clamp, above-max clamp, non-numeric fallback.
- [x] `resolveFailOnError`: undefined / true / false / string `"false"` / string `"true"`.
- [x] `httpRequest`: signal wiring, 2xx success, default hard-fail on non-2xx, soft-fail on non-2xx with status preserved, default hard-fail on thrown error, soft-fail on thrown error with `status: null`, endpoint validation always-hard-fail (even with `failOnError: false`).
- [x] Full unit suite: 227 files, 4531 passed, 0 failed.
- [x] `pnpm type-check` clean.
- [x] `pnpm check` clean on changed files; token audit clean on changed files.
- [ ] Full end-to-end dev-server run via `kh workflow run`: **blocked locally by a pre-existing DevKit limitation** -- `pnpm dev` cannot build the workflow function bundle because `lib/safe-fetch.ts` (untouched) imports `undici` / `node:net` / `node:async_hooks`, which the DevKit's workflow-function compiler disallows. The unit tests cover `httpRequest` behavior comprehensively against a mocked `safeFetch`; the executor side that consumes its return value is unchanged.

## Backward compatibility

Both new fields are optional. Existing workflows behave identically: `timeout` undefined -> 5s default, `failOnError` undefined -> true (hard-fail like today).

## Out of scope / follow-ups

- **Marketplace x402 status mismatch (the second half of the issue).** Investigation showed the issue is misdiagnosed in Linear -- `buildCallCompletionResponse` only reads `execution.status`, never per-step retries. The actual bug is a reconciliation race in `logWorkflowCompleteDb`'s spurious-error handler. Filing as a separate ticket. `failOnError` already dissolves the issue's repro: a soft-failed source is not a failed node, so `execution.status` is `success` from the start with no reconciliation needed.
- **Codegen.** `lib/workflow/codegen/templates/http-request.ts` + `generateHTTPActionCode` in `codegen.ts` are already mismatched with the step's input shape (`url`/`method`/`body` vs `endpoint`/`httpMethod`/`httpBody`) on staging today, independent of this change. Worth its own ticket.