### PR TITLE
fix(test): gate Sepolia coverage suites on TESTNET_FUNDER_PK and wire secret into CI

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -242,6 +242,9 @@ jobs:
           AWS_REGION: us-east-1
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
           CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
+          # Funder EOA for protocol-coverage suites' ensureNativeGas top-up.
+          # When unset the suites skip cleanly (see coverage.test.ts gate).
+          TESTNET_FUNDER_PK: ${{ secrets.TESTNET_FUNDER_PK }}
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''

--- a/tests/e2e/vitest/protocol-coverage/aave-v3/sepolia/coverage.test.ts
+++ b/tests/e2e/vitest/protocol-coverage/aave-v3/sepolia/coverage.test.ts
@@ -24,8 +24,14 @@ import { cleanupAll, createSharedCtx, runSetup } from "../../_shared/setup";
 
 const PROTOCOL = "aave-v3";
 const CHAIN_ID = "11155111";
+// Suite needs a funded Sepolia EOA to top up the test wallet via
+// `ensureNativeGas` in setup. Without TESTNET_FUNDER_PK, beforeAll throws
+// before any test runs — skip cleanly instead so CI environments without
+// the funder provisioned (PR / staging-push) stay green.
 const SKIP_INFRA_TESTS =
-  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+  !process.env.DATABASE_URL ||
+  !process.env.TESTNET_FUNDER_PK ||
+  process.env.SKIP_INFRA_TESTS === "true";
 
 describe.skipIf(SKIP_INFRA_TESTS)(`${PROTOCOL} (Sepolia)`, () => {
   const ctx = createSharedCtx();

--- a/tests/e2e/vitest/protocol-coverage/superfluid/sepolia/coverage.test.ts
+++ b/tests/e2e/vitest/protocol-coverage/superfluid/sepolia/coverage.test.ts
@@ -11,8 +11,14 @@ import { cleanupAll, createSharedCtx, runSetup } from "../../_shared/setup";
 
 const PROTOCOL = "superfluid";
 const CHAIN_ID = "11155111";
+// Suite needs a funded Sepolia EOA to top up the test wallet via
+// `ensureNativeGas` in setup. Without TESTNET_FUNDER_PK, beforeAll throws
+// before any test runs — skip cleanly instead so CI environments without
+// the funder provisioned (PR / staging-push) stay green.
 const SKIP_INFRA_TESTS =
-  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+  !process.env.DATABASE_URL ||
+  !process.env.TESTNET_FUNDER_PK ||
+  process.env.SKIP_INFRA_TESTS === "true";
 
 describe.skipIf(SKIP_INFRA_TESTS)(`${PROTOCOL} (Sepolia)`, () => {
   const ctx = createSharedCtx();


### PR DESCRIPTION
## Summary

The two Sepolia protocol-coverage suites that just landed via #1309 (`aave-v3`, `superfluid`) are red on staging CI. Two related changes here:

1. **Gate tightening** (`tests/e2e/vitest/protocol-coverage/{aave-v3,superfluid}/sepolia/coverage.test.ts`): the existing gate only checked `DATABASE_URL`, but `beforeAll` calls `ensureNativeGas` which **throws** when `TESTNET_FUNDER_PK` is unset ([`funding.ts:78-81`](https://github.com/KeeperHub/keeperhub/blob/staging/tests/e2e/vitest/protocol-coverage/_shared/funding.ts#L78-L81)). Adding `!process.env.TESTNET_FUNDER_PK` to the skip condition matches the suites' actual preconditions.
2. **Wire the secret through** (`.github/workflows/e2e-tests-ephemeral.yml`): `TESTNET_FUNDER_PK` is now provisioned in the `staging` GitHub Environment, so pass it to the `Run E2E Vitest tests` step.

Example pre-fix failure: [run 26148932499](https://github.com/KeeperHub/keeperhub/actions/runs/26148932499/job/76913261147).

## Behavior matrix

| Environment | DB | Funder PK in env | Before | After |
|-------------|----|------------------|--------|-------|
| Ephemeral CI, push to staging | yes | yes (now provisioned) | suite-level FAIL | suites **run** |
| Ephemeral CI, PR from fork (no env access) | yes | no | suite-level FAIL | suites **skipped cleanly** |
| Developer machine, no funder env | yes | no | runs and crashes setup | suites **skipped cleanly** |
| Developer machine, funder env exported | yes | yes | runs (as today) | runs (unchanged) |
| `SKIP_INFRA_TESTS=true` | any | any | skipped | skipped (unchanged) |

## Sepolia funder

- Funder: `0x132Bb78ba04914f295ec2F25632cE4d6538b3E24`
- Current balance: ~0.412 SepoliaETH (~200 top-ups at 0.002 ETH each).
- Per-test top-up only fires when the test wallet's native balance drops below 0.001 ETH (`MIN_NATIVE_BALANCE_WEI_BY_CHAIN`), so most CI runs are no-ops on the funding path.
- Single EOA = single point of failure. Rotation responsibility is unowned today; flag for follow-up if these suites become load-bearing.

## Test plan

- [ ] `e2e-tests / e2e-vitest-ephemeral` job goes green on this PR with both coverage suites **actually running and passing** (not skipped).
- [ ] If the suites end up flaky or the funder runs dry, removing the secret from the `staging` env immediately reverts to the safe-skip path.