### PR TITLE
feat: add project_id so we can filter the testing project from SLI and alert

### DIFF
--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -68,7 +68,7 @@ Counter/Gauge metrics tracking request/event counts.
 
 | Metric Name | Description | Labels | Unit | Source |
 |-------------|-------------|--------|------|--------|
-| `workflow.executions.total` | Total workflow executions by status (all-time) | `status`, `org_slug`, `error_type` (`user`/`system`/`unknown`/`na`) | gauge | DB |
+| `workflow.executions.total` | Total workflow executions by status (all-time) | `status`, `org_slug`, `project_id` (`_unassigned` when no project), `error_type` (`user`/`system`/`unknown`/`na`) | gauge | DB |
 | `workflow.execution.errors.total` | Total failed workflow executions (all-time) | - | gauge | DB |
 | `plugin.invocations.total` | Plugin action invocations | `plugin_name`, `action_name` | count | API |
 | `user.active.daily` | Daily active users (24h) | - | gauge | DB |

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -115,8 +115,8 @@ function getOrCreateGauge(
 const workflowExecutionsTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_workflow_executions_total",
-  "Total workflow executions by status, broken down by org_slug and error_type (all-time)",
-  ["status", "org_slug", "error_type"]
+  "Total workflow executions by status, broken down by org_slug, project_id, and error_type (all-time)",
+  ["status", "org_slug", "project_id", "error_type"]
 );
 
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
@@ -1241,15 +1241,17 @@ export async function updateDbMetrics(): Promise<void> {
       getBillingStatsFromDb(),
     ]);
 
