### PR TITLE
hotfix: single source of truth for SSRF blocklist

### DIFF
--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -10,6 +10,15 @@ import { BlockList, isIP } from "node:net";
 import { captureException } from "@sentry/nextjs";
 import { Agent, buildConnector, fetch as undiciFetch } from "undici";
 import { getMetricsCollector } from "@/lib/metrics";
+import {
+  SSRF_BLOCKED_HOST_EXACT,
+  SSRF_BLOCKED_HOST_SUFFIXES,
+  SSRF_IPV4_BROADCAST_ADDRESSES,
+  SSRF_IPV4_CIDRS,
+  SSRF_IPV6_CIDRS,
+  SSRF_IPV6_LITERAL_ADDRESSES,
+  SSRF_NAT64_PREFIX_CIDR,
+} from "@/lib/ssrf-blocklist";
 
 export type SsrfBlockReason =
   | "scheme"
@@ -60,66 +69,25 @@ const NAT64_UNCOMPRESSED_REGEX =
 const NAT64_DOTTED_REGEX = /^64:ff9b::(\d+\.\d+\.\d+\.\d+)$/;
 
 /**
- * Denylist of IP ranges that must never be reached from user-controlled fetch.
- * IPv4 covers unspecified, private, loopback, link-local (incl. IMDS
- * 169.254.169.254), CGNAT, documentation ranges, benchmarking, multicast,
- * reserved, broadcast. IPv6 covers unspecified, loopback, IPv4-mapped (via
- * extractor), site-local NAT64 (RFC 8215), discard, Teredo, documentation,
- * 6to4, ULA, link-local, multicast.
- *
- * NAT64 well-known prefix (64:ff9b::/96, RFC 6052) is intentionally NOT in
- * this list. In dual-stack / IPv6-preferred networks (e.g. AWS VPCs with
- * `enable_ipv6 = true`) the resolver synthesises NAT64 AAAA records for
- * every IPv4-only public host, so blanket-blocking the prefix would block
- * legitimate public destinations like Discord, Slack, Telegram. Instead,
- * NAT64 hits are detected separately in `isBlockedIp` and the embedded
- * IPv4 is rechecked against this list - preserving the SSRF property (no
- * NAT64 path to RFC 1918, IMDS, etc.) without false positives on public
- * IPv4.
- *
- * Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS blanket-blocked here: the
- * RFC defines it for site-local deployments, so by construction the
- * embedded IPv4 maps to internal infrastructure. Teredo (2001::/32) and
- * 6to4 (2002::/16) are also blanket-blocked despite carrying embedded
- * public-IPv4 in some cases - both transition mechanisms are deprecated
- * and not synthesised by mainstream resolvers, so false-positive risk is
- * low.
+ * Builds the runtime BlockList from the shared data in
+ * `lib/ssrf-blocklist.ts`. See that module for the rationale on which
+ * ranges are blanket-blocked and which are handled specially (IPv4-mapped
+ * IPv6 and the well-known NAT64 prefix).
  */
 function buildBlockList(): BlockList {
   const list = new BlockList();
-
-  list.addSubnet("0.0.0.0", 8, "ipv4");
-  list.addSubnet("10.0.0.0", 8, "ipv4");
-  list.addSubnet("100.64.0.0", 10, "ipv4");
-  list.addSubnet("127.0.0.0", 8, "ipv4");
-  list.addSubnet("169.254.0.0", 16, "ipv4");
-  list.addSubnet("172.16.0.0", 12, "ipv4");
-  list.addSubnet("192.0.0.0", 24, "ipv4");
-  list.addSubnet("192.0.2.0", 24, "ipv4");
-  list.addSubnet("192.88.99.0", 24, "ipv4");
-  list.addSubnet("192.168.0.0", 16, "ipv4");
-  list.addSubnet("198.18.0.0", 15, "ipv4");
-  list.addSubnet("198.51.100.0", 24, "ipv4");
-  list.addSubnet("203.0.113.0", 24, "ipv4");
-  list.addSubnet("224.0.0.0", 4, "ipv4");
-  list.addSubnet("240.0.0.0", 4, "ipv4");
-  list.addAddress("255.255.255.255", "ipv4");
-
-  list.addAddress("::", "ipv6");
-  list.addAddress("::1", "ipv6");
-  // Note: ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not added here.
-  // Node's BlockList treats that subnet as "all IPv4", which makes every
-  // IPv4 check return true. IPv4-mapped IPv6 addresses pointing at private
-  // IPv4 space are caught via extractMappedIpv4 below.
-  list.addSubnet("64:ff9b:1::", 48, "ipv6");
-  list.addSubnet("100::", 64, "ipv6");
-  list.addSubnet("2001::", 32, "ipv6");
-  list.addSubnet("2001:db8::", 32, "ipv6");
-  list.addSubnet("2002::", 16, "ipv6");
-  list.addSubnet("fc00::", 7, "ipv6");
-  list.addSubnet("fe80::", 10, "ipv6");
-  list.addSubnet("ff00::", 8, "ipv6");
-
+  for (const [addr, prefix] of SSRF_IPV4_CIDRS) {
+    list.addSubnet(addr, prefix, "ipv4");
+  }
+  for (const addr of SSRF_IPV4_BROADCAST_ADDRESSES) {
+    list.addAddress(addr, "ipv4");
+  }
+  for (const addr of SSRF_IPV6_LITERAL_ADDRESSES) {
+    list.addAddress(addr, "ipv6");
+  }
+  for (const [addr, prefix] of SSRF_IPV6_CIDRS) {
+    list.addSubnet(addr, prefix, "ipv6");
+  }
   return list;
 }
 
@@ -127,7 +95,7 @@ const BLOCK_LIST = buildBlockList();
 
 const NAT64_BLOCK_LIST = (() => {
   const list = new BlockList();
-  list.addSubnet("64:ff9b::", 96, "ipv6");
+  list.addSubnet(SSRF_NAT64_PREFIX_CIDR[0], SSRF_NAT64_PREFIX_CIDR[1], "ipv6");
   return list;
 })();
 
@@ -270,30 +238,8 @@ export function isBlockedIp(
   return { blocked: false };
 }
 
