### PR TITLE
fix(KEEP-475): follow-up — hoist regex + add bare /agent redirect

### DIFF
--- a/app/agent/route.ts
+++ b/app/agent/route.ts
@@ -1,0 +1,20 @@
+// KEEP-475: ERC-8004 indexers and older A2A clients sometimes probe the bare
+// `/agent` path before falling back to `/.well-known/agent.json` or
+// `/.well-known/agent-card.json`. Without this route they got a 404 and gave
+// up; a 301 keeps them on the canonical card without duplicating content.
+
+const TRAILING_SLASH = /\/$/;
+
+function deriveBaseUrl(request: Request): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
+  if (envUrl) {
+    return envUrl.replace(TRAILING_SLASH, "");
+  }
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+export function GET(request: Request): Response {
+  const baseUrl = deriveBaseUrl(request);
+  return Response.redirect(`${baseUrl}/.well-known/agent-card.json`, 301);
+}

--- a/tests/unit/well-known-erc8004.test.ts
+++ b/tests/unit/well-known-erc8004.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GET as agentGET } from "@/app/agent/route";
 import { GET as agentJsonGET } from "@/app/.well-known/agent.json/route";
 import { GET as erc8004GET } from "@/app/.well-known/erc8004.json/route";
 
 const REQ_URL = "https://app.keeperhub.com/.well-known/test";
+const EIP55_ADDRESS = /^0x[a-fA-F0-9]{40}$/;
 const ORIGINAL_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
 const ORIGINAL_AUTH_URL = process.env.BETTER_AUTH_URL;
 
@@ -38,7 +40,7 @@ describe("/.well-known/erc8004.json (KEEP-475)", () => {
     expect(body.agent_id).toBe(31_875);
     expect(body.chain).toBe("ethereum");
     expect(body.chain_id).toBe(1);
-    expect(body.registry).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(body.registry).toMatch(EIP55_ADDRESS);
     expect(body.reputation.registry).toBe(body.registry);
     expect(body.reputation.type).toBe("erc-8004");
     expect(body.cards.mcp).toBe(
@@ -58,6 +60,17 @@ describe("/.well-known/erc8004.json (KEEP-475)", () => {
 describe("/.well-known/agent.json (KEEP-475)", () => {
   it("301-redirects to the canonical /.well-known/agent-card.json", () => {
     const response = agentJsonGET(new Request(REQ_URL));
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe(
+      "https://app.keeperhub.com/.well-known/agent-card.json"
+    );
+  });
+});
+
+describe("/agent (KEEP-475)", () => {
+  it("301-redirects the bare /agent path to the canonical agent card", () => {
+    const response = agentGET(new Request("https://app.keeperhub.com/agent"));
 
     expect(response.status).toBe(301);
     expect(response.headers.get("location")).toBe(


### PR DESCRIPTION
## Summary

Follow-up to PR #1276 (already merged). Addresses two findings from the review that were missed in the original merge:

- **Lint blocker:** the inline regex `/^0x[a-fA-F0-9]{40}$/` at `tests/unit/well-known-erc8004.test.ts:41` violates `lint/performance/useTopLevelRegex`. Hoisted to a module-level `EIP55_ADDRESS` constant.
- **Bare `/agent` route 404:** Linear KEEP-475 explicitly lists `/agent` (without `.json`) as a 404 alongside the `.well-known/*` variants. ERC-8004 indexers probe this fallback path; without it, KeeperHub's listing on those directories stays incomplete. Added `app/agent/route.ts` as a 301 permanent redirect to `/.well-known/agent-card.json`, mirroring the existing `app/.well-known/agent.json/route.ts` pattern.

## Test plan

- [x] `pnpm check` on changed files: clean
- [x] `pnpm type-check`: clean
- [x] `npx vitest run tests/unit/well-known-erc8004.test.ts`: 4/4 pass (including the new `/agent` redirect assertion)
- [x] Full unit suite: 4616/4616 pass
- [x] Clean merge against current staging (verified via merge-tree)