### PR TITLE
fix: force-enable SAFE_FETCH_ENFORCE on workflow runner pods

### DIFF
--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -244,4 +244,41 @@ describe("createWorkflowJob", () => {
       '{"eth":"http://localhost:8545"}'
     );
   });
+
+  it("force-enables SAFE_FETCH_ENFORCE on runner pods even when unset on controller", async () => {
+    // SSRF guard must be on regardless of controller config to prevent
+    // workflow runs from reaching internal hosts (cloud IMDS, RFC1918,
+    // in-cluster services). The runner pod is the actual execution path,
+    // not the controller; if the controller's env ever drifts the runner
+    // must still enforce.
+    delete process.env.SAFE_FETCH_ENFORCE;
+
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
+  });
+
+  it("force-enables SAFE_FETCH_ENFORCE even when controller has it set to shadow", async () => {
+    // Hardcoded `value: "true"` in k8s-job.ts wins over any controller
+    // env. Flipping shadow mode for runner pods requires a code change.
+    process.env.SAFE_FETCH_ENFORCE = "false";
+
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
+    const occurrences = envVars.filter((v) => v.name === "SAFE_FETCH_ENFORCE");
+    expect(occurrences).toHaveLength(1);
+  });
 });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -58,6 +58,13 @@ export async function createWorkflowJob(params: {
     { name: "PARA_ENVIRONMENT", value: CONFIG.paraEnvironment },
     { name: "WALLET_ENCRYPTION_KEY", value: CONFIG.walletEncryptionKey },
     { name: "CHAIN_RPC_CONFIG", value: CONFIG.chainRpcConfig },
+    // SSRF guard: force-enable on every workflow runner pod regardless
+    // of controller env. Hardcoded (rather than forwarded via
+    // RUNNER_SYSTEM_ENV_VARS) so the runner enforces even if the
+    // controller's Helm values drift or a deploy omits the entry.
+    // Flipping back to shadow mode is a deliberate code change here,
+    // which is the intended posture for SSRF protection.
+    { name: "SAFE_FETCH_ENFORCE", value: "true" },
     ...(CONFIG.etherscanApiKey
       ? [{ name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey }]
       : []),


### PR DESCRIPTION
## Summary

Closes the last hop in the SSRF enforcement chain. The workflow execution path that actually runs user step code (and therefore calls `safeFetch`) is the ephemeral `workflow-*` runner pod that the executor controller spawns via `createWorkflowJob` in `keeperhub-executor/k8s-job.ts`. These runner pods do not read Helm values directly; their env is built from a hardcoded explicit list plus the `RUNNER_SYSTEM_ENV_VARS` allowlist. `SAFE_FETCH_ENFORCE` was on neither, so runner pods ran with `process.env.SAFE_FETCH_ENFORCE === undefined`, `isShadowMode()` returned `true`, and the SSRF guard merely logged blocks while letting outbound traffic through. The IMDS-401 we caught in production was almost certainly from this path.

Hardcodes `{ name: "SAFE_FETCH_ENFORCE", value: "true" }` directly in the explicit `envVars` list. Two tests added: one verifies the runner pod gets `"true"` when the controller env is unset; the other verifies the hardcoded value wins over a controller env set to `"false"` and that the entry appears exactly once (no duplicate from `RUNNER_SYSTEM_ENV_VARS` forwarding).

## Why hardcoded rather than via `RUNNER_SYSTEM_ENV_VARS`

The allowlist pattern would forward the controller's env value, which works only as long as the controller's Helm values hold `SAFE_FETCH_ENFORCE: "true"`. A config drift, Helm rollback, or omission on a new deployment would silently drop the env from runner pods and we'd not notice until something exfiltrated. Hardcoding the value makes runner-pod enforcement orthogonal to controller config. Flipping back to shadow mode now requires a deliberate code change in this file, which is the intended posture for an SSRF guard in an incident-response context.

## Posture chain (post-deploy)

| Layer | Source | State |
|---|---|---|
| Main-app `keeperhub-common` pod | Helm values | `value: "true"` (in PR #1331) |
| Executor controller `keeperhub-executor-common` pod | Helm values | `value: "true"` (in PR #1331) |
| Ephemeral `workflow-*` runner pods | Hardcoded in `k8s-job.ts` | **`value: "true"` (this PR)** |
| Sandbox `keeperhub-sandbox-common` pods | Always-enforce in `child-source.ts` | enforced unconditionally |

## Test plan

- [ ] CI green
- [ ] After merge and deploy: trigger a workflow run that calls `fetch("http://169.254.169.254/")`. Inspect the resulting `workflow-*` pod via `kubectl get pod <name> -o jsonpath='{.spec.containers[0].env[?(@.name=="SAFE_FETCH_ENFORCE")].value}'` and confirm it reads `true`.
- [ ] Same workflow with the SSRF call should now fail with `SsrfBlockedError` (`reason: "link-local"`) before any TCP attempt, instead of the previous 401-from-IMDS.
- [ ] Sentry counter `safe_fetch.blocks.total{shadow="false"}` should increment on the test run.

## Out of scope

- The TOCTOU window in `lib/db/connection-host-guard.ts` is unchanged. A follow-up could close it by resolving DNS once and dialling the resolved IP directly.
- Other non-`safeFetch` outbound paths (Slack, SendGrid, Mailerlite, plugin steps using bare `fetch`) are unchanged; those are tracked separately.