### PR TITLE
feat(api): KEEP-489 add structured error envelope helper + seed adoption

### DIFF
--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -4,6 +4,7 @@ import {
   ensureWalletIntegration,
   getIntegrations,
 } from "@/lib/db/integrations";
+import { apiError, ApiErrorCodes } from "@/lib/errors/api-envelope";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import type {
@@ -43,16 +44,23 @@ export async function GET(request: Request) {
   try {
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return apiError({
+        status: authContext.status,
+        code: ApiErrorCodes.UNAUTHORIZED,
+        detail: authContext.error,
+        hint: "Provide a valid `Authorization: Bearer <token>` header. API keys start with `kh_`; OAuth tokens are issued via /oauth/authorize.",
+      });
     }
 
     const { userId, organizationId } = authContext;
 
     if (!(userId || organizationId)) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError({
+        status: 401,
+        code: ApiErrorCodes.UNAUTHORIZED,
+        detail: "Request has neither a user nor an organization context",
+        hint: "Sign in or supply a valid API key.",
+      });
     }
 
     // Get optional type filter from query params
@@ -113,13 +121,12 @@ export async function GET(request: Request) {
         operation: "get",
       }
     );
-    return NextResponse.json(
-      {
-        error: "Failed to get integrations",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 }
-    );
+    return apiError({
+      status: 500,
+      code: ApiErrorCodes.INTERNAL_ERROR,
+      detail: "Failed to list integrations",
+      hint: "Retry with backoff. If the error persists, check the request_id in server logs.",
+    });
   }
 }
 
@@ -131,14 +138,21 @@ export async function POST(request: Request) {
   try {
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return apiError({
+        status: authContext.status,
+        code: ApiErrorCodes.UNAUTHORIZED,
+        detail: authContext.error,
+        hint: "Provide a valid `Authorization: Bearer <token>` header.",
+      });
     }
 
     if (!authContext.userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError({
+        status: 401,
+        code: ApiErrorCodes.UNAUTHORIZED,
+        detail: "User context is required to create an integration",
+        hint: "Sign in or supply a user-scoped API key (not an org-only key).",
+      });
     }
 
     const { userId, organizationId } = authContext;
@@ -146,10 +160,12 @@ export async function POST(request: Request) {
     const body: CreateIntegrationRequest = await request.json();
 
     if (!(body.type && body.config)) {
-      return NextResponse.json(
-        { error: "Type and config are required" },
-        { status: 400 }
-      );
+      return apiError({
+        status: 400,
+        code: ApiErrorCodes.INVALID_INPUT,
+        detail: "Request body must include both `type` and `config` fields",
+        hint: "See https://docs.keeperhub.com/api/integrations for the full request schema.",
+      });
     }
 
     const integration = await createIntegration({
@@ -174,12 +190,12 @@ export async function POST(request: Request) {
     // integration per org. Surface that as a 409 instead of falling
     // through to the generic 500.
     if (isUniqueViolation(error)) {
-      return NextResponse.json(
-        {
-          error: "This organization already has a web3 integration.",
-        },
-        { status: 409 }
-      );
+      return apiError({
+        status: 409,
+        code: "web3_integration_exists",
+        detail: "This organization already has a web3 integration",
+        hint: "Use GET /api/integrations?type=web3 to find the existing row, then DELETE it before creating a new one.",
+      });
     }
     logSystemError(
       ErrorCategory.DATABASE,
@@ -190,13 +206,12 @@ export async function POST(request: Request) {
         operation: "create",
       }
     );
-    return NextResponse.json(
-      {
-        error: "Failed to create integration",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 }
-    );
+    return apiError({
+      status: 500,
+      code: ApiErrorCodes.INTERNAL_ERROR,
+      detail: "Failed to create integration",
+      hint: "Retry with backoff. If the error persists, check the request_id in server logs.",
+    });
   }
 }
 

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -4,7 +4,7 @@ import {
   ensureWalletIntegration,
   getIntegrations,
 } from "@/lib/db/integrations";
-import { apiError, ApiErrorCodes } from "@/lib/errors/api-envelope";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import type {
@@ -49,6 +49,7 @@ export async function GET(request: Request) {
         code: ApiErrorCodes.UNAUTHORIZED,
         detail: authContext.error,
         hint: "Provide a valid `Authorization: Bearer <token>` header. API keys start with `kh_`; OAuth tokens are issued via /oauth/authorize.",
+        requestHeaders: request.headers,
       });
     }
 
@@ -60,6 +61,7 @@ export async function GET(request: Request) {
         code: ApiErrorCodes.UNAUTHORIZED,
         detail: "Request has neither a user nor an organization context",
         hint: "Sign in or supply a valid API key.",
+        requestHeaders: request.headers,
       });
     }
 
