### PR TITLE
release: To Prod

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -86,6 +86,11 @@ jobs:
         run: |
           kubectl apply -f deploy/keeperhub/${{ vars.TO_HELM_VALUES_DIR }}/rbac.yaml
 
+      - name: Apply NetworkPolicy for workflow runner egress hardening
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: |
+          kubectl apply -f deploy/keeperhub/${{ vars.TO_HELM_VALUES_DIR }}/networkpolicy.yaml
+
       - name: Deploying Service to Kubernetes with Helm
         id: deploy
         if: steps.skip.outputs.skip_deploy != 'true'

--- a/.github/workflows/pr-checks-executor.yml
+++ b/.github/workflows/pr-checks-executor.yml
@@ -13,6 +13,9 @@ on:
       - "keeperhub-executor/**"
       - ".github/workflows/pr-checks-executor.yml"
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks-executor.yml
+++ b/.github/workflows/pr-checks-executor.yml
@@ -1,0 +1,27 @@
+# Type: standalone | PR checks for the keeperhub-executor module.
+# Runs only when keeperhub-executor/** or this workflow change. Unlike
+# keeperhub-events / keeperhub-scheduler, the executor lives in the root
+# pnpm workspace (shared lockfile, shared deps), so the existing
+# setup-node-pnpm action is reused rather than a dedicated setup action.
+# The executor's tests are pure unit tests with mocked external deps -
+# no docker services required.
+name: PR Checks (Executor)
+
+on:
+  pull_request:
+    paths:
+      - "keeperhub-executor/**"
+      - ".github/workflows/pr-checks-executor.yml"
+
+jobs:
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Run executor unit tests
+        run: pnpm test:executor

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,6 +203,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+      - name: Run executor unit tests
+        run: pnpm test:executor
+
   test-unit-sandbox-remote:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,9 +203,6 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
-      - name: Run executor unit tests
-        run: pnpm test:executor
-
   test-unit-sandbox-remote:
     runs-on: ubuntu-latest
     steps:

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -319,6 +319,16 @@ function getAIModel(
 }
 
 export async function POST(request: Request) {
+  // Feature flag gate. Defense-in-depth alongside the UI gate in
+  // components/workflow/workflow-canvas.tsx so direct API callers cannot
+  // bypass the disabled prompt.
+  if (process.env.NEXT_PUBLIC_AI_PROMPT_ENABLED !== "true") {
+    return NextResponse.json(
+      { error: "AI Prompt is disabled" },
+      { status: 503 }
+    );
+  }
+
   const timer = createTimer();
   const metrics = getMetricsCollector();
 

--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -796,8 +796,11 @@ export function WorkflowCanvas() {
         )}
       </Canvas>
 
-      {/* AI Prompt */}
-      {currentWorkflowId && <AIPrompt workflowId={currentWorkflowId} />}
+      {/* AI Prompt - gated by NEXT_PUBLIC_AI_PROMPT_ENABLED feature flag */}
+      {currentWorkflowId &&
+        process.env.NEXT_PUBLIC_AI_PROMPT_ENABLED === "true" && (
+          <AIPrompt workflowId={currentWorkflowId} />
+        )}
 
       {/* Context Menu */}
       <WorkflowContextMenu

--- a/deploy/keeperhub/prod/networkpolicy.yaml
+++ b/deploy/keeperhub/prod/networkpolicy.yaml
@@ -1,0 +1,34 @@
+# Defense-in-depth: even if the JS-level SSRF guard in lib/sandbox/child-source.ts
+# or lib/safe-fetch.ts is bypassed, workflow runner pods must not be able to
+# reach the EC2 instance metadata service (IMDS, 169.254.169.254). Selector
+# matches the `app: workflow-runner` label set by keeperhub-executor/k8s-job.ts.
+#
+# Egress allow rule uses 0.0.0.0/0 with an explicit `except` so we keep
+# legitimate outbound traffic working (RDS in 10.0/8, cluster DNS, public RPC
+# endpoints) while denying the link-local range. IPv6 link-local and ULA are
+# blocked too (AWS IMDSv6 is at fd00:ec2::254 inside fc00::/7).
+#
+# Enforced by the AWS VPC CNI Network Policy Agent on EKS (cluster runs
+# v1.21+ amazon-vpc-cni with NETWORK_POLICY_ENFORCING_MODE=standard).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: workflow-runner-block-imds
+  namespace: keeperhub
+spec:
+  podSelector:
+    matchLabels:
+      app: workflow-runner
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fe80::/10
+              - fc00::/7

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -319,6 +319,12 @@ env:
   NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED:
     type: kv
     value: "false"
+  # AI Prompt feature flag - disabled
+  # (gates UI render in components/workflow/workflow-canvas.tsx
+  #  and /api/ai/generate route)
+  NEXT_PUBLIC_AI_PROMPT_ENABLED:
+    type: kv
+    value: "false"
   STRIPE_SECRET_KEY:
     type: parameterStore
     name: stripe-secret-key

--- a/deploy/keeperhub/staging/networkpolicy.yaml
+++ b/deploy/keeperhub/staging/networkpolicy.yaml
@@ -1,0 +1,34 @@
+# Defense-in-depth: even if the JS-level SSRF guard in lib/sandbox/child-source.ts
+# or lib/safe-fetch.ts is bypassed, workflow runner pods must not be able to
+# reach the EC2 instance metadata service (IMDS, 169.254.169.254). Selector
+# matches the `app: workflow-runner` label set by keeperhub-executor/k8s-job.ts.
+#
+# Egress allow rule uses 0.0.0.0/0 with an explicit `except` so we keep
+# legitimate outbound traffic working (RDS in 10.1/16, cluster DNS, public RPC
+# endpoints) while denying the link-local range. IPv6 link-local and ULA are
+# blocked too (AWS IMDSv6 is at fd00:ec2::254 inside fc00::/7).
+#
+# Enforced by the AWS VPC CNI Network Policy Agent on EKS (cluster runs
+# v1.21+ amazon-vpc-cni with NETWORK_POLICY_ENFORCING_MODE=standard).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: workflow-runner-block-imds
+  namespace: keeperhub
+spec:
+  podSelector:
+    matchLabels:
+      app: workflow-runner
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fe80::/10
+              - fc00::/7

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -318,6 +318,12 @@ env:
   NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED:
     type: kv
     value: "true"
+  # AI Prompt feature flag - disabled
+  # (gates UI render in components/workflow/workflow-canvas.tsx
+  #  and /api/ai/generate route)
+  NEXT_PUBLIC_AI_PROMPT_ENABLED:
+    type: kv
+    value: "false"
   STRIPE_SECRET_KEY:
     type: parameterStore
     name: stripe-secret-key

--- a/drizzle/0082_security_2026_05_21_block_executions_for_deactivated_users.sql
+++ b/drizzle/0082_security_2026_05_21_block_executions_for_deactivated_users.sql
@@ -1,0 +1,84 @@
+-- Security incident 2026-05-21 follow-up: enforce containment at the DB layer.
+--
+-- Two app-layer bugs were exploited during the incident:
+--
+-- 1. Database Query plugin allowed arbitrary SQL against user-supplied
+--    integrations. This was already blocked ad-hoc via the
+--    block_database_integration_type() trigger applied directly to the prod
+--    DB. Re-declare it here so the migration history is the source of truth.
+--
+-- 2. workflow_executions inserts did NOT check whether the owning user was
+--    deactivated or the workflow was soft-deleted. As a result, accounts
+--    flagged as compromised (users.deactivated_at IS NOT NULL) continued to
+--    schedule and run workflows after deactivation, and soft-deleted
+--    workflows (workflows.deleted_at IS NOT NULL) still received executions.
+--    This trigger blocks the INSERT path at the DB.
+--
+-- Both triggers are intentionally permissive on UPDATE/DELETE of existing
+-- rows so the security team can still soft-delete, mark errored, or backfill
+-- history. INSERT is the only path that gates new attacker activity.
+
+-- ---------------------------------------------------------------------------
+-- 1. Block database-type integrations (already enforced in prod, declared here
+--    so a fresh DB built from migrations gets the same protection).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.block_database_integration_type()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION USING
+    MESSAGE = 'Database Query plugin disabled (security incident 2026-05-21). Contact security team.',
+    ERRCODE = '42501';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS block_database_integrations_security_2026_05_21 ON integrations;
+
+CREATE TRIGGER block_database_integrations_security_2026_05_21
+  BEFORE INSERT OR UPDATE OF type, config ON integrations
+  FOR EACH ROW
+  WHEN (NEW.type = 'database')
+  EXECUTE FUNCTION public.block_database_integration_type();
+
+-- ---------------------------------------------------------------------------
+-- 2. Block workflow_executions when owner is deactivated or workflow deleted.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.block_executions_for_inactive_workflows()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_owner_deactivated_at timestamp;
+  v_workflow_deleted_at  timestamp;
+BEGIN
+  SELECT u.deactivated_at, w.deleted_at
+    INTO v_owner_deactivated_at, v_workflow_deleted_at
+  FROM workflows w
+  LEFT JOIN users u ON u.id = w.user_id
+  WHERE w.id = NEW.workflow_id;
+
+  IF v_workflow_deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'Workflow is deleted; new executions are not allowed.',
+      ERRCODE = '42501';
+  END IF;
+
+  IF v_owner_deactivated_at IS NOT NULL THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'Workflow owner is deactivated; new executions are not allowed.',
+      ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS block_executions_security_2026_05_21 ON workflow_executions;
+
+CREATE TRIGGER block_executions_security_2026_05_21
+  BEFORE INSERT ON workflow_executions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.block_executions_for_inactive_workflows();

