### PR TITLE
chore: KEEP-577 tighten /add-protocol command for accuracy and goal-direction

### DIFF
--- a/.claude/commands/add-protocol.md
+++ b/.claude/commands/add-protocol.md
@@ -65,10 +65,8 @@ Use WebSearch and WebFetch to gather concrete facts. Cite URLs and addresses for
 1.1 Identity and version (do this FIRST; everything downstream depends on getting the version right)
 - Canonical name and 1-line description of what the protocol does.
 - **Version**: which specific version of the protocol is being added? Aave V2/V3/V4, Uniswap V2/V3/V4, Compound V2/V3, the Maker -> Sky rebrand, etc. Confirm the exact version explicitly. Do not assume "the latest" or "the most common" - the live deployments answer this, not your priors.
-- Slug convention based on existing protocols in `protocols/`:
-  - When multiple versions of the protocol are supported in this codebase as separate entries, the slug encodes the version: `aave-v3`, `aave-v4`.
-  - When only one version is supported, the slug omits the version: `compound`, `uniswap`, `yearn` (file is named `compound-v3.ts` etc., but slug is bare). This is intentional - users see "Compound", not "Compound V3", in the workflow builder when no other version is exposed.
-  - Decide which case applies based on whether you are adding alongside an existing version of the same protocol.
+- Slug convention: **the slug tracks the protocol's own version branding**. If the protocol team brands itself as V2 / V3 / V4 in their docs and product UI (Aave V4, Uniswap V3, Compound III, Frax Ether V2), the slug includes that version suffix: `aave-v4`, `uniswap-v3`, `frax-ether-v2`. If the protocol does not version itself externally (WETH, ENS, Disperse, Multicall3), the slug omits a version. This rule applies whether or not an earlier version is already present in keeperhub - we are following the protocol's branding, not disambiguating internal entries.
+- Pre-existing inconsistencies: a few protocols already in `protocols/` (`compound`, `uniswap`, `yearn`) use bare slugs even though the protocols they wrap brand themselves as V3, and their files are named `compound-v3.ts` / `uniswap-v3.ts` / `yearn-v3.ts`. These predate the rule above. Do not perpetuate them: new protocols MUST follow the protocol-version-branding rule, even when the result feels redundant.
 - Official website.
 - Confirm the chosen slug does not collide with any entry in `protocols/` or `lib/types/integration.ts`.
 

--- a/.claude/commands/add-protocol.md
+++ b/.claude/commands/add-protocol.md
@@ -7,9 +7,9 @@ argument-hint: <protocol-name-or-spec-file>
 Add a new KeeperHub protocol plugin and iterate until the on-chain integration tests pass.
 
 `$ARGUMENTS` is one of:
-- A protocol name (e.g. `"Aave V4"`, `"Pendle"`). Pipeline researches contracts, ABIs, and chains via web search and explorer lookups.
+- A protocol name **including the version when multiple versions are live** (e.g. `"Aave V4"`, `"Uniswap V3"`, `"Compound V3"`, `"Pendle"`). The pipeline researches contracts, ABIs, and chains via web search and explorer lookups.
 - A path to a spec file ending in `.md`. Pipeline reads it as the source of truth and only researches gaps.
-- Empty. Pipeline asks the user what protocol to add.
+- Empty, or a version-ambiguous name (e.g. just `"Aave"`). Pipeline MUST ask the user which version before researching. Do not default to "the latest" - V3 and V4 of Aave are both in active production use today, and each has its own contracts, ABIs, and slug.
 
 DONE when ALL of the following pass:
 - `pnpm test tests/unit/protocol-{slug}.test.ts`
@@ -62,10 +62,15 @@ PHASE 1 - RESEARCH (web search + explorer lookups, BEFORE any code is written)
 
 Use WebSearch and WebFetch to gather concrete facts. Cite URLs and addresses for every claim. Do not guess; if a fact cannot be confirmed, mark it open and surface to the user.
 
-1.1 Identity
+1.1 Identity and version (do this FIRST; everything downstream depends on getting the version right)
 - Canonical name and 1-line description of what the protocol does.
+- **Version**: which specific version of the protocol is being added? Aave V2/V3/V4, Uniswap V2/V3/V4, Compound V2/V3, the Maker -> Sky rebrand, etc. Confirm the exact version explicitly. Do not assume "the latest" or "the most common" - the live deployments answer this, not your priors.
+- Slug convention based on existing protocols in `protocols/`:
+  - When multiple versions of the protocol are supported in this codebase as separate entries, the slug encodes the version: `aave-v3`, `aave-v4`.
+  - When only one version is supported, the slug omits the version: `compound`, `uniswap`, `yearn` (file is named `compound-v3.ts` etc., but slug is bare). This is intentional - users see "Compound", not "Compound V3", in the workflow builder when no other version is exposed.
+  - Decide which case applies based on whether you are adding alongside an existing version of the same protocol.
 - Official website.
