### PR TITLE
fix: KEEP-483 render reauthorize page title as a real heading

### DIFF
--- a/app/settings/mcp/reauthorize/page.tsx
+++ b/app/settings/mcp/reauthorize/page.tsx
@@ -48,7 +48,11 @@ export default async function McpReauthorizePage({
     <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
       <Card className="w-full max-w-lg">
         <CardHeader>
-          <CardTitle>Reauthorize MCP access</CardTitle>
+          <CardTitle>
+            <h1 className="text-base leading-none font-semibold">
+              Reauthorize MCP access
+            </h1>
+          </CardTitle>
           <CardDescription>
             Your KeeperHub MCP connection has{" "}
             <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">


### PR DESCRIPTION
## Summary

- Unblocks the staging `CI Pipeline` Playwright job, which has been red on every staging-merge run since KEEP-483 landed.
- Root cause: `app/settings/mcp/reauthorize/page.tsx` renders its title via `<CardTitle>`, but `components/ui/card.tsx` defines `CardTitle` as a `<div>`. The e2e smoke test `tests/e2e/playwright/mcp-reauthorize.test.ts:42` asserts `getByRole("heading", ...)`, which only matches native `h1`-`h6` or `role="heading"`, so the locator times out every retry.
- Fix: nest a real `<h1>` inside `<CardTitle>` on the reauthorize page only. Visual styling unchanged (the `<h1>` carries the same Tailwind classes `CardTitle` already applies).
- A follow-up [KEEP-580](https://linear.app/keeperhubapp/issue/KEEP-580/make-shadcn-cardtitle-render-a-semantic-heading) tracks the broader fix to `CardTitle` itself so this class of failure cannot recur on other pages.

## Evidence

Failing job (latest of several consecutive failures):
https://github.com/KeeperHub/keeperhub/actions/runs/26072814982

Playwright trace artifact's ARIA snapshot showed the title rendered as `generic` (a `<div>`), with no heading anywhere in the card subtree.

## Test plan

- [x] Post-merge `CI Pipeline` runs `e2e-tests / e2e-playwright-ephemeral` to green.
- [x] `tests/e2e/playwright/mcp-reauthorize.test.ts` both tests pass (returns 200 / renders scopes / heading visible AND re-authorize link points at `/oauth/authorize?scope=mcp:read+mcp:write&intent=upgrade`).
- [ ] Visual spot check of `/settings/mcp/reauthorize?required=mcp:write&granted=mcp:read` shows the title at the same size/weight as before.