### PR TITLE
fix(workflow-save): KEEP-571 accept stringified container fields and legacy aliases

### DIFF
--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -20,6 +20,12 @@ const RESERVED_CONFIG_KEYS = new Set([
   ADDRESS_BOOK_SELECTION_KEY,
   "usePrivateMempool",
   "strict",
+  // UI-only state written by the abi-with-auto-fetch field renderer
+  // (components/workflow/config/abi-with-auto-fetch-field.tsx). Persisted on
+  // every action that uses that field type so the form remembers the user's
+  // manual-vs-fetched ABI toggle across reloads. The step runtime never reads
+  // it.
+  "useManualAbi",
 ]);
 
 const TEMPLATE_VALUE_PATTERN = /\{\{[^}]+}}/;
@@ -133,8 +139,24 @@ const LEGACY_FIELD_ALIASES: Record<string, Record<string, string>> = {
   "web3/write-contract": { functionName: "abiFunction" },
 };
 
+// Legacy config keys that don't map to a canonical field but should not be
+// rejected on save. Typically these are leftovers from a sibling action's
+// form state (e.g. an editor session that started as batch-read-contract and
+// was switched to query-transactions persisted batch-read's `inputMode` /
+// `batchSize`) or fields that were removed during a refactor. The runtime
+// ignores them; the validator must too, otherwise legacy / cross-org imports
+// can't be saved.
+const LEGACY_IGNORED_FIELDS: Record<string, Set<string>> = {
+  "web3/query-transactions": new Set(["inputMode", "batchSize"]),
+  "web3/query-events": new Set(["inputMode", "batchSize"]),
+};
+
 function getLegacyAliasMap(actionType: string): Record<string, string> {
   return LEGACY_FIELD_ALIASES[actionType] ?? {};
+}
+
+function isLegacyIgnoredField(actionType: string, key: string): boolean {
+  return LEGACY_IGNORED_FIELDS[actionType]?.has(key) ?? false;
 }
 
 function validateStringLike(value: unknown): boolean {
@@ -315,6 +337,9 @@ export function validateWorkflowActionConfigs(
         continue;
       }
       if (aliasMap[key] && fieldsByKey.has(aliasMap[key])) {
+        continue;
+      }
+      if (isLegacyIgnoredField(actionType, key)) {
         continue;
       }
       issues.push({

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -106,6 +106,37 @@ function isJsonArrayString(value: unknown): boolean {
   }
 }
 
+function isJsonArrayOrObjectString(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return (
+      Array.isArray(parsed) || (typeof parsed === "object" && parsed !== null)
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Legacy field keys that older workflows persisted before a field rename.
+// They are accepted on save (treated as the canonical key for validation) so
+// users can re-save existing workflows that contain the legacy shape. The
+// runtime is responsible for normalizing aliases when it reads the config.
+const LEGACY_FIELD_ALIASES: Record<string, Record<string, string>> = {
+  "web3/read-contract": { functionName: "abiFunction" },
+  "web3/write-contract": { functionName: "abiFunction" },
+};
+
+function getLegacyAliasMap(actionType: string): Record<string, string> {
+  return LEGACY_FIELD_ALIASES[actionType] ?? {};
+}
+
 function validateStringLike(value: unknown): boolean {
   return typeof value === "string" || typeof value === "number";
 }
@@ -217,7 +248,10 @@ function validateFieldValue(
     case "abi-function-args":
     case "call-list-builder":
     case "args-list-builder":
-      return isRecord(value) || Array.isArray(value)
+      return isRecord(value) ||
+        Array.isArray(value) ||
+        valueContainsTemplate(value) ||
+        isJsonArrayOrObjectString(value)
         ? { valid: true }
         : { valid: false, expected: "object or array", received: value };
     default:
@@ -271,21 +305,26 @@ export function validateWorkflowActionConfigs(
 
     const fields = flattenConfigFields(action.configFields);
     const fieldsByKey = new Map(fields.map((field) => [field.key, field]));
+    const aliasMap = getLegacyAliasMap(actionType);
 
     for (const [key, value] of Object.entries(config)) {
       if (RESERVED_CONFIG_KEYS.has(key)) {
         continue;
       }
-      if (!fieldsByKey.has(key)) {
-        issues.push({
-          code: "UNKNOWN_FIELD",
-          path: `nodes[${nodeIndex}].data.config.${key}`,
-          actionType,
-          field: key,
-          received: value,
-          message: `Unknown field "${key}" for action "${actionType}".`,
-        });
+      if (fieldsByKey.has(key)) {
+        continue;
       }
+      if (aliasMap[key] && fieldsByKey.has(aliasMap[key])) {
+        continue;
+      }
+      issues.push({
+        code: "UNKNOWN_FIELD",
+        path: `nodes[${nodeIndex}].data.config.${key}`,
+        actionType,
+        field: key,
+        received: value,
+        message: `Unknown field "${key}" for action "${actionType}".`,
+      });
     }
 
     for (const field of fields) {
@@ -293,7 +332,17 @@ export function validateWorkflowActionConfigs(
         continue;
       }
 
-      const value = config[field.key];
+      const legacyKey = Object.entries(aliasMap).find(
+        ([, canonical]) => canonical === field.key
+      )?.[0];
+      const canonicalValue = config[field.key];
+      const value =
+        canonicalValue !== undefined ||
+        legacyKey === undefined ||
+        config[legacyKey] === undefined
+          ? canonicalValue
+          : config[legacyKey];
+
       if (field.required && isMissingRequiredValue(value)) {
         issues.push({
           code: "MISSING_REQUIRED_FIELD",

--- a/tests/e2e/playwright/workflow-save-stringified-args.test.ts
+++ b/tests/e2e/playwright/workflow-save-stringified-args.test.ts
@@ -336,4 +336,268 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
       await deleteTestWorkflow(workflow.id);
     }
   });
+
+  test("node-count invariance: saves a 6-node workflow with the affected read-contract at index 3", async ({
+    page,
+    apiRequest,
+  }) => {
+    const filler = (id: string, y: number): WorkflowNode => ({
+      id,
+      type: "action",
+      position: { x: 0, y },
+      data: {
+        label: "Discord",
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          discordMessage: `step-${id}`,
+        },
+      },
+    });
+
+    const nodes: WorkflowNode[] = [
+      triggerNode(),
+      filler("f-1", 120),
+      filler("f-2", 240),
+      readContractNode({}, "r-3"),
+      filler("f-4", 480),
+      filler("f-5", 600),
+    ];
+
+    const edges = [
+      { id: "e1", source: "trigger", target: "f-1" },
+      { id: "e2", source: "f-1", target: "f-2" },
+      { id: "e3", source: "f-2", target: "r-3" },
+      { id: "e4", source: "r-3", target: "f-4" },
+      { id: "e5", source: "f-4", target: "f-5" },
+    ];
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-6node-${Date.now()}`,
+      triggerType: "manual",
+      nodes,
+      edges,
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: { nodes, edges },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("node-count invariance: saves a 10-node workflow with TWO affected read-contract nodes (proves no aggregate cap)", async ({
+    page,
+    apiRequest,
+  }) => {
+    const filler = (id: string, y: number): WorkflowNode => ({
+      id,
+      type: "action",
+      position: { x: 0, y },
+      data: {
+        label: "Discord",
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          discordMessage: id,
+        },
+      },
+    });
+
+    const nodes: WorkflowNode[] = [triggerNode()];
+    for (let i = 1; i <= 9; i++) {
+      if (i === 2 || i === 7) {
+        nodes.push(readContractNode({}, `r-${i}`));
+      } else {
+        nodes.push(filler(`f-${i}`, i * 120));
+      }
+    }
+
+    const edges: Array<{ id: string; source: string; target: string }> = [];
+    for (let i = 0; i < nodes.length - 1; i++) {
+      edges.push({
+        id: `e-${i}`,
+        source: nodes[i].id,
+        target: nodes[i + 1].id,
+      });
+    }
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-10node-${Date.now()}`,
+      triggerType: "manual",
+      nodes,
+      edges,
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: { nodes, edges },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("saves a 2-node workflow (trigger + single affected read-contract) -- baseline for the original report", async ({
+    page,
+    apiRequest,
+  }) => {
+    const nodes = [triggerNode(), readContractNode({}, "r-1")];
+    const edges = [{ id: "e1", source: "trigger", target: "r-1" }];
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-2node-${Date.now()}`,
+      triggerType: "manual",
+      nodes,
+      edges,
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: { nodes, edges },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("partial PATCH that does not include `nodes` succeeds without triggering validation", async ({
+    page,
+    apiRequest,
+  }) => {
+    const nodes = [triggerNode(), readContractNode(), discordNode()];
+    const edges = [
+      { id: "e1", source: "trigger", target: "read-1" },
+      { id: "e2", source: "read-1", target: "notify-1" },
+    ];
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-partial-${Date.now()}`,
+      triggerType: "manual",
+      nodes,
+      edges,
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: { name: `renamed-${Date.now()}` },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("rejected error response reports the correct node-index path in a large workflow", async ({
+    page,
+    apiRequest,
+  }) => {
+    const filler = (id: string, y: number): WorkflowNode => ({
+      id,
+      type: "action",
+      position: { x: 0, y },
+      data: {
+        label: "Discord",
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          discordMessage: id,
+        },
+      },
+    });
+
+    const badNode = readContractNode(
+      { functionArgs: "definitely-not-json-or-template" },
+      "bad-4"
+    );
+
+    const nodes: WorkflowNode[] = [
+      triggerNode(),
+      filler("f-1", 120),
+      filler("f-2", 240),
+      filler("f-3", 360),
+      badNode,
+      filler("f-5", 600),
+    ];
+
+    const edges: Array<{ id: string; source: string; target: string }> = [];
+    for (let i = 0; i < nodes.length - 1; i++) {
+      edges.push({
+        id: `e-${i}`,
+        source: nodes[i].id,
+        target: nodes[i + 1].id,
+      });
+    }
+
+    // The workflow needs valid args to seed; we send the bad args via PATCH below.
+    const seedNodes = [
+      triggerNode(),
+      filler("f-1", 120),
+      filler("f-2", 240),
+      filler("f-3", 360),
+      readContractNode({}, "bad-4"),
+      filler("f-5", 600),
+    ];
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-large-bad-${Date.now()}`,
+      triggerType: "manual",
+      nodes: seedNodes,
+      edges,
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: { nodes, edges },
+      });
+
+      expect(response.status()).toBe(422);
+      const responseBody = await response.json();
+      expect(responseBody.error).toBe("INVALID_ACTION_CONFIG");
+      expect(responseBody.invalidFields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "INVALID_FIELD_TYPE",
+            path: "nodes[4].data.config.functionArgs",
+            field: "functionArgs",
+          }),
+        ])
+      );
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
 });

--- a/tests/e2e/playwright/workflow-save-stringified-args.test.ts
+++ b/tests/e2e/playwright/workflow-save-stringified-args.test.ts
@@ -7,8 +7,8 @@ import {
 
 const READ_CONTRACT_ABI = JSON.stringify([
   {
-    inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
-    name: "ilks",
+    inputs: [{ internalType: "bytes32", name: "id", type: "bytes32" }],
+    name: "reader",
     outputs: [
       { internalType: "uint256", name: "Art", type: "uint256" },
       { internalType: "uint256", name: "rate", type: "uint256" },
@@ -21,7 +21,7 @@ const READ_CONTRACT_ABI = JSON.stringify([
 const WRITE_CONTRACT_ABI = JSON.stringify([
   {
     inputs: [],
-    name: "poke",
+    name: "doWrite",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -68,8 +68,8 @@ function readContractNode(
         network: "1",
         contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         abi: READ_CONTRACT_ABI,
-        abiFunction: "ilks",
-        functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+        abiFunction: "reader",
+        functionArgs: '["{{@prev-loop:Prev Loop.currentItem.idBytes32}}"]',
         ...overrides,
       },
     },
@@ -93,7 +93,7 @@ function discordNode(id = "notify-1"): WorkflowNode {
 }
 
 test.describe("KEEP-571: workflow save with stringified container fields", () => {
-  test("saves a 3-node workflow with web3/read-contract stringified functionArgs (OSM Alert shape)", async ({
+  test("saves a 3-node workflow with web3/read-contract stringified functionArgs (templated-args shape)", async ({
     page,
     apiRequest,
   }) => {
@@ -129,12 +129,12 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
     }
   });
 
-  test("saves a workflow with legacy `functionName` on web3/write-contract (MegaPoker shape)", async ({
+  test("saves a workflow with legacy `functionName` on web3/write-contract (legacy functionName shape)", async ({
     page,
     apiRequest,
   }) => {
     const writeNode: WorkflowNode = {
-      id: "poke-1",
+      id: "write-1",
       type: "action",
       position: { x: 0, y: 120 },
       data: {
@@ -145,7 +145,7 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: WRITE_CONTRACT_ABI,
-          functionName: "poke",
+          functionName: "doWrite",
           functionArgs: "[]",
         },
       },
@@ -156,8 +156,8 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
       triggerType: "manual",
       nodes: [triggerNode(), writeNode, discordNode()],
       edges: [
-        { id: "e1", source: "trigger", target: "poke-1" },
-        { id: "e2", source: "poke-1", target: "notify-1" },
+        { id: "e1", source: "trigger", target: "write-1" },
+        { id: "e2", source: "write-1", target: "notify-1" },
       ],
     });
 
@@ -170,8 +170,8 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
         data: {
           nodes: [triggerNode(), writeNode, discordNode()],
           edges: [
-            { id: "e1", source: "trigger", target: "poke-1" },
-            { id: "e2", source: "poke-1", target: "notify-1" },
+            { id: "e1", source: "trigger", target: "write-1" },
+            { id: "e2", source: "write-1", target: "notify-1" },
           ],
         },
       });
@@ -188,7 +188,7 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
     apiRequest,
   }) => {
     const noArgWrite: WorkflowNode = {
-      id: "poke-1",
+      id: "write-1",
       type: "action",
       position: { x: 0, y: 120 },
       data: {
@@ -199,7 +199,7 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: WRITE_CONTRACT_ABI,
-          abiFunction: "poke",
+          abiFunction: "doWrite",
           functionArgs: "[]",
         },
       },
@@ -210,8 +210,8 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
       triggerType: "manual",
       nodes: [triggerNode(), noArgWrite, discordNode()],
       edges: [
-        { id: "e1", source: "trigger", target: "poke-1" },
-        { id: "e2", source: "poke-1", target: "notify-1" },
+        { id: "e1", source: "trigger", target: "write-1" },
+        { id: "e2", source: "write-1", target: "notify-1" },
       ],
     });
 
@@ -224,8 +224,8 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
         data: {
           nodes: [triggerNode(), noArgWrite, discordNode()],
           edges: [
-            { id: "e1", source: "trigger", target: "poke-1" },
-            { id: "e2", source: "poke-1", target: "notify-1" },
+            { id: "e1", source: "trigger", target: "write-1" },
+            { id: "e2", source: "write-1", target: "notify-1" },
           ],
         },
       });
@@ -286,36 +286,37 @@ test.describe("KEEP-571: workflow save with stringified container fields", () =>
     }
   });
 
-  test("saves the exact OSM Alert prod node shape that was failing (ooiuqkddnj6fnssg93kgr)", async ({
+  test("saves the exact templated-args prod node shape that was failing (mock-workflow-id)", async ({
     page,
     apiRequest,
   }) => {
-    const osmAlertNode: WorkflowNode = {
+    const mockTemplatedNode: WorkflowNode = {
       id: "node-6",
       type: "action",
       position: { x: 0, y: 120 },
       data: {
-        label: "Read Vat ilks",
+        label: "Read mock contract",
         type: "action",
         config: {
           actionType: "web3/read-contract",
-          abi: '[{"inputs":[{"internalType":"bytes32","name":"ilk","type":"bytes32"}],"name":"ilks","outputs":[{"internalType":"uint256","name":"Art","type":"uint256"},{"internalType":"uint256","name":"rate","type":"uint256"},{"internalType":"uint256","name":"spot","type":"uint256"},{"internalType":"uint256","name":"line","type":"uint256"},{"internalType":"uint256","name":"dust","type":"uint256"}],"stateMutability":"view","type":"function"}]',
+          abi: '[{"inputs":[{"internalType":"bytes32","name":"id","type":"bytes32"}],"name":"reader","outputs":[{"internalType":"uint256","name":"Art","type":"uint256"},{"internalType":"uint256","name":"rate","type":"uint256"},{"internalType":"uint256","name":"spot","type":"uint256"},{"internalType":"uint256","name":"line","type":"uint256"},{"internalType":"uint256","name":"dust","type":"uint256"}],"stateMutability":"view","type":"function"}]',
           network: "1",
-          abiFunction: "ilks",
-          functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
-          contractAddress: "{{@fetch-chainlog:Fetch Chainlog.data.MCD_VAT}}",
+          abiFunction: "reader",
+          functionArgs: '["{{@prev-loop:Prev Loop.currentItem.idBytes32}}"]',
+          contractAddress:
+            "{{@fetch@prev-fetch:Prev Fetch.data.targetAddress}}",
         },
       },
     };
 
-    const nodes = [triggerNode(), osmAlertNode, discordNode("notify-1")];
+    const nodes = [triggerNode(), mockTemplatedNode, discordNode("notify-1")];
     const edges = [
       { id: "e1", source: "trigger", target: "node-6" },
       { id: "e2", source: "node-6", target: "notify-1" },
     ];
 
     const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
-      name: `keep-571-osm-alert-${Date.now()}`,
+      name: `keep-571-templated-args-${Date.now()}`,
       triggerType: "manual",
       nodes,
       edges,

--- a/tests/e2e/playwright/workflow-save-stringified-args.test.ts
+++ b/tests/e2e/playwright/workflow-save-stringified-args.test.ts
@@ -1,0 +1,339 @@
+import { expect, test } from "./fixtures";
+import {
+  createTestWorkflow,
+  deleteTestWorkflow,
+  PERSISTENT_TEST_USER_EMAIL,
+} from "./utils/db";
+
+const READ_CONTRACT_ABI = JSON.stringify([
+  {
+    inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
+    name: "ilks",
+    outputs: [
+      { internalType: "uint256", name: "Art", type: "uint256" },
+      { internalType: "uint256", name: "rate", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+]);
+
+const WRITE_CONTRACT_ABI = JSON.stringify([
+  {
+    inputs: [],
+    name: "poke",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+]);
+
+type WorkflowNode = {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: {
+    label?: string;
+    type: string;
+    config: Record<string, unknown>;
+  };
+};
+
+function triggerNode(): WorkflowNode {
+  return {
+    id: "trigger",
+    type: "trigger",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "Manual",
+      type: "trigger",
+      config: { actionType: "Manual" },
+    },
+  };
+}
+
+function readContractNode(
+  overrides: Partial<Record<string, unknown>> = {},
+  id = "read-1"
+): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 120 },
+    data: {
+      label: "Read Contract",
+      type: "action",
+      config: {
+        actionType: "web3/read-contract",
+        network: "1",
+        contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        abi: READ_CONTRACT_ABI,
+        abiFunction: "ilks",
+        functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+        ...overrides,
+      },
+    },
+  };
+}
+
+function discordNode(id = "notify-1"): WorkflowNode {
+  return {
+    id,
+    type: "action",
+    position: { x: 0, y: 240 },
+    data: {
+      label: "Discord",
+      type: "action",
+      config: {
+        actionType: "discord/send-message",
+        discordMessage: "done",
+      },
+    },
+  };
+}
+
+test.describe("KEEP-571: workflow save with stringified container fields", () => {
+  test("saves a 3-node workflow with web3/read-contract stringified functionArgs (OSM Alert shape)", async ({
+    page,
+    apiRequest,
+  }) => {
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-read-contract-${Date.now()}`,
+      triggerType: "manual",
+      nodes: [triggerNode(), readContractNode(), discordNode()],
+      edges: [
+        { id: "e1", source: "trigger", target: "read-1" },
+        { id: "e2", source: "read-1", target: "notify-1" },
+      ],
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: {
+          nodes: [triggerNode(), readContractNode(), discordNode()],
+          edges: [
+            { id: "e1", source: "trigger", target: "read-1" },
+            { id: "e2", source: "read-1", target: "notify-1" },
+          ],
+        },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("saves a workflow with legacy `functionName` on web3/write-contract (MegaPoker shape)", async ({
+    page,
+    apiRequest,
+  }) => {
+    const writeNode: WorkflowNode = {
+      id: "poke-1",
+      type: "action",
+      position: { x: 0, y: 120 },
+      data: {
+        label: "Write Contract",
+        type: "action",
+        config: {
+          actionType: "web3/write-contract",
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: WRITE_CONTRACT_ABI,
+          functionName: "poke",
+          functionArgs: "[]",
+        },
+      },
+    };
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-legacy-fn-name-${Date.now()}`,
+      triggerType: "manual",
+      nodes: [triggerNode(), writeNode, discordNode()],
+      edges: [
+        { id: "e1", source: "trigger", target: "poke-1" },
+        { id: "e2", source: "poke-1", target: "notify-1" },
+      ],
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: {
+          nodes: [triggerNode(), writeNode, discordNode()],
+          edges: [
+            { id: "e1", source: "trigger", target: "poke-1" },
+            { id: "e2", source: "poke-1", target: "notify-1" },
+          ],
+        },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("saves a workflow with an empty-array stringified functionArgs (no-arg function)", async ({
+    page,
+    apiRequest,
+  }) => {
+    const noArgWrite: WorkflowNode = {
+      id: "poke-1",
+      type: "action",
+      position: { x: 0, y: 120 },
+      data: {
+        label: "Write Contract",
+        type: "action",
+        config: {
+          actionType: "web3/write-contract",
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: WRITE_CONTRACT_ABI,
+          abiFunction: "poke",
+          functionArgs: "[]",
+        },
+      },
+    };
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-empty-args-${Date.now()}`,
+      triggerType: "manual",
+      nodes: [triggerNode(), noArgWrite, discordNode()],
+      edges: [
+        { id: "e1", source: "trigger", target: "poke-1" },
+        { id: "e2", source: "poke-1", target: "notify-1" },
+      ],
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: {
+          nodes: [triggerNode(), noArgWrite, discordNode()],
+          edges: [
+            { id: "e1", source: "trigger", target: "poke-1" },
+            { id: "e2", source: "poke-1", target: "notify-1" },
+          ],
+        },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("rejects a non-JSON, non-template literal in functionArgs with 422 INVALID_ACTION_CONFIG", async ({
+    page,
+    apiRequest,
+  }) => {
+    const badNode = readContractNode({
+      functionArgs: "this-is-not-json-or-a-template",
+    });
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-bad-args-${Date.now()}`,
+      triggerType: "manual",
+      nodes: [triggerNode(), readContractNode(), discordNode()],
+      edges: [
+        { id: "e1", source: "trigger", target: "read-1" },
+        { id: "e2", source: "read-1", target: "notify-1" },
+      ],
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: {
+          nodes: [triggerNode(), badNode, discordNode()],
+          edges: [
+            { id: "e1", source: "trigger", target: "read-1" },
+            { id: "e2", source: "read-1", target: "notify-1" },
+          ],
+        },
+      });
+
+      expect(response.status()).toBe(422);
+      const body = await response.json();
+      expect(body.error).toBe("INVALID_ACTION_CONFIG");
+      expect(body.invalidFields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "INVALID_FIELD_TYPE",
+            field: "functionArgs",
+          }),
+        ])
+      );
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+
+  test("saves the exact OSM Alert prod node shape that was failing (ooiuqkddnj6fnssg93kgr)", async ({
+    page,
+    apiRequest,
+  }) => {
+    const osmAlertNode: WorkflowNode = {
+      id: "node-6",
+      type: "action",
+      position: { x: 0, y: 120 },
+      data: {
+        label: "Read Vat ilks",
+        type: "action",
+        config: {
+          actionType: "web3/read-contract",
+          abi: '[{"inputs":[{"internalType":"bytes32","name":"ilk","type":"bytes32"}],"name":"ilks","outputs":[{"internalType":"uint256","name":"Art","type":"uint256"},{"internalType":"uint256","name":"rate","type":"uint256"},{"internalType":"uint256","name":"spot","type":"uint256"},{"internalType":"uint256","name":"line","type":"uint256"},{"internalType":"uint256","name":"dust","type":"uint256"}],"stateMutability":"view","type":"function"}]',
+          network: "1",
+          abiFunction: "ilks",
+          functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+          contractAddress: "{{@fetch-chainlog:Fetch Chainlog.data.MCD_VAT}}",
+        },
+      },
+    };
+
+    const nodes = [triggerNode(), osmAlertNode, discordNode("notify-1")];
+    const edges = [
+      { id: "e1", source: "trigger", target: "node-6" },
+      { id: "e2", source: "node-6", target: "notify-1" },
+    ];
+
+    const workflow = await createTestWorkflow(PERSISTENT_TEST_USER_EMAIL, {
+      name: `keep-571-osm-alert-${Date.now()}`,
+      triggerType: "manual",
+      nodes,
+      edges,
+    });
+
+    try {
+      await page.goto(`/workflows/${workflow.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const response = await apiRequest.patch(`/api/workflows/${workflow.id}`, {
+        data: { nodes, edges },
+      });
+
+      const body = await response.text();
+      expect(response.status(), `PATCH failed with body: ${body}`).toBe(200);
+    } finally {
+      await deleteTestWorkflow(workflow.id);
+    }
+  });
+});

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -449,6 +449,179 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(mockUpdateReturning).not.toHaveBeenCalled();
   });
 
+  it("KEEP-571: PATCH accepts a 3+ node workflow whose web3/read-contract uses stringified functionArgs (UI wire format)", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: {
+              type: "trigger",
+              config: { actionType: "Manual" },
+            },
+          },
+          {
+            id: "read-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/read-contract",
+                network: "1",
+                contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                abi: JSON.stringify([
+                  {
+                    inputs: [
+                      { internalType: "bytes32", name: "ilk", type: "bytes32" },
+                    ],
+                    name: "ilks",
+                    outputs: [
+                      { internalType: "uint256", name: "Art", type: "uint256" },
+                    ],
+                    stateMutability: "view",
+                    type: "function",
+                  },
+                ]),
+                abiFunction: "ilks",
+                functionArgs:
+                  '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+              },
+            },
+          },
+          {
+            id: "msg-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "discord/send-message",
+                discordMessage: "ilk read",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH accepts legacy `functionName` on web3/write-contract (MegaPoker case)", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: {
+              type: "trigger",
+              config: { actionType: "Manual" },
+            },
+          },
+          {
+            id: "poke-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/write-contract",
+                network: "1",
+                contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                abi: JSON.stringify([
+                  {
+                    inputs: [],
+                    name: "poke",
+                    outputs: [],
+                    stateMutability: "nonpayable",
+                    type: "function",
+                  },
+                ]),
+                functionName: "poke",
+                functionArgs: "[]",
+              },
+            },
+          },
+          {
+            id: "notify",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "discord/send-message",
+                discordMessage: "poked",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH still rejects bogus values for stringified container fields", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: {
+              type: "trigger",
+              config: { actionType: "Manual" },
+            },
+          },
+          {
+            id: "read-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/read-contract",
+                network: "1",
+                contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                abi: "[]",
+                abiFunction: "ilks",
+                functionArgs: "this-is-not-json-or-a-template",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    const data = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(data.error).toBe("INVALID_ACTION_CONFIG");
+    expect(data.invalidFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          field: "functionArgs",
+        }),
+      ])
+    );
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
   it("KEEP-467: PATCH validates integration ownership after sanitizer moves misplaced config fields", async () => {
     mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
     mockValidateWorkflowIntegrations.mockResolvedValue({

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -622,6 +622,278 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(mockUpdateReturning).not.toHaveBeenCalled();
   });
 
+  it("KEEP-571: PATCH saves a 6-node workflow with the affected node at index 3 (proves node-count is not a threshold)", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const readContractAbi = JSON.stringify([
+      {
+        inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
+        name: "ilks",
+        outputs: [{ internalType: "uint256", name: "Art", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+      },
+    ]);
+
+    const fillerNode = (id: string): Record<string, unknown> => ({
+      id,
+      type: "action",
+      data: {
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          discordMessage: `msg-${id}`,
+        },
+      },
+    });
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: { type: "trigger", config: { actionType: "Manual" } },
+          },
+          fillerNode("n-1"),
+          fillerNode("n-2"),
+          {
+            id: "read-3",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/read-contract",
+                network: "1",
+                contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                abi: readContractAbi,
+                abiFunction: "ilks",
+                functionArgs:
+                  '["0x0000000000000000000000000000000000000000000000000000000000000001"]',
+              },
+            },
+          },
+          fillerNode("n-4"),
+          fillerNode("n-5"),
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH saves a 10-node workflow with two affected read-contract nodes at different indices", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const readAbi = JSON.stringify([
+      {
+        inputs: [],
+        name: "totalSupply",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+      },
+    ]);
+
+    const filler = (id: string): Record<string, unknown> => ({
+      id,
+      type: "action",
+      data: {
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          discordMessage: id,
+        },
+      },
+    });
+
+    const readContract = (id: string): Record<string, unknown> => ({
+      id,
+      type: "action",
+      data: {
+        type: "action",
+        config: {
+          actionType: "web3/read-contract",
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: readAbi,
+          abiFunction: "totalSupply",
+          functionArgs: "[]",
+        },
+      },
+    });
+
+    const nodes: Record<string, unknown>[] = [
+      {
+        id: "trigger",
+        type: "trigger",
+        data: { type: "trigger", config: { actionType: "Manual" } },
+      },
+    ];
+    for (let i = 1; i <= 9; i++) {
+      if (i === 2 || i === 7) {
+        nodes.push(readContract(`r-${i}`));
+      } else {
+        nodes.push(filler(`f-${i}`));
+      }
+    }
+
+    const response = await PATCH(createRequest("PATCH", { nodes, edges: [] }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH still surfaces correct node-index paths in invalidFields for large workflows", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+
+    const filler = (id: string): Record<string, unknown> => ({
+      id,
+      type: "action",
+      data: {
+        type: "action",
+        config: {
+          actionType: "discord/send-message",
+          discordMessage: id,
+        },
+      },
+    });
+
+    const nodes: Record<string, unknown>[] = [
+      {
+        id: "trigger",
+        type: "trigger",
+        data: { type: "trigger", config: { actionType: "Manual" } },
+      },
+      filler("f-1"),
+      filler("f-2"),
+      filler("f-3"),
+      {
+        id: "bad-4",
+        type: "action",
+        data: {
+          type: "action",
+          config: {
+            actionType: "web3/read-contract",
+            network: "1",
+            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            abi: "[]",
+            abiFunction: "ilks",
+            functionArgs: "not-json",
+          },
+        },
+      },
+      filler("f-5"),
+    ];
+
+    const response = await PATCH(createRequest("PATCH", { nodes, edges: [] }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.invalidFields).toEqual([
+      expect.objectContaining({
+        code: "INVALID_FIELD_TYPE",
+        path: "nodes[4].data.config.functionArgs",
+        field: "functionArgs",
+      }),
+    ]);
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH with a 1-node workflow (trigger only, no actions) succeeds", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: { type: "trigger", config: { actionType: "Manual" } },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH with a 2-node workflow (trigger + single read-contract using stringified args) succeeds", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: { type: "trigger", config: { actionType: "Manual" } },
+          },
+          {
+            id: "read-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/read-contract",
+                network: "1",
+                contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                abi: "[]",
+                abiFunction: "balanceOf",
+                functionArgs: '["{{trigger.walletAddress}}"]',
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH with empty nodes array succeeds (cleared workflow)", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH without nodes in body (partial update) skips action-config validation", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { name: "Renamed only" }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
   it("KEEP-467: PATCH validates integration ownership after sanitizer moves misplaced config fields", async () => {
     mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
     mockValidateWorkflowIntegrations.mockResolvedValue({

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -476,9 +476,9 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
                 abi: JSON.stringify([
                   {
                     inputs: [
-                      { internalType: "bytes32", name: "ilk", type: "bytes32" },
+                      { internalType: "bytes32", name: "id", type: "bytes32" },
                     ],
-                    name: "ilks",
+                    name: "reader",
                     outputs: [
                       { internalType: "uint256", name: "Art", type: "uint256" },
                     ],
@@ -486,9 +486,9 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
                     type: "function",
                   },
                 ]),
-                abiFunction: "ilks",
+                abiFunction: "reader",
                 functionArgs:
-                  '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+                  '["{{@prev-loop:Prev Loop.currentItem.idBytes32}}"]',
               },
             },
           },
@@ -499,7 +499,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
               type: "action",
               config: {
                 actionType: "discord/send-message",
-                discordMessage: "ilk read",
+                discordMessage: "id read",
               },
             },
           },
@@ -513,7 +513,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(mockUpdateReturning).toHaveBeenCalled();
   });
 
