### PR TITLE
feat(blockscout): add chain selector for zero-config multi-chain queries

### DIFF
--- a/docs/plugins/blockscout.md
+++ b/docs/plugins/blockscout.md
@@ -5,7 +5,7 @@ description: "Query the Blockscout block explorer REST API for address, transact
 
 # Blockscout Plugin
 
-Read on-chain data from any Blockscout-powered block explorer. All actions are read-only and work against the public Ethereum mainnet instance out of the box. Connect an instance to query a different chain or raise rate limits with an API key.
+Read on-chain data from any Blockscout-powered block explorer. All actions are read-only and require no credentials. Pick a chain on the action and it queries that chain's Blockscout explorer automatically.
 
 ## Actions
 
@@ -17,20 +17,39 @@ Read on-chain data from any Blockscout-powered block explorer. All actions are r
 | Get Transaction | Fetch details for a transaction by hash |
 | Get Token Info | Fetch metadata for an ERC-20/721/1155 token contract |
 
-## Setup
+Every action takes a **Chain** input that selects which Blockscout explorer to query (defaults to Ethereum mainnet).
 
-No setup is required to query Ethereum mainnet. To use a different Blockscout instance or an API key:
+## Choosing a chain
+
+Each action has a **Chain** selector backed by hosted Blockscout instances, so no connection is needed for supported chains:
+
+| Chain | Chain ID |
+|-------|----------|
+| Ethereum Mainnet | 1 |
+| Ethereum Sepolia | 11155111 |
+| Base | 8453 |
+| Base Sepolia | 84532 |
+| Optimism | 10 |
+| Arbitrum One | 42161 |
+| Gnosis | 100 |
+| Polygon | 137 |
+
+## Setup (custom or self-hosted instances only)
+
+For a chain not in the list above, or to use a self-hosted instance or an API key:
 
 1. In KeeperHub, go to **Connections > Add Connection > Blockscout**
-2. Set the **Blockscout Instance URL** (for example `https://base.blockscout.com`)
+2. Set the **Blockscout Instance URL** (for example `https://gnosis.blockscout.com`)
 3. Optionally add an **API Key** for higher rate limits
 4. Save the connection and select it on the action
+
+A connection's instance URL takes precedence over the Chain selector.
 
 ## Get Address Balance
 
 Look up the native coin balance and metadata for an account or contract address.
 
-**Inputs:** Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `address`, `balance` (wei), `isContract`, `ensName`, `success`, `error`
 
@@ -48,7 +67,7 @@ Schedule (every 10 min)
 
 Fetch the full Blockscout address summary in one call -- balance, exchange rate, reputation, verification, and engagement flags.
 
-**Inputs:** Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `address`, `coinBalance` (wei), `exchangeRate` (USD), `isScam`, `isVerified`, `isContract`, `reputation`, `ensName`, `proxyType`, `publicTags`, `hasTokenTransfers`, `hasTokens`, `hasLogs`, `blockNumberBalanceUpdatedAt`, `success`, `error`
 
@@ -66,7 +85,7 @@ Manual trigger
 
 Fetch lifetime activity counters for an address.
 
-**Inputs:** Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `transactionsCount`, `tokenTransfersCount`, `gasUsageCount`, `validationsCount`, `success`, `error`
 
@@ -84,7 +103,7 @@ Webhook (address received)
 
 Fetch status and details for a transaction by hash.
 
