### PR TITLE
hotfix: SSRF guard parity across HTTP and database plugins

### DIFF
--- a/lib/db/connection-host-guard.ts
+++ b/lib/db/connection-host-guard.ts
@@ -1,5 +1,14 @@
 /**
- * SSRF guards for the database connection-test endpoint.
+ * SSRF guards for non-HTTP outbound connections (Postgres today; MongoDB,
+ * Redis, SMTP, etc. in future). The HTTP path uses `safeFetch` /
+ * `assertUrlIsPublic` from `lib/safe-fetch.ts`; this module is the single
+ * source of truth for everything else that opens a socket to a
+ * user-supplied host.
+ *
+ * `assertConnectionUrlIsPublic` is the call any such plugin should make
+ * before it hands a connection string to its driver. It composes URL
+ * parsing, IPv6-bracket stripping, and the underlying `assertHostIsPublic`
+ * check, so a plugin needs exactly one import and one call.
  *
  * Lives in its own module (rather than connection-utils.ts) because it
  * pulls in `lib/safe-fetch.ts`, which has `import "server-only"`.
@@ -16,7 +25,7 @@ import "server-only";
 import type { LookupAddress } from "node:dns";
 import { promises as dns } from "node:dns";
 import { isIP } from "node:net";
-import { isBlockedIp } from "@/lib/safe-fetch";
+import { isBlockedHost, isBlockedIp } from "@/lib/safe-fetch";
 
 /**
  * Reject connection-test attempts against private / loopback / link-local
@@ -39,6 +48,10 @@ export async function assertHostIsPublic(host: string): Promise<void> {
   const trimmed = host.trim();
   if (trimmed === "") {
     throw new Error("Host is required");
+  }
+
+  if (isBlockedHost(trimmed).blocked) {
+    throw new Error("Host is not allowed: must resolve to a public address");
   }
 
   if (isIP(trimmed) !== 0) {
@@ -76,4 +89,35 @@ export function extractHostFromConnectionString(url: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * The single source of truth for "is this connection string allowed to be
+ * dialled?" for non-HTTP outbound plugins.
+ *
+ * Composes URL parsing, IPv6-bracket stripping, and the underlying
+ * `assertHostIsPublic` check. Plugins that take a user-supplied connection
+ * string (Postgres today; MongoDB, Redis, SMTP, raw TCP, anything that
+ * opens a socket to a user-controlled host) should call this once at the
+ * top of their step, before constructing any client.
+ *
+ * Throws on:
+ * - missing or unparseable host (`Error("Connection string is missing a host")`)
+ * - blocked hostname pattern, blocked IP, or DNS that resolves to one
+ *   (`Error("Host is not allowed: must resolve to a public address")`)
+ * - DNS failure (`Error("Host could not be resolved")`)
+ *
+ * Error messages never echo the input URL, so they are safe to surface
+ * to the workflow caller. Plugins that already strip secrets from
+ * connection strings before logging do not need any additional sanitisation
+ * for errors raised here.
+ */
+export async function assertConnectionUrlIsPublic(url: string): Promise<void> {
+  const host = extractHostFromConnectionString(url);
+  if (!host) {
+    throw new Error("Connection string is missing a host");
+  }
+  const stripped =
+    host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  await assertHostIsPublic(stripped);
 }

--- a/lib/db/test-connection.ts
+++ b/lib/db/test-connection.ts
@@ -1,8 +1,5 @@
 import postgres from "postgres";