-  it("KEEP-571: PATCH accepts legacy `functionName` on web3/write-contract (MegaPoker case)", async () => {
+  it("KEEP-571: PATCH accepts legacy `functionName` on web3/write-contract (legacy functionName case)", async () => {
     mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
     mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
 
@@ -529,7 +529,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
             },
           },
           {
-            id: "poke-1",
+            id: "doWrite-1",
             type: "action",
             data: {
               type: "action",
@@ -540,13 +540,13 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
                 abi: JSON.stringify([
                   {
                     inputs: [],
-                    name: "poke",
+                    name: "doWrite",
                     outputs: [],
                     stateMutability: "nonpayable",
                     type: "function",
                   },
                 ]),
-                functionName: "poke",
+                functionName: "doWrite",
                 functionArgs: "[]",
               },
             },
@@ -558,7 +558,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
               type: "action",
               config: {
                 actionType: "discord/send-message",
-                discordMessage: "poked",
+                discordMessage: "done",
               },
             },
           },
@@ -596,7 +596,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
                 network: "1",
                 contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
                 abi: "[]",
-                abiFunction: "ilks",
+                abiFunction: "reader",
                 functionArgs: "this-is-not-json-or-a-template",
               },
             },
@@ -622,14 +622,92 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
     expect(mockUpdateReturning).not.toHaveBeenCalled();
   });
 
