### PR TITLE
perf(db): KEEP-432 cherry-pick db-indexes migration to prod

### DIFF
--- a/drizzle/0075_keep_432_db_indexes.sql
+++ b/drizzle/0075_keep_432_db_indexes.sql
@@ -1,0 +1,73 @@
+-- @requires-db-prep
+-- KEEP-432: post-incident additive index migration.
+--
+-- The `-- @requires-db-prep` directive on line 1 makes the
+-- `.github/workflows/db-prep-check.yml` workflow block merge of this PR
+-- (and any future PR including this file) until the matching
+-- `db-prepped-<target-branch>` label is set. The label signals that an
+-- operator has applied each index via `CREATE INDEX CONCURRENTLY IF NOT
+-- EXISTS` against the real DB out-of-band, BEFORE the deploy runs the
+-- normal `drizzle-kit migrate`.
+--
+-- Why: drizzle-kit wraps every migration in a transaction, and
+-- `CREATE INDEX CONCURRENTLY` cannot run in a transaction. Without the
+-- pre-applied CONCURRENTLY indexes, the plain CREATE INDEX statements
+-- below would take an ACCESS EXCLUSIVE lock on workflow_execution_logs
+-- (1.9 GB on prod) for the duration of the build - the multi-minute lock
+-- this PR exists to avoid. With CONCURRENTLY pre-applied, the IF NOT
+-- EXISTS clauses make each statement here a no-op on real envs. On dev /
+-- PR-environment DBs the tables are small or empty so the plain CREATE
+-- INDEX runs without user-visible impact.
+--
+-- Operator runbook (per target environment):
+--   1. Connect to the target DB via psql or kubectl exec.
+--   2. Run each statement below with `CREATE INDEX CONCURRENTLY IF NOT
+--      EXISTS` instead of `CREATE INDEX IF NOT EXISTS`. CONCURRENTLY
+--      statements must be run one-at-a-time, NOT inside a transaction
+--      block.
+--   3. Verify no INVALID indexes were left behind:
+--      `SELECT relname FROM pg_index JOIN pg_class ON pg_class.oid =
+--      indexrelid WHERE NOT indisvalid;`
+--   4. Add the `db-prepped-<branch>` label to the PR.
+--
+-- Background: the 2026-05-05 RDS CPU incident traced to a per-org
+-- gas-usage aggregate over workflow_execution_logs which seq-scanned a
+-- 1.9 GB table. That query path now has direct index support via
+-- idx_exec_logs_started_at. The rest of this migration adds the missing
+-- FK indexes Postgres does not auto-create.
+
+CREATE INDEX IF NOT EXISTS "idx_exec_logs_started_at"
+  ON "workflow_execution_logs" ("started_at");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_user_id"
+  ON "workflow_executions" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflows_tag_id"
+  ON "workflows" ("tag_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflows_project_id"
+  ON "workflows" ("project_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_workflows_user_id"
+  ON "workflows" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_accounts_user_id"
+  ON "accounts" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_sessions_user_id"
+  ON "sessions" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_member_user_id"
+  ON "member" ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_member_organization_id"
+  ON "member" ("organization_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_org_api_keys_org_id"
+  ON "organization_api_keys" ("organization_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_org_api_keys_created_by"
+  ON "organization_api_keys" ("created_by");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_integrations_user_id"
+  ON "integrations" ("user_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1777760000008,
       "tag": "0074_keep440_workflows_soft_delete",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1777760000009,
+      "tag": "0075_keep_432_db_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -122,24 +122,31 @@ export const keyExportCodes = pgTable("key_export_codes", {
  * NOTE: This is separate from the user-scoped apiKeys table in the main schema.
  * Organization keys have broader permissions and are meant for API/MCP access.
  */
-export const organizationApiKeys = pgTable("organization_api_keys", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => generateId()),
-  organizationId: text("organization_id")
-    .notNull()
-    .references(() => organization.id, { onDelete: "cascade" }),
-  name: text("name").notNull(), // User-provided label for the key
-  keyHash: text("key_hash").notNull().unique(), // SHA-256 hash of the key
-  keyPrefix: text("key_prefix").notNull(), // First 8 chars for identification (e.g., "kh_abc12")
-  createdBy: text("created_by").references(() => users.id, {
-    onDelete: "set null",
-  }), // User who created the key
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  lastUsedAt: timestamp("last_used_at"), // Track usage for audit
-  expiresAt: timestamp("expires_at"), // Optional expiration
-  revokedAt: timestamp("revoked_at"), // Soft delete via revocation
-});
+export const organizationApiKeys = pgTable(
+  "organization_api_keys",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull(), // User-provided label for the key
+    keyHash: text("key_hash").notNull().unique(), // SHA-256 hash of the key
+    keyPrefix: text("key_prefix").notNull(), // First 8 chars for identification (e.g., "kh_abc12")
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }), // User who created the key
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at"), // Track usage for audit
+    expiresAt: timestamp("expires_at"), // Optional expiration
+    revokedAt: timestamp("revoked_at"), // Soft delete via revocation
+  },
+  (table) => [
+    index("idx_org_api_keys_org_id").on(table.organizationId),
+    index("idx_org_api_keys_created_by").on(table.createdBy),
+  ]
+);
 
 // Type exports for the Organization API Keys table
 export type OrganizationApiKey = typeof organizationApiKeys.$inferSelect;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -46,37 +46,45 @@ export const users = pgTable("users", {
   deactivatedAt: timestamp("deactivated_at"),
 });
 