-import {
-  assertHostIsPublic,
-  extractHostFromConnectionString,
-} from "@/lib/db/connection-host-guard";
+import { assertConnectionUrlIsPublic } from "@/lib/db/connection-host-guard";
 import {
   buildDatabaseUrlFromConfig,
   type DatabaseConnectionConfig,
@@ -32,14 +29,17 @@ export async function testDatabaseConnection(
       sslMode
     );
 
-    const host = extractHostFromConnectionString(normalizedUrl);
-    if (!host) {
+    try {
+      await assertConnectionUrlIsPublic(normalizedUrl);
+    } catch (guardError) {
       return {
         status: "error",
-        message: "Connection string is missing a host",
+        message:
+          guardError instanceof Error
+            ? guardError.message
+            : "Host is not allowed: must resolve to a public address",
       };
     }
-    await assertHostIsPublic(host);
 
     connection = postgres(normalizedUrl, {
       max: 1,

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -19,7 +19,8 @@ export type SsrfBlockReason =
   | "multicast"
   | "reserved"
   | "ipv4-mapped-private"
-  | "ipv4-nat64-private";
+  | "ipv4-nat64-private"
+  | "blocked-host";
 
 export class SsrfBlockedError extends Error {
   readonly code = "SSRF_BLOCKED";
@@ -63,16 +64,26 @@ const NAT64_DOTTED_REGEX = /^64:ff9b::(\d+\.\d+\.\d+\.\d+)$/;
  * IPv4 covers unspecified, private, loopback, link-local (incl. IMDS
  * 169.254.169.254), CGNAT, documentation ranges, benchmarking, multicast,
  * reserved, broadcast. IPv6 covers unspecified, loopback, IPv4-mapped (via
- * extractor), discard, ULA, link-local, multicast.
+ * extractor), site-local NAT64 (RFC 8215), discard, Teredo, documentation,
+ * 6to4, ULA, link-local, multicast.
  *
- * NAT64 (64:ff9b::/96) is intentionally NOT in this list. In dual-stack /
- * IPv6-preferred networks (e.g. AWS VPCs with `enable_ipv6 = true`) the
- * resolver synthesises NAT64 AAAA records for every IPv4-only public host,
- * so blanket-blocking the prefix would block legitimate public destinations
- * like Discord, Slack, Telegram. Instead, NAT64 hits are detected
- * separately in `isBlockedIp` and the embedded IPv4 is rechecked against
- * this list — preserving the SSRF property (no NAT64 path to RFC 1918,
- * IMDS, etc.) without false positives on public IPv4.
+ * NAT64 well-known prefix (64:ff9b::/96, RFC 6052) is intentionally NOT in
+ * this list. In dual-stack / IPv6-preferred networks (e.g. AWS VPCs with
+ * `enable_ipv6 = true`) the resolver synthesises NAT64 AAAA records for
+ * every IPv4-only public host, so blanket-blocking the prefix would block
+ * legitimate public destinations like Discord, Slack, Telegram. Instead,
+ * NAT64 hits are detected separately in `isBlockedIp` and the embedded
+ * IPv4 is rechecked against this list - preserving the SSRF property (no
+ * NAT64 path to RFC 1918, IMDS, etc.) without false positives on public
+ * IPv4.
+ *
+ * Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS blanket-blocked here: the
+ * RFC defines it for site-local deployments, so by construction the
+ * embedded IPv4 maps to internal infrastructure. Teredo (2001::/32) and
+ * 6to4 (2002::/16) are also blanket-blocked despite carrying embedded
+ * public-IPv4 in some cases - both transition mechanisms are deprecated
+ * and not synthesised by mainstream resolvers, so false-positive risk is
+ * low.
  */
 function buildBlockList(): BlockList {
   const list = new BlockList();
@@ -100,7 +111,11 @@ function buildBlockList(): BlockList {
   // Node's BlockList treats that subnet as "all IPv4", which makes every
   // IPv4 check return true. IPv4-mapped IPv6 addresses pointing at private
   // IPv4 space are caught via extractMappedIpv4 below.
+  list.addSubnet("64:ff9b:1::", 48, "ipv6");
   list.addSubnet("100::", 64, "ipv6");
+  list.addSubnet("2001::", 32, "ipv6");
+  list.addSubnet("2001:db8::", 32, "ipv6");
+  list.addSubnet("2002::", 16, "ipv6");
   list.addSubnet("fc00::", 7, "ipv6");
   list.addSubnet("fe80::", 10, "ipv6");
   list.addSubnet("ff00::", 8, "ipv6");
@@ -252,6 +267,66 @@ export function isBlockedIp(
     }
   }
 
+  return { blocked: false };
+}
+
+const BLOCKED_HOST_EXACT = new Set(["localhost"]);
+
+/**
+ * Suffixes that mark a hostname as referring to a local / internal /
+ * in-cluster service. Matched against the normalised hostname (lower-cased,
+ * trailing dot stripped) using `String.prototype.endsWith`. Each entry must
+ * begin with a `.` so that a top-level token like "internal" cannot match
+ * an unrelated host such as "myinternal.com".
+ *
+ * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
+ * patterns, but the cluster suffixes are listed explicitly so the intent
+ * is visible at the denylist site and so any future narrowing of `.local`
+ * (e.g. to mDNS-only) does not silently re-open the in-cluster path.
+ *
+ * Cluster suffix scope: KeeperHub staging and production both run on AWS
+ * EKS with the default `clusterDomain` of `cluster.local`. If we move to a
+ * cluster with a custom `clusterDomain`, add it here.
+ */
+const BLOCKED_HOST_SUFFIXES = [
+  ".local",
+  ".internal",
+  ".svc.cluster.local",
+  ".pod.cluster.local",
+];
+
+/**
+ * Pre-DNS hostname denylist. Pure string match - no DNS lookup, no IP
+ * resolution. Intended as defense-in-depth on top of `isBlockedIp`: catches
+ * hosts that are internal by NAME (localhost, *.svc.cluster.local, EC2 VPC
+ * internal hostnames like *.compute.internal) before any resolver gets to
+ * synthesise a record. Pairs with the existing IP-resolution checks in
+ * `safeFetch` and `assertUrlIsPublic`.
+ *
+ * Returns `{ blocked: false }` for IP literals - those are validated by
+ * `isBlockedIp` instead.
+ */
+export function isBlockedHost(
+  host: string
+): { blocked: true; reason: "blocked-host" } | { blocked: false } {
+  if (host === "") {
+    return { blocked: false };
+  }
+  let normalised = host.trim().toLowerCase();
+  if (normalised.endsWith(".")) {
+    normalised = normalised.slice(0, -1);
+  }
+  if (normalised === "") {
+    return { blocked: false };
+  }
+  if (BLOCKED_HOST_EXACT.has(normalised)) {
+    return { blocked: true, reason: "blocked-host" };
+  }
+  for (const suffix of BLOCKED_HOST_SUFFIXES) {
+    if (normalised.endsWith(suffix)) {
+      return { blocked: true, reason: "blocked-host" };
+    }
+  }
   return { blocked: false };
 }
 
@@ -453,6 +528,23 @@ export async function safeFetch(
   }
 
   const hostname = stripIpv6Brackets(parsed.hostname);
+
+  const hostCheck = isBlockedHost(hostname);
+  if (hostCheck.blocked) {
+    recordBlock({ hostname, reason: hostCheck.reason, plugin }, shadow);
+    if (!shadow) {
+      throw new SsrfBlockedError({
+        hostname,
+        reason: hostCheck.reason,
+        message: blockedMessage({
+          hostname,
+          reason: hostCheck.reason,
+          plugin,
+        }),
+      });
+    }
+  }
+
   if (isIP(hostname) !== 0) {
     const check = isBlockedIp(hostname);
     if (check.blocked) {
@@ -533,6 +625,15 @@ export async function assertUrlIsPublic(rawUrl: string): Promise<void> {
   const hostname = stripIpv6Brackets(parsed.hostname);
   if (hostname === "") {
     throw new TypeError(`URL has no hostname: ${rawUrl}`);
+  }
+
+  const hostCheck = isBlockedHost(hostname);
+  if (hostCheck.blocked) {
+    throw new SsrfBlockedError({
+      hostname,
+      reason: hostCheck.reason,
+      message: blockedMessage({ hostname, reason: hostCheck.reason }),
+    });
   }
 
   if (isIP(hostname) !== 0) {

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -342,16 +342,35 @@ type BlockContext = {
 };
 
 /**
- * Carries the calling plugin label across the async boundary into the
+ * Carries per-request state across the async boundary into the
  * module-level Agent's lookup callback, where the original `safeFetch`
- * closure is out of scope. Without this, DNS-path blocks record
- * plugin_name="unknown" — precisely the case the shadow-mode soak needs
- * to attribute.
+ * closure is out of scope.
+ *
+ * - `plugin` attributes DNS-path blocks (without this, they record
+ *   plugin_name="unknown" — precisely the case the shadow-mode soak
+ *   needs to attribute).
+ * - `initialBlockRecorded` lets the synchronous entry-point checks
+ *   (`isBlockedHost` and the IP-literal `isBlockedIp` check) tell the
+ *   connector "we already counted this request as blocked." Without this
+ *   signal, a single shadow-mode request to e.g. `http://localhost/` is
+ *   counted twice (once for the hostname-pattern match, once again when
+ *   the connector's `dnsLookup` resolves it to 127.0.0.1). The flag
+ *   short-circuits the second `recordBlock` while still letting the
+ *   connector enforce in non-shadow mode.
  */
-const pluginContext = new AsyncLocalStorage<{ plugin?: string }>();
+type SafeFetchStore = {
+  plugin?: string;
+  initialBlockRecorded?: boolean;
+};
+
+const pluginContext = new AsyncLocalStorage<SafeFetchStore>();
 
 function currentPlugin(): string | undefined {
   return pluginContext.getStore()?.plugin;
+}
+
+function initialBlockAlreadyRecorded(): boolean {
+  return pluginContext.getStore()?.initialBlockRecorded === true;
 }
 
 function recordBlock(ctx: BlockContext, shadow: boolean): void {
@@ -448,10 +467,12 @@ function validatingConnect(
     const plugin = currentPlugin();
 
     if (check.blocked) {
-      recordBlock(
-        { hostname, resolvedIp: resolved, reason: check.reason, plugin },
-        shadow
-      );
+      if (!initialBlockAlreadyRecorded()) {
+        recordBlock(
+          { hostname, resolvedIp: resolved, reason: check.reason, plugin },
+          shadow
+        );
+      }
       if (!shadow) {
         callback(
           new SsrfBlockedError({
@@ -529,9 +550,20 @@ export async function safeFetch(
 
   const hostname = stripIpv6Brackets(parsed.hostname);
 
+  // Tracks whether one of the synchronous entry-point checks below has
+  // already incremented the block counter for this request. In shadow
+  // mode, execution continues past the block, the request reaches the
+  // connector, and the connector's own `isBlockedIp` check would record
+  // a second block for the same request (the resolved IP for a hostname
+  // pattern, or the literal itself for an IP-URL). Passing this flag
+  // through `pluginContext` lets the connector skip its `recordBlock`
+  // while still enforcing in non-shadow mode.
+  let initialBlockRecorded = false;
+
   const hostCheck = isBlockedHost(hostname);
   if (hostCheck.blocked) {
     recordBlock({ hostname, reason: hostCheck.reason, plugin }, shadow);
+    initialBlockRecorded = true;
     if (!shadow) {
       throw new SsrfBlockedError({
         hostname,
@@ -552,6 +584,7 @@ export async function safeFetch(
         { hostname, resolvedIp: hostname, reason: check.reason, plugin },
         shadow
       );
+      initialBlockRecorded = true;
       if (!shadow) {
         throw new SsrfBlockedError({
           hostname,
@@ -581,9 +614,12 @@ export async function safeFetch(
   } as unknown as UndiciFetchInit;
 
   // Run the fetch inside the plugin-context store so the shared Agent's
-  // DNS lookup can attribute blocks to the calling plugin.
-  const response = await pluginContext.run({ plugin }, () =>
-    undiciFetch(rawUrl, initWithDispatcher)
+  // DNS lookup can attribute blocks to the calling plugin, and so the
+  // connector can suppress a duplicate `recordBlock` when the
+  // synchronous checks above have already counted this request.
+  const response = await pluginContext.run(
+    { plugin, initialBlockRecorded },
+    () => undiciFetch(rawUrl, initWithDispatcher)
   );
   return response as unknown as Response;
 }

--- a/lib/workflow/nodes/database-query/step.ts
+++ b/lib/workflow/nodes/database-query/step.ts
@@ -9,13 +9,17 @@ import "server-only";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { assertConnectionUrlIsPublic } from "@/lib/db/connection-host-guard";
 import {
   getDatabaseErrorMessage,
   getPostgresConnectionOptions,
   type PostgresSslOption,
 } from "@/lib/db/connection-utils";
-import { fetchCredentials } from "@/lib/credential-fetcher";
-import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
 
 type DatabaseQueryResult =
   | { success: true; rows: unknown; count: number }
@@ -135,6 +139,18 @@ async function databaseQuery(
     databaseUrl,
     credentials.DATABASE_SSL_MODE
   );
+
+  try {
+    await assertConnectionUrlIsPublic(normalizedUrl);
+  } catch (guardError) {
+    return {
+      success: false,
+      error:
+        guardError instanceof Error
+          ? guardError.message
+          : "Host is not allowed: must resolve to a public address",
+    };
+  }
 
   const queryString = (input.dbQuery || input.query) as string;
   let client: postgres.Sql | null = null;

--- a/tests/unit/connection-guards.test.ts
+++ b/tests/unit/connection-guards.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:dns", () => ({
 }));
 
 import {
+  assertConnectionUrlIsPublic,
   assertHostIsPublic,
   extractHostFromConnectionString,
 } from "@/lib/db/connection-host-guard";
@@ -62,9 +63,13 @@ describe("assertHostIsPublic", () => {
   it("rejects hostname that resolves to a private address", async () => {
     mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
 
-    await expect(assertHostIsPublic("internal-db.local")).rejects.toThrow(
+    // Uses .example TLD so the hostname does not match the pre-DNS
+    // isBlockedHost denylist; we want to exercise the DNS-resolution path
+    // specifically.
+    await expect(assertHostIsPublic("internal-db.example")).rejects.toThrow(
       "Host is not allowed: must resolve to a public address"
     );
+    expect(mockLookup).toHaveBeenCalled();
   });
 
   it("rejects hostname that resolves to a mix of public and private addresses", async () => {
@@ -86,18 +91,41 @@ describe("assertHostIsPublic", () => {
     );
   });
 
-  it("rejects localhost (resolves to loopback)", async () => {
+  it("rejects localhost before any DNS lookup", async () => {
+    // isBlockedHost catches `localhost` as a pre-DNS pattern, so the
+    // resolver is never consulted. The mock is only here to prove the
+    // negative.
     mockLookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
 
     await expect(assertHostIsPublic("localhost")).rejects.toThrow(
       "Host is not allowed: must resolve to a public address"
     );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["case-insensitive localhost", "LOCALHOST"],
+    ["trailing-dot FQDN form", "localhost."],
+    ["mDNS .local suffix", "raspberrypi.local"],
+    [".internal suffix", "service.internal"],
+    ["EC2 VPC internal hostname", "ip-10-0-0-5.us-east-2.compute.internal"],
+    ["k8s service DNS", "keeperhub-common.keeperhub.svc.cluster.local"],
+    ["k8s pod DNS", "mypod.keeperhub.pod.cluster.local"],
+  ])("rejects %s before any DNS lookup", async (_label, host) => {
+    await expect(assertHostIsPublic(host)).rejects.toThrow(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
   });
 });
 
 describe("extractHostFromConnectionString", () => {
   it.each([
-    ["postgres scheme with IPv4 host", "postgres://u:p@10.0.0.1:5432/db", "10.0.0.1"],
+    [
+      "postgres scheme with IPv4 host",
+      "postgres://u:p@10.0.0.1:5432/db",
+      "10.0.0.1",
+    ],
     [
       "postgresql scheme with hostname",
       "postgresql://user:pass@db.example.com:5432/mydb",
@@ -138,5 +166,97 @@ describe("extractHostFromConnectionString", () => {
       "Host is not allowed: must resolve to a public address"
     );
     expect(mockLookup).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertConnectionUrlIsPublic", () => {
+  it.each([
+    ["IPv4 loopback", "postgres://u:p@127.0.0.1:5432/db"],
+    ["IPv4 private 10/8", "postgres://u:p@10.0.0.1:5432/db"],
+    ["IPv4 private 192.168/16", "postgres://u:p@192.168.1.1:5432/db"],
+    ["IPv4 IMDS link-local", "postgres://u:p@169.254.169.254:5432/db"],
+    ["IPv6 loopback (bracketed)", "postgres://u:p@[::1]:5432/db"],
+    ["IPv6 ULA (bracketed)", "postgres://u:p@[fc00::1]:5432/db"],
+    ["IPv6 site-local NAT64", "postgres://u:p@[64:ff9b:1::1]:5432/db"],
+    ["IPv6 Teredo", "postgres://u:p@[2001::1]:5432/db"],
+    [
+      "IPv4-mapped IPv6 to private",
+      "postgres://u:p@[::ffff:127.0.0.1]:5432/db",
+    ],
+  ])("rejects %s before any DNS lookup", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).rejects.toThrow(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["localhost", "postgres://u:p@localhost:5432/db"],
+    [
+      "k8s service DNS",
+      "postgres://u:p@db.keeperhub.svc.cluster.local:5432/db",
+    ],
+    [
+      "EC2 VPC internal hostname",
+      "postgres://u:p@ip-10-0-0-5.us-east-2.compute.internal:5432/db",
+    ],
+    ["mDNS suffix", "postgres://u:p@raspberrypi.local:5432/db"],
+  ])("rejects hostname pattern %s before any DNS lookup", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).rejects.toThrow(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostname that resolves to a private address", async () => {
+    mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+    await expect(
+      assertConnectionUrlIsPublic("postgres://u:p@db.example/x")
+    ).rejects.toThrow("Host is not allowed: must resolve to a public address");
+    expect(mockLookup).toHaveBeenCalled();
+  });
+
+  it("permits hostname that resolves only to public addresses", async () => {
+    mockLookup.mockResolvedValue([{ address: "1.1.1.1", family: 4 }]);
+    await expect(
+      assertConnectionUrlIsPublic("postgres://u:p@db.example.com:5432/db")
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["IPv4 literal", "postgres://u:p@1.1.1.1:5432/db"],
+    [
+      "IPv6 literal (bracketed)",
+      "postgres://u:p@[2606:4700:4700::1111]:5432/db",
+    ],
+  ])("permits public %s without any DNS lookup", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).resolves.toBeUndefined();
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["plain garbage", "not-a-url"],
+    ["scheme-only", "postgres://"],
+  ])("throws for malformed URL: %s", async (_label, url) => {
+    await expect(assertConnectionUrlIsPublic(url)).rejects.toThrow(
+      "Connection string is missing a host"
+    );
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("error messages never echo the connection string", async () => {
+    let thrown: unknown;
+    try {
+      await assertConnectionUrlIsPublic(
+        "postgres://supersecretuser:supersecretpassword@10.0.0.1:5432/internal"
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).not.toContain("supersecret");
+    expect(message).not.toContain("10.0.0.1");
+    expect(message).not.toContain("internal");
   });
 });

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/lib/metrics", () => ({
 
 import {
   assertUrlIsPublic,
+  isBlockedHost,
   isBlockedIp,
   SsrfBlockedError,
   type SsrfBlockReason,
@@ -86,6 +87,19 @@ describe("isBlockedIp", () => {
     ["fc00::1", "private-ip"],
     ["fd00::1", "private-ip"],
     ["ff02::1", "multicast"],
+    // Site-local NAT64 (RFC 8215). Distinct from the well-known 64:ff9b::/96
+    // prefix, which is intentionally allowed when embedded IPv4 is public.
+    ["64:ff9b:1::1", "private-ip"],
+    ["64:ff9b:1:abcd::1", "private-ip"],
+    // Teredo tunneling (2001::/32). Deprecated transition mechanism.
+    ["2001::1", "private-ip"],
+    ["2001:0:abcd:ef01:1234:5678:9abc:def0", "private-ip"],
+    // 6to4 (2002::/16). Deprecated transition mechanism.
+    ["2002::1", "private-ip"],
+    ["2002:0102:0304::1", "private-ip"],
+    // Documentation (2001:db8::/32). No legitimate traffic.
+    ["2001:db8::1", "private-ip"],
+    ["2001:db8:abcd::1", "private-ip"],
   ];
 
   for (const [ip, reason] of blockedV6) {
@@ -186,6 +200,61 @@ describe("isBlockedIp", () => {
   });
 });
 
+describe("isBlockedHost", () => {
+  const blockedHosts = [
+    "localhost",
+    "LOCALHOST",
+    "localhost.",
+    "  localhost  ",
+    "foo.local",
+    "raspberrypi.local",
+    "service.internal",
+    "ip-10-0-0-5.us-east-2.compute.internal",
+    "ip-172-31-1-1.ec2.internal",
+    "instance-data.ec2.internal",
+    "keeperhub-common.keeperhub.svc.cluster.local",
+    "mypod.keeperhub.pod.cluster.local",
+  ];
+
+  for (const host of blockedHosts) {
+    it(`blocks "${host}"`, () => {
+      const result = isBlockedHost(host);
+      expect(result.blocked).toBe(true);
+      if (result.blocked) {
+        expect(result.reason).toBe("blocked-host");
+      }
+    });
+  }
+
+  const allowedHosts = [
+    "example.com",
+    "www.example.com",
+    "db.us-east-1.rds.amazonaws.com",
+    "discord.com",
+    "keeperhub.com",
+    "myinternal.com",
+    "mylocal.com",
+    // IP literals are out of scope for the hostname check - isBlockedIp
+    // catches them. isBlockedHost must not match them on the suffix rules.
+    "127.0.0.1",
+    "10.0.0.1",
+    "::1",
+    "fe80::1",
+  ];
+
+  for (const host of allowedHosts) {
+    it(`allows "${host}"`, () => {
+      expect(isBlockedHost(host).blocked).toBe(false);
+    });
+  }
+
+  it("returns not-blocked for empty input", () => {
+    expect(isBlockedHost("").blocked).toBe(false);
+    expect(isBlockedHost("   ").blocked).toBe(false);
+    expect(isBlockedHost(".").blocked).toBe(false);
+  });
+});
+
 describe("safeFetch (enforce mode)", () => {
   const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
 
@@ -257,11 +326,14 @@ describe("safeFetch (enforce mode)", () => {
     );
   });
 
-  it("attributes plugin on DNS-resolved private IP (localhost)", async () => {
-    // `localhost` is not an IP literal, so it reaches the DNS path and is
-    // resolved inside the Agent's connector to 127.0.0.1 or ::1. The plugin
-    // label must propagate there via AsyncLocalStorage. Port 9999 avoids
-    // the WHATWG fetch "bad port" list (which includes port 1).
+  it("attributes plugin on hostname-pattern block (localhost)", async () => {
+    // `localhost` is caught by the pre-DNS hostname denylist (isBlockedHost)
+    // before any resolver runs, so the block is recorded synchronously with
+    // the directly-passed plugin label. The previous DNS-resolved-attribution
+    // path through AsyncLocalStorage is still present in the connector but
+    // is no longer reachable via `localhost`; covering it would require
+    // mocking the undici connector or using a non-pattern-matching
+    // hostname that resolves to a private IP.
     await expect(
       safeFetch("http://localhost:9999/", { plugin: "webhook" })
     ).rejects.toThrow();
@@ -269,10 +341,30 @@ describe("safeFetch (enforce mode)", () => {
       "safe_fetch.blocks.total",
       expect.objectContaining({
         plugin_name: "webhook",
-        reason: "loopback",
+        reason: "blocked-host",
       })
     );
   });
+
+  const blockedHostnames = [
+    "http://localhost/",
+    "http://localhost:9999/",
+    "http://foo.local/",
+    "http://service.internal/",
+    "http://ip-10-0-0-5.us-east-2.compute.internal/",
+    "http://keeperhub-common.keeperhub.svc.cluster.local/",
+    "http://mypod.keeperhub.pod.cluster.local/",
+  ];
+
+  for (const url of blockedHostnames) {
+    it(`rejects hostname-pattern ${url}`, async () => {
+      await expect(safeFetch(url)).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(incrementCounter).toHaveBeenCalledWith(
+        "safe_fetch.blocks.total",
+        expect.objectContaining({ reason: "blocked-host", shadow: "false" })
+      );
+    });
+  }
 
   it("throws TypeError for malformed URLs", async () => {
     await expect(safeFetch("not a url")).rejects.toBeInstanceOf(TypeError);
@@ -565,4 +657,27 @@ describe("assertUrlIsPublic", () => {
     expect(thrown).not.toBeInstanceOf(SsrfBlockedError);
     expect(thrown).not.toBeInstanceOf(TypeError);
   });
+
+  const blockedHostnames = [
+    "http://localhost/",
+    "http://foo.local/",
+    "http://service.internal/",
+    "http://ip-10-0-0-5.us-east-2.compute.internal/",
+    "http://keeperhub-common.keeperhub.svc.cluster.local/",
+    "http://mypod.keeperhub.pod.cluster.local/",
+  ];
+
+  for (const url of blockedHostnames) {
+    it(`rejects hostname-pattern ${url} before any DNS lookup`, async () => {
+      let thrown: unknown;
+      try {
+        await assertUrlIsPublic(url);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(SsrfBlockedError);
+      expect((thrown as SsrfBlockedError).reason).toBe("blocked-host");
+      expect(mockPromisesLookup).not.toHaveBeenCalled();
+    });
+  }
 });

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -400,10 +400,17 @@ describe("safeFetch (shadow mode)", () => {
     } catch (err) {
       expect(err).not.toBeInstanceOf(SsrfBlockedError);
     }
-    expect(incrementCounter).toHaveBeenCalledWith(
-      "safe_fetch.blocks.total",
-      expect.objectContaining({ reason: "loopback", shadow: "true" })
+    const blockCalls = incrementCounter.mock.calls.filter(
+      (call) => call[0] === "safe_fetch.blocks.total"
     );
+    // Exactly one block per request, even though the connector's
+    // post-DNS check would otherwise re-fire on the resolved IP. See
+    // SafeFetchStore.initialBlockRecorded in safe-fetch.ts.
+    expect(blockCalls).toHaveLength(1);
+    expect(blockCalls[0]?.[1]).toMatchObject({
+      reason: "loopback",
+      shadow: "true",
+    });
     expect(captureException).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
@@ -414,6 +421,31 @@ describe("safeFetch (shadow mode)", () => {
         }),
       })
     );
+  });
+
+  it("records exactly one block in shadow mode for a hostname-pattern URL", async () => {
+    // Regression: a single shadow-mode request to `http://localhost/` used
+    // to be counted twice - once for the pre-DNS isBlockedHost match
+    // (reason="blocked-host"), then again inside the connector's DNS
+    // callback after `localhost` resolved to 127.0.0.1 (reason="loopback").
+    // The fix threads `initialBlockRecorded` through pluginContext so the
+    // connector skips its recordBlock when the entry-point check already
+    // counted this request. The connect itself still happens, preserving
+    // shadow-mode "log and continue" semantics.
+    try {
+      await safeFetch("http://localhost:9999/", { plugin: "webhook" });
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(SsrfBlockedError);
+    }
+    const blockCalls = incrementCounter.mock.calls.filter(
+      (call) => call[0] === "safe_fetch.blocks.total"
+    );
+    expect(blockCalls).toHaveLength(1);
+    expect(blockCalls[0]?.[1]).toMatchObject({
+      reason: "blocked-host",
+      plugin_name: "webhook",
+      shadow: "true",
+    });
   });
 
   it("records scheme block with shadow=true on non-http URL", async () => {


### PR DESCRIPTION
## Summary

Closes the SSRF gap that allowed the database-query workflow node to reach internal hosts. Brings the HTTP and non-HTTP outbound plugins to parity behind a single source of truth.

- Extends `lib/safe-fetch.ts` block list with `64:ff9b:1::/48` (RFC 8215 site-local NAT64), `2001::/32` (Teredo), `2002::/16` (6to4), `2001:db8::/32` (documentation).
- Adds `isBlockedHost` for pre-DNS hostname patterns (`localhost`, `*.local`, `*.internal`, `*.svc.cluster.local`, `*.pod.cluster.local`). Wires into `safeFetch` and `assertUrlIsPublic`.
- Adds `assertConnectionUrlIsPublic` in `lib/db/connection-host-guard.ts` as the canonical one-call helper for non-HTTP outbound plugins. Wires into the workflow database-query step (previously hit `postgres.js` with zero host validation) and into the existing test-connection endpoint.

## Single source of truth

- HTTP outbound: `safeFetch` from `lib/safe-fetch.ts`.
- Non-HTTP outbound (DB now; Mongo, Redis, SMTP, etc. later): `assertConnectionUrlIsPublic` from `lib/db/connection-host-guard.ts`. New plugins should mirror the pattern at `lib/workflow/nodes/database-query/step.ts:143-153`.
- Block rules (CIDRs + hostname patterns) live in `lib/safe-fetch.ts` only. Both call paths delegate to it.

## Deploy-time action required

`safeFetch` defaults to shadow mode unless `SAFE_FETCH_ENFORCE=true`. Without that env var set in staging and production, the HTTP path's new blocks only log. **The DB path is unaffected by that flag** (the assert always throws), so the database-query node will block regardless. Setting `SAFE_FETCH_ENFORCE=true` should land alongside this merge.

## Cluster DNS suffix confirmation

The hostname denylist hard-codes `cluster.local`-family suffixes. Both staging and production run AWS EKS, which uses `cluster.local` by default; I could not verify this directly via `kubectl exec` (auto-mode denied) or via the CoreDNS ConfigMap (RBAC). EKS does not expose a managed-launch path to override `clusterDomain`, so the assumption is very likely correct, but worth a fast infra confirmation before merging if cheap.

## Test plan

- [x] `pnpm vitest run tests/unit/safe-fetch.test.ts tests/unit/connection-guards.test.ts` - 188/188 pass
- [x] `pnpm check` - no new lint errors on changed files
- [x] `pnpm type-check` - no new TS errors on changed files (9 pre-existing errors on staging unrelated to this change)
- [x] Staging smoke: build a workflow with a Database Query step pointing at `postgres://u:p@localhost:5432/db` and one pointing at `postgres://u:p@10.0.0.1:5432/db`; both should fail with the SSRF reason, not connect.
- [ ] Staging smoke: build a workflow with an HTTP Request step against `http://169.254.169.254/`, `http://internal.svc.cluster.local`, and a public URL; first two fail, third succeeds (assuming `SAFE_FETCH_ENFORCE=true` is set).
- [ ] Confirm the test-connection endpoint (Project Integrations form) still gives an actionable error for blocked hosts and is not regressed for normal public DBs.
