### PR TITLE
feat(web3): expand sponsored gas chains, surface in billing UI

### DIFF
--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -1,13 +1,23 @@
 "use client";
 
+import { Info } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { BILLING_ALERTS, BILLING_API } from "@/lib/billing/constants";
 import { PLANS, type PlanName } from "@/lib/billing/plans";
+import {
+  SPONSORSHIP_MAINNET_NAMES,
+  SPONSORSHIP_TESTNET_NAMES,
+} from "@/lib/web3/sponsorship-chains-meta";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 
 type OverageCharge = {
@@ -464,7 +474,33 @@ function GasCreditsBar({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between text-sm">
-        <span className="text-muted-foreground">Gas sponsorship credits</span>
+        <span className="flex items-center gap-1 text-muted-foreground">
+          Gas sponsorship credits
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                aria-label="Supported networks"
+                className="inline-flex cursor-help items-center text-muted-foreground transition-colors hover:text-foreground"
+                type="button"
+              >
+                <Info className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <div className="space-y-1.5">
+                <p className="font-medium">Supported networks</p>
+                <p>
+                  <span className="font-medium">Mainnets:</span>{" "}
+                  {SPONSORSHIP_MAINNET_NAMES.join(", ")}
+                </p>
+                <p>
+                  <span className="font-medium">Testnets:</span>{" "}
+                  {SPONSORSHIP_TESTNET_NAMES.join(", ")}
+                </p>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </span>
         <span className="font-medium">
           ${(gasCredits.usedCents / 100).toFixed(2)} / $
           {(gasCredits.totalCents / 100).toFixed(2)}

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -1,15 +1,51 @@
 "use client";
 
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Info } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { BillingInterval } from "@/lib/billing/plans";
 import { PLANS } from "@/lib/billing/plans";
 import { cn } from "@/lib/utils";
+import {
+  SPONSORSHIP_MAINNET_NAMES,
+  SPONSORSHIP_TESTNET_NAMES,
+} from "@/lib/web3/sponsorship-chains-meta";
 import { PlanCard } from "./plan-card";
 import type { PricingTableProps } from "./types";
 
-const COMPARISON_ROWS = [
+function formatGasCredits(cents: number): string {
+  return `$${(cents / 100).toFixed(0)} / mo`;
+}
+
+type ComparisonRow = {
+  label: string;
+  free: string;
+  pro: string;
+  business: string;
+  enterprise: string;
+  tooltip?: React.ReactNode;
+};
+
+const SPONSORED_NETWORKS_TOOLTIP: React.ReactNode = (
+  <div className="space-y-1.5">
+    <p className="font-medium">Supported networks</p>
+    <p>
+      <span className="font-medium">Mainnets:</span>{" "}
+      {SPONSORSHIP_MAINNET_NAMES.join(", ")}
+    </p>
+    <p>
+      <span className="font-medium">Testnets:</span>{" "}
+      {SPONSORSHIP_TESTNET_NAMES.join(", ")}
+    </p>
+  </div>
+);
+
+const COMPARISON_ROWS: ComparisonRow[] = [
   {
     label: "Workflows",
     free: "Unlimited",
@@ -23,6 +59,14 @@ const COMPARISON_ROWS = [
     pro: "All EVM",
     business: "All EVM",
     enterprise: "Custom",
+  },
+  {
+    label: "Sponsored gas",
+    free: formatGasCredits(PLANS.free.features.gasCreditsCents),
+    pro: formatGasCredits(PLANS.pro.features.gasCreditsCents),
+    business: formatGasCredits(PLANS.business.features.gasCreditsCents),
+    enterprise: `${formatGasCredits(PLANS.enterprise.features.gasCreditsCents)} (custom)`,
+    tooltip: SPONSORED_NETWORKS_TOOLTIP,
   },
   {
     label: "Triggers",
@@ -133,7 +177,25 @@ function ComparisonTable(): React.ReactElement {
                   key={row.label}
                 >
                   <td className="px-5 py-3 font-medium text-muted-foreground">
-                    {row.label}
+                    <span className="inline-flex items-center gap-1">
+                      {row.label}
+                      {row.tooltip && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              aria-label={`More info about ${row.label}`}
+                              className="inline-flex cursor-help items-center text-muted-foreground transition-colors hover:text-foreground"
+                              type="button"
+                            >
+                              <Info className="size-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-xs">
+                            {row.tooltip}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </span>
                   </td>
                   <td className="px-5 py-3 text-center text-muted-foreground">
                     {row.free}

--- a/lib/web3/pimlico-config.ts
+++ b/lib/web3/pimlico-config.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { Address } from "viem";
+import { SPONSORSHIP_CHAIN_IDS } from "./sponsorship-chains-meta";
 
 function getPimlicoBaseUrl(): string {
   const url = process.env.PIMLICO_BASE_URL;
@@ -9,19 +10,8 @@ function getPimlicoBaseUrl(): string {
   return url;
 }
 
-/**
- * Chain IDs where gas sponsorship via EIP-7702 + Pimlico is supported.
- * Chains must support both EIP-7702 and have Pimlico bundler coverage.
- */
-export const SUPPORTED_SPONSORSHIP_CHAINS: ReadonlySet<number> = new Set([
-  8453, // Base
-  84_532, // Base Sepolia
-  10, // Optimism
-  42_161, // Arbitrum One
-  137, // Polygon
-  1, // Ethereum Mainnet
-  11_155_111, // Sepolia
-]);
+export const SUPPORTED_SPONSORSHIP_CHAINS: ReadonlySet<number> =
+  SPONSORSHIP_CHAIN_IDS;
 
 export function isSponsorshipSupported(chainId: number): boolean {
   return SUPPORTED_SPONSORSHIP_CHAINS.has(chainId);

--- a/lib/web3/sponsorship-chains-meta.ts
+++ b/lib/web3/sponsorship-chains-meta.ts
@@ -1,0 +1,30 @@
+export type SponsorshipChain = {
+  chainId: number;
+  name: string;
+  isTestnet: boolean;
+};
+
+export const SPONSORSHIP_CHAINS: readonly SponsorshipChain[] = [
+  { chainId: 1, name: "Ethereum", isTestnet: false },
+  { chainId: 10, name: "Optimism", isTestnet: false },
+  { chainId: 56, name: "BNB Chain", isTestnet: false },
+  { chainId: 137, name: "Polygon", isTestnet: false },
+  { chainId: 8453, name: "Base", isTestnet: false },
+  { chainId: 42_161, name: "Arbitrum One", isTestnet: false },
+  { chainId: 97, name: "BNB Testnet", isTestnet: true },
+  { chainId: 80_002, name: "Polygon Amoy", isTestnet: true },
+  { chainId: 84_532, name: "Base Sepolia", isTestnet: true },
+  { chainId: 421_614, name: "Arbitrum Sepolia", isTestnet: true },
+  { chainId: 11_155_111, name: "Sepolia", isTestnet: true },
+  { chainId: 11_155_420, name: "OP Sepolia", isTestnet: true },
+];
+
+export const SPONSORSHIP_CHAIN_IDS: ReadonlySet<number> = new Set(
+  SPONSORSHIP_CHAINS.map((c) => c.chainId)
+);
+
+export const SPONSORSHIP_MAINNET_NAMES: readonly string[] =
+  SPONSORSHIP_CHAINS.filter((c) => !c.isTestnet).map((c) => c.name);
+
+export const SPONSORSHIP_TESTNET_NAMES: readonly string[] =
+  SPONSORSHIP_CHAINS.filter((c) => c.isTestnet).map((c) => c.name);


### PR DESCRIPTION
## Summary

- Adds BNB mainnet plus 4 testnets (BNB Testnet, Polygon Amoy, Arbitrum Sepolia, OP Sepolia) to `SUPPORTED_SPONSORSHIP_CHAINS`. Each chain is verified to have Pimlico bundler coverage and EIP-7702 support.
- Extracts the chain list to a client-safe meta module (`lib/web3/sponsorship-chains-meta.ts`) so UI surfaces can render network names without pulling in server-only code.
- Adds an info tooltip next to "Gas sponsorship credits" on the billing status card, listing supported mainnets and testnets.
- Adds a new "Sponsored gas" row to the pricing comparison table with an info tooltip showing the same network list. Pulls the allocation amounts from `PLANS[*].features.gasCreditsCents` so they stay in sync.

## Verification rationale

Each new chain was checked against two requirements:
- Pimlico maintains a bundler/paymaster for it (confirmed against Pimlico's supported chains list).
- EIP-7702 is live, since the sponsorship code path uses `SimpleAccount7702` delegation. BNB has it on BSC mainnet, OP Sepolia inherits via OP-Stack, Polygon Amoy mirrors Polygon's Bhilai upgrade, Arbitrum Sepolia mirrors Callisto.

Avalanche, Tempo, Plasma, and 0G were deliberately excluded. Avalanche has no 7702 yet (ACP-209 pending), Tempo uses native account abstraction incompatible with our code path, and Plasma / 0G are not on Pimlico's bundler list.