### PR TITLE
feat: add error_type label to workflow metrics & wider rename

### DIFF
--- a/app/api/agentic-wallet/provision/route.ts
+++ b/app/api/agentic-wallet/provision/route.ts
@@ -14,7 +14,7 @@
  * - Delegates the Turnkey + DB pipeline to provisionAgenticWallet()
  *   (Plan 33-01a).
  * - 200 response body: { subOrgId, walletAddress, hmacSecret }. The 10s
- *   wall-clock SLO is enforced by the integration test.
+ *   wall-clock SLI is enforced by the integration test.
  * - Error mapping: Turnkey errors (TurnkeyRequestError /
  *   TurnkeyActivityError / TurnkeyUpstreamError) -> 502 with
  *   code="TURNKEY_UPSTREAM"; any other failure -> 500 with

--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -101,7 +101,7 @@ export async function GET(request: Request): Promise<NextResponse> {
         status: "error",
         error: reaperErrorMessage,
         errorCategory: reaperClassification.errorCategory,
-        isUserError: reaperClassification.isUserError,
+        errorType: reaperClassification.errorType,
         completedAt: new Date(),
         duration: sql`ROUND(EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000)`,
       })

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -381,7 +381,7 @@ async function handlePaidWorkflow(
               status: "error",
               error: errorMessage,
               errorCategory: classification.errorCategory,
-              isUserError: classification.isUserError,
+              errorType: classification.errorType,
             })
             .where(eq(workflowExecutions.id, executionId))
             .returning({ workflowId: workflowExecutions.workflowId });

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -67,7 +67,7 @@ async function executeWorkflowBackground(
     logSystemError(ErrorCategory.WORKFLOW_ENGINE, "[Workflow Execute] Error during execution", error, { endpoint: "/api/workflow/[workflowId]/execute", operation: "executeWorkflow" });
 
     // KEEP-545: classify the error so the row carries error_category and
-    // is_user_error and so the per-execution counter is incremented post-update.
+    // error_type and so the per-execution counter is incremented post-update.
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     const classification = classifyExecutionError(errorMessage);
@@ -78,7 +78,7 @@ async function executeWorkflowBackground(
         status: "error",
         error: errorMessage,
         errorCategory: classification.errorCategory,
-        isUserError: classification.isUserError,
+        errorType: classification.errorType,
         completedAt: new Date(),
       })
       .where(eq(workflowExecutions.id, executionId))

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -197,7 +197,7 @@ async function executeWorkflowBackground(
         status: "error",
         error: errorMessage,
         errorCategory: classification.errorCategory,
-        isUserError: classification.isUserError,
+        errorType: classification.errorType,
         completedAt: new Date(),
       })
       .where(eq(workflowExecutions.id, executionId))

--- a/drizzle/0077_error_type_label_rename.sql
+++ b/drizzle/0077_error_type_label_rename.sql
@@ -1,0 +1,24 @@
+-- Rename the `is_user_error` boolean column on `workflow_executions` to a
+-- text `error_type` column with values 'user' | 'system'. Aligns the column
+-- name with the new Prometheus label vocabulary used across the counter,
+-- gauge, structured logs, Sentry tags, and SLA alert.
+--
+-- Backfill uses a three-state CASE that preserves NULL for rows predating
+-- classification:
+--   is_user_error = TRUE   -> 'user'
+--   is_user_error = FALSE  -> 'system'
+--   is_user_error IS NULL  -> NULL (stays unclassified)
+--
+-- Mapping NULL to 'system' (as the original spec suggested) would pull
+-- ~10.7k historical pre-classification errors into the platform SLO
+-- denominator. Keeping NULL as NULL lets the SLO query exclude them via
+-- `error_type IN ('user', 'system')` until a separate backfill decision is
+-- made about that incident window.
+ALTER TABLE "workflow_executions" ADD COLUMN "error_type" text;--> statement-breakpoint
+UPDATE "workflow_executions"
+  SET "error_type" = CASE
+    WHEN "is_user_error" = TRUE  THEN 'user'
+    WHEN "is_user_error" = FALSE THEN 'system'
+  END
+  WHERE "is_user_error" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "workflow_executions" DROP COLUMN "is_user_error";

--- a/drizzle/0077_error_type_label_rename.sql
+++ b/drizzle/0077_error_type_label_rename.sql
@@ -1,7 +1,7 @@
 -- Rename the `is_user_error` boolean column on `workflow_executions` to a
 -- text `error_type` column with values 'user' | 'system'. Aligns the column
 -- name with the new Prometheus label vocabulary used across the counter,
--- gauge, structured logs, Sentry tags, and SLA alert.
+-- gauge, structured logs, Sentry tags, and SLI alert.
 --
 -- Backfill uses a three-state CASE that preserves NULL for rows predating
 -- classification:

--- a/drizzle/0077_error_type_label_rename.sql
+++ b/drizzle/0077_error_type_label_rename.sql
@@ -10,8 +10,8 @@
 --   is_user_error IS NULL  -> NULL (stays unclassified)
 --
 -- Mapping NULL to 'system' (as the original spec suggested) would pull
--- ~10.7k historical pre-classification errors into the platform SLO
--- denominator. Keeping NULL as NULL lets the SLO query exclude them via
+-- ~10.7k historical pre-classification errors into the platform SLI
+-- denominator. Keeping NULL as NULL lets the SLI query exclude them via
 -- `error_type IN ('user', 'system')` until a separate backfill decision is
 -- made about that incident window.
 ALTER TABLE "workflow_executions" ADD COLUMN "error_type" text;--> statement-breakpoint

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1777760000010,
       "tag": "0076_keep484_backfill_wallet_integration_name",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1777760000011,
