### PR TITLE
fix(executor): preserve prior in-memory success in catch handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 - **No co-authored with Claude in PR descriptions and git commits**
 - **Do not git push or create Github PRs without user's confirmation**
 - **Do not leave code comments with summaries of user's prompt**
+- **No Linear ticket IDs in code comments, PR titles, or PR descriptions**: Do not include Linear IDs (e.g. `KEEP-XXX`) in code comments, PR titles, or PR descriptions. Linear's GitHub integration cross-links via the branch name; the ticket ID does not need to appear in the artifact. Commit messages and internal docs under `.planning/` / `specs/` may still reference them.
 - **PR titles must follow conventional commit format**: `<type>: <description>` or `<type>(scope): <description>`. Allowed types: `feat`, `fix`, `hotfix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `breaking`, `release`. This is enforced by the `pr-title-check` workflow on PRs targeting `staging`.
 - **Use `kh` CLI and KeeperHub MCP tools for all KeeperHub API interactions**: NEVER use raw `curl` or `fetch` against KeeperHub endpoints. Use MCP tools (`mcp__keeperhub-dev__*`, `mcp__keeperhub-staging__*`, `mcp__keeperhub__*`) for the target environment, or the `kh` CLI which handles auth and CF Access headers automatically via `~/.config/kh/hosts.yml`.
 

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -126,6 +126,32 @@ export {
 
 type NodeOutputs = Record<string, { label: string; data: unknown }>;
 
+/**
+ * Catch-time write of a node's entry in the `outputs` map. Preserves a prior
+ * non-null success when one exists; otherwise writes `{ label, data: null }`
+ * so downstream resolvers see a sentinel rather than `undefined`.
+ *
+ * Rationale: the workflow SDK occasionally replays a step after its first
+ * attempt has already populated `outputs[sanitizedNodeId]` with a successful
+ * object (the post-step `step_completed` event is lost under heavy fan-in,
+ * the same race covered by the spurious-max-retries reconciliation above).
+ * Unconditionally overwriting that prior success with `data: null` caused
+ * downstream templates to fail with `Node "X" produced no data.` This helper
+ * keeps the catch handler's null-fallback contract for the no-prior-data case
+ * while leaving real replay-survivor data intact.
+ */
+export function recordCatchOutput(
+  outputs: NodeOutputs,
+  sanitizedNodeId: string,
+  label: string
+): void {
+  const prior = outputs[sanitizedNodeId];
+  if (prior !== undefined && prior.data !== null && prior.data !== undefined) {
+    return;
+  }
+  outputs[sanitizedNodeId] = { label, data: null };
+}
+
 /** Matches path segment like "carts[0]" for array index access (same as template.ts) */
 const ARRAY_ACCESS_PATTERN = /^([^[]+)\[(\d+)\]$/;
 
@@ -2673,13 +2699,15 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         }
       }
 
-      // Store null output so downstream templates resolve to null rather than
-      // being undefined (same pattern as disabled nodes).
+      // Catch-time output write. Preserves a prior in-memory success when one
+      // exists (the SDK occasionally replays a step after its first attempt
+      // has already populated `outputs[sanitizedNodeId]` under heavy fan-in),
+      // and otherwise falls back to `{ data: null }` so downstream templates
+      // resolve to a sentinel instead of `undefined`. The previous
+      // unconditional overwrite discarded replay-survivor output and caused
+      // downstream resolvers to throw `Node "X" produced no data.`
       const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
-      outputs[sanitizedNodeId] = {
-        label: getNodeName(node),
-        data: null,
-      };
+      recordCatchOutput(outputs, sanitizedNodeId, getNodeName(node));
 
       // Signal arrival at downstream convergence nodes to prevent deadlocks.
       // If this failure was the last arrival, execute the convergence node

--- a/tests/unit/executor-catch-output.test.ts
+++ b/tests/unit/executor-catch-output.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  processCodeTemplates,
+  processTemplates,
+  recordCatchOutput,
+} from "@/lib/workflow/executor/executor.workflow";
+import { createTracker } from "@/lib/workflow/executor/template-resolution";
+
+const successOutputs = {
+  bungee: {
+    label: "Bungee",
+    data: {
+      success: true,
+      data: { result: { autoRoute: { output: { amount: "998899" } } } },
+      status: 200,
+    },
+  },
+};
+
+const softFailOutputs = {
+  bungee: {
+    label: "Bungee",
+    data: { success: true, data: null, status: 400, error: "Validation Error" },
+  },
+};
+
+const nullifiedOutputs = {
+  bungee: {
+    label: "Bungee",
+    data: null,
+  },
+};
+
+describe("template resolver baseline (bungee fixtures)", () => {
+  it("processCodeTemplates resolves a successful step's data", () => {
+    const t = createTracker();
+    processCodeTemplates("const x = {{@bungee:Bungee}};", successOutputs, t);
+    expect(t.unresolved.map((r) => r.reason)).toEqual([]);
+  });
+  it("processCodeTemplates passes a soft-fail wrapper (success:true, inner data:null) through to the user code", () => {
+    const t = createTracker();
+    processCodeTemplates("const x = {{@bungee:Bungee}};", softFailOutputs, t);
+    expect(t.unresolved.map((r) => r.reason)).toEqual([]);
+  });
+  it("processTemplates resolves a successful step's data", () => {
+    const t = createTracker();
+    processTemplates(
+      { code: "const x = {{@bungee:Bungee}};" },
+      successOutputs,
+      t
+    );
+    expect(t.unresolved.map((r) => r.reason)).toEqual([]);
+  });
+  it("processTemplates passes a soft-fail wrapper through", () => {
+    const t = createTracker();
+    processTemplates(
+      { code: "const x = {{@bungee:Bungee}};" },
+      softFailOutputs,
+      t
+    );
+    expect(t.unresolved.map((r) => r.reason)).toEqual([]);
+  });
+
+  // Sentinel: confirms the post-nullify shape (output present, data===null)
+  // is what triggers the strict-mode "produced no data" error. If this stops
+  // reporting "no-data", the resolver semantics have shifted and the
+  // catch-handler preserve-prior-success fix may no longer be load-bearing.
+  it("processCodeTemplates records no-data when output exists but data===null (post-nullify shape)", () => {
+    const t = createTracker();
+    processCodeTemplates("const x = {{@bungee:Bungee}};", nullifiedOutputs, t);
+    expect(t.unresolved.map((r) => r.reason)).toEqual(["no-data"]);
+  });
+});
+
+// recordCatchOutput is the catch-handler write previously inlined at the
+// catch site. It must preserve a prior in-memory success so that an SDK
+// replay (whose first attempt already populated outputs) does not destroy
+// successful data on its way to providing a downstream-safe null for
+// genuinely-failed nodes.
+describe("recordCatchOutput", () => {
+  it("writes {data: null} when there is no prior entry for the node", () => {
+    const outputs: Record<string, { label: string; data: unknown }> = {};
+    recordCatchOutput(outputs, "bungee", "Bungee");
+    expect(outputs.bungee).toEqual({ label: "Bungee", data: null });
+  });
+
+  it("writes {data: null} when the prior entry has data===undefined", () => {
+    const outputs = {
+      bungee: { label: "Bungee", data: undefined as unknown },
+    };
+    recordCatchOutput(outputs, "bungee", "Bungee");
+    expect(outputs.bungee).toEqual({ label: "Bungee", data: null });
+  });
+
+  it("writes {data: null} when the prior entry has data===null", () => {
+    const outputs = {
+      bungee: { label: "Bungee", data: null as unknown },
+    };
+    recordCatchOutput(outputs, "bungee", "Bungee");
+    expect(outputs.bungee).toEqual({ label: "Bungee", data: null });
+  });
+
+  // Failing-without-fix case.
+  // Before the fix, the catch handler unconditionally wrote {data: null},
+  // discarding the prior success object stored by the first (succeeded)
+  // attempt of a step that the SDK then replayed. Downstream resolvers
+  // then reported `Node "bungee" produced no data.`
+  it("preserves a prior success object (SDK replay after first attempt succeeded)", () => {
+    const successData = {
+      success: true,
+      data: { result: { autoRoute: { output: { amount: "998899" } } } },
+      status: 200,
+    };
+    const outputs = {
+      bungee: { label: "Bungee", data: successData as unknown },
+    };
+    recordCatchOutput(outputs, "bungee", "Bungee");
+    expect(outputs.bungee.data).toBe(successData);
+  });
+
+  it("preserves a prior soft-fail wrapper (success:true, inner data:null) which is still a valid output shape", () => {
+    const softFailData = {
+      success: true,
+      data: null,
+      status: 400,
+      error: "Validation Error",
+    };
+    const outputs = {
+      bungee: { label: "Bungee", data: softFailData as unknown },
+    };
+    recordCatchOutput(outputs, "bungee", "Bungee");
+    expect(outputs.bungee.data).toBe(softFailData);
+  });
+});


### PR DESCRIPTION
## Summary

- The executor's catch handler in `lib/workflow/executor/executor.workflow.ts` unconditionally wrote `outputs[sanitizedNodeId] = { data: null }` after a step threw. When the workflow SDK replayed a step whose first attempt had already populated the outputs map (the lost-step-completed-event race already handled by the spurious-max-retries reconciliation just above), the catch destroyed the surviving success. Downstream resolvers then reported `Node "X" produced no data.` and the convergence combine step errored out.
- Extracted the catch-time write into `recordCatchOutput(outputs, sanitizedId, label)` which preserves a prior non-null/non-undefined `data` and otherwise writes the existing `{label, data: null}` fallback so downstream templates still get a sentinel instead of `undefined`.
- Removed four diagnostic `console.log` calls added during the investigation.
- Adds a CLAUDE.md rule forbidding Linear ticket IDs in code comments, PR titles, and PR descriptions (commit messages and `.planning/` / `specs/` internal docs may still reference them).

## Test plan

- [x] `pnpm vitest run tests/unit/executor-catch-output.test.ts` — 10/10 pass (4 `recordCatchOutput` cases, 1 sentinel resolver case asserting `data === null` still triggers strict-mode `no-data`, 5 baseline resolver cases)
- [x] `pnpm test:unit` — 4697 pass, 1 skipped, 0 regressions
- [x] `pnpm type-check` — clean
- [x] `biome format` clean on the changed files
- [ ] **Post-merge prod smoke (manual, after staging -> prod release):** re-run the 5-node forked `bridge-optimizer-usdc` workflow on `app.keeperhub.com` with the Bungee leg + `receiverAddress` + `userAddress` URL. Expected: `combine.status=success`, `routes[].name="Bungee"` includes a real `amount_out_raw`, `_race_warnings` is empty.

## Out of scope

- Spurious-retry / `mergeFromAuthority` reconciliation logic is unchanged.
- Strict-resolver no-data semantics in other paths (Database Query, For Each, Condition) are unchanged.