-const BLOCKED_HOST_EXACT = new Set(["localhost"]);
-
-/**
- * Suffixes that mark a hostname as referring to a local / internal /
- * in-cluster service. Matched against the normalised hostname (lower-cased,
- * trailing dot stripped) using `String.prototype.endsWith`. Each entry must
- * begin with a `.` so that a top-level token like "internal" cannot match
- * an unrelated host such as "myinternal.com".
- *
- * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
- * patterns, but the cluster suffixes are listed explicitly so the intent
- * is visible at the denylist site and so any future narrowing of `.local`
- * (e.g. to mDNS-only) does not silently re-open the in-cluster path.
- *
- * Cluster suffix scope: KeeperHub staging and production both run on AWS
- * EKS with the default `clusterDomain` of `cluster.local`. If we move to a
- * cluster with a custom `clusterDomain`, add it here.
- */
-const BLOCKED_HOST_SUFFIXES = [
-  ".local",
-  ".internal",
-  ".svc.cluster.local",
-  ".pod.cluster.local",
-];
+const BLOCKED_HOST_EXACT = new Set<string>(SSRF_BLOCKED_HOST_EXACT);
+const BLOCKED_HOST_SUFFIXES = SSRF_BLOCKED_HOST_SUFFIXES;
 
 /**
  * Pre-DNS hostname denylist. Pure string match - no DNS lookup, no IP

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -22,6 +22,11 @@
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
+// Relative import: this file is compiled by two separate tsconfigs (the
+// keeperhub app and the standalone @keeperhub/sandbox package), and the
+// sandbox tsconfig's `@/*` alias points at its own src dir rather than the
+// keeperhub workspace. The relative path resolves identically from both
+// build contexts.
 import {
   SSRF_BLOCKED_HOST_EXACT,
   SSRF_BLOCKED_HOST_SUFFIXES,
@@ -30,7 +35,7 @@ import {
   SSRF_IPV6_CIDRS,
   SSRF_IPV6_LITERAL_ADDRESSES,
   SSRF_NAT64_PREFIX_CIDR,
-} from "@/lib/ssrf-blocklist";
+} from "../ssrf-blocklist";
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -22,11 +22,15 @@
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
-// Relative import: this file is compiled by two separate tsconfigs (the
-// keeperhub app and the standalone @keeperhub/sandbox package), and the
-// sandbox tsconfig's `@/*` alias points at its own src dir rather than the
-// keeperhub workspace. The relative path resolves identically from both
-// build contexts.
+// Relative import with explicit `.js` extension. This file is compiled
+// by two separate tsconfigs (the keeperhub app and the standalone
+// @keeperhub/sandbox package). The sandbox package is `"type": "module"`
+// and runs the compiled output via plain `node`, whose strict ESM loader
+// requires explicit file extensions in imports - extension-less or
+// `@/`-aliased forms fail at runtime with ERR_MODULE_NOT_FOUND. TS
+// resolves "../ssrf-blocklist.js" to the matching .ts source at compile
+// time (matching the convention used by `sandbox/src/run-code.ts` which
+// imports `"../../lib/sandbox/child-source.js"`).
 import {
   SSRF_BLOCKED_HOST_EXACT,
   SSRF_BLOCKED_HOST_SUFFIXES,
@@ -35,7 +39,7 @@ import {
   SSRF_IPV6_CIDRS,
   SSRF_IPV6_LITERAL_ADDRESSES,
   SSRF_NAT64_PREFIX_CIDR,
-} from "../ssrf-blocklist";
+} from "../ssrf-blocklist.js";
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -22,24 +22,16 @@
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
-// Relative import with explicit `.js` extension. This file is compiled
-// by two separate tsconfigs (the keeperhub app and the standalone
-// @keeperhub/sandbox package). The sandbox package is `"type": "module"`
-// and runs the compiled output via plain `node`, whose strict ESM loader
-// requires explicit file extensions in imports - extension-less or
-// `@/`-aliased forms fail at runtime with ERR_MODULE_NOT_FOUND. TS
-// resolves "../ssrf-blocklist.js" to the matching .ts source at compile
-// time (matching the convention used by `sandbox/src/run-code.ts` which
-// imports `"../../lib/sandbox/child-source.js"`).
-import {
-  SSRF_BLOCKED_HOST_EXACT,
-  SSRF_BLOCKED_HOST_SUFFIXES,
-  SSRF_IPV4_BROADCAST_ADDRESSES,
-  SSRF_IPV4_CIDRS,
-  SSRF_IPV6_CIDRS,
-  SSRF_IPV6_LITERAL_ADDRESSES,
-  SSRF_NAT64_PREFIX_CIDR,
-} from "../ssrf-blocklist.js";
+// The blocklist data is imported as JSON (not as a `.ts` module) because
+// this file is compiled by two separate tsconfigs with incompatible
+// `.js`/`.ts` resolution conventions: the keeperhub app (Next.js
+// Turbopack) wants extension-less imports for `.ts` sources, while the
+// standalone @keeperhub/sandbox package is `"type": "module"` and its
+// strict ESM runtime requires explicit file extensions. A `.json`
+// extension resolves identically in both contexts, so the data lives in
+// `lib/ssrf-blocklist.json` and `lib/ssrf-blocklist.ts` is just a typed
+// re-export used by the keeperhub-side consumers.
+import blocklist from "../ssrf-blocklist.json" with { type: "json" };
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result
@@ -119,11 +111,11 @@ const NAT64_DOTTED_REGEX = /^64:ff9b::(\\d+\\.\\d+\\.\\d+\\.\\d+)$/;
 // (64:ff9b::/96) is also kept separate for the same reason - dual-stack
 // resolvers synthesise it for every IPv4-only public host, so we extract
 // the embedded IPv4 and recheck it against the IPv4 list.
-const SSRF_IPV4_CIDRS = ${JSON.stringify(SSRF_IPV4_CIDRS)};
-const SSRF_IPV4_BROADCAST_ADDRESSES = ${JSON.stringify(SSRF_IPV4_BROADCAST_ADDRESSES)};
-const SSRF_IPV6_LITERAL_ADDRESSES = ${JSON.stringify(SSRF_IPV6_LITERAL_ADDRESSES)};
-const SSRF_IPV6_CIDRS = ${JSON.stringify(SSRF_IPV6_CIDRS)};
-const SSRF_NAT64_PREFIX_CIDR = ${JSON.stringify(SSRF_NAT64_PREFIX_CIDR)};
+const SSRF_IPV4_CIDRS = ${JSON.stringify(blocklist.ipv4Cidrs)};
+const SSRF_IPV4_BROADCAST_ADDRESSES = ${JSON.stringify(blocklist.ipv4BroadcastAddresses)};
+const SSRF_IPV6_LITERAL_ADDRESSES = ${JSON.stringify(blocklist.ipv6LiteralAddresses)};
+const SSRF_IPV6_CIDRS = ${JSON.stringify(blocklist.ipv6Cidrs)};
+const SSRF_NAT64_PREFIX_CIDR = ${JSON.stringify(blocklist.nat64PrefixCidr)};
 
 const SSRF_BLOCK_LIST = new BlockList();
 for (const cidr of SSRF_IPV4_CIDRS) {
@@ -224,8 +216,8 @@ function stripIpv6Brackets(hostname) {
 // Pre-DNS hostname denylist interpolated from lib/ssrf-blocklist.ts at
 // module-render time. See that module for the rationale (case handling,
 // suffix semantics, cluster-domain assumption).
-const BLOCKED_HOST_EXACT = new Set(${JSON.stringify(Array.from(SSRF_BLOCKED_HOST_EXACT))});
-const BLOCKED_HOST_SUFFIXES = ${JSON.stringify(SSRF_BLOCKED_HOST_SUFFIXES)};
+const BLOCKED_HOST_EXACT = new Set(${JSON.stringify(blocklist.blockedHostExact)});
+const BLOCKED_HOST_SUFFIXES = ${JSON.stringify(blocklist.blockedHostSuffixes)};
 
 function isBlockedHost(host) {
   if (host === "") {

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -8,16 +8,29 @@
  * ~240 lines of this grandchild source verbatim; this module is the single
  * source of truth.
  *
- * DO NOT IMPORT anything into this module — the exported string is passed
- * intact to `node -e`, so any `import` statements would not propagate and
- * any value-level logic would not execute in the grandchild. Everything
- * the grandchild needs must be expressed inside the template literal.
+ * Module imports here are restricted to pure data. The exported string is
+ * passed intact to `node -e`, so any TypeScript-level import is only
+ * usable at template-render time via `JSON.stringify` interpolation - no
+ * runtime behaviour can cross into the grandchild because the grandchild
+ * has no access to npm or to the rest of this codebase. Importing pure
+ * data is the SSRF-blocklist sharing pattern used here (see
+ * `lib/ssrf-blocklist.ts`); importing anything with runtime side effects
+ * or third-party deps would not propagate to the grandchild.
  *
  * The grandchild uses only node: builtins (node:vm, node:v8, node:dns,
  * node:net) so the downstream sandbox package can remain zero-runtime-dep
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
+import {
+  SSRF_BLOCKED_HOST_EXACT,
+  SSRF_BLOCKED_HOST_SUFFIXES,
+  SSRF_IPV4_BROADCAST_ADDRESSES,
+  SSRF_IPV4_CIDRS,
+  SSRF_IPV6_CIDRS,
+  SSRF_IPV6_LITERAL_ADDRESSES,
+  SSRF_NAT64_PREFIX_CIDR,
+} from "@/lib/ssrf-blocklist";
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result
@@ -50,12 +63,18 @@ const { BlockList, isIP } = require("node:net");
 
 const MAX_LOG_ENTRIES = 200;
 
-// SSRF guard: ported from lib/safe-fetch.ts (KEEP-314). Modeled on the
-// main-app pattern but inlined here because the sandbox package is
+// SSRF guard: ported from lib/safe-fetch.ts. Modeled on the main-app
+// pattern but inlined here because the sandbox package is
 // zero-runtime-dep by design and the grandchild gets only node: builtins.
-// The defense here is DNS-resolved denylist — it catches hostnames that
-// resolve to RFC 1918, loopback, link-local (IMDS), CGNAT, and reserved
-// ranges, where the old substring check only caught named metadata hosts.
+// Two layers fire before the wrapped fetch dials anything:
+//   1. Pre-DNS hostname denylist (isBlockedHost) catches localhost and
+//      patterns like *.local, *.internal, *.svc.cluster.local,
+//      *.pod.cluster.local. Defense-in-depth on top of the IP check;
+//      also surfaces in error messages as the original hostname.
+//   2. DNS-resolved IP denylist catches hostnames that resolve to RFC
+//      1918, loopback, link-local (IMDS), CGNAT, reserved ranges, ULA,
+//      multicast, and the additional IPv6 transition prefixes
+//      (64:ff9b:1::/48, 2001::/32 Teredo, 2002::/16 6to4, 2001:db8::/32).
 // NAT64 (64:ff9b::/96): the well-known prefix is treated specially. In
 // dual-stack / IPv6-preferred pods (typical for our AWS prod VPC) the
 // resolver synthesises NAT64 AAAA records for every IPv4-only public
@@ -67,6 +86,11 @@ const MAX_LOG_ENTRIES = 200;
 // undici as a sandbox dep), so there is a small window between our
 // dns.lookup and the fetch's internal connect where the record could
 // change. NetworkPolicy is the real defense for that (tracked elsewhere).
+// Testing note: the sandbox guard is not unit-tested directly because
+// this entire file is a template literal executed in a subprocess via
+// "node -e". The parallel behavior in lib/safe-fetch.ts is unit-tested
+// (tests/unit/safe-fetch.test.ts) and these CIDR / hostname denylists
+// are kept in lockstep with that file by convention.
 const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
 const IPV4_MAPPED_PREFIX = "::ffff:";
 const IPV4_MAPPED_HEX_REGEX = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
@@ -76,40 +100,38 @@ const NAT64_CANONICAL_REGEX = /^64:ff9b::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
 const NAT64_UNCOMPRESSED_REGEX = /^64:ff9b:0:0:0:0:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
 const NAT64_DOTTED_REGEX = /^64:ff9b::(\\d+\\.\\d+\\.\\d+\\.\\d+)$/;
 
+// CIDR ranges and special prefixes interpolated from
+// lib/ssrf-blocklist.ts at module-render time. See that file for the
+// rationale on which ranges are blanket-blocked vs handled specially.
+// Note: ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not added —
+// Node treats that subnet as "all IPv4" which would make every IPv4
+// check return true. IPv4-mapped IPv6 pointing at private IPv4 is
+// caught via the mapped extraction below. The NAT64 well-known prefix
+// (64:ff9b::/96) is also kept separate for the same reason - dual-stack
+// resolvers synthesise it for every IPv4-only public host, so we extract
+// the embedded IPv4 and recheck it against the IPv4 list.
+const SSRF_IPV4_CIDRS = ${JSON.stringify(SSRF_IPV4_CIDRS)};
+const SSRF_IPV4_BROADCAST_ADDRESSES = ${JSON.stringify(SSRF_IPV4_BROADCAST_ADDRESSES)};
+const SSRF_IPV6_LITERAL_ADDRESSES = ${JSON.stringify(SSRF_IPV6_LITERAL_ADDRESSES)};
+const SSRF_IPV6_CIDRS = ${JSON.stringify(SSRF_IPV6_CIDRS)};
+const SSRF_NAT64_PREFIX_CIDR = ${JSON.stringify(SSRF_NAT64_PREFIX_CIDR)};
+
 const SSRF_BLOCK_LIST = new BlockList();
-SSRF_BLOCK_LIST.addSubnet("0.0.0.0", 8, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("10.0.0.0", 8, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("100.64.0.0", 10, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("127.0.0.0", 8, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("169.254.0.0", 16, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("172.16.0.0", 12, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.0.0.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.0.2.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.88.99.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.168.0.0", 16, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("198.18.0.0", 15, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("198.51.100.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("203.0.113.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("224.0.0.0", 4, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("240.0.0.0", 4, "ipv4");
-SSRF_BLOCK_LIST.addAddress("255.255.255.255", "ipv4");
-SSRF_BLOCK_LIST.addAddress("::", "ipv6");
-SSRF_BLOCK_LIST.addAddress("::1", "ipv6");
-// Note: ::ffff:0:0/96 (IPv4-mapped IPv6) not added — Node treats that
-// subnet as "all IPv4" which would make every IPv4 check return true.
-// IPv4-mapped IPv6 pointing at private IPv4 is caught via the mapped
-// extraction below.
-// NAT64 (64:ff9b::/96) is intentionally separate: dual-stack networks
-// synthesise it for every IPv4-only public host, so blanket-blocking the
-// prefix would block legitimate destinations. The embedded IPv4 is
-// rechecked against the IPv4 list below.
-SSRF_BLOCK_LIST.addSubnet("100::", 64, "ipv6");
-SSRF_BLOCK_LIST.addSubnet("fc00::", 7, "ipv6");
-SSRF_BLOCK_LIST.addSubnet("fe80::", 10, "ipv6");
-SSRF_BLOCK_LIST.addSubnet("ff00::", 8, "ipv6");
+for (const cidr of SSRF_IPV4_CIDRS) {
+  SSRF_BLOCK_LIST.addSubnet(cidr[0], cidr[1], "ipv4");
+}
+for (const addr of SSRF_IPV4_BROADCAST_ADDRESSES) {
+  SSRF_BLOCK_LIST.addAddress(addr, "ipv4");
+}
+for (const addr of SSRF_IPV6_LITERAL_ADDRESSES) {
+  SSRF_BLOCK_LIST.addAddress(addr, "ipv6");
+}
+for (const cidr of SSRF_IPV6_CIDRS) {
+  SSRF_BLOCK_LIST.addSubnet(cidr[0], cidr[1], "ipv6");
+}
 
 const NAT64_BLOCK_LIST = new BlockList();
-NAT64_BLOCK_LIST.addSubnet("64:ff9b::", 96, "ipv6");
+NAT64_BLOCK_LIST.addSubnet(SSRF_NAT64_PREFIX_CIDR[0], SSRF_NAT64_PREFIX_CIDR[1], "ipv6");
 
 function hexGroupsToIpv4(highHex, lowHex) {
   const high = Number.parseInt(highHex, 16);
@@ -190,7 +212,38 @@ function stripIpv6Brackets(hostname) {
   return hostname;
 }
 
+// Pre-DNS hostname denylist interpolated from lib/ssrf-blocklist.ts at
+// module-render time. See that module for the rationale (case handling,
+// suffix semantics, cluster-domain assumption).
+const BLOCKED_HOST_EXACT = new Set(${JSON.stringify(Array.from(SSRF_BLOCKED_HOST_EXACT))});
+const BLOCKED_HOST_SUFFIXES = ${JSON.stringify(SSRF_BLOCKED_HOST_SUFFIXES)};
+
+function isBlockedHost(host) {
+  if (host === "") {
+    return false;
+  }
+  let normalised = host.trim().toLowerCase();
+  if (normalised.endsWith(".")) {
+    normalised = normalised.slice(0, -1);
+  }
+  if (normalised === "") {
+    return false;
+  }
+  if (BLOCKED_HOST_EXACT.has(normalised)) {
+    return true;
+  }
+  for (const suffix of BLOCKED_HOST_SUFFIXES) {
+    if (normalised.endsWith(suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function checkHostnameSsrf(hostname) {
+  if (isBlockedHost(hostname)) {
+    return { blocked: true, ip: hostname };
+  }
   if (isIP(hostname) !== 0) {
     return isBlockedIp(hostname);
   }

--- a/lib/ssrf-blocklist.json
+++ b/lib/ssrf-blocklist.json
@@ -1,0 +1,40 @@
+{
+  "$schema-comment": "SSRF blocklist data. Single source of truth for: lib/safe-fetch.ts (HTTP guards, runtime BlockList + host pattern Set), and lib/sandbox/child-source.ts (sandbox grandchild, interpolated into the node -e template literal via JSON.stringify). Stored as JSON so both consumers can import it with a single canonical extension - the keeperhub bundler (Turbopack) and the standalone sandbox package's strict ESM runtime resolve .json identically, whereas .js/.ts variants need different specifiers in each context. NAT64 well-known prefix is kept separate as nat64PrefixCidr because it must be handled specially: the last 32 bits encode an IPv4 destination, so consumers extract the embedded IPv4 and recheck it against ipv4Cidrs. Site-local NAT64 (64:ff9b:1::/48) is in ipv6Cidrs because it is by construction site-local. ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not listed because Node BlockList treats it as 'all IPv4'; consumers handle it via an embedded-IPv4 extraction. Cluster suffix scope: KeeperHub staging and production both run on AWS EKS with the default clusterDomain of cluster.local; if we move to a cluster with a custom clusterDomain, add it to blockedHostSuffixes.",
+  "ipv4Cidrs": [
+    ["0.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["100.64.0.0", 10],
+    ["127.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["172.16.0.0", 12],
+    ["192.0.0.0", 24],
+    ["192.0.2.0", 24],
+    ["192.88.99.0", 24],
+    ["192.168.0.0", 16],
+    ["198.18.0.0", 15],
+    ["198.51.100.0", 24],
+    ["203.0.113.0", 24],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4]
+  ],
+  "ipv4BroadcastAddresses": ["255.255.255.255"],
+  "ipv6Cidrs": [
+    ["64:ff9b:1::", 48],
+    ["100::", 64],
+    ["2001::", 32],
+    ["2001:db8::", 32],
+    ["2002::", 16],
+    ["fc00::", 7],
+    ["fe80::", 10],
+    ["ff00::", 8]
+  ],
+  "ipv6LiteralAddresses": ["::", "::1"],
+  "nat64PrefixCidr": ["64:ff9b::", 96],
+  "blockedHostExact": ["localhost"],
+  "blockedHostSuffixes": [
+    ".local",
+    ".internal",
+    ".svc.cluster.local",
+    ".pod.cluster.local"
+  ]
+}

--- a/lib/ssrf-blocklist.ts
+++ b/lib/ssrf-blocklist.ts
@@ -1,0 +1,130 @@
+/**
+ * Single source of truth for the SSRF blocklist: CIDR ranges that must
+ * never be reached from user-controlled fetch, and hostname patterns
+ * that mark a host as local / internal / in-cluster.
+ *
+ * Pure data, no runtime side effects, no `import "server-only"`. Two
+ * consumers today:
+ *
+ *   1. `lib/safe-fetch.ts` (and transitively `lib/db/connection-host-guard.ts`)
+ *      builds a `node:net` BlockList and a Set of host patterns from
+ *      these arrays at module load time.
+ *
+ *   2. `lib/sandbox/child-source.ts` interpolates these values into the
+ *      sandbox grandchild's template literal via `JSON.stringify`. The
+ *      grandchild runs in a separate `node -e` subprocess with no
+ *      access to npm or the rest of the codebase, so the data has to
+ *      cross the process boundary as inlined literals; consuming from
+ *      this module at template-render time keeps that inlined copy
+ *      automatically in sync.
+ *
+ * Adding a new range:
+ *   - IPv4 prefix:           append to `SSRF_IPV4_CIDRS`
+ *   - IPv4 single address:   append to `SSRF_IPV4_BROADCAST_ADDRESSES`
+ *   - IPv6 prefix:           append to `SSRF_IPV6_CIDRS`
+ *   - IPv6 single address:   append to `SSRF_IPV6_LITERAL_ADDRESSES`
+ *   - Hostname exact match:  append to `SSRF_BLOCKED_HOST_EXACT`
+ *   - Hostname suffix:       append to `SSRF_BLOCKED_HOST_SUFFIXES` with leading `.`
+ *
+ * Note: `SSRF_NAT64_PREFIX_CIDR` (64:ff9b::/96) is intentionally NOT in
+ * `SSRF_IPV6_CIDRS`. In dual-stack networks resolvers synthesise this
+ * prefix for every IPv4-only public host; blanket-blocking it would
+ * block legitimate destinations. Consumers handle this prefix specially
+ * by extracting the embedded IPv4 and rechecking it against the IPv4
+ * list. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS in the regular
+ * list because by-construction the embedded IPv4 maps to internal infra.
+ */
+
+export type Cidr = readonly [address: string, prefix: number];
+
+/**
+ * Covers unspecified, RFC 1918 private, loopback, CGNAT (RFC 6598),
+ * link-local incl. cloud IMDS (169.254.169.254), IETF protocol
+ * assignments, IPv4 documentation ranges, benchmarking, multicast,
+ * reserved future use. Broadcast is in `SSRF_IPV4_BROADCAST_ADDRESSES`.
+ */
+export const SSRF_IPV4_CIDRS: readonly Cidr[] = [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+];
+
+export const SSRF_IPV4_BROADCAST_ADDRESSES: readonly string[] = [
+  "255.255.255.255",
+];
+
+/**
+ * IPv6 ranges. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) and
+ * deprecated transition mechanisms (Teredo 2001::/32, 6to4 2002::/16)
+ * are blanket-blocked here despite carrying embedded IPv4: the RFC
+ * 8215 prefix is by-construction site-local, and Teredo / 6to4 are
+ * deprecated and not synthesised by mainstream resolvers, so the
+ * false-positive risk is low.
+ *
+ * `::ffff:0:0/96` (IPv4-mapped) is NOT in this list because Node's
+ * BlockList treats it as "all IPv4" - consumers handle IPv4-mapped via
+ * an embedded-IPv4 extraction instead. Same shape applies to
+ * `64:ff9b::/96` (well-known NAT64) - see `SSRF_NAT64_PREFIX_CIDR`.
+ */
+export const SSRF_IPV6_CIDRS: readonly Cidr[] = [
+  ["64:ff9b:1::", 48],
+  ["100::", 64],
+  ["2001::", 32],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8],
+];
+
+export const SSRF_IPV6_LITERAL_ADDRESSES: readonly string[] = ["::", "::1"];
+
+/**
+ * NAT64 well-known prefix (RFC 6052). Kept separate from
+ * `SSRF_IPV6_CIDRS` because it must be handled specially - the last 32
+ * bits encode an IPv4 destination that may be a legitimate public
+ * address. Consumers detect membership in this prefix, extract the
+ * embedded IPv4, and recheck it against the IPv4 list.
+ */
+export const SSRF_NAT64_PREFIX_CIDR: Cidr = ["64:ff9b::", 96];
+
+/**
+ * Hostnames matched exactly (case-insensitive, trailing dot stripped)
+ * before any DNS resolution.
+ */
+export const SSRF_BLOCKED_HOST_EXACT: readonly string[] = ["localhost"];
+
+/**
+ * Hostname suffixes matched (case-insensitive, trailing dot stripped)
+ * before any DNS resolution. Each entry begins with `.` so a top-level
+ * token like "internal" cannot match an unrelated host such as
+ * "myinternal.com".
+ *
+ * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
+ * patterns, but the cluster suffixes are listed explicitly so the
+ * intent is visible at the denylist site and so any future narrowing
+ * of `.local` (e.g. to mDNS-only) does not silently re-open the
+ * in-cluster path.
+ *
+ * Cluster suffix scope: KeeperHub staging and production both run on
+ * AWS EKS with the default `clusterDomain` of `cluster.local`. If we
+ * move to a cluster with a custom `clusterDomain`, add it here.
+ */
+export const SSRF_BLOCKED_HOST_SUFFIXES: readonly string[] = [
+  ".local",
+  ".internal",
+  ".svc.cluster.local",
+  ".pod.cluster.local",
+];