+      "tag": "0077_error_type_label_rename",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -354,7 +354,7 @@ export const workflowExecutions = pgTable(
       | "workflow_engine"
       | "unknown"
     >(),
-    isUserError: boolean("is_user_error"),
+    errorType: text("error_type").$type<"user" | "system">(),
     startedAt: timestamp("started_at").notNull().defaultNow(),
     completedAt: timestamp("completed_at"),
     duration: numeric("duration"), // Duration in milliseconds

--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -16,7 +16,7 @@ describe("classifyExecutionError", () => {
     ])("returns workflow_engine + system for %s", (_label, input) => {
       const r = classifyExecutionError(input);
       expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
   });
 
@@ -28,7 +28,7 @@ describe("classifyExecutionError", () => {
     ])("classifies %s as configuration + user", (input) => {
       const r = classifyExecutionError(input);
       expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
   });
 
@@ -41,7 +41,7 @@ describe("classifyExecutionError", () => {
     ])("classifies %s as validation + user", (input) => {
       const r = classifyExecutionError(input);
       expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
   });
 
@@ -51,13 +51,13 @@ describe("classifyExecutionError", () => {
         "Code execution failed: require is not defined"
       );
       expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
 
     it("Invalid contract address: validation + user", () => {
       const r = classifyExecutionError("Invalid contract address: ");
       expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
 
     it("Invalid function arguments: validation + user", () => {
@@ -65,7 +65,7 @@ describe("classifyExecutionError", () => {
         "Invalid function arguments: _fee.nativeFee: uint256 cannot be empty"
       );
       expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
 
     it("For Each: arraySource is required: configuration + user", () => {
@@ -73,7 +73,7 @@ describe("classifyExecutionError", () => {
         "For Each: arraySource is required. Configure a template reference to an array"
       );
       expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
 
     it("Condition references field: configuration + user", () => {
@@ -81,13 +81,13 @@ describe("classifyExecutionError", () => {
         'Condition references field "logs" but "logs" does not exist on the data'
       );
       expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
 
     it("No token selected: configuration + user", () => {
       const r = classifyExecutionError("No token selected to check");
       expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
 
     it("Contract call failed: transaction + user", () => {
@@ -95,7 +95,7 @@ describe("classifyExecutionError", () => {
         "Contract call failed: Error(This spell has already been scheduled)"
       );
       expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
   });
 
@@ -105,7 +105,7 @@ describe("classifyExecutionError", () => {
         "RPC failed on both endpoints. Primary: request timeout. Fallback: request timeout"
       );
       expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Failed to check balance: RPC failed: network_rpc + system", () => {
@@ -113,7 +113,7 @@ describe("classifyExecutionError", () => {
         "Failed to check balance: RPC failed on both endpoints. Primary: request timeout"
       );
       expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Failed to send webhook DNS failure: external_service + user (likely bad URL)", () => {
@@ -121,7 +121,7 @@ describe("classifyExecutionError", () => {
         "Failed to send webhook: fetch failed: getaddrinfo EAI_AGAIN events.pagerduty.com"
       );
       expect(r.errorCategory).toBe(ErrorCategory.EXTERNAL_SERVICE);
-      expect(r.isUserError).toBe(true);
+      expect(r.errorType).toBe("user");
     });
   });
 
@@ -133,7 +133,7 @@ describe("classifyExecutionError", () => {
     ])("classifies %s as database + system", (input) => {
       const r = classifyExecutionError(input);
       expect(r.errorCategory).toBe(ErrorCategory.DATABASE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
   });
 
@@ -143,7 +143,7 @@ describe("classifyExecutionError", () => {
         "Execution timed out: no progress for 30 minutes"
       );
       expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Step exceeded max retries: workflow_engine + system", () => {
@@ -151,7 +151,7 @@ describe("classifyExecutionError", () => {
         'Step "step//./plugins/web3/steps/read-contract//readContractStep" exceeded max retries (1 retry)'
       );
       expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Unknown action type: workflow_engine + system", () => {
@@ -159,7 +159,7 @@ describe("classifyExecutionError", () => {
         'Unknown action type: "condition". This action is not registered in the plugin system.'
       );
       expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Failed to acquire nonce lock: workflow_engine + system", () => {
@@ -167,7 +167,7 @@ describe("classifyExecutionError", () => {
         "Failed to acquire nonce lock for 0xae36bc35098e24bbaed3dee86ec4653eb88a71a9:1 after 50 attempts"
       );
       expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
   });
 
@@ -175,7 +175,7 @@ describe("classifyExecutionError", () => {
     it("Workflow terminated by SIGTERM: infrastructure + system", () => {
       const r = classifyExecutionError("Workflow terminated by SIGTERM signal");
       expect(r.errorCategory).toBe(ErrorCategory.INFRASTRUCTURE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Cannot find module: infrastructure + system", () => {
@@ -183,7 +183,7 @@ describe("classifyExecutionError", () => {
         "Cannot find module './credential-map'\nRequire stack:\n- /app/lib/credential-fetcher.ts"
       );
       expect(r.errorCategory).toBe(ErrorCategory.INFRASTRUCTURE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
 
     it("Failed to initialize organization wallet (missing Turnkey key): infrastructure + system", () => {
@@ -191,7 +191,7 @@ describe("classifyExecutionError", () => {
         "Failed to initialize organization wallet: TURNKEY_API_PUBLIC_KEY and TURNKEY_API_PRIVATE_KEY must be set"
       );
       expect(r.errorCategory).toBe(ErrorCategory.INFRASTRUCTURE);
-      expect(r.isUserError).toBe(false);
+      expect(r.errorType).toBe("system");
     });
   });
 
@@ -213,7 +213,7 @@ describe("classifyExecutionError", () => {
       for (const s of samples) {
         const r = classifyExecutionError(s);
         expect(allCategoryValues.has(r.errorCategory)).toBe(true);
-        expect(typeof r.isUserError).toBe("boolean");
+        expect(r.errorType === "user" || r.errorType === "system").toBe(true);
       }
     });
   });

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -3,31 +3,31 @@ import { ErrorCategory } from "@/lib/logging";
 /**
  * Classification of a workflow execution failure into:
  *   - errorCategory: one of the ErrorCategory enum values
- *   - isUserError:   true if the failure was caused by the workflow author's
+ *   - errorType:     "user" if the failure was caused by the workflow author's
  *                    configuration (template variables, contract args, code
- *                    typos, missing tokens, etc.) and false if the failure
+ *                    typos, missing tokens, etc.) and "system" if the failure
  *                    was caused by KeeperHub itself (database, infra, plugin
  *                    registry, missing secret, etc.).
  *
  * The classifier is intentionally pattern-driven against real production
  * messages observed for managed clients (Sky/Ajna) so the resulting
- * `is_user_error` label on `workflow_executions` lets the SLA alert filter
+ * `error_type` label on `workflow_executions` lets the SLA alert filter
  * out user-config noise.
  *
- * Default for unmatched messages is WORKFLOW_ENGINE / isUserError=false.
+ * Default for unmatched messages is WORKFLOW_ENGINE / errorType="system".
  * That defaults to "treat unknown as system" so a real engine failure that
  * doesn't match any known pattern still pages, and a new user-config family
  * shows up in dashboards as engine-classified until a pattern is added.
  */
 export type ExecutionErrorClassification = {
   errorCategory: ErrorCategory;
-  isUserError: boolean;
+  errorType: "user" | "system";
 };
 
 type Rule = {
   pattern: RegExp;
   errorCategory: ErrorCategory;
-  isUserError: boolean;
+  errorType: "user" | "system";
 };
 
 /**
@@ -39,169 +39,169 @@ const RULES: readonly Rule[] = [
   {
     pattern: /^Unresolved template reference/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /Missing template variable/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /safe-fetch:\s*invalid URL/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /safe-fetch:\s*scheme .* not allowed/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /blocked by SSRF policy/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^URL is required/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
 
   // User-config: code-step authoring mistakes
   {
     pattern: /^Code execution failed/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
 
   // User-config: contract / web3 inputs the author wired up
   {
     pattern: /^Contract call failed/i,
     errorCategory: ErrorCategory.TRANSACTION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^Invalid contract address/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^Invalid (function arguments|ABI JSON|payable value)/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^For Each:\s*arraySource is required/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^Condition references field/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^Failed to evaluate condition expression/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^No token selected/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^HTTP request failed:\s*Missing template variable/i,
     errorCategory: ErrorCategory.CONFIGURATION,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^HTTP request failed:\s*Request with GET\/HEAD method/i,
     errorCategory: ErrorCategory.VALIDATION,
-    isUserError: true,
+    errorType: "user",
   },
 
   // External-service / network: dependencies outside KeeperHub
   {
     pattern: /^Failed to check balance:\s*RPC failed/i,
     errorCategory: ErrorCategory.NETWORK_RPC,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /RPC failed on both endpoints/i,
     errorCategory: ErrorCategory.NETWORK_RPC,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Failed to send webhook:\s*fetch failed:\s*getaddrinfo/i,
     errorCategory: ErrorCategory.EXTERNAL_SERVICE,
-    isUserError: true,
+    errorType: "user",
   },
   {
     pattern: /^Failed to send webhook/i,
     errorCategory: ErrorCategory.EXTERNAL_SERVICE,
-    isUserError: false,
+    errorType: "system",
   },
 
   // System: database / persistence layer
   {
     pattern: /^Database query failed/i,
     errorCategory: ErrorCategory.DATABASE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Failed query:/i,
     errorCategory: ErrorCategory.DATABASE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^getaddrinfo .*\.rds\.amazonaws\.com/i,
     errorCategory: ErrorCategory.DATABASE,
-    isUserError: false,
+    errorType: "system",
   },
 
   // System: workflow engine / executor
   {
     pattern: /^Execution timed out/i,
     errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Workflow terminated by SIGTERM/i,
     errorCategory: ErrorCategory.INFRASTRUCTURE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Step ".*" exceeded max retries/i,
     errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Unknown action type:/i,
     errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Failed to acquire nonce lock/i,
     errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-    isUserError: false,
+    errorType: "system",
   },
 
   // System: deploy bugs / missing modules / missing secrets
   {
     pattern: /^Cannot find module/i,
     errorCategory: ErrorCategory.INFRASTRUCTURE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /must be set\s*$/i,
     errorCategory: ErrorCategory.INFRASTRUCTURE,
-    isUserError: false,
+    errorType: "system",
   },
   {
     pattern: /^Failed to initialize organization wallet/i,
     errorCategory: ErrorCategory.INFRASTRUCTURE,
-    isUserError: false,
+    errorType: "system",
   },
 ];
 
@@ -209,7 +209,7 @@ const RULES: readonly Rule[] = [
  * Classify a workflow execution error message into an `ErrorCategory` and a
  * user-vs-system flag.
  *
- * Returns `WORKFLOW_ENGINE` / `isUserError=false` for null, empty, or
+ * Returns `WORKFLOW_ENGINE` / `errorType="system"` for null, empty, or
  * unmatched messages so unknown failures still surface to system-level
  * alerting until a more specific rule is added.
  */
@@ -219,7 +219,7 @@ export function classifyExecutionError(
   if (!errorMessage) {
     return {
       errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-      isUserError: false,
+      errorType: "system",
     };
   }
 
@@ -227,7 +227,7 @@ export function classifyExecutionError(
   if (trimmed.length === 0) {
     return {
       errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-      isUserError: false,
+      errorType: "system",
     };
   }
 
@@ -235,13 +235,13 @@ export function classifyExecutionError(
     if (rule.pattern.test(trimmed)) {
       return {
         errorCategory: rule.errorCategory,
-        isUserError: rule.isUserError,
+        errorType: rule.errorType,
       };
     }
   }
 
   return {
     errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-    isUserError: false,
+    errorType: "system",
   };
 }

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -11,7 +11,7 @@ import { ErrorCategory } from "@/lib/logging";
  *
  * The classifier is intentionally pattern-driven against real production
  * messages observed for managed clients (Sky/Ajna) so the resulting
- * `error_type` label on `workflow_executions` lets the SLA alert filter
+ * `error_type` label on `workflow_executions` lets the SLI alert filter
  * out user-config noise.
  *
  * Default for unmatched messages is WORKFLOW_ENGINE / errorType="system".

--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -23,7 +23,7 @@ export async function recordExecutionErrorFinalized(args: {
   errorMessage: string | null | undefined;
 }): Promise<void> {
   try {
-    const { errorCategory, isUserError } = classifyExecutionError(
+    const { errorCategory, errorType } = classifyExecutionError(
       args.errorMessage
     );
 
@@ -39,7 +39,7 @@ export async function recordExecutionErrorFinalized(args: {
     recordWorkflowExecutionError({
       orgSlug,
       errorCategory,
-      isUserError,
+      errorType,
     });
   } catch {
     // Counter emission must not break the execution finalize path.

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -12,7 +12,7 @@
  * - Logs to console (warn for user errors, error for system errors)
  * - Emits a Prometheus metric with proper categorization
  * - Extracts context from message prefix (e.g., "[Discord]" → "Discord")
- * - Includes standard labels (error_category, error_context, is_user_error)
+ * - Includes standard labels (error_category, error_context, error_type)
  *
  * @example
  * logUserError(ErrorCategory.VALIDATION, "[Check Balance] Invalid address:", address, { plugin_name: "web3" });
@@ -109,7 +109,7 @@ function buildErrPayload(
  * KEEP-545: serialize an error/log event as a single-line JSON object so
  * Grafana Cloud Loki can extract top-level keys via `| json`. Drilldown
  * from the managed-client SLA alert to the failing execution requires
- * `execution_id`, `is_user_error`, and `error_category` to be available as
+ * `execution_id`, `error_type`, and `error_category` to be available as
  * Loki labels, not just as text inside the message string.
  *
  * The human-readable `msg` field retains the original message and the
@@ -122,7 +122,7 @@ function serializeStructuredLogLine(args: {
   fullLabels: Record<string, string>;
   category: ErrorCategory;
   context: string;
-  isUserError: "true" | "false" | undefined;
+  errorType: "user" | "system" | undefined;
   error: unknown;
 }): string {
   const errPayload = buildErrPayload(args.error);
@@ -133,8 +133,8 @@ function serializeStructuredLogLine(args: {
     error_category: args.category,
     error_context: args.context,
   };
-  if (args.isUserError !== undefined) {
-    payload.is_user_error = args.isUserError;
+  if (args.errorType !== undefined) {
+    payload.error_type = args.errorType;
   }
   for (const [k, v] of Object.entries(args.fullLabels)) {
     if (v !== undefined && !(k in payload)) {
@@ -238,7 +238,7 @@ export function logUserError(
   // Merge async-local workflow context (org/owner/workflow ids).
   const fullLabels = mergeLabels(labels);
 
-  // KEEP-545: emit structured JSON so Loki indexes is_user_error,
+  // KEEP-545: emit structured JSON so Loki indexes error_type,
   // error_category, execution_id, org_slug as queryable labels via `| json`.
   // User errors are logged at warn level so they don't page on-call.
   const tag = buildLogTag(fullLabels);
@@ -250,7 +250,7 @@ export function logUserError(
       fullLabels,
       category,
       context,
-      isUserError: "true",
+      errorType: "user",
       error,
     })
   );
@@ -264,7 +264,7 @@ export function logUserError(
       ...metricLabels,
       [LabelKeys.ERROR_CATEGORY]: category,
       [LabelKeys.ERROR_CONTEXT]: context,
-      [LabelKeys.IS_USER_ERROR]: "true",
+      [LabelKeys.ERROR_TYPE]: "user",
     }
   );
 
@@ -277,7 +277,7 @@ export function logUserError(
       tags: {
         error_category: category,
         error_context: context,
-        is_user_error: "true",
+        error_type: "user",
       },
       extra: fullLabels,
     });
@@ -313,7 +313,7 @@ export function logSystemError(
   // Merge async-local workflow context (org/owner/workflow ids).
   const fullLabels = mergeLabels(labels);
 
-  // KEEP-545: emit structured JSON so Loki indexes is_user_error,
+  // KEEP-545: emit structured JSON so Loki indexes error_type,
   // error_category, execution_id, org_slug as queryable labels via `| json`.
   const tag = buildLogTag(fullLabels);
   console.error(
@@ -324,7 +324,7 @@ export function logSystemError(
       fullLabels,
       category,
       context,
-      isUserError: "false",
+      errorType: "system",
       error,
     })
   );
@@ -338,7 +338,7 @@ export function logSystemError(
       ...metricLabels,
       [LabelKeys.ERROR_CATEGORY]: category,
       [LabelKeys.ERROR_CONTEXT]: context,
-      [LabelKeys.IS_USER_ERROR]: "false",
+      [LabelKeys.ERROR_TYPE]: "system",
     }
   );
 
@@ -372,10 +372,10 @@ export function logSystemError(
  * | logUserError           | warn        | warning event   | counter+1 |
  *
  * Sentry tag policy:
- *   - is_user_error is intentionally NOT set. At the call sites where this
+ *   - error_type is intentionally NOT set. At the call sites where this
  *     helper fires we typically do not yet know whether the underlying
- *     failure is user-caused or engine-caused -- forcing the tag to "false"
- *     would let alerts filtering `is_user_error:false` match these events
+ *     failure is user-caused or engine-caused -- forcing the tag to "system"
+ *     would let alerts filtering `error_type:system` match these events
  *     and re-trip the same dashboards we are trying to keep quiet. The
  *     event's `level=warning` is the canonical filter.
  */
@@ -389,10 +389,10 @@ export function logSystemWarn(
   const fullLabels = mergeLabels(labels);
 
   // KEEP-545: emit structured JSON so Loki indexes execution_id, org_slug,
-  // and error_category for the warn-level recovery/notice events. is_user_error
+  // and error_category for the warn-level recovery/notice events. error_type
   // is intentionally omitted on logSystemWarn (the call site does not yet
   // know whether the underlying failure is user-caused or engine-caused);
-  // alerts that filter `is_user_error="false"` therefore won't re-trip on
+  // alerts that filter `error_type="system"` therefore won't re-trip on
   // these events. See logSystemWarn jsdoc for full reasoning.
   const tag = buildLogTag(fullLabels);
   console.warn(
@@ -403,7 +403,7 @@ export function logSystemWarn(
       fullLabels,
       category,
       context,
-      isUserError: undefined,
+      errorType: undefined,
       error,
     })
   );

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -108,7 +108,7 @@ function buildErrPayload(
 /**
  * KEEP-545: serialize an error/log event as a single-line JSON object so
  * Grafana Cloud Loki can extract top-level keys via `| json`. Drilldown
- * from the managed-client SLA alert to the failing execution requires
+ * from the managed-client SLI alert to the failing execution requires
  * `execution_id`, `error_type`, and `error_category` to be available as
  * Loki labels, not just as text inside the message string.
  *

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -68,7 +68,7 @@ Counter/Gauge metrics tracking request/event counts.
 
 | Metric Name | Description | Labels | Unit | Source |
 |-------------|-------------|--------|------|--------|
-| `workflow.executions.total` | Total workflow executions by status (all-time) | `status` | gauge | DB |
+| `workflow.executions.total` | Total workflow executions by status (all-time) | `status`, `org_slug`, `error_type` (`user`/`system`/`unknown`/`na`) | gauge | DB |
 | `workflow.execution.errors.total` | Total failed workflow executions (all-time) | - | gauge | DB |
 | `plugin.invocations.total` | Plugin action invocations | `plugin_name`, `action_name` | count | API |
 | `user.active.daily` | Daily active users (24h) | - | gauge | DB |

--- a/lib/metrics/__tests__/error-labels.test.ts
+++ b/lib/metrics/__tests__/error-labels.test.ts
@@ -11,14 +11,14 @@ const { ERROR_LABELS } = await import("@/lib/metrics/collectors/prometheus");
  * KEEP-545 (closes KEEP-536): regression guard for the Prometheus error
  * counter label set. The `specs/logging-and-metrics/keeperhub-errors-dashboard.json`
  * and the managed-client alert PromQL both group by `error_category` and
- * filter by `is_user_error`. Removing either of these labels from the shared
+ * filter by `error_type`. Removing either of these labels from the shared
  * `ERROR_LABELS` array would silently produce empty panels and a no-data
  * alert without any test or type failure. This snapshot prevents that.
  */
 describe("ERROR_LABELS regression guard (KEEP-545 / closes KEEP-536)", () => {
   it("includes the labels required by the errors dashboard and SLA alert", () => {
     expect(ERROR_LABELS).toContain("error_category");
-    expect(ERROR_LABELS).toContain("is_user_error");
+    expect(ERROR_LABELS).toContain("error_type");
     expect(ERROR_LABELS).toContain("error_context");
   });
 
@@ -34,7 +34,6 @@ describe("ERROR_LABELS regression guard (KEEP-545 / closes KEEP-536)", () => {
         "error_type",
         "execution_id",
         "integration_id",
-        "is_user_error",
         "org_slug",
         "plan",
         "plugin_name",

--- a/lib/metrics/__tests__/error-labels.test.ts
+++ b/lib/metrics/__tests__/error-labels.test.ts
@@ -16,7 +16,7 @@ const { ERROR_LABELS } = await import("@/lib/metrics/collectors/prometheus");
  * alert without any test or type failure. This snapshot prevents that.
  */
 describe("ERROR_LABELS regression guard (KEEP-545 / closes KEEP-536)", () => {
-  it("includes the labels required by the errors dashboard and SLA alert", () => {
+  it("includes the labels required by the errors dashboard and SLI alert", () => {
     expect(ERROR_LABELS).toContain("error_category");
     expect(ERROR_LABELS).toContain("error_type");
     expect(ERROR_LABELS).toContain("error_context");

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -106,8 +106,8 @@ function getOrCreateGauge(
 //
 // PromQL queries that do not filter on error_type continue to work — Prometheus
 // auto-aggregates across all label values when a label is unconstrained. The
-// label unlocks platform-side SLO queries (filter error_type="system") and
-// managed-client end-to-end SLO panels that need to separate system vs user
+// label unlocks platform-side SLI queries (filter error_type="system") and
+// managed-client end-to-end SLI panels that need to separate system vs user
 // failures. Sourced from the DB scan via projection of the existing
 // `workflow_executions.error_type` column, so this metric stays
 // authoritative even when short-lived workflow runner processes exit before

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -109,7 +109,7 @@ function getOrCreateGauge(
 // label unlocks platform-side SLO queries (filter error_type="system") and
 // managed-client end-to-end SLO panels that need to separate system vs user
 // failures. Sourced from the DB scan via projection of the existing
-// `workflow_executions.is_user_error` column, so this metric stays
+// `workflow_executions.error_type` column, so this metric stays
 // authoritative even when short-lived workflow runner processes exit before
 // Prometheus can scrape their in-memory counters.
 const workflowExecutionsTotal = getOrCreateGauge(
@@ -788,7 +788,6 @@ const apiErrors = getOrCreateCounter(
 export const ERROR_LABELS = [
   "error_category",
   "error_context",
-  "is_user_error",
   "error_type",
   "plugin_name",
   "action_name",
@@ -879,7 +878,7 @@ const systemWorkflowEngineErrors = getOrCreateCounter(
 //   org_slug       per-organization slug (or ANONYMOUS_ORG_SLUG for personal)
 //   error_category one of the ErrorCategory enum values (validation,
 //                  configuration, database, workflow_engine, etc.)
-//   is_user_error  "true" for workflow-author bugs, "false" for engine/infra
+//   error_type     "user" for workflow-author bugs, "system" for engine/infra
 //
 // Cardinality: ~200 active orgs * 10 categories * 2 = 4k worst case;
 // realistic ~1k (most orgs hit 1-2 categories).
@@ -887,18 +886,18 @@ const workflowExecutionErrorsCreated = getOrCreateCounter(
   apiRegistry,
   "keeperhub_workflow_execution_errors_created_total",
   "Workflow execution errors observed since pod start, by classification",
-  ["org_slug", "error_category", "is_user_error"]
+  ["org_slug", "error_category", "error_type"]
 );
 
 export function recordWorkflowExecutionError(labels: {
   orgSlug: string;
   errorCategory: string;
-  isUserError: boolean;
+  errorType: "user" | "system";
 }): void {
   workflowExecutionErrorsCreated.inc({
     org_slug: labels.orgSlug,
     error_category: labels.errorCategory,
-    is_user_error: labels.isUserError ? "true" : "false",
+    error_type: labels.errorType,
   });
 }
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -94,14 +94,29 @@ function getOrCreateGauge(
 // All metrics are GAUGES (point-in-time snapshots). Use max() aggregation across pods.
 // For rate/delta queries, use PromQL delta() function: max(delta(metric[1h]))
 
-// Workflow execution counts by status and org_slug. Personal/anonymous
-// workflows are emitted under org_slug="_anonymous" so the sum across
-// org_slug for a given status equals the global per-status total.
+// Workflow execution counts by status, org_slug, and error_type. Personal/
+// anonymous workflows are emitted under org_slug="_anonymous" so the sum
+// across org_slug for a given status equals the global per-status total.
+//
+// error_type label values:
+//   "user"    - errored execution caused by user input/config/external service
+//   "system"  - errored execution caused by KeeperHub system/infrastructure
+//   "unknown" - errored row predating classification (NULL in DB)
+//   "na"      - non-error status (success/running/pending/cancelled)
+//
+// PromQL queries that do not filter on error_type continue to work — Prometheus
+// auto-aggregates across all label values when a label is unconstrained. The
+// label unlocks platform-side SLO queries (filter error_type="system") and
+// managed-client end-to-end SLO panels that need to separate system vs user
+// failures. Sourced from the DB scan via projection of the existing
+// `workflow_executions.is_user_error` column, so this metric stays
+// authoritative even when short-lived workflow runner processes exit before
+// Prometheus can scrape their in-memory counters.
 const workflowExecutionsTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_workflow_executions_total",
-  "Total workflow executions by status, broken down by org_slug (all-time)",
-  ["status", "org_slug"]
+  "Total workflow executions by status, broken down by org_slug and error_type (all-time)",
+  ["status", "org_slug", "error_type"]
 );
 
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
@@ -1227,13 +1242,17 @@ export async function updateDbMetrics(): Promise<void> {
       getBillingStatsFromDb(),
     ]);
 
-    // Update workflow execution counts per (status, org_slug). Reset before
-    // populating so series for orgs that no longer have executions in a given
-    // status clear out instead of going stale.
+    // Update workflow execution counts per (status, org_slug, error_type).
+    // Reset before populating so series for orgs that no longer have executions
+    // in a given bucket clear out instead of going stale.
     workflowExecutionsTotal.reset();
     for (const row of workflowStats.executionsByStatusAndOrgSlug) {
       workflowExecutionsTotal.set(
-        { status: row.status, org_slug: row.orgSlug },
+        {
+          status: row.status,
+          org_slug: row.orgSlug,
+          error_type: row.errorType,
+        },
         row.count
       );
     }

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -62,17 +62,16 @@ export type WorkflowStats = {
   // workflows are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for
   // a given status across all orgs matches the corresponding total* above.
   //
-  // errorType is projected from the existing workflow_executions.is_user_error
-  // boolean column. The column itself is not renamed by this change — the
-  // projection only changes how the value surfaces as a Prometheus label so
-  // the SLO panel can split system vs user failures without depending on
-  // counter increments (which can be lost when short-lived workflow runner
-  // processes exit before Prometheus scrape).
+  // errorType is read directly from the workflow_executions.error_type text
+  // column (KEEP-545 rename — see drizzle/0077_error_type_label_rename.sql).
+  // For non-error rows and for rows that predate classification, the column
+  // is NULL; both cases are projected to a sentinel string so every gauge
+  // series carries a populated label.
   //
   // errorType values:
-  //   "user"    - errored row with is_user_error = TRUE
-  //   "system"  - errored row with is_user_error = FALSE
-  //   "unknown" - errored row predating classification (NULL in DB)
+  //   "user"    - errored row with error_type = 'user'
+  //   "system"  - errored row with error_type = 'system'
+  //   "unknown" - errored row with error_type IS NULL (predates classification)
   //   "na"      - non-error status (success/running/pending/cancelled)
   executionsByStatusAndOrgSlug: Array<{
     status: string;
@@ -116,19 +115,14 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     // Postgres groups NULLs together (NULLs are equal in GROUP BY), and the
     // SELECT-side expressions render those groups as ANONYMOUS_ORG_SLUG /
     // "unknown" / "na" as appropriate.
-    //
-    // error_type is projected from the existing is_user_error column without
-    // a schema change so this metric addition can land independently of the
-    // team's planned column rename.
     const breakdown = await db
       .select({
         status: workflowExecutions.status,
         orgSlug: sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`,
         errorType: sql<string>`CASE
           WHEN ${workflowExecutions.status} <> 'error' THEN 'na'
-          WHEN ${workflowExecutions.isUserError} IS NULL THEN 'unknown'
-          WHEN ${workflowExecutions.isUserError} = TRUE THEN 'user'
-          ELSE 'system'
+          WHEN ${workflowExecutions.errorType} IS NULL THEN 'unknown'
+          ELSE ${workflowExecutions.errorType}
         END`,
         count: count(),
       })
@@ -138,7 +132,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       .groupBy(
         workflowExecutions.status,
         organization.slug,
-        workflowExecutions.isUserError
+        workflowExecutions.errorType
       );
 
     for (const row of breakdown) {

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -58,12 +58,26 @@ export type WorkflowStats = {
   totalPending: number;
   totalCancelled: number;
 
-  // Per-(status, org_slug) execution counts. Personal/anonymous workflows
-  // are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for a given
-  // status across all orgs matches the corresponding total* above.
+  // Per-(status, org_slug, error_type) execution counts. Personal/anonymous
+  // workflows are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for
+  // a given status across all orgs matches the corresponding total* above.
+  //
+  // errorType is projected from the existing workflow_executions.is_user_error
+  // boolean column. The column itself is not renamed by this change — the
+  // projection only changes how the value surfaces as a Prometheus label so
+  // the SLO panel can split system vs user failures without depending on
+  // counter increments (which can be lost when short-lived workflow runner
+  // processes exit before Prometheus scrape).
+  //
+  // errorType values:
+  //   "user"    - errored row with is_user_error = TRUE
+  //   "system"  - errored row with is_user_error = FALSE
+  //   "unknown" - errored row predating classification (NULL in DB)
+  //   "na"      - non-error status (success/running/pending/cancelled)
   executionsByStatusAndOrgSlug: Array<{
     status: string;
     orgSlug: string;
+    errorType: string;
     count: number;
   }>;
 
@@ -93,30 +107,46 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       durationCount: 0,
     };
 
-    // Per-(status, org_slug) execution breakdown: JOIN workflows + organization,
-    // LEFT JOIN so anonymous workflows still contribute (under ANONYMOUS_ORG_SLUG).
-    // GROUP BY uses the organization.slug column reference (not the COALESCE
-    // expression): Drizzle would otherwise bind ANONYMOUS_ORG_SLUG as separate
-    // parameters in SELECT and GROUP BY clauses, and Postgres rejects the query
-    // because the two COALESCE expressions are not textually identical. Postgres
-    // groups all NULL slugs into one group (NULLs are equal in GROUP BY), and
-    // the SELECT-side COALESCE renders that group as ANONYMOUS_ORG_SLUG.
+    // Per-(status, org_slug, error_type) execution breakdown: JOIN workflows +
+    // organization, LEFT JOIN so anonymous workflows still contribute (under
+    // ANONYMOUS_ORG_SLUG). GROUP BY uses the underlying columns (not the
+    // COALESCE/CASE expressions): Drizzle would otherwise bind constants as
+    // separate parameters in SELECT and GROUP BY clauses, and Postgres rejects
+    // the query because the two expressions are not textually identical.
+    // Postgres groups NULLs together (NULLs are equal in GROUP BY), and the
+    // SELECT-side expressions render those groups as ANONYMOUS_ORG_SLUG /
+    // "unknown" / "na" as appropriate.
+    //
+    // error_type is projected from the existing is_user_error column without
+    // a schema change so this metric addition can land independently of the
+    // team's planned column rename.
     const breakdown = await db
       .select({
         status: workflowExecutions.status,
         orgSlug: sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`,
+        errorType: sql<string>`CASE
+          WHEN ${workflowExecutions.status} <> 'error' THEN 'na'
+          WHEN ${workflowExecutions.isUserError} IS NULL THEN 'unknown'
+          WHEN ${workflowExecutions.isUserError} = TRUE THEN 'user'
+          ELSE 'system'
+        END`,
         count: count(),
       })
       .from(workflowExecutions)
       .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
       .leftJoin(organization, eq(workflows.organizationId, organization.id))
-      .groupBy(workflowExecutions.status, organization.slug);
+      .groupBy(
+        workflowExecutions.status,
+        organization.slug,
+        workflowExecutions.isUserError
+      );
 
     for (const row of breakdown) {
       const c = Number(row.count) || 0;
       stats.executionsByStatusAndOrgSlug.push({
         status: row.status,
         orgSlug: row.orgSlug,
+        errorType: row.errorType,
         count: c,
       });
       switch (row.status) {

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -182,7 +182,6 @@ export const LabelKeys = {
   SERVICE: "service",
   ERROR_CATEGORY: "error_category",
   ERROR_CONTEXT: "error_context",
-  IS_USER_ERROR: "is_user_error",
   BILLING_STATUS: "billing_status",
   TIER: "tier",
 } as const;

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -617,7 +617,7 @@ export async function logWorkflowCompleteDb(
       : [];
 
   // KEEP-545: classify the error so the row carries error_category and
-  // is_user_error at write time. Success rows get null for both columns.
+  // error_type at write time. Success rows get null for both columns.
   const classification =
     resolvedStatus === "error" ? classifyExecutionError(resolvedError) : null;
 
@@ -628,7 +628,7 @@ export async function logWorkflowCompleteDb(
       output: params.output,
       error: resolvedError,
       errorCategory: classification?.errorCategory ?? null,
-      isUserError: classification?.isUserError ?? null,
+      errorType: classification?.errorType ?? null,
       completedAt: new Date(),
       duration: duration.toString(),
       // Clear current step on completion
@@ -662,7 +662,7 @@ export async function logWorkflowCompleteDb(
       recordWorkflowExecutionError({
         orgSlug,
         errorCategory: classification.errorCategory,
-        isUserError: classification.isUserError,
+        errorType: classification.errorType,
       });
     } catch {
       // Counter emission must never break finalization.

--- a/scripts/backfill-error-classification.ts
+++ b/scripts/backfill-error-classification.ts
@@ -1,5 +1,5 @@
 /**
- * KEEP-545: one-time backfill of `error_category` and `is_user_error`
+ * KEEP-545: one-time backfill of `error_category` and `error_type`
  * columns on `workflow_executions` rows for managed-client orgs (Sky and
  * Ajna) over the last 90 days.
  *
@@ -20,7 +20,7 @@
  *
  * Output:
  *   - Progress lines per batch (`processed=N updated=M skipped=K`)
- *   - Final summary table by (org_slug, error_category, is_user_error)
+ *   - Final summary table by (org_slug, error_category, error_type)
  */
 
 import { and, eq, gte, inArray, isNull, or, sql } from "drizzle-orm";
@@ -98,7 +98,7 @@ async function fetchUnclassifiedBatch(args: {
         inArray(organization.slug, args.orgs),
         or(
           isNull(workflowExecutions.errorCategory),
-          isNull(workflowExecutions.isUserError)
+          isNull(workflowExecutions.errorType)
         ),
         args.afterId ? sql`${workflowExecutions.id} > ${args.afterId}` : undefined
       )
@@ -113,7 +113,7 @@ function recordInSummary(
   summary: Summary,
   orgSlug: string,
   errorCategory: string,
-  isUserError: boolean
+  errorType: "user" | "system"
 ): void {
   if (!summary[orgSlug]) {
     summary[orgSlug] = {};
@@ -121,11 +121,7 @@ function recordInSummary(
   if (!summary[orgSlug][errorCategory]) {
     summary[orgSlug][errorCategory] = { user: 0, system: 0 };
   }
-  if (isUserError) {
-    summary[orgSlug][errorCategory].user += 1;
-  } else {
-    summary[orgSlug][errorCategory].system += 1;
-  }
+  summary[orgSlug][errorCategory][errorType] += 1;
 }
 
 function formatSummary(summary: Summary): string {
@@ -171,13 +167,13 @@ async function main(): Promise<void> {
     let updatedInBatch = 0;
     for (const row of rows) {
       const orgSlug = row.orgSlug ?? "_anonymous";
-      const { errorCategory, isUserError } = classifyExecutionError(row.error);
-      recordInSummary(summary, orgSlug, errorCategory, isUserError);
+      const { errorCategory, errorType } = classifyExecutionError(row.error);
+      recordInSummary(summary, orgSlug, errorCategory, errorType);
 
       if (!args.dryRun) {
         await db
           .update(workflowExecutions)
-          .set({ errorCategory, isUserError })
+          .set({ errorCategory, errorType })
           .where(eq(workflowExecutions.id, row.id));
         updatedInBatch += 1;
       }

--- a/specs/logging-and-metrics/keeperhub-errors-dashboard.json
+++ b/specs/logging-and-metrics/keeperhub-errors-dashboard.json
@@ -403,8 +403,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (error_category, is_user_error) (rate(keeperhub_errors_user_validation_total[5m]) + rate(keeperhub_errors_user_configuration_total[5m]) + rate(keeperhub_errors_external_service_total[5m]) + rate(keeperhub_errors_network_rpc_total[5m]) + rate(keeperhub_errors_transaction_blockchain_total[5m]) + rate(keeperhub_errors_system_database_total[5m]) + rate(keeperhub_errors_system_auth_total[5m]) + rate(keeperhub_errors_system_infrastructure_total[5m]) + rate(keeperhub_errors_system_workflow_engine_total[5m])) * 60",
-          "legendFormat": "{{error_category}} ({{is_user_error}})",
+          "expr": "sum by (error_category, error_type) (rate(keeperhub_errors_user_validation_total[5m]) + rate(keeperhub_errors_user_configuration_total[5m]) + rate(keeperhub_errors_external_service_total[5m]) + rate(keeperhub_errors_network_rpc_total[5m]) + rate(keeperhub_errors_transaction_blockchain_total[5m]) + rate(keeperhub_errors_system_database_total[5m]) + rate(keeperhub_errors_system_auth_total[5m]) + rate(keeperhub_errors_system_infrastructure_total[5m]) + rate(keeperhub_errors_system_workflow_engine_total[5m])) * 60",
+          "legendFormat": "{{error_category}} ({{error_type}})",
           "refId": "A"
         }
       ],

--- a/specs/logging-and-metrics/logging-metrics-system.md
+++ b/specs/logging-and-metrics/logging-metrics-system.md
@@ -28,7 +28,7 @@ Use for errors caused by user actions or external factors (not system failures).
 
 **Behavior:**
 - Logs to console using `console.warn` (user errors don't wake up DevOps)
-- Emits Prometheus metric with `is_user_error: "true"`
+- Emits Prometheus metric with `error_type: "user"`
 - Extracts context from message prefix (e.g., `"[Discord]"` becomes `"Discord"`)
 
 #### logSystemError
@@ -46,7 +46,7 @@ Use for errors caused by system failures (critical infrastructure issues).
 
 **Behavior:**
 - Logs to console using `console.error` (critical failures)
-- Emits Prometheus metric with `is_user_error: "false"`
+- Emits Prometheus metric with `error_type: "system"`
 - Extracts context from message prefix
 
 ## Usage Examples
@@ -163,7 +163,7 @@ Every logging call automatically includes these labels:
 
 - `error_category` - The ErrorCategory value (e.g., "validation", "database")
 - `error_context` - Extracted from message prefix (e.g., "Discord", "Etherscan")
-- `is_user_error` - "true" for logUserError, "false" for logSystemError
+- `error_type` - "user" for logUserError, "system" for logSystemError
 
 ## Prometheus Metrics
 
@@ -273,7 +273,7 @@ logSystemError(ErrorCategory.DATABASE, message, error, labels);
 **Internal Functions:**
 - `extractContext(message)` - Extracts `[Context]` from message prefix using regex
 - `getMetricName(category)` - Maps ErrorCategory to Prometheus metric name
-- `isUserError(category)` - Determines if category is user-caused
+- `errorTypeForCategory(category)` - Determines whether category is "user" or "system"
 
 ## Testing
 

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -8,7 +8,7 @@ vi.mock("server-only", () => ({}));
 vi.mock("@/lib/errors/classify", () => ({
   classifyExecutionError: () => ({
     errorCategory: "workflow_engine",
-    isUserError: false,
+    errorType: "system",
   }),
 }));
 vi.mock("@/lib/errors/finalize-error", () => ({

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -31,7 +31,7 @@ const {
     output: "output",
     error: "error",
     errorCategory: "error_category",
-    isUserError: "is_user_error",
+    errorType: "error_type",
     completedAt: "completed_at",
     duration: "duration",
     currentNodeId: "current_node_id",
@@ -76,7 +76,7 @@ vi.mock("@/lib/db/schema", () => ({
 vi.mock("@/lib/errors/classify", () => ({
   classifyExecutionError: (msg: string | null | undefined) => ({
     errorCategory: msg ? "workflow_engine" : "workflow_engine",
-    isUserError: false,
+    errorType: "system",
   }),
 }));
 vi.mock("@/lib/metrics/collectors/prometheus", () => ({

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -77,7 +77,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Test",
-          [LabelKeys.ERROR_TYPE]: "true",
+          [LabelKeys.ERROR_TYPE]: "user",
           foo: "bar",
         })
       );
@@ -96,7 +96,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Context",
-          [LabelKeys.ERROR_TYPE]: "true",
+          [LabelKeys.ERROR_TYPE]: "user",
         })
       );
     });
@@ -111,7 +111,7 @@ describe("Unified Logging Helpers", () => {
         MetricNames.USER_VALIDATION_ERRORS,
         { message: "[Test] Simple warning" },
         expect.objectContaining({
-          [LabelKeys.ERROR_TYPE]: "true",
+          [LabelKeys.ERROR_TYPE]: "user",
         })
       );
     });
@@ -203,7 +203,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.DATABASE,
           [LabelKeys.ERROR_CONTEXT]: "DB",
-          [LabelKeys.ERROR_TYPE]: "false",
+          [LabelKeys.ERROR_TYPE]: "system",
           table: "workflows",
         })
       );
@@ -349,7 +349,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Check Balance",
-          [LabelKeys.ERROR_TYPE]: "true",
+          [LabelKeys.ERROR_TYPE]: "user",
           plugin_name: "web3",
           action_name: "check-balance",
         })
@@ -466,7 +466,7 @@ describe("Unified Logging Helpers", () => {
         error,
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.DATABASE,
-          [LabelKeys.ERROR_TYPE]: "false",
+          [LabelKeys.ERROR_TYPE]: "system",
           table: "workflows",
         })
       );
@@ -486,7 +486,7 @@ describe("Unified Logging Helpers", () => {
         error,
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.AUTH,
-          [LabelKeys.ERROR_TYPE]: "false",
+          [LabelKeys.ERROR_TYPE]: "system",
         })
       );
     });
@@ -535,7 +535,7 @@ describe("Unified Logging Helpers", () => {
         error,
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.WORKFLOW_ENGINE,
-          [LabelKeys.ERROR_TYPE]: "false",
+          [LabelKeys.ERROR_TYPE]: "system",
           workflow_id: "abc123",
           step_id: "xyz789",
         })
@@ -606,7 +606,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Test",
-          [LabelKeys.ERROR_TYPE]: "true",
+          [LabelKeys.ERROR_TYPE]: "user",
           custom_label: "value",
           another_label: "value2",
         })

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -40,7 +40,7 @@ describe("Unified Logging Helpers", () => {
   });
 
   // KEEP-545: log helpers now emit a single structured JSON line so Grafana
-  // Cloud Loki can index `is_user_error`, `error_category`, `execution_id`,
+  // Cloud Loki can index `error_type`, `error_category`, `execution_id`,
   // and `org_slug` via `| json`. This helper parses the JSON arg and returns
   // the payload so per-test assertions can check fields without coupling to
   // the on-the-wire serialization order.
@@ -64,7 +64,7 @@ describe("Unified Logging Helpers", () => {
       const line = lastJsonLine(consoleWarnSpy);
       expect(line.level).toBe("warn");
       expect(line.msg).toBe("[Test] Invalid input");
-      expect(line.is_user_error).toBe("true");
+      expect(line.error_type).toBe("user");
       expect(line.error_category).toBe(ErrorCategory.VALIDATION);
       expect(line.error_context).toBe("Test");
       expect(line.foo).toBe("bar");
@@ -77,7 +77,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Test",
-          [LabelKeys.IS_USER_ERROR]: "true",
+          [LabelKeys.ERROR_TYPE]: "true",
           foo: "bar",
         })
       );
@@ -96,7 +96,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Context",
-          [LabelKeys.IS_USER_ERROR]: "true",
+          [LabelKeys.ERROR_TYPE]: "true",
         })
       );
     });
@@ -111,7 +111,7 @@ describe("Unified Logging Helpers", () => {
         MetricNames.USER_VALIDATION_ERRORS,
         { message: "[Test] Simple warning" },
         expect.objectContaining({
-          [LabelKeys.IS_USER_ERROR]: "true",
+          [LabelKeys.ERROR_TYPE]: "true",
         })
       );
     });
@@ -187,7 +187,7 @@ describe("Unified Logging Helpers", () => {
       const line = lastJsonLine(consoleErrorSpy);
       expect(line.level).toBe("error");
       expect(line.msg).toBe("[DB] Connection failed");
-      expect(line.is_user_error).toBe("false");
+      expect(line.error_type).toBe("system");
       expect(line.error_category).toBe(ErrorCategory.DATABASE);
       expect(line.error_context).toBe("DB");
       expect(line.table).toBe("workflows");
@@ -203,7 +203,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.DATABASE,
           [LabelKeys.ERROR_CONTEXT]: "DB",
-          [LabelKeys.IS_USER_ERROR]: "false",
+          [LabelKeys.ERROR_TYPE]: "false",
           table: "workflows",
         })
       );
@@ -284,9 +284,9 @@ describe("Unified Logging Helpers", () => {
       );
       expect(line.error_category).toBe(ErrorCategory.WORKFLOW_ENGINE);
       expect(line.error_context).toBe("Workflow Logging");
-      // is_user_error intentionally not set on logSystemWarn so alerts
-      // filtering on is_user_error="false" don't match these events.
-      expect(line.is_user_error).toBeUndefined();
+      // error_type intentionally not set on logSystemWarn so alerts
+      // filtering on error_type="system" don't match these events.
+      expect(line.error_type).toBeUndefined();
       expect(line.execution_id).toBe("exec-123");
       expect(consoleErrorSpy).not.toHaveBeenCalled();
 
@@ -349,7 +349,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Check Balance",
-          [LabelKeys.IS_USER_ERROR]: "true",
+          [LabelKeys.ERROR_TYPE]: "true",
           plugin_name: "web3",
           action_name: "check-balance",
         })
@@ -466,7 +466,7 @@ describe("Unified Logging Helpers", () => {
         error,
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.DATABASE,
-          [LabelKeys.IS_USER_ERROR]: "false",
+          [LabelKeys.ERROR_TYPE]: "false",
           table: "workflows",
         })
       );
@@ -486,7 +486,7 @@ describe("Unified Logging Helpers", () => {
         error,
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.AUTH,
-          [LabelKeys.IS_USER_ERROR]: "false",
+          [LabelKeys.ERROR_TYPE]: "false",
         })
       );
     });
@@ -535,7 +535,7 @@ describe("Unified Logging Helpers", () => {
         error,
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.WORKFLOW_ENGINE,
-          [LabelKeys.IS_USER_ERROR]: "false",
+          [LabelKeys.ERROR_TYPE]: "false",
           workflow_id: "abc123",
           step_id: "xyz789",
         })
@@ -606,7 +606,7 @@ describe("Unified Logging Helpers", () => {
         expect.objectContaining({
           [LabelKeys.ERROR_CATEGORY]: ErrorCategory.VALIDATION,
           [LabelKeys.ERROR_CONTEXT]: "Test",
-          [LabelKeys.IS_USER_ERROR]: "true",
+          [LabelKeys.ERROR_TYPE]: "true",
           custom_label: "value",
           another_label: "value2",
         })

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -945,7 +945,7 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
   vi.mock("@/lib/errors/classify", () => ({
     classifyExecutionError: () => ({
       errorCategory: "workflow_engine",
-      isUserError: false,
+      errorType: "system",
     }),
   }));
   vi.mock("@/lib/errors/finalize-error", () => ({

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -126,7 +126,7 @@ vi.mock("@/lib/payments/x402/execution-wait", () => ({
 vi.mock("@/lib/errors/classify", () => ({
   classifyExecutionError: (msg: unknown) => ({
     errorCategory: "workflow_engine",
-    isUserError: false,
+    errorType: "system",
     _msg: msg,
   }),
 }));


### PR DESCRIPTION
## Summary

Adds an `error_type` label to the DB-sourced gauge `keeperhub_workflow_executions_total` so the managed-client SLO panels can split system-side vs user-side failures from a single authoritative source.

This is a deliberate scope-down of the wider `is_user_error` -> `error_type` rename discussed Monday. It only touches the gauge — no schema migration, no counter rename, no changes to log keys, classifier output, or the SLA alert PromQL. The wider rename remains independent.

## Why

The managed-client SLI dashboard currently has three pain points:

1. **SLI panel and Error panels read different metrics.** SLI uses the DB-sourced gauge (`workflow_executions_total`), Error panels use the per-pod counter (`workflow_execution_errors_created_total`). The counter can under-report when short-lived workflow runner processes exit before Prometheus scrape, which is why "Managed Client Error = 0" and "Managed Client SLI = 99.6%" can show simultaneously.

2. **The gauge cannot filter on error classification.** Today the gauge only carries `status` and `org_slug`. The SLI PromQL therefore counts every `status="error"` row against the SLI denominator, regardless of whether KeeperHub infra or user-side conditions caused the failure.

3. **The wider rename complete

## Test Plan
- [x] CI green
- [ ] After deploy into staging test the following on staging grafana dashboard with the new label