-export const sessions = pgTable("sessions", {
-  id: text("id").primaryKey(),
-  expiresAt: timestamp("expires_at").notNull(),
-  token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-  ipAddress: text("ip_address"),
-  userAgent: text("user_agent"),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  activeOrganizationId: text("active_organization_id"),
-});
+export const sessions = pgTable(
+  "sessions",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    activeOrganizationId: text("active_organization_id"),
+  },
+  (table) => [index("idx_sessions_user_id").on(table.userId)]
+);
 
-export const accounts = pgTable("accounts", {
-  id: text("id").primaryKey(),
-  accountId: text("account_id").notNull(),
-  providerId: text("provider_id").notNull(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id),
-  accessToken: text("access_token"),
-  refreshToken: text("refresh_token"),
-  idToken: text("id_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at"),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-  scope: text("scope"),
-  password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-});
+export const accounts = pgTable(
+  "accounts",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+  },
+  (table) => [index("idx_accounts_user_id").on(table.userId)]
+);
 
 export const verifications = pgTable("verifications", {
   id: text("id").primaryKey(),
@@ -97,17 +105,24 @@ export const organization = pgTable("organization", {
   metadata: text("metadata"),
 });
 
-export const member = pgTable("member", {
-  id: text("id").primaryKey(),
-  organizationId: text("organization_id")
-    .notNull()
-    .references(() => organization.id, { onDelete: "cascade" }),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  role: text("role").default("member").notNull(),
-  createdAt: timestamp("created_at").notNull(),
-});
+export const member = pgTable(
+  "member",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: text("role").default("member").notNull(),
+    createdAt: timestamp("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_member_user_id").on(table.userId),
+    index("idx_member_organization_id").on(table.organizationId),
+  ]
+);
 
 export const invitation = pgTable("invitation", {
   id: text("id").primaryKey(),
@@ -254,6 +269,9 @@ export const workflows = pgTable(
     uniqueIndex("idx_workflows_listed_slug")
       .on(table.listedSlug)
       .where(isNotNull(table.listedSlug)),
+    index("idx_workflows_user_id").on(table.userId),
+    index("idx_workflows_tag_id").on(table.tagId),
+    index("idx_workflows_project_id").on(table.projectId),
   ]
 );
 
@@ -290,6 +308,7 @@ export const integrations = pgTable(
       .where(
         sql`${table.type} = 'web3' AND ${table.organizationId} IS NOT NULL`
       ),
+    index("idx_integrations_user_id").on(table.userId),
   ]
 );
 
@@ -369,14 +388,19 @@ export const workflowExecutions = pgTable(
      */
     billable: boolean("billable").notNull().default(true),
   },
-  (table) => [index("idx_workflow_executions_status").on(table.status)]
+  (table) => [
+    index("idx_workflow_executions_status").on(table.status),
+    index("idx_workflow_executions_user_id").on(table.userId),
+  ]
 );
 
 // Workflow execution logs to track individual node executions
-export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => generateId()),
+export const workflowExecutionLogs = pgTable(
+  "workflow_execution_logs",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
   executionId: text("execution_id")
     .notNull()
     .references(() => workflowExecutions.id),
@@ -403,7 +427,9 @@ export const workflowExecutionLogs = pgTable("workflow_execution_logs", {
   timestamp: timestamp("timestamp").notNull().defaultNow(),
   iterationIndex: integer("iteration_index"), // 0-based loop iteration (null for non-loop nodes)
   forEachNodeId: text("for_each_node_id"), // parent For Each node ID (null for non-loop nodes)
-});
+  },
+  (table) => [index("idx_exec_logs_started_at").on(table.startedAt)]
+);
 
 export {
   type AgenticWalletCredit,


### PR DESCRIPTION
## Summary

Cherry-pick of the KEEP-432 index migration ([PR #1219](https://github.com/techops-services/keeperhub/pull/1219), already merged to `staging`) directly onto `prod` to deliver these indexes without waiting for the next staging->prod release.

Tracking: [KEEP-432](https://linear.app/keeperhubapp/issue/KEEP-432)

## What this adds

12 indexes - identical to PR #1219:

- ``workflow_execution_logs(started_at)`` - closes the seq-scan path that caused the 2026-05-05 RDS CPU incident
- 11 missing FK indexes: ``workflow_executions(user_id)``, ``workflows(user_id, tag_id, project_id)``, ``accounts(user_id)``, ``sessions(user_id)``, ``member(user_id, organization_id)``, ``organization_api_keys(organization_id, created_by)``, ``integrations(user_id)``

All declared in ``lib/db/schema.ts`` / ``lib/db/schema-extensions.ts`` via the ``index()`` helper.

## Status of prod DB

**Indexes already applied to prod DB via ``CREATE INDEX CONCURRENTLY``** before this PR was opened. Verified: 12/12 valid + ready, 0 invalid indexes anywhere.

When ``drizzle-kit migrate`` runs on this PR's deploy, all 12 ``CREATE INDEX IF NOT EXISTS`` statements are no-ops because the indexes already exist.

## Test plan

- [x] Identical migration verified clean on staging (PR #1219 deploy log: ``migrations applied successfully``)
- [x] Prod DB pre-applied via CONCURRENTLY - 5s total, 0 invalid indexes
- [x] ``db-prep-check`` workflow will fire on this PR's directive ``-- @requires-db-prep`` and pass once ``db-prepped-prod`` label is set
- [ ] After merge: prod deploy ``drizzle-kit migrate`` is a no-op for the 12 indexes
- [ ] After merge: verify ``pg_index`` still shows 12 valid + 0 invalid