-**Inputs:** Transaction Hash (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Transaction Hash (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `hash`, `status`, `value`, `from`, `to`, `blockNumber`, `fee`, `method`, `success`, `error`
 
@@ -102,7 +121,7 @@ Webhook (tx hash received)
 
 Fetch metadata for a token contract.
 
-**Inputs:** Token Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Token Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `address`, `name`, `symbol`, `decimals`, `totalSupply`, `type`, `holders`, `success`, `error`
 

--- a/plugins/blockscout/chains.ts
+++ b/plugins/blockscout/chains.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical hosted Blockscout instance per chain ID.
+ *
+ * Single source of truth shared by the plugin definition (the Chain selector's
+ * allowed chains) and the step runtime (instance resolution). Adding a chain
+ * here makes it available everywhere -- no other edits needed.
+ *
+ * Chains not listed here require a Blockscout connection with an explicit
+ * instance URL (BLOCKSCOUT_API_URL).
+ *
+ * Kept free of "server-only" so the client-loaded plugin definition can import
+ * it (the step runtime is server-only and imports it via blockscout-core).
+ */
+export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
+  1: "https://eth.blockscout.com",
+  11_155_111: "https://eth-sepolia.blockscout.com",
+  8453: "https://base.blockscout.com",
+  84_532: "https://base-sepolia.blockscout.com",
+  10: "https://explorer.optimism.io",
+  42_161: "https://arbitrum.blockscout.com",
+  100: "https://gnosis.blockscout.com",
+  137: "https://polygon.blockscout.com",
+};
+
+// Chain IDs (as strings) with a hosted instance, for chain-select allowlists.
+export const SUPPORTED_BLOCKSCOUT_CHAIN_IDS = Object.keys(BLOCKSCOUT_INSTANCES);

--- a/plugins/blockscout/index.ts
+++ b/plugins/blockscout/index.ts
@@ -1,6 +1,21 @@
-import type { IntegrationPlugin } from "@/plugins/registry";
+import type { ActionConfigField, IntegrationPlugin } from "@/plugins/registry";
 import { registerIntegration } from "@/plugins/registry-core";
 import { BlockscoutIcon } from "./icon";
+
+// Chain picker shared by every action. Maps to a hosted Blockscout instance so
+// a workflow can query any supported chain with no connection setup. Defaults
+// to Ethereum mainnet; for a chain not listed, attach a Blockscout connection
+// with its instance URL.
+const NETWORK_FIELD: ActionConfigField = {
+  key: "network",
+  label: "Chain",
+  type: "chain-select",
+  chainTypeFilter: "evm",
+  allowedChainIds: ["1", "11155111", "8453", "84532", "10", "42161", "100", "137"],
+  defaultValue: "1",
+  helpTip:
+    "Which chain's Blockscout explorer to query. Defaults to Ethereum mainnet. For a chain not listed here, add a Blockscout connection with its instance URL.",
+};
 
 const blockscoutPlugin: IntegrationPlugin = {
   type: "blockscout",
@@ -63,6 +78,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "address",
           label: "Address",
@@ -100,6 +116,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "address",
           label: "Address",
@@ -127,6 +144,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "address",
           label: "Address",
@@ -157,6 +175,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "txHash",
           label: "Transaction Hash",
@@ -187,6 +206,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "tokenAddress",
           label: "Token Address",

--- a/plugins/blockscout/index.ts
+++ b/plugins/blockscout/index.ts
@@ -1,5 +1,6 @@
 import type { ActionConfigField, IntegrationPlugin } from "@/plugins/registry";
 import { registerIntegration } from "@/plugins/registry-core";
+import { SUPPORTED_BLOCKSCOUT_CHAIN_IDS } from "./chains";
 import { BlockscoutIcon } from "./icon";
 
 // Chain picker shared by every action. Maps to a hosted Blockscout instance so
@@ -11,7 +12,7 @@ const NETWORK_FIELD: ActionConfigField = {
   label: "Chain",
   type: "chain-select",
   chainTypeFilter: "evm",
-  allowedChainIds: ["1", "11155111", "8453", "84532", "10", "42161", "100", "137"],
+  allowedChainIds: SUPPORTED_BLOCKSCOUT_CHAIN_IDS,
   defaultValue: "1",
   helpTip:
     "Which chain's Blockscout explorer to query. Defaults to Ethereum mainnet. For a chain not listed here, add a Blockscout connection with its instance URL.",

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -1,42 +1,103 @@
 import "server-only";
 
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getErrorMessage } from "@/lib/utils";
 import type { BlockscoutCredentials } from "../credentials";
 
-// Default public Blockscout instance (Ethereum mainnet). Users can point at a
-// different instance by configuring BLOCKSCOUT_API_URL in Project Integrations.
+// Default public Blockscout instance (Ethereum mainnet), used when no chain is
+// selected and no custom instance URL is configured.
 const DEFAULT_BLOCKSCOUT_API_URL = "https://eth.blockscout.com";
 
 // Strips one or more trailing slashes so paths can be appended consistently.
 const TRAILING_SLASH_RE = /\/+$/;
 
+/**
+ * Canonical hosted Blockscout instance per chain ID. Lets a workflow pick a
+ * chain on the node and query the right explorer with zero connection setup.
+ * Chains not listed here require a Blockscout connection with an explicit
+ * instance URL (BLOCKSCOUT_API_URL).
+ */
+export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
+  1: "https://eth.blockscout.com",
+  11_155_111: "https://eth-sepolia.blockscout.com",
+  8453: "https://base.blockscout.com",
+  84_532: "https://base-sepolia.blockscout.com",
+  10: "https://explorer.optimism.io",
+  42_161: "https://arbitrum.blockscout.com",
+  100: "https://gnosis.blockscout.com",
+  137: "https://polygon.blockscout.com",
+};
+
+export const SUPPORTED_BLOCKSCOUT_CHAIN_IDS = Object.keys(BLOCKSCOUT_INSTANCES);
+
 export type BlockscoutFetchResult<T> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+type InstanceResolution =
+  | { url: string }
+  | { error: string };
+
 /**
- * Resolve the Blockscout instance base URL from credentials, falling back to
- * the public Ethereum mainnet instance. Trailing slashes are stripped so paths
- * can be appended consistently.
+ * Resolve which Blockscout instance to query.
+ *
+ * Precedence:
+ *   1. An explicit connection instance URL (BLOCKSCOUT_API_URL) always wins --
+ *      this is the opt-in for self-hosted or rate-limited instances.
+ *   2. Otherwise the selected chain's hosted instance.
+ *   3. Otherwise the default Ethereum mainnet instance.
+ *
+ * Returns an error when a chain is selected that has no known hosted instance
+ * and no connection override, rather than silently falling back to Ethereum.
  */
-export function resolveBaseUrl(credentials: BlockscoutCredentials): string {
-  const url = credentials.BLOCKSCOUT_API_URL?.trim() || DEFAULT_BLOCKSCOUT_API_URL;
-  return url.replace(TRAILING_SLASH_RE, "");
+export function resolveInstance(
+  credentials: BlockscoutCredentials,
+  network?: string | number
+): InstanceResolution {
+  const override = credentials.BLOCKSCOUT_API_URL?.trim();
+  if (override) {
+    return { url: override.replace(TRAILING_SLASH_RE, "") };
+  }
+
+  const hasNetwork =
+    network !== undefined && network !== null && String(network).trim() !== "";
+  if (hasNetwork) {
+    let chainId: number;
+    try {
+      chainId = getChainIdFromNetwork(network as string | number);
+    } catch {
+      return { error: `Unrecognized chain "${network}".` };
+    }
+    const mapped = BLOCKSCOUT_INSTANCES[chainId];
+    if (mapped) {
+      return { url: mapped };
+    }
+    return {
+      error: `No hosted Blockscout instance is configured for chain ${chainId}. Add a Blockscout connection with that chain's instance URL.`,
+    };
+  }
+
+  return { url: DEFAULT_BLOCKSCOUT_API_URL };
 }
 
 /**
- * Perform a read-only GET against the Blockscout REST API (v2). Appends an
- * optional API key for higher rate limits and normalizes errors into the
+ * Perform a read-only GET against the Blockscout REST API (v2). Resolves the
+ * target instance from the selected chain or connection, appends an optional
+ * API key for higher rate limits, and normalizes errors into the
  * discriminated-union result shape used by every step.
  */
 export async function blockscoutGet<T>(
   path: string,
-  credentials: BlockscoutCredentials
+  credentials: BlockscoutCredentials,
+  network?: string | number
 ): Promise<BlockscoutFetchResult<T>> {
-  const baseUrl = resolveBaseUrl(credentials);
-  const apiKey = credentials.BLOCKSCOUT_API_KEY?.trim();
+  const resolved = resolveInstance(credentials, network);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
 
-  const url = new URL(`${baseUrl}${path}`);
+  const apiKey = credentials.BLOCKSCOUT_API_KEY?.trim();
+  const url = new URL(`${resolved.url}${path}`);
   if (apiKey) {
     url.searchParams.set("apikey", apiKey);
   }

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getErrorMessage } from "@/lib/utils";
 import type { BlockscoutCredentials } from "../credentials";
+import { BLOCKSCOUT_INSTANCES } from "../chains";
 
 // Default public Blockscout instance (Ethereum mainnet), used when no chain is
 // selected and no custom instance URL is configured.
@@ -10,25 +11,6 @@ const DEFAULT_BLOCKSCOUT_API_URL = "https://eth.blockscout.com";
 
 // Strips one or more trailing slashes so paths can be appended consistently.
 const TRAILING_SLASH_RE = /\/+$/;
-
-/**
- * Canonical hosted Blockscout instance per chain ID. Lets a workflow pick a
- * chain on the node and query the right explorer with zero connection setup.
- * Chains not listed here require a Blockscout connection with an explicit
- * instance URL (BLOCKSCOUT_API_URL).
- */
-export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
-  1: "https://eth.blockscout.com",
-  11_155_111: "https://eth-sepolia.blockscout.com",
-  8453: "https://base.blockscout.com",
-  84_532: "https://base-sepolia.blockscout.com",
-  10: "https://explorer.optimism.io",
-  42_161: "https://arbitrum.blockscout.com",
-  100: "https://gnosis.blockscout.com",
-  137: "https://polygon.blockscout.com",
-};
-
-export const SUPPORTED_BLOCKSCOUT_CHAIN_IDS = Object.keys(BLOCKSCOUT_INSTANCES);
 
 export type BlockscoutFetchResult<T> =
   | { success: true; data: T }

--- a/plugins/blockscout/steps/get-address-balance.ts
+++ b/plugins/blockscout/steps/get-address-balance.ts
@@ -28,6 +28,7 @@ type GetAddressBalanceResult =
 
 export type GetAddressBalanceCoreInput = {
   address: string;
+  network?: string;
 };
 
 export type GetAddressBalanceInput = StepInput &
@@ -46,7 +47,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<AddressResponse>(
     `/api/v2/addresses/${encodeURIComponent(address)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-address-counters.ts
+++ b/plugins/blockscout/steps/get-address-counters.ts
@@ -28,6 +28,7 @@ type GetAddressCountersResult =
 
 export type GetAddressCountersCoreInput = {
   address: string;
+  network?: string;
 };
 
 export type GetAddressCountersInput = StepInput &
@@ -46,7 +47,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<CountersResponse>(
     `/api/v2/addresses/${encodeURIComponent(address)}/counters`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-address-info.ts
+++ b/plugins/blockscout/steps/get-address-info.ts
@@ -48,6 +48,7 @@ type GetAddressInfoResult =
 
 export type GetAddressInfoCoreInput = {
   address: string;
+  network?: string;
 };
 
 export type GetAddressInfoInput = StepInput &
@@ -66,7 +67,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<AddressInfoResponse>(
     `/api/v2/addresses/${encodeURIComponent(address)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-token-info.ts
+++ b/plugins/blockscout/steps/get-token-info.ts
@@ -35,6 +35,7 @@ type GetTokenInfoResult =
 
 export type GetTokenInfoCoreInput = {
   tokenAddress: string;
+  network?: string;
 };
 
 export type GetTokenInfoInput = StepInput &
@@ -53,7 +54,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<TokenResponse>(
     `/api/v2/tokens/${encodeURIComponent(tokenAddress)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-transaction.ts
+++ b/plugins/blockscout/steps/get-transaction.ts
@@ -38,6 +38,7 @@ type GetTransactionResult =
 
 export type GetTransactionCoreInput = {
   txHash: string;
+  network?: string;
 };
 
 export type GetTransactionInput = StepInput &
@@ -56,7 +57,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<TransactionResponse>(
     `/api/v2/transactions/${encodeURIComponent(txHash)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/tests/unit/blockscout-steps.test.ts
+++ b/tests/unit/blockscout-steps.test.ts
@@ -307,3 +307,60 @@ describe("blockscout get-address-counters", () => {
     expect(result).toEqual({ success: false, error: "Address is required." });
   });
 });
+
+describe("blockscout chain selection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries the selected chain's hosted instance (Base)", async () => {
+    mockFetchOnce({ hash: "0xabc" });
+
+    await getAddressInfoStep({ address: "0xabc", network: "8453" });
+
+    expect(lastFetchUrl()).toContain("https://base.blockscout.com/api/v2/addresses/0xabc");
+  });
+
+  it("maps Optimism to its canonical instance", async () => {
+    mockFetchOnce({});
+
+    await getAddressCountersStep({ address: "0xabc", network: "10" });
+
+    expect(lastFetchUrl()).toContain("https://explorer.optimism.io/api/v2/addresses/0xabc/counters");
+  });
+
+  it("defaults to Ethereum mainnet when no chain is selected", async () => {
+    mockFetchOnce({ hash: "0xabc" });
+
+    await getAddressInfoStep({ address: "0xabc" });
+
+    expect(lastFetchUrl()).toContain("https://eth.blockscout.com/");
+  });
+
+  it("errors for a chain with no hosted instance and no connection", async () => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    const result = await getAddressInfoStep({ address: "0xabc", network: "999999" });
+
+    expect(result.success).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+    if (result.success === false) {
+      expect(result.error).toContain("No hosted Blockscout instance");
+    }
+  });
+
+  it("lets a connection instance URL override the selected chain", async () => {
+    mockFetchCredentials.mockResolvedValue({
+      BLOCKSCOUT_API_URL: "https://custom.blockscout.example",
+    });
+    mockFetchOnce({ hash: "0xabc" });
+
+    await getAddressInfoStep({
+      address: "0xabc",
+      network: "8453",
+      integrationId: "int-1",
+    });
+
+    expect(lastFetchUrl()).toContain("https://custom.blockscout.example/api/v2/addresses/0xabc");
+  });
+});