-- Confirm the kebab-case slug does not collide with any entry in `protocols/` or `lib/types/integration.ts`.
+- Confirm the chosen slug does not collide with any entry in `protocols/` or `lib/types/integration.ts`.
 
 1.2 Chains
 - Which chains is the protocol deployed on?
@@ -74,15 +79,17 @@ Use WebSearch and WebFetch to gather concrete facts. Cite URLs and addresses for
 
 1.3 Contracts
 - For each contract the user will interact with: label, address per chain, and the curated function set to expose.
+- **Version isolation**: every contract MUST belong to the version identified in Phase 1.1. Do not mix V3 and V4 contracts in one protocol entry. When a version has sub-surfaces (Aave V4 Hub vs Spoke, Uniswap V3 SwapRouter02 vs older SwapRouter, Maker DSR vs Sky Savings Rate), name the exact surface in the contract label.
 - Curate aggressively. Exposing every public function bloats the UI; pick the actions a user actually wants to run.
 - Flag any contract whose address is per-user input (e.g. user supplies a pool address); these set `userSpecifiedAddress: true`.
 
 1.4 ABI
 - Obtain a reduced ABI for each contract. Source order of preference:
-  a. npm package shipped by the protocol team (use the latest tagged release, not main).
-  b. Verified contract on the relevant block explorer (Etherscan-style "Contract" tab).
-  c. Protocol's GitHub repo (look under `abi/`, `artifacts/`, or `out/` for forge projects).
+  a. npm package shipped by the protocol team **for the target version** (use the latest tagged release of that version's package, not main, not a different version's package).
+  b. Verified contract on the relevant block explorer (Etherscan-style "Contract" tab). The explorer page MUST be for the version's deployment address from Phase 1.3 - confirm before copying the ABI. A V3 ABI scraped from a V4 contract page (or vice versa) will compile, pass unit tests, and fail integration tests with `INVALID_ARGUMENT` or `BAD_DATA`.
+  c. Protocol's GitHub repo (look under `abi/`, `artifacts/`, or `out/` for forge projects). Pin to the version's tag or release branch, not `main` or `master`.
   d. Official protocol docs.
+- **ABI-to-version match is a hard gate.** Function signatures drift between versions (Aave V3 `supply(asset, amount, onBehalfOf, referralCode)` becomes V4 `supply(reserveId, amount, onBehalfOf)`). The integration tests in Phase 4 will catch a version mismatch, but the cost is one or more failed iterations. Cite the exact source URL for each ABI in the Phase 2 report so reviewers can verify the version match before any code is written.
 - Reduce: keep only the functions and events being exposed. Drop everything else.
 
 1.5 Documentation URLs
@@ -98,11 +105,11 @@ Use WebSearch and WebFetch to gather concrete facts. Cite URLs and addresses for
 PHASE 2 - CONFIRM (gate: do NOT proceed without explicit user approval)
 
 Post a research report to the user containing:
-- Protocol: name, slug, 1-line description.
+- Protocol: name, **version**, slug, 1-line description. State the version prominently; do not bury it.
 - Chains: intersection list with rationale for each inclusion/exclusion.
-- Contracts: table of label / function set / source ABI URL / docs URL.
+- Contracts: table of label / function set / source ABI URL / docs URL. All contracts belong to the named version only.
 - Definition strategy + why this one fits.
-- ABI source(s) per contract.
+- ABI source(s) per contract, with the version each ABI corresponds to and the exact URL it came from.
 
 WAIT for explicit user confirmation on chains AND contracts. If the user says "add chain X" or "drop function Y", loop back to Phase 1 with the adjustment. Do not begin writing code.
 
@@ -177,6 +184,7 @@ BAIL-OUT CONDITIONS (stop the loop and surface to user):
 - The same integration test failure recurs across 3 consecutive iterations.
 - Research surfaces a chain / contract requirement that conflicts with the Phase 2 confirmation - re-confirm before proceeding.
 - No ABI source can be obtained from any explorer, npm package, GitHub repo, or official docs - escalate; do not invent ABI fragments.