--- a/lib/ssrf-blocklist.ts
+++ b/lib/ssrf-blocklist.ts
@@ -1,130 +1,59 @@
 /**
- * Single source of truth for the SSRF blocklist: CIDR ranges that must
- * never be reached from user-controlled fetch, and hostname patterns
- * that mark a host as local / internal / in-cluster.
+ * Typed re-exports of the SSRF blocklist data in `lib/ssrf-blocklist.json`.
  *
- * Pure data, no runtime side effects, no `import "server-only"`. Two
- * consumers today:
+ * The underlying data lives in a JSON file (not this `.ts` file) for a
+ * specific reason: two consumers need to read it, and they have
+ * incompatible module-resolution conventions for `.ts`/`.js` files.
  *
- *   1. `lib/safe-fetch.ts` (and transitively `lib/db/connection-host-guard.ts`)
- *      builds a `node:net` BlockList and a Set of host patterns from
- *      these arrays at module load time.
+ *   1. `lib/safe-fetch.ts` and `lib/db/connection-host-guard.ts` are
+ *      bundled by Next.js Turbopack and want extension-less imports.
+ *   2. `lib/sandbox/child-source.ts` is also compiled by the standalone
+ *      `@keeperhub/sandbox` package (separate tsconfig) and runs under
+ *      strict ESM in a `"type": "module"` Node process, which requires
+ *      explicit file extensions in import specifiers.
  *
- *   2. `lib/sandbox/child-source.ts` interpolates these values into the
- *      sandbox grandchild's template literal via `JSON.stringify`. The
- *      grandchild runs in a separate `node -e` subprocess with no
- *      access to npm or the rest of the codebase, so the data has to
- *      cross the process boundary as inlined literals; consuming from
- *      this module at template-render time keeps that inlined copy
- *      automatically in sync.
+ * A `.json` extension resolves identically in both contexts, so the
+ * data lives there. This `.ts` file is a thin typed wrapper used only
+ * by the keeperhub-side consumers; the sandbox `child-source.ts`
+ * imports the JSON directly without going through this wrapper.
  *
- * Adding a new range:
- *   - IPv4 prefix:           append to `SSRF_IPV4_CIDRS`
- *   - IPv4 single address:   append to `SSRF_IPV4_BROADCAST_ADDRESSES`
- *   - IPv6 prefix:           append to `SSRF_IPV6_CIDRS`
- *   - IPv6 single address:   append to `SSRF_IPV6_LITERAL_ADDRESSES`
- *   - Hostname exact match:  append to `SSRF_BLOCKED_HOST_EXACT`
- *   - Hostname suffix:       append to `SSRF_BLOCKED_HOST_SUFFIXES` with leading `.`
+ * Adding a new range: edit `lib/ssrf-blocklist.json`. Both consumers
+ * pick it up automatically.
  *
- * Note: `SSRF_NAT64_PREFIX_CIDR` (64:ff9b::/96) is intentionally NOT in
- * `SSRF_IPV6_CIDRS`. In dual-stack networks resolvers synthesise this
- * prefix for every IPv4-only public host; blanket-blocking it would
- * block legitimate destinations. Consumers handle this prefix specially
- * by extracting the embedded IPv4 and rechecking it against the IPv4
- * list. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS in the regular
- * list because by-construction the embedded IPv4 maps to internal infra.
+ * Note: `nat64PrefixCidr` (64:ff9b::/96) is intentionally NOT in
+ * `ipv6Cidrs`. In dual-stack networks resolvers synthesise this prefix
+ * for every IPv4-only public host; blanket-blocking would block
+ * legitimate destinations. Consumers handle this prefix specially by
+ * extracting the embedded IPv4 and rechecking it against the IPv4
+ * list. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS in `ipv6Cidrs`
+ * because by-construction the embedded IPv4 maps to internal infra.
  */
