### PR TITLE
fix(api): KEEP-481 coerce execution step counts to number|null

### DIFF
--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -6,6 +6,14 @@ import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 
+function parseIntOrNull(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 export async function GET(
   request: Request,
   context: { params: Promise<{ workflowId: string }> }
@@ -55,7 +63,19 @@ export async function GET(
       limit: 50,
     });
 
-    return NextResponse.json(executions);
+    // KEEP-481: `total_steps` and `completed_steps` are stored as TEXT and
+    // Drizzle returns them as strings, which leaks into the response as
+    // string-or-null and breaks type-checked SDK clients (Pydantic, Zod, Go).
+    // Coerce to `number | null` before serializing so the response matches the
+    // numeric shape clients expect; non-numeric strings (shouldn't happen) fall
+    // through as null rather than NaN.
+    const serialized = executions.map((execution) => ({
+      ...execution,
+      totalSteps: parseIntOrNull(execution.totalSteps),
+      completedSteps: parseIntOrNull(execution.completedSteps),
+    }));
+
+    return NextResponse.json(serialized);
   } catch (error) {
     logSystemError(ErrorCategory.DATABASE, "Failed to get executions", error, {
       endpoint: "/api/workflows/[workflowId]/executions",

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -65,8 +65,8 @@ type WorkflowExecution = {
   duration: string | null;
   error: string | null;
   // Progress tracking fields
-  totalSteps: string | null;
-  completedSteps: string | null;
+  totalSteps: number | null;
+  completedSteps: number | null;
   currentNodeId: string | null;
   currentNodeName: string | null;
   lastSuccessfulNodeId: string | null;

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -627,8 +627,8 @@ export const workflowApi = {
         completedAt: Date | null;
         duration: string | null;
         // Progress tracking fields
-        totalSteps: string | null;
-        completedSteps: string | null;
+        totalSteps: number | null;
+        completedSteps: number | null;
         currentNodeId: string | null;
         currentNodeName: string | null;
         lastSuccessfulNodeId: string | null;

--- a/tests/unit/executions-route-step-coercion.test.ts
+++ b/tests/unit/executions-route-step-coercion.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const findManyMock = vi.fn();
+const findFirstMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      workflows: { findFirst: findFirstMock },
+      workflowExecutions: { findMany: findManyMock },
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: vi.fn().mockResolvedValue({
+    userId: "user_1",
+    organizationId: null,
+    authMethod: "session",
+  }),
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: vi
+    .fn()
+    .mockResolvedValue({ hasFullAccess: true, isDeleted: false }),
+}));
+
+describe("KEEP-481: executions list coerces step counts to number|null", () => {
+  it("returns totalSteps and completedSteps as numbers when set", async () => {
+    findFirstMock.mockResolvedValueOnce({ id: "wf_1", userId: "user_1" });
+    findManyMock.mockResolvedValueOnce([
+      {
+        id: "exec_1",
+        workflowId: "wf_1",
+        userId: "user_1",
+        status: "success",
+        totalSteps: "4",
+        completedSteps: "4",
+      },
+    ]);
+
+    const { GET } = await import(
+      "@/app/api/workflows/[workflowId]/executions/route"
+    );
+    const response = await GET(new Request("http://test/executions"), {
+      params: Promise.resolve({ workflowId: "wf_1" }),
+    });
+    const body = (await response.json()) as Array<{
+      totalSteps: unknown;
+      completedSteps: unknown;
+    }>;
+
+    expect(body[0].totalSteps).toBe(4);
+    expect(body[0].completedSteps).toBe(4);
+  });
+
+  it("returns null when totalSteps is null in the database row", async () => {
+    findFirstMock.mockResolvedValueOnce({ id: "wf_1", userId: "user_1" });
+    findManyMock.mockResolvedValueOnce([
+      {
+        id: "exec_1",
+        workflowId: "wf_1",
+        userId: "user_1",
+        status: "running",
+        totalSteps: null,
+        completedSteps: "0",
+      },
+    ]);
+
+    const { GET } = await import(
+      "@/app/api/workflows/[workflowId]/executions/route"
+    );
+    const response = await GET(new Request("http://test/executions"), {
+      params: Promise.resolve({ workflowId: "wf_1" }),
+    });
+    const body = (await response.json()) as Array<{
+      totalSteps: unknown;
+      completedSteps: unknown;
+    }>;
+
+    expect(body[0].totalSteps).toBeNull();
+    expect(body[0].completedSteps).toBe(0);
+  });
+
+  it("returns null for non-numeric strings rather than NaN", async () => {
+    findFirstMock.mockResolvedValueOnce({ id: "wf_1", userId: "user_1" });
+    findManyMock.mockResolvedValueOnce([
+      {
+        id: "exec_1",
+        workflowId: "wf_1",
+        userId: "user_1",
+        status: "error",
+        totalSteps: "garbage",
+        completedSteps: "also-bad",
+      },
+    ]);
+
+    const { GET } = await import(
+      "@/app/api/workflows/[workflowId]/executions/route"
+    );
+    const response = await GET(new Request("http://test/executions"), {
+      params: Promise.resolve({ workflowId: "wf_1" }),
+    });
+    const body = (await response.json()) as Array<{
+      totalSteps: unknown;
+      completedSteps: unknown;
+    }>;
+
+    expect(body[0].totalSteps).toBeNull();
+    expect(body[0].completedSteps).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `GET /api/workflows/{id}/executions` now returns `totalSteps` and `completedSteps` as `number | null` rather than `string | null`.
- Coercion happens in the route handler (`app/api/workflows/[workflowId]/executions/route.ts`); column type stays TEXT for now to avoid a migration ordering dance with the executor that still writes strings.
- Non-numeric strings (shouldn't happen, defensive) parse to `null` rather than `NaN`.
- Updated client-side types: `lib/api-client.ts` `getExecutions` and the matching `WorkflowRun` type in `components/workflow/workflow-runs.tsx`.

## Why

KEEP-481: `lib/db/schema.ts` declares both columns as `text("...")`, Drizzle returns them as strings, and the route serialized them verbatim. Type-checked SDK clients (Pydantic, Zod, Go structs) hit the mismatch and either fail or coerce silently. The column-level fix can come later as a follow-up; this PR closes the consumer pain immediately.

Linear: https://linear.app/keeperhubapp/issue/KEEP-481