+- **Version ambiguity**: $ARGUMENTS does not uniquely identify a version (e.g. just `"Aave"` when V3 and V4 are both live), OR research surfaces a candidate ABI / contract whose version cannot be confirmed. Surface the available versions to the user and wait for disambiguation. Do not pick a default.
 
 On bail-out, surface to the user:
 - Current state of all generated files.

--- a/.claude/commands/add-protocol.md
+++ b/.claude/commands/add-protocol.md
@@ -1,108 +1,198 @@
 ---
-description: Add a new protocol plugin to KeeperHub via the agent pipeline
+description: Add a new protocol plugin to KeeperHub via an iterative agent pipeline
 argument-hint: <protocol-name-or-spec-file>
 ---
 
 <objective>
-Add a new KeeperHub protocol plugin. $ARGUMENTS is either:
-- A protocol name (e.g., "Aave", "Uniswap V3"). Pipeline will gather contract details.
-- A file path ending in `.md` (e.g., `specs/my-protocol.md`). Pipeline reads spec file for details.
-- Empty. Pipeline will ask user what protocol to add.
+Add a new KeeperHub protocol plugin and iterate until the on-chain integration tests pass.
 
-This command invokes the Orchestrator agent which runs the full Blueprint pipeline: DECOMPOSE -> RESEARCH -> IMPLEMENT -> VERIFY -> PR. The pipeline produces a complete, lint-clean, type-safe protocol definition in `protocols/` with tests and documentation.
+`$ARGUMENTS` is one of:
+- A protocol name (e.g. `"Aave V4"`, `"Pendle"`). Pipeline researches contracts, ABIs, and chains via web search and explorer lookups.
+- A path to a spec file ending in `.md`. Pipeline reads it as the source of truth and only researches gaps.
+- Empty. Pipeline asks the user what protocol to add.
+
+DONE when ALL of the following pass:
+- `pnpm test tests/unit/protocol-{slug}.test.ts`
+- `pnpm test tests/integration/protocol-{slug}-onchain.test.ts` (against a real RPC for the test chain, OR via the public-RPC-fallback pattern, see `<process>` Phase 4)
+- `pnpm check` (Ultracite lint)
+- `pnpm type-check` (TypeScript)
+- `pnpm discover-plugins` (protocol is registered and `protocols/index.ts` + `lib/types/integration.ts` regenerate cleanly)
+
+The pipeline does NOT exit on partial work. If integration tests do not pass, it loops back to BUILD with the specific failure as the next problem to solve.
 </objective>
 
 <context>
 Domain knowledge: @.claude/agents/protocol-domain.md
-Example protocol (ABI-driven, Sepolia integration tests): @protocols/weth.ts
-Example protocol (mainnet-only, struct returns, docUrl tooltips): @protocols/aave-v4.ts
-Example reduced ABI: @protocols/abis/weth.json
-Protocol registry (defineAbiProtocol, defineProtocol): @lib/protocol-registry.ts
-ABI derivation: @lib/protocol-abi-derive.ts
-Solidity type -> UI field mapping: @lib/solidity-type-fields.ts
-Tooltip/docUrl rendering: @lib/extensions.tsx (see ProtocolFieldLabel)
-Project conventions: @CLAUDE.md
 Blueprint pipeline: @.claude/agents/blueprint-pipeline.md
+Project conventions: @CLAUDE.md
+
+ABI-driven, Sepolia, 1:1 contract->surface (canonical reference): @protocols/wrapped.ts + @protocols/abis/weth.json
+Mainnet-only, struct returns, docUrl tooltips: @protocols/aave-v4.ts
+Multi-contract, struct-arg writes: @protocols/uniswap-v3.ts
+Hybrid pattern (one ABI backing many UX surfaces; uses `deriveActionsFromAbi` + `defineProtocol`): @protocols/chainlink.ts
+
+Unit test template: @tests/unit/protocol-wrapped.test.ts
+Integration test template (Sepolia, gated): @tests/integration/protocol-wrapped-onchain.test.ts
+Integration test template (mainnet, gated): @tests/integration/protocol-aave-v4-onchain.test.ts
+Integration test template (ungated, public-RPC fallback): @tests/integration/protocol-uniswap-onchain.test.ts
+
+Protocol registry: @lib/protocol-registry.ts
+ABI derivation internals: @lib/abi/protocol-derive.ts
+Solidity type to field mapping: @lib/solidity-type-fields.ts
+Tooltip/docUrl rendering: @lib/extensions.tsx (see `ProtocolFieldLabel`)
+
 Existing protocols: !`ls protocols/`
 Existing reduced ABIs: !`ls protocols/abis/ 2>/dev/null`