+
+import data from "./ssrf-blocklist.json" with { type: "json" };
 
 export type Cidr = readonly [address: string, prefix: number];
 
-/**
- * Covers unspecified, RFC 1918 private, loopback, CGNAT (RFC 6598),
- * link-local incl. cloud IMDS (169.254.169.254), IETF protocol
- * assignments, IPv4 documentation ranges, benchmarking, multicast,
- * reserved future use. Broadcast is in `SSRF_IPV4_BROADCAST_ADDRESSES`.
- */
-export const SSRF_IPV4_CIDRS: readonly Cidr[] = [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.0.0.0", 24],
-  ["192.0.2.0", 24],
-  ["192.88.99.0", 24],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["198.51.100.0", 24],
-  ["203.0.113.0", 24],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4],
-];
+// The cast goes via `unknown` because JSON arrays-of-tuples widen to
+// `(string | number)[][]` at parse time, which TS deems too broad for a
+// direct `Cidr[]` assertion. The JSON schema is documented at the top of
+// `lib/ssrf-blocklist.json`; entries must be `[address: string, prefix:
+// number]` pairs by convention.
+export const SSRF_IPV4_CIDRS: readonly Cidr[] =
+  data.ipv4Cidrs as unknown as Cidr[];
 
-export const SSRF_IPV4_BROADCAST_ADDRESSES: readonly string[] = [
-  "255.255.255.255",
-];
+export const SSRF_IPV4_BROADCAST_ADDRESSES: readonly string[] =
+  data.ipv4BroadcastAddresses;
 
