### PR TITLE
chore: KEEP-570 add WS frame instrumentation and local probe scripts

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -204,6 +204,14 @@ export class ChainMonitor {
   // SILENT_FAILOVER_THRESHOLD, the next reconnect flips currentUrlIndex so the
   // monitor tries the other configured URL (primary <-> fallback).
   private silentReconnects = 0;
+  // KEEP-570 diagnostic counters. These observe the raw ws socket independent
+  // of ethers' subscription routing. They distinguish "subscription confirmed,
+  // pushes routed, dedup discarded them" from "pushes never arrived" from
+  // "pushes arrived but ethers never routed them". Reset in subscribeToBlocks.
+  private wsFrameCount = 0;
+  private subscriptionPushCount = 0;
+  private lastWsFrameAt: number | null = null;
+  private wsMessageHandler: ((data: unknown) => void) | null = null;
 
   constructor(config: ChainMonitorConfig) {
     this.chainId = config.chain.chainId;
@@ -347,10 +355,20 @@ export class ChainMonitor {
       // stale handlers from firing handleDisconnect during teardown
       if (this.wsCloseHandler) {
         const ws = this.provider.websocket as unknown as {
-          removeListener?: (event: string, cb: () => void) => void;
+          removeListener?: (event: string, cb: (data?: unknown) => void) => void;
         };
         ws?.removeListener?.("close", this.wsCloseHandler);
         this.wsCloseHandler = null;
+      }
+      // KEEP-570: detach the diagnostic message tap before destroying so it
+      // does not retain a reference to the closed socket or fire on the
+      // teardown frames ethers sends during eth_unsubscribe.
+      if (this.wsMessageHandler) {
+        const ws = this.provider.websocket as unknown as {
+          removeListener?: (event: string, cb: (data?: unknown) => void) => void;
+        };
+        ws?.removeListener?.("message", this.wsMessageHandler);
+        this.wsMessageHandler = null;
       }
 
       // ethers v6 removeAllListeners/destroy fire an internal eth_unsubscribe
@@ -515,6 +533,12 @@ export class ChainMonitor {
     // a real block looked permanently alive to the reconciler. The cold-
     // start warmup case is now handled by monitorBootAt in isAlive().
     const subscribedAt = Date.now();
+    // KEEP-570 diagnostic: reset the per-subscription frame counters so the
+    // noBlockTimer log shows what happened on THIS subscription, not the
+    // cumulative since pod start.
+    this.wsFrameCount = 0;
+    this.subscriptionPushCount = 0;
+    this.lastWsFrameAt = null;
     metrics.setHasActiveSubscription(this.chainName, true);
     metrics.setSubscribedAt(this.chainName, subscribedAt);
     // resetNoBlockTimer is called from start/reconnect, but seed it here too
@@ -526,7 +550,7 @@ export class ChainMonitor {
 
     // Handle WebSocket close for reconnection - store reference for cleanup
     const ws = this.provider.websocket as unknown as {
-      on?: (event: string, cb: () => void) => void;
+      on?: (event: string, cb: (data?: unknown) => void) => void;
     };
     if (ws?.on) {
       this.wsCloseHandler = (): void => {
@@ -537,6 +561,33 @@ export class ChainMonitor {
         this.handleDisconnect();
       };
       ws.on("close", this.wsCloseHandler);
+
+      // KEEP-570 diagnostic: tap the raw ws below ethers' subscription
+      // routing. Counts every incoming frame and decodes enough JSON to
+      // identify eth_subscription pushes. Lets the noBlockTimer log
+      // distinguish "no frames at all" from "frames arrived but ethers did
+      // not route them to onBlock". The ws library's "message" event fires
+      // alongside ethers' onmessage property handler, so this tap does not
+      // intercept or shadow ethers' own message processing.
+      this.wsMessageHandler = (data: unknown): void => {
+        this.wsFrameCount++;
+        this.lastWsFrameAt = Date.now();
+        try {
+          const text =
+            typeof data === "string"
+              ? data
+              : data instanceof Buffer
+                ? data.toString("utf8")
+                : String(data);
+          const parsed = JSON.parse(text) as { method?: string };
+          if (parsed?.method === "eth_subscription") {
+            this.subscriptionPushCount++;
+          }
+        } catch {
+          // Non-JSON or partial frame; counted in wsFrameCount, ignored here.
+        }
+      };
+      ws.on("message", this.wsMessageHandler);
     }
   }
 
@@ -827,8 +878,23 @@ export class ChainMonitor {
           this.silentReconnects,
         );
         metrics.recordWsClose(this.chainName, "block_advance_timeout");
+        // KEEP-570: enrich the silent-window warning with the raw ws frame
+        // counters. The three load-bearing comparisons:
+        //   wsFrameCount == 0  -> no frames at all (network or upstream silent)
+        //   wsFrameCount > 0 && subscriptionPushCount == 0 -> only req/response
+        //                       and keepalives, no newHeads pushes
+        //   subscriptionPushCount > 0 && blocksReceived == 0 -> ethers received
+        //                       pushes but did not route them to onBlock
+        //                       (the ethers v6 sharp edge)
+        const lastFrameAgoMs =
+          this.lastWsFrameAt === null
+            ? null
+            : Date.now() - this.lastWsFrameAt;
         console.warn(
-          `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s (silent reconnects=${this.silentReconnects}), triggering reconnect`,
+          `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s ` +
+            `(silentReconnects=${this.silentReconnects}, wsFrames=${this.wsFrameCount}, ` +
+            `subscriptionPushes=${this.subscriptionPushCount}, blocksReceived=${this.blocksReceived}, ` +
+            `lastFrameAgo=${lastFrameAgoMs === null ? "never" : `${lastFrameAgoMs}ms`}), triggering reconnect`,
         );
         this.handleDisconnect();
       }

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -355,7 +355,10 @@ export class ChainMonitor {
       // stale handlers from firing handleDisconnect during teardown
       if (this.wsCloseHandler) {
         const ws = this.provider.websocket as unknown as {
-          removeListener?: (event: string, cb: (data?: unknown) => void) => void;
+          removeListener?: (
+            event: string,
+            cb: (data?: unknown) => void,
+          ) => void;
         };
         ws?.removeListener?.("close", this.wsCloseHandler);
         this.wsCloseHandler = null;
@@ -365,7 +368,10 @@ export class ChainMonitor {
       // teardown frames ethers sends during eth_unsubscribe.
       if (this.wsMessageHandler) {
         const ws = this.provider.websocket as unknown as {
-          removeListener?: (event: string, cb: (data?: unknown) => void) => void;
+          removeListener?: (
+            event: string,
+            cb: (data?: unknown) => void,
+          ) => void;
         };
         ws?.removeListener?.("message", this.wsMessageHandler);
         this.wsMessageHandler = null;
@@ -887,9 +893,7 @@ export class ChainMonitor {
         //                       pushes but did not route them to onBlock
         //                       (the ethers v6 sharp edge)
         const lastFrameAgoMs =
-          this.lastWsFrameAt === null
-            ? null
-            : Date.now() - this.lastWsFrameAt;
+          this.lastWsFrameAt === null ? null : Date.now() - this.lastWsFrameAt;
         console.warn(
           `[BlockMonitor:${this.chainName}] Block height has not advanced in ${timeoutMs / 1000}s ` +
             `(silentReconnects=${this.silentReconnects}, wsFrames=${this.wsFrameCount}, ` +

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -141,6 +141,30 @@ type ChainMonitorConfig = {
   workflows: BlockWorkflow[];
 };
 
+// Decodes a `ws` library "message" event payload to a string for the KEEP-570
+// raw-frame diagnostic. The ws library can deliver `data` as string, Buffer,
+// Buffer[] (fragmented frames, when the high-water mark is reached mid-frame),
+// or ArrayBuffer (when binaryType is "arraybuffer"). ethers v6 configures
+// Buffer today, but a silent under-count if upstream changes that is exactly
+// the regression the diagnostic exists to prevent. Returns null when the
+// payload is none of those shapes; the caller still counts the frame but
+// will not attempt to parse it for the subscription-push tally.
+function decodeWsFrame(data: unknown): string | null {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  if (Array.isArray(data) && data.every((d) => Buffer.isBuffer(d))) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  return null;
+}
+
 // Reduces a probe-failure error to a single short tag like "HTTP 429",
 // "timeout", or a 60-char first-line slice. Keeps log lines compact —
 // ethers errors can include long JSON-RPC payloads and ABI dumps otherwise.
@@ -578,13 +602,17 @@ export class ChainMonitor {
       this.wsMessageHandler = (data: unknown): void => {
         this.wsFrameCount++;
         this.lastWsFrameAt = Date.now();
+        // The ws library can deliver a frame as string, Buffer, Buffer[]
+        // (fragmented), or ArrayBuffer (when binaryType is set). ethers v6
+        // configures Buffer today, but a quiet under-count if upstream
+        // changes that is exactly the kind of regression this diagnostic
+        // is supposed to prevent. Decode all four shapes; anything else
+        // counts as a frame but is not parsed for the push counter.
+        const text = decodeWsFrame(data);
+        if (text === null) {
+          return;
+        }
         try {
-          const text =
-            typeof data === "string"
-              ? data
-              : data instanceof Buffer
-                ? data.toString("utf8")
-                : String(data);
           const parsed = JSON.parse(text) as { method?: string };
           if (parsed?.method === "eth_subscription") {
             this.subscriptionPushCount++;

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -149,7 +149,7 @@ type ChainMonitorConfig = {
 // the regression the diagnostic exists to prevent. Returns null when the
 // payload is none of those shapes; the caller still counts the frame but
 // will not attempt to parse it for the subscription-push tally.
-function decodeWsFrame(data: unknown): string | null {
+export function decodeWsFrame(data: unknown): string | null {
   if (typeof data === "string") {
     return data;
   }

--- a/keeperhub-scheduler/debug/ethers-stress-repro.ts
+++ b/keeperhub-scheduler/debug/ethers-stress-repro.ts
@@ -63,7 +63,9 @@ process.on("unhandledRejection", (reason: unknown) => {
 
 function startHealthyMockServer(serverPort: number): WebSocketServer {
   let blockNumber = 0x1000;
-  const server = new WebSocketServer({ port: serverPort });
+  // Bind to loopback only; this is a debug-only mock that does not need
+  // to be reachable externally.
+  const server = new WebSocketServer({ port: serverPort, host: "127.0.0.1" });
   let connectionCount = 0;
   let liveConnections = 0;
 

--- a/keeperhub-scheduler/debug/ethers-stress-repro.ts
+++ b/keeperhub-scheduler/debug/ethers-stress-repro.ts
@@ -1,0 +1,347 @@
+/**
+ * KEEP-570 - Ethers v6 WebSocketProvider accumulated-state stress repro.
+ *
+ * Hypothesis: the prod failure mode where a long-running dispatcher Node
+ * process stops routing newHeads to its subscribers, while a fresh Node
+ * process in the same pod against the same URL works fine, is caused by
+ * accumulated state inside ethers v6 (or the `ws` library) across many
+ * connect-and-destroy cycles in a single process.
+ *
+ * This script tries to reproduce that. In a single Node process:
+ *   1. Starts a healthy in-process ws mock server that pushes a newHead
+ *      every 200 ms to any subscriber.
+ *   2. Runs a stress loop: create a fresh `ethers.WebSocketProvider`,
+ *      call getBlockNumber, attach a "block" listener, wait briefly,
+ *      then tear it down. Repeat thousands of times.
+ *   3. Every N cycles, runs a "probe": creates a fresh provider and
+ *      counts how many `newHeads` it actually receives in a fixed window.
+ *      If a probe ever receives zero newHeads from the same healthy
+ *      server the bug has reproduced locally.
+ *   4. Logs heap RSS, event-loop lag, and provider counts at each probe
+ *      so we can correlate the failure with any resource trend.
+ *
+ * If the script completes thousands of cycles and every probe reads
+ * newHeads correctly, the bug is below ethers (provider-side, network,
+ * cluster-egress) and the fix needs to look elsewhere.
+ *
+ * Usage:
+ *   pnpm tsx keeperhub-scheduler/debug/ethers-stress-repro.ts \
+ *     [stressCycles=2000] [probeEvery=100] [probeDurationMs=5000] [port=19200]
+ */
+
+import { ethers } from "ethers";
+import { type WebSocket, WebSocketServer } from "ws";
+
+const stressCycles = Number.parseInt(process.argv[2] ?? "2000", 10);
+const probeEvery = Number.parseInt(process.argv[3] ?? "100", 10);
+const probeDurationMs = Number.parseInt(process.argv[4] ?? "5000", 10);
+const port = Number.parseInt(process.argv[5] ?? "19200", 10);
+
+console.log("─".repeat(72));
+console.log(
+  `Stress params: cycles=${stressCycles} probeEvery=${probeEvery} probeDurationMs=${probeDurationMs} port=${port}`,
+);
+console.log("─".repeat(72));
+
+// Track unhandled rejections that come from the benign destroy-race.
+const benignRejections: string[] = [];
+process.on("unhandledRejection", (reason: unknown) => {
+  if (reason instanceof Error) {
+    const code = (reason as Error & { code?: string }).code;
+    const operation = (reason as Error & { operation?: string }).operation;
+    if (code === "UNSUPPORTED_OPERATION" && operation === "eth_unsubscribe") {
+      benignRejections.push(reason.message);
+      return;
+    }
+  }
+  console.error("UNHANDLED REJECTION", reason);
+});
+
+// ---------------------------------------------------------------------------
+// Mock server (healthy mode only)
+// ---------------------------------------------------------------------------
+
+function startHealthyMockServer(serverPort: number): WebSocketServer {
+  let blockNumber = 0x1000;
+  const server = new WebSocketServer({ port: serverPort });
+  let connectionCount = 0;
+  let liveConnections = 0;
+
+  function send(ws: WebSocket, payload: unknown): void {
+    if (ws.readyState !== 1) {
+      return;
+    }
+    ws.send(JSON.stringify(payload));
+  }
+
+  function pushNewHead(ws: WebSocket, subId: string): void {
+    blockNumber++;
+    const num = `0x${blockNumber.toString(16)}`;
+    send(ws, {
+      jsonrpc: "2.0",
+      method: "eth_subscription",
+      params: {
+        subscription: subId,
+        result: {
+          number: num,
+          hash: `0x${blockNumber.toString(16).padStart(64, "a")}`,
+          parentHash: `0x${(blockNumber - 1).toString(16).padStart(64, "b")}`,
+          timestamp: `0x${Math.floor(Date.now() / 1000).toString(16)}`,
+          gasLimit: "0x1c9c380",
+          gasUsed: "0x0",
+          baseFeePerGas: "0x1",
+          miner: "0x0000000000000000000000000000000000000000",
+          difficulty: "0x0",
+        },
+      },
+    });
+  }
+
+  server.on("connection", (ws) => {
+    connectionCount++;
+    liveConnections++;
+    const timers: NodeJS.Timeout[] = [];
+
+    ws.on("message", (raw) => {
+      let msg: { id?: number; method?: string };
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      if (msg.method === "eth_chainId") {
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: "0x1" });
+        return;
+      }
+      if (msg.method === "net_version") {
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: "1" });
+        return;
+      }
+      if (msg.method === "eth_blockNumber") {
+        send(ws, {
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: `0x${blockNumber.toString(16)}`,
+        });
+        return;
+      }
+      if (msg.method === "eth_subscribe") {
+        const subId = `0x${Math.random()
+          .toString(16)
+          .slice(2)
+          .padEnd(32, "0")}`;
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: subId });
+        const t = setInterval(() => pushNewHead(ws, subId), 200);
+        timers.push(t);
+        return;
+      }
+      if (msg.method === "eth_unsubscribe") {
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: true });
+        return;
+      }
+      send(ws, {
+        jsonrpc: "2.0",
+        id: msg.id,
+        error: { code: -32601, message: `method ${msg.method} not found` },
+      });
+    });
+
+    ws.on("close", () => {
+      liveConnections--;
+      for (const t of timers) {
+        clearInterval(t);
+      }
+    });
+  });
+
+  Object.defineProperty(server, "stats", {
+    get: () => ({ total: connectionCount, live: liveConnections }),
+  });
+
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// Single provider cycle: create, connect, subscribe, tear down.
+// ---------------------------------------------------------------------------
+
+async function runStressCycle(url: string, lifetimeMs: number): Promise<void> {
+  const provider = new ethers.WebSocketProvider(url);
+  try {
+    await provider.getBlockNumber();
+  } catch {
+    // ignore; the tear-down still has to happen
+  }
+  try {
+    await provider.on("block", () => {
+      // discard
+    });
+  } catch {
+    // ignore
+  }
+  await new Promise((r) => setTimeout(r, lifetimeMs));
+  try {
+    await provider.removeAllListeners();
+  } catch {
+    // ignore
+  }
+  try {
+    await provider.destroy();
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probe: how many newHeads does a fresh provider see in `durationMs`?
+// ---------------------------------------------------------------------------
+
+async function runProbe(url: string, durationMs: number): Promise<number> {
+  const provider = new ethers.WebSocketProvider(url);
+  let blocks = 0;
+  try {
+    await provider.getBlockNumber();
+    await provider.on("block", () => {
+      blocks++;
+    });
+    await new Promise((r) => setTimeout(r, durationMs));
+  } finally {
+    try {
+      await provider.removeAllListeners();
+    } catch {
+      // ignore
+    }
+    try {
+      await provider.destroy();
+    } catch {
+      // ignore
+    }
+  }
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function fmtBytes(b: number): string {
+  return `${(b / 1024 / 1024).toFixed(1)}MB`;
+}
+
+async function eventLoopLagMs(): Promise<number> {
+  const start = Date.now();
+  await new Promise((r) => setImmediate(r));
+  return Date.now() - start;
+}
+
+async function main(): Promise<void> {
+  const server = startHealthyMockServer(port);
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", () => resolve());
+    server.once("error", reject);
+  });
+  const url = `ws://localhost:${port}`;
+  console.log(`Mock server listening on ${url}`);
+
+  // Sanity probe first
+  const sanity = await runProbe(url, 2_000);
+  console.log(`Sanity probe (cycle 0): newHeads=${sanity}`);
+  if (sanity === 0) {
+    console.error("FATAL: sanity probe failed - mock server or ethers not working");
+    process.exit(1);
+  }
+
+  const probeHistory: Array<{
+    cycle: number;
+    blocks: number;
+    heapRss: number;
+    heapUsed: number;
+    eventLoopLag: number;
+    liveConnections: number;
+    totalConnections: number;
+    benignRejectionCount: number;
+  }> = [];
+
+  const stressStart = Date.now();
+  let stressBudgetMs = 0;
+
+  for (let cycle = 1; cycle <= stressCycles; cycle++) {
+    const cycleStart = Date.now();
+    await runStressCycle(url, 200);
+    stressBudgetMs += Date.now() - cycleStart;
+
+    if (cycle % probeEvery === 0) {
+      const lag = await eventLoopLagMs();
+      const mem = process.memoryUsage();
+      const stats = (server as unknown as {
+        stats: { total: number; live: number };
+      }).stats;
+      const blocks = await runProbe(url, probeDurationMs);
+      const sample = {
+        cycle,
+        blocks,
+        heapRss: mem.rss,
+        heapUsed: mem.heapUsed,
+        eventLoopLag: lag,
+        liveConnections: stats.live,
+        totalConnections: stats.total,
+        benignRejectionCount: benignRejections.length,
+      };
+      probeHistory.push(sample);
+      const tag = blocks === 0 ? " <<< FAILURE" : "";
+      console.log(
+        `cycle=${cycle.toString().padStart(5)} ` +
+          `probe newHeads=${blocks.toString().padStart(3)} ` +
+          `rss=${fmtBytes(mem.rss).padStart(7)} ` +
+          `heap=${fmtBytes(mem.heapUsed).padStart(7)} ` +
+          `lag=${lag}ms ` +
+          `live=${stats.live} ` +
+          `total=${stats.total} ` +
+          `benignRejects=${benignRejections.length}${tag}`,
+      );
+      if (blocks === 0) {
+        console.log(
+          "REPRO HIT: a fresh ethers WebSocketProvider in this process " +
+            "received zero newHeads from the same server that delivered " +
+            `${sanity} blocks at process start.`,
+        );
+        console.log(
+          "Letting the loop continue so we can see whether subsequent " +
+            "probes also fail or whether this was a transient hiccup.",
+        );
+      }
+    }
+  }
+
+  const totalElapsedMs = Date.now() - stressStart;
+  console.log("─".repeat(72));
+  console.log(
+    `Done. ${stressCycles} stress cycles in ${(totalElapsedMs / 1000).toFixed(1)}s ` +
+      `(avg ${Math.round(stressBudgetMs / stressCycles)}ms/cycle).`,
+  );
+  const failures = probeHistory.filter((p) => p.blocks === 0);
+  if (failures.length === 0) {
+    console.log(
+      `All ${probeHistory.length} probes received newHeads. Hypothesis ` +
+        "REFUTED: in-process accumulated state in ethers/ws does not " +
+        "explain the prod failure mode (within this many cycles).",
+    );
+  } else {
+    console.log(
+      `REPRODUCED on ${failures.length}/${probeHistory.length} probes: ` +
+        `cycles ${failures.map((f) => f.cycle).join(", ")}`,
+    );
+  }
+  console.log(
+    `Benign destroy-race rejections: ${benignRejections.length}. ` +
+      "(These mirror the 53/5000 lines we saw in prod logs.)",
+  );
+
+  server.close();
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch((err: unknown) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/keeperhub-scheduler/debug/ethers-stress-repro.ts
+++ b/keeperhub-scheduler/debug/ethers-stress-repro.ts
@@ -247,7 +247,9 @@ async function main(): Promise<void> {
   const sanity = await runProbe(url, 2_000);
   console.log(`Sanity probe (cycle 0): newHeads=${sanity}`);
   if (sanity === 0) {
-    console.error("FATAL: sanity probe failed - mock server or ethers not working");
+    console.error(
+      "FATAL: sanity probe failed - mock server or ethers not working",
+    );
     process.exit(1);
   }
 
@@ -273,9 +275,11 @@ async function main(): Promise<void> {
     if (cycle % probeEvery === 0) {
       const lag = await eventLoopLagMs();
       const mem = process.memoryUsage();
-      const stats = (server as unknown as {
-        stats: { total: number; live: number };
-      }).stats;
+      const stats = (
+        server as unknown as {
+          stats: { total: number; live: number };
+        }
+      ).stats;
       const blocks = await runProbe(url, probeDurationMs);
       const sample = {
         cycle,
@@ -301,9 +305,7 @@ async function main(): Promise<void> {
       );
       if (blocks === 0) {
         console.log(
-          "REPRO HIT: a fresh ethers WebSocketProvider in this process " +
-            "received zero newHeads from the same server that delivered " +
-            `${sanity} blocks at process start.`,
+          `REPRO HIT: a fresh ethers WebSocketProvider in this process received zero newHeads from the same server that delivered ${sanity} blocks at process start.`,
         );
         console.log(
           "Letting the loop continue so we can see whether subsequent " +
@@ -322,9 +324,7 @@ async function main(): Promise<void> {
   const failures = probeHistory.filter((p) => p.blocks === 0);
   if (failures.length === 0) {
     console.log(
-      `All ${probeHistory.length} probes received newHeads. Hypothesis ` +
-        "REFUTED: in-process accumulated state in ethers/ws does not " +
-        "explain the prod failure mode (within this many cycles).",
+      `All ${probeHistory.length} probes received newHeads. Hypothesis REFUTED: in-process accumulated state in ethers/ws does not explain the prod failure mode (within this many cycles).`,
     );
   } else {
     console.log(
@@ -333,8 +333,7 @@ async function main(): Promise<void> {
     );
   }
   console.log(
-    `Benign destroy-race rejections: ${benignRejections.length}. ` +
-      "(These mirror the 53/5000 lines we saw in prod logs.)",
+    `Benign destroy-race rejections: ${benignRejections.length}. (These mirror the 53/5000 lines we saw in prod logs.)`,
   );
 
   server.close();

--- a/keeperhub-scheduler/debug/wss-compare.ts
+++ b/keeperhub-scheduler/debug/wss-compare.ts
@@ -105,7 +105,9 @@ rawWs.on("error", (err: Error) => {
 });
 
 rawWs.on("close", (code: number, reason: Buffer) => {
-  console.log(`[raw] close code=${code} reason=${reason.toString() || "(none)"}`);
+  console.log(
+    `[raw] close code=${code} reason=${reason.toString() || "(none)"}`,
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/keeperhub-scheduler/debug/wss-compare.ts
+++ b/keeperhub-scheduler/debug/wss-compare.ts
@@ -1,0 +1,212 @@
+/**
+ * KEEP-570 — WSS Subscription Comparison Probe
+ *
+ * Opens TWO independent WebSocket connections to the same URL:
+ *   1. A raw `ws` socket that sends eth_subscribe(["newHeads"]) directly.
+ *   2. An ethers v6 WebSocketProvider with provider.on("block", cb).
+ *
+ * Counts incoming frames on each for a fixed window and prints a verdict.
+ *
+ * Distinguishes the three failure modes the dispatcher cannot tell apart on
+ * its own:
+ *
+ *   raw newHeads > 0, ethers blocks == 0, ethers pushes > 0
+ *     ETHERS_ROUTING: pushes arrive at ethers' socket but never reach the
+ *     "block" listener. The bug is in ethers' SocketSubscriber lifecycle,
+ *     most likely _register never fired because the eth_subscribe response
+ *     was lost or the subscriber.start() chain rejected silently.
+ *
+ *   raw newHeads > 0, ethers blocks == 0, ethers pushes == 0
+ *     CONNECTION_SPECIFIC: same URL, different connection, different
+ *     behavior. Suggests the upstream is doing per-connection sticky
+ *     routing and sending one client to a healthy backend and another to
+ *     a zombie one. Less likely but worth seeing.
+ *
+ *   raw newHeads == 0, ethers blocks == 0
+ *     UPSTREAM_SILENT: the endpoint accepts the subscription but never
+ *     sends newHeads pushes to anyone. Provider-side issue, not ours.
+ *
+ *   raw newHeads > 0, ethers blocks > 0
+ *     BOTH_HEALTHY: cannot reproduce the bug against this endpoint right
+ *     now. Try again when the dispatcher reports a chain stuck.
+ *
+ * Usage:
+ *   pnpm tsx keeperhub-scheduler/debug/wss-compare.ts <wss-url> [duration-seconds]
+ *
+ * Example:
+ *   pnpm tsx keeperhub-scheduler/debug/wss-compare.ts \
+ *     'wss://lb.drpc.live/polygon/<key>' 60
+ *
+ * To probe a Cloudflare-Access-gated primary, run this inside the cluster:
+ *   kubectl run probe --rm -it --image=node:24-slim --restart=Never -- \
+ *     sh -c 'npm i ethers ws tsx >/dev/null && \
+ *            npx tsx https://raw.githubusercontent.com/.../wss-compare.ts <url>'
+ */
+
+import { ethers } from "ethers";
+import WebSocket from "ws";
+
+const url = process.argv[2];
+const durationSec = Number.parseInt(process.argv[3] ?? "60", 10);
+if (!url) {
+  console.error(
+    "usage: pnpm tsx keeperhub-scheduler/debug/wss-compare.ts <wss-url> [duration-seconds]",
+  );
+  process.exit(1);
+}
+
+console.log(`Probing ${url} for ${durationSec}s`);
+console.log("─".repeat(72));
+
+// ---------------------------------------------------------------------------
+// Raw ws probe
+// ---------------------------------------------------------------------------
+
+const rawWs = new WebSocket(url);
+let rawSubscriptionId: string | null = null;
+let rawNewHeads = 0;
+let rawAllFrames = 0;
+const rawStartedAt = Date.now();
+
+rawWs.on("open", () => {
+  console.log(`[raw] open at +${Date.now() - rawStartedAt}ms`);
+  rawWs.send(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_subscribe",
+      params: ["newHeads"],
+    }),
+  );
+});
+
+rawWs.on("message", (data: Buffer) => {
+  rawAllFrames++;
+  let msg: { id?: number; result?: string; method?: string };
+  try {
+    msg = JSON.parse(data.toString("utf8"));
+  } catch {
+    return;
+  }
+  if (msg.id === 1 && typeof msg.result === "string") {
+    rawSubscriptionId = msg.result;
+    console.log(
+      `[raw] subscribed at +${Date.now() - rawStartedAt}ms id=${rawSubscriptionId}`,
+    );
+    return;
+  }
+  if (msg.method === "eth_subscription") {
+    rawNewHeads++;
+  }
+});
+
+rawWs.on("error", (err: Error) => {
+  console.error(`[raw] error: ${err.message}`);
+});
+
+rawWs.on("close", (code: number, reason: Buffer) => {
+  console.log(`[raw] close code=${code} reason=${reason.toString() || "(none)"}`);
+});
+
+// ---------------------------------------------------------------------------
+// Ethers v6 probe (same code path as the dispatcher)
+// ---------------------------------------------------------------------------
+
+const ethersProvider = new ethers.WebSocketProvider(url);
+let ethersBlocks = 0;
+let ethersAllFrames = 0;
+let ethersPushFrames = 0;
+const ethersStartedAt = Date.now();
+
+const ethersWs = ethersProvider.websocket as unknown as {
+  on?: (event: string, cb: (data: unknown) => void) => void;
+};
+ethersWs.on?.("message", (data: unknown) => {
+  ethersAllFrames++;
+  let text: string;
+  if (typeof data === "string") {
+    text = data;
+  } else if (data instanceof Buffer) {
+    text = data.toString("utf8");
+  } else {
+    return;
+  }
+  try {
+    const parsed = JSON.parse(text) as { method?: string };
+    if (parsed.method === "eth_subscription") {
+      ethersPushFrames++;
+    }
+  } catch {
+    // ignore non-JSON frames
+  }
+});
+
+async function startEthersProbe(): Promise<void> {
+  // Match the dispatcher's connect path: do a real send to confirm readiness.
+  const blockNumber = await ethersProvider.getBlockNumber();
+  console.log(
+    `[ethers] socket ready at +${Date.now() - ethersStartedAt}ms head=${blockNumber}`,
+  );
+  await ethersProvider.on("block", (n: number) => {
+    ethersBlocks++;
+    if (ethersBlocks === 1) {
+      console.log(
+        `[ethers] first block delivered at +${Date.now() - ethersStartedAt}ms (n=${n})`,
+      );
+    }
+  });
+  console.log(
+    `[ethers] block listener attached at +${Date.now() - ethersStartedAt}ms`,
+  );
+}
+
+startEthersProbe().catch((err: unknown) => {
+  console.error(
+    `[ethers] startup error: ${err instanceof Error ? err.message : String(err)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Verdict
+// ---------------------------------------------------------------------------
+
+setTimeout(() => {
+  console.log("─".repeat(72));
+  console.log(`Window: ${durationSec}s`);
+  console.log(
+    `[raw]    subscriptionId=${rawSubscriptionId ?? "NONE"}, allFrames=${rawAllFrames}, newHeads=${rawNewHeads}`,
+  );
+  console.log(
+    `[ethers] blocks=${ethersBlocks}, allFrames=${ethersAllFrames}, subscriptionPushes=${ethersPushFrames}`,
+  );
+  console.log("─".repeat(72));
+
+  let verdict: string;
+  if (rawNewHeads > 0 && ethersBlocks === 0 && ethersPushFrames > 0) {
+    verdict =
+      "ETHERS_ROUTING: pushes reached ethers' socket but not the listener. " +
+      "Bug is in ethers v6 SocketSubscriber. _register likely never fired.";
+  } else if (rawNewHeads > 0 && ethersBlocks === 0 && ethersPushFrames === 0) {
+    verdict =
+      "CONNECTION_SPECIFIC: raw ws receives pushes on this URL but the " +
+      "ethers connection to the same URL receives none. Sticky upstream " +
+      "routing or per-connection rate limiting.";
+  } else if (rawNewHeads === 0 && ethersBlocks === 0) {
+    verdict =
+      "UPSTREAM_SILENT: neither client receives newHeads. Endpoint is " +
+      "in the prod failure state right now. Provider-side issue.";
+  } else if (rawNewHeads > 0 && ethersBlocks > 0) {
+    verdict =
+      "BOTH_HEALTHY: endpoint is delivering newHeads to both clients. " +
+      "Cannot reproduce the bug against this URL in this window.";
+  } else {
+    verdict = "INCONCLUSIVE: see counters above";
+  }
+  console.log(`VERDICT: ${verdict}`);
+
+  rawWs.close();
+  ethersProvider.destroy().catch(() => {
+    // ignore teardown errors
+  });
+  setTimeout(() => process.exit(0), 500);
+}, durationSec * 1000);

--- a/keeperhub-scheduler/debug/wss-mock-zombie.ts
+++ b/keeperhub-scheduler/debug/wss-mock-zombie.ts
@@ -1,0 +1,225 @@
+/**
+ * KEEP-570 — Mock WSS Server with Selectable Failure Modes
+ *
+ * Speaks just enough JSON-RPC for ethers v6's WebSocketProvider startup
+ * (eth_chainId, eth_blockNumber, net_version, eth_subscribe) and then
+ * behaves according to the chosen scenario. Lets us reproduce each of the
+ * three suspected failure modes offline.
+ *
+ * Scenarios:
+ *
+ *   healthy
+ *     Responds to eth_subscribe with a subscription ID and pushes a
+ *     newHeads notification every 2 seconds. Baseline / control.
+ *
+ *   zombie
+ *     Responds to eth_subscribe with a subscription ID. Never pushes any
+ *     newHeads. Reproduces what Joel observed in prod: "Block subscription
+ *     active" + zero newHeads.
+ *
+ *   subscribe-no-response
+ *     Receives the eth_subscribe but never sends back a response. The
+ *     ethers SocketSubscriber's #filterId promise never resolves and
+ *     _register is never called. Any push that did arrive afterward would
+ *     queue in #pending. Reproduces the ethers v6 sharp edge directly.
+ *
+ *   push-without-register
+ *     Responds to eth_subscribe with a subscription ID and starts pushing
+ *     newHeads BEFORE the response is fully processed. Tests whether
+ *     ethers' #pending queue actually flushes correctly. Use to verify
+ *     the queue mechanism on a known-good ethers version.
+ *
+ * Usage:
+ *   pnpm tsx keeperhub-scheduler/debug/wss-mock-zombie.ts <scenario> [port]
+ *
+ * Example session:
+ *   # terminal 1
+ *   pnpm tsx keeperhub-scheduler/debug/wss-mock-zombie.ts zombie 8546
+ *   # terminal 2
+ *   pnpm tsx keeperhub-scheduler/debug/wss-compare.ts ws://localhost:8546 30
+ */
+
+import { WebSocketServer, type WebSocket } from "ws";
+
+type Scenario =
+  | "healthy"
+  | "zombie"
+  | "subscribe-no-response"
+  | "push-without-register";
+
+const scenario = (process.argv[2] ?? "zombie") as Scenario;
+const port = Number.parseInt(process.argv[3] ?? "8546", 10);
+
+const VALID_SCENARIOS: Scenario[] = [
+  "healthy",
+  "zombie",
+  "subscribe-no-response",
+  "push-without-register",
+];
+if (!VALID_SCENARIOS.includes(scenario)) {
+  console.error(
+    `Invalid scenario '${scenario}'. Valid: ${VALID_SCENARIOS.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const wss = new WebSocketServer({ port });
+console.log(
+  `Mock WSS listening on ws://localhost:${port} in '${scenario}' mode`,
+);
+
+let blockNumber = 0x1000;
+
+type JsonRpcMessage = {
+  jsonrpc: "2.0";
+  id?: number;
+  method?: string;
+  params?: unknown;
+};
+
+function send(ws: WebSocket, payload: unknown): void {
+  if (ws.readyState !== 1) {
+    return;
+  }
+  ws.send(JSON.stringify(payload));
+}
+
+function pushNewHead(ws: WebSocket, subId: string): void {
+  blockNumber++;
+  const number = `0x${blockNumber.toString(16)}`;
+  send(ws, {
+    jsonrpc: "2.0",
+    method: "eth_subscription",
+    params: {
+      subscription: subId,
+      result: {
+        number,
+        hash: `0x${blockNumber.toString(16).padStart(64, "a")}`,
+        parentHash: `0x${(blockNumber - 1).toString(16).padStart(64, "b")}`,
+        timestamp: `0x${Math.floor(Date.now() / 1000).toString(16)}`,
+        gasLimit: "0x1c9c380",
+        gasUsed: "0x0",
+        baseFeePerGas: "0x1",
+        miner: "0x0000000000000000000000000000000000000000",
+        difficulty: "0x0",
+      },
+    },
+  });
+}
+
+wss.on("connection", (ws: WebSocket) => {
+  console.log("client connected");
+  const subscriptions = new Map<string, NodeJS.Timeout>();
+
+  ws.on("message", (raw: Buffer) => {
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(raw.toString()) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+    console.log(`<- id=${msg.id ?? "-"} method=${msg.method ?? "-"}`);
+
+    if (msg.method === "eth_chainId") {
+      send(ws, { jsonrpc: "2.0", id: msg.id, result: "0x1" });
+      return;
+    }
+    if (msg.method === "net_version") {
+      send(ws, { jsonrpc: "2.0", id: msg.id, result: "1" });
+      return;
+    }
+    if (msg.method === "eth_blockNumber") {
+      send(ws, {
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: `0x${blockNumber.toString(16)}`,
+      });
+      return;
+    }
+    if (msg.method === "eth_subscribe") {
+      const subId = `0x${Math.random().toString(16).slice(2).padEnd(32, "0")}`;
+
+      if (scenario === "subscribe-no-response") {
+        // Drop the eth_subscribe RESPONSE but keep pushing newHeads with
+        // the (server-side known) subId. ethers' SocketSubscriber.start()
+        // promise chain never resolves -> _register is never called ->
+        // every push lands in #pending[subId] forever. Raw ws probe still
+        // counts the pushes because it does not need the subscription id
+        // to identify eth_subscription method messages. This is the
+        // canonical ethers v6 sharp edge that produces ETHERS_ROUTING.
+        console.log(
+          `   (scenario) dropping subscribe response, pushing newHeads under subId=${subId}`,
+        );
+        const timer = setInterval(() => {
+          pushNewHead(ws, subId);
+        }, 2000);
+        subscriptions.set(subId, timer);
+        return;
+      }
+
+      if (scenario === "push-without-register") {
+        // Push a frame BEFORE sending the subscribe response. ethers'
+        // _processMessage should queue this in #pending. Then send the
+        // response; when start()'s .then runs _register, the queued frame
+        // should drain.
+        console.log(`   (scenario) pushing newHead before subscribe response`);
+        pushNewHead(ws, subId);
+      }
+
+      send(ws, { jsonrpc: "2.0", id: msg.id, result: subId });
+      console.log(`   subscribed id=${subId}`);
+
+      if (scenario === "zombie") {
+        console.log(`   (scenario) holding subscription silent`);
+        return;
+      }
+
+      // healthy / push-without-register: stream newHeads
+      const intervalMs = 2000;
+      const timer = setInterval(() => {
+        pushNewHead(ws, subId);
+      }, intervalMs);
+      subscriptions.set(subId, timer);
+      return;
+    }
+    if (msg.method === "eth_unsubscribe") {
+      const params = msg.params as unknown[] | undefined;
+      const subId =
+        Array.isArray(params) && typeof params[0] === "string"
+          ? params[0]
+          : null;
+      if (subId !== null) {
+        const timer = subscriptions.get(subId);
+        if (timer) {
+          clearInterval(timer);
+          subscriptions.delete(subId);
+        }
+      }
+      send(ws, { jsonrpc: "2.0", id: msg.id, result: true });
+      return;
+    }
+
+    // Unknown method: respond with method-not-found so ethers' send promise
+    // resolves instead of hanging.
+    send(ws, {
+      jsonrpc: "2.0",
+      id: msg.id,
+      error: { code: -32601, message: `method ${msg.method} not found` },
+    });
+  });
+
+  ws.on("close", () => {
+    console.log("client disconnected");
+    for (const timer of subscriptions.values()) {
+      clearInterval(timer);
+    }
+    subscriptions.clear();
+  });
+});
+
+const shutdown = (): void => {
+  console.log("\nshutting down");
+  wss.close(() => process.exit(0));
+};
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/keeperhub-scheduler/debug/wss-mock-zombie.ts
+++ b/keeperhub-scheduler/debug/wss-mock-zombie.ts
@@ -39,7 +39,7 @@
  *   pnpm tsx keeperhub-scheduler/debug/wss-compare.ts ws://localhost:8546 30
  */
 
-import { WebSocketServer, type WebSocket } from "ws";
+import { type WebSocket, WebSocketServer } from "ws";
 
 type Scenario =
   | "healthy"
@@ -162,7 +162,7 @@ wss.on("connection", (ws: WebSocket) => {
         // _processMessage should queue this in #pending. Then send the
         // response; when start()'s .then runs _register, the queued frame
         // should drain.
-        console.log(`   (scenario) pushing newHead before subscribe response`);
+        console.log("   (scenario) pushing newHead before subscribe response");
         pushNewHead(ws, subId);
       }
 
@@ -170,7 +170,7 @@ wss.on("connection", (ws: WebSocket) => {
       console.log(`   subscribed id=${subId}`);
 
       if (scenario === "zombie") {
-        console.log(`   (scenario) holding subscription silent`);
+        console.log("   (scenario) holding subscription silent");
         return;
       }
 

--- a/keeperhub-scheduler/debug/wss-mock-zombie.ts
+++ b/keeperhub-scheduler/debug/wss-mock-zombie.ts
@@ -63,9 +63,14 @@ if (!VALID_SCENARIOS.includes(scenario)) {
   process.exit(1);
 }
 
-const wss = new WebSocketServer({ port });
+// Bind to loopback only. The debug server has no auth and speaks just enough
+// JSON-RPC for ethers' startup; binding to 0.0.0.0 (the WebSocketServer
+// default) would advertise a fake-Ethereum endpoint on every interface for
+// the lifetime of the script. Loopback is sufficient for wss-compare runs
+// on the same host.
+const wss = new WebSocketServer({ port, host: "127.0.0.1" });
 console.log(
-  `Mock WSS listening on ws://localhost:${port} in '${scenario}' mode`,
+  `Mock WSS listening on ws://127.0.0.1:${port} in '${scenario}' mode`,
 );
 
 let blockNumber = 0x1000;

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -1,20 +1,20 @@
 /**
- * KEEP-570 - End-to-end validation of the diagnostic warning produced by
- * this PR, against the real ChainMonitor and real ethers v6.
+ * KEEP-570 - End-to-end validation of the diagnostic warning AND the reaper
+ * behavior, against the real ChainMonitor and real ethers v6.
  *
  * Unlike tests/unit/chain-monitor.test.ts which mocks ethers, this test
  * runs ChainMonitor against a real `ws` server we control. The server
- * implements each candidate failure mode; we observe the noBlockTimer
- * warning and verify that the (wsFrames, subscriptionPushes, blocksReceived)
- * triple in the warning correctly distinguishes the three modes.
+ * implements each candidate failure mode and the assertions cover:
  *
- * The reaper-side assertion (isAlive returns false past
- * MONITOR_RECREATE_TIMEOUT_MS while subscribe re-fires) belongs with the
- * companion PR that fixes the staleness-clock reset on reconnect; it is
- * out of scope here.
+ *   1. The noBlockTimer warning's (wsFrames, subscriptionPushes,
+ *      blocksReceived) triple correctly distinguishes the three modes.
+ *   2. isAlive() flips to false once MONITOR_RECREATE_TIMEOUT_MS elapses
+ *      without a real block height advance, even while subscribe re-fires
+ *      on reconnect attempts (the reaper backstop). isAlive() returns true
+ *      transiently while isReconnecting, so the assertion polls.
  *
  * This is a synthetic stuck state, not a reproduction of the actual prod
- * bug. It validates the discrimination logic end-to-end.
+ * bug. It validates the discrimination + reaper logic end-to-end.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -147,6 +147,25 @@ function startMockServer(
   return { server, serverStarted };
 }
 
+// Poll isAlive() because it returns true transiently while isReconnecting is
+// set during the reconnect-with-backoff loop. The reaper-relevant moments are
+// the windows between reconnect attempts where staleness exceeds
+// MONITOR_RECREATE_TIMEOUT_MS and the monitor is not reconnecting; the
+// reconciler runs every 30s in prod and only needs one such reading.
+async function waitForReap(
+  monitor: ChainMonitor,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!monitor.isAlive()) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
 function captureWarnings(): { warnings: string[]; restore: () => void } {
   const warnings: string[] = [];
   const original = console.warn;
@@ -257,6 +276,16 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
     // the server never sends pushes in zombie mode.
     expect(warning).toMatch(/subscriptionPushes=0/);
     expect(warning).toMatch(/blocksReceived=0/);
+
+    // Reaper backstop: staleness from monitorBootAt has exceeded
+    // MONITOR_RECREATE_TIMEOUT_MS and no real block ever arrived, so
+    // isAlive() must report false between reconnect attempts. The
+    // reconciler relies on this signal to tear the monitor down.
+    const reaped = await waitForReap(monitor, MONITOR_RECREATE_MS);
+    expect(
+      reaped,
+      "monitor should report isAlive=false once MONITOR_RECREATE_TIMEOUT_MS has elapsed without a real block",
+    ).toBe(true);
   }, 30_000);
 
   it("subscribe-no-response mode -> warning shows subscriptionPushes>0, blocksReceived=0 (ethers routing bug)", async () => {
@@ -281,6 +310,16 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
     // in our raw-ws tap counter even though they never reach onBlock.
     expect(warning).toMatch(/subscriptionPushes=[1-9]/);
     expect(warning).toMatch(/blocksReceived=0/);
+
+    // Reaper backstop: even though subscription pushes are being received
+    // at the socket, no real block ever advances height, so the staleness
+    // baseline (monitorBootAt) exceeds MONITOR_RECREATE_TIMEOUT_MS and the
+    // monitor must report isAlive=false to the reconciler.
+    const reaped = await waitForReap(monitor, MONITOR_RECREATE_MS);
+    expect(
+      reaped,
+      "monitor should report isAlive=false once MONITOR_RECREATE_TIMEOUT_MS has elapsed without a real block",
+    ).toBe(true);
   }, 30_000);
 
   it("healthy mode -> blocks arrive, no stuck warning, isAlive stays true", async () => {

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -37,7 +37,10 @@ function startMockServer(
   scenario: Scenario,
 ): { server: WebSocketServer; serverStarted: Promise<void> } {
   let blockNumber = 0x1000;
-  const server = new WebSocketServer({ port });
+  // Bind to loopback only. WebSocketServer's default host is 0.0.0.0, which
+  // opens a transient public port on CI runners. Tests are loopback-only by
+  // construction; there is no reason to advertise externally.
+  const server = new WebSocketServer({ port, host: "127.0.0.1" });
   const subscriptions = new Map<string, NodeJS.Timeout>();
 
   const serverStarted = new Promise<void>((resolve, reject) => {

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -1,0 +1,328 @@
+/**
+ * KEEP-570 - End-to-end validation of the diagnostic warning produced by
+ * this PR, against the real ChainMonitor and real ethers v6.
+ *
+ * Unlike tests/unit/chain-monitor.test.ts which mocks ethers, this test
+ * runs ChainMonitor against a real `ws` server we control. The server
+ * implements each candidate failure mode; we observe the noBlockTimer
+ * warning and verify that the (wsFrames, subscriptionPushes, blocksReceived)
+ * triple in the warning correctly distinguishes the three modes.
+ *
+ * The reaper-side assertion (isAlive returns false past
+ * MONITOR_RECREATE_TIMEOUT_MS while subscribe re-fires) belongs with the
+ * companion PR that fixes the staleness-clock reset on reconnect; it is
+ * out of scope here.
+ *
+ * This is a synthetic stuck state, not a reproduction of the actual prod
+ * bug. It validates the discrimination logic end-to-end.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type WebSocket, WebSocketServer } from "ws";
+import { ChainMonitor } from "../../block-dispatcher/chain-monitor.js";
+
+vi.mock("../../block-dispatcher/sqs-enqueue.js", () => ({
+  enqueueBlockTrigger: vi.fn().mockResolvedValue(undefined),
+}));
+
+const BLOCK_ADVANCE_MS = 2_000;
+const MONITOR_RECREATE_MS = 6_000;
+const PRIMARY_PROBE_INTERVAL_MS = 60_000;
+const STUCK_WINDOW_MS = MONITOR_RECREATE_MS + 2_000;
+
+type Scenario = "healthy" | "zombie" | "subscribe-no-response";
+
+function startMockServer(
+  port: number,
+  scenario: Scenario,
+): { server: WebSocketServer; serverStarted: Promise<void> } {
+  let blockNumber = 0x1000;
+  const server = new WebSocketServer({ port });
+  const subscriptions = new Map<string, NodeJS.Timeout>();
+
+  const serverStarted = new Promise<void>((resolve, reject) => {
+    server.once("listening", () => resolve());
+    server.once("error", reject);
+  });
+
+  function send(ws: WebSocket, payload: unknown): void {
+    if (ws.readyState !== 1) {
+      return;
+    }
+    ws.send(JSON.stringify(payload));
+  }
+
+  function pushNewHead(ws: WebSocket, subId: string): void {
+    blockNumber++;
+    const number = `0x${blockNumber.toString(16)}`;
+    send(ws, {
+      jsonrpc: "2.0",
+      method: "eth_subscription",
+      params: {
+        subscription: subId,
+        result: {
+          number,
+          hash: `0x${blockNumber.toString(16).padStart(64, "a")}`,
+          parentHash: `0x${(blockNumber - 1).toString(16).padStart(64, "b")}`,
+          timestamp: `0x${Math.floor(Date.now() / 1000).toString(16)}`,
+          gasLimit: "0x1c9c380",
+          gasUsed: "0x0",
+          baseFeePerGas: "0x1",
+          miner: "0x0000000000000000000000000000000000000000",
+          difficulty: "0x0",
+        },
+      },
+    });
+  }
+
+  server.on("connection", (ws) => {
+    ws.on("message", (raw) => {
+      let msg: { id?: number; method?: string; params?: unknown };
+      try {
+        msg = JSON.parse(raw.toString()) as typeof msg;
+      } catch {
+        return;
+      }
+      if (msg.method === "eth_chainId") {
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: "0x1" });
+        return;
+      }
+      if (msg.method === "net_version") {
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: "1" });
+        return;
+      }
+      if (msg.method === "eth_blockNumber") {
+        send(ws, {
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: `0x${blockNumber.toString(16)}`,
+        });
+        return;
+      }
+      if (msg.method === "eth_subscribe") {
+        const subId = `0x${Math.random()
+          .toString(16)
+          .slice(2)
+          .padEnd(32, "0")}`;
+
+        if (scenario === "subscribe-no-response") {
+          const timer = setInterval(() => {
+            pushNewHead(ws, subId);
+          }, 200);
+          subscriptions.set(subId, timer);
+          return;
+        }
+
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: subId });
+
+        if (scenario === "zombie") {
+          return;
+        }
+
+        const timer = setInterval(() => {
+          pushNewHead(ws, subId);
+        }, 200);
+        subscriptions.set(subId, timer);
+        return;
+      }
+      if (msg.method === "eth_unsubscribe") {
+        send(ws, { jsonrpc: "2.0", id: msg.id, result: true });
+        return;
+      }
+      send(ws, {
+        jsonrpc: "2.0",
+        id: msg.id,
+        error: { code: -32601, message: `method ${msg.method} not found` },
+      });
+    });
+
+    ws.on("close", () => {
+      for (const timer of subscriptions.values()) {
+        clearInterval(timer);
+      }
+      subscriptions.clear();
+    });
+  });
+
+  return { server, serverStarted };
+}
+
+function captureWarnings(): { warnings: string[]; restore: () => void } {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]): void => {
+    warnings.push(args.map((a) => String(a)).join(" "));
+  };
+  return {
+    warnings,
+    restore: () => {
+      console.warn = original;
+    },
+  };
+}
+
+function makeChain(port: number): {
+  chainId: number;
+  name: string;
+  defaultPrimaryWss: string;
+  defaultFallbackWss: null;
+} {
+  return {
+    chainId: 1,
+    name: "TestChain",
+    defaultPrimaryWss: `ws://localhost:${port}`,
+    defaultFallbackWss: null,
+  };
+}
+
+// The benign destroy-race in chain-monitor.ts:
+// subscriber.stop()'s .then microtask races provider.destroy(); the in-flight
+// eth_unsubscribe rejects with "provider destroyed; cancelled request". This
+// happens in prod on every teardown (53 in 5000 log lines, documented on
+// KEEP-570) and propagates as an unhandled rejection. Swallow it here so
+// vitest does not fail the run on what is documented benign noise.
+function isBenignDestroyRace(reason: unknown): boolean {
+  if (!(reason instanceof Error)) {
+    return false;
+  }
+  const code = (reason as Error & { code?: string }).code;
+  const operation = (reason as Error & { operation?: string }).operation;
+  return code === "UNSUPPORTED_OPERATION" && operation === "eth_unsubscribe";
+}
+
+describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws mock", () => {
+  let serverHandle:
+    | { server: WebSocketServer; serverStarted: Promise<void> }
+    | null = null;
+  let monitor: ChainMonitor | null = null;
+  let warningCapture: { warnings: string[]; restore: () => void } | null =
+    null;
+  const rejectionHandler = (reason: unknown): void => {
+    if (!isBenignDestroyRace(reason)) {
+      throw reason;
+    }
+  };
+  let port = 19100;
+
+  beforeEach(() => {
+    port++;
+    vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", String(BLOCK_ADVANCE_MS));
+    vi.stubEnv("MONITOR_RECREATE_TIMEOUT_MS", String(MONITOR_RECREATE_MS));
+    vi.stubEnv(
+      "PRIMARY_PROBE_INTERVAL_MS",
+      String(PRIMARY_PROBE_INTERVAL_MS),
+    );
+    warningCapture = captureWarnings();
+    process.on("unhandledRejection", rejectionHandler);
+  });
+
+  afterEach(async () => {
+    if (monitor) {
+      await monitor.stop().catch(() => {
+        // ignore teardown errors; we have process-level handler
+      });
+      monitor = null;
+    }
+    if (serverHandle) {
+      await new Promise<void>((resolve) => {
+        serverHandle?.server.close(() => resolve());
+      });
+      serverHandle = null;
+    }
+    if (warningCapture) {
+      warningCapture.restore();
+      warningCapture = null;
+    }
+    process.off("unhandledRejection", rejectionHandler);
+    vi.unstubAllEnvs();
+  });
+
+  it(
+    "zombie mode -> warning shows subscriptionPushes=0, blocksReceived=0",
+    async () => {
+      serverHandle = startMockServer(port, "zombie");
+      await serverHandle.serverStarted;
+
+      monitor = new ChainMonitor({
+        chain: makeChain(port),
+        workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
+      });
+
+      await monitor.start();
+
+      // Wait through at least one noBlockTimer firing plus reconnect.
+      await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
+
+      const warning = warningCapture?.warnings.find((w) =>
+        w.includes("Block height has not advanced"),
+      );
+      expect(
+        warning,
+        "expected at least one noBlockTimer warning",
+      ).toBeDefined();
+      // wsFrames > 0 because chainId/blockNumber/subscribe round-trips
+      // produce non-subscription frames. subscriptionPushes is 0 because
+      // the server never sends pushes in zombie mode.
+      expect(warning).toMatch(/subscriptionPushes=0/);
+      expect(warning).toMatch(/blocksReceived=0/);
+    },
+    30_000,
+  );
+
+  it(
+    "subscribe-no-response mode -> warning shows subscriptionPushes>0, blocksReceived=0 (ethers routing bug)",
+    async () => {
+      serverHandle = startMockServer(port, "subscribe-no-response");
+      await serverHandle.serverStarted;
+
+      monitor = new ChainMonitor({
+        chain: makeChain(port),
+        workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
+      });
+
+      await monitor.start();
+      await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
+
+      const warning = warningCapture?.warnings.find((w) =>
+        w.includes("Block height has not advanced"),
+      );
+      expect(
+        warning,
+        "expected at least one noBlockTimer warning",
+      ).toBeDefined();
+      // Pushes are arriving (server sends eth_subscription messages with
+      // the server-side known subId), but ethers never registered the
+      // subscriber in #subs because the response was dropped. Frames show
+      // in our raw-ws tap counter even though they never reach onBlock.
+      expect(warning).toMatch(/subscriptionPushes=[1-9]/);
+      expect(warning).toMatch(/blocksReceived=0/);
+    },
+    30_000,
+  );
+
+  it(
+    "healthy mode -> blocks arrive, no stuck warning, isAlive stays true",
+    async () => {
+      serverHandle = startMockServer(port, "healthy");
+      await serverHandle.serverStarted;
+
+      monitor = new ChainMonitor({
+        chain: makeChain(port),
+        workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
+      });
+
+      await monitor.start();
+      await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
+
+      const stuckWarning = warningCapture?.warnings.find((w) =>
+        w.includes("Block height has not advanced"),
+      );
+      expect(
+        stuckWarning,
+        "should not see a stuck warning in healthy mode",
+      ).toBeUndefined();
+      expect(monitor.isAlive()).toBe(true);
+    },
+    30_000,
+  );
+});

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -41,9 +41,7 @@ const STUCK_WINDOW_MS = MONITOR_RECREATE_MS + 2_000;
 
 type Scenario = "healthy" | "zombie" | "subscribe-no-response";
 
-function startMockServer(
-  scenario: Scenario,
-): {
+function startMockServer(scenario: Scenario): {
   server: WebSocketServer;
   serverStarted: Promise<number>;
 } {

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -17,7 +17,16 @@
  * bug. It validates the discrimination + reaper logic end-to-end.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { type WebSocket, WebSocketServer } from "ws";
 import { ChainMonitor } from "../../block-dispatcher/chain-monitor.js";
 
@@ -219,6 +228,9 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
   } | null = null;
   let monitor: ChainMonitor | null = null;
   let warningCapture: { warnings: string[]; restore: () => void } | null = null;
+  // process.on/off is a global side effect. Install once for the file and
+  // tear down once at the end, so a crash in afterEach cannot leave a
+  // dangling handler or accumulate duplicates across iterations.
   const rejectionHandler = (reason: unknown): void => {
     if (!isBenignDestroyRace(reason)) {
       throw reason;
@@ -226,13 +238,20 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
   };
   let port = 19100;
 
+  beforeAll(() => {
+    process.on("unhandledRejection", rejectionHandler);
+  });
+
+  afterAll(() => {
+    process.off("unhandledRejection", rejectionHandler);
+  });
+
   beforeEach(() => {
     port++;
     vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", String(BLOCK_ADVANCE_MS));
     vi.stubEnv("MONITOR_RECREATE_TIMEOUT_MS", String(MONITOR_RECREATE_MS));
     vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", String(PRIMARY_PROBE_INTERVAL_MS));
     warningCapture = captureWarnings();
-    process.on("unhandledRejection", rejectionHandler);
   });
 
   afterEach(async () => {
@@ -252,7 +271,6 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
       warningCapture.restore();
       warningCapture = null;
     }
-    process.off("unhandledRejection", rejectionHandler);
     vi.unstubAllEnvs();
   });
 

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -191,12 +191,12 @@ function isBenignDestroyRace(reason: unknown): boolean {
 }
 
 describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws mock", () => {
-  let serverHandle:
-    | { server: WebSocketServer; serverStarted: Promise<void> }
-    | null = null;
+  let serverHandle: {
+    server: WebSocketServer;
+    serverStarted: Promise<void>;
+  } | null = null;
   let monitor: ChainMonitor | null = null;
-  let warningCapture: { warnings: string[]; restore: () => void } | null =
-    null;
+  let warningCapture: { warnings: string[]; restore: () => void } | null = null;
   const rejectionHandler = (reason: unknown): void => {
     if (!isBenignDestroyRace(reason)) {
       throw reason;
@@ -208,10 +208,7 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
     port++;
     vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", String(BLOCK_ADVANCE_MS));
     vi.stubEnv("MONITOR_RECREATE_TIMEOUT_MS", String(MONITOR_RECREATE_MS));
-    vi.stubEnv(
-      "PRIMARY_PROBE_INTERVAL_MS",
-      String(PRIMARY_PROBE_INTERVAL_MS),
-    );
+    vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", String(PRIMARY_PROBE_INTERVAL_MS));
     warningCapture = captureWarnings();
     process.on("unhandledRejection", rejectionHandler);
   });
@@ -237,92 +234,74 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
     vi.unstubAllEnvs();
   });
 
-  it(
-    "zombie mode -> warning shows subscriptionPushes=0, blocksReceived=0",
-    async () => {
-      serverHandle = startMockServer(port, "zombie");
-      await serverHandle.serverStarted;
+  it("zombie mode -> warning shows subscriptionPushes=0, blocksReceived=0", async () => {
+    serverHandle = startMockServer(port, "zombie");
+    await serverHandle.serverStarted;
 
-      monitor = new ChainMonitor({
-        chain: makeChain(port),
-        workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
-      });
+    monitor = new ChainMonitor({
+      chain: makeChain(port),
+      workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
+    });
 
-      await monitor.start();
+    await monitor.start();
 
-      // Wait through at least one noBlockTimer firing plus reconnect.
-      await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
+    // Wait through at least one noBlockTimer firing plus reconnect.
+    await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
 
-      const warning = warningCapture?.warnings.find((w) =>
-        w.includes("Block height has not advanced"),
-      );
-      expect(
-        warning,
-        "expected at least one noBlockTimer warning",
-      ).toBeDefined();
-      // wsFrames > 0 because chainId/blockNumber/subscribe round-trips
-      // produce non-subscription frames. subscriptionPushes is 0 because
-      // the server never sends pushes in zombie mode.
-      expect(warning).toMatch(/subscriptionPushes=0/);
-      expect(warning).toMatch(/blocksReceived=0/);
-    },
-    30_000,
-  );
+    const warning = warningCapture?.warnings.find((w) =>
+      w.includes("Block height has not advanced"),
+    );
+    expect(warning, "expected at least one noBlockTimer warning").toBeDefined();
+    // wsFrames > 0 because chainId/blockNumber/subscribe round-trips
+    // produce non-subscription frames. subscriptionPushes is 0 because
+    // the server never sends pushes in zombie mode.
+    expect(warning).toMatch(/subscriptionPushes=0/);
+    expect(warning).toMatch(/blocksReceived=0/);
+  }, 30_000);
 
-  it(
-    "subscribe-no-response mode -> warning shows subscriptionPushes>0, blocksReceived=0 (ethers routing bug)",
-    async () => {
-      serverHandle = startMockServer(port, "subscribe-no-response");
-      await serverHandle.serverStarted;
+  it("subscribe-no-response mode -> warning shows subscriptionPushes>0, blocksReceived=0 (ethers routing bug)", async () => {
+    serverHandle = startMockServer(port, "subscribe-no-response");
+    await serverHandle.serverStarted;
 
-      monitor = new ChainMonitor({
-        chain: makeChain(port),
-        workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
-      });
+    monitor = new ChainMonitor({
+      chain: makeChain(port),
+      workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
+    });
 
-      await monitor.start();
-      await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
+    await monitor.start();
+    await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
 
-      const warning = warningCapture?.warnings.find((w) =>
-        w.includes("Block height has not advanced"),
-      );
-      expect(
-        warning,
-        "expected at least one noBlockTimer warning",
-      ).toBeDefined();
-      // Pushes are arriving (server sends eth_subscription messages with
-      // the server-side known subId), but ethers never registered the
-      // subscriber in #subs because the response was dropped. Frames show
-      // in our raw-ws tap counter even though they never reach onBlock.
-      expect(warning).toMatch(/subscriptionPushes=[1-9]/);
-      expect(warning).toMatch(/blocksReceived=0/);
-    },
-    30_000,
-  );
+    const warning = warningCapture?.warnings.find((w) =>
+      w.includes("Block height has not advanced"),
+    );
+    expect(warning, "expected at least one noBlockTimer warning").toBeDefined();
+    // Pushes are arriving (server sends eth_subscription messages with
+    // the server-side known subId), but ethers never registered the
+    // subscriber in #subs because the response was dropped. Frames show
+    // in our raw-ws tap counter even though they never reach onBlock.
+    expect(warning).toMatch(/subscriptionPushes=[1-9]/);
+    expect(warning).toMatch(/blocksReceived=0/);
+  }, 30_000);
 
-  it(
-    "healthy mode -> blocks arrive, no stuck warning, isAlive stays true",
-    async () => {
-      serverHandle = startMockServer(port, "healthy");
-      await serverHandle.serverStarted;
+  it("healthy mode -> blocks arrive, no stuck warning, isAlive stays true", async () => {
+    serverHandle = startMockServer(port, "healthy");
+    await serverHandle.serverStarted;
 
-      monitor = new ChainMonitor({
-        chain: makeChain(port),
-        workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
-      });
+    monitor = new ChainMonitor({
+      chain: makeChain(port),
+      workflows: [{ id: "wf1", userId: "u1", blockInterval: 1 }],
+    });
 
-      await monitor.start();
-      await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
+    await monitor.start();
+    await new Promise((r) => setTimeout(r, STUCK_WINDOW_MS));
 
-      const stuckWarning = warningCapture?.warnings.find((w) =>
-        w.includes("Block height has not advanced"),
-      );
-      expect(
-        stuckWarning,
-        "should not see a stuck warning in healthy mode",
-      ).toBeUndefined();
-      expect(monitor.isAlive()).toBe(true);
-    },
-    30_000,
-  );
+    const stuckWarning = warningCapture?.warnings.find((w) =>
+      w.includes("Block height has not advanced"),
+    );
+    expect(
+      stuckWarning,
+      "should not see a stuck warning in healthy mode",
+    ).toBeUndefined();
+    expect(monitor.isAlive()).toBe(true);
+  }, 30_000);
 });

--- a/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
+++ b/keeperhub-scheduler/tests/integration/chain-monitor-mock-wss.test.ts
@@ -42,18 +42,28 @@ const STUCK_WINDOW_MS = MONITOR_RECREATE_MS + 2_000;
 type Scenario = "healthy" | "zombie" | "subscribe-no-response";
 
 function startMockServer(
-  port: number,
   scenario: Scenario,
-): { server: WebSocketServer; serverStarted: Promise<void> } {
+): {
+  server: WebSocketServer;
+  serverStarted: Promise<number>;
+} {
   let blockNumber = 0x1000;
-  // Bind to loopback only. WebSocketServer's default host is 0.0.0.0, which
-  // opens a transient public port on CI runners. Tests are loopback-only by
-  // construction; there is no reason to advertise externally.
-  const server = new WebSocketServer({ port, host: "127.0.0.1" });
+  // Port 0 => OS picks a free port. Read the actual port back from
+  // server.address() once listening fires. Removes flake from a
+  // static-counter scheme racing against anything else on the host.
+  // Loopback-only for the reasons in the previous commit.
+  const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
   const subscriptions = new Map<string, NodeJS.Timeout>();
 
-  const serverStarted = new Promise<void>((resolve, reject) => {
-    server.once("listening", () => resolve());
+  const serverStarted = new Promise<number>((resolve, reject) => {
+    server.once("listening", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("server.address() did not return an AddressInfo"));
+        return;
+      }
+      resolve(address.port);
+    });
     server.once("error", reject);
   });
 
@@ -224,7 +234,7 @@ function isBenignDestroyRace(reason: unknown): boolean {
 describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws mock", () => {
   let serverHandle: {
     server: WebSocketServer;
-    serverStarted: Promise<void>;
+    serverStarted: Promise<number>;
   } | null = null;
   let monitor: ChainMonitor | null = null;
   let warningCapture: { warnings: string[]; restore: () => void } | null = null;
@@ -236,7 +246,6 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
       throw reason;
     }
   };
-  let port = 19100;
 
   beforeAll(() => {
     process.on("unhandledRejection", rejectionHandler);
@@ -247,7 +256,6 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
   });
 
   beforeEach(() => {
-    port++;
     vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", String(BLOCK_ADVANCE_MS));
     vi.stubEnv("MONITOR_RECREATE_TIMEOUT_MS", String(MONITOR_RECREATE_MS));
     vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", String(PRIMARY_PROBE_INTERVAL_MS));
@@ -275,8 +283,8 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
   });
 
   it("zombie mode -> warning shows subscriptionPushes=0, blocksReceived=0", async () => {
-    serverHandle = startMockServer(port, "zombie");
-    await serverHandle.serverStarted;
+    serverHandle = startMockServer("zombie");
+    const port = await serverHandle.serverStarted;
 
     monitor = new ChainMonitor({
       chain: makeChain(port),
@@ -310,8 +318,8 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
   }, 30_000);
 
   it("subscribe-no-response mode -> warning shows subscriptionPushes>0, blocksReceived=0 (ethers routing bug)", async () => {
-    serverHandle = startMockServer(port, "subscribe-no-response");
-    await serverHandle.serverStarted;
+    serverHandle = startMockServer("subscribe-no-response");
+    const port = await serverHandle.serverStarted;
 
     monitor = new ChainMonitor({
       chain: makeChain(port),
@@ -344,8 +352,8 @@ describe("KEEP-570 integration: ChainMonitor warning patterns against a real ws 
   }, 30_000);
 
   it("healthy mode -> blocks arrive, no stuck warning, isAlive stays true", async () => {
-    serverHandle = startMockServer(port, "healthy");
-    await serverHandle.serverStarted;
+    serverHandle = startMockServer("healthy");
+    const port = await serverHandle.serverStarted;
 
     monitor = new ChainMonitor({
       chain: makeChain(port),

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -1186,11 +1186,9 @@ describe("ChainMonitor", () => {
       vi.stubEnv("PONG_TIMEOUT_MS", String(60 * 60_000));
       vi.stubEnv("PING_INTERVAL_MS", String(60 * 60_000));
 
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation((): void => {
-          // capture only; suppress test output
-        });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {
+        // capture only; suppress test output
+      });
 
       try {
         const monitor = new ChainMonitor({
@@ -1217,10 +1215,7 @@ describe("ChainMonitor", () => {
           Buffer.from('{"method":"eth_su', "utf8"),
           Buffer.from('bscription"}', "utf8"),
         ]);
-        provider.websocket.emit(
-          "message",
-          '{"method":"eth_subscription"}',
-        );
+        provider.websocket.emit("message", '{"method":"eth_subscription"}');
 
         // Drive the no-block timer; no real blocks were emitted so it must
         // fire and emit the warning containing the counters.
@@ -1250,11 +1245,9 @@ describe("ChainMonitor", () => {
       vi.stubEnv("PONG_TIMEOUT_MS", String(60 * 60_000));
       vi.stubEnv("PING_INTERVAL_MS", String(60 * 60_000));
 
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation((): void => {
-          // capture only; suppress test output
-        });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {
+        // capture only; suppress test output
+      });
 
       try {
         const monitor = new ChainMonitor({

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -1171,4 +1171,119 @@ describe("ChainMonitor", () => {
       await monitor.stop();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // KEEP-570 raw-ws diagnostic tap
+  // -------------------------------------------------------------------------
+
+  describe("ws frame diagnostic tap", () => {
+    it("counts every frame, only parses JSON for eth_subscription, and surfaces both counters in the noBlockTimer warning", async () => {
+      // Drive the tap with a mix of frame shapes and contents, then drive
+      // the no-block timer to fire and assert the warning's diagnostic
+      // counters reflect what we sent.
+      vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", "2000");
+      vi.stubEnv("SOCKET_MAX_AGE_MS", String(60 * 60_000));
+      vi.stubEnv("PONG_TIMEOUT_MS", String(60 * 60_000));
+      vi.stubEnv("PING_INTERVAL_MS", String(60 * 60_000));
+
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((): void => {
+          // capture only; suppress test output
+        });
+
+      try {
+        const monitor = new ChainMonitor({
+          chain: makeChain(),
+          workflows: [makeWorkflow()],
+        });
+        await monitor.start();
+        const provider = latestProvider();
+
+        // 5 frames total, 3 of which are eth_subscription pushes. Mixed
+        // shapes (string, Buffer, fragmented Buffer[]) to exercise
+        // decodeWsFrame as part of the tap, plus one malformed frame to
+        // confirm the parse-error path is silent.
+        provider.websocket.emit(
+          "message",
+          Buffer.from('{"id":1,"result":"0x1"}', "utf8"),
+        );
+        provider.websocket.emit("message", "not-json");
+        provider.websocket.emit(
+          "message",
+          Buffer.from('{"method":"eth_subscription"}', "utf8"),
+        );
+        provider.websocket.emit("message", [
+          Buffer.from('{"method":"eth_su', "utf8"),
+          Buffer.from('bscription"}', "utf8"),
+        ]);
+        provider.websocket.emit(
+          "message",
+          '{"method":"eth_subscription"}',
+        );
+
+        // Drive the no-block timer; no real blocks were emitted so it must
+        // fire and emit the warning containing the counters.
+        await vi.advanceTimersByTimeAsync(2_500);
+
+        const warnings = warnSpy.mock.calls
+          .map((args) => String(args[0]))
+          .filter((line) => line.includes("Block height has not advanced"));
+        expect(warnings.length).toBeGreaterThanOrEqual(1);
+        const warning = warnings[0];
+        expect(warning).toMatch(/wsFrames=5/);
+        expect(warning).toMatch(/subscriptionPushes=3/);
+        expect(warning).toMatch(/blocksReceived=0/);
+
+        await monitor.stop();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does not increment the push counter when a frame is malformed", async () => {
+      // Isolates the parse-error branch: malformed JSON frames must
+      // increment wsFrameCount but not subscriptionPushCount, and must
+      // not throw / unhandle.
+      vi.stubEnv("BLOCK_ADVANCE_TIMEOUT_MS", "2000");
+      vi.stubEnv("SOCKET_MAX_AGE_MS", String(60 * 60_000));
+      vi.stubEnv("PONG_TIMEOUT_MS", String(60 * 60_000));
+      vi.stubEnv("PING_INTERVAL_MS", String(60 * 60_000));
+
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((): void => {
+          // capture only; suppress test output
+        });
+
+      try {
+        const monitor = new ChainMonitor({
+          chain: makeChain(),
+          workflows: [makeWorkflow()],
+        });
+        await monitor.start();
+        const provider = latestProvider();
+
+        for (let i = 0; i < 4; i++) {
+          provider.websocket.emit(
+            "message",
+            Buffer.from("not-json-at-all", "utf8"),
+          );
+        }
+
+        await vi.advanceTimersByTimeAsync(2_500);
+
+        const warning = warnSpy.mock.calls
+          .map((args) => String(args[0]))
+          .find((line) => line.includes("Block height has not advanced"));
+        expect(warning).toBeDefined();
+        expect(warning).toMatch(/wsFrames=4/);
+        expect(warning).toMatch(/subscriptionPushes=0/);
+
+        await monitor.stop();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
 });

--- a/keeperhub-scheduler/tests/unit/decode-ws-frame.test.ts
+++ b/keeperhub-scheduler/tests/unit/decode-ws-frame.test.ts
@@ -33,8 +33,7 @@ describe("decodeWsFrame", () => {
   });
 
   it("decodes an ArrayBuffer", () => {
-    const arrayBuffer = new TextEncoder().encode("hello")
-      .buffer as ArrayBuffer;
+    const arrayBuffer = new TextEncoder().encode("hello").buffer as ArrayBuffer;
     expect(decodeWsFrame(arrayBuffer)).toBe("hello");
   });
 

--- a/keeperhub-scheduler/tests/unit/decode-ws-frame.test.ts
+++ b/keeperhub-scheduler/tests/unit/decode-ws-frame.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { decodeWsFrame } from "../../block-dispatcher/chain-monitor.js";
+
+// The ws library can deliver a "message" event payload in any of these four
+// shapes depending on its options and the size/fragmentation of the incoming
+// frame. ethers v6 receives Buffer today, but the KEEP-570 diagnostic tap
+// must not silently mis-decode if that ever changes - a wrong push count is
+// worse than no diagnostic at all.
+describe("decodeWsFrame", () => {
+  it("returns the input when it is already a string", () => {
+    expect(decodeWsFrame('{"method":"eth_subscription"}')).toBe(
+      '{"method":"eth_subscription"}',
+    );
+  });
+
+  it("decodes a Buffer as UTF-8", () => {
+    expect(decodeWsFrame(Buffer.from("hello", "utf8"))).toBe("hello");
+  });
+
+  it("concatenates and decodes a fragmented Buffer[]", () => {
+    expect(
+      decodeWsFrame([Buffer.from("hel", "utf8"), Buffer.from("lo", "utf8")]),
+    ).toBe("hello");
+  });
+
+  it("concatenates Buffer[] across a multi-byte UTF-8 boundary", () => {
+    // 'é' is 0xC3 0xA9 in UTF-8. Split across two Buffers to verify the
+    // decoder joins bytes before decoding rather than decoding each chunk
+    // independently (which would corrupt the character).
+    const a = Buffer.from([0xc3]);
+    const b = Buffer.from([0xa9, 0x21]);
+    expect(decodeWsFrame([a, b])).toBe("é!");
+  });
+
+  it("decodes an ArrayBuffer", () => {
+    const arrayBuffer = new TextEncoder().encode("hello")
+      .buffer as ArrayBuffer;
+    expect(decodeWsFrame(arrayBuffer)).toBe("hello");
+  });
+
+  it("returns null for shapes the tap does not understand", () => {
+    expect(decodeWsFrame(42)).toBeNull();
+    expect(decodeWsFrame(null)).toBeNull();
+    expect(decodeWsFrame(undefined)).toBeNull();
+    expect(decodeWsFrame({ message: "object, not bytes" })).toBeNull();
+    // Array of non-Buffers (e.g. ws delivering parsed JSON via a typed
+    // socket): not what the tap expects, must not be coerced.
+    expect(decodeWsFrame([1, 2, 3])).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.2",
     "dotenv-expand": "^12.0.3",
     "drizzle-kit": "^0.31.10",
@@ -153,7 +154,8 @@
     "typescript": "^5",
     "ultracite": "6.5.1",
     "viem": "^2.47.1",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "ws": "^8.20.1"
   },
   "pnpm": {
     "neverBuiltDependencies_comment": "prisma is an unused optional dep of better-auth's prisma adapter; we use drizzle. Skip its preinstall which requires Node 20.19+.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^4.1.2
         version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
@@ -323,6 +326,9 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@27.4.0(@noble/hashes@2.0.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      ws:
+        specifier: ^8.20.1
+        version: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   sandbox:
     devDependencies:
@@ -9154,8 +9160,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10530,7 +10536,7 @@ snapshots:
       '@getpara/user-management-client': 2.20.0
       '@getpara/viem-v2-integration': 2.20.0(viem@2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       uuid: 11.1.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -10841,7 +10847,7 @@ snapshots:
       '@types/stream-buffers': 3.0.8
       form-data: 4.0.4
       hpagent: 1.2.0
-      isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isomorphic-ws: 5.0.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       js-yaml: 4.1.1
       jsonpath-plus: 10.3.0
       node-fetch: 2.7.0
@@ -10850,7 +10856,7 @@ snapshots:
       socks-proxy-agent: 8.0.5
       stream-buffers: 3.0.3
       tar-fs: 3.1.1
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -13456,7 +13462,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16896,9 +16902,9 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
-  isomorphic-ws@5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+  isomorphic-ws@5.0.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
@@ -16996,7 +17002,7 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -18190,7 +18196,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.4
       uuid: 8.3.2
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
@@ -19226,7 +19232,7 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
 
-  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10


### PR DESCRIPTION
## Summary

Diagnostic patch for [KEEP-570](https://linear.app/keeperhubapp/issue/KEEP-570/block-trigger-workflows-silently-dropped-between-sqs-enqueue-and). Adds WS-frame-level counters to `ChainMonitor` and two local probe scripts. No runtime behavior change beyond enriched logging on `noBlockTimer` fire.

The incident: chain-monitor logs `Block subscription active` but receives zero `newHeads`. The dispatcher's existing logging cannot tell apart these three failure modes:

| Mode | What happened | Where the push goes |
|---|---|---|
| A | `eth_subscribe` response lost (ethers v6 sharp edge or single-frame drop) | `provider.#pending[subId]` forever; never reaches `onBlock` |
| B (network) | Cluster egress drops everything | Nothing arrives at the pod's WS socket at all |
| B (app) | Upstream stops pushing `newHeads` but keepalives still flow | Frames arrive but none are subscription pushes |

After this patch the warning line is self-discriminating, so the next stuck-chain incident doesn't need a manual probe in the pod to diagnose.

## Changes

### `keeperhub-scheduler/block-dispatcher/chain-monitor.ts`

Three new per-subscription counters populated from a `ws.on(\"message\", ...)` tap that runs alongside ethers' `onmessage` property handler (independent paths in the `ws` library, ethers' own message processing is not touched):

- `wsFrameCount` - total incoming WS frames since the current subscription started
- `subscriptionPushCount` - frames whose JSON has `method === \"eth_subscription\"`
- `lastWsFrameAt` - timestamp of the most recent frame

Counters reset in `subscribeToBlocks` and the tap is detached in `destroyProvider`.

The `noBlockTimer` fire warning now reads:

\`\`\`
[BlockMonitor:<chain>] Block height has not advanced in 60s
  (silentReconnects=N, wsFrames=N, subscriptionPushes=N,
   blocksReceived=N, lastFrameAgo=Nms), triggering reconnect
\`\`\`

Discrimination:

- \`wsFrames == 0\` -> mode B at the network layer (no frames at all)
- \`wsFrames > 0 && subscriptionPushes == 0\` -> mode B at the application layer (upstream stopped pushing newHeads but req/response keepalives still flow)
- \`subscriptionPushes > 0 && blocksReceived == 0\` -> mode A (ethers SocketSubscriber.start()'s \`_register\` never ran; pushes queued in \`#pending[subId]\` forever)

### `keeperhub-scheduler/debug/wss-compare.ts`

Side-by-side probe of a single WSS URL. Opens a raw \`ws\` connection (eth_subscribe directly) and an ethers v6 \`WebSocketProvider\` connection in parallel, counts frames on each for a fixed window, prints a verdict from \`{BOTH_HEALTHY, UPSTREAM_SILENT, ETHERS_ROUTING, CONNECTION_SPECIFIC}\`.

Usage:

\`\`\`
pnpm tsx keeperhub-scheduler/debug/wss-compare.ts <wss-url> [duration-seconds]
\`\`\`

### \`keeperhub-scheduler/debug/wss-mock-zombie.ts\`

Mock JSON-RPC WSS server with four selectable scenarios for offline iteration:

- \`healthy\` - normal newHeads at 2s cadence
- \`zombie\` - eth_subscribe acknowledged, no pushes
- \`subscribe-no-response\` - eth_subscribe response dropped, pushes keep flowing under the server-side subscription id (reproduces mode A deterministically)
- \`push-without-register\` - pushes before the subscribe response (exercises ethers' \`#pending\` drain path)

### \`package.json\` / \`pnpm-lock.yaml\`

\`ws@^8.20.1\` and \`@types/ws@^8.18.1\` added as devDependencies so the probe scripts resolve from the root \`node_modules\`. \`ws\` is already installed transitively via ethers; this just promotes it to a direct dep.

## Test plan

- [x] \`pnpm test:unit\` in \`keeperhub-scheduler\` - 80/80 pass
- [x] \`pnpm tsc --noEmit -p keeperhub-scheduler/tsconfig.json\` - clean
- [x] wss-compare vs wss-mock-zombie in zombie mode -> verdict \`UPSTREAM_SILENT\`
- [x] wss-compare vs wss-mock-zombie in subscribe-no-response mode -> verdict \`ETHERS_ROUTING\` (validates the discrimination logic catches the ethers v6 sharp edge)
- [x] wss-compare against the 4 stuck-chain fallback URLs from chain-config production.json - all \`BOTH_HEALTHY\` from outside the cluster (rules out upstream provider degradation as the cause of the prod incident; matches Joel's independent external probe)
- [ ] Canary deploy to one keeperhub-block-common pod. Next stuck-chain event should print a self-discriminating warning line.