### PR TITLE
hotfix: set SAFE_FETCH_ENFORCE in prod and executor Helm values

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -174,6 +174,9 @@ env:
     type: parameterStore
     name: simple-account-7702-address
     parameter_name: /eks/techops-prod/keeperhub/simple-account-7702-address
+  SAFE_FETCH_ENFORCE:
+    type: kv
+    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-prod

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -174,6 +174,9 @@ env:
     type: parameterStore
     name: simple-account-7702-address
     parameter_name: /eks/techops-staging/keeperhub/simple-account-7702-address
+  SAFE_FETCH_ENFORCE:
+    type: kv
+    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-staging

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -437,6 +437,9 @@ env:
     type: parameterStore
     name: feedback-api-key
     parameter_name: /eks/techops-prod/keeperhub-feedback/feedback-api-key
+  SAFE_FETCH_ENFORCE:
+    type: kv
+    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-prod


### PR DESCRIPTION
## Summary

Closes the deploy-side gap left by the merged SSRF guard PR. `safeFetch` defaults to shadow mode unless `process.env.SAFE_FETCH_ENFORCE === "true"` (strict string match). The production `keeperhub-common` pod has no `SAFE_FETCH_ENFORCE` env entry today, so blocks are logged but never enforced and the underlying request to e.g. `http://169.254.169.254` reaches AWS IMDS, returning a 401 from the IMDSv2 token challenge instead of being refused by the guard.

Adds `SAFE_FETCH_ENFORCE: "true"` to:

- `deploy/keeperhub/prod/values.yaml` - the immediate prod hole (verified missing by inspecting the live pod manifest in `techops-prod`).
- `deploy/executor/staging/values.yaml` - silent gap. Workflow HTTP Request steps execute in the `executor` deployment, and staging executor is not enforcing today.
- `deploy/executor/prod/values.yaml` - same gap on the prod side.

`deploy/keeperhub/staging/values.yaml` already has the entry; no change.

## Why the executor needs this too

`safeFetch` call sites are split across services:

| Caller | Runs in |
|---|---|
| `lib/workflow/nodes/http-request/perform.ts` | executor |
| `plugins/webhook/steps/send-webhook.ts` | executor |
| `plugins/hyperliquid/steps/info-request-core.ts` | executor |
| `app/api/user/rpc-preferences/[chainId]/route.ts` | common |
| `lib/rpc/providers/solana.ts` + `lib/rpc/safe-ethers-fetch.ts` | both |
| `lib/codegen-registry.ts` + `lib/workflow/codegen/registry.ts` | both |

Enforcing on `common` only would miss the workflow HTTP path, which is where the original incident vector lives.

## Why the value is quoted

`isShadowMode()` checks `process.env.SAFE_FETCH_ENFORCE !== "true"` with strict equality. YAML's unquoted `true` becomes a boolean and the rendered env can surface as something other than the literal string `"true"` depending on the renderer. Quoting forces the safe-fetch check to see exactly what it expects.

## Test plan

- [ ] Render the Helm chart for `deploy/keeperhub/prod` and confirm the generated deployment manifest contains `SAFE_FETCH_ENFORCE` with value `"true"` in the container's `env`.
- [ ] Same render check for `deploy/executor/{staging,prod}`.
- [ ] After deploy: `kubectl get pod -n keeperhub keeperhub-common-<new-rev> -o jsonpath='{.spec.containers[0].env[?(@.name=="SAFE_FETCH_ENFORCE")].value}'` returns `true`.
- [ ] Repeat for `keeperhub-executor-common-<new-rev>`.
- [ ] Post-deploy smoke: in production, a workflow with an HTTP Request step pointing at `http://169.254.169.254/` fails with the SSRF block error before any TCP attempt - no 401 from IMDS, no Sentry event from AWS metadata.
- [ ] Sentry counter `safe_fetch.blocks.total{shadow="false"}` starts incrementing on prod traffic.

## Out of scope (separate follow-up)

- `lib/sandbox/child-source.ts` is a ported copy of the SSRF guard with its own configuration surface. The `keeperhub-sandbox` deployment is not touched by this change. Worth a separate ticket to confirm the sandbox's guard is enforcing.
- Audit of non-`safeFetch` outbound HTTP origins (third-party SDKs, raw `fetch`) in this codebase. The IMDS bypass that triggered this work could also exist via clients that never reach `safeFetch`. Recommended as a follow-up audit.