### PR TITLE
fix(mcp): correct validate_workflow false-positive on flat outputMapping

### DIFF
--- a/lib/mcp/validate-workflow.ts
+++ b/lib/mcp/validate-workflow.ts
@@ -222,9 +222,28 @@ function runOutputMappingCheck(
   if (outputMapping === null || typeof outputMapping !== "object") {
     return;
   }
+
+  // Flat shape: `{ nodeId: string, field?/fields?: ... }`. This is what the
+  // runtime (applyOutputMapping) reads — it pulls the top-level `nodeId` and
+  // picks `field`/`fields` off that node's output. The sibling `field`/`fields`
+  // keys NAME output fields, they are not node references, so only `nodeId` is
+  // verified. Matches `typeof mapping.nodeId === "string"` in
+  // lib/payments/x402/execution-wait.ts.
+  const flatNodeId = (outputMapping as { nodeId?: unknown }).nodeId;
+  if (typeof flatNodeId === "string") {
+    if (!nodeIds.has(flatNodeId)) {
+      errors.push({
+        code: VALIDATION_ERROR_CODES.UNKNOWN_OUTPUT_MAPPING_NODE,
+        message: `outputMapping.nodeId references nodeId "${flatNodeId}" which is not present in nodes[]`,
+        parameterPath: "outputMapping.nodeId",
+      });
+    }
+    return;
+  }
+
+  // Keyed shape: `{ outputKey: <{{@nodeId:Label.field}} template | { nodeId, field } | nodeIdString> }`.
+  // Extract any concrete node reference from each value and verify it.
   for (const [key, value] of Object.entries(outputMapping)) {
-    // outputMapping shape (per existing listing flow): { outputKey: { nodeId, field } | nodeIdString }
-    // Be defensive: extract any string-typed nodeId reference and verify it.
     const referencedNodeId = extractNodeIdReference(value);
     if (referencedNodeId !== null && !nodeIds.has(referencedNodeId)) {
       errors.push({
@@ -236,8 +255,16 @@ function runOutputMappingCheck(
   }
 }
 
+// Captures the nodeId from a `{{@nodeId:Label.field}}` template reference.
+// Mirrors TEMPLATE_REF_PATTERN in lib/utils/template.ts.
+const OUTPUT_MAPPING_TEMPLATE_RE = /\{\{@([^:]+):[^}]+\}\}/;
+
 function extractNodeIdReference(value: unknown): string | null {
   if (typeof value === "string") {
+    const templateMatch = value.match(OUTPUT_MAPPING_TEMPLATE_RE);
+    if (templateMatch) {
+      return templateMatch[1].trim();
+    }
     return value;
   }
   if (value !== null && typeof value === "object" && "nodeId" in value) {

--- a/tests/unit/validate-workflow-structural.test.ts
+++ b/tests/unit/validate-workflow-structural.test.ts
@@ -348,6 +348,59 @@ describe("validateWorkflow — unknown-output-mapping-node (VALID-03)", () => {
     expect(err).toBeUndefined();
   });
 
+  it("does not error on flat {field, nodeId} shape when nodeId references a valid node", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        outputMapping: { field: "result", nodeId: "action-1" },
+      })
+    );
+    const err = result.errors.find(
+      (e) => e.code === "unknown-output-mapping-node"
+    );
+    expect(err).toBeUndefined();
+  });
+
+  it("errors on flat {field, nodeId} shape when nodeId is dangling", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        outputMapping: { field: "result", nodeId: "ghost-node" },
+      })
+    );
+    expect(result.valid).toBe(false);
+    const err = result.errors.find(
+      (e) => e.code === "unknown-output-mapping-node"
+    );
+    expect(err).toBeDefined();
+    expect(err?.parameterPath).toBe("outputMapping.nodeId");
+    expect(err?.message).toContain("ghost-node");
+  });
+
+  it("does not error on keyed template-string shape referencing a valid node", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        outputMapping: { result: "{{@action-1:Action.result}}" },
+      })
+    );
+    const err = result.errors.find(
+      (e) => e.code === "unknown-output-mapping-node"
+    );
+    expect(err).toBeUndefined();
+  });
+
+  it("errors on keyed template-string shape referencing a dangling node", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        outputMapping: { result: "{{@ghost-node:Ghost.result}}" },
+      })
+    );
+    expect(result.valid).toBe(false);
+    const err = result.errors.find(
+      (e) => e.code === "unknown-output-mapping-node"
+    );
+    expect(err).toBeDefined();
+    expect(err?.message).toContain("ghost-node");
+  });
+
   it("does not error when outputMapping is null", () => {
     const result = validateWorkflow(makeWorkflow({ outputMapping: null }));
     const err = result.errors.find(


### PR DESCRIPTION
## Summary

`validate_workflow` returned `valid: false` with `unknown-output-mapping-node` for any workflow using the flat `{ "field": "result", "nodeId": "combine" }` outputMapping shape. `runOutputMappingCheck` iterated `Object.entries(outputMapping)` and treated every value as a candidate nodeId, so it read the value of `field` (`"result"`) as a node reference and false-positived. 22 of 26 listed marketplace workflows (bridge-route-optimizer, yield-curve, liquidation-watcher, etc.) flunked validation despite executing fine.

## Fix

- Detect the flat shape first (top-level string `nodeId`, matching the runtime contract in `applyOutputMapping`) and verify only `outputMapping.nodeId`. `field`/`fields` name output fields, not node references.
- Make `extractNodeIdReference` template-aware so the keyed `{ key: "{{@nodeId:Label.field}}" }` shape (hyperliquid-vault-* workflows) extracts the nodeId from the `{{@nodeId:...}}` token instead of treating the whole template string as a node id -- that shape was also false-positiving.
- Existing keyed-bare-string and `{nodeId, field}` behavior preserved.

The check is advisory-only: `listWorkflow` does not call `validateWorkflow`, so this never blocked listing -- it only produced false `valid: false` from the `validate_workflow` MCP tool.

## Test plan

- [x] Added 4 unit tests: flat `{field,nodeId}` valid + dangling, keyed template-string valid + dangling
- [x] Confirmed red before the fix, green after
- [x] All 86 tests across validator + execution-wait suites pass
- [x] Existing outputMapping tests still pass