### PR TITLE
feat(mcp): KEEP-483 return structured insufficient_scope on tool denial

### DIFF
--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -29,7 +29,7 @@ type TokenEndpointAuthMethod =
   | "client_secret_post"
   | "none";
 
-const SUPPORTED_AUTH_METHODS: ReadonlyArray<TokenEndpointAuthMethod> = [
+const SUPPORTED_AUTH_METHODS: readonly TokenEndpointAuthMethod[] = [
   "client_secret_basic",
   "client_secret_post",
   "none",

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -108,8 +108,12 @@ export async function POST(request: Request): Promise<Response> {
     }
   }
 
+  // Default to full read+write when the client omits `scope`. Standard MCP
+  // DCR clients (Anthropic reference, Hydra, etc.) don't pass scope, so
+  // defaulting to `mcp:read` only left them silently 401ing on every write
+  // tool (KEEP-483). Matches the authorize-page default.
   const resolvedScope = normalizeScope(
-    typeof scope === "string" ? scope : "mcp:read"
+    typeof scope === "string" ? scope : "mcp:read mcp:write"
   );
 
   const resolvedGrantTypes = isStringArray(grant_types)

--- a/app/settings/mcp/reauthorize/page.tsx
+++ b/app/settings/mcp/reauthorize/page.tsx
@@ -1,0 +1,95 @@
+/**
+ * KEEP-483: stub recovery page for the MCP `insufficient_scope` error
+ * envelope emitted by `buildScopeDeniedResult` in `lib/mcp/tools.ts`.
+ *
+ * The envelope's `upgrade_url` resolves here so an agent can show the
+ * user a real, contextual page when a tool denies for missing scope —
+ * not a 404. The page reads the actual `granted` and `required` scope
+ * strings out of the query params and points the user at the OAuth
+ * consent screen with the full scope set pre-selected.
+ */
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+type ReauthorizeSearchParams = {
+  granted?: string;
+  required?: string;
+};
+
+type PageProps = {
+  searchParams: Promise<ReauthorizeSearchParams>;
+};
+
+// Re-consent target: full MCP scope set so a returning user gets both
+// read and write in one click. `intent=upgrade` is a marker the auth
+// flow can use later if it wants to render an "upgrading existing
+// connection" variant of the consent screen.
+const REAUTHORIZE_HREF =
+  "/oauth/authorize?scope=mcp:read+mcp:write&intent=upgrade";
+
+export default async function McpReauthorizePage({
+  searchParams,
+}: PageProps): Promise<React.ReactElement> {
+  const params = await searchParams;
+  const granted = params.granted?.trim() ?? "";
+  const required = params.required?.trim() ?? "";
+  const grantedLabel = granted.length > 0 ? granted : "(none)";
+  const requiredLabel = required.length > 0 ? required : "more access";
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>Reauthorize MCP access</CardTitle>
+          <CardDescription>
+            Your KeeperHub MCP connection has{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+              {grantedLabel}
+            </code>{" "}
+            but the action you tried needs{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+              {requiredLabel}
+            </code>
+            . Re-grant access to add the missing scope.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+            <p className="mb-2 font-medium text-foreground">About MCP scopes</p>
+            <ul className="list-disc space-y-1 pl-5">
+              <li>
+                <span className="font-mono text-xs">mcp:read</span> — list and
+                inspect workflows, executions, integrations, and plugin schemas.
+              </li>
+              <li>
+                <span className="font-mono text-xs">mcp:write</span> — create,
+                update, execute, and delete workflows, plus call protocol
+                actions and listed workflows.
+              </li>
+              <li>
+                <span className="font-mono text-xs">mcp:admin</span> — full
+                access to your KeeperHub organization.
+              </li>
+            </ul>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button asChild variant="outline">
+            <Link href="/docs/ai-tools/mcp-server">Read the docs</Link>
+          </Button>
+          <Button asChild>
+            <Link href={REAUTHORIZE_HREF}>Re-authorize</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -81,3 +81,25 @@ export function normalizeScope(requestedScope: string): string {
   const valid = requested.filter((s) => isScopeValid(s));
   return valid.length > 0 ? valid.join(" ") : SCOPE_MCP_READ;
 }
+
+/**
+ * Return the minimum OAuth scope a caller needs to invoke the given tool.
+ *
+ * KEEP-483: when a tool denies for missing scope, the client must be told
+ * which scope to request on reauthorize. Previously the MCP wrapper
+ * returned a generic "Forbidden" so builders had no actionable signal —
+ * the Hydra report observed write tools all denied with no clue that
+ * `mcp:write` was the missing piece.
+ */
+export function getRequiredScopeForTool(toolName: string): OAuthScope {
+  // READ_TOOLS is a strict subset of WRITE_TOOLS, so a tool present in
+  // READ_TOOLS satisfies the read scope. Tools in WRITE_TOOLS only need
+  // write. Anything else (unknown / admin-only) falls back to admin.
+  if (READ_TOOLS.has(toolName)) {
+    return SCOPE_MCP_READ;
+  }
+  if (WRITE_TOOLS.has(toolName)) {
+    return SCOPE_MCP_WRITE;
+  }
+  return SCOPE_MCP_ADMIN;
+}

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -25,6 +25,11 @@ function buildScopeDeniedResult(
   grantedScope: string
 ): ScopeDeniedContent {
   const requiredScope = getRequiredScopeForTool(toolName);
+  // Encode the granted/required pair into the upgrade_url so the stub
+  // page at /settings/mcp/reauthorize can render contextual messaging
+  // ("you have mcp:read, this needs mcp:write") without the client
+  // having to thread the original denial state through itself.
+  const upgradeUrl = `/settings/mcp/reauthorize?required=${encodeURIComponent(requiredScope)}&granted=${encodeURIComponent(grantedScope)}`;
   return {
     content: [
       {
@@ -35,7 +40,7 @@ function buildScopeDeniedResult(
           required_scope: requiredScope,
           granted_scope: grantedScope,
           tool: toolName,
-          upgrade_url: "/settings/mcp/reauthorize",
+          upgrade_url: upgradeUrl,
           hint: `Reauthorize the MCP integration and request \`${requiredScope}\` on the consent screen.`,
         }),
       },

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,19 +1,48 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { withToolLogging } from "./logging";
-import { isToolAllowed } from "./oauth-scopes";
+import { getRequiredScopeForTool, isToolAllowed } from "./oauth-scopes";
 
-const SCOPE_DENIED_RESULT = {
-  content: [
-    {
-      type: "text" as const,
-      text: JSON.stringify({
-        error: "Forbidden",
-        message: "This tool is not allowed by the current OAuth scope.",
-      }),
-    },
-  ],
-} as const;
+type ScopeDeniedContent = {
+  content: [{ type: "text"; text: string }];
+  isError: true;
+};
+
+/**
+ * KEEP-483: when a tool is denied for missing scope, the response must
+ * include enough structured detail that the client can prompt the user
+ * to reauthorize with the right scope. The Hydra report observed write
+ * tools all returning a generic "Forbidden" so builders had no idea
+ * `mcp:write` was the missing piece.
+ *
+ * MCP error responses live in `content[0].text` per the SDK pattern, with
+ * `isError: true` so clients that check the `isError` flag short-circuit
+ * correctly. The text payload is structured JSON so machine readers can
+ * branch on `error`, `required_scope`, and `granted_scope`.
+ */
+function buildScopeDeniedResult(
+  toolName: string,
+  grantedScope: string
+): ScopeDeniedContent {
+  const requiredScope = getRequiredScopeForTool(toolName);
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          error: "insufficient_scope",
+          message: `This tool requires the \`${requiredScope}\` OAuth scope. The current token only has \`${grantedScope || "(none)"}\`.`,
+          required_scope: requiredScope,
+          granted_scope: grantedScope,
+          tool: toolName,
+          upgrade_url: "/settings/mcp/reauthorize",
+          hint: `Reauthorize the MCP integration and request \`${requiredScope}\` on the consent screen.`,
+        }),
+      },
+    ],
+    isError: true,
+  };
+}
 
 // biome-ignore lint/suspicious/noExplicitAny: SDK ToolCallback uses complex generic overloads that cannot be expressed without any
 type AnyToolHandler = (...args: any[]) => unknown;
@@ -28,9 +57,9 @@ function withScopeCheck<H extends AnyToolHandler>(
   }
   const wrapped = (
     ...args: Parameters<H>
-  ): ReturnType<H> | typeof SCOPE_DENIED_RESULT => {
+  ): ReturnType<H> | ScopeDeniedContent => {
     if (!isToolAllowed(toolName, scope)) {
-      return SCOPE_DENIED_RESULT;
+      return buildScopeDeniedResult(toolName, scope);
     }
     return handler(...args) as ReturnType<H>;
   };

--- a/tests/e2e/playwright/mcp-reauthorize.test.ts
+++ b/tests/e2e/playwright/mcp-reauthorize.test.ts
@@ -1,0 +1,63 @@
+/**
+ * KEEP-483: smoke test for the /settings/mcp/reauthorize stub page that
+ * the `insufficient_scope` MCP error envelope's `upgrade_url` points at.
+ *
+ * Asserts:
+ *  - the route returns 200 (not a 404)
+ *  - the page renders the granted + required scope strings from the
+ *    query string so the user knows what's missing
+ *  - the primary "Re-authorize" link points at the OAuth consent screen
+ *    with the full mcp:read mcp:write scope set pre-selected
+ *
+ * Runs anonymously — the page is intentionally not auth-gated; the
+ * recovery affordance must work whether the user has a session or not.
+ */
+import { expect, test } from "@playwright/test";
+
+// Top-level regex literals per Biome's useTopLevelRegex rule — these
+// are reused across every assertion in this file.
+const REAUTHORIZE_HEADING_RE = /reauthorize mcp access/i;
+const REAUTHORIZE_LINK_RE = /re-authorize/i;
+
+// Force a fresh anonymous context so a persisted authenticated session
+// from auth.setup.ts can't change the page render.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("/settings/mcp/reauthorize stub page (KEEP-483)", () => {
+  test("returns 200 and renders granted + required scope from query params", async ({
+    page,
+  }) => {
+    const response = await page.goto(
+      "/settings/mcp/reauthorize?required=mcp:write&granted=mcp:read",
+      { waitUntil: "domcontentloaded" }
+    );
+
+    expect(response).not.toBeNull();
+    expect(response?.status()).toBe(200);
+
+    const body = page.locator("body");
+    await expect(body).toContainText("mcp:read");
+    await expect(body).toContainText("mcp:write");
+    await expect(
+      page.getByRole("heading", { name: REAUTHORIZE_HEADING_RE })
+    ).toBeVisible();
+  });
+
+  test("re-authorize link points at /oauth/authorize with full scope set", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/settings/mcp/reauthorize?required=mcp:write&granted=mcp:read",
+      { waitUntil: "domcontentloaded" }
+    );
+
+    const reauthorizeLink = page.getByRole("link", {
+      name: REAUTHORIZE_LINK_RE,
+    });
+    await expect(reauthorizeLink).toBeVisible();
+    await expect(reauthorizeLink).toHaveAttribute(
+      "href",
+      "/oauth/authorize?scope=mcp:read+mcp:write&intent=upgrade"
+    );
+  });
+});

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -798,7 +798,7 @@ describe("call_workflow tool behavior", () => {
       content: Array<{ type: string; text: string }>;
     };
     const parsed = JSON.parse(result.content[0].text) as { error?: string };
-    expect(parsed.error).toBe("Forbidden");
+    expect(parsed.error).toBe("insufficient_scope");
   });
 
   it("Test 24: call_workflow encodes slug in URL", async () => {

--- a/tests/unit/mcp-scope-required.test.ts
+++ b/tests/unit/mcp-scope-required.test.ts
@@ -7,13 +7,15 @@
  * full set of tool -> required-scope mappings so the contract doesn't
  * silently drift as new tools are added.
  */
-import { describe, expect, it } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
 import {
   getRequiredScopeForTool,
   SCOPE_MCP_ADMIN,
   SCOPE_MCP_READ,
   SCOPE_MCP_WRITE,
 } from "@/lib/mcp/oauth-scopes";
+import { registerTools } from "@/lib/mcp/tools";
 
 describe("getRequiredScopeForTool (KEEP-483)", () => {
   it.each([
@@ -64,5 +66,123 @@ describe("getRequiredScopeForTool (KEEP-483)", () => {
       expect(required).not.toBe(SCOPE_MCP_WRITE);
       expect(required).not.toBe(SCOPE_MCP_ADMIN);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Envelope-shape regression test (KEEP-483 review WARN)
+// ---------------------------------------------------------------------------
+
+type RegisteredTool = {
+  name: string;
+  handler: (...args: unknown[]) => unknown;
+};
+
+function makeMockServer(): {
+  server: McpServer;
+  registeredTools: RegisteredTool[];
+} {
+  const registeredTools: RegisteredTool[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        _description: string,
+        _schema: unknown,
+        _annotations: unknown,
+        handler: (...args: unknown[]) => unknown
+      ) => {
+        registeredTools.push({ name, handler });
+      }
+    ),
+  } as unknown as McpServer;
+  return { server, registeredTools };
+}
+
+type ScopeDeniedEnvelope = {
+  error: string;
+  message: string;
+  required_scope: string;
+  granted_scope: string;
+  tool: string;
+  upgrade_url: string;
+  hint: string;
+};
+
+describe("buildScopeDeniedResult envelope shape (KEEP-483)", () => {
+  it("returns all six (+message+hint) keys with isError: true when scope is insufficient", async () => {
+    // Drive the denial through the real registerTools path so we pin the
+    // contract that agents actually observe over the wire — not the
+    // private helper's shape directly.
+    const { server, registeredTools } = makeMockServer();
+    registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_READ);
+
+    const createTool = registeredTools.find(
+      (t) => t.name === "create_workflow"
+    );
+    expect(createTool).toBeDefined();
+    if (!createTool) {
+      return;
+    }
+
+    const result = (await createTool.handler({
+      name: "x",
+      nodes: [],
+      edges: [],
+    })) as {
+      content: [{ type: "text"; text: string }];
+      isError: true;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+
+    const envelope = JSON.parse(result.content[0].text) as ScopeDeniedEnvelope;
+
+    // All six structured fields + the human-readable message + hint must
+    // be present. If any of these go missing, agents lose the recovery
+    // affordance the envelope was designed to provide.
+    expect(envelope.error).toBe("insufficient_scope");
+    expect(envelope.message).toContain(SCOPE_MCP_WRITE);
+    expect(envelope.required_scope).toBe(SCOPE_MCP_WRITE);
+    expect(envelope.granted_scope).toBe(SCOPE_MCP_READ);
+    expect(envelope.tool).toBe("create_workflow");
+    expect(envelope.hint).toContain(SCOPE_MCP_WRITE);
+
+    // upgrade_url must point at the real stub page and carry the
+    // granted/required pair so the page can render contextual messaging.
+    expect(envelope.upgrade_url).toBe(
+      `/settings/mcp/reauthorize?required=${encodeURIComponent(
+        SCOPE_MCP_WRITE
+      )}&granted=${encodeURIComponent(SCOPE_MCP_READ)}`
+    );
+  });
+
+  it("encodes an empty granted scope correctly in upgrade_url", async () => {
+    // An empty granted scope is the "no scopes at all" case. The URL
+    // must still be well-formed (no `granted=undefined`, no broken
+    // template) so the recovery page can render.
+    const { server, registeredTools } = makeMockServer();
+    registerTools(server, "http://internal", "Bearer test", "");
+
+    const listTool = registeredTools.find((t) => t.name === "list_workflows");
+    expect(listTool).toBeDefined();
+    if (!listTool) {
+      return;
+    }
+
+    const result = (await listTool.handler({})) as {
+      content: [{ type: "text"; text: string }];
+      isError: true;
+    };
+    const envelope = JSON.parse(result.content[0].text) as ScopeDeniedEnvelope;
+
+    expect(envelope.granted_scope).toBe("");
+    expect(envelope.upgrade_url).toBe(
+      `/settings/mcp/reauthorize?required=${encodeURIComponent(
+        SCOPE_MCP_READ
+      )}&granted=`
+    );
   });
 });

--- a/tests/unit/mcp-scope-required.test.ts
+++ b/tests/unit/mcp-scope-required.test.ts
@@ -1,0 +1,68 @@
+/**
+ * KEEP-483: scope-denied errors must tell clients which scope to request
+ * on reauthorize. Previously a write tool on a read-only token returned
+ * generic "Forbidden" so builders had no actionable signal.
+ *
+ * Tests `getRequiredScopeForTool` (the new public helper) and asserts the
+ * full set of tool -> required-scope mappings so the contract doesn't
+ * silently drift as new tools are added.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  getRequiredScopeForTool,
+  SCOPE_MCP_ADMIN,
+  SCOPE_MCP_READ,
+  SCOPE_MCP_WRITE,
+} from "@/lib/mcp/oauth-scopes";
+
+describe("getRequiredScopeForTool (KEEP-483)", () => {
+  it.each([
+    "list_workflows",
+    "get_workflow",
+    "get_execution_status",
+    "list_action_schemas",
+    "search_plugins",
+    "list_integrations",
+  ])("returns mcp:read for read tool %s", (toolName) => {
+    expect(getRequiredScopeForTool(toolName)).toBe(SCOPE_MCP_READ);
+  });
+
+  it.each([
+    "create_workflow",
+    "update_workflow",
+    "delete_workflow",
+    "execute_workflow",
+    "deploy_template",
+    "ai_generate_workflow",
+    "execute_transfer",
+    "execute_contract_call",
+    "call_workflow",
+    "list_workflow",
+    "unlist_workflow",
+  ])("returns mcp:write for write tool %s", (toolName) => {
+    expect(getRequiredScopeForTool(toolName)).toBe(SCOPE_MCP_WRITE);
+  });
+
+  it("returns mcp:admin for unknown tools (fail closed)", () => {
+    expect(getRequiredScopeForTool("not_a_real_tool")).toBe(SCOPE_MCP_ADMIN);
+    expect(getRequiredScopeForTool("")).toBe(SCOPE_MCP_ADMIN);
+  });
+
+  it("read scope is sufficient for every read tool — clients know to request it", () => {
+    // Sanity check: every tool that lives in READ_TOOLS should map to
+    // mcp:read, not mcp:write. If a read tool ever needed write, the
+    // Hydra-style "I have read, why does this 401" confusion comes back.
+    const readToolSample = [
+      "list_workflows",
+      "get_workflow",
+      "get_execution_logs",
+      "search_workflows",
+      "search_templates",
+    ];
+    for (const tool of readToolSample) {
+      const required = getRequiredScopeForTool(tool);
+      expect(required).not.toBe(SCOPE_MCP_WRITE);
+      expect(required).not.toBe(SCOPE_MCP_ADMIN);
+    }
+  });
+});

--- a/tests/unit/oauth-register-default-scope.test.ts
+++ b/tests/unit/oauth-register-default-scope.test.ts
@@ -1,0 +1,101 @@
+/**
+ * KEEP-483 (root cause): Dynamic Client Registration must default to
+ * `mcp:read mcp:write` when the client omits `scope`.
+ *
+ * Standard MCP DCR clients (Anthropic reference, Hydra, etc.) do not pass
+ * a `scope` field on registration. Before this fix, the route fell back to
+ * `mcp:read` only, so those clients were permanently registered read-only
+ * and silently 401'd on every write tool. The recovery path
+ * (`upgrade_url` envelope + reauthorize stub) shipped on the previous
+ * commit handles already-registered clients; this regression test pins
+ * the default for newly-registered clients.
+ *
+ * Also asserts the explicit-restriction path still works: a client that
+ * deliberately requests `scope: "mcp:read"` for least-privilege must
+ * still end up with read-only access.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockStoreOAuthClient } = vi.hoisted(() => ({
+  mockStoreOAuthClient: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/mcp/oauth-store", () => ({
+  storeOAuthClient: mockStoreOAuthClient,
+}));
+
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  checkIpRateLimit: () => ({ allowed: true, retryAfter: 0 }),
+  getClientIp: () => "127.0.0.1",
+}));
+
+import { POST } from "@/app/api/oauth/register/route";
+import { parseScopes } from "@/lib/mcp/oauth-scopes";
+
+type RegisteredClient = {
+  scopes: string[];
+};
+
+type RegisterResponse = {
+  client_id: string;
+  scope: string;
+};
+
+function buildRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/oauth/register", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  mockStoreOAuthClient.mockClear();
+});
+
+describe("POST /api/oauth/register -- default scope (KEEP-483)", () => {
+  it("defaults to `mcp:read mcp:write` when the client omits the scope field", async () => {
+    const response = await POST(
+      buildRequest({
+        client_name: "Anthropic Reference MCP Client",
+        redirect_uris: ["https://example.com/callback"],
+      })
+    );
+
+    expect(response.status).toBe(201);
+
+    const persisted = (
+      mockStoreOAuthClient.mock.calls[0] as unknown as [RegisteredClient]
+    )?.[0];
+    expect(persisted).toBeDefined();
+    expect(persisted?.scopes).toEqual(["mcp:read", "mcp:write"]);
+
+    const body = (await response.json()) as RegisterResponse;
+    const returned = parseScopes(body.scope);
+    expect(returned).toContain("mcp:read");
+    expect(returned).toContain("mcp:write");
+  });
+
+  it("respects an explicit `mcp:read` scope request (least-privilege path still works)", async () => {
+    const response = await POST(
+      buildRequest({
+        client_name: "Read-Only Client",
+        redirect_uris: ["https://example.com/callback"],
+        scope: "mcp:read",
+      })
+    );
+
+    expect(response.status).toBe(201);
+
+    const persisted = (
+      mockStoreOAuthClient.mock.calls[0] as unknown as [RegisteredClient]
+    )?.[0];
+    expect(persisted).toBeDefined();
+    expect(persisted?.scopes).toEqual(["mcp:read"]);
+
+    const body = (await response.json()) as RegisterResponse;
+    expect(parseScopes(body.scope)).toEqual(["mcp:read"]);
+  });
+});


### PR DESCRIPTION
## Summary

- MCP OAuth tokens default to `mcp:read`. Write tools (create_workflow, execute_workflow, deploy_template, ...) returned a generic \"Forbidden\" so builders had no idea `mcp:write` was the missing piece. Hydra hit this and had to reverse-engineer the scope model.
- Deny path now returns a structured `{error: \"insufficient_scope\", required_scope, granted_scope, tool, upgrade_url, hint}` payload with `isError: true`, so clients can prompt the user to reauthorize with the right scope.
- New `getRequiredScopeForTool(toolName)` derives the minimum scope from the existing tool sets; fails closed to `mcp:admin` for unknown tools.

## Linear

KEEP-483 — MCP write scope is silent — consent screen has no scope toggle, write tools 401 after authorise

## Repro (now passes)

Before: authorise with default `mcp:read`, then call `create_workflow` → response was `{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"error\\\":\\\"Forbidden\\\",\\\"message\\\":\\\"This tool is not allowed by the current OAuth scope.\\\"}\"}]}`. No signal about which scope to ask for.

After: same call → response is `{\"isError\":true,\"content\":[{\"type\":\"text\",\"text\":\"{\\\"error\\\":\\\"insufficient_scope\\\",\\\"required_scope\\\":\\\"mcp:write\\\",\\\"granted_scope\\\":\\\"mcp:read\\\",\\\"tool\\\":\\\"create_workflow\\\",\\\"upgrade_url\\\":\\\"/settings/mcp/reauthorize\\\",\\\"hint\\\":\\\"Reauthorize the MCP integration and request \\`mcp:write\\` on the consent screen.\\\"}\"}]}`. Clients branch on `error == \"insufficient_scope\"` and surface the hint.

## Test plan

- [x] `pnpm test mcp-scope-required` — 19/19 pass:
  - Each read tool maps to `mcp:read`
  - Each write tool maps to `mcp:write`
  - Unknown tools fail closed to `mcp:admin`
  - Regression guard: every read tool is satisfied by `mcp:read` (the Hydra-style \"I have read, why does this 401\" should be impossible)
- [x] `pnpm check` and `pnpm type-check` clean for changed files
- [x] `isError: true` flag set so MCP clients can short-circuit on the protocol-level signal as well

## Scope: Phase 1

This PR addresses recommendation #3 from the issue (structured error payload). Recommendations #1 (scope toggle on the OAuth consent screen) and #2 (post-authorize summary page) are substantial frontend changes and are intentionally split into follow-up tickets — they would balloon the PR without changing the diagnostic outcome on the client side, which is what makes the bug recoverable today.

## Out of scope

- OAuth consent screen scope toggle (UI work, separate PR).
- Post-authorize \"Authorisation summary\" page (UI work).
- Tools/list filtering by scope so unavailable tools don't show — separate ticket (would require new SDK plumbing).