-/**
- * IPv6 ranges. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) and
- * deprecated transition mechanisms (Teredo 2001::/32, 6to4 2002::/16)
- * are blanket-blocked here despite carrying embedded IPv4: the RFC
- * 8215 prefix is by-construction site-local, and Teredo / 6to4 are
- * deprecated and not synthesised by mainstream resolvers, so the
- * false-positive risk is low.
- *
- * `::ffff:0:0/96` (IPv4-mapped) is NOT in this list because Node's
- * BlockList treats it as "all IPv4" - consumers handle IPv4-mapped via
- * an embedded-IPv4 extraction instead. Same shape applies to
- * `64:ff9b::/96` (well-known NAT64) - see `SSRF_NAT64_PREFIX_CIDR`.
- */
-export const SSRF_IPV6_CIDRS: readonly Cidr[] = [
-  ["64:ff9b:1::", 48],
-  ["100::", 64],
-  ["2001::", 32],
-  ["2001:db8::", 32],
-  ["2002::", 16],
-  ["fc00::", 7],
-  ["fe80::", 10],
-  ["ff00::", 8],
-];
+export const SSRF_IPV6_CIDRS: readonly Cidr[] =
+  data.ipv6Cidrs as unknown as Cidr[];
 
-export const SSRF_IPV6_LITERAL_ADDRESSES: readonly string[] = ["::", "::1"];
+export const SSRF_IPV6_LITERAL_ADDRESSES: readonly string[] =
+  data.ipv6LiteralAddresses;
 
