### PR TITLE
refactor: KEEP-579 extract buildCalldata from protocol on-chain integration tests

### DIFF
--- a/lib/abi/struct-args.ts
+++ b/lib/abi/struct-args.ts
@@ -10,19 +10,19 @@
 const TEMPLATE_VARIABLE_RE = /^\{\{.+\}\}$/;
 const ARRAY_SUFFIX_RE = /\[\d*\]$/;
 
-type AbiComponent = {
+export type AbiComponent = {
   name: string;
   type: string;
   components?: AbiComponent[];
 };
 
-type AbiInput = {
+export type AbiInput = {
   name: string;
   type: string;
   components?: AbiComponent[];
 };
 
-type FunctionAbiEntry = {
+export type FunctionAbiEntry = {
   inputs?: AbiInput[];
 };
 

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -24,12 +24,21 @@
  */
 
 import { ethers } from "ethers";
-import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
+import {
+  coerceArgsForAbi,
+  type FunctionAbiEntry,
+  reshapeArgsForAbi,
+} from "@/lib/abi/struct-args";
 import type {
   ProtocolAction,
   ProtocolContract,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
+
+type AbiEntry = FunctionAbiEntry & {
+  type: string;
+  name?: string;
+};
 
 export type Calldata = {
   to: string;
@@ -91,16 +100,20 @@ export function buildCalldata(
     (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
   );
 
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
+  const parsedAbi = JSON.parse(contract.abi) as AbiEntry[];
+  const functionAbi = parsedAbi.find(
+    (f) => f.type === "function" && f.name === action.function
   );
+  if (!functionAbi) {
+    throw new Error(
+      `Function ${action.function} not found in ABI for contract ${action.contract}`
+    );
+  }
   const reshaped = reshapeArgsForAbi(rawArgs, functionAbi);
   const args = options.coerceArgs
     ? coerceArgsForAbi(reshaped, functionAbi)
     : reshaped;
-  const iface = new ethers.Interface(abi);
+  const iface = new ethers.Interface(parsedAbi);
   const data = iface.encodeFunctionData(action.function, args);
 
   return { to, data, action, contract };

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -47,18 +47,22 @@ export type Calldata = {
   contract: ProtocolContract;
 };
 
-export type BuildCalldataOptions = {
-  /**
-   * Chain ID string as it appears in `protocol.contracts[key].addresses`.
-   * Required; mistakes here are silent bugs (wrong contract on wrong
-   * chain) so the helper does not default.
-   */
+export type BuildCalldataParams = {
+  /** The protocol definition the action belongs to. */
+  protocol: ProtocolDefinition;
+  /** Slug of the action to encode, as declared on `protocol.actions[i].slug`. */
+  actionSlug: string;
+  /** Map of input name to stringly-typed value. Must not contain keys
+   *  that the action does not declare; unknown keys throw. Missing
+   *  declared keys fall back to `inp.default ?? ""`. */
+  sampleInputs: Record<string, string>;
+  /** Chain ID string as it appears in `protocol.contracts[key].addresses`.
+   *  Required; mistakes here are silent bugs (wrong contract on wrong
+   *  chain) so the helper does not default. */
   chainId: string;
-  /**
-   * Override the resolved contract address. Use for contracts marked
-   * `userSpecifiedAddress` where the address is supplied per call rather
-   * than from the protocol definition.
-   */
+  /** Override the resolved contract address. Use for contracts marked
+   *  `userSpecifiedAddress` where the address is supplied per call rather
+   *  than from the protocol definition. */
   toOverride?: string;
   /**
    * Run `coerceArgsForAbi` after `reshapeArgsForAbi`, matching the
@@ -75,12 +79,16 @@ export type BuildCalldataOptions = {
   coerceArgs?: boolean;
 };
 
-export function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>,
-  options: BuildCalldataOptions
-): Calldata {
+export function buildCalldata(params: BuildCalldataParams): Calldata {
+  const {
+    protocol,
+    actionSlug,
+    sampleInputs,
+    chainId,
+    toOverride,
+    coerceArgs,
+  } = params;
+
   const action = protocol.actions.find((a) => a.slug === actionSlug);
   if (!action) {
     throw new Error(`Action ${actionSlug} not found`);
@@ -104,10 +112,10 @@ export function buildCalldata(
     throw new Error(`Contract ${action.contract} has no ABI`);
   }
 
-  const to = options.toOverride ?? contract.addresses[options.chainId];
+  const to = toOverride ?? contract.addresses[chainId];
   if (!to) {
     throw new Error(
-      `No address for contract ${action.contract} on chain ${options.chainId} and no toOverride given`
+      `No address for contract ${action.contract} on chain ${chainId} and no toOverride given`
     );
   }
 
@@ -126,9 +134,7 @@ export function buildCalldata(
   }
   const reshaped = reshapeArgsForAbi(rawArgs, functionAbi);
   const args =
-    options.coerceArgs === false
-      ? reshaped
-      : coerceArgsForAbi(reshaped, functionAbi);
+    coerceArgs === false ? reshaped : coerceArgsForAbi(reshaped, functionAbi);
   const iface = new ethers.Interface(parsedAbi);
   const data = iface.encodeFunctionData(action.function, args);
 

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -83,7 +83,7 @@ export function buildCalldata(
   const to = options.toOverride ?? contract.addresses[options.chainId];
   if (!to) {
     throw new Error(
-      `No address for contract ${action.contract} on chain ${options.chainId}`
+      `No address for contract ${action.contract} on chain ${options.chainId} and no toOverride given`
     );
   }
 

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared calldata builder for protocol on-chain integration tests.
+ *
+ * Every protocol's on-chain integration test does the same six steps to
+ * turn a (protocol, action slug, sample inputs, chain) tuple into the
+ * `{ to, data }` pair eth_call needs:
+ *
+ *   1. Find the action by slug.
+ *   2. Resolve the contract and its address for the target chain.
+ *   3. Map sampleInputs to rawArgs via input.name.
+ *   4. reshapeArgsForAbi against the function's ABI (re-wraps flattened
+ *      tuple components into the object ethers.js expects).
+ *   5. Encode calldata via ethers.Interface.
+ *   6. Return { to, data, action, contract } for the caller to assert on.
+ *
+ * `chainId` is required so the helper cannot silently pick a wrong
+ * chain when a protocol is deployed on multiple. `toOverride` is
+ * opt-in for contracts marked `userSpecifiedAddress` (e.g. a Uniswap
+ * V3 pool whose address is computed per pair at runtime).
+ *
+ * Per-protocol assertion patterns stay in their own test files; this
+ * module deliberately handles only the calldata-encoding half of the
+ * test setup.
+ */
+
+import { ethers } from "ethers";
+import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
+import type {
+  ProtocolAction,
+  ProtocolContract,
+  ProtocolDefinition,
+} from "@/lib/protocol-registry";
+
+export type Calldata = {
+  to: string;
+  data: string;
+  action: ProtocolAction;
+  contract: ProtocolContract;
+};
+
+export type BuildCalldataOptions = {
+  /**
+   * Chain ID string as it appears in `protocol.contracts[key].addresses`.
+   * Required; mistakes here are silent bugs (wrong contract on wrong
+   * chain) so the helper does not default.
+   */
+  chainId: string;
+  /**
+   * Override the resolved contract address. Use for contracts marked
+   * `userSpecifiedAddress` where the address is supplied per call rather
+   * than from the protocol definition.
+   */
+  toOverride?: string;
+};
+
+export function buildCalldata(
+  protocol: ProtocolDefinition,
+  actionSlug: string,
+  sampleInputs: Record<string, string>,
+  options: BuildCalldataOptions
+): Calldata {
+  const action = protocol.actions.find((a) => a.slug === actionSlug);
+  if (!action) {
+    throw new Error(`Action ${actionSlug} not found`);
+  }
+
+  const contract = protocol.contracts[action.contract];
+  if (!contract.abi) {
+    throw new Error(`Contract ${action.contract} has no ABI`);
+  }
+
+  const to = options.toOverride ?? contract.addresses[options.chainId];
+  if (!to) {
+    throw new Error(
+      `No address for contract ${action.contract} on chain ${options.chainId}`
+    );
+  }
+
+  const rawArgs = action.inputs.map(
+    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
+  );
+
+  const abi = JSON.parse(contract.abi);
+  const functionAbi = abi.find(
+    (f: { name: string; type: string }) =>
+      f.type === "function" && f.name === action.function
+  );
+  const args = reshapeArgsForAbi(rawArgs, functionAbi);
+  const iface = new ethers.Interface(abi);
+  const data = iface.encodeFunctionData(action.function, args);
+
+  return { to, data, action, contract };
+}

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -24,7 +24,7 @@
  */
 
 import { ethers } from "ethers";
-import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
+import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import type {
   ProtocolAction,
   ProtocolContract,
@@ -51,6 +51,17 @@ export type BuildCalldataOptions = {
    * than from the protocol definition.
    */
   toOverride?: string;
+  /**
+   * Run `coerceArgsForAbi` after `reshapeArgsForAbi`, matching the
+   * production write path in `plugins/web3/steps/write-contract-core.ts`
+   * (reshape -> coerce -> encode). Required for protocols whose sample
+   * inputs include stringly-typed booleans (`"true"`, `"false"`), since
+   * `ethers.encodeFunctionData` treats any non-empty string as truthy and
+   * silently encodes `"false"` as `true`. Default off to preserve the
+   * pre-existing behavior of the 4 test suites converted in the same
+   * PR as this helper; opt in per call site as needed.
+   */
+  coerceArgs?: boolean;
 };
 
 export function buildCalldata(
@@ -85,7 +96,10 @@ export function buildCalldata(
     (f: { name: string; type: string }) =>
       f.type === "function" && f.name === action.function
   );
-  const args = reshapeArgsForAbi(rawArgs, functionAbi);
+  const reshaped = reshapeArgsForAbi(rawArgs, functionAbi);
+  const args = options.coerceArgs
+    ? coerceArgsForAbi(reshaped, functionAbi)
+    : reshaped;
   const iface = new ethers.Interface(abi);
   const data = iface.encodeFunctionData(action.function, args);
 

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -66,9 +66,11 @@ export type BuildCalldataOptions = {
    * (reshape -> coerce -> encode). Required for protocols whose sample
    * inputs include stringly-typed booleans (`"true"`, `"false"`), since
    * `ethers.encodeFunctionData` treats any non-empty string as truthy and
-   * silently encodes `"false"` as `true`. Default off to preserve the
-   * pre-existing behavior of the 4 test suites converted in the same
-   * PR as this helper; opt in per call site as needed.
+   * silently encodes `"false"` as `true` without coercion.
+   *
+   * Defaults to `true` so tests match the production encoding pipeline
+   * by default. Pass `false` only to deliberately exercise the
+   * pre-coerce shape (e.g. a regression test asserting the trap exists).
    */
   coerceArgs?: boolean;
 };
@@ -123,9 +125,10 @@ export function buildCalldata(
     );
   }
   const reshaped = reshapeArgsForAbi(rawArgs, functionAbi);
-  const args = options.coerceArgs
-    ? coerceArgsForAbi(reshaped, functionAbi)
-    : reshaped;
+  const args =
+    options.coerceArgs === false
+      ? reshaped
+      : coerceArgsForAbi(reshaped, functionAbi);
   const iface = new ethers.Interface(parsedAbi);
   const data = iface.encodeFunctionData(action.function, args);
 

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -84,6 +84,19 @@ export function buildCalldata(
     throw new Error(`Action ${actionSlug} not found`);
   }
 
+  const declaredInputNames = new Set(action.inputs.map((i) => i.name));
+  for (const key of Object.keys(sampleInputs)) {
+    if (!declaredInputNames.has(key)) {
+      const known =
+        action.inputs.length === 0
+          ? "(none)"
+          : action.inputs.map((i) => i.name).join(", ");
+      throw new Error(
+        `Sample input '${key}' is not declared for action '${action.slug}'. Known inputs: ${known}`
+      );
+    }
+  }
+
   const contract = protocol.contracts[action.contract];
   if (!contract.abi) {
     throw new Error(`Contract ${action.contract} has no ABI`);

--- a/tests/integration/protocol-aave-v4-onchain.test.ts
+++ b/tests/integration/protocol-aave-v4-onchain.test.ts
@@ -20,64 +20,17 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 // otherwise throw under vitest's Node runtime.
 vi.mock("server-only", () => ({}));
 
-import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
-import type {
-  ProtocolAction,
-  ProtocolContract,
-  ProtocolDefinition,
-} from "@/lib/protocol-registry";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import aaveV4Def from "@/protocols/aave-v4";
+import { buildCalldata } from "./_shared/build-calldata";
 
 const RPC_URL = process.env.INTEGRATION_TEST_MAINNET_RPC_URL;
 const CHAIN_ID = "1";
 const MAINNET_CHAIN_ID = 1;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 const CORE_HUB = "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9";
-
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>
-): {
-  to: string;
-  data: string;
-  action: ProtocolAction;
-  contract: ProtocolContract;
-} {
-  const action = protocol.actions.find((a) => a.slug === actionSlug);
-  if (!action) {
-    throw new Error(`Action ${actionSlug} not found`);
-  }
-
-  const contract = protocol.contracts[action.contract];
-  if (!contract.abi) {
-    throw new Error(`Contract ${action.contract} has no ABI`);
-  }
-
-  const contractAddress = contract.addresses[CHAIN_ID];
-  if (!contractAddress) {
-    throw new Error(`Contract ${action.contract} not on chain ${CHAIN_ID}`);
-  }
-
-  const rawArgs = action.inputs.map((inp) => {
-    const val = sampleInputs[inp.name] ?? inp.default ?? "";
-    return val;
-  });
-
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
-  );
-  const args = reshapeArgsForAbi(rawArgs, functionAbi);
-  const iface = new ethers.Interface(abi);
-  const data = iface.encodeFunctionData(action.function, args);
-
-  return { to: contractAddress, data, action, contract };
-}
 
 // Assertion model:
 //  - Read tests: let the RPC call fail loudly. A success path asserts the
@@ -113,10 +66,12 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   });
 
   it("getReserveId: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(aaveV4Def, "get-reserve-id", {
-      hub: CORE_HUB,
-      assetId: "0",
-    });
+    const { to, data, contract } = buildCalldata(
+      aaveV4Def,
+      "get-reserve-id",
+      { hub: CORE_HUB, assetId: "0" },
+      { chainId: CHAIN_ID }
+    );
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -132,7 +87,8 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
     const { to, data, contract } = buildCalldata(
       aaveV4Def,
       "get-user-supplied-assets",
-      { reserveId: "0", user: TEST_ADDRESS }
+      { reserveId: "0", user: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
     );
 
     const result = await manager.executeWithFailover((p) =>
@@ -146,10 +102,12 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   }, 15_000);
 
   it("getUserDebt: eth_call returns two decodable uint256 values", async () => {
-    const { to, data, contract } = buildCalldata(aaveV4Def, "get-user-debt", {
-      reserveId: "0",
-      user: TEST_ADDRESS,
-    });
+    const { to, data, contract } = buildCalldata(
+      aaveV4Def,
+      "get-user-debt",
+      { reserveId: "0", user: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
+    );
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -167,7 +125,8 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
     const { to, data, contract } = buildCalldata(
       aaveV4Def,
       "get-user-account-data",
-      { user: TEST_ADDRESS }
+      { user: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
     );
 
     const result = await manager.executeWithFailover((p) =>
@@ -185,21 +144,31 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   }, 15_000);
 
   it("supply: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(aaveV4Def, "supply", {
-      reserveId: "0",
-      amount: "1000000000000000000",
-      onBehalfOf: TEST_ADDRESS,
-    });
+    const { to, data } = buildCalldata(
+      aaveV4Def,
+      "supply",
+      {
+        reserveId: "0",
+        amount: "1000000000000000000",
+        onBehalfOf: TEST_ADDRESS,
+      },
+      { chainId: CHAIN_ID }
+    );
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);
 
   it("setUsingAsCollateral: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(aaveV4Def, "set-collateral", {
-      reserveId: "0",
-      usingAsCollateral: "true",
-      onBehalfOf: TEST_ADDRESS,
-    });
+    const { to, data } = buildCalldata(
+      aaveV4Def,
+      "set-collateral",
+      {
+        reserveId: "0",
+        usingAsCollateral: "true",
+        onBehalfOf: TEST_ADDRESS,
+      },
+      { chainId: CHAIN_ID }
+    );
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);

--- a/tests/integration/protocol-aave-v4-onchain.test.ts
+++ b/tests/integration/protocol-aave-v4-onchain.test.ts
@@ -66,12 +66,12 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   });
 
   it("getReserveId: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      aaveV4Def,
-      "get-reserve-id",
-      { hub: CORE_HUB, assetId: "0" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: aaveV4Def,
+      actionSlug: "get-reserve-id",
+      sampleInputs: { hub: CORE_HUB, assetId: "0" },
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -84,12 +84,12 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   }, 15_000);
 
   it("getUserSuppliedAssets: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      aaveV4Def,
-      "get-user-supplied-assets",
-      { reserveId: "0", user: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: aaveV4Def,
+      actionSlug: "get-user-supplied-assets",
+      sampleInputs: { reserveId: "0", user: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -102,12 +102,12 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   }, 15_000);
 
   it("getUserDebt: eth_call returns two decodable uint256 values", async () => {
-    const { to, data, contract } = buildCalldata(
-      aaveV4Def,
-      "get-user-debt",
-      { reserveId: "0", user: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: aaveV4Def,
+      actionSlug: "get-user-debt",
+      sampleInputs: { reserveId: "0", user: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -122,12 +122,12 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   }, 15_000);
 
   it("getUserAccountData: eth_call returns a decodable struct with named fields", async () => {
-    const { to, data, contract } = buildCalldata(
-      aaveV4Def,
-      "get-user-account-data",
-      { user: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: aaveV4Def,
+      actionSlug: "get-user-account-data",
+      sampleInputs: { user: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -144,31 +144,31 @@ describe.skipIf(!RPC_URL)("Aave V4 Lido Spoke on-chain integration", () => {
   }, 15_000);
 
   it("supply: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(
-      aaveV4Def,
-      "supply",
-      {
+    const { to, data } = buildCalldata({
+      protocol: aaveV4Def,
+      actionSlug: "supply",
+      sampleInputs: {
         reserveId: "0",
         amount: "1000000000000000000",
         onBehalfOf: TEST_ADDRESS,
       },
-      { chainId: CHAIN_ID }
-    );
+      chainId: CHAIN_ID,
+    });
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);
 
   it("setUsingAsCollateral: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(
-      aaveV4Def,
-      "set-collateral",
-      {
+    const { to, data } = buildCalldata({
+      protocol: aaveV4Def,
+      actionSlug: "set-collateral",
+      sampleInputs: {
         reserveId: "0",
         usingAsCollateral: "true",
         onBehalfOf: TEST_ADDRESS,
       },
-      { chainId: CHAIN_ID }
-    );
+      chainId: CHAIN_ID,
+    });
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);

--- a/tests/integration/protocol-chainlink-onchain.test.ts
+++ b/tests/integration/protocol-chainlink-onchain.test.ts
@@ -85,12 +85,12 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
     );
 
   it("ccip-get-fee: eth_call returns decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      chainlinkDef,
-      "ccip-get-fee",
-      CCIP_MESSAGE_SAMPLE,
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: chainlinkDef,
+      actionSlug: "ccip-get-fee",
+      sampleInputs: CCIP_MESSAGE_SAMPLE,
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -113,12 +113,13 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("ccip-check-bridge-balance: eth_call returns decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      chainlinkDef,
-      "ccip-check-bridge-balance",
-      { account: TEST_ADDRESS },
-      { chainId: CHAIN_ID, toOverride: CCIP_BNM_SEPOLIA }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: chainlinkDef,
+      actionSlug: "ccip-check-bridge-balance",
+      sampleInputs: { account: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+      toOverride: CCIP_BNM_SEPOLIA,
+    });
 
     const provider = await makeProvider();
     const result = await provider.executeWithFailover(
@@ -132,12 +133,13 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("ccip-check-bridge-allowance: eth_call returns decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      chainlinkDef,
-      "ccip-check-bridge-allowance",
-      { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
-      { chainId: CHAIN_ID, toOverride: CCIP_BNM_SEPOLIA }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: chainlinkDef,
+      actionSlug: "ccip-check-bridge-allowance",
+      sampleInputs: { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
+      chainId: CHAIN_ID,
+      toOverride: CCIP_BNM_SEPOLIA,
+    });
 
     const provider = await makeProvider();
     const result = await provider.executeWithFailover(
@@ -151,12 +153,16 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("ccip-approve-bridge-token: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      chainlinkDef,
-      "ccip-approve-bridge-token",
-      { spender: ethers.ZeroAddress, amount: "1000000000000000000" },
-      { chainId: CHAIN_ID, toOverride: CCIP_BNM_SEPOLIA }
-    );
+    const { to, data } = buildCalldata({
+      protocol: chainlinkDef,
+      actionSlug: "ccip-approve-bridge-token",
+      sampleInputs: {
+        spender: ethers.ZeroAddress,
+        amount: "1000000000000000000",
+      },
+      chainId: CHAIN_ID,
+      toOverride: CCIP_BNM_SEPOLIA,
+    });
 
     const provider = await makeProvider();
     try {
@@ -172,12 +178,12 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("ccip-send: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      chainlinkDef,
-      "ccip-send",
-      CCIP_MESSAGE_SAMPLE,
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: chainlinkDef,
+      actionSlug: "ccip-send",
+      sampleInputs: CCIP_MESSAGE_SAMPLE,
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -202,12 +208,12 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("ccip-bnm-drip: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      chainlinkDef,
-      "ccip-bnm-drip",
-      { to: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: chainlinkDef,
+      actionSlug: "ccip-bnm-drip",
+      sampleInputs: { to: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {

--- a/tests/integration/protocol-chainlink-onchain.test.ts
+++ b/tests/integration/protocol-chainlink-onchain.test.ts
@@ -28,12 +28,6 @@ import { describe, expect, it, vi } from "vitest";
 // otherwise throw under vitest's Node runtime.
 vi.mock("server-only", () => ({}));
 
-import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
-import type {
-  ProtocolAction,
-  ProtocolContract,
-  ProtocolDefinition,
-} from "@/lib/protocol-registry";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import {
   createRpcUrlResolver,
@@ -41,6 +35,7 @@ import {
   parseRpcConfig,
 } from "@/lib/rpc/rpc-config";
 import chainlinkDef from "@/protocols/chainlink";
+import { buildCalldata } from "./_shared/build-calldata";
 
 const CHAIN_ID = "11155111"; // Sepolia
 const CHAIN_ID_NUMBER = 11_155_111;
@@ -80,56 +75,6 @@ const CCIP_MESSAGE_SAMPLE: Record<string, string> = {
   extraArgs: EXTRA_ARGS_V1_GAS_LIMIT_ZERO,
 };
 
-type Calldata = {
-  to: string;
-  data: string;
-  action: ProtocolAction;
-  contract: ProtocolContract;
-};
-
-// Builds calldata from a protocol action. For contracts with
-// userSpecifiedAddress: true, pass `toOverride` so the request targets a real
-// runtime token address rather than the reference address baked into the
-// protocol definition.
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>,
-  toOverride?: string
-): Calldata {
-  const action = protocol.actions.find((a) => a.slug === actionSlug);
-  if (!action) {
-    throw new Error(`Action ${actionSlug} not found`);
-  }
-
-  const contract = protocol.contracts[action.contract];
-  if (!contract.abi) {
-    throw new Error(`Contract ${action.contract} has no ABI`);
-  }
-
-  const to = toOverride ?? contract.addresses[CHAIN_ID];
-  if (!to) {
-    throw new Error(
-      `No address for contract ${action.contract} on chain ${CHAIN_ID}`
-    );
-  }
-
-  const rawArgs = action.inputs.map(
-    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
-  );
-
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
-  );
-  const args = reshapeArgsForAbi(rawArgs, functionAbi);
-  const iface = new ethers.Interface(abi);
-  const data = iface.encodeFunctionData(action.function, args);
-
-  return { to, data, action, contract };
-}
-
 describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   const makeProvider = () =>
     getRpcProviderFromUrls(
@@ -143,7 +88,8 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
     const { to, data, contract } = buildCalldata(
       chainlinkDef,
       "ccip-get-fee",
-      CCIP_MESSAGE_SAMPLE
+      CCIP_MESSAGE_SAMPLE,
+      { chainId: CHAIN_ID }
     );
 
     const provider = await makeProvider();
@@ -171,7 +117,7 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
       chainlinkDef,
       "ccip-check-bridge-balance",
       { account: TEST_ADDRESS },
-      CCIP_BNM_SEPOLIA
+      { chainId: CHAIN_ID, toOverride: CCIP_BNM_SEPOLIA }
     );
 
     const provider = await makeProvider();
@@ -190,7 +136,7 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
       chainlinkDef,
       "ccip-check-bridge-allowance",
       { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
-      CCIP_BNM_SEPOLIA
+      { chainId: CHAIN_ID, toOverride: CCIP_BNM_SEPOLIA }
     );
 
     const provider = await makeProvider();
@@ -209,7 +155,7 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
       chainlinkDef,
       "ccip-approve-bridge-token",
       { spender: ethers.ZeroAddress, amount: "1000000000000000000" },
-      CCIP_BNM_SEPOLIA
+      { chainId: CHAIN_ID, toOverride: CCIP_BNM_SEPOLIA }
     );
 
     const provider = await makeProvider();
@@ -229,7 +175,8 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
     const { to, data } = buildCalldata(
       chainlinkDef,
       "ccip-send",
-      CCIP_MESSAGE_SAMPLE
+      CCIP_MESSAGE_SAMPLE,
+      { chainId: CHAIN_ID }
     );
 
     const provider = await makeProvider();
@@ -255,9 +202,12 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("ccip-bnm-drip: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata(chainlinkDef, "ccip-bnm-drip", {
-      to: TEST_ADDRESS,
-    });
+    const { to, data } = buildCalldata(
+      chainlinkDef,
+      "ccip-bnm-drip",
+      { to: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {

--- a/tests/integration/protocol-rocket-pool-onchain.test.ts
+++ b/tests/integration/protocol-rocket-pool-onchain.test.ts
@@ -24,63 +24,16 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 // otherwise throw under vitest's Node runtime.
 vi.mock("server-only", () => ({}));
 
-import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
-import type {
-  ProtocolAction,
-  ProtocolContract,
-  ProtocolDefinition,
-} from "@/lib/protocol-registry";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import rocketPoolDef from "@/protocols/rocket-pool";
+import { buildCalldata } from "./_shared/build-calldata";
 
 const RPC_URL = process.env.INTEGRATION_TEST_MAINNET_RPC_URL;
 const CHAIN_ID = "1";
 const MAINNET_CHAIN_ID = 1;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
-
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>
-): {
-  to: string;
-  data: string;
-  action: ProtocolAction;
-  contract: ProtocolContract;
-} {
-  const action = protocol.actions.find((a) => a.slug === actionSlug);
-  if (!action) {
-    throw new Error(`Action ${actionSlug} not found`);
-  }
-
-  const contract = protocol.contracts[action.contract];
-  if (!contract.abi) {
-    throw new Error(`Contract ${action.contract} has no ABI`);
-  }
-
-  const contractAddress = contract.addresses[CHAIN_ID];
-  if (!contractAddress) {
-    throw new Error(`Contract ${action.contract} not on chain ${CHAIN_ID}`);
-  }
-
-  const rawArgs = action.inputs.map((inp) => {
-    const val = sampleInputs[inp.name] ?? inp.default ?? "";
-    return val;
-  });
-
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
-  );
-  const args = reshapeArgsForAbi(rawArgs, functionAbi);
-  const iface = new ethers.Interface(abi);
-  const data = iface.encodeFunctionData(action.function, args);
-
-  return { to: contractAddress, data, action, contract };
-}
 
 // Assertion model:
 //  - Read tests: let the RPC call fail loudly. A success path asserts the
@@ -116,7 +69,8 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
     const { to, data, contract } = buildCalldata(
       rocketPoolDef,
       "get-exchange-rate",
-      {}
+      {},
+      { chainId: CHAIN_ID }
     );
 
     const result = await manager.executeWithFailover((p) =>
@@ -133,7 +87,8 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
     const { to, data, contract } = buildCalldata(
       rocketPoolDef,
       "balance-of",
-      { account: TEST_ADDRESS }
+      { account: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
     );
 
     const result = await manager.executeWithFailover((p) =>
@@ -150,7 +105,8 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
     const { to, data, contract } = buildCalldata(
       rocketPoolDef,
       "total-supply",
-      {}
+      {},
+      { chainId: CHAIN_ID }
     );
 
     const result = await manager.executeWithFailover((p) =>
@@ -167,7 +123,8 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
     const { to, data, contract } = buildCalldata(
       rocketPoolDef,
       "get-total-collateral",
-      {}
+      {},
+      { chainId: CHAIN_ID }
     );
 
     const result = await manager.executeWithFailover((p) =>
@@ -181,15 +138,23 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
   }, 15_000);
 
   it("deposit: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(rocketPoolDef, "deposit", {});
+    const { to, data } = buildCalldata(
+      rocketPoolDef,
+      "deposit",
+      {},
+      { chainId: CHAIN_ID }
+    );
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);
 
   it("burn: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(rocketPoolDef, "burn", {
-      amount: "1000000000000000000",
-    });
+    const { to, data } = buildCalldata(
+      rocketPoolDef,
+      "burn",
+      { amount: "1000000000000000000" },
+      { chainId: CHAIN_ID }
+    );
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);

--- a/tests/integration/protocol-rocket-pool-onchain.test.ts
+++ b/tests/integration/protocol-rocket-pool-onchain.test.ts
@@ -66,12 +66,12 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
   });
 
   it("getExchangeRate: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      rocketPoolDef,
-      "get-exchange-rate",
-      {},
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: rocketPoolDef,
+      actionSlug: "get-exchange-rate",
+      sampleInputs: {},
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -84,12 +84,12 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
   }, 15_000);
 
   it("balanceOf: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      rocketPoolDef,
-      "balance-of",
-      { account: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: rocketPoolDef,
+      actionSlug: "balance-of",
+      sampleInputs: { account: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -102,12 +102,12 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
   }, 15_000);
 
   it("totalSupply: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      rocketPoolDef,
-      "total-supply",
-      {},
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: rocketPoolDef,
+      actionSlug: "total-supply",
+      sampleInputs: {},
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -120,12 +120,12 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
   }, 15_000);
 
   it("getTotalCollateral: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      rocketPoolDef,
-      "get-total-collateral",
-      {},
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: rocketPoolDef,
+      actionSlug: "get-total-collateral",
+      sampleInputs: {},
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -138,23 +138,23 @@ describe.skipIf(!RPC_URL)("Rocket Pool on-chain integration", () => {
   }, 15_000);
 
   it("deposit: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(
-      rocketPoolDef,
-      "deposit",
-      {},
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: rocketPoolDef,
+      actionSlug: "deposit",
+      sampleInputs: {},
+      chainId: CHAIN_ID,
+    });
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);
 
   it("burn: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata(
-      rocketPoolDef,
-      "burn",
-      { amount: "1000000000000000000" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: rocketPoolDef,
+      actionSlug: "burn",
+      sampleInputs: { amount: "1000000000000000000" },
+      chainId: CHAIN_ID,
+    });
 
     await expectCallAcceptedByBytecode(manager, { to, data });
   }, 15_000);

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -101,12 +101,13 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     action: ProtocolAction;
     to: string;
   }> {
-    const { to, data, contract, action } = buildCalldata(
-      superfluidDef,
-      slug,
-      inputs,
-      { chainId: CHAIN_ID, toOverride: contractAddressOverride }
-    );
+    const { to, data, contract, action } = buildCalldata({
+      protocol: superfluidDef,
+      actionSlug: slug,
+      sampleInputs: inputs,
+      chainId: CHAIN_ID,
+      toOverride: contractAddressOverride,
+    });
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
     );
@@ -125,7 +126,10 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     inputs: Record<string, string>,
     contractAddressOverride?: string
   ): Promise<string> {
-    const { to, data } = buildCalldata(superfluidDef, slug, inputs, {
+    const { to, data } = buildCalldata({
+      protocol: superfluidDef,
+      actionSlug: slug,
+      sampleInputs: inputs,
       chainId: CHAIN_ID,
       toOverride: contractAddressOverride,
     });
@@ -436,18 +440,14 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
   it('does NOT misfire on data="0x..." with actual revert payload', () => {
     // Guards against the obvious regression of writing `/data="0x/`
     // (no closing quote), which would match every revert.
-    const err = ethers.makeError(
-      'execution reverted: "X"',
-      "CALL_EXCEPTION",
-      {
-        action: "estimateGas",
-        data: "0x08c379a0deadbeef",
-        reason: "X",
-        transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
-        invocation: null,
-        revert: { args: ["X"], name: "Error", signature: "Error(string)" },
-      }
-    );
+    const err = ethers.makeError('execution reverted: "X"', "CALL_EXCEPTION", {
+      action: "estimateGas",
+      data: "0x08c379a0deadbeef",
+      reason: "X",
+      transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
+      invocation: null,
+      revert: { args: ["X"], name: "Error", signature: "Error(string)" },
+    });
     expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
   });
 
@@ -467,19 +467,15 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
     // ever produced a transaction object whose data was literally "0x"
     // while the top-level data was populated, the old `data="0x"` pattern
     // would have false-positived. The anchor prevents that.
-    const err = ethers.makeError(
-      'execution reverted: "X"',
-      "CALL_EXCEPTION",
-      {
-        action: "estimateGas",
-        data: "0x08c379a0deadbeef",
-        reason: "X",
-        // Nested transaction with empty data (hypothetical fallback call):
-        transaction: { data: "0x", to: TEST_ADDRESS },
-        invocation: null,
-        revert: { args: ["X"], name: "Error", signature: "Error(string)" },
-      }
-    );
+    const err = ethers.makeError('execution reverted: "X"', "CALL_EXCEPTION", {
+      action: "estimateGas",
+      data: "0x08c379a0deadbeef",
+      reason: "X",
+      // Nested transaction with empty data (hypothetical fallback call):
+      transaction: { data: "0x", to: TEST_ADDRESS },
+      invocation: null,
+      revert: { args: ["X"], name: "Error", signature: "Error(string)" },
+    });
     expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
   });
 

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -20,12 +20,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 // otherwise throw under vitest's Node runtime.
 vi.mock("server-only", () => ({}));
 
-import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
-import type {
-  ProtocolAction,
-  ProtocolContract,
-  ProtocolDefinition,
-} from "@/lib/protocol-registry";
+import type { ProtocolAction, ProtocolContract } from "@/lib/protocol-registry";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
@@ -33,6 +28,7 @@ import superfluidDef, {
   CFA_FORWARDER_ADDRESS,
   GDA_FORWARDER_ADDRESS,
 } from "@/protocols/superfluid";
+import { buildCalldata } from "./_shared/build-calldata";
 
 const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
 const CHAIN_ID = "11155111";
@@ -78,55 +74,6 @@ const DUMMY_BYTES = "0x";
 const DISPATCH_FAILURE_RE =
   /INVALID_ARGUMENT|could not decode|invalid function|missing revert data|,\s*data="0x"/;
 
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>,
-  contractAddressOverride?: string
-): {
-  to: string;
-  data: string;
-  action: ProtocolAction;
-  contract: ProtocolContract;
-} {
-  const action = protocol.actions.find((a) => a.slug === actionSlug);
-  if (!action) {
-    throw new Error(`Action ${actionSlug} not found`);
-  }
-
-  const contract = protocol.contracts[action.contract];
-  if (!contract.abi) {
-    throw new Error(`Contract ${action.contract} has no ABI`);
-  }
-
-  const contractAddress =
-    contractAddressOverride ?? contract.addresses[CHAIN_ID];
-  if (!contractAddress) {
-    throw new Error(
-      `Contract ${action.contract} not on chain ${CHAIN_ID} and no override given`
-    );
-  }
-
-  const rawArgs = action.inputs.map(
-    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
-  );
-
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
-  );
-  // Reproduce the production pipeline: reshape flat args into tuples per
-  // ABI, then coerce stringly-typed leaves (bool "false" -> false) before
-  // encoding. Same order as plugins/web3/steps/write-contract-core.ts.
-  const reshaped = reshapeArgsForAbi(rawArgs, functionAbi);
-  const args = coerceArgsForAbi(reshaped, functionAbi);
-  const iface = new ethers.Interface(abi);
-  const data = iface.encodeFunctionData(action.function, args);
-
-  return { to: contractAddress, data, action, contract };
-}
-
 describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
   let manager: RpcProviderManager;
 
@@ -158,7 +105,11 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       superfluidDef,
       slug,
       inputs,
-      contractAddressOverride
+      {
+        chainId: CHAIN_ID,
+        toOverride: contractAddressOverride,
+        coerceArgs: true,
+      }
     );
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -178,12 +129,11 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     inputs: Record<string, string>,
     contractAddressOverride?: string
   ): Promise<string> {
-    const { to, data } = buildCalldata(
-      superfluidDef,
-      slug,
-      inputs,
-      contractAddressOverride
-    );
+    const { to, data } = buildCalldata(superfluidDef, slug, inputs, {
+      chainId: CHAIN_ID,
+      toOverride: contractAddressOverride,
+      coerceArgs: true,
+    });
     try {
       await manager.executeWithFailover((p) =>
         p.estimateGas({ to, data, from: TEST_ADDRESS })

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -105,11 +105,7 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
       superfluidDef,
       slug,
       inputs,
-      {
-        chainId: CHAIN_ID,
-        toOverride: contractAddressOverride,
-        coerceArgs: true,
-      }
+      { chainId: CHAIN_ID, toOverride: contractAddressOverride }
     );
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -132,7 +128,6 @@ describe.skipIf(!RPC_URL)("Superfluid on-chain integration", () => {
     const { to, data } = buildCalldata(superfluidDef, slug, inputs, {
       chainId: CHAIN_ID,
       toOverride: contractAddressOverride,
-      coerceArgs: true,
     });
     try {
       await manager.executeWithFailover((p) =>

--- a/tests/integration/protocol-uniswap-onchain.test.ts
+++ b/tests/integration/protocol-uniswap-onchain.test.ts
@@ -32,12 +32,6 @@ import { describe, expect, it, vi } from "vitest";
 // otherwise throw under vitest's Node runtime.
 vi.mock("server-only", () => ({}));
 
-import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
-import type {
-  ProtocolAction,
-  ProtocolContract,
-  ProtocolDefinition,
-} from "@/lib/protocol-registry";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import {
   createRpcUrlResolver,
@@ -45,6 +39,7 @@ import {
   parseRpcConfig,
 } from "@/lib/rpc/rpc-config";
 import uniswapDef from "@/protocols/uniswap-v3";
+import { buildCalldata } from "./_shared/build-calldata";
 
 const CHAIN_ID = "11155111"; // Sepolia
 const CHAIN_ID_NUMBER = 11_155_111;
@@ -77,57 +72,6 @@ const SEPOLIA_FALLBACK_URL = resolveRpcUrl(
   "fallback"
 );
 
-type Calldata = {
-  to: string;
-  data: string;
-  action: ProtocolAction;
-  contract: ProtocolContract;
-};
-
-// Builds calldata from a protocol action. For contracts with
-// userSpecifiedAddress: true, pass `toOverride` so the request targets a
-// real runtime token address rather than the reference address baked into
-// the protocol definition. (Uniswap V3 has no userSpecifiedAddress
-// contracts today, but the hook is preserved to match the CCIP helper.)
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>,
-  toOverride?: string
-): Calldata {
-  const action = protocol.actions.find((a) => a.slug === actionSlug);
-  if (!action) {
-    throw new Error(`Action ${actionSlug} not found`);
-  }
-
-  const contract = protocol.contracts[action.contract];
-  if (!contract.abi) {
-    throw new Error(`Contract ${action.contract} has no ABI`);
-  }
-
-  const to = toOverride ?? contract.addresses[CHAIN_ID];
-  if (!to) {
-    throw new Error(
-      `No address for contract ${action.contract} on chain ${CHAIN_ID}`
-    );
-  }
-
-  const rawArgs = action.inputs.map(
-    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
-  );
-
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
-  );
-  const args = reshapeArgsForAbi(rawArgs, functionAbi);
-  const iface = new ethers.Interface(abi);
-  const data = iface.encodeFunctionData(action.function, args);
-
-  return { to, data, action, contract };
-}
-
 describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   const makeProvider = () =>
     getRpcProviderFromUrls(
@@ -140,11 +84,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- factory ---------------------------------------------------------------
 
   it("get-pool: eth_call returns a decodable address", async () => {
-    const { to, data, contract } = buildCalldata(uniswapDef, "get-pool", {
-      tokenA: SEPOLIA_WETH,
-      tokenB: SEPOLIA_USDC,
-      fee: FEE_TIER_030,
-    });
+    const { to, data, contract } = buildCalldata(
+      uniswapDef,
+      "get-pool",
+      { tokenA: SEPOLIA_WETH, tokenB: SEPOLIA_USDC, fee: FEE_TIER_030 },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     const result = await provider.executeWithFailover(
@@ -160,9 +105,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- positionManager -------------------------------------------------------
 
   it("balance-of: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(uniswapDef, "balance-of", {
-      owner: TEST_ADDRESS,
-    });
+    const { to, data, contract } = buildCalldata(
+      uniswapDef,
+      "balance-of",
+      { owner: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     const result = await provider.executeWithFailover(
@@ -175,9 +123,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("owner-of: calldata encodes (business revert expected for invalid tokenId)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "owner-of", {
-      tokenId: "1",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "owner-of",
+      { tokenId: "1" },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -193,9 +144,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("get-position: calldata encodes (business revert expected for invalid tokenId)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "get-position", {
-      tokenId: "1",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "get-position",
+      { tokenId: "1" },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -211,10 +165,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("approve-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "approve-position", {
-      to: TEST_ADDRESS,
-      tokenId: "1",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "approve-position",
+      { to: TEST_ADDRESS, tokenId: "1" },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -230,11 +186,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("transfer-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "transfer-position", {
-      from: TEST_ADDRESS,
-      to: TEST_ADDRESS,
-      tokenId: "1",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "transfer-position",
+      { from: TEST_ADDRESS, to: TEST_ADDRESS, tokenId: "1" },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -250,9 +207,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("burn-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "burn-position", {
-      tokenId: "1",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "burn-position",
+      { tokenId: "1" },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -270,13 +230,18 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- quoter (tuple-flattened inputs) ---------------------------------------
 
   it("quote-exact-input: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "quote-exact-input", {
-      tokenIn: SEPOLIA_WETH,
-      tokenOut: SEPOLIA_USDC,
-      amountIn: ONE_ETH,
-      fee: FEE_TIER_030,
-      sqrtPriceLimitX96: "0",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "quote-exact-input",
+      {
+        tokenIn: SEPOLIA_WETH,
+        tokenOut: SEPOLIA_USDC,
+        amountIn: ONE_ETH,
+        fee: FEE_TIER_030,
+        sqrtPriceLimitX96: "0",
+      },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -292,13 +257,18 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("quote-exact-output: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "quote-exact-output", {
-      tokenIn: SEPOLIA_WETH,
-      tokenOut: SEPOLIA_USDC,
-      amount: ONE_ETH,
-      fee: FEE_TIER_030,
-      sqrtPriceLimitX96: "0",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "quote-exact-output",
+      {
+        tokenIn: SEPOLIA_WETH,
+        tokenOut: SEPOLIA_USDC,
+        amount: ONE_ETH,
+        fee: FEE_TIER_030,
+        sqrtPriceLimitX96: "0",
+      },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -316,15 +286,20 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- swapRouter (tuple-flattened inputs) -----------------------------------
 
   it("swap-exact-input: estimateGas calldata is valid (business revert expected - no approval)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "swap-exact-input", {
-      tokenIn: SEPOLIA_WETH,
-      tokenOut: SEPOLIA_USDC,
-      fee: FEE_TIER_030,
-      recipient: TEST_ADDRESS,
-      amountIn: ONE_ETH,
-      amountOutMinimum: "0",
-      sqrtPriceLimitX96: "0",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "swap-exact-input",
+      {
+        tokenIn: SEPOLIA_WETH,
+        tokenOut: SEPOLIA_USDC,
+        fee: FEE_TIER_030,
+        recipient: TEST_ADDRESS,
+        amountIn: ONE_ETH,
+        amountOutMinimum: "0",
+        sqrtPriceLimitX96: "0",
+      },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {
@@ -340,15 +315,20 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("swap-exact-output: estimateGas calldata is valid (business revert expected - no approval)", async () => {
-    const { to, data } = buildCalldata(uniswapDef, "swap-exact-output", {
-      tokenIn: SEPOLIA_WETH,
-      tokenOut: SEPOLIA_USDC,
-      fee: FEE_TIER_030,
-      recipient: TEST_ADDRESS,
-      amountOut: ONE_ETH,
-      amountInMaximum: ONE_ETH,
-      sqrtPriceLimitX96: "0",
-    });
+    const { to, data } = buildCalldata(
+      uniswapDef,
+      "swap-exact-output",
+      {
+        tokenIn: SEPOLIA_WETH,
+        tokenOut: SEPOLIA_USDC,
+        fee: FEE_TIER_030,
+        recipient: TEST_ADDRESS,
+        amountOut: ONE_ETH,
+        amountInMaximum: ONE_ETH,
+        sqrtPriceLimitX96: "0",
+      },
+      { chainId: CHAIN_ID }
+    );
 
     const provider = await makeProvider();
     try {

--- a/tests/integration/protocol-uniswap-onchain.test.ts
+++ b/tests/integration/protocol-uniswap-onchain.test.ts
@@ -84,12 +84,16 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- factory ---------------------------------------------------------------
 
   it("get-pool: eth_call returns a decodable address", async () => {
-    const { to, data, contract } = buildCalldata(
-      uniswapDef,
-      "get-pool",
-      { tokenA: SEPOLIA_WETH, tokenB: SEPOLIA_USDC, fee: FEE_TIER_030 },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "get-pool",
+      sampleInputs: {
+        tokenA: SEPOLIA_WETH,
+        tokenB: SEPOLIA_USDC,
+        fee: FEE_TIER_030,
+      },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     const result = await provider.executeWithFailover(
@@ -105,12 +109,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- positionManager -------------------------------------------------------
 
   it("balance-of: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      uniswapDef,
-      "balance-of",
-      { owner: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "balance-of",
+      sampleInputs: { owner: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     const result = await provider.executeWithFailover(
@@ -123,12 +127,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("owner-of: calldata encodes (business revert expected for invalid tokenId)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "owner-of",
-      { tokenId: "1" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "owner-of",
+      sampleInputs: { tokenId: "1" },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -144,12 +148,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("get-position: calldata encodes (business revert expected for invalid tokenId)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "get-position",
-      { tokenId: "1" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "get-position",
+      sampleInputs: { tokenId: "1" },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -165,12 +169,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("approve-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "approve-position",
-      { to: TEST_ADDRESS, tokenId: "1" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "approve-position",
+      sampleInputs: { to: TEST_ADDRESS, tokenId: "1" },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -186,12 +190,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("transfer-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "transfer-position",
-      { from: TEST_ADDRESS, to: TEST_ADDRESS, tokenId: "1" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "transfer-position",
+      sampleInputs: { from: TEST_ADDRESS, to: TEST_ADDRESS, tokenId: "1" },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -207,12 +211,12 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("burn-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "burn-position",
-      { tokenId: "1" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "burn-position",
+      sampleInputs: { tokenId: "1" },
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -230,18 +234,18 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- quoter (tuple-flattened inputs) ---------------------------------------
 
   it("quote-exact-input: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "quote-exact-input",
-      {
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "quote-exact-input",
+      sampleInputs: {
         tokenIn: SEPOLIA_WETH,
         tokenOut: SEPOLIA_USDC,
         amountIn: ONE_ETH,
         fee: FEE_TIER_030,
         sqrtPriceLimitX96: "0",
       },
-      { chainId: CHAIN_ID }
-    );
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -257,18 +261,18 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("quote-exact-output: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "quote-exact-output",
-      {
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "quote-exact-output",
+      sampleInputs: {
         tokenIn: SEPOLIA_WETH,
         tokenOut: SEPOLIA_USDC,
         amount: ONE_ETH,
         fee: FEE_TIER_030,
         sqrtPriceLimitX96: "0",
       },
-      { chainId: CHAIN_ID }
-    );
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -286,10 +290,10 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   // -- swapRouter (tuple-flattened inputs) -----------------------------------
 
   it("swap-exact-input: estimateGas calldata is valid (business revert expected - no approval)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "swap-exact-input",
-      {
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "swap-exact-input",
+      sampleInputs: {
         tokenIn: SEPOLIA_WETH,
         tokenOut: SEPOLIA_USDC,
         fee: FEE_TIER_030,
@@ -298,8 +302,8 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
         amountOutMinimum: "0",
         sqrtPriceLimitX96: "0",
       },
-      { chainId: CHAIN_ID }
-    );
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {
@@ -315,10 +319,10 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
   }, 30_000);
 
   it("swap-exact-output: estimateGas calldata is valid (business revert expected - no approval)", async () => {
-    const { to, data } = buildCalldata(
-      uniswapDef,
-      "swap-exact-output",
-      {
+    const { to, data } = buildCalldata({
+      protocol: uniswapDef,
+      actionSlug: "swap-exact-output",
+      sampleInputs: {
         tokenIn: SEPOLIA_WETH,
         tokenOut: SEPOLIA_USDC,
         fee: FEE_TIER_030,
@@ -327,8 +331,8 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
         amountInMaximum: ONE_ETH,
         sqrtPriceLimitX96: "0",
       },
-      { chainId: CHAIN_ID }
-    );
+      chainId: CHAIN_ID,
+    });
 
     const provider = await makeProvider();
     try {

--- a/tests/integration/protocol-wrapped-onchain.test.ts
+++ b/tests/integration/protocol-wrapped-onchain.test.ts
@@ -46,12 +46,12 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   });
 
   it("balanceOf: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(
-      wrappedDef,
-      "balance-of",
-      { account: TEST_ADDRESS },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data, contract } = buildCalldata({
+      protocol: wrappedDef,
+      actionSlug: "balance-of",
+      sampleInputs: { account: TEST_ADDRESS },
+      chainId: CHAIN_ID,
+    });
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -65,12 +65,12 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   }, 15_000);
 
   it("deposit: estimateGas succeeds with ETH value", async () => {
-    const { to, data } = buildCalldata(
-      wrappedDef,
-      "wrap",
-      {},
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: wrappedDef,
+      actionSlug: "wrap",
+      sampleInputs: {},
+      chainId: CHAIN_ID,
+    });
 
     const gas = await manager.executeWithFailover((p) =>
       p.estimateGas({
@@ -85,12 +85,12 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   }, 15_000);
 
   it("withdraw: calldata encodes correctly (business revert expected)", async () => {
-    const { to, data } = buildCalldata(
-      wrappedDef,
-      "unwrap",
-      { wad: "1000000000000000000" },
-      { chainId: CHAIN_ID }
-    );
+    const { to, data } = buildCalldata({
+      protocol: wrappedDef,
+      actionSlug: "unwrap",
+      sampleInputs: { wad: "1000000000000000000" },
+      chainId: CHAIN_ID,
+    });
 
     try {
       await manager.executeWithFailover((p) =>

--- a/tests/integration/protocol-wrapped-onchain.test.ts
+++ b/tests/integration/protocol-wrapped-onchain.test.ts
@@ -15,63 +15,16 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 // otherwise throw under vitest's Node runtime.
 vi.mock("server-only", () => ({}));
 
-import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
-import type {
-  ProtocolAction,
-  ProtocolContract,
-  ProtocolDefinition,
-} from "@/lib/protocol-registry";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
 import wrappedDef from "@/protocols/wrapped";
+import { buildCalldata } from "./_shared/build-calldata";
 
 const RPC_URL = process.env.INTEGRATION_TEST_RPC_URL;
 const CHAIN_ID = "11155111";
 const SEPOLIA_CHAIN_ID = 11_155_111;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
-
-function buildCalldata(
-  protocol: ProtocolDefinition,
-  actionSlug: string,
-  sampleInputs: Record<string, string>
-): {
-  to: string;
-  data: string;
-  action: ProtocolAction;
-  contract: ProtocolContract;
-} {
-  const action = protocol.actions.find((a) => a.slug === actionSlug);
-  if (!action) {
-    throw new Error(`Action ${actionSlug} not found`);
-  }
-
-  const contract = protocol.contracts[action.contract];
-  if (!contract.abi) {
-    throw new Error(`Contract ${action.contract} has no ABI`);
-  }
-
-  const contractAddress = contract.addresses[CHAIN_ID];
-  if (!contractAddress) {
-    throw new Error(`Contract ${action.contract} not on chain ${CHAIN_ID}`);
-  }
-
-  const rawArgs = action.inputs.map((inp) => {
-    const val = sampleInputs[inp.name] ?? inp.default ?? "";
-    return val;
-  });
-
-  const abi = JSON.parse(contract.abi);
-  const functionAbi = abi.find(
-    (f: { name: string; type: string }) =>
-      f.type === "function" && f.name === action.function
-  );
-  const args = reshapeArgsForAbi(rawArgs, functionAbi);
-  const iface = new ethers.Interface(abi);
-  const data = iface.encodeFunctionData(action.function, args);
-
-  return { to: contractAddress, data, action, contract };
-}
 
 describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   // Route every RPC call through the failover manager so a primary-endpoint
@@ -93,9 +46,12 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   });
 
   it("balanceOf: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata(wrappedDef, "balance-of", {
-      account: TEST_ADDRESS,
-    });
+    const { to, data, contract } = buildCalldata(
+      wrappedDef,
+      "balance-of",
+      { account: TEST_ADDRESS },
+      { chainId: CHAIN_ID }
+    );
 
     const result = await manager.executeWithFailover((p) =>
       p.call({ to, data })
@@ -109,7 +65,12 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   }, 15_000);
 
   it("deposit: estimateGas succeeds with ETH value", async () => {
-    const { to, data } = buildCalldata(wrappedDef, "wrap", {});
+    const { to, data } = buildCalldata(
+      wrappedDef,
+      "wrap",
+      {},
+      { chainId: CHAIN_ID }
+    );
 
     const gas = await manager.executeWithFailover((p) =>
       p.estimateGas({
@@ -124,9 +85,12 @@ describe.skipIf(!RPC_URL)("Wrapped on-chain integration", () => {
   }, 15_000);
 
   it("withdraw: calldata encodes correctly (business revert expected)", async () => {
-    const { to, data } = buildCalldata(wrappedDef, "unwrap", {
-      wad: "1000000000000000000",
-    });
+    const { to, data } = buildCalldata(
+      wrappedDef,
+      "unwrap",
+      { wad: "1000000000000000000" },
+      { chainId: CHAIN_ID }
+    );
 
     try {
       await manager.executeWithFailover((p) =>

--- a/tests/unit/build-calldata.test.ts
+++ b/tests/unit/build-calldata.test.ts
@@ -96,6 +96,15 @@ const fixture: ProtocolDefinition = {
       function: "balanceOf",
       inputs: [],
     },
+    {
+      slug: "unknown-function",
+      label: "Unknown Function",
+      description: "Action whose function is not in the ABI",
+      type: "read",
+      contract: "token",
+      function: "doesNotExist",
+      inputs: [],
+    },
   ],
 };
 
@@ -209,6 +218,14 @@ describe("buildCalldata", () => {
       expect(() =>
         buildCalldata(fixture, "no-abi-action", {}, { chainId: "1" })
       ).toThrow("Contract noAbi has no ABI");
+    });
+
+    it("throws when the action.function is not declared in the ABI", () => {
+      expect(() =>
+        buildCalldata(fixture, "unknown-function", {}, { chainId: "1" })
+      ).toThrow(
+        "Function doesNotExist not found in ABI for contract token"
+      );
     });
 
     it("throws with a toOverride hint when no address is found", () => {

--- a/tests/unit/build-calldata.test.ts
+++ b/tests/unit/build-calldata.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the shared on-chain integration test helper.
+ *
+ * These cover the helper's branching logic (toOverride fallback,
+ * coerceArgs gating) and error paths without requiring a live RPC, so
+ * regressions are caught in the test-unit CI job even when the on-chain
+ * integration suites skip.
+ */
+
+import { ethers } from "ethers";
+import { describe, expect, it } from "vitest";
+import type { ProtocolDefinition } from "@/lib/protocol-registry";
+import { buildCalldata } from "../integration/_shared/build-calldata";
+
+const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
+const OVERRIDE_ADDRESS = "0x000000000000000000000000000000000000DEAD";
+const FOO_ADDRESS = "0x000000000000000000000000000000000000F00D";
+const NOABI_ADDRESS = "0x000000000000000000000000000000000000ABCD";
+
+const BALANCE_OF_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "setFlag",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "flag", type: "bool" }],
+    outputs: [],
+  },
+]);
+
+const fixture: ProtocolDefinition = {
+  name: "Fixture",
+  slug: "fixture",
+  description: "Synthetic protocol for buildCalldata unit tests.",
+  contracts: {
+    token: {
+      label: "Token",
+      addresses: { "1": FOO_ADDRESS },
+      abi: BALANCE_OF_ABI,
+    },
+    userToken: {
+      label: "User-supplied Token",
+      addresses: {},
+      abi: BALANCE_OF_ABI,
+      userSpecifiedAddress: true,
+    },
+    noAbi: {
+      label: "No ABI",
+      addresses: { "1": NOABI_ADDRESS },
+    },
+  },
+  actions: [
+    {
+      slug: "balance-of",
+      label: "Balance Of",
+      description: "ERC20 balanceOf",
+      type: "read",
+      contract: "token",
+      function: "balanceOf",
+      inputs: [
+        { name: "account", type: "address", label: "Account" },
+      ],
+    },
+    {
+      slug: "balance-of-user-token",
+      label: "Balance Of (User Token)",
+      description: "balanceOf against a user-supplied contract",
+      type: "read",
+      contract: "userToken",
+      function: "balanceOf",
+      inputs: [
+        { name: "account", type: "address", label: "Account" },
+      ],
+    },
+    {
+      slug: "set-flag",
+      label: "Set Flag",
+      description: "Toggle a bool",
+      type: "write",
+      contract: "token",
+      function: "setFlag",
+      inputs: [{ name: "flag", type: "bool", label: "Flag" }],
+    },
+    {
+      slug: "no-abi-action",
+      label: "No ABI",
+      description: "Action on a contract without an ABI",
+      type: "read",
+      contract: "noAbi",
+      function: "balanceOf",
+      inputs: [],
+    },
+  ],
+};
+
+const iface = new ethers.Interface(BALANCE_OF_ABI);
+
+describe("buildCalldata", () => {
+  describe("address resolution", () => {
+    it("resolves to addresses[chainId] when no toOverride", () => {
+      const result = buildCalldata(
+        fixture,
+        "balance-of",
+        { account: TEST_ADDRESS },
+        { chainId: "1" }
+      );
+      expect(result.to).toBe(FOO_ADDRESS);
+    });
+
+    it("toOverride takes precedence over addresses[chainId]", () => {
+      const result = buildCalldata(
+        fixture,
+        "balance-of",
+        { account: TEST_ADDRESS },
+        { chainId: "1", toOverride: OVERRIDE_ADDRESS }
+      );
+      expect(result.to).toBe(OVERRIDE_ADDRESS);
+    });
+
+    it("toOverride supplies the address for userSpecifiedAddress contracts", () => {
+      const result = buildCalldata(
+        fixture,
+        "balance-of-user-token",
+        { account: TEST_ADDRESS },
+        { chainId: "1", toOverride: OVERRIDE_ADDRESS }
+      );
+      expect(result.to).toBe(OVERRIDE_ADDRESS);
+    });
+  });
+
+  describe("calldata encoding", () => {
+    it("encodes the function selector and args via ethers.Interface", () => {
+      const result = buildCalldata(
+        fixture,
+        "balance-of",
+        { account: TEST_ADDRESS },
+        { chainId: "1" }
+      );
+      const expected = iface.encodeFunctionData("balanceOf", [TEST_ADDRESS]);
+      expect(result.data).toBe(expected);
+    });
+
+    it("returns the resolved action and contract for caller assertions", () => {
+      const result = buildCalldata(
+        fixture,
+        "balance-of",
+        { account: TEST_ADDRESS },
+        { chainId: "1" }
+      );
+      expect(result.action.slug).toBe("balance-of");
+      expect(result.contract.label).toBe("Token");
+    });
+  });
+
+  describe("coerceArgs option", () => {
+    it("coerceArgs: false documents the trap: 'false' encodes as boolean true", () => {
+      // Without coerce, ethers treats any non-empty string as truthy, so
+      // the literal "false" round-trips through encodeFunctionData as true.
+      // This test pins the production-divergence behavior the option
+      // exists to disarm. Pass an explicit flag rather than relying on
+      // the default so the test survives a default flip.
+      const result = buildCalldata(
+        fixture,
+        "set-flag",
+        { flag: "false" },
+        { chainId: "1", coerceArgs: false }
+      );
+      const decoded = iface.decodeFunctionData("setFlag", result.data);
+      expect(decoded[0]).toBe(true);
+    });
+
+    it("coerceArgs: true preserves the boolean value of 'false'", () => {
+      const result = buildCalldata(
+        fixture,
+        "set-flag",
+        { flag: "false" },
+        { chainId: "1", coerceArgs: true }
+      );
+      const decoded = iface.decodeFunctionData("setFlag", result.data);
+      expect(decoded[0]).toBe(false);
+    });
+
+    it("coerceArgs: true preserves 'true' as boolean true", () => {
+      const result = buildCalldata(
+        fixture,
+        "set-flag",
+        { flag: "true" },
+        { chainId: "1", coerceArgs: true }
+      );
+      const decoded = iface.decodeFunctionData("setFlag", result.data);
+      expect(decoded[0]).toBe(true);
+    });
+  });
+
+  describe("error paths", () => {
+    it("throws when the action slug is unknown", () => {
+      expect(() =>
+        buildCalldata(fixture, "nope", {}, { chainId: "1" })
+      ).toThrow("Action nope not found");
+    });
+
+    it("throws when the resolved contract has no ABI", () => {
+      expect(() =>
+        buildCalldata(fixture, "no-abi-action", {}, { chainId: "1" })
+      ).toThrow("Contract noAbi has no ABI");
+    });
+
+    it("throws with a toOverride hint when no address is found", () => {
+      expect(() =>
+        buildCalldata(
+          fixture,
+          "balance-of",
+          { account: TEST_ADDRESS },
+          { chainId: "999" }
+        )
+      ).toThrow(
+        "No address for contract token on chain 999 and no toOverride given"
+      );
+    });
+
+    it("throws on userSpecifiedAddress contracts when toOverride is omitted", () => {
+      expect(() =>
+        buildCalldata(
+          fixture,
+          "balance-of-user-token",
+          { account: TEST_ADDRESS },
+          { chainId: "1" }
+        )
+      ).toThrow(
+        "No address for contract userToken on chain 1 and no toOverride given"
+      );
+    });
+  });
+});

--- a/tests/unit/build-calldata.test.ts
+++ b/tests/unit/build-calldata.test.ts
@@ -168,6 +168,17 @@ describe("buildCalldata", () => {
   });
 
   describe("coerceArgs option", () => {
+    it("defaults to true: 'false' encodes as boolean false (production parity)", () => {
+      const result = buildCalldata(
+        fixture,
+        "set-flag",
+        { flag: "false" },
+        { chainId: "1" }
+      );
+      const decoded = iface.decodeFunctionData("setFlag", result.data);
+      expect(decoded[0]).toBe(false);
+    });
+
     it("coerceArgs: false documents the trap: 'false' encodes as boolean true", () => {
       // Without coerce, ethers treats any non-empty string as truthy, so
       // the literal "false" round-trips through encodeFunctionData as true.

--- a/tests/unit/build-calldata.test.ts
+++ b/tests/unit/build-calldata.test.ts
@@ -228,6 +228,32 @@ describe("buildCalldata", () => {
       );
     });
 
+    it("throws when sampleInputs contains a key the action does not declare", () => {
+      expect(() =>
+        buildCalldata(
+          fixture,
+          "balance-of",
+          { account: TEST_ADDRESS, accountt: TEST_ADDRESS },
+          { chainId: "1" }
+        )
+      ).toThrow(
+        "Sample input 'accountt' is not declared for action 'balance-of'. Known inputs: account"
+      );
+    });
+
+    it("throws with '(none)' hint when the action declares no inputs at all", () => {
+      expect(() =>
+        buildCalldata(
+          fixture,
+          "no-abi-action",
+          { stray: "value" },
+          { chainId: "1" }
+        )
+      ).toThrow(
+        "Sample input 'stray' is not declared for action 'no-abi-action'. Known inputs: (none)"
+      );
+    });
+
     it("throws with a toOverride hint when no address is found", () => {
       expect(() =>
         buildCalldata(

--- a/tests/unit/build-calldata.test.ts
+++ b/tests/unit/build-calldata.test.ts
@@ -63,9 +63,7 @@ const fixture: ProtocolDefinition = {
       type: "read",
       contract: "token",
       function: "balanceOf",
-      inputs: [
-        { name: "account", type: "address", label: "Account" },
-      ],
+      inputs: [{ name: "account", type: "address", label: "Account" }],
     },
     {
       slug: "balance-of-user-token",
@@ -74,9 +72,7 @@ const fixture: ProtocolDefinition = {
       type: "read",
       contract: "userToken",
       function: "balanceOf",
-      inputs: [
-        { name: "account", type: "address", label: "Account" },
-      ],
+      inputs: [{ name: "account", type: "address", label: "Account" }],
     },
     {
       slug: "set-flag",
@@ -113,55 +109,57 @@ const iface = new ethers.Interface(BALANCE_OF_ABI);
 describe("buildCalldata", () => {
   describe("address resolution", () => {
     it("resolves to addresses[chainId] when no toOverride", () => {
-      const result = buildCalldata(
-        fixture,
-        "balance-of",
-        { account: TEST_ADDRESS },
-        { chainId: "1" }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "balance-of",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: "1",
+      });
       expect(result.to).toBe(FOO_ADDRESS);
     });
 
     it("toOverride takes precedence over addresses[chainId]", () => {
-      const result = buildCalldata(
-        fixture,
-        "balance-of",
-        { account: TEST_ADDRESS },
-        { chainId: "1", toOverride: OVERRIDE_ADDRESS }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "balance-of",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: "1",
+        toOverride: OVERRIDE_ADDRESS,
+      });
       expect(result.to).toBe(OVERRIDE_ADDRESS);
     });
 
     it("toOverride supplies the address for userSpecifiedAddress contracts", () => {
-      const result = buildCalldata(
-        fixture,
-        "balance-of-user-token",
-        { account: TEST_ADDRESS },
-        { chainId: "1", toOverride: OVERRIDE_ADDRESS }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "balance-of-user-token",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: "1",
+        toOverride: OVERRIDE_ADDRESS,
+      });
       expect(result.to).toBe(OVERRIDE_ADDRESS);
     });
   });
 
   describe("calldata encoding", () => {
     it("encodes the function selector and args via ethers.Interface", () => {
-      const result = buildCalldata(
-        fixture,
-        "balance-of",
-        { account: TEST_ADDRESS },
-        { chainId: "1" }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "balance-of",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: "1",
+      });
       const expected = iface.encodeFunctionData("balanceOf", [TEST_ADDRESS]);
       expect(result.data).toBe(expected);
     });
 
     it("returns the resolved action and contract for caller assertions", () => {
-      const result = buildCalldata(
-        fixture,
-        "balance-of",
-        { account: TEST_ADDRESS },
-        { chainId: "1" }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "balance-of",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: "1",
+      });
       expect(result.action.slug).toBe("balance-of");
       expect(result.contract.label).toBe("Token");
     });
@@ -169,12 +167,12 @@ describe("buildCalldata", () => {
 
   describe("coerceArgs option", () => {
     it("defaults to true: 'false' encodes as boolean false (production parity)", () => {
-      const result = buildCalldata(
-        fixture,
-        "set-flag",
-        { flag: "false" },
-        { chainId: "1" }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "set-flag",
+        sampleInputs: { flag: "false" },
+        chainId: "1",
+      });
       const decoded = iface.decodeFunctionData("setFlag", result.data);
       expect(decoded[0]).toBe(false);
     });
@@ -185,34 +183,37 @@ describe("buildCalldata", () => {
       // This test pins the production-divergence behavior the option
       // exists to disarm. Pass an explicit flag rather than relying on
       // the default so the test survives a default flip.
-      const result = buildCalldata(
-        fixture,
-        "set-flag",
-        { flag: "false" },
-        { chainId: "1", coerceArgs: false }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "set-flag",
+        sampleInputs: { flag: "false" },
+        chainId: "1",
+        coerceArgs: false,
+      });
       const decoded = iface.decodeFunctionData("setFlag", result.data);
       expect(decoded[0]).toBe(true);
     });
 
     it("coerceArgs: true preserves the boolean value of 'false'", () => {
-      const result = buildCalldata(
-        fixture,
-        "set-flag",
-        { flag: "false" },
-        { chainId: "1", coerceArgs: true }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "set-flag",
+        sampleInputs: { flag: "false" },
+        chainId: "1",
+        coerceArgs: true,
+      });
       const decoded = iface.decodeFunctionData("setFlag", result.data);
       expect(decoded[0]).toBe(false);
     });
 
     it("coerceArgs: true preserves 'true' as boolean true", () => {
-      const result = buildCalldata(
-        fixture,
-        "set-flag",
-        { flag: "true" },
-        { chainId: "1", coerceArgs: true }
-      );
+      const result = buildCalldata({
+        protocol: fixture,
+        actionSlug: "set-flag",
+        sampleInputs: { flag: "true" },
+        chainId: "1",
+        coerceArgs: true,
+      });
       const decoded = iface.decodeFunctionData("setFlag", result.data);
       expect(decoded[0]).toBe(true);
     });
@@ -221,32 +222,45 @@ describe("buildCalldata", () => {
   describe("error paths", () => {
     it("throws when the action slug is unknown", () => {
       expect(() =>
-        buildCalldata(fixture, "nope", {}, { chainId: "1" })
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "nope",
+          sampleInputs: {},
+          chainId: "1",
+        })
       ).toThrow("Action nope not found");
     });
 
     it("throws when the resolved contract has no ABI", () => {
       expect(() =>
-        buildCalldata(fixture, "no-abi-action", {}, { chainId: "1" })
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "no-abi-action",
+          sampleInputs: {},
+          chainId: "1",
+        })
       ).toThrow("Contract noAbi has no ABI");
     });
 
     it("throws when the action.function is not declared in the ABI", () => {
       expect(() =>
-        buildCalldata(fixture, "unknown-function", {}, { chainId: "1" })
-      ).toThrow(
-        "Function doesNotExist not found in ABI for contract token"
-      );
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "unknown-function",
+          sampleInputs: {},
+          chainId: "1",
+        })
+      ).toThrow("Function doesNotExist not found in ABI for contract token");
     });
 
     it("throws when sampleInputs contains a key the action does not declare", () => {
       expect(() =>
-        buildCalldata(
-          fixture,
-          "balance-of",
-          { account: TEST_ADDRESS, accountt: TEST_ADDRESS },
-          { chainId: "1" }
-        )
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "balance-of",
+          sampleInputs: { account: TEST_ADDRESS, accountt: TEST_ADDRESS },
+          chainId: "1",
+        })
       ).toThrow(
         "Sample input 'accountt' is not declared for action 'balance-of'. Known inputs: account"
       );
@@ -254,12 +268,12 @@ describe("buildCalldata", () => {
 
     it("throws with '(none)' hint when the action declares no inputs at all", () => {
       expect(() =>
-        buildCalldata(
-          fixture,
-          "no-abi-action",
-          { stray: "value" },
-          { chainId: "1" }
-        )
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "no-abi-action",
+          sampleInputs: { stray: "value" },
+          chainId: "1",
+        })
       ).toThrow(
         "Sample input 'stray' is not declared for action 'no-abi-action'. Known inputs: (none)"
       );
@@ -267,12 +281,12 @@ describe("buildCalldata", () => {
 
     it("throws with a toOverride hint when no address is found", () => {
       expect(() =>
-        buildCalldata(
-          fixture,
-          "balance-of",
-          { account: TEST_ADDRESS },
-          { chainId: "999" }
-        )
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "balance-of",
+          sampleInputs: { account: TEST_ADDRESS },
+          chainId: "999",
+        })
       ).toThrow(
         "No address for contract token on chain 999 and no toOverride given"
       );
@@ -280,12 +294,12 @@ describe("buildCalldata", () => {
 
     it("throws on userSpecifiedAddress contracts when toOverride is omitted", () => {
       expect(() =>
-        buildCalldata(
-          fixture,
-          "balance-of-user-token",
-          { account: TEST_ADDRESS },
-          { chainId: "1" }
-        )
+        buildCalldata({
+          protocol: fixture,
+          actionSlug: "balance-of-user-token",
+          sampleInputs: { account: TEST_ADDRESS },
+          chainId: "1",
+        })
       ).toThrow(
         "No address for contract userToken on chain 1 and no toOverride given"
       );


### PR DESCRIPTION
## Summary

Extract the `buildCalldata` helper that was duplicated across 6 protocol on-chain integration test files into a shared module. Closes [KEEP-579](https://linear.app/keeperhubapp/issue/KEEP-579).

This PR is scoped to the refactor and the helper-correctness follow-ups from review. The gate-removal work that was originally bundled here lives in #1307 (stacked on this branch).

## What changed

- **New**: `tests/integration/_shared/build-calldata.ts` exports `buildCalldata({ protocol, actionSlug, sampleInputs, chainId, toOverride?, coerceArgs? })` plus the `Calldata` and `BuildCalldataParams` types.
  - Pure options-object signature - every argument is named at the call site so the (slug, sampleInputs) pair cannot be misordered.
  - `chainId` is required; the helper does not default it. Mistakes here are silent wrong-chain bugs.
  - `toOverride` is opt-in for contracts marked `userSpecifiedAddress`. Exercised by chainlink (CCIP-BnM) and superfluid (per-pair SuperToken proxies).
  - `coerceArgs` defaults to `true` so tests match the production write pipeline (`plugins/web3/steps/write-contract-core.ts`). Pass `false` only to deliberately exercise the un-coerced shape. Without coerce, `ethers.encodeFunctionData` silently encodes the literal `'false'` as `true`.
  - The helper throws on: unknown action slug, sampleInputs keys not declared by the action (typo catcher), contract without ABI, no resolvable address (the error includes a `toOverride` hint), and ABI missing the action's function.
  - `JSON.parse(contract.abi)` is typed via a narrow `AbiEntry` shape built on the now-exported `FunctionAbiEntry` from `lib/abi/struct-args`.
- **Converted** (6 files):
  - `protocol-{wrapped,aave-v4,rocket-pool,uniswap}-onchain.test.ts` - mechanical replacement.
  - `protocol-chainlink-onchain.test.ts` - 3 of 6 sites pass `toOverride: CCIP_BNM_SEPOLIA` for the CCIP-BnM token contract.
  - `protocol-superfluid-onchain.test.ts` - wrappers `callAndDecode` / `estimateGasError` forward the params object to the shared helper.
- **Unit tests**: `tests/unit/build-calldata.test.ts` - 16 tests covering address resolution, encoding, both `coerceArgs` branches, and every throw path. Catches helper regressions in the CI `test-unit` job, which currently does not exercise the on-chain integration suites (those are gated on RPC env vars - removal is in #1307).

## Verified

Re-run on commit `2fcb91d2` (branch tip with all 10 commits, including the 6 review fixes).

| Test | Result | Duration | RPC source |
|---|---|---|---|
| `tests/unit/build-calldata.test.ts` | 16 / 16 pass | 2.42s | n/a (no RPC) |
| `protocol-wrapped-onchain.test.ts` | 3 / 3 pass | 3.36s | Sepolia (`INTEGRATION_TEST_RPC_URL`) |
| `protocol-aave-v4-onchain.test.ts` | 6 / 6 pass | 3.93s | Mainnet (`INTEGRATION_TEST_MAINNET_RPC_URL`) |
| `protocol-rocket-pool-onchain.test.ts` | 6 / 6 pass | 3.85s | Mainnet (`INTEGRATION_TEST_MAINNET_RPC_URL`) |
| `protocol-uniswap-onchain.test.ts` | 11 / 11 pass | 5.82s | Public Sepolia (auto-resolved) |
| `protocol-chainlink-onchain.test.ts` | 6 / 6 pass | 4.23s | Public Sepolia (auto-resolved) |
| `protocol-superfluid-onchain.test.ts` | 24 / 24 pass | 7.92s | Sepolia (`INTEGRATION_TEST_RPC_URL`) |

Total: 72 / 72 (16 unit + 56 integration). `pnpm type-check` passes.

Reproducing locally: the 4 still-gated suites (wrapped, aave-v4, rocket-pool, superfluid) require `INTEGRATION_TEST_RPC_URL` (Sepolia) or `INTEGRATION_TEST_MAINNET_RPC_URL` (mainnet) to be set, otherwise they skip silently. The auto-resolve-to-public-RPC behavior lands in stacked PR #1307. Example:

    INTEGRATION_TEST_RPC_URL=https://ethereum-sepolia.publicnode.com \
    INTEGRATION_TEST_MAINNET_RPC_URL=https://ethereum-rpc.publicnode.com \
    pnpm vitest run tests/integration/protocol-*-onchain.test.ts

## Test plan

- [x] Unit tests: 16 tests cover every branch and throw path of the shared helper.
- [x] Integration tests for each of the 6 migrated protocols pass.
- [x] `pnpm type-check` passes; biome clean on every line this PR touches.
- [x] `coerceArgs: true` (default) verified end-to-end via superfluid `create-pool` (passes `'false'` for two bool inputs; encodes as `false` under the default).
- [x] Default flip verified harmless for the 4 first-converted suites (no bool inputs in their fixtures; coerce is a no-op).

## Not in scope

- Removing the `describe.skipIf(!RPC_URL)` gates on the 4 still-gated suites. Moved to stacked PR #1307.