### PR TITLE
fix(executor): right-size workflow Job pod CPU and memory requests

### DIFF
--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -138,8 +138,8 @@ export async function createWorkflowJob(params: {
               imagePullPolicy: CONFIG.imagePullPolicy,
               env: envVars,
               resources: {
-                requests: { memory: "128Mi", cpu: "100m" },
-                limits: { memory: "512Mi", cpu: "500m" },
+                requests: { memory: "160Mi", cpu: "200m" },
+                limits: { memory: "320Mi", cpu: "750m" },
               },
             },
           ],


### PR DESCRIPTION
## Summary
- Bump workflow Job pod `requests.cpu` 100m -> 200m
- Bump `requests.memory` 128Mi -> 160Mi
- Raise `limits.cpu` 500m -> 750m (was throttling startup bursts)
- Trim `limits.memory` 512Mi -> 320Mi (was over-provisioned, p99 = 192Mi)

## Why
The techops-prod cluster has been saturating at 100% CPU on multiple nodes because workflow Job pods were under-requested. The K8s scheduler was packing 27+ pods on a 2-vCPU node based on the old 100m request, while real CPU usage averaged ~218m per pod. Karpenter could not see scheduling pressure (sum-of-requests was nominally fine) and the cluster never scaled out.

New values are based on Prometheus p95/p99 measurements from techops-prod taken after the canary-traffic noise was reduced. With 200m requests, the scheduler treats each pod realistically and Karpenter scales the node pool when load grows.

See KEEP-582 for the full investigation, including dimensional analysis, growth timeline, and prior incident correlation.

## Test plan
- [x] `biome check keeperhub-executor/k8s-job.ts` clean
- [x] `pnpm type-check` passes
- [x] `pnpm test:unit` 4869/4869 pass
- [ ] Soak in staging, confirm workflow Jobs schedule successfully with new values
- [ ] Confirm Karpenter adds nodes under scheduling pressure when load grows
- [ ] Watch for CPU throttling under heavier customer workflows; raise `limits.cpu` to 1000m if observed