-/**
- * NAT64 well-known prefix (RFC 6052). Kept separate from
- * `SSRF_IPV6_CIDRS` because it must be handled specially - the last 32
- * bits encode an IPv4 destination that may be a legitimate public
- * address. Consumers detect membership in this prefix, extract the
- * embedded IPv4, and recheck it against the IPv4 list.
- */
-export const SSRF_NAT64_PREFIX_CIDR: Cidr = ["64:ff9b::", 96];
+export const SSRF_NAT64_PREFIX_CIDR: Cidr =
+  data.nat64PrefixCidr as unknown as Cidr;
 
-/**
- * Hostnames matched exactly (case-insensitive, trailing dot stripped)
- * before any DNS resolution.
- */
-export const SSRF_BLOCKED_HOST_EXACT: readonly string[] = ["localhost"];
+export const SSRF_BLOCKED_HOST_EXACT: readonly string[] = data.blockedHostExact;
 
-/**
- * Hostname suffixes matched (case-insensitive, trailing dot stripped)
- * before any DNS resolution. Each entry begins with `.` so a top-level
- * token like "internal" cannot match an unrelated host such as
- * "myinternal.com".
- *
- * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
- * patterns, but the cluster suffixes are listed explicitly so the
- * intent is visible at the denylist site and so any future narrowing
- * of `.local` (e.g. to mDNS-only) does not silently re-open the
- * in-cluster path.
- *
- * Cluster suffix scope: KeeperHub staging and production both run on
- * AWS EKS with the default `clusterDomain` of `cluster.local`. If we
- * move to a cluster with a custom `clusterDomain`, add it here.
- */
-export const SSRF_BLOCKED_HOST_SUFFIXES: readonly string[] = [
-  ".local",
-  ".internal",
-  ".svc.cluster.local",
-  ".pod.cluster.local",
-];
+export const SSRF_BLOCKED_HOST_SUFFIXES: readonly string[] =
+  data.blockedHostSuffixes;

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -16,6 +16,11 @@ COPY sandbox/src ./sandbox/src
 # `../../lib/sandbox/child-source.js`. sandbox/tsconfig.json has
 # rootDir=".." so tsc can compile this file as part of the sandbox build.
 COPY lib/sandbox/child-source.ts ./lib/sandbox/child-source.ts
+# Shared SSRF blocklist data (CIDR ranges + hostname patterns),
+# imported by lib/sandbox/child-source.ts. tsc resolves the relative
+# import and emits dist/lib/ssrf-blocklist.js, which child-source.js
+# requires at runtime.
+COPY lib/ssrf-blocklist.ts ./lib/ssrf-blocklist.ts
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/sandbox/node_modules ./sandbox/node_modules
 RUN pnpm --filter @keeperhub/sandbox build

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -17,10 +17,11 @@ COPY sandbox/src ./sandbox/src
 # rootDir=".." so tsc can compile this file as part of the sandbox build.
 COPY lib/sandbox/child-source.ts ./lib/sandbox/child-source.ts
 # Shared SSRF blocklist data (CIDR ranges + hostname patterns),
