### PR TITLE
release: to prod

### DIFF
--- a/docs/plugins/blockscout.md
+++ b/docs/plugins/blockscout.md
@@ -5,7 +5,7 @@ description: "Query the Blockscout block explorer REST API for address, transact
 
 # Blockscout Plugin
 
-Read on-chain data from any Blockscout-powered block explorer. All actions are read-only and work against the public Ethereum mainnet instance out of the box. Connect an instance to query a different chain or raise rate limits with an API key.
+Read on-chain data from any Blockscout-powered block explorer. All actions are read-only and require no credentials. Pick a chain on the action and it queries that chain's Blockscout explorer automatically.
 
 ## Actions
 
@@ -17,20 +17,39 @@ Read on-chain data from any Blockscout-powered block explorer. All actions are r
 | Get Transaction | Fetch details for a transaction by hash |
 | Get Token Info | Fetch metadata for an ERC-20/721/1155 token contract |
 
-## Setup
+Every action takes a **Chain** input that selects which Blockscout explorer to query (defaults to Ethereum mainnet).
 
-No setup is required to query Ethereum mainnet. To use a different Blockscout instance or an API key:
+## Choosing a chain
+
+Each action has a **Chain** selector backed by hosted Blockscout instances, so no connection is needed for supported chains:
+
+| Chain | Chain ID |
+|-------|----------|
+| Ethereum Mainnet | 1 |
+| Ethereum Sepolia | 11155111 |
+| Base | 8453 |
+| Base Sepolia | 84532 |
+| Optimism | 10 |
+| Arbitrum One | 42161 |
+| Gnosis | 100 |
+| Polygon | 137 |
+
+## Setup (custom or self-hosted instances only)
+
+For a chain not in the list above, or to use a self-hosted instance or an API key:
 
 1. In KeeperHub, go to **Connections > Add Connection > Blockscout**
-2. Set the **Blockscout Instance URL** (for example `https://base.blockscout.com`)
+2. Set the **Blockscout Instance URL** (for example `https://gnosis.blockscout.com`)
 3. Optionally add an **API Key** for higher rate limits
 4. Save the connection and select it on the action
+
+A connection's instance URL takes precedence over the Chain selector.
 
 ## Get Address Balance
 
 Look up the native coin balance and metadata for an account or contract address.
 
-**Inputs:** Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `address`, `balance` (wei), `isContract`, `ensName`, `success`, `error`
 
@@ -48,7 +67,7 @@ Schedule (every 10 min)
 
 Fetch the full Blockscout address summary in one call -- balance, exchange rate, reputation, verification, and engagement flags.
 
-**Inputs:** Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `address`, `coinBalance` (wei), `exchangeRate` (USD), `isScam`, `isVerified`, `isContract`, `reputation`, `ensName`, `proxyType`, `publicTags`, `hasTokenTransfers`, `hasTokens`, `hasLogs`, `blockNumberBalanceUpdatedAt`, `success`, `error`
 
@@ -66,7 +85,7 @@ Manual trigger
 
 Fetch lifetime activity counters for an address.
 
-**Inputs:** Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `transactionsCount`, `tokenTransfersCount`, `gasUsageCount`, `validationsCount`, `success`, `error`
 
@@ -84,7 +103,7 @@ Webhook (address received)
 
 Fetch status and details for a transaction by hash.
 