-Existing on-chain integration tests: !`ls tests/integration/protocol-*-onchain.test.ts 2>/dev/null`
+Existing integration tests: !`ls tests/integration/protocol-*-onchain.test.ts 2>/dev/null`
 </context>
 
 <process>
-Spawn the Orchestrator agent with the following task description:
+Spawn the Orchestrator agent with the iteration loop below. The Orchestrator MUST NOT exit until DONE (see `<objective>`) or a hard bail-out condition is hit.
 
 ```
-Protocol Task: Add protocol "$ARGUMENTS" to KeeperHub
+Protocol Task: Add protocol "$ARGUMENTS" to KeeperHub via the iterative pipeline.
 
 Domain Reference: .claude/agents/protocol-domain.md
 
-Task Type: Protocol plugin creation (Tier 1, follows existing pattern)
+ITERATION LOOP
 
-Definition strategy:
-- DEFAULT: use `defineAbiProtocol()` with a reduced ABI at `protocols/abis/{slug}.json`. All new protocols use this pattern unless explicitly blocked.
-- FALLBACK to `defineProtocol()` only when BOTH: (a) the contract is unverified on every supported explorer, AND (b) no reliable ABI source exists (npm package, GitHub repo, project docs). Document in the PR why the fallback was required.
-- For ERC-4626 vaults: keep using `defineProtocol()` + `erc4626VaultActions()` for the vault surface (no ABI-driven helper exists yet).
+Phases run in order. After VERIFY, if any check failed, loop back to BUILD with the specific failure as the next problem. Do not silently exit on partial work.
 
-Required artifacts:
-- protocols/{slug}.ts: protocol definition using defineAbiProtocol() (or defineProtocol() fallback). Every input with a helpTip SHOULD also have a docUrl pointing to canonical protocol docs (enables click-through tooltips). See <field_tooltips> in protocol-domain.md.
-- protocols/abis/{slug}.json: reduced ABI JSON file (ABI-driven path only; skip for fallback). Contains ONLY the functions exposed as actions.
-- tests/unit/protocol-{slug}.test.ts: Vitest unit tests (shape + override integrity)
-- tests/integration/protocol-{slug}-onchain.test.ts: Vitest on-chain integration tests. REQUIRED for all ABI-driven protocols. Gate on INTEGRATION_TEST_RPC_URL (Sepolia, default) or INTEGRATION_TEST_MAINNET_RPC_URL (mainnet-only protocols). One test per action: reads verify decodable output types, writes verify calldata encodes without ABI errors (business reverts are acceptable). See <test_structure> in protocol-domain.md for the full pattern and env-var matrix.
-- docs/plugins/{slug}.md: documentation page
-- public/protocols/{slug}.png: icon (if user provides one)
-- Example workflows inserted into local DB via postgres MCP (test workflow per read action + up to 8-10 example workflows, scaled to protocol complexity)
+PHASE 1 - RESEARCH (web search + explorer lookups, BEFORE any code is written)
+
+Use WebSearch and WebFetch to gather concrete facts. Cite URLs and addresses for every claim. Do not guess; if a fact cannot be confirmed, mark it open and surface to the user.
+
+1.1 Identity
+- Canonical name and 1-line description of what the protocol does.
+- Official website.
+- Confirm the kebab-case slug does not collide with any entry in `protocols/` or `lib/types/integration.ts`.
+
+1.2 Chains
+- Which chains is the protocol deployed on?
+- Intersect with KeeperHub's supported chains. Source of truth: existing protocols in `protocols/` and the chain entries in `chain-config/`. Any chain not in `chain-config/` will not have an explorer config and cannot be used.
+- Report the intersection. That is the candidate `addresses` map.
+
+1.3 Contracts
+- For each contract the user will interact with: label, address per chain, and the curated function set to expose.
+- Curate aggressively. Exposing every public function bloats the UI; pick the actions a user actually wants to run.
+- Flag any contract whose address is per-user input (e.g. user supplies a pool address); these set `userSpecifiedAddress: true`.
+
+1.4 ABI
+- Obtain a reduced ABI for each contract. Source order of preference:
+  a. npm package shipped by the protocol team (use the latest tagged release, not main).
+  b. Verified contract on the relevant block explorer (Etherscan-style "Contract" tab).
+  c. Protocol's GitHub repo (look under `abi/`, `artifacts/`, or `out/` for forge projects).
+  d. Official protocol docs.
+- Reduce: keep only the functions and events being exposed. Drop everything else.
+
+1.5 Documentation URLs
+- For each function being exposed, identify the canonical per-page docs URL. This populates `docUrl` on overrides.
+- Prefer per-function pages over the docs root. Skip docUrl rather than link to a non-canonical page (blog, third-party tutorial).
+
+1.6 Definition strategy (pick ONE; record why)
+- DEFAULT: `defineAbiProtocol()` with one reduced ABI per contract.
+- HYBRID: `defineProtocol()` with `...deriveActionsFromAbi(...)` spread into the actions array. Use when one ABI backs many distinct UX surfaces (price feeds, per-asset markets, curated bundles). Reference: `protocols/chainlink.ts`.
+- FALLBACK: pure `defineProtocol()`. ONLY when no ABI source exists anywhere. Document the unavailability in the PR.
+- ERC-4626 vaults: `defineProtocol()` + `erc4626VaultActions()` (no ABI-driven helper yet).
+
+PHASE 2 - CONFIRM (gate: do NOT proceed without explicit user approval)
+
+Post a research report to the user containing:
+- Protocol: name, slug, 1-line description.
+- Chains: intersection list with rationale for each inclusion/exclusion.
+- Contracts: table of label / function set / source ABI URL / docs URL.
+- Definition strategy + why this one fits.
+- ABI source(s) per contract.
+
+WAIT for explicit user confirmation on chains AND contracts. If the user says "add chain X" or "drop function Y", loop back to Phase 1 with the adjustment. Do not begin writing code.
+
+Rationale: the chain selector auto-restricts to `Object.keys(contract.addresses)`. Any chain in the map becomes user-selectable in the workflow builder, and any user-selectable chain without a real deployment breaks workflows at runtime. This gate exists to prevent that class of bug.
+
+PHASE 3 - BUILD
+
+Once Phase 2 is confirmed, produce these files. For each, match the structure of the example called out:
+
+- `protocols/{slug}.ts` - protocol definition. Match the example file picked in Phase 1.6.
+- `protocols/abis/{slug}.json` (or `{slug}-{contract}.json` if multiple contracts) - reduced ABI(s). Functions plus only the events being exposed. Nothing else.
+- `tests/unit/protocol-{slug}.test.ts` - shape and override integrity. Model on `tests/unit/protocol-wrapped.test.ts`. Cover at minimum:
+  - Default export imports without throwing; name and slug correct.
+  - Protocol slug matches kebab-case regex.
+  - All action slugs match kebab-case regex.
+  - Every action's `contract` references a defined contract key.
+  - No duplicate action slugs (the registry does NOT check this; the unit test is the safety net).
+  - Every read action has non-empty `outputs`.
+  - Every contract address matches `^0x[0-9a-fA-F]{40}$`.
+  - Action count + slugs (shape lock so future edits surface intent changes).
+  - Per-action: function name, payable flag, input names/types/labels/helpTip/docUrl, output names/labels/decimals.
+  - Chain coverage list - both inclusions AND explicit exclusions (e.g. `expect(chains).not.toContain("10")` for a gap).
+  - Registry round-trip: `registerProtocol(def)` then `getProtocol(slug)`.
+- `tests/integration/protocol-{slug}-onchain.test.ts` - calldata validation. Model on whichever of these matches the protocol's deployment:
+  - Sepolia testnet deployment: `tests/integration/protocol-wrapped-onchain.test.ts` (gated on `INTEGRATION_TEST_RPC_URL`).
+  - Mainnet-only deployment: `tests/integration/protocol-aave-v4-onchain.test.ts` (gated on `INTEGRATION_TEST_MAINNET_RPC_URL`).
+  - Reliable public RPC available AND test should run in CI without secrets: `tests/integration/protocol-uniswap-onchain.test.ts` (ungated; uses `CHAIN_RPC_CONFIG` resolver with public-RPC fallback). Default to gated unless there is a specific reason.
+  - All three patterns require: `vi.mock("server-only", () => ({}));` at the top. RPC routed through `getRpcProviderFromUrls` + `executeWithFailover` (same failover the prod request path uses). One test per exposed action: reads decode the return type; writes call `estimateGas` or `provider.call` and accept `CALL_EXCEPTION` (business revert) while rejecting ABI errors (see Phase 4).
+- `docs/plugins/{slug}.md` - public docs page with actions table and per-action sections.
+- `docs/plugins/_meta.ts` - add nav entry.
+- `docs/plugins/overview.md` - add to protocols table.
+- `public/protocols/{slug}.png` - icon. Skip if the user did not provide one; do not block on this.
+
+Auto-generated (do NOT hand-edit):
+- `protocols/index.ts` - regenerated by `pnpm discover-plugins`.
+- `lib/types/integration.ts` - slug appended by discover-plugins.
 
 User-visible string formatting (HARD RULE):
-- The `description`, `label`, and `helpTip` fields on the protocol and on each action input/output appear in the KeeperHub UI. These strings MUST NOT contain em dashes (`—`) or double-hyphens (`--`). Use periods, colons, semicolons, or restructure the sentence. Hyphens inside compound words (e.g. `pro-rata`, `wei/sec`, `CFA+GDA`) are fine; the rule is specifically about the dash-as-clause-separator pattern.
-- This applies equally to action descriptions, output labels, and any free-form strings in the docs/plugins/{slug}.md page that ship with the protocol.
+- `description`, `label`, and `helpTip` strings on the protocol, actions, inputs, and outputs MUST NOT contain em dashes or double-hyphens (`--`). Use periods, colons, semicolons, or restructure the sentence. Hyphens inside compound words (e.g. `pro-rata`, `wei/sec`, `CFA+GDA`) are fine; the rule is specifically about the dash-as-clause-separator pattern.
+- Applies equally to the docs/plugins/{slug}.md page.
 
-Required modifications:
-- docs/plugins/_meta.ts: add nav entry
-- docs/plugins/overview.md: add to protocols table
-- (auto-generated) protocols/index.ts
-- (auto-generated) lib/types/integration.ts
+PHASE 4 - VERIFY
 
-Research questions for the Researcher agent:
-- What contracts does this protocol have and on which chains?
-- For each contract, what is the reduced set of functions to expose? (Provide the ABI fragments for those functions.)
-- Does any existing ABI-driven protocol serve as a closer pattern than WETH?
-- Does the slug "{slug}" already exist in lib/types/integration.ts or protocols/?
-- Does the protocol have Sepolia testnet deployments? If yes, use INTEGRATION_TEST_RPC_URL. If no, use INTEGRATION_TEST_MAINNET_RPC_URL against chain 1.
-- Which chains in the protocol's contracts have explorer configs? (Only 1, 8453, 84532, 11155111. See protocol-domain.md.)
-- **Chain scope confirmation (REQUIRED before Builder proceeds):** Compute the intersection of (a) chains where the protocol is deployed and (b) chains KeeperHub supports. Present this list to the user and get explicit confirmation before finalizing the `addresses` map. The chain selector auto-restricts to `Object.keys(contract.addresses)`, so any chain in the map becomes user-selectable, and any user-selectable chain without a real deployment breaks workflows at runtime.
-- **Docs URL discovery:** For each input that needs a helpTip, identify the most specific canonical docs URL (e.g. "supply" page, "borrow" page) from the protocol's official documentation. Prefer stable URLs (official docs) over blog posts. Pass these in the research report so the Builder can populate `docUrl` on overrides.
-- Are there unnamed ABI parameters (empty "name") that need `arg0`/`arg1` overrides?
-- Does any function require a pre-ABI-encode transform? (Almost always no. See <encode_transforms> in protocol-domain.md.)
-- Does any read function return a struct/tuple? If so, document the component field names so users know what dotted paths are available (`result.fieldName`).
+Run in order. Do NOT advance past a failing step. Re-run the FULL sequence after every fix (do not assume earlier passes still pass).
 
-Success criteria:
-- protocols/{slug}.ts imports without throwing (defineAbiProtocol validation + ABI derivation pass)
-- For ABI-driven path: protocols/abis/{slug}.json parses as valid ABI JSON array
-- Chain scope confirmed with user before implementation (list of supported chain IDs in contract.addresses matches user expectation)
-- Every input with a helpTip has a docUrl unless no official docs exist (in which case note the absence in the PR description)
-- pnpm discover-plugins runs without errors and registers the protocol
-- pnpm check passes with zero lint errors
-- pnpm type-check passes with zero TypeScript errors
-- Vitest unit tests pass: `pnpm test protocol-{slug}`
-- Vitest on-chain integration tests pass locally with the appropriate RPC env var set (INTEGRATION_TEST_RPC_URL for Sepolia or INTEGRATION_TEST_MAINNET_RPC_URL for mainnet). Skipped in CI without the env var, safe to commit.
-- Documentation page exists with actions table and per-action sections
-- Example workflows created via postgres MCP: test workflows (1 per read action) + example workflows (up to 8-10, as many as the protocol's actions meaningfully support)
-- All workflows target only chains with explorer configs AND chains defined in the protocol's addresses map
-- Code nodes use bare template references (no manual quotes) and divide-by-zero guards
+4.1 `pnpm discover-plugins` exits 0 and registers the protocol (check stdout includes the new slug; check `protocols/index.ts` was regenerated).
+4.2 `pnpm check` passes.
+4.3 `pnpm type-check` passes.
+4.4 `pnpm test tests/unit/protocol-{slug}.test.ts` passes.
+4.5 `pnpm test tests/integration/protocol-{slug}-onchain.test.ts` passes against a real RPC. RPC selection by gating pattern:
+  - `INTEGRATION_TEST_RPC_URL` set to a Sepolia RPC (gated Sepolia tests).
+  - `INTEGRATION_TEST_MAINNET_RPC_URL` set to a mainnet RPC (gated mainnet tests).
+  - No env var needed for ungated tests; the public-RPC fallback will be used.
+  - If the required env var is unset, the test SKIPS, which counts as "did not pass". The Orchestrator must ask the user to provide the RPC URL (or accept the ungated pattern) before declaring DONE.
+
+When a check fails, classify and resolve:
+- Lint / type / shape failure -> patch the source file or the unit test, depending on which is wrong. Tests encode intent; if the intent was wrong, update both.
+- Integration test ABI errors (`INVALID_ARGUMENT`, `BAD_DATA`, `BUFFER_OVERRUN`, `"could not decode"`, `"invalid function"`) -> the reduced ABI does NOT match the deployed bytecode. Fix the ABI. Do NOT loosen the test.
+- Integration test `CALL_EXCEPTION` on a write action -> ACCEPT. A business revert (zero allowance, nonexistent reserve, missing approval) still proves the bytecode parsed the calldata. Document the revert in a comment if it is non-obvious.
+- Integration test `CALL_EXCEPTION` on a read action -> investigate. Reads should not revert unless the calldata is wrong (e.g. calling `balanceOf` on a non-token).
+
+Loop back to PHASE 3 with the specific failure as the problem to solve. Do not declare DONE until all five checks pass cleanly.
+
+PHASE 5 - EXIT
+
+Once Phase 4 passes:
+- Summarise: protocol slug, contracts, chains, action count, definition strategy used.
+- Draft PR title and body, conventional commit format (e.g. `feat: KEEP-XXX add <Protocol> protocol plugin`). Branch `feat/KEEP-XXXX-add-{slug}` if a Linear ticket is set; else `feat/add-{slug}-protocol`.
+- DO NOT create the PR. User confirmation is required per CLAUDE.md ("Do not git push or create GitHub PRs without user's confirmation").
+
+BAIL-OUT CONDITIONS (stop the loop and surface to user):
+- The same integration test failure recurs across 3 consecutive iterations.
+- Research surfaces a chain / contract requirement that conflicts with the Phase 2 confirmation - re-confirm before proceeding.
+- No ABI source can be obtained from any explorer, npm package, GitHub repo, or official docs - escalate; do not invent ABI fragments.
+
+On bail-out, surface to the user:
+- Current state of all generated files.
+- The specific failure that blocked progress (full error text, not a summary).
+- A concrete question to unblock (not "what should I do?", but e.g. "Pendle's `redeemPY` returns a struct with a `bytes32` field that decodes as a malformed tuple - should I expose this as a single struct field or flatten with named field overrides?").
 ```
 