+  it("KEEP-571: PATCH accepts useManualAbi UI state on web3 actions (global reserved key)", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: { type: "trigger", config: { actionType: "Manual" } },
+          },
+          {
+            id: "read-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/read-contract",
+                network: "1",
+                contractAddress: "0x0000000000000000000000000000000000000001",
+                abi: "[]",
+                abiFunction: "reader",
+                functionArgs: "[]",
+                useManualAbi: "true",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
+  it("KEEP-571: PATCH accepts inputMode/batchSize leak on web3/query-transactions", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
+    mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            data: { type: "trigger", config: { actionType: "Manual" } },
+          },
+          {
+            id: "query-1",
+            type: "action",
+            data: {
+              type: "action",
+              config: {
+                actionType: "web3/query-transactions",
+                network: "1",
+                contractAddress: "0x0000000000000000000000000000000000000001",
+                abi: "[]",
+                abiFunction: "doWrite",
+                inputMode: "uniform",
+                batchSize: "100",
+                blockCount: "225000",
+                useManualAbi: "true",
+              },
+            },
+          },
+        ],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateReturning).toHaveBeenCalled();
+  });
+
   it("KEEP-571: PATCH saves a 6-node workflow with the affected node at index 3 (proves node-count is not a threshold)", async () => {
     mockWorkflowsFindFirst.mockResolvedValue(makeWorkflow());
     mockUpdateReturning.mockResolvedValue([makeWorkflow()]);
 
     const readContractAbi = JSON.stringify([
       {
-        inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
-        name: "ilks",
+        inputs: [{ internalType: "bytes32", name: "id", type: "bytes32" }],
+        name: "reader",
         outputs: [{ internalType: "uint256", name: "Art", type: "uint256" }],
         stateMutability: "view",
         type: "function",
@@ -668,7 +746,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
                 network: "1",
                 contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
                 abi: readContractAbi,
-                abiFunction: "ilks",
+                abiFunction: "reader",
                 functionArgs:
                   '["0x0000000000000000000000000000000000000000000000000000000000000001"]',
               },
@@ -785,7 +863,7 @@ describe("PATCH /api/workflows/[workflowId] — listing fields", () => {
             network: "1",
             contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
             abi: "[]",
-            abiFunction: "ilks",
+            abiFunction: "reader",
             functionArgs: "not-json",
           },
         },

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -541,6 +541,335 @@ describe("validateWorkflowActionConfigs", () => {
       expect(result).toEqual({ valid: true, issues: [] });
     });
   });
+
+  describe("node-count invariance (prove >2 node failures were per-node, not threshold)", () => {
+    const READ_CONTRACT_ABI = JSON.stringify([
+      {
+        inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
+        name: "ilks",
+        outputs: [{ internalType: "uint256", name: "Art", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+      },
+    ]);
+
+    function makeAffectedReadNode(id: string): ReturnType<typeof actionNode> {
+      return actionNode(
+        "web3/read-contract",
+        {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs:
+            '["0x0000000000000000000000000000000000000000000000000000000000000001"]',
+        },
+        id
+      );
+    }
+
+    function makeFillerNode(id: string): ReturnType<typeof actionNode> {
+      return actionNode("discord/send-message", { discordMessage: id }, id);
+    }
+
+    it.each([
+      1, 2, 3, 5, 10, 20,
+    ])("a workflow of size %i with the affected node passes", (size) => {
+      const nodes: ReturnType<typeof actionNode>[] = [];
+      for (let i = 0; i < size; i++) {
+        nodes.push(
+          i === 0 ? makeAffectedReadNode(`n-${i}`) : makeFillerNode(`n-${i}`)
+        );
+      }
+
+      const result = validateWorkflowActionConfigs(nodes);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it.each([
+      0, 1, 3, 5, 9,
+    ])("validation outcome is identical regardless of affected-node index (idx=%i in 10-node workflow)", (affectedIndex) => {
+      const nodes: ReturnType<typeof actionNode>[] = [];
+      for (let i = 0; i < 10; i++) {
+        nodes.push(
+          i === affectedIndex
+            ? makeAffectedReadNode(`n-${i}`)
+            : makeFillerNode(`n-${i}`)
+        );
+      }
+
+      const result = validateWorkflowActionConfigs(nodes);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("a workflow with N affected nodes still passes (no aggregate cap)", () => {
+      const nodes: ReturnType<typeof actionNode>[] = [];
+      for (let i = 0; i < 15; i++) {
+        nodes.push(makeAffectedReadNode(`n-${i}`));
+      }
+
+      const result = validateWorkflowActionConfigs(nodes);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("reports invalid fields at the correct node index in a 6-node workflow", () => {
+      const nodes = [
+        makeFillerNode("n-0"),
+        makeFillerNode("n-1"),
+        makeFillerNode("n-2"),
+        actionNode(
+          "web3/read-contract",
+          {
+            network: "1",
+            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            abi: READ_CONTRACT_ABI,
+            abiFunction: "ilks",
+            functionArgs: "not-json-not-template",
+          },
+          "n-3"
+        ),
+        makeFillerNode("n-4"),
+        makeFillerNode("n-5"),
+      ];
+
+      const result = validateWorkflowActionConfigs(nodes);
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          path: "nodes[3].data.config.functionArgs",
+        }),
+      ]);
+    });
+
+    it("collects issues from multiple affected nodes spread across the array", () => {
+      const nodes = [
+        actionNode(
+          "web3/read-contract",
+          {
+            network: "1",
+            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            abi: READ_CONTRACT_ABI,
+            abiFunction: "ilks",
+            functionArgs: "bogus-a",
+          },
+          "n-0"
+        ),
+        makeFillerNode("n-1"),
+        makeFillerNode("n-2"),
+        actionNode(
+          "web3/read-contract",
+          {
+            network: "1",
+            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            abi: READ_CONTRACT_ABI,
+            abiFunction: "ilks",
+            functionArgs: "bogus-b",
+          },
+          "n-3"
+        ),
+        makeFillerNode("n-4"),
+      ];
+
+      const result = validateWorkflowActionConfigs(nodes);
+      expect(result.valid).toBe(false);
+      expect(result.issues).toHaveLength(2);
+      expect(result.issues[0]).toMatchObject({
+        path: "nodes[0].data.config.functionArgs",
+        received: "bogus-a",
+      });
+      expect(result.issues[1]).toMatchObject({
+        path: "nodes[3].data.config.functionArgs",
+        received: "bogus-b",
+      });
+    });
+  });
+
+  describe("broader save-time edge cases (not specific to KEEP-571)", () => {
+    it("accepts an empty nodes array (new workflow placeholder)", () => {
+      const result = validateWorkflowActionConfigs([]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("skips trigger nodes entirely (validator only gates action nodes)", () => {
+      const result = validateWorkflowActionConfigs([
+        {
+          id: "trigger",
+          type: "trigger",
+          data: {
+            type: "trigger",
+            config: { actionType: "Manual", anyArbitraryField: 42 },
+          },
+        },
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("skips nodes whose data.config is missing or non-object", () => {
+      const result = validateWorkflowActionConfigs([
+        { id: "n-0", type: "action", data: { type: "action" } },
+        {
+          id: "n-1",
+          type: "action",
+          data: { type: "action", config: null as never },
+        },
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("skips nodes with missing or blank actionType (incomplete authoring state)", () => {
+      const result = validateWorkflowActionConfigs([
+        {
+          id: "n-0",
+          type: "action",
+          data: { type: "action", config: { actionType: "" } },
+        },
+        {
+          id: "n-1",
+          type: "action",
+          data: { type: "action", config: {} },
+        },
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("does not flag RESERVED_CONFIG_KEYS (integrationId, actionType, addressBookSelection, usePrivateMempool, strict)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("discord/send-message", {
+          discordMessage: "hi",
+          integrationId: "intg-1",
+          usePrivateMempool: true,
+          strict: false,
+        }),
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a number for a string-like field (validator coerces stringLike)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("discord/send-message", { discordMessage: 12_345 }),
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("rejects an object for a string-like field", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("discord/send-message", {
+          discordMessage: { not: "a string" },
+        }),
+      ]);
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          field: "discordMessage",
+        }),
+      ]);
+    });
+
+    it("respects showWhen gating: hidden required field is not flagged missing", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/batch-read-contract", {
+          inputMode: "mixed",
+          calls:
+            '[{"network":"1","contractAddress":"0x6B175474E89094C44Da98b954EedeAC495271d0F","abi":[],"abiFunction":"foo","args":[]}]',
+        }),
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("flags a missing required field that IS visible under showWhen", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/batch-read-contract", {
+          inputMode: "uniform",
+        }),
+      ]);
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "MISSING_REQUIRED_FIELD",
+            field: "network",
+          }),
+        ])
+      );
+    });
+
+    it("validates each node independently: one broken node does not invalidate sibling nodes", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("discord/send-message", { discordMessage: "valid" }, "n-0"),
+        actionNode(
+          "webhook/send-webhook",
+          {
+            webhookUrl: "https://example.com",
+            webhookMethod: "POST",
+          },
+          "n-1"
+        ),
+        actionNode("discord/send-message", { Message: "wrong-case" }, "n-2"),
+      ]);
+      expect(result.valid).toBe(false);
+      const paths = result.issues.map((i) => i.path);
+      expect(paths.every((p) => p.startsWith("nodes[2]"))).toBe(true);
+    });
+
+    it("returns deterministic issue ordering across the node array", () => {
+      const nodes: ReturnType<typeof actionNode>[] = [];
+      for (let i = 0; i < 5; i++) {
+        nodes.push(
+          actionNode("discord/send-message", { Message: `bad-${i}` }, `n-${i}`)
+        );
+      }
+      const result = validateWorkflowActionConfigs(nodes);
+      const unknownFieldPaths = result.issues
+        .filter((i) => i.code === "UNKNOWN_FIELD")
+        .map((i) => i.path);
+      expect(unknownFieldPaths).toEqual([
+        "nodes[0].data.config.Message",
+        "nodes[1].data.config.Message",
+        "nodes[2].data.config.Message",
+        "nodes[3].data.config.Message",
+        "nodes[4].data.config.Message",
+      ]);
+    });
+
+    it("does not double-report the same field as both UNKNOWN_FIELD and INVALID_FIELD_TYPE", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("discord/send-message", { discordMessage: "ok" }),
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a node that uses an integer-string for a protocol-uint field (chainId-style)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("aave-v3/supply", {
+          network: "1",
+          asset: "0x0000000000000000000000000000000000000001",
+          amount: "1000000000000000000",
+          onBehalfOf: "0x0000000000000000000000000000000000000002",
+        }),
+      ]);
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("rejects an empty string for a required string field (treated as missing)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("webhook/send-webhook", {
+          webhookUrl: "",
+          webhookMethod: "POST",
+        }),
+      ]);
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "MISSING_REQUIRED_FIELD",
+            field: "webhookUrl",
+          }),
+        ])
+      );
+    });
+  });
 });
 
 describe("formatActionConfigValidationResponse", () => {

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -201,8 +201,8 @@ describe("validateWorkflowActionConfigs", () => {
   describe("KEEP-571 stringified container fields (UI wire format)", () => {
     const READ_CONTRACT_ABI = JSON.stringify([
       {
-        inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
-        name: "ilks",
+        inputs: [{ internalType: "bytes32", name: "id", type: "bytes32" }],
+        name: "reader",
         outputs: [
           { internalType: "uint256", name: "Art", type: "uint256" },
           { internalType: "uint256", name: "rate", type: "uint256" },
@@ -218,8 +218,8 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
-          functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+          abiFunction: "reader",
+          functionArgs: '["{{@prev-loop:Prev Loop.currentItem.idBytes32}}"]',
         }),
       ]);
 
@@ -234,13 +234,13 @@ describe("validateWorkflowActionConfigs", () => {
           abi: JSON.stringify([
             {
               inputs: [],
-              name: "poke",
+              name: "doWrite",
               outputs: [],
               stateMutability: "nonpayable",
               type: "function",
             },
           ]),
-          abiFunction: "poke",
+          abiFunction: "doWrite",
           functionArgs: "[]",
         }),
       ]);
@@ -254,7 +254,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs: "",
         }),
       ]);