-**Inputs:** Transaction Hash (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Transaction Hash (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `hash`, `status`, `value`, `from`, `to`, `blockNumber`, `fee`, `method`, `success`, `error`
 
@@ -102,7 +121,7 @@ Webhook (tx hash received)
 
 Fetch metadata for a token contract.
 
-**Inputs:** Token Address (supports `{{NodeName.field}}` variables)
+**Inputs:** Chain, Token Address (supports `{{NodeName.field}}` variables)
 
 **Outputs:** `address`, `name`, `symbol`, `decimals`, `totalSupply`, `type`, `holders`, `success`, `error`
 

--- a/lib/db/connection-host-guard.ts
+++ b/lib/db/connection-host-guard.ts
@@ -1,5 +1,14 @@
 /**
- * SSRF guards for the database connection-test endpoint.
+ * SSRF guards for non-HTTP outbound connections (Postgres today; MongoDB,
+ * Redis, SMTP, etc. in future). The HTTP path uses `safeFetch` /
+ * `assertUrlIsPublic` from `lib/safe-fetch.ts`; this module is the single
+ * source of truth for everything else that opens a socket to a
+ * user-supplied host.
+ *
+ * `assertConnectionUrlIsPublic` is the call any such plugin should make
+ * before it hands a connection string to its driver. It composes URL
+ * parsing, IPv6-bracket stripping, and the underlying `assertHostIsPublic`
+ * check, so a plugin needs exactly one import and one call.
  *
  * Lives in its own module (rather than connection-utils.ts) because it
  * pulls in `lib/safe-fetch.ts`, which has `import "server-only"`.
@@ -16,7 +25,7 @@ import "server-only";
 import type { LookupAddress } from "node:dns";
 import { promises as dns } from "node:dns";
 import { isIP } from "node:net";
-import { isBlockedIp } from "@/lib/safe-fetch";
+import { isBlockedHost, isBlockedIp } from "@/lib/safe-fetch";
 
 /**
  * Reject connection-test attempts against private / loopback / link-local
@@ -39,6 +48,10 @@ export async function assertHostIsPublic(host: string): Promise<void> {
   const trimmed = host.trim();
   if (trimmed === "") {
     throw new Error("Host is required");
+  }
+
+  if (isBlockedHost(trimmed).blocked) {
+    throw new Error("Host is not allowed: must resolve to a public address");
   }
 
   if (isIP(trimmed) !== 0) {
@@ -76,4 +89,35 @@ export function extractHostFromConnectionString(url: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * The single source of truth for "is this connection string allowed to be
+ * dialled?" for non-HTTP outbound plugins.
+ *
+ * Composes URL parsing, IPv6-bracket stripping, and the underlying
+ * `assertHostIsPublic` check. Plugins that take a user-supplied connection
+ * string (Postgres today; MongoDB, Redis, SMTP, raw TCP, anything that
+ * opens a socket to a user-controlled host) should call this once at the
+ * top of their step, before constructing any client.
+ *
+ * Throws on:
+ * - missing or unparseable host (`Error("Connection string is missing a host")`)
+ * - blocked hostname pattern, blocked IP, or DNS that resolves to one
+ *   (`Error("Host is not allowed: must resolve to a public address")`)
+ * - DNS failure (`Error("Host could not be resolved")`)
+ *
+ * Error messages never echo the input URL, so they are safe to surface
+ * to the workflow caller. Plugins that already strip secrets from
+ * connection strings before logging do not need any additional sanitisation
+ * for errors raised here.
+ */
+export async function assertConnectionUrlIsPublic(url: string): Promise<void> {
+  const host = extractHostFromConnectionString(url);
+  if (!host) {
+    throw new Error("Connection string is missing a host");
+  }
+  const stripped =
+    host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  await assertHostIsPublic(stripped);
 }

--- a/lib/db/test-connection.ts
+++ b/lib/db/test-connection.ts
@@ -1,8 +1,5 @@
 import postgres from "postgres";
-import {
-  assertHostIsPublic,
-  extractHostFromConnectionString,
-} from "@/lib/db/connection-host-guard";
+import { assertConnectionUrlIsPublic } from "@/lib/db/connection-host-guard";
 import {
   buildDatabaseUrlFromConfig,
   type DatabaseConnectionConfig,
@@ -32,14 +29,17 @@ export async function testDatabaseConnection(
       sslMode
     );
 
-    const host = extractHostFromConnectionString(normalizedUrl);
-    if (!host) {
+    try {
+      await assertConnectionUrlIsPublic(normalizedUrl);
+    } catch (guardError) {
       return {
         status: "error",
-        message: "Connection string is missing a host",
+        message:
+          guardError instanceof Error
+            ? guardError.message
+            : "Host is not allowed: must resolve to a public address",
       };
     }
-    await assertHostIsPublic(host);
 
     connection = postgres(normalizedUrl, {
       max: 1,

--- a/lib/mcp/validate-workflow-deep.ts
+++ b/lib/mcp/validate-workflow-deep.ts
@@ -20,6 +20,7 @@ import {
   validateWorkflow,
 } from "@/lib/mcp/validate-workflow";
 import { VALIDATION_WARNING_CODES } from "@/lib/mcp/validate-workflow-codes";
+import { isTemplateReference } from "@/lib/mcp/validate-workflow-web3";
 
 export type ValidateWorkflowDeepOptions = {
   /** Chain IDs to consider valid (passed through to the fast tier when 48-02 lands). */
@@ -111,6 +112,12 @@ export function collectContractRefs(nodes: unknown): ContractRef[] {
       network.length === 0 ||
       declaredAbi.length === 0
     ) {
+      continue;
+    }
+    // A template-valued contractAddress (e.g. {{@prep:Prep.addr}}) resolves
+    // to a real address only at execution time; feeding the literal template
+    // to resolveAbi would always mismatch and emit a spurious warning.
+    if (isTemplateReference(contractAddress)) {
       continue;
     }
     const isWeb3 =

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -81,15 +81,21 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
     return issues;
   }
   for (const [idx, rawNode] of nodes.entries()) {
-    const contractAddress = readStringConfig(rawNode as NodeLike, "contractAddress");
-    if (contractAddress !== null && contractAddress.length > 0) {
-      if (!ethers.isAddress(contractAddress)) {
-        issues.push({
-          code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
-          message: `nodes[${idx}].config.contractAddress "${contractAddress}" is not a valid EVM address`,
-          parameterPath: `nodes[${idx}].config.contractAddress`,
-        });
-      }
+    const contractAddress = readStringConfig(
+      rawNode as NodeLike,
+      "contractAddress"
+    );
+    if (
+      contractAddress !== null &&
+      contractAddress.length > 0 &&
+      !isTemplateReference(contractAddress) &&
+      !ethers.isAddress(contractAddress)
+    ) {
+      issues.push({
+        code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
+        message: `nodes[${idx}].config.contractAddress "${contractAddress}" is not a valid EVM address`,
+        parameterPath: `nodes[${idx}].config.contractAddress`,
+      });
     }
 
     // tokenConfig is a JSON string (token-select field type — see
@@ -106,7 +112,11 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
       continue;
     }
     const embeddedAddress = extractTokenConfigAddress(parsed);
-    if (embeddedAddress !== null && !ethers.isAddress(embeddedAddress)) {
+    if (
+      embeddedAddress !== null &&
+      !isTemplateReference(embeddedAddress) &&
+      !ethers.isAddress(embeddedAddress)
+    ) {
       issues.push({
         code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
         message: `nodes[${idx}].config.tokenConfig.customToken.address "${embeddedAddress}" is not a valid EVM address`,
@@ -115,6 +125,16 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
     }
   }
   return issues;
+}
+
+// Address fields may hold a `{{...}}` template that resolves to a real
+// address at execution time (e.g. `{{@prep:Prep.governor_address_safe}}`).
+// These are not literal addresses, so the ethers.isAddress format check
+// must skip them rather than report a false invalid-token-address.
+const TEMPLATE_REFERENCE_RE = /\{\{.*?\}\}/;
+
+function isTemplateReference(value: string): boolean {
+  return TEMPLATE_REFERENCE_RE.test(value);
 }
 
 function readStringConfig(node: NodeLike, key: string): string | null {

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -133,7 +133,7 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
 // must skip them rather than report a false invalid-token-address.
 const TEMPLATE_REFERENCE_RE = /\{\{.*?\}\}/;
 
-function isTemplateReference(value: string): boolean {
+export function isTemplateReference(value: string): boolean {
   return TEMPLATE_REFERENCE_RE.test(value);
 }
 

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -19,7 +19,8 @@ export type SsrfBlockReason =
   | "multicast"
   | "reserved"
   | "ipv4-mapped-private"
-  | "ipv4-nat64-private";
+  | "ipv4-nat64-private"
+  | "blocked-host";
 
 export class SsrfBlockedError extends Error {
   readonly code = "SSRF_BLOCKED";
@@ -63,16 +64,26 @@ const NAT64_DOTTED_REGEX = /^64:ff9b::(\d+\.\d+\.\d+\.\d+)$/;
  * IPv4 covers unspecified, private, loopback, link-local (incl. IMDS
  * 169.254.169.254), CGNAT, documentation ranges, benchmarking, multicast,
  * reserved, broadcast. IPv6 covers unspecified, loopback, IPv4-mapped (via
- * extractor), discard, ULA, link-local, multicast.
+ * extractor), site-local NAT64 (RFC 8215), discard, Teredo, documentation,
+ * 6to4, ULA, link-local, multicast.
  *
- * NAT64 (64:ff9b::/96) is intentionally NOT in this list. In dual-stack /
- * IPv6-preferred networks (e.g. AWS VPCs with `enable_ipv6 = true`) the
- * resolver synthesises NAT64 AAAA records for every IPv4-only public host,
- * so blanket-blocking the prefix would block legitimate public destinations
- * like Discord, Slack, Telegram. Instead, NAT64 hits are detected
- * separately in `isBlockedIp` and the embedded IPv4 is rechecked against
- * this list — preserving the SSRF property (no NAT64 path to RFC 1918,
- * IMDS, etc.) without false positives on public IPv4.
+ * NAT64 well-known prefix (64:ff9b::/96, RFC 6052) is intentionally NOT in
+ * this list. In dual-stack / IPv6-preferred networks (e.g. AWS VPCs with
+ * `enable_ipv6 = true`) the resolver synthesises NAT64 AAAA records for
+ * every IPv4-only public host, so blanket-blocking the prefix would block
+ * legitimate public destinations like Discord, Slack, Telegram. Instead,
+ * NAT64 hits are detected separately in `isBlockedIp` and the embedded
+ * IPv4 is rechecked against this list - preserving the SSRF property (no
+ * NAT64 path to RFC 1918, IMDS, etc.) without false positives on public
+ * IPv4.
+ *
+ * Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS blanket-blocked here: the
+ * RFC defines it for site-local deployments, so by construction the
+ * embedded IPv4 maps to internal infrastructure. Teredo (2001::/32) and
+ * 6to4 (2002::/16) are also blanket-blocked despite carrying embedded
+ * public-IPv4 in some cases - both transition mechanisms are deprecated
+ * and not synthesised by mainstream resolvers, so false-positive risk is
+ * low.
  */
 function buildBlockList(): BlockList {
   const list = new BlockList();
@@ -100,7 +111,11 @@ function buildBlockList(): BlockList {
   // Node's BlockList treats that subnet as "all IPv4", which makes every
   // IPv4 check return true. IPv4-mapped IPv6 addresses pointing at private
   // IPv4 space are caught via extractMappedIpv4 below.
+  list.addSubnet("64:ff9b:1::", 48, "ipv6");
   list.addSubnet("100::", 64, "ipv6");
+  list.addSubnet("2001::", 32, "ipv6");
+  list.addSubnet("2001:db8::", 32, "ipv6");
+  list.addSubnet("2002::", 16, "ipv6");
   list.addSubnet("fc00::", 7, "ipv6");
   list.addSubnet("fe80::", 10, "ipv6");
   list.addSubnet("ff00::", 8, "ipv6");
@@ -252,6 +267,66 @@ export function isBlockedIp(
     }
   }
 
+  return { blocked: false };
+}
+
+const BLOCKED_HOST_EXACT = new Set(["localhost"]);
+
+/**
+ * Suffixes that mark a hostname as referring to a local / internal /
+ * in-cluster service. Matched against the normalised hostname (lower-cased,
+ * trailing dot stripped) using `String.prototype.endsWith`. Each entry must
+ * begin with a `.` so that a top-level token like "internal" cannot match
+ * an unrelated host such as "myinternal.com".
+ *
+ * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
+ * patterns, but the cluster suffixes are listed explicitly so the intent
+ * is visible at the denylist site and so any future narrowing of `.local`
+ * (e.g. to mDNS-only) does not silently re-open the in-cluster path.
+ *
+ * Cluster suffix scope: KeeperHub staging and production both run on AWS
+ * EKS with the default `clusterDomain` of `cluster.local`. If we move to a
+ * cluster with a custom `clusterDomain`, add it here.
+ */
+const BLOCKED_HOST_SUFFIXES = [
+  ".local",
+  ".internal",
+  ".svc.cluster.local",
+  ".pod.cluster.local",
+];
+
+/**
+ * Pre-DNS hostname denylist. Pure string match - no DNS lookup, no IP
+ * resolution. Intended as defense-in-depth on top of `isBlockedIp`: catches
+ * hosts that are internal by NAME (localhost, *.svc.cluster.local, EC2 VPC
+ * internal hostnames like *.compute.internal) before any resolver gets to
+ * synthesise a record. Pairs with the existing IP-resolution checks in
+ * `safeFetch` and `assertUrlIsPublic`.
+ *
+ * Returns `{ blocked: false }` for IP literals - those are validated by
+ * `isBlockedIp` instead.
+ */
+export function isBlockedHost(
+  host: string
+): { blocked: true; reason: "blocked-host" } | { blocked: false } {
+  if (host === "") {
+    return { blocked: false };
+  }
+  let normalised = host.trim().toLowerCase();
+  if (normalised.endsWith(".")) {
+    normalised = normalised.slice(0, -1);
+  }
+  if (normalised === "") {
+    return { blocked: false };
+  }
+  if (BLOCKED_HOST_EXACT.has(normalised)) {
+    return { blocked: true, reason: "blocked-host" };
+  }
+  for (const suffix of BLOCKED_HOST_SUFFIXES) {
+    if (normalised.endsWith(suffix)) {
+      return { blocked: true, reason: "blocked-host" };
+    }
+  }
   return { blocked: false };
 }
 
@@ -453,6 +528,23 @@ export async function safeFetch(
   }
 
   const hostname = stripIpv6Brackets(parsed.hostname);
+
+  const hostCheck = isBlockedHost(hostname);
+  if (hostCheck.blocked) {
+    recordBlock({ hostname, reason: hostCheck.reason, plugin }, shadow);
+    if (!shadow) {
+      throw new SsrfBlockedError({
+        hostname,
+        reason: hostCheck.reason,
+        message: blockedMessage({
+          hostname,
+          reason: hostCheck.reason,
+          plugin,
+        }),
+      });
+    }
+  }
+
   if (isIP(hostname) !== 0) {
     const check = isBlockedIp(hostname);
     if (check.blocked) {
@@ -533,6 +625,15 @@ export async function assertUrlIsPublic(rawUrl: string): Promise<void> {
   const hostname = stripIpv6Brackets(parsed.hostname);
   if (hostname === "") {
     throw new TypeError(`URL has no hostname: ${rawUrl}`);
+  }
+
+  const hostCheck = isBlockedHost(hostname);
+  if (hostCheck.blocked) {
+    throw new SsrfBlockedError({
+      hostname,
+      reason: hostCheck.reason,
+      message: blockedMessage({ hostname, reason: hostCheck.reason }),
+    });
   }
 
   if (isIP(hostname) !== 0) {

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -342,16 +342,35 @@ type BlockContext = {
 };
 
 /**
- * Carries the calling plugin label across the async boundary into the
+ * Carries per-request state across the async boundary into the
  * module-level Agent's lookup callback, where the original `safeFetch`
- * closure is out of scope. Without this, DNS-path blocks record
- * plugin_name="unknown" — precisely the case the shadow-mode soak needs
- * to attribute.
+ * closure is out of scope.
+ *
+ * - `plugin` attributes DNS-path blocks (without this, they record
+ *   plugin_name="unknown" — precisely the case the shadow-mode soak
+ *   needs to attribute).
+ * - `initialBlockRecorded` lets the synchronous entry-point checks
+ *   (`isBlockedHost` and the IP-literal `isBlockedIp` check) tell the
+ *   connector "we already counted this request as blocked." Without this
+ *   signal, a single shadow-mode request to e.g. `http://localhost/` is
+ *   counted twice (once for the hostname-pattern match, once again when
+ *   the connector's `dnsLookup` resolves it to 127.0.0.1). The flag
+ *   short-circuits the second `recordBlock` while still letting the
+ *   connector enforce in non-shadow mode.
  */
-const pluginContext = new AsyncLocalStorage<{ plugin?: string }>();
+type SafeFetchStore = {
+  plugin?: string;
+  initialBlockRecorded?: boolean;
+};
+
+const pluginContext = new AsyncLocalStorage<SafeFetchStore>();
 
 function currentPlugin(): string | undefined {
   return pluginContext.getStore()?.plugin;
+}
+
+function initialBlockAlreadyRecorded(): boolean {
+  return pluginContext.getStore()?.initialBlockRecorded === true;
 }
 
 function recordBlock(ctx: BlockContext, shadow: boolean): void {
@@ -448,10 +467,12 @@ function validatingConnect(
     const plugin = currentPlugin();
 
     if (check.blocked) {
-      recordBlock(
-        { hostname, resolvedIp: resolved, reason: check.reason, plugin },
-        shadow
-      );
+      if (!initialBlockAlreadyRecorded()) {
+        recordBlock(
+          { hostname, resolvedIp: resolved, reason: check.reason, plugin },
+          shadow
+        );
+      }
       if (!shadow) {
         callback(
           new SsrfBlockedError({
@@ -529,9 +550,20 @@ export async function safeFetch(
 
   const hostname = stripIpv6Brackets(parsed.hostname);
 
+  // Tracks whether one of the synchronous entry-point checks below has
+  // already incremented the block counter for this request. In shadow
+  // mode, execution continues past the block, the request reaches the
+  // connector, and the connector's own `isBlockedIp` check would record
+  // a second block for the same request (the resolved IP for a hostname
+  // pattern, or the literal itself for an IP-URL). Passing this flag
+  // through `pluginContext` lets the connector skip its `recordBlock`
+  // while still enforcing in non-shadow mode.
+  let initialBlockRecorded = false;
+
   const hostCheck = isBlockedHost(hostname);
   if (hostCheck.blocked) {
     recordBlock({ hostname, reason: hostCheck.reason, plugin }, shadow);
+    initialBlockRecorded = true;
     if (!shadow) {
       throw new SsrfBlockedError({
         hostname,
@@ -552,6 +584,7 @@ export async function safeFetch(
         { hostname, resolvedIp: hostname, reason: check.reason, plugin },
         shadow
       );
+      initialBlockRecorded = true;
       if (!shadow) {
         throw new SsrfBlockedError({
           hostname,
@@ -581,9 +614,12 @@ export async function safeFetch(
   } as unknown as UndiciFetchInit;
 
   // Run the fetch inside the plugin-context store so the shared Agent's
-  // DNS lookup can attribute blocks to the calling plugin.
-  const response = await pluginContext.run({ plugin }, () =>
-    undiciFetch(rawUrl, initWithDispatcher)
+  // DNS lookup can attribute blocks to the calling plugin, and so the
+  // connector can suppress a duplicate `recordBlock` when the
+  // synchronous checks above have already counted this request.
+  const response = await pluginContext.run(
+    { plugin, initialBlockRecorded },
+    () => undiciFetch(rawUrl, initWithDispatcher)
   );
   return response as unknown as Response;
 }

--- a/lib/workflow/nodes/database-query/step.ts
+++ b/lib/workflow/nodes/database-query/step.ts
@@ -9,13 +9,17 @@ import "server-only";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { assertConnectionUrlIsPublic } from "@/lib/db/connection-host-guard";
 import {
   getDatabaseErrorMessage,
   getPostgresConnectionOptions,
   type PostgresSslOption,
 } from "@/lib/db/connection-utils";
-import { fetchCredentials } from "@/lib/credential-fetcher";
-import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
 
 type DatabaseQueryResult =
   | { success: true; rows: unknown; count: number }
@@ -135,6 +139,18 @@ async function databaseQuery(
     databaseUrl,
     credentials.DATABASE_SSL_MODE
   );
+
+  try {
+    await assertConnectionUrlIsPublic(normalizedUrl);
+  } catch (guardError) {
+    return {
+      success: false,
+      error:
+        guardError instanceof Error
+          ? guardError.message
+          : "Host is not allowed: must resolve to a public address",
+    };
+  }
 
   const queryString = (input.dbQuery || input.query) as string;
   let client: postgres.Sql | null = null;

--- a/plugins/blockscout/chains.ts
+++ b/plugins/blockscout/chains.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical hosted Blockscout instance per chain ID.
+ *
+ * Single source of truth shared by the plugin definition (the Chain selector's
+ * allowed chains) and the step runtime (instance resolution). Adding a chain
+ * here makes it available everywhere -- no other edits needed.
+ *
+ * Chains not listed here require a Blockscout connection with an explicit
+ * instance URL (BLOCKSCOUT_API_URL).
+ *
+ * Kept free of "server-only" so the client-loaded plugin definition can import
+ * it (the step runtime is server-only and imports it via blockscout-core).
+ */
+export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
+  1: "https://eth.blockscout.com",
+  11_155_111: "https://eth-sepolia.blockscout.com",
+  8453: "https://base.blockscout.com",
+  84_532: "https://base-sepolia.blockscout.com",
+  10: "https://explorer.optimism.io",
+  42_161: "https://arbitrum.blockscout.com",
+  100: "https://gnosis.blockscout.com",
+  137: "https://polygon.blockscout.com",
+};
+
+// Chain IDs (as strings) with a hosted instance, for chain-select allowlists.
+export const SUPPORTED_BLOCKSCOUT_CHAIN_IDS = Object.keys(BLOCKSCOUT_INSTANCES);

--- a/plugins/blockscout/index.ts
+++ b/plugins/blockscout/index.ts
@@ -1,6 +1,21 @@
-import type { IntegrationPlugin } from "@/plugins/registry";
+import type { ActionConfigField, IntegrationPlugin } from "@/plugins/registry";
 import { registerIntegration } from "@/plugins/registry-core";
 import { BlockscoutIcon } from "./icon";
+
+// Chain picker shared by every action. Maps to a hosted Blockscout instance so
+// a workflow can query any supported chain with no connection setup. Defaults
+// to Ethereum mainnet; for a chain not listed, attach a Blockscout connection
+// with its instance URL.
+const NETWORK_FIELD: ActionConfigField = {
+  key: "network",
+  label: "Chain",
+  type: "chain-select",
+  chainTypeFilter: "evm",
+  allowedChainIds: ["1", "11155111", "8453", "84532", "10", "42161", "100", "137"],
+  defaultValue: "1",
+  helpTip:
+    "Which chain's Blockscout explorer to query. Defaults to Ethereum mainnet. For a chain not listed here, add a Blockscout connection with its instance URL.",
+};
 
 const blockscoutPlugin: IntegrationPlugin = {
   type: "blockscout",
@@ -63,6 +78,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "address",
           label: "Address",
@@ -100,6 +116,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "address",
           label: "Address",
@@ -127,6 +144,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "address",
           label: "Address",
@@ -157,6 +175,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "txHash",
           label: "Transaction Hash",
@@ -187,6 +206,7 @@ const blockscoutPlugin: IntegrationPlugin = {
         { field: "error", description: "Error message if failed" },
       ],
       configFields: [
+        NETWORK_FIELD,
         {
           key: "tokenAddress",
           label: "Token Address",

--- a/plugins/blockscout/index.ts
+++ b/plugins/blockscout/index.ts
@@ -1,5 +1,6 @@
 import type { ActionConfigField, IntegrationPlugin } from "@/plugins/registry";
 import { registerIntegration } from "@/plugins/registry-core";
+import { SUPPORTED_BLOCKSCOUT_CHAIN_IDS } from "./chains";
 import { BlockscoutIcon } from "./icon";
 
 // Chain picker shared by every action. Maps to a hosted Blockscout instance so
@@ -11,7 +12,7 @@ const NETWORK_FIELD: ActionConfigField = {
   label: "Chain",
   type: "chain-select",
   chainTypeFilter: "evm",
-  allowedChainIds: ["1", "11155111", "8453", "84532", "10", "42161", "100", "137"],
+  allowedChainIds: SUPPORTED_BLOCKSCOUT_CHAIN_IDS,
   defaultValue: "1",
   helpTip:
     "Which chain's Blockscout explorer to query. Defaults to Ethereum mainnet. For a chain not listed here, add a Blockscout connection with its instance URL.",

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -1,42 +1,103 @@
 import "server-only";
 
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getErrorMessage } from "@/lib/utils";
 import type { BlockscoutCredentials } from "../credentials";
 
-// Default public Blockscout instance (Ethereum mainnet). Users can point at a
-// different instance by configuring BLOCKSCOUT_API_URL in Project Integrations.
+// Default public Blockscout instance (Ethereum mainnet), used when no chain is
+// selected and no custom instance URL is configured.
 const DEFAULT_BLOCKSCOUT_API_URL = "https://eth.blockscout.com";
 
 // Strips one or more trailing slashes so paths can be appended consistently.
 const TRAILING_SLASH_RE = /\/+$/;
 
+/**
+ * Canonical hosted Blockscout instance per chain ID. Lets a workflow pick a
+ * chain on the node and query the right explorer with zero connection setup.
+ * Chains not listed here require a Blockscout connection with an explicit
+ * instance URL (BLOCKSCOUT_API_URL).
+ */
+export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
+  1: "https://eth.blockscout.com",
+  11_155_111: "https://eth-sepolia.blockscout.com",
+  8453: "https://base.blockscout.com",
+  84_532: "https://base-sepolia.blockscout.com",
+  10: "https://explorer.optimism.io",
+  42_161: "https://arbitrum.blockscout.com",
+  100: "https://gnosis.blockscout.com",
+  137: "https://polygon.blockscout.com",
+};
+
+export const SUPPORTED_BLOCKSCOUT_CHAIN_IDS = Object.keys(BLOCKSCOUT_INSTANCES);
+
 export type BlockscoutFetchResult<T> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+type InstanceResolution =
+  | { url: string }
+  | { error: string };
+
 /**
- * Resolve the Blockscout instance base URL from credentials, falling back to
- * the public Ethereum mainnet instance. Trailing slashes are stripped so paths
- * can be appended consistently.
+ * Resolve which Blockscout instance to query.
+ *
+ * Precedence:
+ *   1. An explicit connection instance URL (BLOCKSCOUT_API_URL) always wins --
+ *      this is the opt-in for self-hosted or rate-limited instances.
+ *   2. Otherwise the selected chain's hosted instance.
+ *   3. Otherwise the default Ethereum mainnet instance.
+ *
+ * Returns an error when a chain is selected that has no known hosted instance
+ * and no connection override, rather than silently falling back to Ethereum.
  */
-export function resolveBaseUrl(credentials: BlockscoutCredentials): string {
-  const url = credentials.BLOCKSCOUT_API_URL?.trim() || DEFAULT_BLOCKSCOUT_API_URL;
-  return url.replace(TRAILING_SLASH_RE, "");
+export function resolveInstance(
+  credentials: BlockscoutCredentials,
+  network?: string | number
+): InstanceResolution {
+  const override = credentials.BLOCKSCOUT_API_URL?.trim();
+  if (override) {
+    return { url: override.replace(TRAILING_SLASH_RE, "") };
+  }
+
+  const hasNetwork =
+    network !== undefined && network !== null && String(network).trim() !== "";
+  if (hasNetwork) {
+    let chainId: number;
+    try {
+      chainId = getChainIdFromNetwork(network as string | number);
+    } catch {
+      return { error: `Unrecognized chain "${network}".` };
+    }
+    const mapped = BLOCKSCOUT_INSTANCES[chainId];
+    if (mapped) {
+      return { url: mapped };
+    }
+    return {
+      error: `No hosted Blockscout instance is configured for chain ${chainId}. Add a Blockscout connection with that chain's instance URL.`,
+    };
+  }
+
+  return { url: DEFAULT_BLOCKSCOUT_API_URL };
 }
 
 /**
- * Perform a read-only GET against the Blockscout REST API (v2). Appends an
- * optional API key for higher rate limits and normalizes errors into the
+ * Perform a read-only GET against the Blockscout REST API (v2). Resolves the
+ * target instance from the selected chain or connection, appends an optional
+ * API key for higher rate limits, and normalizes errors into the
  * discriminated-union result shape used by every step.
  */
 export async function blockscoutGet<T>(
   path: string,
-  credentials: BlockscoutCredentials
+  credentials: BlockscoutCredentials,
+  network?: string | number
 ): Promise<BlockscoutFetchResult<T>> {
-  const baseUrl = resolveBaseUrl(credentials);
-  const apiKey = credentials.BLOCKSCOUT_API_KEY?.trim();
+  const resolved = resolveInstance(credentials, network);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
 
-  const url = new URL(`${baseUrl}${path}`);
+  const apiKey = credentials.BLOCKSCOUT_API_KEY?.trim();
+  const url = new URL(`${resolved.url}${path}`);
   if (apiKey) {
     url.searchParams.set("apikey", apiKey);
   }

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getErrorMessage } from "@/lib/utils";
 import type { BlockscoutCredentials } from "../credentials";
+import { BLOCKSCOUT_INSTANCES } from "../chains";
 
 // Default public Blockscout instance (Ethereum mainnet), used when no chain is
 // selected and no custom instance URL is configured.
@@ -10,25 +11,6 @@ const DEFAULT_BLOCKSCOUT_API_URL = "https://eth.blockscout.com";
 
 // Strips one or more trailing slashes so paths can be appended consistently.
 const TRAILING_SLASH_RE = /\/+$/;
-
-/**
- * Canonical hosted Blockscout instance per chain ID. Lets a workflow pick a
- * chain on the node and query the right explorer with zero connection setup.
- * Chains not listed here require a Blockscout connection with an explicit
- * instance URL (BLOCKSCOUT_API_URL).
- */
-export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
-  1: "https://eth.blockscout.com",
-  11_155_111: "https://eth-sepolia.blockscout.com",
-  8453: "https://base.blockscout.com",
-  84_532: "https://base-sepolia.blockscout.com",
-  10: "https://explorer.optimism.io",
-  42_161: "https://arbitrum.blockscout.com",
-  100: "https://gnosis.blockscout.com",
-  137: "https://polygon.blockscout.com",
-};
-
-export const SUPPORTED_BLOCKSCOUT_CHAIN_IDS = Object.keys(BLOCKSCOUT_INSTANCES);
 
 export type BlockscoutFetchResult<T> =
   | { success: true; data: T }

--- a/plugins/blockscout/steps/get-address-balance.ts
+++ b/plugins/blockscout/steps/get-address-balance.ts
@@ -28,6 +28,7 @@ type GetAddressBalanceResult =
 
 export type GetAddressBalanceCoreInput = {
   address: string;
+  network?: string;
 };
 
 export type GetAddressBalanceInput = StepInput &
@@ -46,7 +47,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<AddressResponse>(
     `/api/v2/addresses/${encodeURIComponent(address)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-address-counters.ts
+++ b/plugins/blockscout/steps/get-address-counters.ts
@@ -28,6 +28,7 @@ type GetAddressCountersResult =
 
 export type GetAddressCountersCoreInput = {
   address: string;
+  network?: string;
 };
 
 export type GetAddressCountersInput = StepInput &
@@ -46,7 +47,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<CountersResponse>(
     `/api/v2/addresses/${encodeURIComponent(address)}/counters`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-address-info.ts
+++ b/plugins/blockscout/steps/get-address-info.ts
@@ -48,6 +48,7 @@ type GetAddressInfoResult =
 
 export type GetAddressInfoCoreInput = {
   address: string;
+  network?: string;
 };
 
 export type GetAddressInfoInput = StepInput &
@@ -66,7 +67,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<AddressInfoResponse>(
     `/api/v2/addresses/${encodeURIComponent(address)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-token-info.ts
+++ b/plugins/blockscout/steps/get-token-info.ts
@@ -35,6 +35,7 @@ type GetTokenInfoResult =
 
 export type GetTokenInfoCoreInput = {
   tokenAddress: string;
+  network?: string;
 };
 
 export type GetTokenInfoInput = StepInput &
@@ -53,7 +54,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<TokenResponse>(
     `/api/v2/tokens/${encodeURIComponent(tokenAddress)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/plugins/blockscout/steps/get-transaction.ts
+++ b/plugins/blockscout/steps/get-transaction.ts
@@ -38,6 +38,7 @@ type GetTransactionResult =
 
 export type GetTransactionCoreInput = {
   txHash: string;
+  network?: string;
 };
 
 export type GetTransactionInput = StepInput &
@@ -56,7 +57,8 @@ async function stepHandler(
 
   const result = await blockscoutGet<TransactionResponse>(
     `/api/v2/transactions/${encodeURIComponent(txHash)}`,
-    credentials
+    credentials,
+    input.network
   );
 
   if (!result.success) {

--- a/tests/unit/blockscout-steps.test.ts
+++ b/tests/unit/blockscout-steps.test.ts
@@ -307,3 +307,60 @@ describe("blockscout get-address-counters", () => {
     expect(result).toEqual({ success: false, error: "Address is required." });
   });
 });
+
+describe("blockscout chain selection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries the selected chain's hosted instance (Base)", async () => {
+    mockFetchOnce({ hash: "0xabc" });
+
+    await getAddressInfoStep({ address: "0xabc", network: "8453" });
+
+    expect(lastFetchUrl()).toContain("https://base.blockscout.com/api/v2/addresses/0xabc");
+  });
+
+  it("maps Optimism to its canonical instance", async () => {
+    mockFetchOnce({});
+
+    await getAddressCountersStep({ address: "0xabc", network: "10" });
+
+    expect(lastFetchUrl()).toContain("https://explorer.optimism.io/api/v2/addresses/0xabc/counters");
+  });
+
+  it("defaults to Ethereum mainnet when no chain is selected", async () => {
+    mockFetchOnce({ hash: "0xabc" });
+
+    await getAddressInfoStep({ address: "0xabc" });
+
+    expect(lastFetchUrl()).toContain("https://eth.blockscout.com/");
+  });
+
+  it("errors for a chain with no hosted instance and no connection", async () => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    const result = await getAddressInfoStep({ address: "0xabc", network: "999999" });
+
+    expect(result.success).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+    if (result.success === false) {
+      expect(result.error).toContain("No hosted Blockscout instance");
+    }
+  });
+
+  it("lets a connection instance URL override the selected chain", async () => {
+    mockFetchCredentials.mockResolvedValue({
+      BLOCKSCOUT_API_URL: "https://custom.blockscout.example",
+    });
+    mockFetchOnce({ hash: "0xabc" });
+
+    await getAddressInfoStep({
+      address: "0xabc",
+      network: "8453",
+      integrationId: "int-1",
+    });
+
+    expect(lastFetchUrl()).toContain("https://custom.blockscout.example/api/v2/addresses/0xabc");
+  });
+});

--- a/tests/unit/connection-guards.test.ts
+++ b/tests/unit/connection-guards.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:dns", () => ({
 }));
 
 import {
+  assertConnectionUrlIsPublic,
   assertHostIsPublic,
   extractHostFromConnectionString,
 } from "@/lib/db/connection-host-guard";
@@ -62,9 +63,13 @@ describe("assertHostIsPublic", () => {
   it("rejects hostname that resolves to a private address", async () => {
     mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
 
-    await expect(assertHostIsPublic("internal-db.local")).rejects.toThrow(
+    // Uses .example TLD so the hostname does not match the pre-DNS
+    // isBlockedHost denylist; we want to exercise the DNS-resolution path
+    // specifically.
+    await expect(assertHostIsPublic("internal-db.example")).rejects.toThrow(
       "Host is not allowed: must resolve to a public address"
     );
+    expect(mockLookup).toHaveBeenCalled();
   });
 
   it("rejects hostname that resolves to a mix of public and private addresses", async () => {
@@ -86,18 +91,41 @@ describe("assertHostIsPublic", () => {
     );
   });
 
-  it("rejects localhost (resolves to loopback)", async () => {
+  it("rejects localhost before any DNS lookup", async () => {
+    // isBlockedHost catches `localhost` as a pre-DNS pattern, so the
+    // resolver is never consulted. The mock is only here to prove the
+    // negative.
     mockLookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
 
     await expect(assertHostIsPublic("localhost")).rejects.toThrow(
       "Host is not allowed: must resolve to a public address"
     );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["case-insensitive localhost", "LOCALHOST"],
+    ["trailing-dot FQDN form", "localhost."],
+    ["mDNS .local suffix", "raspberrypi.local"],
+    [".internal suffix", "service.internal"],
+    ["EC2 VPC internal hostname", "ip-10-0-0-5.us-east-2.compute.internal"],
+    ["k8s service DNS", "keeperhub-common.keeperhub.svc.cluster.local"],
+    ["k8s pod DNS", "mypod.keeperhub.pod.cluster.local"],
+  ])("rejects %s before any DNS lookup", async (_label, host) => {
+    await expect(assertHostIsPublic(host)).rejects.toThrow(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
   });
 });
 
 describe("extractHostFromConnectionString", () => {
   it.each([
-    ["postgres scheme with IPv4 host", "postgres://u:p@10.0.0.1:5432/db", "10.0.0.1"],
+    [
+      "postgres scheme with IPv4 host",
+      "postgres://u:p@10.0.0.1:5432/db",
+      "10.0.0.1",
+    ],
     [
       "postgresql scheme with hostname",
       "postgresql://user:pass@db.example.com:5432/mydb",
@@ -138,5 +166,97 @@ describe("extractHostFromConnectionString", () => {
       "Host is not allowed: must resolve to a public address"
     );
     expect(mockLookup).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertConnectionUrlIsPublic", () => {
+  it.each([
+    ["IPv4 loopback", "postgres://u:p@127.0.0.1:5432/db"],
+    ["IPv4 private 10/8", "postgres://u:p@10.0.0.1:5432/db"],
+    ["IPv4 private 192.168/16", "postgres://u:p@192.168.1.1:5432/db"],
+    ["IPv4 IMDS link-local", "postgres://u:p@169.254.169.254:5432/db"],
+    ["IPv6 loopback (bracketed)", "postgres://u:p@[::1]:5432/db"],
+    ["IPv6 ULA (bracketed)", "postgres://u:p@[fc00::1]:5432/db"],
+    ["IPv6 site-local NAT64", "postgres://u:p@[64:ff9b:1::1]:5432/db"],
+    ["IPv6 Teredo", "postgres://u:p@[2001::1]:5432/db"],
+    [
+      "IPv4-mapped IPv6 to private",
+      "postgres://u:p@[::ffff:127.0.0.1]:5432/db",
+    ],
+  ])("rejects %s before any DNS lookup", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).rejects.toThrow(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["localhost", "postgres://u:p@localhost:5432/db"],
+    [
+      "k8s service DNS",
+      "postgres://u:p@db.keeperhub.svc.cluster.local:5432/db",
+    ],
+    [
+      "EC2 VPC internal hostname",
+      "postgres://u:p@ip-10-0-0-5.us-east-2.compute.internal:5432/db",
+    ],
+    ["mDNS suffix", "postgres://u:p@raspberrypi.local:5432/db"],
+  ])("rejects hostname pattern %s before any DNS lookup", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).rejects.toThrow(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostname that resolves to a private address", async () => {
+    mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+    await expect(
+      assertConnectionUrlIsPublic("postgres://u:p@db.example/x")
+    ).rejects.toThrow("Host is not allowed: must resolve to a public address");
+    expect(mockLookup).toHaveBeenCalled();
+  });
+
+  it("permits hostname that resolves only to public addresses", async () => {
+    mockLookup.mockResolvedValue([{ address: "1.1.1.1", family: 4 }]);
+    await expect(
+      assertConnectionUrlIsPublic("postgres://u:p@db.example.com:5432/db")
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["IPv4 literal", "postgres://u:p@1.1.1.1:5432/db"],
+    [
+      "IPv6 literal (bracketed)",
+      "postgres://u:p@[2606:4700:4700::1111]:5432/db",
+    ],
+  ])("permits public %s without any DNS lookup", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).resolves.toBeUndefined();
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["plain garbage", "not-a-url"],
+    ["scheme-only", "postgres://"],
+  ])("throws for malformed URL: %s", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).rejects.toThrow(
+      "Connection string is missing a host"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("error messages never echo the connection string", async () => {
+    let thrown: unknown;
+    try {
+      await assertConnectionUrlIsPublic(
+        "postgres://supersecretuser:supersecretpassword@10.0.0.1:5432/internal"
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).not.toContain("supersecret");
+    expect(message).not.toContain("10.0.0.1");
+    expect(message).not.toContain("internal");
   });
 });

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/lib/metrics", () => ({
 
 import {
   assertUrlIsPublic,
+  isBlockedHost,
   isBlockedIp,
   SsrfBlockedError,
   type SsrfBlockReason,
@@ -86,6 +87,19 @@ describe("isBlockedIp", () => {
     ["fc00::1", "private-ip"],
     ["fd00::1", "private-ip"],
     ["ff02::1", "multicast"],
+    // Site-local NAT64 (RFC 8215). Distinct from the well-known 64:ff9b::/96
+    // prefix, which is intentionally allowed when embedded IPv4 is public.
+    ["64:ff9b:1::1", "private-ip"],
+    ["64:ff9b:1:abcd::1", "private-ip"],
+    // Teredo tunneling (2001::/32). Deprecated transition mechanism.
+    ["2001::1", "private-ip"],
+    ["2001:0:abcd:ef01:1234:5678:9abc:def0", "private-ip"],
+    // 6to4 (2002::/16). Deprecated transition mechanism.
+    ["2002::1", "private-ip"],
+    ["2002:0102:0304::1", "private-ip"],
+    // Documentation (2001:db8::/32). No legitimate traffic.
+    ["2001:db8::1", "private-ip"],
+    ["2001:db8:abcd::1", "private-ip"],
   ];
 
   for (const [ip, reason] of blockedV6) {
@@ -186,6 +200,61 @@ describe("isBlockedIp", () => {
   });
 });
 
+describe("isBlockedHost", () => {
+  const blockedHosts = [
+    "localhost",
+    "LOCALHOST",
+    "localhost.",
+    "  localhost  ",
+    "foo.local",
+    "raspberrypi.local",
+    "service.internal",
+    "ip-10-0-0-5.us-east-2.compute.internal",
+    "ip-172-31-1-1.ec2.internal",
+    "instance-data.ec2.internal",
+    "keeperhub-common.keeperhub.svc.cluster.local",
+    "mypod.keeperhub.pod.cluster.local",
+  ];
+
+  for (const host of blockedHosts) {
+    it(`blocks "${host}"`, () => {
+      const result = isBlockedHost(host);
+      expect(result.blocked).toBe(true);
+      if (result.blocked) {
+        expect(result.reason).toBe("blocked-host");
+      }
+    });
+  }
+
+  const allowedHosts = [
+    "example.com",
+    "www.example.com",
+    "db.us-east-1.rds.amazonaws.com",
+    "discord.com",
+    "keeperhub.com",
+    "myinternal.com",
+    "mylocal.com",
+    // IP literals are out of scope for the hostname check - isBlockedIp
+    // catches them. isBlockedHost must not match them on the suffix rules.
+    "127.0.0.1",
+    "10.0.0.1",
+    "::1",
+    "fe80::1",
+  ];
+
+  for (const host of allowedHosts) {
+    it(`allows "${host}"`, () => {
+      expect(isBlockedHost(host).blocked).toBe(false);
+    });
+  }
+
+  it("returns not-blocked for empty input", () => {
+    expect(isBlockedHost("").blocked).toBe(false);
+    expect(isBlockedHost("   ").blocked).toBe(false);
+    expect(isBlockedHost(".").blocked).toBe(false);
+  });
+});
+
 describe("safeFetch (enforce mode)", () => {
   const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
 
@@ -257,11 +326,14 @@ describe("safeFetch (enforce mode)", () => {
     );
   });
 
-  it("attributes plugin on DNS-resolved private IP (localhost)", async () => {
-    // `localhost` is not an IP literal, so it reaches the DNS path and is
-    // resolved inside the Agent's connector to 127.0.0.1 or ::1. The plugin
-    // label must propagate there via AsyncLocalStorage. Port 9999 avoids
-    // the WHATWG fetch "bad port" list (which includes port 1).
+  it("attributes plugin on hostname-pattern block (localhost)", async () => {
+    // `localhost` is caught by the pre-DNS hostname denylist (isBlockedHost)
+    // before any resolver runs, so the block is recorded synchronously with
+    // the directly-passed plugin label. The previous DNS-resolved-attribution
+    // path through AsyncLocalStorage is still present in the connector but
+    // is no longer reachable via `localhost`; covering it would require
+    // mocking the undici connector or using a non-pattern-matching
+    // hostname that resolves to a private IP.
     await expect(
       safeFetch("http://localhost:9999/", { plugin: "webhook" })
     ).rejects.toThrow();
@@ -269,10 +341,30 @@ describe("safeFetch (enforce mode)", () => {
       "safe_fetch.blocks.total",
       expect.objectContaining({
         plugin_name: "webhook",
-        reason: "loopback",
+        reason: "blocked-host",
       })
     );
   });
+
+  const blockedHostnames = [
+    "http://localhost/",
+    "http://localhost:9999/",
+    "http://foo.local/",
+    "http://service.internal/",
+    "http://ip-10-0-0-5.us-east-2.compute.internal/",
+    "http://keeperhub-common.keeperhub.svc.cluster.local/",
+    "http://mypod.keeperhub.pod.cluster.local/",
+  ];
+
+  for (const url of blockedHostnames) {
+    it(`rejects hostname-pattern ${url}`, async () => {
+      await expect(safeFetch(url)).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(incrementCounter).toHaveBeenCalledWith(
+        "safe_fetch.blocks.total",
+        expect.objectContaining({ reason: "blocked-host", shadow: "false" })
+      );
+    });
+  }
 
   it("throws TypeError for malformed URLs", async () => {
     await expect(safeFetch("not a url")).rejects.toBeInstanceOf(TypeError);
@@ -565,4 +657,27 @@ describe("assertUrlIsPublic", () => {
     expect(thrown).not.toBeInstanceOf(SsrfBlockedError);
     expect(thrown).not.toBeInstanceOf(TypeError);
   });
+
+  const blockedHostnames = [
+    "http://localhost/",
+    "http://foo.local/",
+    "http://service.internal/",
+    "http://ip-10-0-0-5.us-east-2.compute.internal/",
+    "http://keeperhub-common.keeperhub.svc.cluster.local/",
+    "http://mypod.keeperhub.pod.cluster.local/",
+  ];
+
+  for (const url of blockedHostnames) {
+    it(`rejects hostname-pattern ${url} before any DNS lookup`, async () => {
+      let thrown: unknown;
+      try {
+        await assertUrlIsPublic(url);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(SsrfBlockedError);
+      expect((thrown as SsrfBlockedError).reason).toBe("blocked-host");
+      expect(mockPromisesLookup).not.toHaveBeenCalled();
+    });
+  }
 });

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -400,10 +400,17 @@ describe("safeFetch (shadow mode)", () => {
     } catch (err) {
       expect(err).not.toBeInstanceOf(SsrfBlockedError);
     }
-    expect(incrementCounter).toHaveBeenCalledWith(
-      "safe_fetch.blocks.total",
-      expect.objectContaining({ reason: "loopback", shadow: "true" })
+    const blockCalls = incrementCounter.mock.calls.filter(
+      (call) => call[0] === "safe_fetch.blocks.total"
     );
+    // Exactly one block per request, even though the connector's
+    // post-DNS check would otherwise re-fire on the resolved IP. See
+    // SafeFetchStore.initialBlockRecorded in safe-fetch.ts.
+    expect(blockCalls).toHaveLength(1);
+    expect(blockCalls[0]?.[1]).toMatchObject({
+      reason: "loopback",
+      shadow: "true",
+    });
     expect(captureException).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
@@ -414,6 +421,31 @@ describe("safeFetch (shadow mode)", () => {
         }),
       })
     );
+  });
+
+  it("records exactly one block in shadow mode for a hostname-pattern URL", async () => {
+    // Regression: a single shadow-mode request to `http://localhost/` used
+    // to be counted twice - once for the pre-DNS isBlockedHost match
+    // (reason="blocked-host"), then again inside the connector's DNS
+    // callback after `localhost` resolved to 127.0.0.1 (reason="loopback").
+    // The fix threads `initialBlockRecorded` through pluginContext so the
+    // connector skips its recordBlock when the entry-point check already
+    // counted this request. The connect itself still happens, preserving
+    // shadow-mode "log and continue" semantics.
+    try {
+      await safeFetch("http://localhost:9999/", { plugin: "webhook" });
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(SsrfBlockedError);
+    }
+    const blockCalls = incrementCounter.mock.calls.filter(
+      (call) => call[0] === "safe_fetch.blocks.total"
+    );
+    expect(blockCalls).toHaveLength(1);
+    expect(blockCalls[0]?.[1]).toMatchObject({
+      reason: "blocked-host",
+      plugin_name: "webhook",
+      shadow: "true",
+    });
   });
 
   it("records scheme block with shadow=true on non-http URL", async () => {

--- a/tests/unit/validate-workflow-deep.test.ts
+++ b/tests/unit/validate-workflow-deep.test.ts
@@ -122,10 +122,17 @@ describe("collectContractRefs", () => {
   });
 
   it("collects a web3/write-contract node", () => {
-    const node = makeWriteNode(0, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "1", SIMPLE_ABI_TRANSFER);
+    const node = makeWriteNode(
+      0,
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const refs = collectContractRefs([makeTriggerNode(), node]);
     expect(refs).toHaveLength(1);
-    expect(refs[0].contractAddress).toBe("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(refs[0].contractAddress).toBe(
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
     expect(refs[0].isAbiAutoFetch).toBe(true);
   });
 
@@ -156,6 +163,17 @@ describe("collectContractRefs", () => {
       },
     };
     const refs = collectContractRefs([node]);
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips nodes whose contractAddress is a template reference (no spurious ABI fetch)", () => {
+    const node = makeWriteNode(
+      0,
+      "{{@prep:Prep.governor_address_safe}}",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
+    const refs = collectContractRefs([makeTriggerNode(), node]);
     expect(refs).toHaveLength(0);
   });
 });
@@ -205,7 +223,12 @@ describe("validateWorkflowDeep — fast tier composition", () => {
 
 describe("validateWorkflowDeep — ABI match", () => {
   it("emits no warning when declared ABI matches resolved ABI", async () => {
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -229,7 +252,12 @@ describe("validateWorkflowDeep — ABI match", () => {
 describe("validateWorkflowDeep — ABI mismatch (Pitfall 1)", () => {
   it("emits a warning when declared ABI differs from resolved ABI", async () => {
     // Declared: transfer. Resolved: approve. Mismatch.
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -256,7 +284,12 @@ describe("validateWorkflowDeep — ABI mismatch (Pitfall 1)", () => {
   });
 
   it("mismatch result lands in warnings[], NEVER errors[] (assertion on errors array explicitly)", async () => {
-    const writeNode = makeWriteNode(0, "0xdefdefdefdefdefdefdefdefdefdefdefdefdef0", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xdefdefdefdefdefdefdefdefdefdefdefdefdef0",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -284,7 +317,12 @@ describe("validateWorkflowDeep — proxy contract (Pitfall 1 regression)", () =>
   it("emits only a warning (not error) when explorer returns implementation ABI for a proxy", async () => {
     // Workflow declares a 3-function proxy stub ABI; explorer returns 100-function impl ABI.
     // This is the Aave V3 / Uniswap pattern — resolveAbi already handled the proxy.
-    const writeNode = makeWriteNode(0, "0x1111111111111111111111111111111111111111", "1", PROXY_STUB_ABI);
+    const writeNode = makeWriteNode(
+      0,
+      "0x1111111111111111111111111111111111111111",
+      "1",
+      PROXY_STUB_ABI
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -312,7 +350,12 @@ describe("validateWorkflowDeep — proxy contract (Pitfall 1 regression)", () =>
 
 describe("validateWorkflowDeep — resolveAbi failure handling", () => {
   it("emits no warning or error when resolveAbi rejects (degraded explorer)", async () => {
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",
@@ -338,7 +381,12 @@ describe("validateWorkflowDeep — resolveAbi failure handling", () => {
 describe("validateWorkflowDeep — per-call timeout", () => {
   it("silently abandons a call that never resolves, completes in < 2500ms", async () => {
     vi.useRealTimers();
-    const writeNode = makeWriteNode(0, "0xabcabcabcabcabcabcabcabcabcabcabcabcabca", "1", SIMPLE_ABI_TRANSFER);
+    const writeNode = makeWriteNode(
+      0,
+      "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      "1",
+      SIMPLE_ABI_TRANSFER
+    );
     const workflow = makeWorkflow({
       nodes: [makeTriggerNode(), writeNode],
       workflowType: "write",

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -294,6 +294,22 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
     expect(err).toBeUndefined();
   });
 
+  it("treats a contractAddress containing any template token as dynamic (skips format check even with a literal prefix)", () => {
+    // Policy: a value with a {{...}} token is dynamic and cannot be
+    // statically format-checked, so it is skipped rather than flagged —
+    // even if it carries a literal-looking prefix.
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { contractAddress: "0xbad{{Prep.suffix}}" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
   it("does NOT error for a contractAddress that is a display-format template reference", () => {
     const wf = makeWorkflow({
       nodes: [

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -22,10 +22,7 @@ import {
 describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
   it("passes when action node network is in the chainIds Set", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "1" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "1" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
@@ -36,10 +33,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
 
   it("errors when action node network is NOT in the chainIds Set", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "9999" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "9999" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
@@ -51,10 +45,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
 
   it("errors when network value is a non-numeric string", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "abc" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "abc" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
@@ -65,10 +56,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
 
   it("skips chain check entirely when chainIds is undefined (no false errors)", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { network: "99999" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { network: "99999" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf);
@@ -227,10 +215,7 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
 
   it("does NOT error for an empty contractAddress (empty is a different validation surface)", () => {
     const wf = makeWorkflow({
-      nodes: [
-        triggerNode(),
-        actionNode("a1", { contractAddress: "" }),
-      ],
+      nodes: [triggerNode(), actionNode("a1", { contractAddress: "" })],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     const result = validateWorkflow(wf);
@@ -294,11 +279,77 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
     expect(err).toBeUndefined();
   });
 
+  it("does NOT error for a contractAddress that is a stored-format template reference", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          contractAddress: "{{@prep:Prep.governor_address_safe}}",
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("does NOT error for a contractAddress that is a display-format template reference", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { contractAddress: "{{Prep.tokenAddress}}" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("does NOT error for a template address embedded in tokenConfig JSON", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          tokenConfig: JSON.stringify({
+            mode: "custom",
+            customToken: {
+              address: "{{@prep:Prep.token_address}}",
+              symbol: "X",
+            },
+          }),
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("STILL errors for a literal non-address contractAddress (template skip does not mask real errors)", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { contractAddress: "0xnotanaddress" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeDefined();
+    expect(err?.message).toContain("0xnotanaddress");
+  });
+
   it("does NOT crash or error on deeply malformed / adversarial node config", () => {
     const wf: ValidatorWorkflow = {
       id: "wf-adversarial",
       nodes: [
-        { id: "trigger-1", data: { type: "trigger", config: { triggerType: "Manual" } } },
+        {
+          id: "trigger-1",
+          data: { type: "trigger", config: { triggerType: "Manual" } },
+        },
         null as unknown as object,
         { id: "a1", data: null },
         { id: "a2", data: { config: null } },


### PR DESCRIPTION
## Summary

Promote the following merged PRs from staging to prod:

- #1326 feat(blockscout): add chain selector for zero-config multi-chain queries
- #1325 fix(mcp): skip template-valued addresses in validate_workflow address check

## Post-deploy verification

- [ ] `deploy-keeperhub` workflow finishes green
- [ ] `curl -fsS https://app.keeperhub.com/api/health` returns 200
- [ ] Blockscout actions expose a working **Chain** selector (Base/Optimism/etc. query the right instance; unmapped chain errors instead of falling back to Ethereum)
- [ ] `validate_workflow` no longer rejects template-valued address fields (#1325)
- [ ] Watch Sentry / logs for ~10 minutes after the rollout