-    // Update workflow execution counts per (status, org_slug, error_type).
-    // Reset before populating so series for orgs that no longer have executions
-    // in a given bucket clear out instead of going stale.
+    // Update workflow execution counts per (status, org_slug, project_id,
+    // error_type). Reset before populating so series for orgs/projects that
+    // no longer have executions in a given bucket clear out instead of
+    // going stale.
     workflowExecutionsTotal.reset();
     for (const row of workflowStats.executionsByStatusAndOrgSlug) {
       workflowExecutionsTotal.set(
         {
           status: row.status,
           org_slug: row.orgSlug,
+          project_id: row.projectId,
           error_type: row.errorType,
         },
         row.count

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -44,6 +44,12 @@ import type { BillingStatus } from "./types";
 // workflows still produce a series rather than silently dropping increments.
 export const ANONYMOUS_ORG_SLUG = "_anonymous";
 
+// Label value used for workflow executions whose workflow has no project
+// assigned (`workflows.project_id IS NULL`). Keeps every gauge series populated
+// so PromQL aggregates that drop the project_id dimension still sum to the
+// per-(status, org_slug) total.
+export const UNASSIGNED_PROJECT_ID = "_unassigned";
+
 // Histogram bucket boundaries in milliseconds (must match prometheus.ts)
 const WORKFLOW_DURATION_BUCKETS = [
   100, 250, 500, 1000, 2000, 5000, 10_000, 30_000,
@@ -58,9 +64,15 @@ export type WorkflowStats = {
   totalPending: number;
   totalCancelled: number;
 
-  // Per-(status, org_slug, error_type) execution counts. Personal/anonymous
-  // workflows are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for
-  // a given status across all orgs matches the corresponding total* above.
+  // Per-(status, org_slug, project_id, error_type) execution counts.
+  // Personal/anonymous workflows are bucketed under ANONYMOUS_ORG_SLUG.
+  // Workflows with no project assigned are bucketed under UNASSIGNED_PROJECT_ID.
+  // The sum of counts for a given status across all orgs/projects matches
+  // the corresponding total* above.
+  //
+  // projectId carries the raw `projects.id` value (globally unique nanoid).
+  // PromQL filters can therefore use `project_id` directly without needing
+  // org_slug to disambiguate, since project ids never collide across orgs.
   //
   // errorType is read directly from the workflow_executions.error_type text
   // column (KEEP-545 rename — see drizzle/0077_error_type_label_rename.sql).
@@ -76,6 +88,7 @@ export type WorkflowStats = {
   executionsByStatusAndOrgSlug: Array<{
     status: string;
     orgSlug: string;
+    projectId: string;
     errorType: string;
     count: number;
   }>;
@@ -106,19 +119,22 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       durationCount: 0,
     };
 
-    // Per-(status, org_slug, error_type) execution breakdown: JOIN workflows +
-    // organization, LEFT JOIN so anonymous workflows still contribute (under
-    // ANONYMOUS_ORG_SLUG). GROUP BY uses the underlying columns (not the
-    // COALESCE/CASE expressions): Drizzle would otherwise bind constants as
-    // separate parameters in SELECT and GROUP BY clauses, and Postgres rejects
-    // the query because the two expressions are not textually identical.
-    // Postgres groups NULLs together (NULLs are equal in GROUP BY), and the
-    // SELECT-side expressions render those groups as ANONYMOUS_ORG_SLUG /
-    // "unknown" / "na" as appropriate.
+    // Per-(status, org_slug, project_id, error_type) execution breakdown:
+    // JOIN workflows + organization, LEFT JOIN so anonymous workflows still
+    // contribute (under ANONYMOUS_ORG_SLUG). Workflows without a project_id
+    // are bucketed under UNASSIGNED_PROJECT_ID via COALESCE. GROUP BY uses
+    // the underlying columns (not the COALESCE/CASE expressions): Drizzle
+    // would otherwise bind constants as separate parameters in SELECT and
+    // GROUP BY clauses, and Postgres rejects the query because the two
+    // expressions are not textually identical. Postgres groups NULLs
+    // together (NULLs are equal in GROUP BY), and the SELECT-side
+    // expressions render those groups as ANONYMOUS_ORG_SLUG /
+    // UNASSIGNED_PROJECT_ID / "unknown" / "na" as appropriate.
     const breakdown = await db
       .select({
         status: workflowExecutions.status,
         orgSlug: sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`,
+        projectId: sql<string>`COALESCE(${workflows.projectId}, ${UNASSIGNED_PROJECT_ID})`,
         errorType: sql<string>`CASE
           WHEN ${workflowExecutions.status} <> 'error' THEN 'na'
           WHEN ${workflowExecutions.errorType} IS NULL THEN 'unknown'
@@ -132,6 +148,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       .groupBy(
         workflowExecutions.status,
         organization.slug,
+        workflows.projectId,
         workflowExecutions.errorType
       );
 
@@ -140,6 +157,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       stats.executionsByStatusAndOrgSlug.push({
         status: row.status,
         orgSlug: row.orgSlug,
+        projectId: row.projectId,
         errorType: row.errorType,
         count: c,
       });

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -195,6 +195,7 @@ export const LabelKeys = {
   ORG_ID: "org_id",
   ORG_SLUG: "org_slug",
   ORG_NAME: "org_name",
+  PROJECT_ID: "project_id",
   PLAN: "plan",
   OWNER_ID: "owner_id",
   PLUGIN_ID: "plugin_id",


### PR DESCRIPTION
## Context

The Managed-Client alert for techops-services currently includes every workflow under that org — including the internal `testing` project, which has 45 workflows (out of 79 total under techops-services). Test workflows break
intentionally during development, which pollutes the SLI numerator and makes the managed-client error rate look worse than the reality our managed clients actually experience.

Today there is no way to exclude individual projects from SLI/alert PromQL because `keeperhub_workflow_executions_total` only carries `org_slug` and `error_type` labels. Per-project filtering has to happen in the metric itself.

## What changed

Adds `project_id` as a fourth label on the DB-sourced gauge `keeperhub_workflow_executions_total`. The label value is `workflows.project_id` (globally unique nanoid) or the sentinel `_unassigned` for workflows that
have no project assigned.

- `lib/metrics/db-metrics.ts` — extend the breakdown SQL with `COALESCE(workflows.project_id, '_unassigned')`, add `projectId` to `WorkflowStats.executionsByStatusAndOrgSlug`, group by `workflows.project_id`.
- `lib/metrics/collectors/prometheus.ts` — add `project_id` to the gauge's declared label set, pass `row.projectId` in the per-bucket `set()` call.
- `lib/metrics/types.ts` — add `LabelKeys.PROJECT_ID`.
- `lib/metrics/METRICS_REFERENCE.md` — document the new label.

## Why project_id and not project_slug or project_name

`projects.id` is globally unique (per-system nanoid). Filtering by `project_id` alone is sufficient — there is no need to also pin `org_slug` to disambiguate. Project names are not unique across orgs, and the table has no `slug` column today. Using the raw id keeps this PR a pure metric-pipeline change with no schema migration.

## Impact on existing queries

None. Queries that aggregate with `sum()`, `rate()`, or `increase()` drop the new label dimension automatically and produce the same result.

## Post release
- Update the dashboard panel and alert rule to exclude techops-service `testing` project