### PR TITLE
fix(ci): route Turnkey + wallet encryption key through start-app to the e2e app container

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -47,6 +47,22 @@ inputs:
     description: 'INTEGRATION_ENCRYPTION_KEY for decrypting integration config (must match the key used by tests when seeding integrations)'
     required: false
     default: ''
+  wallet_encryption_key:
+    description: 'WALLET_ENCRYPTION_KEY for decrypting encrypted wallet shares from the DB (lib/encryption.ts)'
+    required: false
+    default: ''
+  turnkey_api_public_key:
+    description: 'TURNKEY_API_PUBLIC_KEY for the Turnkey-managed org wallet path (lib/turnkey/turnkey-operations.ts)'
+    required: false
+    default: ''
+  turnkey_api_private_key:
+    description: 'TURNKEY_API_PRIVATE_KEY for the Turnkey-managed org wallet path'
+    required: false
+    default: ''
+  turnkey_organization_id:
+    description: 'TURNKEY_ORGANIZATION_ID for the Turnkey-managed org wallet path'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -76,6 +92,10 @@ runs:
         TEST_API_KEY: ${{ inputs.test_api_key }}
         CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}
         INTEGRATION_ENCRYPTION_KEY: ${{ inputs.integration_encryption_key }}
+        WALLET_ENCRYPTION_KEY: ${{ inputs.wallet_encryption_key }}
+        TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
+        TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
+        TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
       run: |
         IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
@@ -93,16 +113,20 @@ runs:
           "WORKFLOW_TARGET_WORLD=@workflow/world-postgres" \
           > /tmp/keeperhub-app.env
 
-        # Pass CHAIN_RPC_CONFIG and INTEGRATION_ENCRYPTION_KEY via -e (not the
-        # env-file) because their values can contain JSON / characters that
-        # docker's env-file parser does not handle. INTEGRATION_ENCRYPTION_KEY
-        # must match the key the test process uses to encrypt integration
-        # config rows -- otherwise getIntegrationById's decryptConfig fails
-        # silently and credentials never reach step bundles.
+        # Pass values with potentially special chars (JSON / base64 / =-padding)
+        # via -e rather than the env-file, which parses literally and breaks on
+        # such values. INTEGRATION_ENCRYPTION_KEY must match the test process's
+        # key so getIntegrationById's decryptConfig can read seeded rows.
+        # WALLET_ENCRYPTION_KEY + TURNKEY_* are required for the Turnkey-managed
+        # org-wallet path the protocol-coverage suites exercise.
         docker run -d --name keeperhub-app --network host \
           --env-file /tmp/keeperhub-app.env \
           -e "CHAIN_RPC_CONFIG=${CHAIN_RPC_CONFIG}" \
           -e "INTEGRATION_ENCRYPTION_KEY=${INTEGRATION_ENCRYPTION_KEY}" \
+          -e "WALLET_ENCRYPTION_KEY=${WALLET_ENCRYPTION_KEY}" \
+          -e "TURNKEY_API_PUBLIC_KEY=${TURNKEY_API_PUBLIC_KEY}" \
+          -e "TURNKEY_API_PRIVATE_KEY=${TURNKEY_API_PRIVATE_KEY}" \
+          -e "TURNKEY_ORGANIZATION_ID=${TURNKEY_ORGANIZATION_ID}" \
           "${IMAGE}"
 
         for i in $(seq 1 30); do
@@ -167,3 +191,7 @@ runs:
         INTEGRATION_ENCRYPTION_KEY: ${{ inputs.integration_encryption_key }}
         WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
         CHAIN_RPC_CONFIG: ${{ inputs.chain_rpc_config }}
+        WALLET_ENCRYPTION_KEY: ${{ inputs.wallet_encryption_key }}
+        TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
+        TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
+        TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -200,6 +200,10 @@ jobs:
           test_api_key: ${{ secrets.TEST_API_KEY }}
           chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
           integration_encryption_key: ${{ secrets.TEST_INTEGRATION_ENCRYPTION_KEY }}
