### PR TITLE
fix(api): KEEP-490 accept chainId as canonical chain input on execute endpoints

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { getProtocol } from "@/lib/protocol-registry";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { PLUGIN_STEP_IMPORTERS } from "@/lib/step-registry";
 import { resolveProtocolMeta } from "@/plugins/protocol/steps/resolve-protocol-meta";
 import {
@@ -80,13 +81,36 @@ async function executeProtocolAction(
     );
   }
 
-  const network = String(body.network ?? "");
-  if (!network) {
+  // KEEP-490: accept `chainId` as the canonical input, with `network` as a
+  // deprecated alias. Either field may carry the numeric chain ID (1, 11155111)
+  // or a known chain name/slug ("ethereum", "sepolia", "base"). Downstream
+  // helpers (contract.addresses, resolveAbi, the chain adapter) are keyed by
+  // numeric chainId, so normalize here once.
+  const rawNetwork = String(body.chainId ?? body.network ?? "");
+  if (!rawNetwork) {
     return NextResponse.json(
-      { success: false, error: "Missing required field: network" },
+      {
+        success: false,
+        error:
+          "Missing required field: chainId (or network, which is a deprecated alias)",
+      },
       { status: 400 }
     );
   }
+
+  let resolvedChainId: number;
+  try {
+    resolvedChainId = getChainIdFromNetwork(rawNetwork);
+  } catch (err: unknown) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 400 }
+    );
+  }
+  const network = String(resolvedChainId);
 
   const contractAddress = contract.userSpecifiedAddress
     ? String(body.contractAddress ?? "")
@@ -98,7 +122,7 @@ async function executeProtocolAction(
         success: false,
         error: contract.userSpecifiedAddress
           ? `Missing contract address for "${meta.contractKey}"`
-          : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on network "${network}"`,
+          : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on chain ${network} (input: "${rawNetwork}")`,
       },
       { status: 400 }
     );

--- a/app/api/execute/_lib/validate.ts
+++ b/app/api/execute/_lib/validate.ts
@@ -22,6 +22,30 @@ function requiredFieldError(field: string): ValidationResult {
   };
 }
 
