### PR TITLE
fix(ci): create keeperhub-network before bringing up anvil fork in e2e job

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -203,6 +203,11 @@ jobs:
 
       - name: Start anvil Sepolia fork for orchestrator integration tests
         run: |
+          # docker-compose.yml attaches every service to the external
+          # `keeperhub-network`; the ephemeral start-app step uses
+          # `docker run --network host` and never creates it, so compose
+          # bails before bringing test-anvil-fork up. Create it idempotently.
+          docker network create keeperhub-network 2>/dev/null || true
           docker compose --profile test up -d --wait test-anvil-fork || \
             docker compose --profile test up -d test-anvil-fork
           # Health-poll the fork up to ~60s -- the wait flag above is best-effort


### PR DESCRIPTION
## Summary

- The `e2e-vitest-ephemeral` job is hard-failing at the `Start anvil Sepolia fork for orchestrator integration tests` step with `network keeperhub-network declared as external, but could not be found` (example: [run 26145109743](https://github.com/KeeperHub/keeperhub/actions/runs/26145109743/job/76900509210)).
- `docker-compose.yml` attaches every service to the default external network `keeperhub-network` (intentionally external so multiple worktrees can share it locally). The ephemeral CI job's `Start application` step starts the app via `docker run --network host` and never touches compose, so nothing creates that network before the anvil step runs `docker compose --profile test up`.
- Fix is one line: `docker network create keeperhub-network 2>/dev/null || true` immediately before the compose call. Idempotent (no-op when the network already exists in the local/worktree case), unblocks the ephemeral CI job.

## Why not the alternatives

- Removing `external: true` on the default network would break the worktree-sharing use case the compose file explicitly calls out.
- Marking the step `continue-on-error: true` would silently swallow real anvil-startup regressions on top of this CI wiring gap.

## Test plan

- [ ] CI: `e2e-tests / e2e-vitest-ephemeral` job reaches `Run E2E Vitest tests` (i.e. anvil step no longer exits 1 before the runner starts).
- [ ] No regression in other jobs (no other workflow uses the anvil step).