### PR TITLE
feat: add link-only workflow sharing

### DIFF
--- a/app/api/og/generate-og.tsx
+++ b/app/api/og/generate-og.tsx
@@ -804,7 +804,9 @@ export async function generateWorkflowOGImage(
       return new Response("Workflow not found", { status: 404 });
     }
 
-    if (workflow.visibility !== "public") {
+    // Unlisted workflows are link-shareable, so they also get an OG preview.
+    // Only private workflows refuse OG rendering.
+    if (workflow.visibility === "private") {
       return new Response("Workflow is private", { status: 403 });
     }
 

--- a/app/api/workflows/[workflowId]/go-live/route.ts
+++ b/app/api/workflows/[workflowId]/go-live/route.ts
@@ -47,12 +47,32 @@ export async function PUT(
 
     const body = await request.json().catch(() => ({}));
     const name = body.name?.trim();
+    const rawMode = body.mode;
+    const mode: "public" | "unlisted" =
+      rawMode === "unlisted" ? "unlisted" : "public";
+
+    if (rawMode !== undefined && rawMode !== "public" && rawMode !== "unlisted") {
+      return NextResponse.json(
+        { error: "Invalid mode. Must be 'public' or 'unlisted'." },
+        { status: 400 }
+      );
+    }
+
     const publicTagIds: string[] = Array.isArray(body.publicTagIds)
       ? body.publicTagIds
       : [];
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
+    }
+
+    // Unlisted = link-only sharing; tags are a Hub-discovery feature, so
+    // reject tag payloads under unlisted rather than silently dropping them.
+    if (mode === "unlisted" && publicTagIds.length > 0) {
+      return NextResponse.json(
+        { error: "Tags are not allowed when sharing as unlisted." },
+        { status: 400 }
+      );
     }
 
     if (publicTagIds.length > 5) {
@@ -67,16 +87,18 @@ export async function PUT(
         .update(workflows)
         .set({
           name,
-          visibility: "public",
+          visibility: mode,
           updatedAt: new Date(),
         })
         .where(eq(workflows.id, workflowId));
 
+      // Unlisted workflows never carry Hub tags; clear any leftover rows
+      // from a previous public listing so demote-to-unlisted is clean.
       await tx
         .delete(workflowPublicTags)
         .where(eq(workflowPublicTags.workflowId, workflowId));
 
-      if (publicTagIds.length > 0) {
+      if (mode === "public" && publicTagIds.length > 0) {
         await tx.insert(workflowPublicTags).values(
           publicTagIds.map((tagId) => ({
             workflowId,

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -100,10 +100,11 @@ export async function GET(
     });
 
     // Access control:
-    // - Public workflows: anyone can view (sanitized)
+    // - Public workflows: anyone can view (sanitized), Hub-listed
+    // - Unlisted workflows: anyone with the link can view (sanitized), not on Hub
     // - Private workflows: owner or org member can view
     // - Anonymous workflows: only owner can view
-    if (!access.hasFullAccess && workflow.visibility !== "public") {
+    if (!access.hasFullAccess && workflow.visibility === "private") {
       return NextResponse.json(
         { error: "Workflow not found" },
         { status: 404 }
@@ -211,6 +212,7 @@ function isValidVisibility(visibility: unknown): boolean {
   return (
     visibility === undefined ||
     visibility === "private" ||
+    visibility === "unlisted" ||
     visibility === "public"
   );
 }
@@ -251,7 +253,9 @@ async function handlePostUpdateSideEffects(
   workflowId: string,
   body: Record<string, unknown>
 ): Promise<void> {
-  if (body.visibility === "private") {
+  // Tags are Hub-discovery only; clear them on any demote off of "public",
+  // including demote-to-unlisted (link-only) and demote-to-private.
+  if (body.visibility === "private" || body.visibility === "unlisted") {
     await db
       .delete(workflowPublicTags)
       .where(eq(workflowPublicTags.workflowId, workflowId));
@@ -337,7 +341,10 @@ export async function PATCH(
     // Validate visibility value if provided
     if (!isValidVisibility(body.visibility)) {
       return NextResponse.json(
-        { error: "Invalid visibility value. Must be 'private' or 'public'" },
+        {
+          error:
+            "Invalid visibility value. Must be 'private', 'unlisted', or 'public'",
+        },
         { status: 400 }
       );
     }

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -157,7 +157,7 @@ export default async function HubPage({
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-x-hidden overflow-y-auto bg-sidebar [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       <div className="flex min-h-full flex-col md:ml-[var(--nav-sidebar-width,60px)]">
-        <div className="container mx-auto max-w-7xl px-6 pt-20 pb-8">
+        <div className="container mx-auto max-w-7xl px-6 pb-8 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <HubHero />
           <HubTabsShell
             actionsSlot={<HubExternalLinks />}

--- a/app/workflows/[workflowId]/layout.tsx
+++ b/app/workflows/[workflowId]/layout.tsx
@@ -17,7 +17,10 @@ export async function generateMetadata({
 
   // Try to fetch the workflow to get its name
   let title = "Workflow";
-  let isPublic = false;
+  // isShareable = anyone with the link may view (public OR unlisted). Drives
+  // both name/OG-image exposure in metadata and rich link previews; private
+  // workflows stay fully redacted to prevent name enumeration.
+  let isShareable = false;
 
   try {
     const workflow = await db.query.workflows.findFirst({
@@ -29,10 +32,8 @@ export async function generateMetadata({
     });
 
     if (workflow) {
-      isPublic = workflow.visibility === "public";
-      // Only expose workflow name in metadata if it's public
-      // This prevents private workflow name enumeration
-      if (isPublic) {
+      isShareable = workflow.visibility !== "private";
+      if (isShareable) {
         title = workflow.name;
       }
     }
@@ -43,7 +44,7 @@ export async function generateMetadata({
   const baseUrl =
     process.env.NEXT_PUBLIC_APP_URL || "https://app.keeperhub.com";
   const workflowUrl = `${baseUrl}/workflows/${workflowId}`;
-  const ogImageUrl = isPublic
+  const ogImageUrl = isShareable
     ? `${baseUrl}/api/og/workflow/${workflowId}`
     : `${baseUrl}/api/og/default`;
 

--- a/components/app-banner.tsx
+++ b/components/app-banner.tsx
@@ -3,7 +3,9 @@
 import { Info, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useSession } from "@/lib/auth-client";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
+import { isAnonymousUser } from "@/lib/is-anonymous";
 
 const STORAGE_KEY = "kh-billing-announce-v1";
 
@@ -17,6 +19,9 @@ export function AppBanner(): React.ReactElement | null {
 function BillingBanner(): React.ReactElement | null {
   const [mounted, setMounted] = useState(false);
   const [dismissed, setDismissed] = useState(true);
+  const { data: session, isPending } = useSession();
+  const isAnonymous = isAnonymousUser(session?.user);
+  const visible = mounted && !dismissed && !isPending && !isAnonymous;
 
   useEffect(() => {
     setMounted(true);
@@ -29,18 +34,15 @@ function BillingBanner(): React.ReactElement | null {
   }, []);
 
   useEffect(() => {
-    if (!mounted) {
-      return;
-    }
-    if (dismissed) {
-      document.documentElement.style.removeProperty("--app-banner-height");
-    } else {
+    if (visible) {
       document.documentElement.style.setProperty("--app-banner-height", "36px");
+    } else {
+      document.documentElement.style.removeProperty("--app-banner-height");
     }
     return (): void => {
       document.documentElement.style.removeProperty("--app-banner-height");
     };
-  }, [mounted, dismissed]);
+  }, [visible]);
 
   function handleDismiss(): void {
     try {
@@ -51,7 +53,7 @@ function BillingBanner(): React.ReactElement | null {
     setDismissed(true);
   }
 
-  if (!mounted || dismissed) {
+  if (!visible) {
     return null;
   }
 

--- a/components/overlays/configuration-overlay.tsx
+++ b/components/overlays/configuration-overlay.tsx
@@ -524,8 +524,8 @@ export function ConfigurationOverlay({ overlayId }: ConfigurationOverlayProps) {
               {!isOwner && (
                 <div className="rounded-lg border border-muted bg-muted/30 p-3">
                   <p className="text-muted-foreground text-sm">
-                    You are viewing a public workflow. Duplicate it to make
-                    changes.
+                    You're viewing this workflow in read-only mode.
+                    Use it as a template to create your own editable copy.
                   </p>
                 </div>
               )}

--- a/components/overlays/go-live-overlay.tsx
+++ b/components/overlays/go-live-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, Share2 } from "lucide-react";
+import { AlertTriangle, Globe, Link2, Lock } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Overlay } from "@/components/overlays/overlay";
@@ -8,69 +8,136 @@ import { useOverlay } from "@/components/overlays/overlay-provider";
 import type { OverlayComponentProps } from "@/components/overlays/types";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { api, type PublicTag } from "@/lib/api-client";
+import type { WorkflowVisibility } from "@/lib/workflow/store";
 import { PublicTagSelector } from "./public-tag-selector";
+
+type GoLiveResult = {
+  name: string;
+  publicTags: PublicTag[];
+  visibility: WorkflowVisibility;
+};
 
 type GoLiveOverlayProps = OverlayComponentProps<{
   workflowId: string;
   currentName: string;
+  currentVisibility: WorkflowVisibility;
   orgTagNames: string[];
   initialTags?: PublicTag[];
   isEditing?: boolean;
-  onConfirm: (data: { name: string; publicTags: PublicTag[] }) => void;
+  onConfirm: (data: GoLiveResult) => void;
 }>;
 
 export function GoLiveOverlay({
   overlayId,
   workflowId,
   currentName,
+  currentVisibility,
   orgTagNames,
   initialTags = [],
   isEditing = false,
   onConfirm,
-}: GoLiveOverlayProps) {
+}: GoLiveOverlayProps): React.JSX.Element {
   const { closeAll } = useOverlay();
   const [name, setName] = useState(currentName);
   const [selectedTags, setSelectedTags] = useState<PublicTag[]>(initialTags);
+  const [access, setAccess] = useState<WorkflowVisibility>(
+    currentVisibility ?? "private"
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCopying, setIsCopying] = useState(false);
   const [copied, setCopied] = useState(false);
 
   const title = isEditing ? "Share Settings" : "Share";
-  const submitLabel = isEditing ? "Save Changes" : "Share";
-  const submittingTitle = isEditing ? "Saving..." : "Sharing...";
 
-  const handleSubmit = async (): Promise<void> => {
+  const persistChanges = async (
+    targetVisibility: WorkflowVisibility,
+    options: { closeAfter: boolean; quiet?: boolean }
+  ): Promise<GoLiveResult | null> => {
     const trimmedName = name.trim();
     if (!trimmedName) {
       toast.error("Please enter a workflow name");
-      return;
+      return null;
     }
 
-    setIsSubmitting(true);
+    if (!options.quiet) {
+      setIsSubmitting(true);
+    }
     try {
-      await api.workflow.goLive(workflowId, {
+      if (targetVisibility === "private") {
+        await api.workflow.update(workflowId, {
+          name: trimmedName,
+          visibility: "private",
+        });
+      } else {
+        await api.workflow.goLive(workflowId, {
+          name: trimmedName,
+          mode: targetVisibility,
+          publicTagIds:
+            targetVisibility === "public"
+              ? selectedTags.map((t) => t.id)
+              : undefined,
+        });
+      }
+      const result: GoLiveResult = {
         name: trimmedName,
-        publicTagIds: selectedTags.map((t) => t.id),
-      });
-      closeAll();
-      // Defer state updates until after close animation to prevent visual glitch
-      setTimeout(() => {
-        onConfirm({ name: trimmedName, publicTags: selectedTags });
-      }, 250);
+        publicTags: targetVisibility === "public" ? selectedTags : [],
+        visibility: targetVisibility,
+      };
+      if (options.closeAfter) {
+        closeAll();
+        setTimeout(() => onConfirm(result), 250);
+      } else {
+        setIsSubmitting(false);
+        onConfirm(result);
+      }
+      return result;
     } catch (error) {
       setIsSubmitting(false);
       toast.error(
-        error instanceof Error
-          ? error.message
-          : `Failed to ${title.toLowerCase()}`
+        error instanceof Error ? error.message : `Failed to ${title.toLowerCase()}`
       );
+      return null;
     }
+  };
+
+  const handleDone = async (): Promise<void> => {
+    await persistChanges(access, { closeAfter: true });
+  };
+
+  const handleCopyLink = async (): Promise<void> => {
+    setIsCopying(true);
+    // Persist any pending non-private access change first so the recipient's
+    // link matches what's shown in the dialog. Private stays private — the
+    // user is explicitly copying a private URL and we don't silently promote.
+    if (access !== "private" && access !== currentVisibility) {
+      const result = await persistChanges(access, {
+        closeAfter: false,
+        quiet: true,
+      });
+      if (!result) {
+        setIsCopying(false);
+        return;
+      }
+    }
+    await navigator.clipboard.writeText(window.location.href);
+    setIsCopying(false);
+    setCopied(true);
+    toast.success("Link copied to clipboard");
+    setTimeout(() => setCopied(false), 2000);
   };
 
   if (isSubmitting) {
     return (
-      <Overlay overlayId={overlayId} title={submittingTitle}>
+      <Overlay overlayId={overlayId} title={`${title}...`}>
         <div className="flex items-center justify-center py-8">
           <Spinner />
         </div>
@@ -82,21 +149,20 @@ export function GoLiveOverlay({
     <Overlay
       actions={[
         {
-          label: copied ? "Copied" : "Copy link",
+          label: isCopying ? "Copying..." : copied ? "Copied" : "Copy link",
           variant: "ghost" as const,
           onClick: () => {
-            navigator.clipboard.writeText(window.location.href);
-            setCopied(true);
-            toast.success("Link copied to clipboard");
-            setTimeout(() => setCopied(false), 2000);
+            void handleCopyLink();
           },
+          disabled: isCopying,
         },
-        { label: "Cancel", variant: "outline", onClick: closeAll },
         {
-          label: submitLabel,
+          label: "Done",
           variant: "outline" as const,
-          onClick: handleSubmit,
-          disabled: !name.trim(),
+          onClick: () => {
+            void handleDone();
+          },
+          disabled: !name.trim() || isCopying,
         },
       ]}
       overlayId={overlayId}
@@ -120,21 +186,57 @@ export function GoLiveOverlay({
         </div>
 
         <div className="space-y-2">
-          <Label>Tags</Label>
-          <p className="text-muted-foreground text-sm">
-            Choose tags to make your workflow discoverable on the Hub.
-          </p>
-          <PublicTagSelector
-            initialTags={initialTags}
-            onTagsChange={setSelectedTags}
-            orgTagNames={orgTagNames}
-            selectedTags={selectedTags}
-          />
+          <Label htmlFor="general-access">General access</Label>
+          <div className="flex items-center gap-3">
+            <AccessIcon visibility={access} />
+            <Select
+              onValueChange={(v) => setAccess(v as WorkflowVisibility)}
+              value={access}
+            >
+              <SelectTrigger id="general-access">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">Private</SelectItem>
+                <SelectItem value="unlisted">Anyone with the link</SelectItem>
+                <SelectItem value="public">Public (on the Hub)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
 
-        {!isEditing && (
+        {access === "public" && (
+          <div className="space-y-2">
+            <Label>Tags</Label>
+            <p className="text-muted-foreground text-sm">
+              Choose tags to make your workflow discoverable on the Hub.
+            </p>
+            <PublicTagSelector
+              initialTags={initialTags}
+              onTagsChange={setSelectedTags}
+              orgTagNames={orgTagNames}
+              selectedTags={selectedTags}
+            />
+          </div>
+        )}
+
+        {access === "unlisted" && (
           <div className="flex items-start gap-2.5 rounded-md border border-border/40 bg-muted/30 px-3 py-2.5">
-            <Share2 className="mt-[3px] size-4 shrink-0 text-muted-foreground" />
+            <Link2 className="mt-[3px] size-4 shrink-0 text-muted-foreground" />
+            <div className="space-y-1 text-muted-foreground text-sm">
+              <p>
+                Anyone with the link can open this workflow and view its full
+                configuration, including any potentially sensitive values in
+                node fields. Your credentials and logs remain private.
+              </p>
+              <p>The workflow will not appear on the Hub.</p>
+            </div>
+          </div>
+        )}
+
+        {access === "public" && (
+          <div className="flex items-start gap-2.5 rounded-md border border-border/40 bg-muted/30 px-3 py-2.5">
+            <Globe className="mt-[3px] size-4 shrink-0 text-muted-foreground" />
             <div className="space-y-1 text-muted-foreground text-sm">
               <p>
                 Shared workflows are visible on the{" "}
@@ -153,8 +255,35 @@ export function GoLiveOverlay({
             </div>
           </div>
         )}
-
       </div>
     </Overlay>
+  );
+}
+
+function AccessIcon({
+  visibility,
+}: {
+  visibility: WorkflowVisibility;
+}): React.JSX.Element {
+  const wrapper =
+    "flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground";
+  if (visibility === "public") {
+    return (
+      <div className={wrapper}>
+        <Globe className="size-4" />
+      </div>
+    );
+  }
+  if (visibility === "unlisted") {
+    return (
+      <div className={wrapper}>
+        <Link2 className="size-4" />
+      </div>
+    );
+  }
+  return (
+    <div className={wrapper}>
+      <Lock className="size-4" />
+    </div>
   );
 }

--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -883,8 +883,8 @@ export const PanelInner = () => {
               {!isOwner && (
                 <div className="rounded-lg border border-muted bg-muted/30 p-3">
                   <p className="text-muted-foreground text-sm">
-                    You are viewing a public workflow. Duplicate it to make
-                    changes.
+                    You're viewing this workflow in read-only mode.
+                    Use it as a template to create your own editable copy.
                   </p>
                 </div>
               )}
@@ -1160,8 +1160,8 @@ export const PanelInner = () => {
               {!isOwner && (
                 <div className="rounded-lg border border-muted bg-muted/30 p-3">
                   <p className="text-muted-foreground text-sm">
-                    You are viewing a public workflow. Duplicate it to make
-                    changes.
+                    You're viewing this workflow in read-only mode.
+                    Use it as a template to create your own editable copy.
                   </p>
                 </div>
               )}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -6,6 +6,8 @@ import {
   Check,
   Copy,
   Download,
+  Globe,
+  Link2,
   Loader2,
   Lock,
   Share2,
@@ -912,6 +914,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
     setIsSaving,
     setHasUnsavedChanges,
     clearWorkflow,
+    workflowVisibility,
     setWorkflowVisibility,
     workflowPublicTags, // keeperhub custom field //
     setWorkflowPublicTags, // keeperhub custom field //
@@ -1086,6 +1089,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       openOverlay(GoLiveOverlay, {
         workflowId: currentWorkflowId,
         currentName: workflowName,
+        currentVisibility: workflowVisibility,
         orgTagNames: allTags.map((t) => t.name),
         onConfirm: ({ name, publicTags }) => {
           setWorkflowVisibility("public");
@@ -1120,10 +1124,12 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
     openOverlay(GoLiveOverlay, {
       workflowId: currentWorkflowId,
       currentName: workflowName,
+      currentVisibility: workflowVisibility,
       orgTagNames: allTags.map((t) => t.name),
       initialTags: workflowPublicTags,
       isEditing: true,
-      onConfirm: ({ name, publicTags }) => {
+      onConfirm: ({ name, publicTags, visibility }) => {
+        setWorkflowVisibility(visibility);
         setWorkflowPublicTags(publicTags);
         if (name !== workflowName) {
           state.setCurrentWorkflowName(name);
@@ -1281,12 +1287,12 @@ function ToolbarActions({
   const selectedEdge = edges.find((edge) => edge.id === selectedEdgeId);
   const hasSelection = selectedNode || selectedEdge;
 
-  // Hide toolbar actions (Run, Save, Edit, Settings) in preview context:
-  // either the viewer is not the owner, OR the workflow is publicly visible
-  // (preview surface). Owners viewing their own public templates see the
-  // Use-template CTA in the main toolbar instead.
-  const isPreviewContext =
-    !state.isOwner || state.workflowVisibility === "public";
+  // Hide owner-only toolbar actions (Run, Save, Edit, Settings) only for
+  // non-owners. Shared-link viewers of public/unlisted workflows still see
+  // the workflow exactly as the owner does (read-only canvas + the same
+  // visual chrome); the per-action buttons that mutate the workflow are
+  // already gated by ownership elsewhere.
+  const isPreviewContext = !state.isOwner;
   if (workflowId && isPreviewContext) {
     return null;
   }
@@ -1586,57 +1592,39 @@ function VisibilityButton({
   state: ReturnType<typeof useWorkflowState>;
   actions: ReturnType<typeof useWorkflowActions>;
 }) {
-  const isPublic = state.workflowVisibility === "public";
+  const visibility = state.workflowVisibility;
+  const isUnlisted = visibility === "unlisted";
+  const isPublic = visibility === "public";
+  const isShared = isUnlisted || isPublic;
+
+  let icon: React.ReactNode;
+  let tooltip: string;
+  if (isPublic) {
+    icon = <Globe className="size-4" />;
+    tooltip = "Listed on Hub";
+  } else if (isUnlisted) {
+    icon = <Link2 className="size-4" />;
+    tooltip = "Anyone with the link";
+  } else {
+    icon = <Lock className="size-4" />;
+    tooltip = "Private workflow";
+  }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          className={
-            isPublic
-              ? "border border-keeperhub-green/20 text-keeperhub-green hover:bg-keeperhub-green/10"
-              : "border hover:bg-black/5 dark:hover:bg-white/5"
-          }
-          disabled={!state.currentWorkflowId || state.isGenerating}
-          size="icon"
-          title={isPublic ? "Shared workflow" : "Private workflow"}
-          variant="secondary"
-        >
-          {isPublic ? (
-            <Share2 className="size-4" />
-          ) : (
-            <Lock className="size-4" />
-          )}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          className="flex items-center gap-2"
-          onClick={() => actions.handleToggleVisibility("private")}
-        >
-          <Lock className="size-4" />
-          Private
-          {!isPublic && <Check className="ml-auto size-4" />}
-        </DropdownMenuItem>
-        {isPublic ? (
-          <DropdownMenuItem
-            className="flex items-center gap-2"
-            onClick={() => actions.handleEditPublicSettings()}
-          >
-            <Settings2 className="size-4" />
-            Share Settings
-          </DropdownMenuItem>
-        ) : (
-          <DropdownMenuItem
-            className="flex items-center gap-2"
-            onClick={() => actions.handleToggleVisibility("public")}
-          >
-            <Share2 className="size-4" />
-            Share
-          </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      className={
+        isShared
+          ? "border border-keeperhub-green/20 text-keeperhub-green hover:bg-keeperhub-green/10"
+          : "border hover:bg-black/5 dark:hover:bg-white/5"
+      }
+      disabled={!state.currentWorkflowId || state.isGenerating}
+      onClick={() => actions.handleEditPublicSettings()}
+      size="icon"
+      title={tooltip}
+      variant="secondary"
+    >
+      {icon}
+    </Button>
   );
 }
 
@@ -1800,9 +1788,6 @@ function WorkflowMenuComponent({
 
   return (
     <div className="flex flex-col gap-1">
-      {isWorkflowRoute && workflowId && (state.workflowVisibility === "public" || !state.isOwner) && (
-        <ReadOnlyBadge className="lg:hidden" />
-      )}
     </div>
   );
 }
@@ -1871,7 +1856,8 @@ export const WorkflowToolbar = ({
           />
           {isWorkflowRoute &&
             effectiveWorkflowId &&
-            (state.workflowVisibility === "public" || !state.isOwner) && (
+            !state.isOwner &&
+            state.workflowVisibility === "public" && (
               <>
                 <ReadOnlyBadge className="hidden lg:inline-flex" />
                 <UseTemplateButton
@@ -1930,7 +1916,8 @@ export const WorkflowToolbar = ({
           />
           {isWorkflowRoute &&
             effectiveWorkflowId &&
-            (state.workflowVisibility === "public" || !state.isOwner) && (
+            !state.isOwner &&
+            state.workflowVisibility === "public" && (
               <>
                 <ReadOnlyBadge className="hidden lg:inline-flex" />
                 <UseTemplateButton

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -9,7 +9,7 @@ import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import type { IntegrationConfig, IntegrationType } from "./types/integration";
 
 // Workflow data types
-export type WorkflowVisibility = "private" | "public";
+export type WorkflowVisibility = "private" | "unlisted" | "public";
 
 export type WorkflowData = {
   id?: string;
@@ -567,7 +567,14 @@ export const workflowApi = {
       body: JSON.stringify({}),
     }),
 
-  goLive: (id: string, data: { name: string; publicTagIds: string[] }) =>
+  goLive: (
+    id: string,
+    data: {
+      name: string;
+      publicTagIds?: string[];
+      mode?: "public" | "unlisted";
+    }
+  ) =>
     apiCall<SavedWorkflow>(`/api/workflows/${id}/go-live`, {
       method: "PUT",
       body: JSON.stringify(data),

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -200,7 +200,10 @@ export const tags = pgTable(
   (table) => [index("idx_tags_org").on(table.organizationId)]
 );
 // Workflow visibility type
-export type WorkflowVisibility = "private" | "public";
+// - private: only owner / org members can view (default)
+// - unlisted: anyone with the URL can view read-only; not surfaced in Hub feed
+// - public: viewable by anyone AND listed on the Hub
+export type WorkflowVisibility = "private" | "unlisted" | "public";
 
 // Workflows table with user association
 export const workflows = pgTable(

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -47,7 +47,10 @@ export type WorkflowNode = Node<WorkflowNodeData>;
 export type WorkflowEdge = Edge;
 
 // Workflow visibility type
-export type WorkflowVisibility = "private" | "public";
+// - private: only owner / org members can view (default)
+// - unlisted: anyone with the URL can view read-only; not surfaced in Hub feed
+// - public: viewable by anyone AND listed on the Hub
+export type WorkflowVisibility = "private" | "unlisted" | "public";
 
 // Atoms for workflow state (now backed by database)
 export const nodesAtom = atom<WorkflowNode[]>([]);


### PR DESCRIPTION
## Summary

- Adds an `unlisted` visibility tier between `private` and `public` so a workflow can be shared by URL without being published on the Hub — letting users send a workflow link to specific people without making it discoverable.
- Redesigns the share overlay around a Google-Docs-style general-access combobox (Private / Anyone with the link / Public on the Hub), with matching explainer callouts that appear only for the selected option and a tag picker only when Public is selected.
- Updates the read-only callout shown in side panels for non-owner viewers to point them at the toolbar's `Use template` button instead of the previous "duplicate it" wording that didn't match any visible affordance.
- Gates the billing announcement banner to logged-in users (via `useSession` + `isAnonymousUser`) so anonymous link-followers don't see it, and adjusts the hub page top padding to `calc(5rem + var(--app-banner-height, 0px))` so the heading clears the persistent toolbar when the banner is visible.

No SQL migration: `workflows.visibility` is a `text` column; the new value flows through the existing schema. `lib/api-client.ts` and `lib/workflow/store.ts` both have `WorkflowVisibility` extended to `"private" | "unlisted" | "public"`.

Risk: MEDIUM. Touches share/visibility wiring and the workflow toolbar's overlay invocations. Rollback is a clean revert (no migration to back out).

## Test plan

- [ ] On a workflow you own, open the share dialog and step through Private / Anyone with the link / Public on the Hub; the matching explainer callout (and the tag picker for Public) appears for each option, none for Private
- [ ] Set a workflow to "Anyone with the link", copy the URL, open it in a private window: workflow loads, side panels show "You're viewing this workflow in read-only mode. Use it as a template to create your own editable copy.", and the workflow does NOT appear on `/hub`
- [ ] Set a workflow to "Public (on the Hub)": appears on `/hub`, OG image renders, tag picker accepted
- [ ] Set a workflow to "Private": non-owners hit auth refusal, OG image refuses
- [ ] Sign out / open in a private window: the billing announcement banner is hidden; signed-in users still see it (until they dismiss)
- [ ] On `/hub` with the banner visible, the page heading is no longer occluded by the persistent toolbar (heading at y≈116px, toolbar bottom at y=97px)