-The Orchestrator handles: gathering protocol details from user or spec file, decomposing subtasks, delegating to Researcher/Builder/Verifier agents, and creating the PR.
+The Orchestrator handles: web search, decomposing subtasks, delegating to Researcher / Builder / Verifier agents, running the iteration loop, and drafting the PR.
 </process>
 
 <success_criteria>
-- Orchestrator pipeline completes end-to-end
-- Protocol definition at protocols/{slug}.ts passes defineAbiProtocol() (or defineProtocol() fallback) validation
-- Reduced ABI at protocols/abis/{slug}.json exists and parses (ABI-driven path only)
-- Chain scope explicitly confirmed with user before Builder proceeds
-- Input docUrls populated where canonical docs exist
-- All checks pass: pnpm check, pnpm type-check, vitest unit tests
-- On-chain integration tests at tests/integration/protocol-{slug}-onchain.test.ts pass locally (Sepolia via INTEGRATION_TEST_RPC_URL or mainnet via INTEGRATION_TEST_MAINNET_RPC_URL; skipped in CI, safe to commit)
-- PR created targeting staging branch with conventional commit format
-- Verifier agent explicitly approved before PR creation (SAFE-04 gate)
-- Pipeline safeguards enforced: risk tier classified (SAFE-01), iteration limits tracked (SAFE-02), build verified (SAFE-03)
+- Integration tests at `tests/integration/protocol-{slug}-onchain.test.ts` pass against the configured RPC (skipped is not pass).
+- Unit tests at `tests/unit/protocol-{slug}.test.ts` pass.
+- `pnpm check`, `pnpm type-check`, `pnpm discover-plugins` all exit 0.
+- Chain and contract scope was explicitly confirmed by the user in Phase 2 before any code was written.
+- Definition strategy is justified in the PR description (which of defineAbiProtocol / hybrid / fallback was used and why).
+- Input docUrls populated for every input where a canonical per-page docs URL exists; absences noted in the PR.
+- PR drafted but not created; user confirmation required to push and open.
 </success_criteria>