@@ -126,6 +128,7 @@ export async function GET(request: Request) {
       code: ApiErrorCodes.INTERNAL_ERROR,
       detail: "Failed to list integrations",
       hint: "Retry with backoff. If the error persists, check the request_id in server logs.",
+      requestHeaders: request.headers,
     });
   }
 }
@@ -143,6 +146,7 @@ export async function POST(request: Request) {
         code: ApiErrorCodes.UNAUTHORIZED,
         detail: authContext.error,
         hint: "Provide a valid `Authorization: Bearer <token>` header.",
+        requestHeaders: request.headers,
       });
     }
 
@@ -152,6 +156,7 @@ export async function POST(request: Request) {
         code: ApiErrorCodes.UNAUTHORIZED,
         detail: "User context is required to create an integration",
         hint: "Sign in or supply a user-scoped API key (not an org-only key).",
+        requestHeaders: request.headers,
       });
     }
 
@@ -165,6 +170,7 @@ export async function POST(request: Request) {
         code: ApiErrorCodes.INVALID_INPUT,
         detail: "Request body must include both `type` and `config` fields",
         hint: "See https://docs.keeperhub.com/api/integrations for the full request schema.",
+        requestHeaders: request.headers,
       });
     }
 
@@ -195,6 +201,7 @@ export async function POST(request: Request) {
         code: "web3_integration_exists",
         detail: "This organization already has a web3 integration",
         hint: "Use GET /api/integrations?type=web3 to find the existing row, then DELETE it before creating a new one.",
+        requestHeaders: request.headers,
       });
     }
     logSystemError(
@@ -211,6 +218,7 @@ export async function POST(request: Request) {
       code: ApiErrorCodes.INTERNAL_ERROR,
       detail: "Failed to create integration",
       hint: "Retry with backoff. If the error persists, check the request_id in server logs.",
+      requestHeaders: request.headers,
     });
   }
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -34,14 +34,38 @@ All responses are returned as JSON with the following structure:
 ```
 
 ### Error Response
+
+Errors return JSON of the form:
+
 ```json
 {
-  "error": {
-    "code": "ERROR_CODE",
-    "message": "Human readable message"
-  }
+  "error": "wallet_not_configured",
+  "detail": "No wallet provisioned for chain 8453 in org acme",
+  "hint": "POST /api/integrations/wallet to provision a wallet for this org",
+  "docs": "https://docs.keeperhub.com/api/integrations",
+  "request_id": "5f5a7d4e-4f4f-4d6b-9c9a-3f7b1c0d2e1f"
 }
 ```
+
+Fields:
+
+| Field        | Type   | Description                                                                                                                  |
+|--------------|--------|------------------------------------------------------------------------------------------------------------------------------|
+| `error`      | string | Machine-readable, stable `snake_case` code. Branch on this — never on `detail` prose.                                        |
+| `detail`     | string | Human-readable description of what went wrong. Safe to log or surface in developer tools, but not user-facing copy.          |
+| `hint`       | string | Optional. Suggested recovery action (e.g. which endpoint to call, which field to fix).                                       |
+| `docs`       | string | Optional. URL to the doc page that explains this error in depth.                                                             |
+| `request_id` | string | Correlation id for the request. Echoed back on the `x-request-id` response header. Quote this in support tickets.            |
+
+Clients should:
+
+- Branch on `error` only. Copy in `detail` and `hint` may change without notice.
+- Tolerate the absence of `hint` and `docs`.
+- Capture `request_id` (or read the `x-request-id` response header) and include it when reporting issues.
+
+A short list of canonical `error` codes is reused across endpoints: `unauthorized`, `insufficient_scope`, `not_found`, `invalid_input`, `conflict`, `rate_limited`, `internal_error`. Endpoint-specific codes (e.g. `wallet_not_configured`, `web3_integration_exists`) are documented on the page for the resource that raises them.
+
+The `x-request-id` request header is honored when present: send any value (≤ 128 chars, no control characters) and it is reflected back on both the `request_id` response field and the `x-request-id` response header.
 
 ## Rate Limits
 

--- a/lib/errors/api-envelope.ts
+++ b/lib/errors/api-envelope.ts
@@ -14,12 +14,15 @@
  *     "detail": "No wallet provisioned for chain 8453 in org X",
  *     "hint": "POST /api/integrations/wallet to provision",
  *     "docs": "https://docs.keeperhub.com/...",   // optional
- *     "request_id": "req_..."                     // optional
+ *     "request_id": "req_..."                     // correlation id
  *   }
  *
  * Callers branch on `error` (the stable code), surface `detail` for
- * debugging, and show `hint` to the developer. `docs` and `request_id` are
- * optional and may be omitted; clients MUST tolerate their absence.
+ * debugging, and show `hint` to the developer. `docs` is optional; clients
+ * MUST tolerate its absence. `request_id` is always emitted (resolved from
+ * the `x-request-id` request header or a fresh UUID) so support and log
+ * correlation are always possible. The same id is echoed back on the
+ * `x-request-id` response header.
  *
  * This module is the canonical helper. The MCP route uses its own JSON-RPC
  * envelope (KEEP-474, `lib/mcp/session-error.ts`) because JSON-RPC has a
@@ -43,7 +46,100 @@ export type ApiErrorOptions = {
   docs?: string;
   requestId?: string;
   headers?: HeadersInit;
+  /**
+   * Inbound request headers. When provided, `request_id` is auto-resolved
+   * from the `x-request-id` header (validated, length-capped) with a
+   * `crypto.randomUUID()` fallback. An explicit `requestId` argument still
+   * wins — useful for background tasks where there is no HTTP request.
+   */
+  requestHeaders?: Headers;
 };
+
+const MAX_REQUEST_ID_LENGTH = 128;
+const MAX_DETAIL_LENGTH = 1024;
+
+// Hoisted to top level so the engine compiles them once. Biome flags
+// in-function regex literals as a perf smell.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: log-injection guard intentionally rejects control characters in inbound header values
+const CONTROL_CHAR_PATTERN = /[\x00-\x1f\x7f]/;
+const NEWLINE_PATTERN = /\r?\n/;
+
+/**
+ * Resolve a correlation id from the inbound `x-request-id` header. Falls
+ * back to `crypto.randomUUID()` when the header is absent, blank, or fails
+ * validation. The cap prevents log-injection via oversized ids.
+ */
+export function resolveRequestId(headers?: Headers, fallback?: string): string {
+  const raw = headers?.get("x-request-id");
+  if (raw && typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (
+      trimmed.length > 0 &&
+      trimmed.length <= MAX_REQUEST_ID_LENGTH &&
+      !CONTROL_CHAR_PATTERN.test(trimmed)
+    ) {
+      return trimmed;
+    }
+  }
+  if (fallback && fallback.length > 0) {
+    return fallback;
+  }
+  return crypto.randomUUID();
+}
+
+// Patterns that look like absolute filesystem paths or stack-trace frames.
+// Stripped in production to keep internal layout out of client-facing
+// errors. Defence-in-depth — callers SHOULD still avoid leaking these.
+const STACK_FRAME_PATTERN = /^\s+at\s/m;
+const PATH_HINTS: RegExp[] = [
+  /\/Users\//,
+  /\/app\//,
+  /\/var\//,
+  /\/home\//,
+  /\/root\//,
+  /[A-Za-z]:\\/,
+  /node_modules\//,
+  /webpack:\//,
+  /\.next\//,
+];
+
+/**
+ * In production, strip filesystem paths and stack-trace fragments from a
+ * detail string before it ships to the client. Truncates to
+ * MAX_DETAIL_LENGTH chars regardless of environment. In development and
+ * test, the string is passed through (minus the length cap) so authors can
+ * see the full context locally.
+ */
+export function sanitizeDetailForEnv(detail?: string): string | undefined {
+  if (detail === undefined || detail === null) {
+    return detail ?? undefined;
+  }
+  let cleaned = detail;
+  if (process.env.NODE_ENV === "production") {
+    // Truncate at the first stack-frame indicator ("    at Module._compile").
+    const stackMatch = cleaned.match(STACK_FRAME_PATTERN);
+    if (stackMatch && typeof stackMatch.index === "number") {
+      cleaned = cleaned.slice(0, stackMatch.index).trimEnd();
+    }
+    // Drop lines containing path-like fragments; keep purely human prose.
+    const lines = cleaned.split(NEWLINE_PATTERN);
+    const kept: string[] = [];
+    for (const line of lines) {
+      const looksLikePath = PATH_HINTS.some((p) => p.test(line));
+      if (!looksLikePath) {
+        kept.push(line);
+      }
+    }
+    cleaned = kept.join("\n").trim();
+    if (cleaned.length === 0) {
+      cleaned = "Internal error (details redacted in production).";
+    }
+  }
+  if (cleaned.length > MAX_DETAIL_LENGTH) {
+    cleaned = `${cleaned.slice(0, MAX_DETAIL_LENGTH - 1)}…`;
+  }
+  return cleaned;
+}
 
 /**
  * Build a structured error response. Returns a NextResponse with the
@@ -52,13 +148,27 @@ export type ApiErrorOptions = {
  *
  * `code` MUST be snake_case and stable across releases — clients pin to it.
  * `detail` MAY include human-readable variable substitution (org id,
- * chain id, etc.) but MUST NOT include secrets, raw error messages from
- * upstream services, or stack traces.
+ * chain id, etc.) but callers SHOULD NOT include secrets, raw error
+ * messages from upstream services, or stack traces. In production the
+ * helper applies a sanitizer (`sanitizeDetailForEnv`) as defence-in-depth
+ * that strips path and stack-frame fragments, but the contract still
+ * relies on callers writing safe messages.
+ *
+ * `request_id` is auto-resolved from the `x-request-id` request header
+ * when `requestHeaders` is provided, with a UUID fallback. An explicit
+ * `requestId` argument still takes precedence (used by cron / background
+ * jobs that lack an HTTP request). The resolved id is echoed back on the
+ * response `x-request-id` header so clients can correlate.
  */
 export function apiError(options: ApiErrorOptions): NextResponse {
+  const requestId =
+    options.requestId ?? resolveRequestId(options.requestHeaders);
+  const detail = sanitizeDetailForEnv(options.detail) ?? options.detail;
+
   const body: ApiErrorBody = {
     error: options.code,
-    detail: options.detail,
+    detail,
+    request_id: requestId,
   };
   if (options.hint) {
     body.hint = options.hint;
@@ -66,12 +176,17 @@ export function apiError(options: ApiErrorOptions): NextResponse {
   if (options.docs) {
     body.docs = options.docs;
   }
-  if (options.requestId) {
-    body.request_id = options.requestId;
+
+  // Merge caller headers with the echoed correlation id. Caller wins if
+  // they explicitly set `x-request-id`.
+  const mergedHeaders = new Headers(options.headers);
+  if (!mergedHeaders.has("x-request-id")) {
+    mergedHeaders.set("x-request-id", requestId);
   }
+
   return NextResponse.json(body, {
     status: options.status,
-    headers: options.headers,
+    headers: mergedHeaders,
   });
 }
 

--- a/lib/errors/api-envelope.ts
+++ b/lib/errors/api-envelope.ts
@@ -1,0 +1,89 @@
+/**
+ * Structured error envelope for REST API responses.
+ *
+ * KEEP-489: errors across REST + MCP have historically returned bare prose
+ * strings ("Unauthorized", "Invalid input"). Builders branch on regex
+ * matches against the message and break every time copy is updated.
+ * Multiple hackathon teams independently reported this; AgentMesh, Aaether,
+ * and ComputePool all reverse-engineered defensive parsers.
+ *
+ * The fix is to ship a stable envelope:
+ *
+ *   {
+ *     "error": "wallet_not_configured",   // machine-readable snake_case
+ *     "detail": "No wallet provisioned for chain 8453 in org X",
+ *     "hint": "POST /api/integrations/wallet to provision",
+ *     "docs": "https://docs.keeperhub.com/...",   // optional
+ *     "request_id": "req_..."                     // optional
+ *   }
+ *
+ * Callers branch on `error` (the stable code), surface `detail` for
+ * debugging, and show `hint` to the developer. `docs` and `request_id` are
+ * optional and may be omitted; clients MUST tolerate their absence.
+ *
+ * This module is the canonical helper. The MCP route uses its own JSON-RPC
+ * envelope (KEEP-474, `lib/mcp/session-error.ts`) because JSON-RPC has a
+ * different wire shape; both share the same `code` / `hint` philosophy.
+ */
+import { NextResponse } from "next/server";
+
+export type ApiErrorBody = {
+  error: string;
+  detail: string;
+  hint?: string;
+  docs?: string;
+  request_id?: string;
+};
+
+export type ApiErrorOptions = {
+  status: number;
+  code: string;
+  detail: string;
+  hint?: string;
+  docs?: string;
+  requestId?: string;
+  headers?: HeadersInit;
+};
+
+/**
+ * Build a structured error response. Returns a NextResponse with the
+ * envelope as JSON. Callers should prefer this over `NextResponse.json({
+ * error: "..." })` so external clients see a consistent shape.
+ *
+ * `code` MUST be snake_case and stable across releases — clients pin to it.
+ * `detail` MAY include human-readable variable substitution (org id,
+ * chain id, etc.) but MUST NOT include secrets, raw error messages from
+ * upstream services, or stack traces.
+ */
+export function apiError(options: ApiErrorOptions): NextResponse {
+  const body: ApiErrorBody = {
+    error: options.code,
+    detail: options.detail,
+  };
+  if (options.hint) {
+    body.hint = options.hint;
+  }
+  if (options.docs) {
+    body.docs = options.docs;
+  }
+  if (options.requestId) {
+    body.request_id = options.requestId;
+  }
+  return NextResponse.json(body, {
+    status: options.status,
+    headers: options.headers,
+  });
+}
+
+// Canonical codes — keep this list short and reuse aggressively. Per-route
+// codes (e.g. WALLET_NOT_CONFIGURED) live next to the route that raises
+// them, not here.
+export const ApiErrorCodes = {
+  UNAUTHORIZED: "unauthorized",
+  INSUFFICIENT_SCOPE: "insufficient_scope",
+  NOT_FOUND: "not_found",
+  INVALID_INPUT: "invalid_input",
+  CONFLICT: "conflict",
+  RATE_LIMITED: "rate_limited",
+  INTERNAL_ERROR: "internal_error",
+} as const;

--- a/tests/integration/integrations-route-envelope.test.ts
+++ b/tests/integration/integrations-route-envelope.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Integration tests for /api/integrations error envelope (KEEP-489).
+ *
+ * Verifies the seed adoption of `apiError()`:
+ * - Unauthenticated GET returns 401 with the {error, detail, hint,
+ *   request_id} envelope shape.
+ * - `request_id` is present and either UUIDv4 or the x-request-id header
+ *   the client sent.
+ * - No legacy `message` field appears.
+ * - x-request-id round-trips on the response header.
+ *
+ * Run with: pnpm vitest tests/integration/integrations-route-envelope.test.ts
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockGetDualAuthContext, mockGetIntegrations } = vi.hoisted(() => ({
+  mockGetDualAuthContext: vi.fn(),
+  mockGetIntegrations: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+}));
+
+vi.mock("@/lib/db/integrations", () => ({
+  createIntegration: vi.fn(),
+  ensureWalletIntegration: vi.fn(),
+  getIntegrations: mockGetIntegrations,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+import { GET, POST } from "@/app/api/integrations/route";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type EnvelopeBody = {
+  error: string;
+  detail: string;
+  hint?: string;
+  docs?: string;
+  request_id: string;
+  message?: unknown;
+};
+
+function createRequest(init?: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}): Request {
+  return new Request("http://localhost:3000/api/integrations", {
+    method: init?.method ?? "GET",
+    headers: init?.headers,
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+describe("GET /api/integrations envelope (KEEP-489)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 with envelope shape when unauthenticated", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const response = await GET(createRequest());
+    const body = (await response.json()) as EnvelopeBody;
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("unauthorized");
+    expect(typeof body.detail).toBe("string");
+    expect(body.detail.length).toBeGreaterThan(0);
+    expect(typeof body.hint).toBe("string");
+    expect(typeof body.request_id).toBe("string");
+    expect(body.request_id.length).toBeGreaterThan(0);
+    // Legacy shape must NOT appear.
+    expect(body.message).toBeUndefined();
+    expect((body as Record<string, unknown>).code).toBeUndefined();
+  });
+
+  it("emits a UUID request_id when no x-request-id header is sent", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const response = await GET(createRequest());
+    const body = (await response.json()) as EnvelopeBody;
+
+    expect(UUID_REGEX.test(body.request_id)).toBe(true);
+    // Echoed on response header for client correlation.
+    expect(response.headers.get("x-request-id")).toBe(body.request_id);
+  });
+
+  it("round-trips x-request-id from request header to response body + header", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const traceId = `test-${crypto.randomUUID()}`;
+    const response = await GET(
+      createRequest({
+        headers: { "x-request-id": traceId },
+      })
+    );
+    const body = (await response.json()) as EnvelopeBody;
+
+    expect(body.request_id).toBe(traceId);
+    expect(response.headers.get("x-request-id")).toBe(traceId);
+  });
+
+  it("returns 401 envelope when auth context has neither user nor org", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: undefined,
+      organizationId: undefined,
+    });
+
+    const response = await GET(createRequest());
+    const body = (await response.json()) as EnvelopeBody;
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("unauthorized");
+    expect(typeof body.request_id).toBe("string");
+    expect(body.message).toBeUndefined();
+  });
+});
+
+describe("POST /api/integrations envelope (KEEP-489)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 envelope when unauthenticated, with request_id round-trip", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const traceId = "client-trace-99";
+    const response = await POST(
+      createRequest({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-request-id": traceId,
+        },
+        body: { type: "web3", config: {} },
+      })
+    );
+    const body = (await response.json()) as EnvelopeBody;
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("unauthorized");
+    expect(body.request_id).toBe(traceId);
+    expect(response.headers.get("x-request-id")).toBe(traceId);
+    expect(body.message).toBeUndefined();
+  });
+
+  it("returns 400 envelope for missing type/config", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    const response = await POST(
+      createRequest({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: {},
+      })
+    );
+    const body = (await response.json()) as EnvelopeBody;
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_input");
+    expect(typeof body.request_id).toBe("string");
+    expect(UUID_REGEX.test(body.request_id)).toBe(true);
+  });
+});

--- a/tests/unit/api-error-envelope.test.ts
+++ b/tests/unit/api-error-envelope.test.ts
@@ -1,0 +1,76 @@
+/**
+ * KEEP-489: REST APIs return a structured `{error, detail, hint, docs,
+ * request_id}` envelope so clients branch on `error` (a stable snake_case
+ * code) instead of regex-matching the prose message. Multiple hackathon
+ * teams independently reverse-engineered defensive parsers; this contract
+ * removes that need.
+ */
+import { describe, expect, it } from "vitest";
+import { apiError, ApiErrorCodes } from "@/lib/errors/api-envelope";
+
+describe("apiError envelope (KEEP-489)", () => {
+  it("emits {error, detail} with the requested HTTP status", async () => {
+    const response = apiError({
+      status: 401,
+      code: ApiErrorCodes.UNAUTHORIZED,
+      detail: "Missing bearer token",
+    });
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).toEqual({
+      error: "unauthorized",
+      detail: "Missing bearer token",
+    });
+  });
+
+  it("includes optional hint, docs, and request_id when provided", async () => {
+    const response = apiError({
+      status: 404,
+      code: "wallet_not_configured",
+      detail: "No wallet provisioned for chain 8453 in org X",
+      hint: "POST /api/integrations/wallet to provision",
+      docs: "https://docs.keeperhub.com/wallets",
+      requestId: "req_abc123",
+    });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body).toEqual({
+      error: "wallet_not_configured",
+      detail: "No wallet provisioned for chain 8453 in org X",
+      hint: "POST /api/integrations/wallet to provision",
+      docs: "https://docs.keeperhub.com/wallets",
+      request_id: "req_abc123",
+    });
+  });
+
+  it("omits optional fields when not provided (clients can rely on key presence)", async () => {
+    const body = (await apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "Bad request",
+    }).json()) as Record<string, unknown>;
+    expect(body.hint).toBeUndefined();
+    expect(body.docs).toBeUndefined();
+    expect(body.request_id).toBeUndefined();
+  });
+
+  it("preserves caller-supplied headers", () => {
+    const response = apiError({
+      status: 429,
+      code: ApiErrorCodes.RATE_LIMITED,
+      detail: "Too many requests",
+      headers: { "Retry-After": "60" },
+    });
+    expect(response.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("exports canonical codes used across routes", () => {
+    expect(ApiErrorCodes.UNAUTHORIZED).toBe("unauthorized");
+    expect(ApiErrorCodes.INSUFFICIENT_SCOPE).toBe("insufficient_scope");
+    expect(ApiErrorCodes.NOT_FOUND).toBe("not_found");
+    expect(ApiErrorCodes.INVALID_INPUT).toBe("invalid_input");
+    expect(ApiErrorCodes.CONFLICT).toBe("conflict");
+    expect(ApiErrorCodes.RATE_LIMITED).toBe("rate_limited");
+    expect(ApiErrorCodes.INTERNAL_ERROR).toBe("internal_error");
+  });
+});

--- a/tests/unit/api-error-envelope.test.ts
+++ b/tests/unit/api-error-envelope.test.ts
@@ -5,22 +5,30 @@
  * teams independently reverse-engineered defensive parsers; this contract
  * removes that need.
  */
-import { describe, expect, it } from "vitest";
-import { apiError, ApiErrorCodes } from "@/lib/errors/api-envelope";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ApiErrorCodes,
+  apiError,
+  resolveRequestId,
+  sanitizeDetailForEnv,
+} from "@/lib/errors/api-envelope";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 describe("apiError envelope (KEEP-489)", () => {
-  it("emits {error, detail} with the requested HTTP status", async () => {
+  it("emits {error, detail, request_id} with the requested HTTP status", async () => {
     const response = apiError({
       status: 401,
       code: ApiErrorCodes.UNAUTHORIZED,
       detail: "Missing bearer token",
     });
     expect(response.status).toBe(401);
-    const body = await response.json();
-    expect(body).toEqual({
-      error: "unauthorized",
-      detail: "Missing bearer token",
-    });
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("unauthorized");
+    expect(body.detail).toBe("Missing bearer token");
+    expect(typeof body.request_id).toBe("string");
+    expect(UUID_REGEX.test(body.request_id as string)).toBe(true);
   });
 
   it("includes optional hint, docs, and request_id when provided", async () => {
@@ -43,7 +51,7 @@ describe("apiError envelope (KEEP-489)", () => {
     });
   });
 
-  it("omits optional fields when not provided (clients can rely on key presence)", async () => {
+  it("omits hint and docs when not provided, but always emits request_id", async () => {
     const body = (await apiError({
       status: 400,
       code: ApiErrorCodes.INVALID_INPUT,
@@ -51,17 +59,46 @@ describe("apiError envelope (KEEP-489)", () => {
     }).json()) as Record<string, unknown>;
     expect(body.hint).toBeUndefined();
     expect(body.docs).toBeUndefined();
-    expect(body.request_id).toBeUndefined();
+    expect(typeof body.request_id).toBe("string");
+    expect((body.request_id as string).length).toBeGreaterThan(0);
   });
 
-  it("preserves caller-supplied headers", () => {
+  it("preserves caller-supplied headers and echoes request_id on x-request-id", () => {
     const response = apiError({
       status: 429,
       code: ApiErrorCodes.RATE_LIMITED,
       detail: "Too many requests",
+      requestId: "req_xyz",
       headers: { "Retry-After": "60" },
     });
     expect(response.headers.get("Retry-After")).toBe("60");
+    expect(response.headers.get("x-request-id")).toBe("req_xyz");
+  });
+
+  it("auto-resolves request_id from x-request-id request header", async () => {
+    const inbound = new Headers({ "x-request-id": "trace-12345" });
+    const response = apiError({
+      status: 401,
+      code: ApiErrorCodes.UNAUTHORIZED,
+      detail: "Nope",
+      requestHeaders: inbound,
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.request_id).toBe("trace-12345");
+    expect(response.headers.get("x-request-id")).toBe("trace-12345");
+  });
+
+  it("explicit requestId beats requestHeaders (background tasks)", async () => {
+    const inbound = new Headers({ "x-request-id": "header-id" });
+    const response = apiError({
+      status: 500,
+      code: ApiErrorCodes.INTERNAL_ERROR,
+      detail: "boom",
+      requestHeaders: inbound,
+      requestId: "explicit-id",
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.request_id).toBe("explicit-id");
   });
 
   it("exports canonical codes used across routes", () => {
@@ -72,5 +109,117 @@ describe("apiError envelope (KEEP-489)", () => {
     expect(ApiErrorCodes.CONFLICT).toBe("conflict");
     expect(ApiErrorCodes.RATE_LIMITED).toBe("rate_limited");
     expect(ApiErrorCodes.INTERNAL_ERROR).toBe("internal_error");
+  });
+});
+
+describe("resolveRequestId", () => {
+  it("returns the header value when valid", () => {
+    const h = new Headers({ "x-request-id": "req_abc" });
+    expect(resolveRequestId(h)).toBe("req_abc");
+  });
+
+  it("falls back to a fresh UUID when header is missing", () => {
+    const result = resolveRequestId(new Headers());
+    expect(UUID_REGEX.test(result)).toBe(true);
+  });
+
+  it("falls back to a fresh UUID when headers argument is undefined", () => {
+    const result = resolveRequestId();
+    expect(UUID_REGEX.test(result)).toBe(true);
+  });
+
+  it("rejects overlong header values (log-injection guard)", () => {
+    const tooLong = "x".repeat(129);
+    const h = new Headers({ "x-request-id": tooLong });
+    const result = resolveRequestId(h);
+    expect(result).not.toBe(tooLong);
+    expect(UUID_REGEX.test(result)).toBe(true);
+  });
+
+  it("rejects header values containing control characters", () => {
+    const h = new Headers({ "x-request-id": "ok-id" });
+    // Replace with a control-char value via raw set since Headers may
+    // normalize. Test the validator path directly with a forged header.
+    const forged = new Headers();
+    forged.set("x-request-id", "abcdef");
+    const result = resolveRequestId(forged);
+    expect(UUID_REGEX.test(result)).toBe(true);
+    // sanity: the good case still wins
+    expect(resolveRequestId(h)).toBe("ok-id");
+  });
+
+  it("honors explicit fallback over UUID when provided", () => {
+    expect(resolveRequestId(new Headers(), "explicit")).toBe("explicit");
+  });
+});
+
+describe("sanitizeDetailForEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("passes through in development unchanged", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const detail = "Error in /Users/skp/foo.ts at line 12";
+    expect(sanitizeDetailForEnv(detail)).toBe(detail);
+  });
+
+  it("passes through in test unchanged", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const detail = "Error in /app/lib/db.ts";
+    expect(sanitizeDetailForEnv(detail)).toBe(detail);
+  });
+
+  it("strips /Users/ path fragments in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const detail =
+      "Something broke\n/Users/skp/Dev/KeeperHub/keeperhub/lib/foo.ts:12\nmore prose";
+    const result = sanitizeDetailForEnv(detail);
+    expect(result).not.toContain("/Users/");
+    expect(result).toContain("Something broke");
+  });
+
+  it("truncates at first stack-frame indicator in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const detail =
+      "Database error: bad query\n    at Module._compile (node:internal/modules/cjs/loader:1234:14)\n    at Object.Module._extensions";
+    const result = sanitizeDetailForEnv(detail);
+    expect(result).toBe("Database error: bad query");
+  });
+
+  it("strips node_modules and webpack:// fragments in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const detail =
+      "Failed\nfrom node_modules/pg/lib/foo.js:1\ncontext: webpack:///./src/x.ts";
+    const result = sanitizeDetailForEnv(detail);
+    expect(result).not.toContain("node_modules");
+    expect(result).not.toContain("webpack:");
+    expect(result).toContain("Failed");
+  });
+
+  it("strips Windows drive-letter paths in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const detail = "Crash\nC:\\Users\\dev\\app\\main.ts:1";
+    const result = sanitizeDetailForEnv(detail);
+    expect(result).not.toContain("C:\\");
+    expect(result).toContain("Crash");
+  });
+
+  it("caps length at 1024 chars regardless of environment", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const detail = "x".repeat(2000);
+    const result = sanitizeDetailForEnv(detail);
+    expect(result?.length).toBeLessThanOrEqual(1024);
+  });
+
+  it("returns a redacted placeholder if production sanitization drops everything", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const detail = "/Users/skp/foo.ts:1\n/app/bar.ts:2";
+    const result = sanitizeDetailForEnv(detail);
+    expect(result).toBe("Internal error (details redacted in production).");
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(sanitizeDetailForEnv(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- REST APIs returned bare prose strings (\"Unauthorized\", \"Invalid input\"). Multiple hackathon teams reverse-engineered defensive parsers because the messages had no machine-readable code or recovery hint.
- New `lib/errors/api-envelope.ts` exports `apiError({status, code, detail, hint?, docs?, requestId?})` returning a NextResponse with the structured envelope `{error, detail, hint, docs, request_id}`.
- `app/api/integrations/route.ts` adopted as the first migrated route — all 5 error paths now return the envelope with a recovery hint.
- 5 unit tests cover envelope shape, optional-field omission, header preservation, canonical-code export.

## Linear

KEEP-489 — Replace generic error strings with structured {code, detail, hint} envelope across all APIs

## Repro (now passes)

Before: `curl -s /api/integrations` (unauthenticated) -> `{\"error\": \"Unauthorized\"}` — no code beyond what's already in the string, no recovery hint, no way for client to differentiate \"no header\" vs \"bad token\" vs \"expired\" without parsing the human message.

After: same call -> `{\"error\": \"unauthorized\", \"detail\": \"Missing Authorization header\", \"hint\": \"Provide a valid \\`Authorization: Bearer <token>\\` header. API keys start with \\`kh_\\`; OAuth tokens are issued via /oauth/authorize.\"}`. Clients branch on `error == \"unauthorized\"` (stable code) and surface `hint` to the developer.

## Test plan

- [x] `pnpm test api-error-envelope` — 5/5 pass:
  - Returns `{error, detail}` with requested status
  - Includes optional hint/docs/request_id when provided
  - Omits optional fields when not provided
  - Preserves caller-supplied headers (e.g. Retry-After on 429)
  - Canonical codes export the documented strings
- [x] `pnpm check` and `pnpm type-check` clean for changed files
- [x] All 5 error paths in `/api/integrations` migrated and exercise the new shape

## Scope: Phase 1

This PR seeds the helper and migrates one representative route. The remaining ~100 routes will migrate opportunistically (each PR that touches a route is expected to migrate its error paths). A single mega-PR is impossible to review and high-risk for regressions.

Pairs with KEEP-474 (MCP session bootstrap errors got JSON-RPC's own envelope; both share `code` + `hint` philosophy).

## Out of scope

- Migrating every existing route (would be a 100+ file diff — unreviewable).
- `request_id` propagation — accepted as an optional field but no infrastructure yet generates them. Tracked as follow-up.
- `docs` URL conventions — the helper accepts the field; per-error doc anchors are a separate docs project.
- The Aaether `WALLET_NOT_CONFIGURED` advertise-vs-call discrepancy is a `tools/list` schema issue, not an error-shape issue.