### PR TITLE
fix(api): KEEP-477 add plural /api/workflows/[id]/execute alias

### DIFF
--- a/app/api/workflows/[workflowId]/execute/route.ts
+++ b/app/api/workflows/[workflowId]/execute/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/app/api/workflow/[workflowId]/execute/route";

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -172,24 +172,38 @@ DELETE /api/workflows/{workflowId}?force=true
 ## Execute Workflow
 
 ```http
-POST /api/workflow/{workflowId}/execute
+POST /api/workflows/{workflowId}/execute
 ```
 
-> **Note:** This endpoint uses singular `/workflow/` in the path, unlike other endpoints which use plural `/workflows/`.
+Manually trigger a workflow execution. The singular form `POST /api/workflow/{workflowId}/execute` is also accepted for backward compatibility.
 
-Manually trigger a workflow execution.
+### Request Body
+
+```json
+{
+  "input": { "key": "value" }
+}
+```
+
+The `input` field is optional. It maps to the workflow's trigger input and is passed to the first node of the run.
+
+### Example
+
+```bash
+curl -X POST https://app.keeperhub.com/api/workflows/wf_123/execute \
+  -H "Authorization: Bearer $KEEPERHUB_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {}}'
+```
 
 ### Response
 
 ```json
 {
   "executionId": "exec_123",
-  "runId": "run_abc123",
-  "status": "pending"
+  "status": "running"
 }
 ```
-
-The `runId` identifies the workflow execution run and is stored in the workflow execution record.
 
 ## Webhook Trigger
 

--- a/tests/unit/workflows-execute-alias.test.ts
+++ b/tests/unit/workflows-execute-alias.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("workflow/api", () => ({ start: vi.fn() }));
+
+describe("KEEP-477: plural /api/workflows/[id]/execute alias", () => {
+  it("re-exports the same POST handler as the singular route", async () => {
+    const singular = await import(
+      "@/app/api/workflow/[workflowId]/execute/route"
+    );
+    const plural = await import(
+      "@/app/api/workflows/[workflowId]/execute/route"
+    );
+
+    expect(typeof plural.POST).toBe("function");
+    expect(plural.POST).toBe(singular.POST);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `app/api/workflows/[workflowId]/execute/route.ts` as an alias that re-exports the POST handler from the singular path. Both routes now resolve to the same handler with no redirect hop.
- Updates `docs/api/workflows.md` to advertise the plural path as canonical, removes the prior note warning about path inconsistency, and adds a curl example.
- Adds a unit test asserting the plural and singular routes export the same `POST` reference.

## Why

KEEP-477: every REST guess at the trigger endpoint returned 404 (HTML, because Next.js owns wrong paths). The handler lived at singular `/api/workflow/` while every other workflow endpoint uses plural `/api/workflows/`, so plural was the natural first guess and silently broke clients (Tradewise had to abandon REST mid-hackathon and switch to MCP).

Singular handler is left in place because internal callers (`keeperhub-executor`, `lib/api-client.ts`, `components/workflow/workflow-toolbar.tsx`, `lib/mcp/tools.ts`) still hit it. No client breakage; canonical path documented.

Linear: https://linear.app/keeperhubapp/issue/KEEP-477