### PR DESCRIPTION
## Summary

- Workflows can now query any supported chain's Blockscout explorer by picking a **Chain** on the action node -- no connection setup. This removes the per-chain-connection friction that made the Base wallet-trust-score listing unable to "just work", and makes adding future chains a one-line map entry.
- Resolution precedence is explicit and safe: a connection's instance URL (the opt-in for self-hosted / rate-limited instances) wins, then the selected chain's hosted instance, then the Ethereum-mainnet default. A chain selected with no known instance and no connection now returns a clear error instead of silently returning Ethereum data.
- Backward compatible: omitting the chain preserves the previous Ethereum-mainnet default, so already-deployed Blockscout nodes (e.g. the reconfigured Ethereum trust-score workflow) are unaffected.

## Supported chains (hosted instances)

Ethereum (1), Ethereum Sepolia (11155111), Base (8453), Base Sepolia (84532), Optimism (10), Arbitrum One (42161), Gnosis (100), Polygon (137). Each instance URL was verified live against its Blockscout v2 API. Other chains use a connection's instance URL.

## Changes

- `blockscout-core.ts`: `BLOCKSCOUT_INSTANCES` map + `resolveInstance()`; `blockscoutGet()` takes an optional `network`.
- All five actions: optional `network` chain-select input (shared `NETWORK_FIELD`, restricted via `allowedChainIds`, defaults to Ethereum).
- Docs: supported-chains table and connection-as-fallback guidance.

## Test Plan

- [x] `pnpm exec vitest run tests/unit/blockscout-steps.test.ts` -- 19 pass (incl. chain->instance mapping, Ethereum default, unmapped-chain error, connection-override precedence)
- [x] `pnpm type-check` and `pnpm check` pass with zero errors
- [x] `pnpm discover-plugins` regenerates cleanly
- [x] Instance URLs confirmed against live Blockscout v2 endpoints

Follow-up after this deploys: reconfigure the Base wallet-trust-score workflow with `chain: 8453` and retest direct + via wallet.