### PR TITLE
fix(mcp): skip template-valued addresses in validate_workflow address check

### DIFF
--- a/lib/mcp/validate-workflow-deep.ts
+++ b/lib/mcp/validate-workflow-deep.ts
@@ -20,6 +20,7 @@ import {
   validateWorkflow,
 } from "@/lib/mcp/validate-workflow";
 import { VALIDATION_WARNING_CODES } from "@/lib/mcp/validate-workflow-codes";
+import { isTemplateReference } from "@/lib/mcp/validate-workflow-web3";
 
 export type ValidateWorkflowDeepOptions = {
   /** Chain IDs to consider valid (passed through to the fast tier when 48-02 lands). */
@@ -111,6 +112,12 @@ export function collectContractRefs(nodes: unknown): ContractRef[] {
       network.length === 0 ||
       declaredAbi.length === 0
     ) {
+      continue;
+    }
+    // A template-valued contractAddress (e.g. {{@prep:Prep.addr}}) resolves
+    // to a real address only at execution time; feeding the literal template
+    // to resolveAbi would always mismatch and emit a spurious warning.
+    if (isTemplateReference(contractAddress)) {
       continue;
     }
     const isWeb3 =

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -81,15 +81,21 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
     return issues;
   }
   for (const [idx, rawNode] of nodes.entries()) {
-    const contractAddress = readStringConfig(rawNode as NodeLike, "contractAddress");
-    if (contractAddress !== null && contractAddress.length > 0) {
-      if (!ethers.isAddress(contractAddress)) {
-        issues.push({
-          code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
-          message: `nodes[${idx}].config.contractAddress "${contractAddress}" is not a valid EVM address`,
-          parameterPath: `nodes[${idx}].config.contractAddress`,
-        });
-      }
+    const contractAddress = readStringConfig(
+      rawNode as NodeLike,
+      "contractAddress"
+    );
+    if (
+      contractAddress !== null &&
+      contractAddress.length > 0 &&
+      !isTemplateReference(contractAddress) &&
+      !ethers.isAddress(contractAddress)
+    ) {
+      issues.push({
+        code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
+        message: `nodes[${idx}].config.contractAddress "${contractAddress}" is not a valid EVM address`,
+        parameterPath: `nodes[${idx}].config.contractAddress`,
+      });
     }
 
     // tokenConfig is a JSON string (token-select field type — see
@@ -106,7 +112,11 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
       continue;
     }
     const embeddedAddress = extractTokenConfigAddress(parsed);
-    if (embeddedAddress !== null && !ethers.isAddress(embeddedAddress)) {
+    if (
+      embeddedAddress !== null &&
+      !isTemplateReference(embeddedAddress) &&
+      !ethers.isAddress(embeddedAddress)
+    ) {
       issues.push({
         code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
         message: `nodes[${idx}].config.tokenConfig.customToken.address "${embeddedAddress}" is not a valid EVM address`,
@@ -115,6 +125,16 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
     }
   }
   return issues;
+}
+
+// Address fields may hold a `{{...}}` template that resolves to a real
+// address at execution time (e.g. `{{@prep:Prep.governor_address_safe}}`).
+// These are not literal addresses, so the ethers.isAddress format check
+// must skip them rather than report a false invalid-token-address.
+const TEMPLATE_REFERENCE_RE = /\{\{.*?\}\}/;
+
+function isTemplateReference(value: string): boolean {
+  return TEMPLATE_REFERENCE_RE.test(value);
 }
 
 function readStringConfig(node: NodeLike, key: string): string | null {

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -133,7 +133,7 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
 // must skip them rather than report a false invalid-token-address.
 const TEMPLATE_REFERENCE_RE = /\{\{.*?\}\}/;
 
-function isTemplateReference(value: string): boolean {
+export function isTemplateReference(value: string): boolean {
   return TEMPLATE_REFERENCE_RE.test(value);
 }
 

--- a/tests/unit/validate-workflow-deep.test.ts
+++ b/tests/unit/validate-workflow-deep.test.ts
@@ -122,10 +122,17 @@ describe("collectContractRefs", () => {
   });
 
   it("collects a web3/write-contract node", () => {
-    const node = makeWriteNode(0, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "1", SIMPLE_ABI_TRANSFER);
+    const node = makeWriteNode(
+      0,
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const refs = collectContractRefs([makeTriggerNode(), node]);
     expect(refs).toHaveLength(1);
-    expect(refs[0].contractAddress).toBe("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(refs[0].contractAddress).toBe(
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
     expect(refs[0].isAbiAutoFetch).toBe(true);
   });
 
@@ -156,6 +163,17 @@ describe("collectContractRefs", () => {
       },
     };
     const refs = collectContractRefs([node]);
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips nodes whose contractAddress is a template reference (no spurious ABI fetch)", () => {
+    const node = makeWriteNode(
+      0,
+      "{{@prep:Prep.governor_address_safe}}",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
+    const refs = collectContractRefs([makeTriggerNode(), node]);
     expect(refs).toHaveLength(0);
   });
 });
@@ -205,7 +223,12 @@ describe("validateWorkflowDeep — fast tier composition", () => {
 
 describe("validateWorkflowDeep — ABI match", () => {
   it("emits no warning when declared ABI matches resolved ABI", async () => {
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -229,7 +252,12 @@ describe("validateWorkflowDeep — ABI match", () => {
 describe("validateWorkflowDeep — ABI mismatch (Pitfall 1)", () => {
   it("emits a warning when declared ABI differs from resolved ABI", async () => {
     // Declared: transfer. Resolved: approve. Mismatch.
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -256,7 +284,12 @@ describe("validateWorkflowDeep — ABI mismatch (Pitfall 1)", () => {
   });
 
   it("mismatch result lands in warnings[], NEVER errors[] (assertion on errors array explicitly)", async () => {
-    const writeNode = makeWriteNode(0, "0xdefdefdefdefdefdefdefdefdefdefdefdefdef0", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xdefdefdefdefdefdefdefdefdefdefdefdefdef0",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -284,7 +317,12 @@ describe("validateWorkflowDeep — proxy contract (Pitfall 1 regression)", () =>
   it("emits only a warning (not error) when explorer returns implementation ABI for a proxy", async () => {
     // Workflow declares a 3-function proxy stub ABI; explorer returns 100-function impl ABI.
     // This is the Aave V3 / Uniswap pattern — resolveAbi already handled the proxy.
-    const writeNode = makeWriteNode(0, "0x1111111111111111111111111111111111111111", "1", PROXY_STUB_ABI);
+    const writeNode = makeWriteNode(
+      0,
+      "0x1111111111111111111111111111111111111111",
+      "1",
+      PROXY_STUB_ABI
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -312,7 +350,12 @@ describe("validateWorkflowDeep — proxy contract (Pitfall 1 regression)", () =>
 
 describe("validateWorkflowDeep — resolveAbi failure handling", () => {
   it("emits no warning or error when resolveAbi rejects (degraded explorer)", async () => {
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -338,7 +381,12 @@ describe("validateWorkflowDeep — resolveAbi failure handling", () => {
 describe("validateWorkflowDeep — per-call timeout", () => {
   it("silently abandons a call that never resolves, completes in < 2500ms", async () => {
     vi.useRealTimers();
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -294,6 +294,22 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
     expect(err).toBeUndefined();
   });
 
+  it("treats a contractAddress containing any template token as dynamic (skips format check even with a literal prefix)", () => {
+    // Policy: a value with a {{...}} token is dynamic and cannot be
+    // statically format-checked, so it is skipped rather than flagged —
+    // even if it carries a literal-looking prefix.
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { contractAddress: "0xbad{{Prep.suffix}}" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
   it("does NOT error for a contractAddress that is a display-format template reference", () => {
     const wf = makeWorkflow({
       nodes: [

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -22,10 +22,7 @@ import {
 describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
   it("passes when action node network is in the chainIds Set", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "1" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "1" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
@@ -36,10 +33,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
 
   it("errors when action node network is NOT in the chainIds Set", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "9999" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "9999" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
@@ -51,10 +45,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
 
   it("errors when network value is a non-numeric string", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "abc" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "abc" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
@@ -65,10 +56,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
 
   it("skips chain check entirely when chainIds is undefined (no false errors)", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "99999" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "99999" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf);
@@ -227,10 +215,7 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
 
   it("does NOT error for an empty contractAddress (empty is a different validation surface)", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { contractAddress: "" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { contractAddress: "" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf);
@@ -294,11 +279,77 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
     expect(err).toBeUndefined();
   });
 
+  it("does NOT error for a contractAddress that is a stored-format template reference", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          contractAddress: "{{@prep:Prep.governor_address_safe}}",
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("does NOT error for a contractAddress that is a display-format template reference", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { contractAddress: "{{Prep.tokenAddress}}" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("does NOT error for a template address embedded in tokenConfig JSON", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          tokenConfig: JSON.stringify({
+            mode: "custom",
+            customToken: {
+              address: "{{@prep:Prep.token_address}}",
+              symbol: "X",
+            },
+          }),
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("STILL errors for a literal non-address contractAddress (template skip does not mask real errors)", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { contractAddress: "0xnotanaddress" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeDefined();
+    expect(err?.message).toContain("0xnotanaddress");
+  });
+
   it("does NOT crash or error on deeply malformed / adversarial node config", () => {
     const wf: ValidatorWorkflow = {
       id: "wf-adversarial",
       nodes: [
-        { id: "trigger-1", data: { type: "trigger", config: { triggerType: "Manual" } } },
+        {
+          id: "trigger-1",
+          data: { type: "trigger", config: { triggerType: "Manual" } },
+        },
         null as unknown as object,
         { id: "a1", data: null },
         { id: "a2", data: { config: null } },


### PR DESCRIPTION
## Summary

`validate_workflow` false-positived on workflows whose `contractAddress` is a runtime template reference like `{{@prep:Prep.governor_address_safe}}` (resolves to a real address only at execution time). Two surfaces were affected:

- **Fast tier (error):** `tokenAddressFormat` ran `ethers.isAddress()` on the literal template string -> false `invalid-token-address`, flipping `valid: false`. Now skips values containing a `{{...}}` token, for both `contractAddress` and the embedded `tokenConfig.customToken.address`.
- **Deep tier (warning):** `collectContractRefs` fed the literal template to `resolveAbi`, which always mismatched -> spurious `low-confidence-abi-match` warning. Now skips refs whose `contractAddress` is a template token. Reuses the `isTemplateReference` helper exported from the fast-tier module.

Literal addresses are still fully validated on both tiers.

## Scope / risk

- Advisory-only: `validateWorkflow` / `validateWorkflowDeep` are NOT on the save/create/update/go-live/publish path -- those gate on `validateWorkflowIntegrations` + `validateWorkflowActionConfigs`. This loosens advisory false-rejections; no persistence boundary, no wire-format change.

## Repro (now passes)

`validate_workflow` on `governance-scanner-ethereum` previously returned 4x `invalid-token-address` on `{{@prep:Prep.governor_address_safe}}`-valued `contractAddress` fields; with `deepCheck=true` it would also emit a spurious ABI-mismatch warning. After this PR both are gone.

## Test plan

- [x] Fast tier: 5 unit tests (stored-format template, display-format template, template in tokenConfig, literal-bad-address regression guard, mixed literal+template policy guard)
- [x] Deep tier: 1 unit test (collectContractRefs skips template-valued contractAddress)
- [x] Confirmed red before each fix, green after
- [x] web3 + structural + deep suites: 77 pass, no regressions
- [x] `pnpm check` (changed files) + `pnpm type-check` clean
- [ ] Post-deploy: re-run `validate_workflow` (and with `deepCheck=true`) on governance-scanner-ethereum to confirm both the error and the warning are gone