-# imported by lib/sandbox/child-source.ts. tsc resolves the relative
-# import and emits dist/lib/ssrf-blocklist.js, which child-source.js
-# requires at runtime.
-COPY lib/ssrf-blocklist.ts ./lib/ssrf-blocklist.ts
+# imported by lib/sandbox/child-source.ts as a JSON module so the
+# specifier resolves identically in both the keeperhub Turbopack
+# bundler and the standalone sandbox's strict ESM runtime. See the
+# docstring in lib/ssrf-blocklist.ts for the full rationale.
+COPY lib/ssrf-blocklist.json ./lib/ssrf-blocklist.json
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/sandbox/node_modules ./sandbox/node_modules
 RUN pnpm --filter @keeperhub/sandbox build

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node dist/sandbox/src/index.js",
-    "build": "tsc",
+    "build": "tsc && cp ../lib/ssrf-blocklist.json dist/lib/ssrf-blocklist.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/sandbox/tsconfig.json
+++ b/sandbox/tsconfig.json
@@ -16,6 +16,10 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["src/**/*", "../lib/sandbox/child-source.ts"],
+  "include": [
+    "src/**/*",
+    "../lib/sandbox/child-source.ts",
+    "../lib/ssrf-blocklist.json"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -1,8 +1,14 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { deserialize } from "node:v8";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { SANDBOX_CHILD_SOURCE } from "@/lib/sandbox/child-source";
+import {
+  SANDBOX_CHILD_SOURCE,
+  SANDBOX_RESULT_SENTINEL,
+} from "@/lib/sandbox/child-source";
 import {
   SSRF_BLOCKED_HOST_EXACT,
   SSRF_BLOCKED_HOST_SUFFIXES,
@@ -16,14 +22,18 @@ import {
 // The sandbox grandchild runs as a separate `node -e <SANDBOX_CHILD_SOURCE>`
 // subprocess with no access to npm or the rest of the codebase, so the SSRF
 // blocklist has to cross the process boundary as inlined literals
-// (`JSON.stringify` interpolation at template-render time). This test locks
-// that contract: every entry in lib/ssrf-blocklist.ts must appear in the
-// rendered source. If someone later regresses by hardcoding the list in
-// child-source.ts and forgetting to update one consumer, this test fails.
+// (`JSON.stringify` interpolation at template-render time). This file locks
+// two contracts:
+//   1. Data parity: every entry in lib/ssrf-blocklist.ts must appear in the
+//      rendered source.
+//   2. Behavioural parity: the rendered source actually blocks the things
+//      it inlines when spawned and asked to fetch them. Item #2 is the
+//      contract the KEEP-603 incident required and the contract data-only
+//      tests cannot prove on their own.
 describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
-  it("inlines every IPv4 CIDR address from the SoT", () => {
-    for (const [addr] of SSRF_IPV4_CIDRS) {
-      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+  it("inlines every IPv4 CIDR tuple from the SoT", () => {
+    for (const cidr of SSRF_IPV4_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(JSON.stringify(cidr));
     }
   });
 
@@ -33,9 +43,9 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
     }
   });
 
-  it("inlines every IPv6 CIDR address from the SoT", () => {
-    for (const [addr] of SSRF_IPV6_CIDRS) {
-      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+  it("inlines every IPv6 CIDR tuple from the SoT", () => {
+    for (const cidr of SSRF_IPV6_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(JSON.stringify(cidr));
     }
   });
 
@@ -45,8 +55,10 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
     }
   });
 
-  it("inlines the NAT64 well-known prefix address from the SoT", () => {
-    expect(SANDBOX_CHILD_SOURCE).toContain(`"${SSRF_NAT64_PREFIX_CIDR[0]}"`);
+  it("inlines the NAT64 well-known prefix tuple from the SoT", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain(
+      JSON.stringify(SSRF_NAT64_PREFIX_CIDR),
+    );
   });
 
   it("inlines every blocked-host exact match from the SoT", () => {
@@ -71,3 +83,160 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
     expect(() => new Script(SANDBOX_CHILD_SOURCE)).not.toThrow();
   });
 });
+
+// Drift-resistance policy guard. The grandchild template is now
+// data-imported from lib/ssrf-blocklist.json; any other import would either
+// silently no-op in the spawned subprocess (runtime values do not propagate
+// across "node -e") or introduce a dependency the standalone sandbox image
+// does not have. Lock the contract here so it cannot regress quietly.
+const IMPORT_STATEMENT_REGEX = /^import\s.+$/gm;
+
+describe("lib/sandbox/child-source.ts only imports pure data", () => {
+  it("has at most one import and it points at the SSRF blocklist JSON", async () => {
+    const src = await readFile("lib/sandbox/child-source.ts", "utf8");
+    const imports = src.match(IMPORT_STATEMENT_REGEX) ?? [];
+    expect(imports).toHaveLength(1);
+    expect(imports[0]).toContain('"../ssrf-blocklist.json"');
+    expect(imports[0]).toContain('with { type: "json" }');
+  });
+});
+
+type SandboxOutcome =
+  | { ok: true; result: unknown; logs: unknown[] }
+  | {
+      ok: false;
+      errorMessage: string;
+      errorStack?: string;
+      logs: unknown[];
+    };
+
+function parseChildOutput(stdout: string): SandboxOutcome {
+  const idx = stdout.lastIndexOf(SANDBOX_RESULT_SENTINEL);
+  if (idx === -1) {
+    return { ok: false, errorMessage: "no sentinel in stdout", logs: [] };
+  }
+  const newlineIdx = stdout.indexOf("\n", idx);
+  const end = newlineIdx === -1 ? stdout.length : newlineIdx;
+  const base64 = stdout
+    .slice(idx + SANDBOX_RESULT_SENTINEL.length, end)
+    .trim();
+  try {
+    return deserialize(Buffer.from(base64, "base64")) as SandboxOutcome;
+  } catch (_err) {
+    return { ok: false, errorMessage: "malformed v8 payload", logs: [] };
+  }
+}
+
+async function runSandboxed(
+  userCode: string,
+  timeoutMs = 3000,
+): Promise<SandboxOutcome> {
+  return await new Promise<SandboxOutcome>((resolve) => {
+    const child = spawn(process.execPath, ["-e", SANDBOX_CHILD_SOURCE], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let settled = false;
+
+    function finish(outcome: SandboxOutcome): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(killTimer);
+      if (!child.killed) {
+        try {
+          child.kill("SIGKILL");
+        } catch (_err) {
+          // child may already have exited
+        }
+      }
+      resolve(outcome);
+    }
+
+    const killTimer = setTimeout(() => {
+      finish({ ok: false, errorMessage: "harness timeout", logs: [] });
+    }, timeoutMs + 3000);
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.on("error", (err: Error) => {
+      finish({ ok: false, errorMessage: err.message, logs: [] });
+    });
+    child.on("close", () => {
+      finish(parseChildOutput(stdout));
+    });
+
+    try {
+      child.stdin.write(JSON.stringify({ code: userCode, timeoutMs }));
+      child.stdin.end();
+    } catch (err) {
+      finish({
+        ok: false,
+        errorMessage: err instanceof Error ? err.message : String(err),
+        logs: [],
+      });
+    }
+  });
+}
+
+function expectBlocked(outcome: SandboxOutcome): void {
+  expect(outcome.ok).toBe(false);
+  if (outcome.ok) {
+    return;
+  }
+  expect(outcome.errorMessage).toMatch(/SSRF blocked/);
+}
+
+// Behavioural parity: spawn the actual grandchild and confirm the SSRF
+// guard fires for every category Sasha listed in the incident response
+// (RFC 1918, link-local incl. IMDSv2, multicast, reserved, IPv6 transition
+// prefixes, and the pre-DNS hostname denylist). These cases use IP
+// literals or pre-DNS-blocked hostnames so the test is deterministic and
+// performs no real DNS / network IO.
+describe("sandbox grandchild SSRF guard fires on every category", () => {
+  it.each([
+    ['await fetch("http://169.254.169.254/")', "IMDSv2 link-local"],
+    ['await fetch("http://10.0.0.1/")', "RFC 1918"],
+    ['await fetch("http://127.0.0.1/")', "loopback IPv4"],
+    ['await fetch("http://255.255.255.255/")', "IPv4 broadcast"],
+    ['await fetch("http://[::1]/")', "IPv6 loopback"],
+    ['await fetch("http://[fc00::1]/")', "ULA IPv6"],
+    ['await fetch("http://[fe80::1]/")', "link-local IPv6"],
+    ['await fetch("http://[2001::1]/")', "Teredo (2001::/32)"],
+    ['await fetch("http://[2002::1]/")', "6to4 (2002::/16)"],
+    [
+      'await fetch("http://[2001:db8::1]/")',
+      "documentation range (2001:db8::/32)",
+    ],
+    [
+      'await fetch("http://[64:ff9b:1::1]/")',
+      "site-local NAT64 (64:ff9b:1::/48)",
+    ],
+    ['await fetch("http://[ff02::1]/")', "multicast IPv6"],
+  ])("blocks %s (%s)", async (snippet) => {
+    const outcome = await runSandboxed(snippet);
+    expectBlocked(outcome);
+  });
+
+  it.each([
+    ['await fetch("http://localhost/")', "pre-DNS exact match"],
+    ['await fetch("http://LOCALHOST/")', "case normalisation"],
+    ['await fetch("http://localhost./")', "trailing-dot normalisation"],
+    [
+      'await fetch("http://probe.svc.cluster.local/")',
+      "*.svc.cluster.local",
+    ],
+    [
+      'await fetch("http://probe.pod.cluster.local/")',
+      "*.pod.cluster.local",
+    ],
+    ['await fetch("http://probe.internal/")', "*.internal"],
+    ['await fetch("http://probe.local/")', "*.local (mDNS / Bonjour)"],
+  ])("blocks %s before DNS (%s)", async (snippet) => {
+    const outcome = await runSandboxed(snippet);
+    expectBlocked(outcome);
+  });
+}, 30_000);

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { SANDBOX_CHILD_SOURCE } from "@/lib/sandbox/child-source";
+import {
+  SSRF_BLOCKED_HOST_EXACT,
+  SSRF_BLOCKED_HOST_SUFFIXES,
+  SSRF_IPV4_BROADCAST_ADDRESSES,
+  SSRF_IPV4_CIDRS,
+  SSRF_IPV6_CIDRS,
+  SSRF_IPV6_LITERAL_ADDRESSES,
+  SSRF_NAT64_PREFIX_CIDR,
+} from "@/lib/ssrf-blocklist";
+
+// The sandbox grandchild runs as a separate `node -e <SANDBOX_CHILD_SOURCE>`
+// subprocess with no access to npm or the rest of the codebase, so the SSRF
+// blocklist has to cross the process boundary as inlined literals
+// (`JSON.stringify` interpolation at template-render time). This test locks
+// that contract: every entry in lib/ssrf-blocklist.ts must appear in the
+// rendered source. If someone later regresses by hardcoding the list in
+// child-source.ts and forgetting to update one consumer, this test fails.
+describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
+  it("inlines every IPv4 CIDR address from the SoT", () => {
+    for (const [addr] of SSRF_IPV4_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines every IPv4 broadcast address from the SoT", () => {
+    for (const addr of SSRF_IPV4_BROADCAST_ADDRESSES) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines every IPv6 CIDR address from the SoT", () => {
+    for (const [addr] of SSRF_IPV6_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines every IPv6 literal address from the SoT", () => {
+    for (const addr of SSRF_IPV6_LITERAL_ADDRESSES) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines the NAT64 well-known prefix address from the SoT", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain(`"${SSRF_NAT64_PREFIX_CIDR[0]}"`);
+  });
+
+  it("inlines every blocked-host exact match from the SoT", () => {
+    for (const host of SSRF_BLOCKED_HOST_EXACT) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${host}"`);
+    }
+  });
+
+  it("inlines every blocked-host suffix from the SoT", () => {
+    for (const suffix of SSRF_BLOCKED_HOST_SUFFIXES) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${suffix}"`);
+    }
+  });
+
+  it("renders syntactically valid JavaScript", async () => {
+    // `node -e` parses the source at process start. If the template literal
+    // ever produces invalid JS (e.g. an interpolation breaks a string
+    // boundary or yields a reserved-word identifier), every Code-node
+    // workflow run would crash at startup. Use Node's vm.Script to do a
+    // parse-only check without executing anything.
+    const { Script } = await import("node:vm");
+    expect(() => new Script(SANDBOX_CHILD_SOURCE)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the SSRF blocklist data (CIDR ranges, hostname patterns, NAT64 well-known prefix) to a new `lib/ssrf-blocklist.ts` module. Both the main app's `safe-fetch.ts` and the sandbox grandchild source consume from this one file:

- `lib/safe-fetch.ts` imports the data and builds its `node:net` BlockList and `Set<string>` at module-load time.
- `lib/sandbox/child-source.ts` interpolates the data into the grandchild template via `JSON.stringify`, so the inlined literals in the rendered `node -e` string stay automatically in sync with the main-app blocklist.

## Why

The sandbox guard in `child-source.ts` was a hand-maintained copy of the original safe-fetch implementation. When KEEP-603 added four new IPv6 ranges (`64:ff9b:1::/48`, `2001::/32` Teredo, `2002::/16` 6to4, `2001:db8::/32` documentation) and a pre-DNS hostname denylist (`localhost`, `*.local`, `*.internal`, `*.svc.cluster.local`, `*.pod.cluster.local`) to `safe-fetch.ts`, the sandbox didn't get the update. This change closes that drift and makes future drift structurally impossible.

## Behaviour change

The sandbox now rejects:

- IPv6 destinations in the four newly-added prefixes listed above.
- Hostnames matching the pre-DNS denylist, before any DNS resolution.

The sandbox guard remains always-enforce - it does not read `SAFE_FETCH_ENFORCE` and there is no need to wire it into the `keeperhub-sandbox` Helm values.

## How the sandbox import works

The grandchild process is spawned via `node -e <SANDBOX_CHILD_SOURCE>` and has no access to npm or to the rest of this repo (zero-runtime-dep by design). The data crosses the process boundary as inlined `JSON.stringify` output at template-render time. The TypeScript module is allowed to `import` pure data; importing anything with runtime side effects would not propagate to the grandchild. The docblock at the top of `child-source.ts` is updated to spell out this nuance.

## Validation

- `pnpm vitest run tests/unit/safe-fetch.test.ts tests/unit/connection-guards.test.ts` - 189 / 189 pass.
- `pnpm exec tsx -e "import { SANDBOX_CHILD_SOURCE } from './lib/sandbox/child-source'; process.stdout.write(SANDBOX_CHILD_SOURCE)"` rendered the template; `node --check` on the rendered output reported zero syntax errors; grep confirmed the IPv4 CIDRs (incl. `169.254.0.0`), the four new IPv6 ranges, the `BLOCKED_HOST_EXACT` and `BLOCKED_HOST_SUFFIXES` literals are all inline.
- `pnpm check` clean on the three changed files (overall lint state on staging unchanged).
- `pnpm type-check` clean on the three changed files (9 pre-existing missing-module errors on staging unrelated to this change).

## Test plan

- [ ] CI green
- [ ] After merge and deploy: spin a workflow with a Code node whose user JS calls `fetch("http://169.254.169.254/")`. Confirm it fails with `sandbox fetch: SSRF blocked (169.254.169.254)`.
- [ ] Same Code-node workflow but `fetch("http://localhost/")` - confirm it fails without any DNS lookup happening.
- [ ] Same Code-node workflow but `fetch("http://internal-svc.keeperhub.svc.cluster.local/")` - confirm the hostname-pattern block fires.
- [ ] Sanity: a Code node calling `fetch("https://discord.com/api/v9/users/@me")` still works (dual-stack-resolved NAT64-wrapped public IPv4 is allowed via the embedded-IPv4 recheck).