@@ -268,7 +268,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs: [
             "0x0000000000000000000000000000000000000000000000000000000000000001",
           ],
@@ -284,7 +284,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs: "{{@previous.argsList}}",
         }),
       ]);
@@ -298,7 +298,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs: "not-json",
         }),
       ]);
@@ -321,7 +321,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs: '"only-a-string"',
         }),
       ]);
@@ -342,7 +342,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           argsList: '[["0x01"],["0x02"]]',
         }),
       ]);
@@ -368,7 +368,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs: '{"named":"args"}',
         }),
       ]);
@@ -393,7 +393,7 @@ describe("validateWorkflowActionConfigs", () => {
             network: "1",
             contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
             abi: READ_CONTRACT_ABI,
-            abiFunction: "ilks",
+            abiFunction: "reader",
             functionArgs: '["0x0000000000000000000000000000000000000001"]',
           },
           "node-1"
@@ -406,13 +406,13 @@ describe("validateWorkflowActionConfigs", () => {
             abi: JSON.stringify([
               {
                 inputs: [],
-                name: "poke",
+                name: "doWrite",
                 outputs: [],
                 stateMutability: "nonpayable",
                 type: "function",
               },
             ]),
-            abiFunction: "poke",
+            abiFunction: "doWrite",
             functionArgs: "[]",
           },
           "node-2"
@@ -432,20 +432,20 @@ describe("validateWorkflowActionConfigs", () => {
     const WRITE_CONTRACT_ABI = JSON.stringify([
       {
         inputs: [],
-        name: "poke",
+        name: "doWrite",
         outputs: [],
         stateMutability: "nonpayable",
         type: "function",
       },
     ]);
 
-    it("accepts legacy functionName on web3/write-contract when abiFunction is absent (MegaPoker case)", () => {
+    it("accepts legacy functionName on web3/write-contract when abiFunction is absent", () => {
       const result = validateWorkflowActionConfigs([
         actionNode("web3/write-contract", {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: WRITE_CONTRACT_ABI,
-          functionName: "poke",
+          functionName: "doWrite",
           functionArgs: "[]",
         }),
       ]);
@@ -473,7 +473,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: WRITE_CONTRACT_ABI,
-          abiFunction: "poke",
+          abiFunction: "doWrite",
           functionName: "stale-legacy-value",
           functionArgs: "[]",
         }),
@@ -488,7 +488,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: WRITE_CONTRACT_ABI,
-          abiFunction: "poke",
+          abiFunction: "doWrite",
           functionArgs: "[]",
           totallyMadeUpField: "nope",
         }),
@@ -525,16 +525,16 @@ describe("validateWorkflowActionConfigs", () => {
     });
   });
 
-  describe("KEEP-571 OSM Alert regression (real prod node shape)", () => {
-    it("accepts the exact node shape that prod workflow ooiuqkddnj6fnssg93kgr was failing to save", () => {
+  describe("KEEP-571 regression on a multi-template, integrationId-bearing node", () => {
+    it("accepts a read-contract node shape that combines stringified args, integrationId, and templated address", () => {
       const result = validateWorkflowActionConfigs([
         actionNode("web3/read-contract", {
-          abi: '[{"inputs":[{"internalType":"bytes32","name":"ilk","type":"bytes32"}],"name":"ilks","outputs":[{"internalType":"uint256","name":"Art","type":"uint256"},{"internalType":"uint256","name":"rate","type":"uint256"},{"internalType":"uint256","name":"spot","type":"uint256"},{"internalType":"uint256","name":"line","type":"uint256"},{"internalType":"uint256","name":"dust","type":"uint256"}],"stateMutability":"view","type":"function"}]',
+          abi: '[{"inputs":[{"internalType":"bytes32","name":"id","type":"bytes32"}],"name":"reader","outputs":[{"internalType":"uint256","name":"a","type":"uint256"},{"internalType":"uint256","name":"b","type":"uint256"}],"stateMutability":"view","type":"function"}]',
           network: "1",
-          abiFunction: "ilks",
-          functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
-          integrationId: "ecw50nj0v9at1p6thn0nh",
-          contractAddress: "{{@fetch-chainlog:Fetch Chainlog.data.MCD_VAT}}",
+          abiFunction: "reader",
+          functionArgs: '["{{@prev-loop:Prev Loop.currentItem.idBytes32}}"]',
+          integrationId: "mock-integration-id-00000",
+          contractAddress: "{{@prev-fetch:Prev Fetch.data.targetAddress}}",
         }),
       ]);
 
@@ -542,11 +542,160 @@ describe("validateWorkflowActionConfigs", () => {
     });
   });
 
+  describe("KEEP-571 UI-only state and cross-action leak fields", () => {
+    it("accepts useManualAbi on web3/write-contract (UI toggle, never a config field)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/write-contract", {
+          network: "1",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+          abi: JSON.stringify([
+            {
+              inputs: [],
+              name: "cast",
+              outputs: [],
+              stateMutability: "nonpayable",
+              type: "function",
+            },
+          ]),
+          abiFunction: "cast",
+          functionArgs: "[]",
+          useManualAbi: "true",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it.each([
+      "web3/read-contract",
+      "web3/write-contract",
+      "web3/query-events",
+      "web3/query-transactions",
+      "web3/batch-read-contract",
+    ])("accepts useManualAbi on %s (global UI state)", (actionType) => {
+      const result = validateWorkflowActionConfigs([
+        actionNode(actionType, {
+          network: "1",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+          abi: "[]",
+          abiFunction: "foo",
+          functionArgs: "[]",
+          useManualAbi: "true",
+        }),
+      ]);
+
+      // We only care that useManualAbi itself does NOT show up as UNKNOWN_FIELD.
+      const useManualAbiIssues = result.issues.filter(
+        (i) => i.field === "useManualAbi"
+      );
+      expect(useManualAbiIssues).toEqual([]);
+    });
+
+    it("accepts inputMode and batchSize leftovers on web3/query-transactions (cross-action UI leak)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/query-transactions", {
+          network: "1",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+          abi: "[]",
+          abiFunction: "schedule",
+          inputMode: "uniform",
+          batchSize: "100",
+          blockCount: "225000",
+        }),
+      ]);
+
+      const leakIssues = result.issues.filter(
+        (i) => i.field === "inputMode" || i.field === "batchSize"
+      );
+      expect(leakIssues).toEqual([]);
+    });
+
+    it("accepts inputMode and batchSize leftovers on web3/query-events (same cross-action leak)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/query-events", {
+          network: "1",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+          abi: "[]",
+          eventName: "Transfer",
+          inputMode: "uniform",
+          batchSize: "100",
+        }),
+      ]);
+
+      const leakIssues = result.issues.filter(
+        (i) => i.field === "inputMode" || i.field === "batchSize"
+      );
+      expect(leakIssues).toEqual([]);
+    });
+
+    it("accepts the full cross-action leak import payload (combined useManualAbi + inputMode + batchSize)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/query-transactions", {
+          network: "1",
+          batchSize: "100",
+          inputMode: "uniform",
+          blockCount: "225000",
+          abi: "[]",
+          abiFunction: "schedule",
+          useManualAbi: "true",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("still rejects a TRULY unknown field even when useManualAbi is present", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+          abi: "[]",
+          abiFunction: "foo",
+          functionArgs: "[]",
+          useManualAbi: "true",
+          completelyMadeUpField: "yes",
+        }),
+      ]);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: "UNKNOWN_FIELD",
+          field: "completelyMadeUpField",
+        }),
+      ]);
+    });
+
+    it("does not extend the inputMode/batchSize ignore to actions that genuinely use them (batch-read-contract still validates)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/batch-read-contract", {
+          inputMode: "not-a-valid-mode",
+          network: "1",
+          contractAddress: "0x0000000000000000000000000000000000000001",
+          abi: "[]",
+          abiFunction: "foo",
+          argsList: "[]",
+        }),
+      ]);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "INVALID_FIELD_TYPE",
+            field: "inputMode",
+          }),
+        ])
+      );
+    });
+  });
+
   describe("node-count invariance (prove >2 node failures were per-node, not threshold)", () => {
     const READ_CONTRACT_ABI = JSON.stringify([
       {
-        inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
-        name: "ilks",
+        inputs: [{ internalType: "bytes32", name: "id", type: "bytes32" }],
+        name: "reader",
         outputs: [{ internalType: "uint256", name: "Art", type: "uint256" }],
         stateMutability: "view",
         type: "function",
@@ -560,7 +709,7 @@ describe("validateWorkflowActionConfigs", () => {
           network: "1",
           contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           abi: READ_CONTRACT_ABI,
-          abiFunction: "ilks",
+          abiFunction: "reader",
           functionArgs:
             '["0x0000000000000000000000000000000000000000000000000000000000000001"]',
         },
@@ -623,7 +772,7 @@ describe("validateWorkflowActionConfigs", () => {
             network: "1",
             contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
             abi: READ_CONTRACT_ABI,
-            abiFunction: "ilks",
+            abiFunction: "reader",
             functionArgs: "not-json-not-template",
           },
           "n-3"
@@ -650,7 +799,7 @@ describe("validateWorkflowActionConfigs", () => {
             network: "1",
             contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
             abi: READ_CONTRACT_ABI,
-            abiFunction: "ilks",
+            abiFunction: "reader",
             functionArgs: "bogus-a",
           },
           "n-0"
@@ -663,7 +812,7 @@ describe("validateWorkflowActionConfigs", () => {
             network: "1",
             contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
             abi: READ_CONTRACT_ABI,
-            abiFunction: "ilks",
+            abiFunction: "reader",
             functionArgs: "bogus-b",
           },
           "n-3"

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -197,6 +197,350 @@ describe("validateWorkflowActionConfigs", () => {
 
     expect(result).toEqual({ valid: true, issues: [] });
   });
+
+  describe("KEEP-571 stringified container fields (UI wire format)", () => {
+    const READ_CONTRACT_ABI = JSON.stringify([
+      {
+        inputs: [{ internalType: "bytes32", name: "ilk", type: "bytes32" }],
+        name: "ilks",
+        outputs: [
+          { internalType: "uint256", name: "Art", type: "uint256" },
+          { internalType: "uint256", name: "rate", type: "uint256" },
+        ],
+        stateMutability: "view",
+        type: "function",
+      },
+    ]);
+
+    it("accepts a JSON-stringified functionArgs array (the format the UI emits)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts an empty-array functionArgs string (no-arg function)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/write-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: JSON.stringify([
+            {
+              inputs: [],
+              name: "poke",
+              outputs: [],
+              stateMutability: "nonpayable",
+              type: "function",
+            },
+          ]),
+          abiFunction: "poke",
+          functionArgs: "[]",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts an empty-string functionArgs (form initial state)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: "",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a native array functionArgs (imported / hand-edited)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: [
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+          ],
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a template-only functionArgs value", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: "{{@previous.argsList}}",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("rejects a non-JSON, non-template literal in functionArgs", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: "not-json",
+        }),
+      ]);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          path: "nodes[0].data.config.functionArgs",
+          field: "functionArgs",
+          expected: "object or array",
+          received: "not-json",
+        }),
+      ]);
+    });
+
+    it("rejects a JSON-stringified scalar in functionArgs (not array/object)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: '"only-a-string"',
+        }),
+      ]);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: "INVALID_FIELD_TYPE",
+          field: "functionArgs",
+        }),
+      ]);
+    });
+
+    it("accepts a JSON-stringified argsList on batch-read-contract", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/batch-read-contract", {
+          inputMode: "uniform",
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          argsList: '[["0x01"],["0x02"]]',
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a JSON-stringified calls list on batch-read-contract (mixed)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/batch-read-contract", {
+          inputMode: "mixed",
+          calls:
+            '[{"network":"1","contractAddress":"0x6B175474E89094C44Da98b954EedeAC495271d0F","abi":[],"abiFunction":"foo","args":[]}]',
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a JSON-stringified object form on a json-editor / object field", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: READ_CONTRACT_ABI,
+          abiFunction: "ilks",
+          functionArgs: '{"named":"args"}',
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts a 3+ node workflow with web3 read-contract using the UI's stringified form", () => {
+      const result = validateWorkflowActionConfigs([
+        {
+          id: "trigger",
+          type: "trigger",
+          data: {
+            label: "Trigger",
+            type: "trigger",
+            config: { actionType: "Manual" },
+          },
+        },
+        actionNode(
+          "web3/read-contract",
+          {
+            network: "1",
+            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            abi: READ_CONTRACT_ABI,
+            abiFunction: "ilks",
+            functionArgs: '["0x0000000000000000000000000000000000000001"]',
+          },
+          "node-1"
+        ),
+        actionNode(
+          "web3/write-contract",
+          {
+            network: "1",
+            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            abi: JSON.stringify([
+              {
+                inputs: [],
+                name: "poke",
+                outputs: [],
+                stateMutability: "nonpayable",
+                type: "function",
+              },
+            ]),
+            abiFunction: "poke",
+            functionArgs: "[]",
+          },
+          "node-2"
+        ),
+        actionNode(
+          "discord/send-message",
+          { discordMessage: "done" },
+          "node-3"
+        ),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+  });
+
+  describe("KEEP-571 legacy field aliases", () => {
+    const WRITE_CONTRACT_ABI = JSON.stringify([
+      {
+        inputs: [],
+        name: "poke",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+      },
+    ]);
+
+    it("accepts legacy functionName on web3/write-contract when abiFunction is absent (MegaPoker case)", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/write-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: WRITE_CONTRACT_ABI,
+          functionName: "poke",
+          functionArgs: "[]",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("accepts legacy functionName on web3/read-contract", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: "[]",
+          functionName: "balanceOf",
+          functionArgs: '["{{trigger.walletAddress}}"]',
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("prefers canonical abiFunction over legacy functionName when both are present", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/write-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: WRITE_CONTRACT_ABI,
+          abiFunction: "poke",
+          functionName: "stale-legacy-value",
+          functionArgs: "[]",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+
+    it("still rejects truly unknown fields even when an alias map exists for the action", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/write-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: WRITE_CONTRACT_ABI,
+          abiFunction: "poke",
+          functionArgs: "[]",
+          totallyMadeUpField: "nope",
+        }),
+      ]);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          code: "UNKNOWN_FIELD",
+          field: "totallyMadeUpField",
+        }),
+      ]);
+    });
+
+    it("still flags missing required abiFunction when neither canonical nor legacy alias is set", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/write-contract", {
+          network: "1",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+          abi: WRITE_CONTRACT_ABI,
+          functionArgs: "[]",
+        }),
+      ]);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "MISSING_REQUIRED_FIELD",
+            field: "abiFunction",
+          }),
+        ])
+      );
+    });
+  });
+
+  describe("KEEP-571 OSM Alert regression (real prod node shape)", () => {
+    it("accepts the exact node shape that prod workflow ooiuqkddnj6fnssg93kgr was failing to save", () => {
+      const result = validateWorkflowActionConfigs([
+        actionNode("web3/read-contract", {
+          abi: '[{"inputs":[{"internalType":"bytes32","name":"ilk","type":"bytes32"}],"name":"ilks","outputs":[{"internalType":"uint256","name":"Art","type":"uint256"},{"internalType":"uint256","name":"rate","type":"uint256"},{"internalType":"uint256","name":"spot","type":"uint256"},{"internalType":"uint256","name":"line","type":"uint256"},{"internalType":"uint256","name":"dust","type":"uint256"}],"stateMutability":"view","type":"function"}]',
+          network: "1",
+          abiFunction: "ilks",
+          functionArgs: '["{{@osm-loop:OSM Loop.currentItem.ilkBytes32}}"]',
+          integrationId: "ecw50nj0v9at1p6thn0nh",
+          contractAddress: "{{@fetch-chainlog:Fetch Chainlog.data.MCD_VAT}}",
+        }),
+      ]);
+
+      expect(result).toEqual({ valid: true, issues: [] });
+    });
+  });
 });
 
 describe("formatActionConfigValidationResponse", () => {


### PR DESCRIPTION
## Summary

PR #1246 (KEEP-467) added a strict pre-save validator that requires
`abi-function-args` / `call-list-builder` / `args-list-builder` / `json-editor`
fields to be **native** object/array values. But the UI renderers for these
fields always `JSON.stringify(...)` the value before saving:

- [components/workflow/config/action-config-renderer.tsx:350](https://github.com/KeeperHub/keeperhub/blob/staging/components/workflow/config/action-config-renderer.tsx#L350) -- `onChange(JSON.stringify(newArgs))`
- [components/workflow/config/call-list-field.tsx:80](https://github.com/KeeperHub/keeperhub/blob/staging/components/workflow/config/call-list-field.tsx#L80)
- [components/workflow/config/args-list-field.tsx:97](https://github.com/KeeperHub/keeperhub/blob/staging/components/workflow/config/args-list-field.tsx#L97)

So every save of a workflow containing a `web3/read-contract` or
`web3/write-contract` node was failing with 422 `INVALID_ACTION_CONFIG`
on prod (118,472 nodes hold the stringified form vs 6 nodes hold a
native array). Reported by Valerii on workflow `ooiuqkddnj6fnssg93kgr`
(OSM Alert) and MegaPoker. Empirically the failure looked correlated
with node count -- 1-2 node workflows usually have no contract action,
3+ node workflows usually do.

A secondary regression: legacy AI-authored workflows persist
`functionName` instead of `abiFunction` (the rename was hardened in
KEEP-371 / commit `e648322d`). The new strict `UNKNOWN_FIELD` check
rejected them outright.

## What changes

In [lib/workflow/validation/action-config.ts](https://github.com/KeeperHub/keeperhub/blob/staging/lib/workflow/validation/action-config.ts):

1. The validator now accepts a JSON-string that parses to an array
   or object for the four container field types (matching the UI's
   wire format), plus the empty-string and template-only forms.
2. Introduces `LEGACY_FIELD_ALIASES` so action types can declare
   pre-rename keys. `web3/read-contract` and `web3/write-contract`
   map `functionName -> abiFunction`; the validator no longer reports
   `UNKNOWN_FIELD` for the alias and falls back to its value when the
   canonical key is missing. Truly unknown keys are still rejected.

## Tests

- **Unit** ([tests/unit/workflow-action-config-validation.test.ts](https://github.com/KeeperHub/keeperhub/blob/fix/KEEP-571-action-config-accept-stringified-args/tests/unit/workflow-action-config-validation.test.ts)): stringified array, empty-array string, empty string, native array, template-only value, non-JSON literal (rejected), JSON-stringified scalar (rejected), batch-read-contract `argsList` and `calls`, object-form string, 3-node mixed-action workflow, the exact prod OSM Alert node shape, and all four legacy-alias edge cases (incl. canonical-wins-over-legacy and still-rejects-truly-unknown).
- **Integration** ([tests/integration/workflow-listing-route.test.ts](https://github.com/KeeperHub/keeperhub/blob/fix/KEEP-571-action-config-accept-stringified-args/tests/integration/workflow-listing-route.test.ts)): three new tests at the PATCH `/api/workflows/[workflowId]` boundary covering stringified-args, legacy-functionName, and still-rejects-bogus.
- **E2E Playwright** ([tests/e2e/playwright/workflow-save-stringified-args.test.ts](https://github.com/KeeperHub/keeperhub/blob/fix/KEEP-571-action-config-accept-stringified-args/tests/e2e/playwright/workflow-save-stringified-args.test.ts)): five tests inject 3-node workflows with the failing shapes via `createTestWorkflow` and round-trip them through the real save route.

Linear: https://linear.app/keeperhubapp/issue/KEEP-571