### PR DESCRIPTION
## Summary

Rewrite `.claude/commands/add-protocol.md` around an explicit 5-phase iteration loop. The pipeline loops back to BUILD on any test failure and does not declare DONE until unit + integration tests, lint, type-check, and `pnpm discover-plugins` all pass.

Closes the immediate goal-direction issues from [KEEP-577](https://linear.app/keeperhubapp/issue/KEEP-577). Defers the larger ticket scope (workflow seeding strategy, SAFE-0X resolution, protocol-coverage harness decision) to follow-up work.

## What changed

- New 5-phase loop: RESEARCH (web search) -> CONFIRM (user gate) -> BUILD -> VERIFY -> EXIT.
- Phase 1 RESEARCH uses WebSearch + WebFetch to gather identity, chains, contracts, ABI source, and per-function docs URLs. ABI source preference order is spelled out (npm package -> verified explorer -> protocol GitHub repo -> docs).
- Phase 2 CONFIRM promotes chain/contract scope from a buried research sub-bullet to a top-level user-confirmation gate. Includes the runtime rationale (chain selector auto-restricts to `Object.keys(contract.addresses)`).
- Phase 4 VERIFY classifies errors: ABI errors (`INVALID_ARGUMENT`, `BAD_DATA`, `BUFFER_OVERRUN`) are always real failures; `CALL_EXCEPTION` on writes is acceptable (business revert proves bytecode parsed the calldata); `CALL_EXCEPTION` on reads is investigated. Loops back to BUILD on any failure.
- Three definition strategies documented: `defineAbiProtocol` (default), hybrid `defineProtocol` + spread `...deriveActionsFromAbi(...)` (chainlink pattern; new), pure `defineProtocol` (fallback). Previously only two.
- Three integration-test gating patterns documented: `INTEGRATION_TEST_RPC_URL`-gated Sepolia, `INTEGRATION_TEST_MAINNET_RPC_URL`-gated mainnet, ungated public-RPC fallback via `CHAIN_RPC_CONFIG` (uniswap pattern; new). Previously only two.
- Bail-out conditions defined (same failure 3 times, conflicting scope, no obtainable ABI).

## Side fixes carried in

- Fixed the broken `@protocols/weth.ts` context reference (actual file is `protocols/wrapped.ts`).
- Removed the "Example workflows inserted into local DB via postgres MCP" line, which conflicted with CLAUDE.md's "Use `kh` CLI and KeeperHub MCP tools for all KeeperHub API interactions. NEVER use raw `curl` or `fetch`" rule. Workflow seeding strategy is left for the larger KEEP-577 follow-up.
- Removed the undefined SAFE-01..04 gates from success criteria.

## Out of scope (KEEP-577 follow-up)

- Workflow seeding via kh CLI / KeeperHub MCP (replaces the dropped postgres-MCP line).
- KEEP-458 protocol-coverage harness integration.
- Updating `protocol-domain.md` and `blueprint-pipeline.md`.

## Test plan

- [ ] Manual: invoke `/add-protocol Pendle` (or another new protocol) and confirm the Orchestrator follows the 5-phase loop, gating at Phase 2 for chain/contract scope confirmation.
- [ ] Manual: confirm the file still renders as a valid slash command in Claude Code (front-matter intact, `<objective>`/`<context>`/`<process>` blocks parsed).
- [ ] Manual: spot-check the @-included file references resolve (`@protocols/wrapped.ts`, `@protocols/chainlink.ts`, etc.).