+// KEEP-490: accept `chainId` as the canonical input field, with `network` as a
+// deprecated alias. Either is treated as present so long as one carries a
+// non-empty string. Numeric chainIds may be sent as numbers; we coerce here.
+function hasChainInput(record: Record<string, unknown>): boolean {
+  if (typeof record.chainId === "number") {
+    return true;
+  }
+  return (
+    isNonEmptyString(record.chainId) || isNonEmptyString(record.network)
+  );
+}
+
+function chainFieldError(): ValidationResult {
+  return {
+    valid: false,
+    error: {
+      error: "Missing required field",
+      field: "chainId",
+      details:
+        "chainId is required (network is accepted as a deprecated alias). Pass a numeric chain ID or a known chain name.",
+    },
+  };
+}
+
 export function validateTransferInput(body: unknown): ValidationResult {
   if (!body || typeof body !== "object") {
     return {
@@ -32,8 +56,8 @@ export function validateTransferInput(body: unknown): ValidationResult {
 
   const record = body as Record<string, unknown>;
 
-  if (!isNonEmptyString(record.network)) {
-    return requiredFieldError("network");
+  if (!hasChainInput(record)) {
+    return chainFieldError();
   }
 
   if (!isNonEmptyString(record.recipientAddress)) {
@@ -61,8 +85,8 @@ export function validateContractCallInput(body: unknown): ValidationResult {
     return requiredFieldError("contractAddress");
   }
 
-  if (!isNonEmptyString(record.network)) {
-    return requiredFieldError("network");
+  if (!hasChainInput(record)) {
+    return chainFieldError();
   }
 
   if (!isNonEmptyString(record.functionName)) {
@@ -248,8 +272,8 @@ export function validateCheckAndExecuteInput(body: unknown): ValidationResult {
     return requiredFieldError("contractAddress");
   }
 
-  if (!isNonEmptyString(record.network)) {
-    return requiredFieldError("network");
+  if (!hasChainInput(record)) {
+    return chainFieldError();
   }
 
   if (!isNonEmptyString(record.functionName)) {

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -170,7 +170,8 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json(validation.error, { status: 400 });
   }
 
-  const network = body.network as string;
+  // KEEP-490: chainId is the canonical input; network is a deprecated alias.
+  const network = String(body.chainId ?? body.network ?? "");
   const condition = body.condition as ConditionInput;
   const action = body.action as ActionBody;
 

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -175,6 +175,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json(validation.error, { status: 400 });
   }
 
+  // KEEP-490: collapse `chainId` (canonical) and `network` (deprecated alias)
+  // onto a single field so the downstream read sites do not have to know about
+  // both. The core helpers normalize chain names/IDs internally.
+  if (body.chainId !== undefined && body.network === undefined) {
+    body.network = String(body.chainId);
+  }
+
   const abiResult = await resolveAbiForRequest(body);
   if ("error" in abiResult) {
     return NextResponse.json(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -61,8 +61,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json(tokenValidation.error, { status: 400 });
   }
 
-  const { network, recipientAddress, amount } = body as {
-    network: string;
+  // KEEP-490: accept `chainId` as canonical, `network` as deprecated alias.
+  // The core helper normalizes the value internally (chainId number / string,
+  // or a known chain name) so we just pick whichever field is present.
+  const network = String((body as Record<string, unknown>).chainId ?? body.network ?? "");
+  const { recipientAddress, amount } = body as {
     recipientAddress: string;
     amount: string;
   };

--- a/app/api/mcp/schemas/route.ts
+++ b/app/api/mcp/schemas/route.ts
@@ -356,7 +356,7 @@ export async function GET(request: Request) {
     tips: [
       "actionType must match exactly (e.g., 'web3/check-balance', not 'Get Wallet Balance')",
       "Use {{@nodeId:Label.field}} syntax to reference outputs from previous nodes",
-      "network should be chain ID as string (e.g., '1' for mainnet, '11155111' for sepolia)",
+      "chainId is the canonical field for the target chain (e.g., 1 for Ethereum mainnet, 11155111 for Sepolia, 8453 for Base). Accepts a number or stringified number. The legacy `network` field is still accepted as a deprecated alias and also resolves common chain names (mainnet/ethereum, sepolia, base, base-sepolia, etc.).",
       "Edges need id, source, and target. For Condition nodes, also set sourceHandle to 'true' or 'false' to control which branch executes.",
       "For verified contracts, ABI is auto-fetched. For unverified contracts, provide ABI manually.",
       "Condition nodes have dual output handles ('true' and 'false'). Set sourceHandle on edges to route execution. For if/else, connect different nodes to each handle of a single Condition node.",

--- a/docs/api/chains.md
+++ b/docs/api/chains.md
@@ -59,13 +59,39 @@ Returns all supported blockchain networks.
 | `evm` | Ethereum Virtual Machine compatible |
 | `solana` | Solana network |
 
+## Chain Identifiers
+
+KeeperHub action and execute endpoints accept either of two equivalent fields for selecting the target chain:
+
+- `chainId` (canonical): the numeric chain ID. Send a number or a stringified number. Examples: `1`, `8453`, `11155111`.
+- `network` (deprecated alias): same field, retained for backward compatibility. In addition to numeric chain IDs, it resolves the common chain names below.
+
+Prefer `chainId` in new clients. Both fields produce identical behavior; passing both is treated as `chainId` winning.
+
+### Accepted Chain Names
+
+These string aliases are normalized to the numeric chain ID before routing. Names are case-insensitive.
+
+| Name aliases | chainId | Network |
+|---|---|---|
+| `mainnet`, `ethereum`, `eth-mainnet`, `ethereum-mainnet` | 1 | Ethereum Mainnet |
+| `sepolia`, `eth-sepolia`, `sepolia-testnet` | 11155111 | Ethereum Sepolia |
+| `base`, `base-mainnet` | 8453 | Base |
+| `base-sepolia`, `base-testnet` | 84532 | Base Sepolia |
+| `tempo`, `tempo-mainnet` | 4217 | Tempo |
+| `tempo-testnet` | 42431 | Tempo Testnet |
+| `solana`, `solana-mainnet` | 101 | Solana |
+| `solana-devnet`, `solana-testnet` | 103 | Solana Devnet |
+
+Numeric chain IDs (as number or string) are accepted on every chain, including any chain present in `GET /api/chains` that does not appear in the alias table above.
+
 ## Fetch Contract ABI
 
 ```http
 GET /api/chains/{chainId}/abi?address={contractAddress}
 ```
 
-Fetches the ABI for a verified contract from the block explorer.
+Fetches the ABI for a verified contract from the block explorer. The `{chainId}` path parameter is the numeric chain ID (e.g., `1`, `8453`, `11155111`), not a chain name and not the internal `id` field from `GET /api/chains`.
 
 ### Query Parameters
 

--- a/tests/unit/execute-protocol-route-chain-resolution.test.ts
+++ b/tests/unit/execute-protocol-route-chain-resolution.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+vi.mock("../../app/api/execute/_lib/auth", () => ({
+  validateApiKey: vi
+    .fn()
+    .mockResolvedValue({ organizationId: "org_1", apiKeyId: "key_1" }),
+}));
+
+vi.mock("../../app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: vi.fn(),
+}));
+
+vi.mock("@/lib/abi/cache", () => ({
+  resolveAbi: vi.fn().mockResolvedValue({ abi: "[]", source: "definition" }),
+}));
+
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: vi.fn().mockReturnValue({
+    protocolSlug: "test-protocol",
+    contractKey: "router",
+    functionName: "swap",
+    actionType: "write",
+  }),
+}));
+
+const getProtocolMock = vi.fn().mockReturnValue({
+  contracts: {
+    router: {
+      addresses: {
+        "1": "0xMainnetRouter",
+        "11155111": "0xSepoliaRouter",
+        "8453": "0xBaseRouter",
+      },
+    },
+  },
+  actions: [],
+});
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: (...args: unknown[]) => getProtocolMock(...args),
+}));
+
+const writeContractCoreMock = vi.fn().mockResolvedValue({
+  success: true,
+  transactionHash: "0xtx",
+});
+vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
+  writeContractCore: (input: unknown) => writeContractCoreMock(input),
+}));
+
+vi.mock("@/plugins/web3/steps/read-contract-core", () => ({
+  readContractCore: vi.fn(),
+}));
+
+vi.mock("@/lib/step-registry", () => ({
+  PLUGIN_STEP_IMPORTERS: { "test-protocol/swap": () => Promise.resolve({}) },
+}));
+
+async function postWithBody(body: Record<string, unknown>): Promise<Response> {
+  const { POST } = await import("@/app/api/execute/[...slug]/route");
+  const req = new Request("http://test/api/execute/test-protocol/swap", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json", authorization: "Bearer x" },
+  });
+  return POST(req, {
+    params: Promise.resolve({ slug: ["test-protocol", "swap"] }),
+  });
+}
+
+describe("KEEP-490: /api/execute/[...slug] resolves chain names and chainId aliases", () => {
+  it("resolves network='sepolia' to chainId 11155111 for contract address lookup", async () => {
+    writeContractCoreMock.mockClear();
+    const response = await postWithBody({ network: "sepolia" });
+
+    expect(response.status).toBe(200);
+    expect(writeContractCoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractAddress: "0xSepoliaRouter",
+        network: "11155111",
+      })
+    );
+  });
+
+  it("accepts chainId as canonical input", async () => {
+    writeContractCoreMock.mockClear();
+    const response = await postWithBody({ chainId: 8453 });
+
+    expect(response.status).toBe(200);
+    expect(writeContractCoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractAddress: "0xBaseRouter",
+        network: "8453",
+      })
+    );
+  });
+
+  it("returns 400 with a clear error when both chainId and network are missing", async () => {
+    const response = await postWithBody({});
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/chainId/);
+  });
+
+  it("returns 400 for an unknown chain name", async () => {
+    const response = await postWithBody({ network: "not-a-real-chain" });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/unit/execute-validate-chain-input.test.ts
+++ b/tests/unit/execute-validate-chain-input.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCheckAndExecuteInput,
+  validateContractCallInput,
+  validateTransferInput,
+} from "@/app/api/execute/_lib/validate";
+
+describe("KEEP-490: execute validators accept chainId or network", () => {
+  describe("validateTransferInput", () => {
+    it("accepts chainId as canonical field", () => {
+      const result = validateTransferInput({
+        chainId: 11_155_111,
+        recipientAddress: "0xabc",
+        amount: "1",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts network as deprecated alias", () => {
+      const result = validateTransferInput({
+        network: "sepolia",
+        recipientAddress: "0xabc",
+        amount: "1",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects when both chainId and network are missing", () => {
+      const result = validateTransferInput({
+        recipientAddress: "0xabc",
+        amount: "1",
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.field).toBe("chainId");
+      }
+    });
+
+    it("accepts stringified chainId", () => {
+      const result = validateTransferInput({
+        chainId: "11155111",
+        recipientAddress: "0xabc",
+        amount: "1",
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("validateContractCallInput", () => {
+    it("accepts chainId as canonical field", () => {
+      const result = validateContractCallInput({
+        chainId: 1,
+        contractAddress: "0xabc",
+        functionName: "balanceOf",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts network alias", () => {
+      const result = validateContractCallInput({
+        network: "ethereum",
+        contractAddress: "0xabc",
+        functionName: "balanceOf",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects when both fields are missing", () => {
+      const result = validateContractCallInput({
+        contractAddress: "0xabc",
+        functionName: "balanceOf",
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.field).toBe("chainId");
+      }
+    });
+  });
+
+  describe("validateCheckAndExecuteInput", () => {
+    const baseValidExtras = {
+      contractAddress: "0xabc",
+      functionName: "deposit",
+      condition: { operator: "lt", value: "1" },
+      action: { contractAddress: "0xabc", functionName: "f" },
+    };
+
+    it("accepts chainId as canonical field", () => {
+      const result = validateCheckAndExecuteInput({
+        chainId: 8453,
+        ...baseValidExtras,
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts network alias", () => {
+      const result = validateCheckAndExecuteInput({
+        network: "base",
+        ...baseValidExtras,
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects when both chain inputs are missing", () => {
+      const result = validateCheckAndExecuteInput(baseValidExtras);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.field).toBe("chainId");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `/api/execute/[...slug]` now normalizes the chain input (`chainId` or `network`, accepting numeric chain ID or known chain name) **before** the `contract.addresses[network]` lookup. Previously `network: \"sepolia\"` failed the lookup outright because `contract.addresses` is keyed by stringified chainId.
- `transfer`, `contract-call`, and `check-and-execute` routes accept `chainId` as the canonical field, with `network` retained as a deprecated alias.
- Validators check that **one of** `chainId | network` is present rather than hard-requiring `network`. Error messages now name `chainId` as canonical.
- MCP schemas `tips` entry rewritten so LLM/MCP clients see `chainId` as the canonical field and the alias set documented inline.
- `docs/api/chains.md` gains a Chain Identifiers section with the full alias table (mainnet/ethereum/eth-mainnet, sepolia/eth-sepolia, base, base-sepolia, tempo, solana, etc.) and clarifies that `{chainId}` in `/api/chains/{chainId}/abi` is the numeric chain ID (not the internal `id`).

## Why

KEEP-490: hackathon evidence showed builders rejected mid-build because `network` required a stringified chainId but docs used names. Aliases like `mainnet`, `eth-mainnet`, `ethereum-mainnet` already resolved inside `getChainIdFromNetwork` but the protocol-execute boundary bypassed the helper. This PR routes every execute boundary through that single normalization point.

## Not in this PR (follow-ups)

- Renaming `network` -> `chainId` in every plugin step's `configFields` definition.
- Saved-workflow data migration converting existing `network` keys on stored node configs.

Both of those touch 50+ files and need a separate, scoped PR with its own migration plan.

## Tests

- `tests/unit/execute-validate-chain-input.test.ts` - validator behavior for chainId/network parity.
- `tests/unit/execute-protocol-route-chain-resolution.test.ts` - route-level chain name resolution for the contract.addresses lookup.

Linear: https://linear.app/keeperhubapp/issue/KEEP-490