+          wallet_encryption_key: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
+          turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
+          turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
+          turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
 
       - name: Start anvil Sepolia fork for orchestrator integration tests
         run: |
@@ -323,6 +327,10 @@ jobs:
           test_api_key: ${{ secrets.TEST_API_KEY }}
           chain_rpc_config: ${{ secrets.CHAIN_RPC_CONFIG }}
           integration_encryption_key: ${{ secrets.TEST_INTEGRATION_ENCRYPTION_KEY }}
+          wallet_encryption_key: ${{ secrets.TEST_WALLET_ENCRYPTION_KEY }}
+          turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
+          turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
+          turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e


### PR DESCRIPTION
## Summary

The `start-app` composite action never declared `turnkey_*` or `wallet_encryption_key` inputs, so the values the workflow was passing for the e2e jobs were silently dropped (composite actions ignore unknown inputs without error). The keeperhub app container started without `TURNKEY_API_PUBLIC_KEY`, `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ORGANIZATION_ID`, or `WALLET_ENCRYPTION_KEY`.

That blew up the new protocol-coverage suites' setup workflow on first wallet operation:

```
Error: setup workflow failed for {protocol}/11155111:
  error - Failed to initialize organization wallet:
  TURNKEY_API_PUBLIC_KEY and TURNKEY_API_PRIVATE_KEY must be set
    at runSetup (tests/e2e/vitest/protocol-coverage/_shared/setup.ts:136)
```

Example run: [26150811512](https://github.com/KeeperHub/keeperhub/actions/runs/26150811512/job/76919777685).

## Changes

- `start-app/action.yml`: add `wallet_encryption_key`, `turnkey_api_public_key`, `turnkey_api_private_key`, `turnkey_organization_id` as inputs; pass them through to the Docker container via `-e` flags (not env-file - WALLET_ENCRYPTION_KEY can contain base64 padding chars that confuse the env-file parser); also wire them into the bare-metal path's `env:` block.
- `e2e-tests-ephemeral.yml`: add the same four `with:` lines at both `Start application` callsites (e2e-vitest and e2e-playwright jobs).

Secrets already exist in the `staging` GitHub Environment - no provisioning required, just routing.

## Why WALLET_ENCRYPTION_KEY too

`lib/encryption.ts:3` reads it at module load. It's needed for decrypting encrypted wallet shares from the DB - without it, the app cannot use the Turnkey-managed test wallet even if Turnkey API creds reach the container. Pre-emptively wired because it's the same class of plumbing gap and would fail next.

## Audit context

While diagnosing, swept all `process.env.*` reads in `tests/e2e/vitest/` against the workflow's `Run E2E Vitest tests` env block. Findings:

- Test-process side: all required vars set (DATABASE_URL, BETTER_AUTH_SECRET, WALLET_ENCRYPTION_KEY, PARA_*, AWS_*, TEST_API_KEY, CHAIN_RPC_CONFIG, TESTNET_FUNDER_PK). Optional/defaulted ones (KEEPERHUB_URL, ANVIL_URL, etc.) resolve to localhost defaults that match the CI topology.
- App-container side: the four vars in this PR were the gap. Everything else (CHAIN_RPC_CONFIG, INTEGRATION_ENCRYPTION_KEY, etc.) is already routed.
- Soft gap (not in this PR): `TEST_PARA_USER_SHARE` is missing from the workflow env block. `write-contract-workflow.test.ts:46` reads it and skips when absent. With Para deprecated, this likely doesn't matter - flagging only for completeness.

## Test plan

- [ ] `e2e-tests / e2e-vitest-ephemeral` job goes green with both protocol-coverage Sepolia suites **executing and passing** (not skipped, not failing in setup).
- [ ] App container logs (dumped on failure) show no `TURNKEY_*` or `WALLET_ENCRYPTION_KEY` "must be set" errors.