### PR TITLE
ci: run keeperhub-executor unit tests in pr-checks

### DIFF
--- a/.github/workflows/pr-checks-executor.yml
+++ b/.github/workflows/pr-checks-executor.yml
@@ -13,6 +13,9 @@ on:
       - "keeperhub-executor/**"
       - ".github/workflows/pr-checks-executor.yml"
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks-executor.yml
+++ b/.github/workflows/pr-checks-executor.yml
@@ -1,0 +1,27 @@
+# Type: standalone | PR checks for the keeperhub-executor module.
+# Runs only when keeperhub-executor/** or this workflow change. Unlike
+# keeperhub-events / keeperhub-scheduler, the executor lives in the root
+# pnpm workspace (shared lockfile, shared deps), so the existing
+# setup-node-pnpm action is reused rather than a dedicated setup action.
+# The executor's tests are pure unit tests with mocked external deps -
+# no docker services required.
+name: PR Checks (Executor)
+
+on:
+  pull_request:
+    paths:
+      - "keeperhub-executor/**"
+      - ".github/workflows/pr-checks-executor.yml"
+
+jobs:
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Run executor unit tests
+        run: pnpm test:executor

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,6 +203,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+      - name: Run executor unit tests
+        run: pnpm test:executor
+
   test-unit-sandbox-remote:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,9 +203,6 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
-      - name: Run executor unit tests
-        run: pnpm test:executor
-
   test-unit-sandbox-remote:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run tests/unit",
+    "test:executor": "vitest run keeperhub-executor",
     "test:integration": "vitest run tests/integration",
     "test:protocol": "vitest run tests/e2e/vitest/protocol-coverage",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary

Enables the six test files under `keeperhub-executor/` (44 tests total) to run in CI. They were discoverable by the root vitest config but never invoked: `pnpm test:unit` (the script the `test-unit` job runs) hard-filters to `tests/unit/`.

Follows the `pr-checks-events.yml` pattern: a dedicated, path-triggered workflow file rather than an extra step on the main PR's `test-unit` job.

| File | Tests |
|---|---|
| `keeperhub-executor/k8s-job.test.ts` | 10 |
| `keeperhub-executor/runner-env.test.ts` | 7 |
| `keeperhub-executor/startup-checks.test.ts` | 7 |
| `keeperhub-executor/api-execute.test.ts` | 9 |
| `keeperhub-executor/lib/metrics-shipping.test.ts` | 8 |
| `keeperhub-executor/lib/ship-metrics.test.ts` | 3 |

## Files changed

- `package.json` - new `test:executor` script (`vitest run keeperhub-executor`).
- `.github/workflows/pr-checks-executor.yml` (new) - path-triggered workflow with one job that runs `pnpm test:executor`.

## Differences from `pr-checks-events.yml`

`keeperhub-events` and `keeperhub-scheduler` are separate pnpm workspaces with their own lockfiles, tsconfigs, and `vitest.config.ts`, so they use a dedicated `setup-events-deps` action and `working-directory` blocks. `keeperhub-executor` lives in the root pnpm workspace and shares dependencies, so the existing `setup-node-pnpm` action is reused.

The executor's tests are pure unit tests with mocked externals - no docker services, no anvil, no localstack. Only a single `test-unit` job is needed; no `test-integration` mirror like events has.

## Why path-triggered

Executor test files import only from local relative paths (confirmed by grep on the test files). A change to root `lib/` or to the main app cannot break executor tests without also touching `keeperhub-executor/**`, so the path filter is sound. If anyone breaks executor source via a root `lib/` change, the actual runtime failure surfaces in workflow runs and in the main `test-unit` job (which exercises that `lib/` code through other tests).

## Test plan

- [x] `pnpm test:executor` runs locally: 44/44 pass in ~10s
- [ ] CI green on this PR (this PR touches `.github/workflows/pr-checks-executor.yml`, so the new workflow should fire on this PR itself)
- [ ] After merge: open a PR that touches only `keeperhub-executor/**` and verify only `PR Checks (Executor)` fires (not the broader `test-unit` job from the main workflow)
- [ ] Confirm a PR touching only main-app paths does NOT fire the executor workflow