### PR TITLE
feat: is_user_error label on the db side

### DIFF
--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -68,7 +68,7 @@ Counter/Gauge metrics tracking request/event counts.
 
 | Metric Name | Description | Labels | Unit | Source |
 |-------------|-------------|--------|------|--------|
-| `workflow.executions.total` | Total workflow executions by status (all-time) | `status` | gauge | DB |
+| `workflow.executions.total` | Total workflow executions by status (all-time) | `status`, `org_slug`, `is_user_error` (`true`/`false`/`unknown`/`na`) | gauge | DB |
 | `workflow.execution.errors.total` | Total failed workflow executions (all-time) | - | gauge | DB |
 | `plugin.invocations.total` | Plugin action invocations | `plugin_name`, `action_name` | count | API |
 | `user.active.daily` | Daily active users (24h) | - | gauge | DB |

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -94,14 +94,27 @@ function getOrCreateGauge(
 // All metrics are GAUGES (point-in-time snapshots). Use max() aggregation across pods.
 // For rate/delta queries, use PromQL delta() function: max(delta(metric[1h]))
 
-// Workflow execution counts by status and org_slug. Personal/anonymous
-// workflows are emitted under org_slug="_anonymous" so the sum across
-// org_slug for a given status equals the global per-status total.
+// Workflow execution counts by status, org_slug, and is_user_error. Personal/
+// anonymous workflows are emitted under org_slug="_anonymous" so the sum
+// across org_slug for a given status equals the global per-status total.
+//
+// is_user_error label values:
+//   "true"    - error caused by user input/config/external service
+//   "false"   - error caused by KeeperHub system/infrastructure
+//   "unknown" - errored row predating classification (NULL in DB)
+//   "na"      - non-error status (success/running/pending/cancelled)
+//
+// PromQL queries that ignore is_user_error still work (Prometheus aggregates
+// across all values by default). The label unlocks "platform-side SLO"
+// queries that exclude user-caused failures from the denominator, since the
+// counter `keeperhub_workflow_execution_errors_created_total` can miss
+// errors when finalization paths bypass it; the gauge is sourced from the DB
+// directly and stays authoritative.
 const workflowExecutionsTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_workflow_executions_total",
-  "Total workflow executions by status, broken down by org_slug (all-time)",
-  ["status", "org_slug"]
+  "Total workflow executions by status, broken down by org_slug and is_user_error (all-time)",
+  ["status", "org_slug", "is_user_error"]
 );
 
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
@@ -1233,7 +1246,11 @@ export async function updateDbMetrics(): Promise<void> {
     workflowExecutionsTotal.reset();
     for (const row of workflowStats.executionsByStatusAndOrgSlug) {
       workflowExecutionsTotal.set(
-        { status: row.status, org_slug: row.orgSlug },
+        {
+          status: row.status,
+          org_slug: row.orgSlug,
+          is_user_error: row.isUserError,
+        },
         row.count
       );
     }

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -58,12 +58,23 @@ export type WorkflowStats = {
   totalPending: number;
   totalCancelled: number;
 
-  // Per-(status, org_slug) execution counts. Personal/anonymous workflows
-  // are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for a given
-  // status across all orgs matches the corresponding total* above.
+  // Per-(status, org_slug, is_user_error) execution counts. Personal/anonymous
+  // workflows are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for a
+  // given status across all orgs matches the corresponding total* above.
+  //
+  // isUserError values:
+  //   "true"    - error caused by user input/config/external service
+  //   "false"   - error caused by KeeperHub system/infrastructure
+  //   "unknown" - errored row predating classification (NULL in DB)
+  //   "na"      - non-error status (success/running/pending/cancelled)
+  //
+  // Encoding NULL as "unknown" rather than dropping the row keeps the gauge
+  // total equal to the all-up execution count and surfaces backfill gaps in
+  // the dashboard rather than hiding them.
   executionsByStatusAndOrgSlug: Array<{
     status: string;
     orgSlug: string;
+    isUserError: string;
     count: number;
   }>;
 
@@ -93,30 +104,42 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       durationCount: 0,
     };
 
-    // Per-(status, org_slug) execution breakdown: JOIN workflows + organization,
-    // LEFT JOIN so anonymous workflows still contribute (under ANONYMOUS_ORG_SLUG).
-    // GROUP BY uses the organization.slug column reference (not the COALESCE
-    // expression): Drizzle would otherwise bind ANONYMOUS_ORG_SLUG as separate
-    // parameters in SELECT and GROUP BY clauses, and Postgres rejects the query
-    // because the two COALESCE expressions are not textually identical. Postgres
-    // groups all NULL slugs into one group (NULLs are equal in GROUP BY), and
-    // the SELECT-side COALESCE renders that group as ANONYMOUS_ORG_SLUG.
+    // Per-(status, org_slug, is_user_error) execution breakdown: JOIN workflows
+    // + organization, LEFT JOIN so anonymous workflows still contribute (under
+    // ANONYMOUS_ORG_SLUG). GROUP BY uses the underlying columns (not the
+    // COALESCE/CASE expressions): Drizzle would otherwise bind constants as
+    // separate parameters in SELECT and GROUP BY clauses, and Postgres rejects
+    // the query because the two expressions are not textually identical.
+    // Postgres groups NULLs together (NULLs are equal in GROUP BY), and the
+    // SELECT-side expressions render those groups as ANONYMOUS_ORG_SLUG /
+    // "unknown" / "na" as appropriate.
     const breakdown = await db
       .select({
         status: workflowExecutions.status,
         orgSlug: sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`,
+        isUserError: sql<string>`CASE
+          WHEN ${workflowExecutions.status} <> 'error' THEN 'na'
+          WHEN ${workflowExecutions.isUserError} IS NULL THEN 'unknown'
+          WHEN ${workflowExecutions.isUserError} = TRUE THEN 'true'
+          ELSE 'false'
+        END`,
         count: count(),
       })
       .from(workflowExecutions)
       .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
       .leftJoin(organization, eq(workflows.organizationId, organization.id))
-      .groupBy(workflowExecutions.status, organization.slug);
+      .groupBy(
+        workflowExecutions.status,
+        organization.slug,
+        workflowExecutions.isUserError
+      );
 
     for (const row of breakdown) {
       const c = Number(row.count) || 0;
       stats.executionsByStatusAndOrgSlug.push({
         status: row.status,
         orgSlug: row.orgSlug,
+        isUserError: row.isUserError,
         count: c,
       });
       switch (row.status) {


### PR DESCRIPTION
## Summary

Adds `is_user_error` as a third label on the DB-sourced `keeperhub_workflow_executions_total` gauge, so SLO PromQL can distinguish KeeperHub-system failures from user-caused failures on the same authoritative data source.

## Why

The managed-client dashboard currently shows inconsistent numbers:

- **Managed Client System Error** = `errors_created_total{org_slug=~"techops|ajna", is_user_error="false"}` → 0
- **Managed Client User Error** = `errors_created_total{org_slug=~"techops|ajna", is_user_error="true"}` → 0
- **Managed Client SLO** = `success / (success + error)` from `executions_total` → 99.6%

Root cause: the two panels read different metrics with different label sets.

- `executions_total` (DB-sourced gauge) only has `status` and `org_slug`, so SLO PromQL cannot filter on `is_user_error`. Every `status="error"` row is treated as a failure regardless of cause.
- `errors_created_total` (API-process counter) has `is_user_error` but is fired by explicit code calls. Finalization paths that bypass the call (or pre-instrumentation rows) leave the counter under-reporting relative to the DB.

Adding `is_user_error` to the gauge unblocks a true platform SLO query (`success / (success + error AND is_user_error="false"`)) sourced entirely from the DB scan, removing both the data-source-mismatch and the under-reporting risk.

## Changes

- `lib/metrics/db-metrics.ts`
- SQL groups by `workflow_executions.is_user_error` and emits a `CASE` expression that normalizes the value into four buckets: `true`, `false`, `unknown` (errored row predating classification), `na` (non-error status).
- `WorkflowStats.executionsByStatusAndOrgSlug` carries the new `isUserError` field.
- `lib/metrics/collectors/prometheus.ts`
- `keeperhub_workflow_executions_total` gauge gains `is_user_error` as a third label.
- `.set()` call in `updateDbMetrics` passes the new label.
- `lib/metrics/METRICS_REFERENCE.md`
- Label column updated for `workflow.executions.total`.

## Backward compatibility

PromQL queries that do not reference `is_user_error` continue to work — Prometheus auto-aggregates across all values of an un-filtered label. Verified no local alert rules or dashboards reference the gauge with non-aggregated queries (only
`METRICS_REFERENCE.md` references it in this repo).

## Cardinality

`is_user_error` takes at most 4 distinct values (`true` / `false` / `unknown` / `na`), bounded against `status` (~5 values) and `org_slug` (~tens). Worst-case ~4x expansion of an already small series set; well within Prometheus health limits.

## Old data handling

Errored rows with `is_user_error = NULL` (pre-classification) are emitted under `is_user_error="unknown"` so backfill gaps are visible on the dashboard rather than hidden. Backfill can happen in a follow-up if the bucket grows large enough to matter.

## Test plan
- [x] CI green
- [ ] In Grafana, plot existing queries (`status="success"` / `status="error"` without `is_user_error` filter) and verify totals unchanged

## Follow-ups (not in this PR)

- Update managed-client dashboard to add Platform SLO panel and align Error / SLO data sources
- Decide on backfill of pre-classification `is_user_error` NULL rows if `"unknown"` bucket is non-trivial


⚠️ MUST UPDATE — unsafe max by patterns

Dashboard JSON: infra repo -> grafana/keeperhub-dashboards/values/keeperhub.json
Alert rules: infra repo -> grafana/keeperhub-dashboards/keeperhub_metrics_alerts.tf

Fix for all 5: add is_user_error to each max by (...) list. E.g., max by (status, org_slug) → max by (status, org_slug,
is_user_error). Outer sum(...) collapses the buckets back into a single total.