--- a/drizzle/meta/0082_snapshot.json
+++ b/drizzle/meta/0082_snapshot.json
@@ -1,0 +1,6437 @@
+{
+  "id": "e88ff1ff-c201-4294-838e-b47be45cc5db",
+  "prevId": "d6f6f371-53de-42ee-baff-3a3bb486ec88",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_book_entry": {
+      "name": "address_book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_address_book_org": {
+          "name": "idx_address_book_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_address_book_org_address": {
+          "name": "idx_address_book_org_address",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_book_entry_organization_id_organization_id_fk": {
+          "name": "address_book_entry_organization_id_organization_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "address_book_entry_created_by_users_id_fk": {
+          "name": "address_book_entry_created_by_users_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_registrations": {
+      "name": "agent_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "registry_address": {
+          "name": "registry_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_credits": {
+      "name": "agentic_wallet_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usdc_cents": {
+          "name": "amount_usdc_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_reason": {
+          "name": "allocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboard_initial'"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_credits_sub_org": {
+          "name": "idx_agentic_wallet_credits_sub_org",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_agentic_wallet_credits_sub_org_reason": {
+          "name": "uq_agentic_wallet_credits_sub_org_reason",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allocation_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallet_credits_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_credits_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_credits",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_daily_spend": {
+      "name": "agentic_wallet_daily_spend",
+      "schema": "",
+      "columns": {
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_utc": {
+          "name": "day_utc",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_micros": {
+          "name": "spent_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_daily_spend_day": {
+          "name": "idx_agentic_wallet_daily_spend_day",
+          "columns": [
+            {
+              "expression": "day_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallet_daily_spend_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_daily_spend_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_daily_spend",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentic_wallet_daily_spend_sub_org_id_day_utc_pk": {
+          "name": "agentic_wallet_daily_spend_sub_org_id_day_utc_pk",
+          "columns": [
+            "sub_org_id",
+            "day_utc"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_hmac_secrets": {
+      "name": "agentic_wallet_hmac_secrets",
+      "schema": "",
+      "columns": {
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentic_wallet_hmac_secrets_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_hmac_secrets_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_hmac_secrets",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentic_wallet_hmac_secrets_sub_org_id_key_version_pk": {
+          "name": "agentic_wallet_hmac_secrets_sub_org_id_key_version_pk",
+          "columns": [
+            "sub_org_id",
+            "key_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_rate_limits": {
+      "name": "agentic_wallet_rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_rate_limits_bucket": {
+          "name": "idx_agentic_wallet_rate_limits_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentic_wallet_rate_limits_key_bucket_start_pk": {
+          "name": "agentic_wallet_rate_limits_key_bucket_start_pk",
+          "columns": [
+            "key",
+            "bucket_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallets": {
+      "name": "agentic_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address_base": {
+          "name": "wallet_address_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address_tempo": {
+          "name": "wallet_address_tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hmac_secret": {
+          "name": "hmac_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallets_linked_user": {
+          "name": "idx_agentic_wallets_linked_user",
+          "columns": [
+            {
+              "expression": "linked_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentic_wallets_wallet_base": {
+          "name": "idx_agentic_wallets_wallet_base",
+          "columns": [
+            {
+              "expression": "wallet_address_base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentic_wallets_wallet_tempo": {
+          "name": "idx_agentic_wallets_wallet_tempo",
+          "columns": [
+            {
+              "expression": "wallet_address_tempo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallets_linked_user_id_users_id_fk": {
+          "name": "agentic_wallets_linked_user_id_users_id_fk",
+          "tableFrom": "agentic_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linked_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agentic_wallets_sub_org_id_unique": {
+          "name": "agentic_wallets_sub_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beta_access_requests": {
+      "name": "beta_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_provider_event_id_unique": {
+          "name": "billing_events_provider_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "default_primary_rpc": {
+          "name": "default_primary_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_fallback_rpc": {
+          "name": "default_fallback_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_primary_wss": {
+          "name": "default_primary_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_wss": {
+          "name": "default_fallback_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_private_mempool_rpc": {
+          "name": "use_private_mempool_rpc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "default_private_rpc_url": {
+          "name": "default_private_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "gas_config": {
+          "name": "gas_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chains_chain_id": {
+          "name": "idx_chains_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chains_chain_id_unique": {
+          "name": "chains_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_code_user_id_users_id_fk": {
+          "name": "device_code_user_id_users_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_executions": {
+      "name": "direct_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price_wei": {
+          "name": "gas_price_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_direct_executions_org": {
+          "name": "idx_direct_executions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_direct_executions_status": {
+          "name": "idx_direct_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_executions_organization_id_organization_id_fk": {
+          "name": "direct_executions_organization_id_organization_id_fk",
+          "tableFrom": "direct_executions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_debt": {
+      "name": "execution_debt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_record_id": {
+          "name": "overage_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debt_executions": {
+          "name": "debt_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_debt_org_status": {
+          "name": "idx_execution_debt_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_execution_debt_invoice": {
+          "name": "idx_execution_debt_invoice",
+          "columns": [
+            {
+              "expression": "provider_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_debt_organization_id_organization_id_fk": {
+          "name": "execution_debt_organization_id_organization_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "execution_debt_overage_record_id_overage_billing_records_id_fk": {
+          "name": "execution_debt_overage_record_id_overage_billing_records_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "overage_billing_records",
+          "columnsFrom": [
+            "overage_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_debt_overage_record_id_unique": {
+          "name": "execution_debt_overage_record_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "overage_record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explorer_configs": {
+      "name": "explorer_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "explorer_url": {
+          "name": "explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_type": {
+          "name": "explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_url": {
+          "name": "explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_tx_path": {
+          "name": "explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/tx/{hash}'"
+        },
+        "explorer_address_path": {
+          "name": "explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/address/{address}'"
+        },
+        "explorer_contract_path": {
+          "name": "explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_explorer_configs_chain_id": {
+          "name": "idx_explorer_configs_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "explorer_configs_chain_id_chains_chain_id_fk": {
+          "name": "explorer_configs_chain_id_chains_chain_id_fk",
+          "tableFrom": "explorer_configs",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "chain_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "explorer_configs_chain_id_unique": {
+          "name": "explorer_configs_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_registry": {
+          "name": "agent_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erc-8004'"
+        },
+        "agent_chain_id": {
+          "name": "agent_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_wallet": {
+          "name": "payer_wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_decimals": {
+          "name": "value_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_hash": {
+          "name": "feedback_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_chain_id": {
+          "name": "tx_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "broadcast_at": {
+          "name": "broadcast_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_execution": {
+          "name": "idx_feedback_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_payer": {
+          "name": "idx_feedback_payer",
+          "columns": [
+            {
+              "expression": "payer_wallet",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_agent": {
+          "name": "idx_feedback_agent",
+          "columns": [
+            {
+              "expression": "agent_registry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status": {
+          "name": "idx_feedback_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_execution_id_workflow_executions_id_fk": {
+          "name": "feedback_execution_id_workflow_executions_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_workflow_id_workflows_id_fk": {
+          "name": "feedback_workflow_id_workflows_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_credit_allocations": {
+      "name": "gas_credit_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocated_cents": {
+          "name": "allocated_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_credit_alloc_org": {
+          "name": "idx_gas_credit_alloc_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_credit_allocations_organization_id_organization_id_fk": {
+          "name": "gas_credit_allocations_organization_id_organization_id_fk",
+          "tableFrom": "gas_credit_allocations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_credit_alloc_org_period": {
+          "name": "gas_credit_alloc_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_credit_usage": {
+      "name": "gas_credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price_wei": {
+          "name": "gas_price_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost_wei": {
+          "name": "gas_cost_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost_micro_usd": {
+          "name": "gas_cost_micro_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eth_price_usd": {
+          "name": "eth_price_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_usage_org_created": {
+          "name": "idx_gas_usage_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_credit_usage_organization_id_organization_id_fk": {
+          "name": "gas_credit_usage_organization_id_organization_id_fk",
+          "tableFrom": "gas_credit_usage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_usage_org_tx": {
+          "name": "gas_usage_org_tx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "tx_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_sponsorship_delegations": {
+      "name": "gas_sponsorship_delegations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_tx_hash": {
+          "name": "delegation_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "implementation_address": {
+          "name": "implementation_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delegated_at": {
+          "name": "delegated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_delegation_org": {
+          "name": "idx_gas_delegation_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_sponsorship_delegations_organization_id_organization_id_fk": {
+          "name": "gas_sponsorship_delegations_organization_id_organization_id_fk",
+          "tableFrom": "gas_sponsorship_delegations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_delegation_org_chain": {
+          "name": "gas_delegation_org_chain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_managed": {
+          "name": "is_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_org_web3": {
+          "name": "idx_integrations_org_web3",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"integrations\".\"type\" = 'web3' AND \"integrations\".\"organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_user_id_users_id_fk": {
+          "name": "integrations_user_id_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "integrations_organization_id_organization_id_fk": {
+          "name": "integrations_organization_id_organization_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_users_id_fk": {
+          "name": "invitation_inviter_id_users_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_export_codes": {
+      "name": "key_export_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "key_export_codes_organization_id_organization_id_fk": {
+          "name": "key_export_codes_organization_id_organization_id_fk",
+          "tableFrom": "key_export_codes",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_auth_codes": {
+      "name": "mcp_oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_auth_codes_code_unique": {
+          "name": "mcp_oauth_auth_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_clients_client_id_unique": {
+          "name": "mcp_oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_refresh_tokens": {
+      "name": "mcp_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_refresh_tokens_client": {
+          "name": "idx_mcp_refresh_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_refresh_tokens_user": {
+          "name": "idx_mcp_refresh_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_refresh_tokens_token_hash_unique": {
+          "name": "mcp_oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_users_id_fk": {
+          "name": "member_user_id_users_id_fk",
+          "tableFrom": "member",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_users_id_fk": {
+          "name": "organization_api_keys_created_by_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_api_keys_key_hash_unique": {
+          "name": "organization_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_spend_caps": {
+      "name": "organization_spend_caps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_cap_wei": {
+          "name": "daily_cap_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_spend_caps_organization_id_organization_id_fk": {
+          "name": "organization_spend_caps_organization_id_organization_id_fk",
+          "tableFrom": "organization_spend_caps",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_spend_caps_organization_id_unique": {
+          "name": "organization_spend_caps_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_subscriptions": {
+      "name": "organization_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_price_id": {
+          "name": "provider_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_alert": {
+          "name": "billing_alert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_alert_url": {
+          "name": "billing_alert_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_overrides": {
+          "name": "plan_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_subscriptions_org": {
+          "name": "idx_org_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_subscriptions_provider_sub": {
+          "name": "idx_org_subscriptions_provider_sub",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_subscriptions_organization_id_organization_id_fk": {
+          "name": "organization_subscriptions_organization_id_organization_id_fk",
+          "tableFrom": "organization_subscriptions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_subscriptions_organization_id_unique": {
+          "name": "organization_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        },
+        "organization_subscriptions_provider_customer_id_unique": {
+          "name": "organization_subscriptions_provider_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tokens": {
+      "name": "organization_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_wallet_id": {
+          "name": "safe_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_tokens_org_chain": {
+          "name": "idx_org_tokens_org_chain",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_tokens_safe": {
+          "name": "idx_org_tokens_safe",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tokens_organization_id_organization_id_fk": {
+          "name": "organization_tokens_organization_id_organization_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_tokens_safe_wallet_id_safe_wallets_id_fk": {
+          "name": "organization_tokens_safe_wallet_id_safe_wallets_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "safe_wallets",
+          "columnsFrom": [
+            "safe_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.para_wallets": {
+      "name": "para_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "para_wallet_id": {
+          "name": "para_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_share": {
+          "name": "user_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_sub_org_id": {
+          "name": "turnkey_sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_wallet_id": {
+          "name": "turnkey_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_private_key_id": {
+          "name": "turnkey_private_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "para_wallets_org_active_unique": {
+          "name": "para_wallets_org_active_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"para_wallets\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "para_wallets_user_id_users_id_fk": {
+          "name": "para_wallets_user_id_users_id_fk",
+          "tableFrom": "para_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "para_wallets_organization_id_organization_id_fk": {
+          "name": "para_wallets_organization_id_organization_id_fk",
+          "tableFrom": "para_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overage_billing_records": {
+      "name": "overage_billing_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_limit": {
+          "name": "execution_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_executions": {
+          "name": "total_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_count": {
+          "name": "overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_rate_cents": {
+          "name": "overage_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_charge_cents": {
+          "name": "total_charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_item_id": {
+          "name": "provider_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overage_billing_org": {
+          "name": "idx_overage_billing_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overage_billing_status": {
+          "name": "idx_overage_billing_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overage_billing_records_organization_id_organization_id_fk": {
+          "name": "overage_billing_records_organization_id_organization_id_fk",
+          "tableFrom": "overage_billing_records",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overage_billing_org_period": {
+          "name": "overage_billing_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start",
+            "period_end"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_transactions": {
+      "name": "pending_transactions",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_pending_tx_status": {
+          "name": "idx_pending_tx_status",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_tx_execution": {
+          "name": "idx_pending_tx_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pending_transactions_wallet_address_chain_id_nonce_pk": {
+          "name": "pending_transactions_wallet_address_chain_id_nonce_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id",
+            "nonce"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_org": {
+          "name": "idx_projects_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_tags": {
+      "name": "public_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "public_tags_name_unique": {
+          "name": "public_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "public_tags_slug_unique": {
+          "name": "public_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_allowances": {
+      "name": "safe_role_allowances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_slug": {
+          "name": "protocol_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowance_key": {
+          "name": "allowance_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_refill_wei": {
+          "name": "max_refill_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_wei": {
+          "name": "refill_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_seconds": {
+          "name": "period_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chain_balance_wei": {
+          "name": "last_chain_balance_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_chain_timestamp": {
+          "name": "last_chain_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_allowances_role_key_unique": {
+          "name": "safe_role_allowances_role_key_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allowance_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_allowances_role": {
+          "name": "idx_safe_role_allowances_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_allowances_role_id_safe_roles_id_fk": {
+          "name": "safe_role_allowances_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_allowances",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_direct_rules": {
+      "name": "safe_role_direct_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_human": {
+          "name": "amount_human",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_seconds": {
+          "name": "period_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allowed'"
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_direct_rules_role_kind_token_cp_unique": {
+          "name": "safe_role_direct_rules_role_kind_token_cp_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_direct_rules_role": {
+          "name": "idx_safe_role_direct_rules_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_direct_rules_role_id_safe_roles_id_fk": {
+          "name": "safe_role_direct_rules_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_direct_rules",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_protocols": {
+      "name": "safe_role_protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_slug": {
+          "name": "protocol_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_token_symbols": {
+          "name": "allowed_token_symbols",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_addresses": {
+          "name": "target_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_selectors": {
+          "name": "allowed_selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allowed'"
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_protocols_role_slug_unique": {
+          "name": "safe_role_protocols_role_slug_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_protocols_role": {
+          "name": "idx_safe_role_protocols_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_protocols_role_id_safe_roles_id_fk": {
+          "name": "safe_role_protocols_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_protocols",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_roles": {
+      "name": "safe_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "safe_wallet_id": {
+          "name": "safe_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'automation'"
+        },
+        "role_key": {
+          "name": "role_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_modifier_address": {
+          "name": "roles_modifier_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_address": {
+          "name": "delegate_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_tx_hash": {
+          "name": "installed_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_roles_safe_type_unique": {
+          "name": "safe_roles_safe_type_unique",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_roles_safe": {
+          "name": "idx_safe_roles_safe",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_roles_safe_wallet_id_safe_wallets_id_fk": {
+          "name": "safe_roles_safe_wallet_id_safe_wallets_id_fk",
+          "tableFrom": "safe_roles",
+          "tableTo": "safe_wallets",
+          "columnsFrom": [
+            "safe_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_wallets": {
+      "name": "safe_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_address": {
+          "name": "safe_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_wallet_id": {
+          "name": "owner_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt_nonce": {
+          "name": "salt_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_version": {
+          "name": "safe_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.4.1'"
+        },
+        "singleton_address": {
+          "name": "singleton_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "factory_address": {
+          "name": "factory_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_block": {
+          "name": "deployment_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_signing_active": {
+          "name": "is_signing_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_wallets_org_chain_unique": {
+          "name": "safe_wallets_org_chain_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_wallets_org": {
+          "name": "idx_safe_wallets_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_wallets_organization_id_organization_id_fk": {
+          "name": "safe_wallets_organization_id_organization_id_fk",
+          "tableFrom": "safe_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "safe_wallets_owner_wallet_id_para_wallets_id_fk": {
+          "name": "safe_wallets_owner_wallet_id_para_wallets_id_fk",
+          "tableFrom": "safe_wallets",
+          "tableTo": "para_wallets",
+          "columnsFrom": [
+            "owner_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supported_tokens": {
+      "name": "supported_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stablecoin": {
+          "name": "is_stablecoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supported_tokens_chain": {
+          "name": "idx_supported_tokens_chain",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supported_tokens_chain_address": {
+          "name": "supported_tokens_chain_address",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id",
+            "token_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_org": {
+          "name": "idx_tags_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_organization_id_organization_id_fk": {
+          "name": "tags_organization_id_organization_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rpc_preferences": {
+      "name": "user_rpc_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_rpc_url": {
+          "name": "primary_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_rpc_url": {
+          "name": "fallback_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_wss_url": {
+          "name": "primary_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_wss_url": {
+          "name": "fallback_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_rpc_user_chain": {
+          "name": "idx_user_rpc_user_chain",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_rpc_user_id": {
+          "name": "idx_user_rpc_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_rpc_preferences_user_id_users_id_fk": {
+          "name": "user_rpc_preferences_user_id_users_id_fk",
+          "tableFrom": "user_rpc_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_approval_requests": {
+      "name": "wallet_approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload": {
+          "name": "operation_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "approval_risk_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_recipient": {
+          "name": "bound_recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_amount_micro": {
+          "name": "bound_amount_micro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_chain": {
+          "name": "bound_chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_contract": {
+          "name": "bound_contract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '15 minutes'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_wallet_approval_sub_org": {
+          "name": "idx_wallet_approval_sub_org",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_status": {
+          "name": "idx_wallet_approval_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_created": {
+          "name": "idx_wallet_approval_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_resolved_by": {
+          "name": "idx_wallet_approval_resolved_by",
+          "columns": [
+            {
+              "expression": "resolved_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_approval_requests_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "wallet_approval_requests_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "wallet_approval_requests",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_approval_requests_resolved_by_user_id_users_id_fk": {
+          "name": "wallet_approval_requests_resolved_by_user_id_users_id_fk",
+          "tableFrom": "wallet_approval_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_locks": {
+      "name": "wallet_locks",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wallet_locks_wallet_address_chain_id_pk": {
+          "name": "wallet_locks_wallet_address_chain_id_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_logs": {
+      "name": "workflow_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_name": {
+          "name": "node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_raw": {
+          "name": "output_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "iteration_index": {
+          "name": "iteration_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_each_node_id": {
+          "name": "for_each_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_execution_logs_execution_id_workflow_executions_id_fk": {
+          "name": "workflow_execution_logs_execution_id_workflow_executions_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_error": {
+          "name": "is_user_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "current_node_id": {
+          "name": "current_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_node_name": {
+          "name": "current_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_id": {
+          "name": "last_successful_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_name": {
+          "name": "last_successful_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_hashes": {
+          "name": "transaction_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_workflow_executions_status": {
+          "name": "idx_workflow_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_executions_workflow_id_workflows_id_fk": {
+          "name": "workflow_executions_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_user_id_users_id_fk": {
+          "name": "workflow_executions_user_id_users_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_payments": {
+      "name": "workflow_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_hash": {
+          "name": "payment_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usdc": {
+          "name": "amount_usdc",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_wallet_address": {
+          "name": "creator_wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'x402'"
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        }
+      },
+      "indexes": {
+        "idx_workflow_payments_hash": {
+          "name": "idx_workflow_payments_hash",
+          "columns": [
+            {
+              "expression": "payment_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_payments_workflow": {
+          "name": "idx_workflow_payments_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_public_tags": {
+      "name": "workflow_public_tags",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_tag_id": {
+          "name": "public_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workflow_public_tags_workflow": {
+          "name": "idx_workflow_public_tags_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_public_tags_tag": {
+          "name": "idx_workflow_public_tags_tag",
+          "columns": [
+            {
+              "expression": "public_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_public_tags_workflow_id_workflows_id_fk": {
+          "name": "workflow_public_tags_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_public_tags_public_tag_id_public_tags_id_fk": {
+          "name": "workflow_public_tags_public_tag_id_public_tags_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "public_tags",
+          "columnsFrom": [
+            "public_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_public_tags_workflow_id_public_tag_id_pk": {
+          "name": "workflow_public_tags_workflow_id_public_tag_id_pk",
+          "columns": [
+            "workflow_id",
+            "public_tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_ratings": {
+      "name": "workflow_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_ratings_workflow": {
+          "name": "idx_workflow_ratings_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_ratings_workflow_id_workflows_id_fk": {
+          "name": "workflow_ratings_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_ratings",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_ratings_user_id_users_id_fk": {
+          "name": "workflow_ratings_user_id_users_id_fk",
+          "tableFrom": "workflow_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_workflow_ratings_workflow_user": {
+          "name": "uq_workflow_ratings_workflow_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_schedules_enabled": {
+          "name": "idx_workflow_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_schedules_workflow": {
+          "name": "idx_workflow_schedules_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_workflow_id_workflows_id_fk": {
+          "name": "workflow_schedules_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_schedules_workflow_id_unique": {
+          "name": "workflow_schedules_workflow_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_order": {
+          "name": "featured_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "featured_protocol": {
+          "name": "featured_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_protocol_order": {
+          "name": "featured_protocol_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_workflow_id": {
+          "name": "source_workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seeded_at": {
+          "name": "seeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "listed_slug": {
+          "name": "listed_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_mapping": {
+          "name": "output_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_usdc_per_call": {
+          "name": "price_usdc_per_call",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_version": {
+          "name": "listing_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workflows_listed_slug": {
+          "name": "idx_workflows_listed_slug",
+          "columns": [
+            {
+              "expression": "listed_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows\".\"listed_slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_user_id_users_id_fk": {
+          "name": "workflows_user_id_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_organization_id_organization_id_fk": {
+          "name": "workflows_organization_id_organization_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_project_id_projects_id_fk": {
+          "name": "workflows_project_id_projects_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflows_tag_id_tags_id_fk": {
+          "name": "workflows_tag_id_tags_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.approval_risk_level": {
+      "name": "approval_risk_level",
+      "schema": "public",
+      "values": [
+        "auto",
+        "ask",
+        "block"
+      ]
+    },
+    "public.approval_status": {
+      "name": "approval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "broadcast",
+        "confirmed",
+        "failed"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_status": {
+      "name": "step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1778873393611,
       "tag": "0081_address_book_unique_address",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1779374522394,
+      "tag": "0082_security_2026_05_21_block_executions_for_deactivated_users",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -244,4 +244,41 @@ describe("createWorkflowJob", () => {
       '{"eth":"http://localhost:8545"}'
     );
   });
+
+  it("force-enables SAFE_FETCH_ENFORCE on runner pods even when unset on controller", async () => {
+    // SSRF guard must be on regardless of controller config to prevent
+    // workflow runs from reaching internal hosts (cloud IMDS, RFC1918,
+    // in-cluster services). The runner pod is the actual execution path,
+    // not the controller; if the controller's env ever drifts the runner
+    // must still enforce.
+    delete process.env.SAFE_FETCH_ENFORCE;
+
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
+  });
+
+  it("force-enables SAFE_FETCH_ENFORCE even when controller has it set to shadow", async () => {
+    // Hardcoded `value: "true"` in k8s-job.ts wins over any controller
+    // env. Flipping shadow mode for runner pods requires a code change.
+    process.env.SAFE_FETCH_ENFORCE = "false";
+
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
+    const occurrences = envVars.filter((v) => v.name === "SAFE_FETCH_ENFORCE");
+    expect(occurrences).toHaveLength(1);
+  });
 });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -58,6 +58,13 @@ export async function createWorkflowJob(params: {
     { name: "PARA_ENVIRONMENT", value: CONFIG.paraEnvironment },
     { name: "WALLET_ENCRYPTION_KEY", value: CONFIG.walletEncryptionKey },
     { name: "CHAIN_RPC_CONFIG", value: CONFIG.chainRpcConfig },
+    // SSRF guard: force-enable on every workflow runner pod regardless
+    // of controller env. Hardcoded (rather than forwarded via
+    // RUNNER_SYSTEM_ENV_VARS) so the runner enforces even if the
+    // controller's Helm values drift or a deploy omits the entry.
+    // Flipping back to shadow mode is a deliberate code change here,
+    // which is the intended posture for SSRF protection.
+    { name: "SAFE_FETCH_ENFORCE", value: "true" },
     ...(CONFIG.etherscanApiKey
       ? [{ name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey }]
       : []),

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -10,6 +10,15 @@ import { BlockList, isIP } from "node:net";
 import { captureException } from "@sentry/nextjs";
 import { Agent, buildConnector, fetch as undiciFetch } from "undici";
 import { getMetricsCollector } from "@/lib/metrics";
+import {
+  SSRF_BLOCKED_HOST_EXACT,
+  SSRF_BLOCKED_HOST_SUFFIXES,
+  SSRF_IPV4_BROADCAST_ADDRESSES,
+  SSRF_IPV4_CIDRS,
+  SSRF_IPV6_CIDRS,
+  SSRF_IPV6_LITERAL_ADDRESSES,
+  SSRF_NAT64_PREFIX_CIDR,
+} from "@/lib/ssrf-blocklist";
 
 export type SsrfBlockReason =
   | "scheme"
@@ -60,66 +69,25 @@ const NAT64_UNCOMPRESSED_REGEX =
 const NAT64_DOTTED_REGEX = /^64:ff9b::(\d+\.\d+\.\d+\.\d+)$/;
 
 /**
- * Denylist of IP ranges that must never be reached from user-controlled fetch.
- * IPv4 covers unspecified, private, loopback, link-local (incl. IMDS
- * 169.254.169.254), CGNAT, documentation ranges, benchmarking, multicast,
- * reserved, broadcast. IPv6 covers unspecified, loopback, IPv4-mapped (via
- * extractor), site-local NAT64 (RFC 8215), discard, Teredo, documentation,
- * 6to4, ULA, link-local, multicast.
- *
- * NAT64 well-known prefix (64:ff9b::/96, RFC 6052) is intentionally NOT in
- * this list. In dual-stack / IPv6-preferred networks (e.g. AWS VPCs with
- * `enable_ipv6 = true`) the resolver synthesises NAT64 AAAA records for
- * every IPv4-only public host, so blanket-blocking the prefix would block
- * legitimate public destinations like Discord, Slack, Telegram. Instead,
- * NAT64 hits are detected separately in `isBlockedIp` and the embedded
- * IPv4 is rechecked against this list - preserving the SSRF property (no
- * NAT64 path to RFC 1918, IMDS, etc.) without false positives on public
- * IPv4.
- *
- * Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS blanket-blocked here: the
- * RFC defines it for site-local deployments, so by construction the
- * embedded IPv4 maps to internal infrastructure. Teredo (2001::/32) and
- * 6to4 (2002::/16) are also blanket-blocked despite carrying embedded
- * public-IPv4 in some cases - both transition mechanisms are deprecated
- * and not synthesised by mainstream resolvers, so false-positive risk is
- * low.
+ * Builds the runtime BlockList from the shared data in
+ * `lib/ssrf-blocklist.ts`. See that module for the rationale on which
+ * ranges are blanket-blocked and which are handled specially (IPv4-mapped
+ * IPv6 and the well-known NAT64 prefix).
  */
 function buildBlockList(): BlockList {
   const list = new BlockList();
-
-  list.addSubnet("0.0.0.0", 8, "ipv4");
-  list.addSubnet("10.0.0.0", 8, "ipv4");
-  list.addSubnet("100.64.0.0", 10, "ipv4");
-  list.addSubnet("127.0.0.0", 8, "ipv4");
-  list.addSubnet("169.254.0.0", 16, "ipv4");
-  list.addSubnet("172.16.0.0", 12, "ipv4");
-  list.addSubnet("192.0.0.0", 24, "ipv4");
-  list.addSubnet("192.0.2.0", 24, "ipv4");
-  list.addSubnet("192.88.99.0", 24, "ipv4");
-  list.addSubnet("192.168.0.0", 16, "ipv4");
-  list.addSubnet("198.18.0.0", 15, "ipv4");
-  list.addSubnet("198.51.100.0", 24, "ipv4");
-  list.addSubnet("203.0.113.0", 24, "ipv4");
-  list.addSubnet("224.0.0.0", 4, "ipv4");
-  list.addSubnet("240.0.0.0", 4, "ipv4");
-  list.addAddress("255.255.255.255", "ipv4");
-
-  list.addAddress("::", "ipv6");
-  list.addAddress("::1", "ipv6");
-  // Note: ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not added here.
-  // Node's BlockList treats that subnet as "all IPv4", which makes every
-  // IPv4 check return true. IPv4-mapped IPv6 addresses pointing at private
-  // IPv4 space are caught via extractMappedIpv4 below.
-  list.addSubnet("64:ff9b:1::", 48, "ipv6");
-  list.addSubnet("100::", 64, "ipv6");
-  list.addSubnet("2001::", 32, "ipv6");
-  list.addSubnet("2001:db8::", 32, "ipv6");
-  list.addSubnet("2002::", 16, "ipv6");
-  list.addSubnet("fc00::", 7, "ipv6");
-  list.addSubnet("fe80::", 10, "ipv6");
-  list.addSubnet("ff00::", 8, "ipv6");
-
+  for (const [addr, prefix] of SSRF_IPV4_CIDRS) {
+    list.addSubnet(addr, prefix, "ipv4");
+  }
+  for (const addr of SSRF_IPV4_BROADCAST_ADDRESSES) {
+    list.addAddress(addr, "ipv4");
+  }
+  for (const addr of SSRF_IPV6_LITERAL_ADDRESSES) {
+    list.addAddress(addr, "ipv6");
+  }
+  for (const [addr, prefix] of SSRF_IPV6_CIDRS) {
+    list.addSubnet(addr, prefix, "ipv6");
+  }
   return list;
 }
 
@@ -127,7 +95,7 @@ const BLOCK_LIST = buildBlockList();
 
 const NAT64_BLOCK_LIST = (() => {
   const list = new BlockList();
-  list.addSubnet("64:ff9b::", 96, "ipv6");
+  list.addSubnet(SSRF_NAT64_PREFIX_CIDR[0], SSRF_NAT64_PREFIX_CIDR[1], "ipv6");
   return list;
 })();
 
@@ -270,30 +238,8 @@ export function isBlockedIp(
   return { blocked: false };
 }
 
-const BLOCKED_HOST_EXACT = new Set(["localhost"]);
-
-/**
- * Suffixes that mark a hostname as referring to a local / internal /
- * in-cluster service. Matched against the normalised hostname (lower-cased,
- * trailing dot stripped) using `String.prototype.endsWith`. Each entry must
- * begin with a `.` so that a top-level token like "internal" cannot match
- * an unrelated host such as "myinternal.com".
- *
- * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
- * patterns, but the cluster suffixes are listed explicitly so the intent
- * is visible at the denylist site and so any future narrowing of `.local`
- * (e.g. to mDNS-only) does not silently re-open the in-cluster path.
- *
- * Cluster suffix scope: KeeperHub staging and production both run on AWS
- * EKS with the default `clusterDomain` of `cluster.local`. If we move to a
- * cluster with a custom `clusterDomain`, add it here.
- */
-const BLOCKED_HOST_SUFFIXES = [
-  ".local",
-  ".internal",
-  ".svc.cluster.local",
-  ".pod.cluster.local",
-];
+const BLOCKED_HOST_EXACT = new Set<string>(SSRF_BLOCKED_HOST_EXACT);
+const BLOCKED_HOST_SUFFIXES = SSRF_BLOCKED_HOST_SUFFIXES;
 
 /**
  * Pre-DNS hostname denylist. Pure string match - no DNS lookup, no IP

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -22,6 +22,11 @@
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
+// Relative import: this file is compiled by two separate tsconfigs (the
+// keeperhub app and the standalone @keeperhub/sandbox package), and the
+// sandbox tsconfig's `@/*` alias points at its own src dir rather than the
+// keeperhub workspace. The relative path resolves identically from both
+// build contexts.
 import {
   SSRF_BLOCKED_HOST_EXACT,
   SSRF_BLOCKED_HOST_SUFFIXES,
@@ -30,7 +35,7 @@ import {
   SSRF_IPV6_CIDRS,
   SSRF_IPV6_LITERAL_ADDRESSES,
   SSRF_NAT64_PREFIX_CIDR,
-} from "@/lib/ssrf-blocklist";
+} from "../ssrf-blocklist";
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -22,11 +22,15 @@
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
-// Relative import: this file is compiled by two separate tsconfigs (the
-// keeperhub app and the standalone @keeperhub/sandbox package), and the
-// sandbox tsconfig's `@/*` alias points at its own src dir rather than the
-// keeperhub workspace. The relative path resolves identically from both
-// build contexts.
+// Relative import with explicit `.js` extension. This file is compiled
+// by two separate tsconfigs (the keeperhub app and the standalone
+// @keeperhub/sandbox package). The sandbox package is `"type": "module"`
+// and runs the compiled output via plain `node`, whose strict ESM loader
+// requires explicit file extensions in imports - extension-less or
+// `@/`-aliased forms fail at runtime with ERR_MODULE_NOT_FOUND. TS
+// resolves "../ssrf-blocklist.js" to the matching .ts source at compile
+// time (matching the convention used by `sandbox/src/run-code.ts` which
+// imports `"../../lib/sandbox/child-source.js"`).
 import {
   SSRF_BLOCKED_HOST_EXACT,
   SSRF_BLOCKED_HOST_SUFFIXES,
@@ -35,7 +39,7 @@ import {
   SSRF_IPV6_CIDRS,
   SSRF_IPV6_LITERAL_ADDRESSES,
   SSRF_NAT64_PREFIX_CIDR,
-} from "../ssrf-blocklist";
+} from "../ssrf-blocklist.js";
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -22,24 +22,16 @@
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
-// Relative import with explicit `.js` extension. This file is compiled
-// by two separate tsconfigs (the keeperhub app and the standalone
-// @keeperhub/sandbox package). The sandbox package is `"type": "module"`
-// and runs the compiled output via plain `node`, whose strict ESM loader
-// requires explicit file extensions in imports - extension-less or
-// `@/`-aliased forms fail at runtime with ERR_MODULE_NOT_FOUND. TS
-// resolves "../ssrf-blocklist.js" to the matching .ts source at compile
-// time (matching the convention used by `sandbox/src/run-code.ts` which
-// imports `"../../lib/sandbox/child-source.js"`).
-import {
-  SSRF_BLOCKED_HOST_EXACT,
-  SSRF_BLOCKED_HOST_SUFFIXES,
-  SSRF_IPV4_BROADCAST_ADDRESSES,
-  SSRF_IPV4_CIDRS,
-  SSRF_IPV6_CIDRS,
-  SSRF_IPV6_LITERAL_ADDRESSES,
-  SSRF_NAT64_PREFIX_CIDR,
-} from "../ssrf-blocklist.js";
+// The blocklist data is imported as JSON (not as a `.ts` module) because
+// this file is compiled by two separate tsconfigs with incompatible
+// `.js`/`.ts` resolution conventions: the keeperhub app (Next.js
+// Turbopack) wants extension-less imports for `.ts` sources, while the
+// standalone @keeperhub/sandbox package is `"type": "module"` and its
+// strict ESM runtime requires explicit file extensions. A `.json`
+// extension resolves identically in both contexts, so the data lives in
+// `lib/ssrf-blocklist.json` and `lib/ssrf-blocklist.ts` is just a typed
+// re-export used by the keeperhub-side consumers.
+import blocklist from "../ssrf-blocklist.json" with { type: "json" };
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result
@@ -119,11 +111,11 @@ const NAT64_DOTTED_REGEX = /^64:ff9b::(\\d+\\.\\d+\\.\\d+\\.\\d+)$/;
 // (64:ff9b::/96) is also kept separate for the same reason - dual-stack
 // resolvers synthesise it for every IPv4-only public host, so we extract
 // the embedded IPv4 and recheck it against the IPv4 list.
-const SSRF_IPV4_CIDRS = ${JSON.stringify(SSRF_IPV4_CIDRS)};
-const SSRF_IPV4_BROADCAST_ADDRESSES = ${JSON.stringify(SSRF_IPV4_BROADCAST_ADDRESSES)};
-const SSRF_IPV6_LITERAL_ADDRESSES = ${JSON.stringify(SSRF_IPV6_LITERAL_ADDRESSES)};
-const SSRF_IPV6_CIDRS = ${JSON.stringify(SSRF_IPV6_CIDRS)};
-const SSRF_NAT64_PREFIX_CIDR = ${JSON.stringify(SSRF_NAT64_PREFIX_CIDR)};
+const SSRF_IPV4_CIDRS = ${JSON.stringify(blocklist.ipv4Cidrs)};
+const SSRF_IPV4_BROADCAST_ADDRESSES = ${JSON.stringify(blocklist.ipv4BroadcastAddresses)};
+const SSRF_IPV6_LITERAL_ADDRESSES = ${JSON.stringify(blocklist.ipv6LiteralAddresses)};
+const SSRF_IPV6_CIDRS = ${JSON.stringify(blocklist.ipv6Cidrs)};
+const SSRF_NAT64_PREFIX_CIDR = ${JSON.stringify(blocklist.nat64PrefixCidr)};
 
 const SSRF_BLOCK_LIST = new BlockList();
 for (const cidr of SSRF_IPV4_CIDRS) {
@@ -224,8 +216,8 @@ function stripIpv6Brackets(hostname) {
 // Pre-DNS hostname denylist interpolated from lib/ssrf-blocklist.ts at
 // module-render time. See that module for the rationale (case handling,
 // suffix semantics, cluster-domain assumption).
-const BLOCKED_HOST_EXACT = new Set(${JSON.stringify(Array.from(SSRF_BLOCKED_HOST_EXACT))});
-const BLOCKED_HOST_SUFFIXES = ${JSON.stringify(SSRF_BLOCKED_HOST_SUFFIXES)};
+const BLOCKED_HOST_EXACT = new Set(${JSON.stringify(blocklist.blockedHostExact)});
+const BLOCKED_HOST_SUFFIXES = ${JSON.stringify(blocklist.blockedHostSuffixes)};
 
 function isBlockedHost(host) {
   if (host === "") {

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -8,16 +8,29 @@
  * ~240 lines of this grandchild source verbatim; this module is the single
  * source of truth.
  *
- * DO NOT IMPORT anything into this module — the exported string is passed
- * intact to `node -e`, so any `import` statements would not propagate and
- * any value-level logic would not execute in the grandchild. Everything
- * the grandchild needs must be expressed inside the template literal.
+ * Module imports here are restricted to pure data. The exported string is
+ * passed intact to `node -e`, so any TypeScript-level import is only
+ * usable at template-render time via `JSON.stringify` interpolation - no
+ * runtime behaviour can cross into the grandchild because the grandchild
+ * has no access to npm or to the rest of this codebase. Importing pure
+ * data is the SSRF-blocklist sharing pattern used here (see
+ * `lib/ssrf-blocklist.ts`); importing anything with runtime side effects
+ * or third-party deps would not propagate to the grandchild.
  *
  * The grandchild uses only node: builtins (node:vm, node:v8, node:dns,
  * node:net) so the downstream sandbox package can remain zero-runtime-dep
  * by design. Adding third-party packages (e.g. undici) would enlarge the
  * supply-chain attack surface of the sandbox container.
  */
+import {
+  SSRF_BLOCKED_HOST_EXACT,
+  SSRF_BLOCKED_HOST_SUFFIXES,
+  SSRF_IPV4_BROADCAST_ADDRESSES,
+  SSRF_IPV4_CIDRS,
+  SSRF_IPV6_CIDRS,
+  SSRF_IPV6_LITERAL_ADDRESSES,
+  SSRF_NAT64_PREFIX_CIDR,
+} from "@/lib/ssrf-blocklist";
 
 /**
  * Byte-sequence that prefixes the grandchild's final v8-serialized result
@@ -50,12 +63,18 @@ const { BlockList, isIP } = require("node:net");
 
 const MAX_LOG_ENTRIES = 200;
 
-// SSRF guard: ported from lib/safe-fetch.ts (KEEP-314). Modeled on the
-// main-app pattern but inlined here because the sandbox package is
+// SSRF guard: ported from lib/safe-fetch.ts. Modeled on the main-app
+// pattern but inlined here because the sandbox package is
 // zero-runtime-dep by design and the grandchild gets only node: builtins.
-// The defense here is DNS-resolved denylist — it catches hostnames that
-// resolve to RFC 1918, loopback, link-local (IMDS), CGNAT, and reserved
-// ranges, where the old substring check only caught named metadata hosts.
+// Two layers fire before the wrapped fetch dials anything:
+//   1. Pre-DNS hostname denylist (isBlockedHost) catches localhost and
+//      patterns like *.local, *.internal, *.svc.cluster.local,
+//      *.pod.cluster.local. Defense-in-depth on top of the IP check;
+//      also surfaces in error messages as the original hostname.
+//   2. DNS-resolved IP denylist catches hostnames that resolve to RFC
+//      1918, loopback, link-local (IMDS), CGNAT, reserved ranges, ULA,
+//      multicast, and the additional IPv6 transition prefixes
+//      (64:ff9b:1::/48, 2001::/32 Teredo, 2002::/16 6to4, 2001:db8::/32).
 // NAT64 (64:ff9b::/96): the well-known prefix is treated specially. In
 // dual-stack / IPv6-preferred pods (typical for our AWS prod VPC) the
 // resolver synthesises NAT64 AAAA records for every IPv4-only public
@@ -67,6 +86,11 @@ const MAX_LOG_ENTRIES = 200;
 // undici as a sandbox dep), so there is a small window between our
 // dns.lookup and the fetch's internal connect where the record could
 // change. NetworkPolicy is the real defense for that (tracked elsewhere).
+// Testing note: the sandbox guard is not unit-tested directly because
+// this entire file is a template literal executed in a subprocess via
+// "node -e". The parallel behavior in lib/safe-fetch.ts is unit-tested
+// (tests/unit/safe-fetch.test.ts) and these CIDR / hostname denylists
+// are kept in lockstep with that file by convention.
 const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
 const IPV4_MAPPED_PREFIX = "::ffff:";
 const IPV4_MAPPED_HEX_REGEX = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
@@ -76,40 +100,38 @@ const NAT64_CANONICAL_REGEX = /^64:ff9b::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
 const NAT64_UNCOMPRESSED_REGEX = /^64:ff9b:0:0:0:0:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
 const NAT64_DOTTED_REGEX = /^64:ff9b::(\\d+\\.\\d+\\.\\d+\\.\\d+)$/;
 
+// CIDR ranges and special prefixes interpolated from
+// lib/ssrf-blocklist.ts at module-render time. See that file for the
+// rationale on which ranges are blanket-blocked vs handled specially.
+// Note: ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not added —
+// Node treats that subnet as "all IPv4" which would make every IPv4
+// check return true. IPv4-mapped IPv6 pointing at private IPv4 is
+// caught via the mapped extraction below. The NAT64 well-known prefix
+// (64:ff9b::/96) is also kept separate for the same reason - dual-stack
+// resolvers synthesise it for every IPv4-only public host, so we extract
+// the embedded IPv4 and recheck it against the IPv4 list.
+const SSRF_IPV4_CIDRS = ${JSON.stringify(SSRF_IPV4_CIDRS)};
+const SSRF_IPV4_BROADCAST_ADDRESSES = ${JSON.stringify(SSRF_IPV4_BROADCAST_ADDRESSES)};
+const SSRF_IPV6_LITERAL_ADDRESSES = ${JSON.stringify(SSRF_IPV6_LITERAL_ADDRESSES)};
+const SSRF_IPV6_CIDRS = ${JSON.stringify(SSRF_IPV6_CIDRS)};
+const SSRF_NAT64_PREFIX_CIDR = ${JSON.stringify(SSRF_NAT64_PREFIX_CIDR)};
+
 const SSRF_BLOCK_LIST = new BlockList();
-SSRF_BLOCK_LIST.addSubnet("0.0.0.0", 8, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("10.0.0.0", 8, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("100.64.0.0", 10, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("127.0.0.0", 8, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("169.254.0.0", 16, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("172.16.0.0", 12, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.0.0.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.0.2.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.88.99.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("192.168.0.0", 16, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("198.18.0.0", 15, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("198.51.100.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("203.0.113.0", 24, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("224.0.0.0", 4, "ipv4");
-SSRF_BLOCK_LIST.addSubnet("240.0.0.0", 4, "ipv4");
-SSRF_BLOCK_LIST.addAddress("255.255.255.255", "ipv4");
-SSRF_BLOCK_LIST.addAddress("::", "ipv6");
-SSRF_BLOCK_LIST.addAddress("::1", "ipv6");
-// Note: ::ffff:0:0/96 (IPv4-mapped IPv6) not added — Node treats that
-// subnet as "all IPv4" which would make every IPv4 check return true.
-// IPv4-mapped IPv6 pointing at private IPv4 is caught via the mapped
-// extraction below.
-// NAT64 (64:ff9b::/96) is intentionally separate: dual-stack networks
-// synthesise it for every IPv4-only public host, so blanket-blocking the
-// prefix would block legitimate destinations. The embedded IPv4 is
-// rechecked against the IPv4 list below.
-SSRF_BLOCK_LIST.addSubnet("100::", 64, "ipv6");
-SSRF_BLOCK_LIST.addSubnet("fc00::", 7, "ipv6");
-SSRF_BLOCK_LIST.addSubnet("fe80::", 10, "ipv6");
-SSRF_BLOCK_LIST.addSubnet("ff00::", 8, "ipv6");
+for (const cidr of SSRF_IPV4_CIDRS) {
+  SSRF_BLOCK_LIST.addSubnet(cidr[0], cidr[1], "ipv4");
+}
+for (const addr of SSRF_IPV4_BROADCAST_ADDRESSES) {
+  SSRF_BLOCK_LIST.addAddress(addr, "ipv4");
+}
+for (const addr of SSRF_IPV6_LITERAL_ADDRESSES) {
+  SSRF_BLOCK_LIST.addAddress(addr, "ipv6");
+}
+for (const cidr of SSRF_IPV6_CIDRS) {
+  SSRF_BLOCK_LIST.addSubnet(cidr[0], cidr[1], "ipv6");
+}
 
 const NAT64_BLOCK_LIST = new BlockList();
-NAT64_BLOCK_LIST.addSubnet("64:ff9b::", 96, "ipv6");
+NAT64_BLOCK_LIST.addSubnet(SSRF_NAT64_PREFIX_CIDR[0], SSRF_NAT64_PREFIX_CIDR[1], "ipv6");
 
 function hexGroupsToIpv4(highHex, lowHex) {
   const high = Number.parseInt(highHex, 16);
@@ -190,7 +212,38 @@ function stripIpv6Brackets(hostname) {
   return hostname;
 }
 
+// Pre-DNS hostname denylist interpolated from lib/ssrf-blocklist.ts at
+// module-render time. See that module for the rationale (case handling,
+// suffix semantics, cluster-domain assumption).
+const BLOCKED_HOST_EXACT = new Set(${JSON.stringify(Array.from(SSRF_BLOCKED_HOST_EXACT))});
+const BLOCKED_HOST_SUFFIXES = ${JSON.stringify(SSRF_BLOCKED_HOST_SUFFIXES)};
+
+function isBlockedHost(host) {
+  if (host === "") {
+    return false;
+  }
+  let normalised = host.trim().toLowerCase();
+  if (normalised.endsWith(".")) {
+    normalised = normalised.slice(0, -1);
+  }
+  if (normalised === "") {
+    return false;
+  }
+  if (BLOCKED_HOST_EXACT.has(normalised)) {
+    return true;
+  }
+  for (const suffix of BLOCKED_HOST_SUFFIXES) {
+    if (normalised.endsWith(suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function checkHostnameSsrf(hostname) {
+  if (isBlockedHost(hostname)) {
+    return { blocked: true, ip: hostname };
+  }
   if (isIP(hostname) !== 0) {
     return isBlockedIp(hostname);
   }

--- a/lib/ssrf-blocklist.json
+++ b/lib/ssrf-blocklist.json
@@ -1,0 +1,40 @@
+{
+  "$schema-comment": "SSRF blocklist data. Single source of truth for: lib/safe-fetch.ts (HTTP guards, runtime BlockList + host pattern Set), and lib/sandbox/child-source.ts (sandbox grandchild, interpolated into the node -e template literal via JSON.stringify). Stored as JSON so both consumers can import it with a single canonical extension - the keeperhub bundler (Turbopack) and the standalone sandbox package's strict ESM runtime resolve .json identically, whereas .js/.ts variants need different specifiers in each context. NAT64 well-known prefix is kept separate as nat64PrefixCidr because it must be handled specially: the last 32 bits encode an IPv4 destination, so consumers extract the embedded IPv4 and recheck it against ipv4Cidrs. Site-local NAT64 (64:ff9b:1::/48) is in ipv6Cidrs because it is by construction site-local. ::ffff:0:0/96 (IPv4-mapped IPv6) is intentionally not listed because Node BlockList treats it as 'all IPv4'; consumers handle it via an embedded-IPv4 extraction. Cluster suffix scope: KeeperHub staging and production both run on AWS EKS with the default clusterDomain of cluster.local; if we move to a cluster with a custom clusterDomain, add it to blockedHostSuffixes.",
+  "ipv4Cidrs": [
+    ["0.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["100.64.0.0", 10],
+    ["127.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["172.16.0.0", 12],
+    ["192.0.0.0", 24],
+    ["192.0.2.0", 24],
+    ["192.88.99.0", 24],
+    ["192.168.0.0", 16],
+    ["198.18.0.0", 15],
+    ["198.51.100.0", 24],
+    ["203.0.113.0", 24],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4]
+  ],
+  "ipv4BroadcastAddresses": ["255.255.255.255"],
+  "ipv6Cidrs": [
+    ["64:ff9b:1::", 48],
+    ["100::", 64],
+    ["2001::", 32],
+    ["2001:db8::", 32],
+    ["2002::", 16],
+    ["fc00::", 7],
+    ["fe80::", 10],
+    ["ff00::", 8]
+  ],
+  "ipv6LiteralAddresses": ["::", "::1"],
+  "nat64PrefixCidr": ["64:ff9b::", 96],
+  "blockedHostExact": ["localhost"],
+  "blockedHostSuffixes": [
+    ".local",
+    ".internal",
+    ".svc.cluster.local",
+    ".pod.cluster.local"
+  ]
+}

--- a/lib/ssrf-blocklist.ts
+++ b/lib/ssrf-blocklist.ts
@@ -1,0 +1,130 @@
+/**
+ * Single source of truth for the SSRF blocklist: CIDR ranges that must
+ * never be reached from user-controlled fetch, and hostname patterns
+ * that mark a host as local / internal / in-cluster.
+ *
+ * Pure data, no runtime side effects, no `import "server-only"`. Two
+ * consumers today:
+ *
+ *   1. `lib/safe-fetch.ts` (and transitively `lib/db/connection-host-guard.ts`)
+ *      builds a `node:net` BlockList and a Set of host patterns from
+ *      these arrays at module load time.
+ *
+ *   2. `lib/sandbox/child-source.ts` interpolates these values into the
+ *      sandbox grandchild's template literal via `JSON.stringify`. The
+ *      grandchild runs in a separate `node -e` subprocess with no
+ *      access to npm or the rest of the codebase, so the data has to
+ *      cross the process boundary as inlined literals; consuming from
+ *      this module at template-render time keeps that inlined copy
+ *      automatically in sync.
+ *
+ * Adding a new range:
+ *   - IPv4 prefix:           append to `SSRF_IPV4_CIDRS`
+ *   - IPv4 single address:   append to `SSRF_IPV4_BROADCAST_ADDRESSES`
+ *   - IPv6 prefix:           append to `SSRF_IPV6_CIDRS`
+ *   - IPv6 single address:   append to `SSRF_IPV6_LITERAL_ADDRESSES`
+ *   - Hostname exact match:  append to `SSRF_BLOCKED_HOST_EXACT`
+ *   - Hostname suffix:       append to `SSRF_BLOCKED_HOST_SUFFIXES` with leading `.`
+ *
+ * Note: `SSRF_NAT64_PREFIX_CIDR` (64:ff9b::/96) is intentionally NOT in
+ * `SSRF_IPV6_CIDRS`. In dual-stack networks resolvers synthesise this
+ * prefix for every IPv4-only public host; blanket-blocking it would
+ * block legitimate destinations. Consumers handle this prefix specially
+ * by extracting the embedded IPv4 and rechecking it against the IPv4
+ * list. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS in the regular
+ * list because by-construction the embedded IPv4 maps to internal infra.
+ */
+
+export type Cidr = readonly [address: string, prefix: number];
+
+/**
+ * Covers unspecified, RFC 1918 private, loopback, CGNAT (RFC 6598),
+ * link-local incl. cloud IMDS (169.254.169.254), IETF protocol
+ * assignments, IPv4 documentation ranges, benchmarking, multicast,
+ * reserved future use. Broadcast is in `SSRF_IPV4_BROADCAST_ADDRESSES`.
+ */
+export const SSRF_IPV4_CIDRS: readonly Cidr[] = [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+];
+
+export const SSRF_IPV4_BROADCAST_ADDRESSES: readonly string[] = [
+  "255.255.255.255",
+];
+
+/**
+ * IPv6 ranges. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) and
+ * deprecated transition mechanisms (Teredo 2001::/32, 6to4 2002::/16)
+ * are blanket-blocked here despite carrying embedded IPv4: the RFC
+ * 8215 prefix is by-construction site-local, and Teredo / 6to4 are
+ * deprecated and not synthesised by mainstream resolvers, so the
+ * false-positive risk is low.
+ *
+ * `::ffff:0:0/96` (IPv4-mapped) is NOT in this list because Node's
+ * BlockList treats it as "all IPv4" - consumers handle IPv4-mapped via
+ * an embedded-IPv4 extraction instead. Same shape applies to
+ * `64:ff9b::/96` (well-known NAT64) - see `SSRF_NAT64_PREFIX_CIDR`.
+ */
+export const SSRF_IPV6_CIDRS: readonly Cidr[] = [
+  ["64:ff9b:1::", 48],
+  ["100::", 64],
+  ["2001::", 32],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8],
+];
+
+export const SSRF_IPV6_LITERAL_ADDRESSES: readonly string[] = ["::", "::1"];
+
+/**
+ * NAT64 well-known prefix (RFC 6052). Kept separate from
+ * `SSRF_IPV6_CIDRS` because it must be handled specially - the last 32
+ * bits encode an IPv4 destination that may be a legitimate public
+ * address. Consumers detect membership in this prefix, extract the
+ * embedded IPv4, and recheck it against the IPv4 list.
+ */
+export const SSRF_NAT64_PREFIX_CIDR: Cidr = ["64:ff9b::", 96];
+
+/**
+ * Hostnames matched exactly (case-insensitive, trailing dot stripped)
+ * before any DNS resolution.
+ */
+export const SSRF_BLOCKED_HOST_EXACT: readonly string[] = ["localhost"];
+
+/**
+ * Hostname suffixes matched (case-insensitive, trailing dot stripped)
+ * before any DNS resolution. Each entry begins with `.` so a top-level
+ * token like "internal" cannot match an unrelated host such as
+ * "myinternal.com".
+ *
+ * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
+ * patterns, but the cluster suffixes are listed explicitly so the
+ * intent is visible at the denylist site and so any future narrowing
+ * of `.local` (e.g. to mDNS-only) does not silently re-open the
+ * in-cluster path.
+ *
+ * Cluster suffix scope: KeeperHub staging and production both run on
+ * AWS EKS with the default `clusterDomain` of `cluster.local`. If we
+ * move to a cluster with a custom `clusterDomain`, add it here.
+ */
+export const SSRF_BLOCKED_HOST_SUFFIXES: readonly string[] = [
+  ".local",
+  ".internal",
+  ".svc.cluster.local",
+  ".pod.cluster.local",
+];

--- a/lib/ssrf-blocklist.ts
+++ b/lib/ssrf-blocklist.ts
@@ -1,130 +1,59 @@
 /**
- * Single source of truth for the SSRF blocklist: CIDR ranges that must
- * never be reached from user-controlled fetch, and hostname patterns
- * that mark a host as local / internal / in-cluster.
+ * Typed re-exports of the SSRF blocklist data in `lib/ssrf-blocklist.json`.
  *
- * Pure data, no runtime side effects, no `import "server-only"`. Two
- * consumers today:
+ * The underlying data lives in a JSON file (not this `.ts` file) for a
+ * specific reason: two consumers need to read it, and they have
+ * incompatible module-resolution conventions for `.ts`/`.js` files.
  *
- *   1. `lib/safe-fetch.ts` (and transitively `lib/db/connection-host-guard.ts`)
- *      builds a `node:net` BlockList and a Set of host patterns from
- *      these arrays at module load time.
+ *   1. `lib/safe-fetch.ts` and `lib/db/connection-host-guard.ts` are
+ *      bundled by Next.js Turbopack and want extension-less imports.
+ *   2. `lib/sandbox/child-source.ts` is also compiled by the standalone
+ *      `@keeperhub/sandbox` package (separate tsconfig) and runs under
+ *      strict ESM in a `"type": "module"` Node process, which requires
+ *      explicit file extensions in import specifiers.
  *
- *   2. `lib/sandbox/child-source.ts` interpolates these values into the
- *      sandbox grandchild's template literal via `JSON.stringify`. The
- *      grandchild runs in a separate `node -e` subprocess with no
- *      access to npm or the rest of the codebase, so the data has to
- *      cross the process boundary as inlined literals; consuming from
- *      this module at template-render time keeps that inlined copy
- *      automatically in sync.
+ * A `.json` extension resolves identically in both contexts, so the
+ * data lives there. This `.ts` file is a thin typed wrapper used only
+ * by the keeperhub-side consumers; the sandbox `child-source.ts`
+ * imports the JSON directly without going through this wrapper.
  *
- * Adding a new range:
- *   - IPv4 prefix:           append to `SSRF_IPV4_CIDRS`
- *   - IPv4 single address:   append to `SSRF_IPV4_BROADCAST_ADDRESSES`
- *   - IPv6 prefix:           append to `SSRF_IPV6_CIDRS`
- *   - IPv6 single address:   append to `SSRF_IPV6_LITERAL_ADDRESSES`
- *   - Hostname exact match:  append to `SSRF_BLOCKED_HOST_EXACT`
- *   - Hostname suffix:       append to `SSRF_BLOCKED_HOST_SUFFIXES` with leading `.`
+ * Adding a new range: edit `lib/ssrf-blocklist.json`. Both consumers
+ * pick it up automatically.
  *
- * Note: `SSRF_NAT64_PREFIX_CIDR` (64:ff9b::/96) is intentionally NOT in
- * `SSRF_IPV6_CIDRS`. In dual-stack networks resolvers synthesise this
- * prefix for every IPv4-only public host; blanket-blocking it would
- * block legitimate destinations. Consumers handle this prefix specially
- * by extracting the embedded IPv4 and rechecking it against the IPv4
- * list. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS in the regular
- * list because by-construction the embedded IPv4 maps to internal infra.
+ * Note: `nat64PrefixCidr` (64:ff9b::/96) is intentionally NOT in
+ * `ipv6Cidrs`. In dual-stack networks resolvers synthesise this prefix
+ * for every IPv4-only public host; blanket-blocking would block
+ * legitimate destinations. Consumers handle this prefix specially by
+ * extracting the embedded IPv4 and rechecking it against the IPv4
+ * list. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) IS in `ipv6Cidrs`
+ * because by-construction the embedded IPv4 maps to internal infra.
  */
+
+import data from "./ssrf-blocklist.json" with { type: "json" };
 
 export type Cidr = readonly [address: string, prefix: number];
 
-/**
- * Covers unspecified, RFC 1918 private, loopback, CGNAT (RFC 6598),
- * link-local incl. cloud IMDS (169.254.169.254), IETF protocol
- * assignments, IPv4 documentation ranges, benchmarking, multicast,
- * reserved future use. Broadcast is in `SSRF_IPV4_BROADCAST_ADDRESSES`.
- */
-export const SSRF_IPV4_CIDRS: readonly Cidr[] = [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.0.0.0", 24],
-  ["192.0.2.0", 24],
-  ["192.88.99.0", 24],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["198.51.100.0", 24],
-  ["203.0.113.0", 24],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4],
-];
+// The cast goes via `unknown` because JSON arrays-of-tuples widen to
+// `(string | number)[][]` at parse time, which TS deems too broad for a
+// direct `Cidr[]` assertion. The JSON schema is documented at the top of
+// `lib/ssrf-blocklist.json`; entries must be `[address: string, prefix:
+// number]` pairs by convention.
+export const SSRF_IPV4_CIDRS: readonly Cidr[] =
+  data.ipv4Cidrs as unknown as Cidr[];
 
-export const SSRF_IPV4_BROADCAST_ADDRESSES: readonly string[] = [
-  "255.255.255.255",
-];
+export const SSRF_IPV4_BROADCAST_ADDRESSES: readonly string[] =
+  data.ipv4BroadcastAddresses;
 
-/**
- * IPv6 ranges. Site-local NAT64 (64:ff9b:1::/48, RFC 8215) and
- * deprecated transition mechanisms (Teredo 2001::/32, 6to4 2002::/16)
- * are blanket-blocked here despite carrying embedded IPv4: the RFC
- * 8215 prefix is by-construction site-local, and Teredo / 6to4 are
- * deprecated and not synthesised by mainstream resolvers, so the
- * false-positive risk is low.
- *
- * `::ffff:0:0/96` (IPv4-mapped) is NOT in this list because Node's
- * BlockList treats it as "all IPv4" - consumers handle IPv4-mapped via
- * an embedded-IPv4 extraction instead. Same shape applies to
- * `64:ff9b::/96` (well-known NAT64) - see `SSRF_NAT64_PREFIX_CIDR`.
- */
-export const SSRF_IPV6_CIDRS: readonly Cidr[] = [
-  ["64:ff9b:1::", 48],
-  ["100::", 64],
-  ["2001::", 32],
-  ["2001:db8::", 32],
-  ["2002::", 16],
-  ["fc00::", 7],
-  ["fe80::", 10],
-  ["ff00::", 8],
-];
+export const SSRF_IPV6_CIDRS: readonly Cidr[] =
+  data.ipv6Cidrs as unknown as Cidr[];
 
-export const SSRF_IPV6_LITERAL_ADDRESSES: readonly string[] = ["::", "::1"];
+export const SSRF_IPV6_LITERAL_ADDRESSES: readonly string[] =
+  data.ipv6LiteralAddresses;
 
-/**
- * NAT64 well-known prefix (RFC 6052). Kept separate from
- * `SSRF_IPV6_CIDRS` because it must be handled specially - the last 32
- * bits encode an IPv4 destination that may be a legitimate public
- * address. Consumers detect membership in this prefix, extract the
- * embedded IPv4, and recheck it against the IPv4 list.
- */
-export const SSRF_NAT64_PREFIX_CIDR: Cidr = ["64:ff9b::", 96];
+export const SSRF_NAT64_PREFIX_CIDR: Cidr =
+  data.nat64PrefixCidr as unknown as Cidr;
 
-/**
- * Hostnames matched exactly (case-insensitive, trailing dot stripped)
- * before any DNS resolution.
- */
-export const SSRF_BLOCKED_HOST_EXACT: readonly string[] = ["localhost"];
+export const SSRF_BLOCKED_HOST_EXACT: readonly string[] = data.blockedHostExact;
 
-/**
- * Hostname suffixes matched (case-insensitive, trailing dot stripped)
- * before any DNS resolution. Each entry begins with `.` so a top-level
- * token like "internal" cannot match an unrelated host such as
- * "myinternal.com".
- *
- * `*.local` covers mDNS / Bonjour and is a superset of the Kubernetes
- * patterns, but the cluster suffixes are listed explicitly so the
- * intent is visible at the denylist site and so any future narrowing
- * of `.local` (e.g. to mDNS-only) does not silently re-open the
- * in-cluster path.
- *
- * Cluster suffix scope: KeeperHub staging and production both run on
- * AWS EKS with the default `clusterDomain` of `cluster.local`. If we
- * move to a cluster with a custom `clusterDomain`, add it here.
- */
-export const SSRF_BLOCKED_HOST_SUFFIXES: readonly string[] = [
-  ".local",
-  ".internal",
-  ".svc.cluster.local",
-  ".pod.cluster.local",
-];
+export const SSRF_BLOCKED_HOST_SUFFIXES: readonly string[] =
+  data.blockedHostSuffixes;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run tests/unit",
+    "test:executor": "vitest run keeperhub-executor",
     "test:integration": "vitest run tests/integration",
     "test:protocol": "vitest run tests/e2e/vitest/protocol-coverage",
     "test:e2e": "playwright test",

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -16,6 +16,11 @@ COPY sandbox/src ./sandbox/src
 # `../../lib/sandbox/child-source.js`. sandbox/tsconfig.json has
 # rootDir=".." so tsc can compile this file as part of the sandbox build.
 COPY lib/sandbox/child-source.ts ./lib/sandbox/child-source.ts
+# Shared SSRF blocklist data (CIDR ranges + hostname patterns),
+# imported by lib/sandbox/child-source.ts. tsc resolves the relative
+# import and emits dist/lib/ssrf-blocklist.js, which child-source.js
+# requires at runtime.
+COPY lib/ssrf-blocklist.ts ./lib/ssrf-blocklist.ts
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/sandbox/node_modules ./sandbox/node_modules
 RUN pnpm --filter @keeperhub/sandbox build

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -17,10 +17,11 @@ COPY sandbox/src ./sandbox/src
 # rootDir=".." so tsc can compile this file as part of the sandbox build.
 COPY lib/sandbox/child-source.ts ./lib/sandbox/child-source.ts
 # Shared SSRF blocklist data (CIDR ranges + hostname patterns),
-# imported by lib/sandbox/child-source.ts. tsc resolves the relative
-# import and emits dist/lib/ssrf-blocklist.js, which child-source.js
-# requires at runtime.
-COPY lib/ssrf-blocklist.ts ./lib/ssrf-blocklist.ts
+# imported by lib/sandbox/child-source.ts as a JSON module so the
+# specifier resolves identically in both the keeperhub Turbopack
+# bundler and the standalone sandbox's strict ESM runtime. See the
+# docstring in lib/ssrf-blocklist.ts for the full rationale.
+COPY lib/ssrf-blocklist.json ./lib/ssrf-blocklist.json
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/sandbox/node_modules ./sandbox/node_modules
 RUN pnpm --filter @keeperhub/sandbox build

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node dist/sandbox/src/index.js",
-    "build": "tsc",
+    "build": "tsc && cp ../lib/ssrf-blocklist.json dist/lib/ssrf-blocklist.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/sandbox/tsconfig.json
+++ b/sandbox/tsconfig.json
@@ -16,6 +16,10 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["src/**/*", "../lib/sandbox/child-source.ts"],
+  "include": [
+    "src/**/*",
+    "../lib/sandbox/child-source.ts",
+    "../lib/ssrf-blocklist.json"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -1,8 +1,14 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { deserialize } from "node:v8";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { SANDBOX_CHILD_SOURCE } from "@/lib/sandbox/child-source";
+import {
+  SANDBOX_CHILD_SOURCE,
+  SANDBOX_RESULT_SENTINEL,
+} from "@/lib/sandbox/child-source";
 import {
   SSRF_BLOCKED_HOST_EXACT,
   SSRF_BLOCKED_HOST_SUFFIXES,
@@ -16,14 +22,18 @@ import {
 // The sandbox grandchild runs as a separate `node -e <SANDBOX_CHILD_SOURCE>`
 // subprocess with no access to npm or the rest of the codebase, so the SSRF
 // blocklist has to cross the process boundary as inlined literals
-// (`JSON.stringify` interpolation at template-render time). This test locks
-// that contract: every entry in lib/ssrf-blocklist.ts must appear in the
-// rendered source. If someone later regresses by hardcoding the list in
-// child-source.ts and forgetting to update one consumer, this test fails.
+// (`JSON.stringify` interpolation at template-render time). This file locks
+// two contracts:
+//   1. Data parity: every entry in lib/ssrf-blocklist.ts must appear in the
+//      rendered source.
+//   2. Behavioural parity: the rendered source actually blocks the things
+//      it inlines when spawned and asked to fetch them. Item #2 is the
+//      contract the KEEP-603 incident required and the contract data-only
+//      tests cannot prove on their own.
 describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
-  it("inlines every IPv4 CIDR address from the SoT", () => {
-    for (const [addr] of SSRF_IPV4_CIDRS) {
-      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+  it("inlines every IPv4 CIDR tuple from the SoT", () => {
+    for (const cidr of SSRF_IPV4_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(JSON.stringify(cidr));
     }
   });
 
@@ -33,9 +43,9 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
     }
   });
 
-  it("inlines every IPv6 CIDR address from the SoT", () => {
-    for (const [addr] of SSRF_IPV6_CIDRS) {
-      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+  it("inlines every IPv6 CIDR tuple from the SoT", () => {
+    for (const cidr of SSRF_IPV6_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(JSON.stringify(cidr));
     }
   });
 
@@ -45,8 +55,10 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
     }
   });
 
-  it("inlines the NAT64 well-known prefix address from the SoT", () => {
-    expect(SANDBOX_CHILD_SOURCE).toContain(`"${SSRF_NAT64_PREFIX_CIDR[0]}"`);
+  it("inlines the NAT64 well-known prefix tuple from the SoT", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain(
+      JSON.stringify(SSRF_NAT64_PREFIX_CIDR),
+    );
   });
 
   it("inlines every blocked-host exact match from the SoT", () => {
@@ -71,3 +83,160 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
     expect(() => new Script(SANDBOX_CHILD_SOURCE)).not.toThrow();
   });
 });
+
+// Drift-resistance policy guard. The grandchild template is now
+// data-imported from lib/ssrf-blocklist.json; any other import would either
+// silently no-op in the spawned subprocess (runtime values do not propagate
+// across "node -e") or introduce a dependency the standalone sandbox image
+// does not have. Lock the contract here so it cannot regress quietly.
+const IMPORT_STATEMENT_REGEX = /^import\s.+$/gm;
+
+describe("lib/sandbox/child-source.ts only imports pure data", () => {
+  it("has at most one import and it points at the SSRF blocklist JSON", async () => {
+    const src = await readFile("lib/sandbox/child-source.ts", "utf8");
+    const imports = src.match(IMPORT_STATEMENT_REGEX) ?? [];
+    expect(imports).toHaveLength(1);
+    expect(imports[0]).toContain('"../ssrf-blocklist.json"');
+    expect(imports[0]).toContain('with { type: "json" }');
+  });
+});
+
+type SandboxOutcome =
+  | { ok: true; result: unknown; logs: unknown[] }
+  | {
+      ok: false;
+      errorMessage: string;
+      errorStack?: string;
+      logs: unknown[];
+    };
+
+function parseChildOutput(stdout: string): SandboxOutcome {
+  const idx = stdout.lastIndexOf(SANDBOX_RESULT_SENTINEL);
+  if (idx === -1) {
+    return { ok: false, errorMessage: "no sentinel in stdout", logs: [] };
+  }
+  const newlineIdx = stdout.indexOf("\n", idx);
+  const end = newlineIdx === -1 ? stdout.length : newlineIdx;
+  const base64 = stdout
+    .slice(idx + SANDBOX_RESULT_SENTINEL.length, end)
+    .trim();
+  try {
+    return deserialize(Buffer.from(base64, "base64")) as SandboxOutcome;
+  } catch (_err) {
+    return { ok: false, errorMessage: "malformed v8 payload", logs: [] };
+  }
+}
+
+async function runSandboxed(
+  userCode: string,
+  timeoutMs = 3000,
+): Promise<SandboxOutcome> {
+  return await new Promise<SandboxOutcome>((resolve) => {
+    const child = spawn(process.execPath, ["-e", SANDBOX_CHILD_SOURCE], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let settled = false;
+
+    function finish(outcome: SandboxOutcome): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(killTimer);
+      if (!child.killed) {
+        try {
+          child.kill("SIGKILL");
+        } catch (_err) {
+          // child may already have exited
+        }
+      }
+      resolve(outcome);
+    }
+
+    const killTimer = setTimeout(() => {
+      finish({ ok: false, errorMessage: "harness timeout", logs: [] });
+    }, timeoutMs + 3000);
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.on("error", (err: Error) => {
+      finish({ ok: false, errorMessage: err.message, logs: [] });
+    });
+    child.on("close", () => {
+      finish(parseChildOutput(stdout));
+    });
+
+    try {
+      child.stdin.write(JSON.stringify({ code: userCode, timeoutMs }));
+      child.stdin.end();
+    } catch (err) {
+      finish({
+        ok: false,
+        errorMessage: err instanceof Error ? err.message : String(err),
+        logs: [],
+      });
+    }
+  });
+}
+
+function expectBlocked(outcome: SandboxOutcome): void {
+  expect(outcome.ok).toBe(false);
+  if (outcome.ok) {
+    return;
+  }
+  expect(outcome.errorMessage).toMatch(/SSRF blocked/);
+}
+
+// Behavioural parity: spawn the actual grandchild and confirm the SSRF
+// guard fires for every category Sasha listed in the incident response
+// (RFC 1918, link-local incl. IMDSv2, multicast, reserved, IPv6 transition
+// prefixes, and the pre-DNS hostname denylist). These cases use IP
+// literals or pre-DNS-blocked hostnames so the test is deterministic and
+// performs no real DNS / network IO.
+describe("sandbox grandchild SSRF guard fires on every category", () => {
+  it.each([
+    ['await fetch("http://169.254.169.254/")', "IMDSv2 link-local"],
+    ['await fetch("http://10.0.0.1/")', "RFC 1918"],
+    ['await fetch("http://127.0.0.1/")', "loopback IPv4"],
+    ['await fetch("http://255.255.255.255/")', "IPv4 broadcast"],
+    ['await fetch("http://[::1]/")', "IPv6 loopback"],
+    ['await fetch("http://[fc00::1]/")', "ULA IPv6"],
+    ['await fetch("http://[fe80::1]/")', "link-local IPv6"],
+    ['await fetch("http://[2001::1]/")', "Teredo (2001::/32)"],
+    ['await fetch("http://[2002::1]/")', "6to4 (2002::/16)"],
+    [
+      'await fetch("http://[2001:db8::1]/")',
+      "documentation range (2001:db8::/32)",
+    ],
+    [
+      'await fetch("http://[64:ff9b:1::1]/")',
+      "site-local NAT64 (64:ff9b:1::/48)",
+    ],
+    ['await fetch("http://[ff02::1]/")', "multicast IPv6"],
+  ])("blocks %s (%s)", async (snippet) => {
+    const outcome = await runSandboxed(snippet);
+    expectBlocked(outcome);
+  });
+
+  it.each([
+    ['await fetch("http://localhost/")', "pre-DNS exact match"],
+    ['await fetch("http://LOCALHOST/")', "case normalisation"],
+    ['await fetch("http://localhost./")', "trailing-dot normalisation"],
+    [
+      'await fetch("http://probe.svc.cluster.local/")',
+      "*.svc.cluster.local",
+    ],
+    [
+      'await fetch("http://probe.pod.cluster.local/")',
+      "*.pod.cluster.local",
+    ],
+    ['await fetch("http://probe.internal/")', "*.internal"],
+    ['await fetch("http://probe.local/")', "*.local (mDNS / Bonjour)"],
+  ])("blocks %s before DNS (%s)", async (snippet) => {
+    const outcome = await runSandboxed(snippet);
+    expectBlocked(outcome);
+  });
+}, 30_000);

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { SANDBOX_CHILD_SOURCE } from "@/lib/sandbox/child-source";
+import {
+  SSRF_BLOCKED_HOST_EXACT,
+  SSRF_BLOCKED_HOST_SUFFIXES,
+  SSRF_IPV4_BROADCAST_ADDRESSES,
+  SSRF_IPV4_CIDRS,
+  SSRF_IPV6_CIDRS,
+  SSRF_IPV6_LITERAL_ADDRESSES,
+  SSRF_NAT64_PREFIX_CIDR,
+} from "@/lib/ssrf-blocklist";
+
+// The sandbox grandchild runs as a separate `node -e <SANDBOX_CHILD_SOURCE>`
+// subprocess with no access to npm or the rest of the codebase, so the SSRF
+// blocklist has to cross the process boundary as inlined literals
+// (`JSON.stringify` interpolation at template-render time). This test locks
+// that contract: every entry in lib/ssrf-blocklist.ts must appear in the
+// rendered source. If someone later regresses by hardcoding the list in
+// child-source.ts and forgetting to update one consumer, this test fails.
+describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
+  it("inlines every IPv4 CIDR address from the SoT", () => {
+    for (const [addr] of SSRF_IPV4_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines every IPv4 broadcast address from the SoT", () => {
+    for (const addr of SSRF_IPV4_BROADCAST_ADDRESSES) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines every IPv6 CIDR address from the SoT", () => {
+    for (const [addr] of SSRF_IPV6_CIDRS) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines every IPv6 literal address from the SoT", () => {
+    for (const addr of SSRF_IPV6_LITERAL_ADDRESSES) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${addr}"`);
+    }
+  });
+
+  it("inlines the NAT64 well-known prefix address from the SoT", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain(`"${SSRF_NAT64_PREFIX_CIDR[0]}"`);
+  });
+
+  it("inlines every blocked-host exact match from the SoT", () => {
+    for (const host of SSRF_BLOCKED_HOST_EXACT) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${host}"`);
+    }
+  });
+
+  it("inlines every blocked-host suffix from the SoT", () => {
+    for (const suffix of SSRF_BLOCKED_HOST_SUFFIXES) {
+      expect(SANDBOX_CHILD_SOURCE).toContain(`"${suffix}"`);
+    }
+  });
+
+  it("renders syntactically valid JavaScript", async () => {
+    // `node -e` parses the source at process start. If the template literal
+    // ever produces invalid JS (e.g. an interpolation breaks a string
+    // boundary or yields a reserved-word identifier), every Code-node
+    // workflow run would crash at startup. Use Node's vm.Script to do a
+    // parse-only check without executing anything.
+    const { Script } = await import("node:vm");
+    expect(() => new Script(SANDBOX_CHILD_SOURCE)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Release `staging` -> `prod`. Notable security-critical content in this release:

### Security incident 2026-05-21 follow-up (PR #1335 merged into staging)
- **NetworkPolicy on workflow runner pods**: kubernetes egress block to `169.254.0.0/16`, `fe80::/10`, `fc00::/7` (IMDS + link-local + ULA).
- **AI Prompt off in prod**: gated behind `NEXT_PUBLIC_AI_PROMPT_ENABLED` (defaults `false`). UI + `/api/ai/generate` both gated.
- **DB-level kill switch (drizzle migration `0082`)**:
  - `block_database_integrations_security_2026_05_21` declared in migrations (the trigger was already ad-hoc on prod).
  - **NEW** `block_executions_security_2026_05_21` rejects INSERT into `workflow_executions` when the workflow owner is `deactivated_at IS NOT NULL` or the workflow is `deleted_at IS NOT NULL`. Raises `42501`.
- Both triggers are idempotent (`CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS / CREATE TRIGGER`).
- This closes the live attacker leak where deactivated accounts continued running workflows.

### Other content
- KEEP-603 SSRF guard parity across HTTP + DB plugins, sandbox tests, blocklist as JSON
- chore: executor unit tests in CI
- Misc fixes (Blockscout chain selector, validator template address)

## Test plan
- [x] CI green on PR #1335 before merge to staging
- [x] Staging deploy succeeded (run 26234015878)
- [ ] CI green on this PR before merge to prod
- [ ] After merge to prod: verify both triggers present on prod DB (`SELECT tgname FROM pg_trigger WHERE tgname LIKE '%security_2026_05_21%'`)
- [ ] Sample insert into `workflow_executions` for a soft-deleted workflow on prod returns `42501` error
- [ ] No spike in legitimate execution errors after deploy (Joel's canaries, Dumitru's Sky monitoring continue running)