### PR TITLE
fix(errors): reclassify user-config failures out of the workflow_engine bucket

### DIFF
--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -97,6 +97,73 @@ describe("classifyExecutionError", () => {
       expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
       expect(r.errorType).toBe("user");
     });
+
+    it.each([
+      "Token approval failed: execution reverted (unknown custom error)",
+      "Token transfer failed: execution reverted",
+      'Transaction failed: missing revert data (action="call", data=null)',
+    ])("classifies %s as transaction + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.errorType).toBe("user");
+    });
+
+    it("Invalid Ethereum address: validation + user", () => {
+      const r = classifyExecutionError(
+        "Invalid Ethereum address: 0x0B3d7DE83b842A78F6d4be3Ad0C66f8b86b79e06"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.errorType).toBe("user");
+    });
+
+    it.each([
+      "Function 'name' not found in ABI",
+      "Call at index 0: Function 'totalSupply' not found in ABI",
+    ])("classifies %s as validation + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.errorType).toBe("user");
+    });
+
+    it("DATABASE_URL is not configured: configuration + user", () => {
+      const r = classifyExecutionError(
+        "DATABASE_URL is not configured. Please add it in Project Integrations."
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.errorType).toBe("user");
+    });
+
+    it("Para session expired: configuration + user (more specific than generic wallet-init system rule)", () => {
+      const r = classifyExecutionError(
+        "Failed to initialize organization wallet: Para session expired. User must re-export from wallet settings."
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.errorType).toBe("user");
+    });
+  });
+
+  describe("user-config: external HTTP endpoint failures", () => {
+    it.each([
+      'HTTP 401: {"error":"unauthorized"}',
+      "HTTP 404: Not Found",
+      "HTTP 500: Internal Server Error",
+      "HTTP 502: Failed to send Discord message",
+    ])("classifies %s as external_service + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.EXTERNAL_SERVICE);
+      expect(r.errorType).toBe("user");
+    });
+
+    it.each([
+      "HTTP request failed: fetch failed: read ECONNRESET",
+      "HTTP request failed: fetch failed: getaddrinfo ENOTFOUND api.example.com",
+      "HTTP request failed: The operation was aborted",
+      "HTTP request failed with status 503: Service Unavailable",
+    ])("classifies %s as external_service + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.EXTERNAL_SERVICE);
+      expect(r.errorType).toBe("user");
+    });
   });
 
   describe("network / RPC: external dependencies", () => {

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -81,12 +81,28 @@ const RULES: readonly Rule[] = [
     errorType: "user",
   },
   {
+    pattern:
+      /^(Token approval failed|Token transfer failed|Transaction failed):/i,
+    errorCategory: ErrorCategory.TRANSACTION,
+    errorType: "user",
+  },
+  {
     pattern: /^Invalid contract address/i,
     errorCategory: ErrorCategory.VALIDATION,
     errorType: "user",
   },
   {
+    pattern: /^Invalid Ethereum address/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: "user",
+  },
+  {
     pattern: /^Invalid (function arguments|ABI JSON|payable value)/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: "user",
+  },
+  {
+    pattern: /Function '.+' not found in ABI/i,
     errorCategory: ErrorCategory.VALIDATION,
     errorType: "user",
   },
@@ -120,6 +136,20 @@ const RULES: readonly Rule[] = [
     errorCategory: ErrorCategory.VALIDATION,
     errorType: "user",
   },
+  // User-config: database integration not configured
+  {
+    pattern: /^DATABASE_URL is not configured/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    errorType: "user",
+  },
+  // User-action: Para wallet session needs re-export
+  // Must come BEFORE the generic `^Failed to initialize organization wallet` rule below.
+  {
+    pattern:
+      /^Failed to initialize organization wallet:\s*Para session expired/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    errorType: "user",
+  },
 
   // External-service / network: dependencies outside KeeperHub
   {
@@ -141,6 +171,21 @@ const RULES: readonly Rule[] = [
     pattern: /^Failed to send webhook/i,
     errorCategory: ErrorCategory.EXTERNAL_SERVICE,
     errorType: "system",
+  },
+  // User-config: external endpoint returned non-2xx (webhook/safe/discord/etc.)
+  {
+    pattern: /^HTTP \d{3}:/,
+    errorCategory: ErrorCategory.EXTERNAL_SERVICE,
+    errorType: "user",
+  },
+  // User-config: HTTP request step couldn't reach the external endpoint
+  // (DNS, ECONNRESET, connection timeout, TLS) or got a non-2xx response.
+  // Falls below the more specific `Missing template variable` /
+  // `GET/HEAD method` rules above.
+  {
+    pattern: /^HTTP request failed(:\s|\s+with status\s+\d+)/i,
+    errorCategory: ErrorCategory.EXTERNAL_SERVICE,
+    errorType: "user",
   },
 
   // System: database / persistence layer


### PR DESCRIPTION
## Summary

The execution error classifier defaults unmatched messages to `workflow_engine` + `system`, so a missing pattern silently lands user-config failures in the engine bucket and inflates the system-error SLI.

Two examples flagged in staging:

- `HTTP 401: {"error":"unauthorized"}` (from a webhook step where the user's endpoint rejected auth) was bucketed as `workflow_engine` + `system`.
- `HTTP request failed: fetch failed: read ECONNRESET` (the user's external endpoint reset the connection) was bucketed the same way.

I also scanned recent `workflow_executions` for other user-config families hitting the default bucket and added rules for the obvious ones.

## Rules added (all classify as `user`)

- `HTTP <status>: ...` &rarr; `external_service` (webhook/safe/discord/sendgrid/etc. non-2xx from the user's endpoint).
- `HTTP request failed: ...` / `HTTP request failed with status N: ...` &rarr; `external_service` (covers fetch failures: ECONNRESET, ENOTFOUND, timeout, TLS). Sits below the more specific `Missing template variable` and `Request with GET/HEAD method` rules so those keep classifying as `configuration` / `validation`.
- `Token approval failed: ...`, `Token transfer failed: ...`, `Transaction failed: ...` &rarr; `transaction` (on-chain reverts produced by `formatContractError`).
- `Invalid Ethereum address: ...` &rarr; `validation`.
- `Function '<name>' not found in ABI` &rarr; `validation` (matches the standalone string and the `Call at index N: ...` batch-read form).
- `DATABASE_URL is not configured. Please add it in Project Integrations.` &rarr; `configuration`.
- `Failed to initialize organization wallet: Para session expired` &rarr; `configuration` (user must re-export). Inserted **before** the generic `^Failed to initialize organization wallet` infra/system rule.

The default fallback for unknown messages stays `workflow_engine` + `system` so new failure families still page.

## Verification

- `pnpm vitest run lib/errors/__tests__/classify.test.ts` -- 49 passed (12 new cases).
- `pnpm type-check` clean.
- `pnpm fix lib/errors/classify.ts lib/errors/__tests__/classify.test.ts` applied formatter.