### PR TITLE
fix(executor): wait for late-landing step success before nullifying on spurious max-retries

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -51,6 +51,7 @@ import {
   clearOutputCache,
   getCompletedStepOutput,
 } from "@/lib/workflow/executor/get-completed-step-output";
+import { awaitCompletedStepOutputStep } from "@/lib/workflow/executor/get-completed-step-output.step";
 import { createPendingTracker } from "@/lib/workflow/executor/pending-tasks";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
@@ -154,6 +155,16 @@ export function recordCatchOutput(
 
 /** Matches path segment like "carts[0]" for array index access (same as template.ts) */
 const ARRAY_ACCESS_PATTERN = /^([^[]+)\[(\d+)\]$/;
+
+/**
+ * Spurious-max-retries recovery poll window. When the framework re-fires a
+ * step after a lost completion event and throws before the step's success row
+ * is committed, the real success lands ~0.3-0.5s later. The catch handler
+ * polls the step authority for up to this window before falling back to
+ * nullifying the node.
+ */
+const SPURIOUS_RECOVERY_POLL_TIMEOUT_MS = 3000;
+const SPURIOUS_RECOVERY_POLL_INTERVAL_MS = 250;
 
 /**
  * KEEP-398: SDK error shapes that indicate a spurious step-completion failure.
@@ -2620,10 +2631,26 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         EXCEEDED_MAX_RETRIES_REGEX.test(errorMessage) ||
         FAILED_AFTER_RETRIES_REGEX.test(errorMessage) ||
         NO_STEP_COMPLETION_REGEX.test(errorMessage);
-      const recordedOutput =
+      let recordedOutput =
         isSpuriousMaxRetries && executionId
           ? (await getCompletedStepOutput(executionId, nodeId))?.output
           : undefined;
+      // The framework re-fires a step after a lost completion event and throws
+      // "exceeded max retries" BEFORE the step body's success row is committed,
+      // so the one-shot read above misses by ~0.3-0.5s. Wait for the
+      // late-landing success inside a step boundary (DB-backed, replay-safe via
+      // memoization) before giving up, so the reconcile path below recovers it
+      // instead of nullifying the node and unblocking convergence with no data.
+      if (isSpuriousMaxRetries && executionId && recordedOutput === undefined) {
+        recordedOutput = (
+          await awaitCompletedStepOutputStep(
+            executionId,
+            nodeId,
+            SPURIOUS_RECOVERY_POLL_TIMEOUT_MS,
+            SPURIOUS_RECOVERY_POLL_INTERVAL_MS
+          )
+        )?.outputRaw;
+      }
       if (isSpuriousMaxRetries && recordedOutput !== undefined) {
         // Recovered execution: the step body succeeded, only the SDK's
         // bookkeeping tripped. Emit a structured warn (no Sentry) and a

--- a/lib/workflow/executor/get-completed-step-output.step.ts
+++ b/lib/workflow/executor/get-completed-step-output.step.ts
@@ -3,13 +3,16 @@ import "server-only";
 import { and, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs } from "@/lib/db/schema";
+import { pollForCompletedOutput } from "@/lib/workflow/executor/poll-for-output";
 
-export async function fetchCompletedStepOutputStep(
+/**
+ * Raw single-row query for a completed success log. Not a step boundary so it
+ * can be reused by both the one-shot and polling step bodies.
+ */
+async function queryCompletedSuccessRow(
   executionId: string,
   nodeId: string
 ): Promise<{ outputRaw: unknown } | null> {
-  "use step";
-
   const row = await db.transaction(async (tx) => {
     await tx.execute(sql`SET LOCAL statement_timeout = '2s'`);
     return tx.query.workflowExecutionLogs.findFirst({
@@ -33,7 +36,45 @@ export async function fetchCompletedStepOutputStep(
   return { outputRaw: row.outputRaw as unknown };
 }
 
+// biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
+export async function fetchCompletedStepOutputStep(
+  executionId: string,
+  nodeId: string
+): Promise<{ outputRaw: unknown } | null> {
+  "use step";
+
+  return queryCompletedSuccessRow(executionId, nodeId);
+}
+
 fetchCompletedStepOutputStep.maxRetries = 1;
+
+/**
+ * Poll `workflow_execution_logs` for a step's recorded success for up to
+ * `timeoutMs`. The wait runs INSIDE this step boundary so the workflow body
+ * stays deterministic and the result is memoized on replay.
+ *
+ * Recovers the spurious-max-retries race: the framework re-fires a step after
+ * a lost completion event and throws before the step body's success row is
+ * committed. The success then lands ~0.3-0.5s later; a one-shot read misses
+ * it. Polling here lets the catch handler reconcile instead of nullifying the
+ * node and racing convergence ahead with no data.
+ */
+// biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
+export async function awaitCompletedStepOutputStep(
+  executionId: string,
+  nodeId: string,
+  timeoutMs: number,
+  intervalMs: number
+): Promise<{ outputRaw: unknown } | null> {
+  "use step";
+
+  return pollForCompletedOutput(
+    () => queryCompletedSuccessRow(executionId, nodeId),
+    { timeoutMs, intervalMs }
+  );
+}
+
+awaitCompletedStepOutputStep.maxRetries = 1;
 
 export async function fetchCompletedStepOutputsBatchStep(
   executionId: string,

--- a/lib/workflow/executor/poll-for-output.ts
+++ b/lib/workflow/executor/poll-for-output.ts
@@ -1,0 +1,41 @@
+/**
+ * Poll `fetchFn` until it returns a non-null value or `timeoutMs` elapses.
+ *
+ * Fetches immediately, then sleeps `intervalMs` between attempts. `now` and
+ * `sleep` are injectable so the loop is deterministic under test.
+ *
+ * Used by the executor's spurious-max-retries recovery: when the framework
+ * re-fires a step after a lost completion event and throws "exceeded max
+ * retries", the step body's recorded success can land a few hundred ms LATER
+ * than the throw. A one-shot read races that late write; this bounded poll
+ * waits for it before the catch handler gives up and nullifies the node.
+ *
+ * Dependency-free (no server-only / DB / metrics) so it imports cleanly into
+ * both the workflow bundle and unit tests, and avoids an import cycle with
+ * get-completed-step-output.ts.
+ */
+export async function pollForCompletedOutput<T>(
+  fetchFn: () => Promise<T | null>,
+  options: {
+    timeoutMs: number;
+    intervalMs: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  }
+): Promise<T | null> {
+  const now = options.now ?? Date.now;
+  const sleep =
+    options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const deadline = now() + options.timeoutMs;
+
+  for (;;) {
+    const result = await fetchFn();
+    if (result !== null) {
+      return result;
+    }
+    if (now() >= deadline) {
+      return null;
+    }
+    await sleep(options.intervalMs);
+  }
+}

--- a/tests/unit/poll-for-completed-output.test.ts
+++ b/tests/unit/poll-for-completed-output.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { pollForCompletedOutput } from "@/lib/workflow/executor/poll-for-output";
+
+// A controllable clock + sleep so the poll loop is fully deterministic.
+function fakeClock(startMs = 0) {
+  let t = startMs;
+  return {
+    now: () => t,
+    // each sleep advances virtual time by exactly ms
+    sleep: (ms: number) => {
+      t += ms;
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("pollForCompletedOutput", () => {
+  it("returns the value on the first hit without sleeping", async () => {
+    const clock = fakeClock();
+    const sleep = vi.fn(clock.sleep);
+    const fetchFn = vi.fn().mockResolvedValue({ outputRaw: "v" });
+    const result = await pollForCompletedOutput(fetchFn, {
+      timeoutMs: 3000,
+      intervalMs: 250,
+      now: clock.now,
+      sleep,
+    });
+    expect(result).toEqual({ outputRaw: "v" });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  // The KEEP-576 race: the recorded success lands a few hundred ms AFTER the
+  // spurious throw. A one-shot read misses; the poll must keep checking until
+  // the late write appears. Without polling this returns null and the catch
+  // nullifies the node -> "produced no data".
+  it("recovers a value that appears after several misses (late-landing success)", async () => {
+    const clock = fakeClock();
+    const sleep = vi.fn(clock.sleep);
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ outputRaw: 998_899 });
+    const result = await pollForCompletedOutput(fetchFn, {
+      timeoutMs: 3000,
+      intervalMs: 250,
+      now: clock.now,
+      sleep,
+    });
+    expect(result).toEqual({ outputRaw: 998_899 });
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(250);
+  });
+
+  it("returns null once the timeout elapses with no hit (genuine never-records)", async () => {
+    const clock = fakeClock();
+    const sleep = vi.fn(clock.sleep);
+    const fetchFn = vi.fn().mockResolvedValue(null);
+    const result = await pollForCompletedOutput(fetchFn, {
+      timeoutMs: 1000,
+      intervalMs: 250,
+      now: clock.now,
+      sleep,
+    });
+    expect(result).toBeNull();
+    // 1000ms / 250ms = 4 sleeps before the deadline is reached.
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it("does exactly one fetch and no sleep when timeoutMs is 0 (one-shot)", async () => {
+    const clock = fakeClock();
+    const sleep = vi.fn(clock.sleep);
+    const fetchFn = vi.fn().mockResolvedValue(null);
+    const result = await pollForCompletedOutput(fetchFn, {
+      timeoutMs: 0,
+      intervalMs: 250,
+      now: clock.now,
+      sleep,
+    });
+    expect(result).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the earlier catch-handler hardening, which did **not** close the issue — prod UAT reproduced the failure ~2/6 runs. This addresses the actual root cause: a time-of-check/time-of-use race in the spurious-max-retries reconciliation.

Under fan-in the Workflow DevKit loses a step's completion event and re-fires it (despite `httpRequestStep.maxRetries = 0`), throwing `Step "...httpRequestStep" exceeded max retries (1 retry)`. The catch handler reads `getCompletedStepOutput` once to reconcile, but the real step body's success row is committed **~0.3–0.5s later** than the throw. The one-shot read misses → recovery skipped → node nullified → convergence unblocked early → a downstream combine resolves `{{@bungee:Bungee}}` to null and aborts with `Node "X" produced no data`.

Prod evidence: bungee logged `status: success` ~0.5s **after** combine errored, on a forked Across+Bungee bridge-optimizer workflow.

### Change

- On a spurious-retries miss, await the recorded success for up to **3s (250ms interval)** before falling back to nullify. The wait runs **inside a step boundary** (`awaitCompletedStepOutputStep`) so it's DB-backed and replay-safe via memoization; the workflow body stays deterministic.
- Extract the pure poll loop (`pollForCompletedOutput`) into its own dependency-free module so it imports cleanly into the workflow bundle and is deterministically unit-testable with an injected clock.
- Genuine never-records still fall through to nullify after the bounded wait (no behavior change for real failures).

## Test plan

- [x] `pnpm vitest run tests/unit/poll-for-completed-output.test.ts` — first-hit (no sleep), recovery after several misses (the late-landing case), timeout→null, one-shot (timeoutMs=0)
- [x] `pnpm test:unit` — 4701 pass, 1 skipped, 0 regressions
- [x] `pnpm type-check` — clean; lint/format clean on changed files
- [ ] **Post-merge prod re-UAT:** run the forked Across+Bungee bridge optimizer ~10× on `app.keeperhub.com`; expect **0** `produced no data` failures (was ~2/6 before this change).

## Notes

- Touches the spurious-retry reconciliation path that the original task scoped out — necessary because the bug lives there, confirmed by prod logs.
- Architectural observation: this and the two prior reconciliation layers all mitigate the same upstream SDK lost-completion-event behavior under fan-in; a framework-level fix would address the class rather than each race.