### PR TITLE
fix: match Hyperliquid action-node icon to Hub protocol logo

### DIFF
--- a/plugins/hyperliquid/icon.tsx
+++ b/plugins/hyperliquid/icon.tsx
@@ -7,21 +7,18 @@ export function HyperliquidIcon({
 }) {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
       className={className}
+      fill="none"
+      role="img"
       style={style}
-      aria-label="Hyperliquid"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
     >
       <title>Hyperliquid</title>
-      <path d="M4 4v16" />
-      <path d="M20 4v16" />
-      <path d="M4 12c2-2.5 4-2.5 6 0s4 2.5 6 0s4-2.5 4 0" />
+      <path
+        d="M11.5 11C9.5 9.5 8 6.5 6.5 6C5 5.5 3 7.5 3 11C3 14.5 5 16.5 6.5 16.5C8 16.5 9.5 14.5 11.5 13C13.5 15 14.5 20.5 16 20.5C19 20.5 22 17 22 12C22 7 19 3.5 16 3.5C14.5 3.5 13.5 9 11.5 11Z"
+        fill="#97FCE4"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Redraw the Hyperliquid plugin icon (`plugins/hyperliquid/icon.tsx`) as the real mint-teal mark — two rounded lobes joined by a narrow waist — so the workflow editor action node matches the Hub > Protocols card.
- Replaces the placeholder stroked "H + waveform" glyph that didn't resemble the brand logo.
- Follows the existing brand-icon convention (`role="img"` + hardcoded brand hex, as in the Discord icon).

## Test plan
- [x] `pnpm type-check` clean
- [x] `node scripts/token-audit.js` adds no new errors (plugin brand hex follows Discord-icon precedent)
- [x] Verified in browser: action search panel, canvas action node, and Service dropdown all render the new mint mark