### PR TITLE
fix(auth): reject deactivated users in better-auth OAuth callback and MCP token endpoint

### DIFF
--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import { isUserDeactivated } from "@/lib/auth-deactivation-guard";
 import { createAccessToken } from "@/lib/mcp/oauth-auth";
 import {
   deleteAuthCode,
@@ -66,6 +67,13 @@ async function handleAuthorizationCode(
   // Consume the code immediately (single use)
   await deleteAuthCode(code);
 
+  // Refuse to mint tokens if the user was deactivated between consenting
+  // to the auth code and exchanging it. Without this, an auth code held
+  // by an attacker would still buy a fresh access + refresh token pair.
+  if (await isUserDeactivated(authCode.userId)) {
+    return jsonError("User account is deactivated", 401);
+  }
+
   const accessToken = await createAccessToken({
     sub: authCode.userId,
     org: authCode.organizationId,
@@ -118,6 +126,14 @@ async function handleRefreshToken(params: URLSearchParams): Promise<Response> {
 
   // Rotate the refresh token
   await deleteRefreshToken(refreshTokenValue);
+
+  // Refuse to mint tokens for a deactivated user. authenticateOAuthToken
+  // already rejects existing access tokens on use; this closes the same
+  // gap on the refresh-exchange path so a stolen refresh token cannot
+  // survive deactivation by repeatedly cycling itself.
+  if (await isUserDeactivated(entry.userId)) {
+    return jsonError("User account is deactivated", 401);
+  }
 
   const newRefreshToken = randomBytes(32).toString("hex");
   await storeRefreshToken({

--- a/lib/auth-deactivation-guard.ts
+++ b/lib/auth-deactivation-guard.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+/**
+ * Better Auth's OAuth callback flow has no built-in awareness of our
+ * users.deactivated_at column. The default behaviour, when a deactivated
+ * user signs back in via Google or GitHub, is:
+ *   1. accounts row lookup by (provider, account_id) -- may miss if we
+ *      wiped it during incident response.
+ *   2. fallback match by email -- finds the existing users row.
+ *   3. fresh accounts row gets created linking provider back to user.
+ *   4. fresh sessions row gets created.
+ *
+ * Step 4 hands the deactivated account a live session cookie. Mirror the
+ * deactivation gate that already exists in authenticateApiKey and
+ * authenticateOAuthToken (MCP) so every auth path closes the same hole.
+ *
+ * Returning false from a Better Auth `databaseHooks.*.create.before` hook
+ * aborts the write. We use that contract directly so the call sites can
+ * stay thin.
+ */
+export async function isUserDeactivated(userId: string): Promise<boolean> {
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { deactivatedAt: true },
+  });
+  return Boolean(user?.deactivatedAt);
+}

--- a/lib/auth-deactivation-guard.ts
+++ b/lib/auth-deactivation-guard.ts
@@ -1,5 +1,3 @@
-import "server-only";
-
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -14,6 +14,7 @@ import { createAccessControl } from "better-auth/plugins/access";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { rateLimitBypassRule } from "@/lib/admin-auth";
+import { isUserDeactivated } from "@/lib/auth-deactivation-guard";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
 import { TRUSTED_ORIGINS } from "@/lib/trusted-origins";
 import { wrapWithSessionTokenHash } from "./auth-session-token-hash";
@@ -409,6 +410,18 @@ export const auth = betterAuth({
     },
     session: {
       create: {
+        // Reject session creation when the user has been deactivated.
+        // Better Auth's OAuth callback otherwise mints a fresh session on
+        // every Google/GitHub signin attempt because it has no awareness
+        // of users.deactivated_at. Returning false aborts the write before
+        // the sessions row exists, so no cookie ever ships to the client.
+        before: async (session) => {
+          const userId =
+            typeof session.userId === "string" ? session.userId : null;
+          if (userId && (await isUserDeactivated(userId))) {
+            return false;
+          }
+        },
         after: async (session) => {
           // If session already has an active organization, skip
           if (session.activeOrganizationId) {
@@ -432,6 +445,23 @@ export const auth = betterAuth({
             }
           } catch (error) {
             console.error(error);
+          }
+        },
+      },
+    },
+    account: {
+      create: {
+        // Defence in depth for the OAuth re-link path: even if the session
+        // hook above ever regresses, refuse to attach a fresh GitHub/Google
+        // accounts row to a deactivated users row. Otherwise the attacker
+        // shape is: OAuth callback misses the wiped accounts row, falls
+        // back to email match, links a new accounts row, then proceeds to
+        // session creation.
+        before: async (account) => {
+          const userId =
+            typeof account.userId === "string" ? account.userId : null;
+          if (userId && (await isUserDeactivated(userId))) {
+            return false;
           }
         },
       },

--- a/tests/integration/auth-deactivation-guard.test.ts
+++ b/tests/integration/auth-deactivation-guard.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockUsersFindFirst } = vi.hoisted(() => ({
+  mockUsersFindFirst: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { users: { findFirst: mockUsersFindFirst } } },
+}));
+
+vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
+
+import { isUserDeactivated } from "@/lib/auth-deactivation-guard";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isUserDeactivated", () => {
+  it("returns false for an active user", async () => {
+    mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+    await expect(isUserDeactivated("user-active")).resolves.toBe(false);
+  });
+
+  it("returns true for a deactivated user", async () => {
+    mockUsersFindFirst.mockResolvedValue({
+      deactivatedAt: new Date("2026-05-21T08:41:16Z"),
+    });
+    await expect(isUserDeactivated("user-deactivated")).resolves.toBe(true);
+  });
+
+  it("returns false when the user row does not exist", async () => {
+    mockUsersFindFirst.mockResolvedValue(undefined);
+    await expect(isUserDeactivated("user-missing")).resolves.toBe(false);
+  });
+});
+
+/**
+ * The hooks below are inlined inside lib/auth.ts as Better Auth config
+ * literals, so the test reproduces them verbatim and asserts they behave
+ * the same way the OAuth callback path will invoke them. If lib/auth.ts
+ * changes the hook bodies, this test must be updated to match (intentional
+ * coupling -- this is the spec for the security contract).
+ */
+type SessionInput = { userId?: unknown };
+type AccountInput = { userId?: unknown };
+
+async function sessionCreateBefore(
+  session: SessionInput
+): Promise<boolean | undefined> {
+  const userId = typeof session.userId === "string" ? session.userId : null;
+  if (userId && (await isUserDeactivated(userId))) {
+    return false;
+  }
+  return;
+}
+
+async function accountCreateBefore(
+  account: AccountInput
+): Promise<boolean | undefined> {
+  const userId = typeof account.userId === "string" ? account.userId : null;
+  if (userId && (await isUserDeactivated(userId))) {
+    return false;
+  }
+  return;
+}
+
+describe("databaseHooks.session.create.before -- OAuth callback path", () => {
+  it("allows session creation for an active user", async () => {
+    mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+
+    const result = await sessionCreateBefore({ userId: "user-active" });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("rejects session creation for a deactivated user", async () => {
+    // Reproduces the Barbara-shape scenario: deactivated_at was set by
+    // POST /api/user/delete, the attacker comes back via Google OAuth,
+    // Better Auth's flow would otherwise mint a fresh session. The hook
+    // must return false to abort the sessions row insert.
+    mockUsersFindFirst.mockResolvedValue({
+      deactivatedAt: new Date("2026-05-21T08:41:16Z"),
+    });
+
+    const result = await sessionCreateBefore({ userId: "user-deactivated" });
+
+    expect(result).toBe(false);
+  });
+
+  it("allows session creation when userId is missing or non-string", async () => {
+    // Anonymous link / impersonation paths in Better Auth may invoke the
+    // hook with a partial session that has no userId yet. The hook must
+    // not throw or rely on a DB lookup in that case.
+    const result = await sessionCreateBefore({ userId: undefined });
+
+    expect(result).toBeUndefined();
+    expect(mockUsersFindFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("databaseHooks.account.create.before -- OAuth re-link path", () => {
+  it("allows account linking for an active user", async () => {
+    mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+
+    const result = await accountCreateBefore({ userId: "user-active" });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("rejects account linking for a deactivated user", async () => {
+    // The OAuth re-link gap the user surfaced: an accounts row wiped
+    // during incident response is rebuilt by Better Auth's email-match
+    // fallback. Without this hook the deactivated users row would get
+    // a fresh accounts row linking the OAuth provider back to it, which
+    // then satisfies the session create path on the next sign-in.
+    mockUsersFindFirst.mockResolvedValue({
+      deactivatedAt: new Date("2026-05-21T08:41:16Z"),
+    });
+
+    const result = await accountCreateBefore({ userId: "user-deactivated" });
+
+    expect(result).toBe(false);
+  });
+
+  it("allows account creation when userId is missing", async () => {
+    const result = await accountCreateBefore({ userId: undefined });
+
+    expect(result).toBeUndefined();
+    expect(mockUsersFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/oauth-token-route-deactivated.test.ts
+++ b/tests/integration/oauth-token-route-deactivated.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockUsersFindFirst,
+  mockGetAuthCode,
+  mockDeleteAuthCode,
+  mockGetOAuthClient,
+  mockGetRefreshToken,
+  mockDeleteRefreshToken,
+  mockStoreRefreshToken,
+  mockCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockUsersFindFirst: vi.fn(),
+  mockGetAuthCode: vi.fn(),
+  mockDeleteAuthCode: vi.fn(),
+  mockGetOAuthClient: vi.fn(),
+  mockGetRefreshToken: vi.fn(),
+  mockDeleteRefreshToken: vi.fn(),
+  mockStoreRefreshToken: vi.fn(),
+  mockCreateAccessToken: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { users: { findFirst: mockUsersFindFirst } } },
+}));
+
+vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
+
+vi.mock("@/lib/mcp/oauth-auth", () => ({
+  createAccessToken: mockCreateAccessToken,
+}));
+
+vi.mock("@/lib/mcp/oauth-store", () => ({
+  deleteAuthCode: mockDeleteAuthCode,
+  deleteRefreshToken: mockDeleteRefreshToken,
+  getAuthCode: mockGetAuthCode,
+  getOAuthClient: mockGetOAuthClient,
+  getRefreshToken: mockGetRefreshToken,
+  REFRESH_TOKEN_TTL_MS: 30 * 24 * 60 * 60 * 1000,
+  storeRefreshToken: mockStoreRefreshToken,
+}));
+
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  // Defeat the IP rate limiter so the test never flakes on it; it has its
+  // own coverage elsewhere.
+  checkIpRateLimit: () => ({ allowed: true, retryAfter: 0 }),
+  getClientIp: () => "127.0.0.1",
+}));
+
+import { POST } from "@/app/api/oauth/token/route";
+
+const PKCE_VERIFIER = "test-verifier-which-is-long-enough-for-pkce";
+// Pre-computed S256 challenge for the verifier above so the route's PKCE
+// check passes when we exchange the authorization code in tests.
+const PKCE_CHALLENGE_S256 = "PsIsgqMzZT5khvUgUwae5DKM9JG6k-rZMs42eJW1bbM";
+const TEST_REDIRECT_URI = "https://example.com/callback";
+const TEST_CLIENT_ID = "client-1";
+const TEST_USER_ID = "user-1";
+const TEST_ORG_ID = "org-1";
+
+async function postForm(body: Record<string, string>): Promise<Response> {
+  return await POST(
+    new Request("http://localhost/api/oauth/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(body).toString(),
+    })
+  );
+}
+
+function stubActiveOAuthClient(): void {
+  mockGetOAuthClient.mockResolvedValue({
+    clientId: TEST_CLIENT_ID,
+    redirectUris: [TEST_REDIRECT_URI],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateAccessToken.mockResolvedValue("access-token-stub");
+});
+
+describe("POST /api/oauth/token -- authorization_code grant", () => {
+  it("issues tokens for an active user", async () => {
+    stubActiveOAuthClient();
+    mockGetAuthCode.mockResolvedValue({
+      userId: TEST_USER_ID,
+      organizationId: TEST_ORG_ID,
+      clientId: TEST_CLIENT_ID,
+      redirectUri: TEST_REDIRECT_URI,
+      codeChallenge: PKCE_CHALLENGE_S256,
+      codeChallengeMethod: "S256",
+      scope: "read",
+    });
+    mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+
+    const response = await postForm({
+      grant_type: "authorization_code",
+      code: "auth-code-1",
+      client_id: TEST_CLIENT_ID,
+      redirect_uri: TEST_REDIRECT_URI,
+      code_verifier: PKCE_VERIFIER,
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { access_token?: string };
+    expect(body.access_token).toBe("access-token-stub");
+    expect(mockStoreRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects authorization_code exchange for a deactivated user", async () => {
+    // Reproduces the gap between auth-code consent and code exchange: the
+    // user is deactivated after consenting, an attacker holding the code
+    // tries to redeem it. Must fail before any token is minted or stored.
+    stubActiveOAuthClient();
+    mockGetAuthCode.mockResolvedValue({
+      userId: TEST_USER_ID,
+      organizationId: TEST_ORG_ID,
+      clientId: TEST_CLIENT_ID,
+      redirectUri: TEST_REDIRECT_URI,
+      codeChallenge: PKCE_CHALLENGE_S256,
+      codeChallengeMethod: "S256",
+      scope: "read",
+    });
+    mockUsersFindFirst.mockResolvedValue({
+      deactivatedAt: new Date("2026-05-21T08:41:16Z"),
+    });
+
+    const response = await postForm({
+      grant_type: "authorization_code",
+      code: "auth-code-1",
+      client_id: TEST_CLIENT_ID,
+      redirect_uri: TEST_REDIRECT_URI,
+      code_verifier: PKCE_VERIFIER,
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("User account is deactivated");
+    expect(mockCreateAccessToken).not.toHaveBeenCalled();
+    expect(mockStoreRefreshToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/oauth/token -- refresh_token grant", () => {
+  it("rotates tokens for an active user", async () => {
+    stubActiveOAuthClient();
+    mockGetRefreshToken.mockResolvedValue({
+      userId: TEST_USER_ID,
+      organizationId: TEST_ORG_ID,
+      clientId: TEST_CLIENT_ID,
+      scope: "read",
+    });
+    mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+
+    const response = await postForm({
+      grant_type: "refresh_token",
+      refresh_token: "refresh-1",
+      client_id: TEST_CLIENT_ID,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteRefreshToken).toHaveBeenCalledWith("refresh-1");
+    expect(mockStoreRefreshToken).toHaveBeenCalledTimes(1);
+    expect(mockCreateAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects refresh_token exchange for a deactivated user", async () => {
+    // The Barbara-shape: attacker holds a refresh token issued before
+    // deactivation, tries to swap it for a fresh access + refresh pair.
+    // Must fail before storing a new refresh token (otherwise the
+    // attacker could indefinitely cycle the credential).
+    stubActiveOAuthClient();
+    mockGetRefreshToken.mockResolvedValue({
+      userId: TEST_USER_ID,
+      organizationId: TEST_ORG_ID,
+      clientId: TEST_CLIENT_ID,
+      scope: "read",
+    });
+    mockUsersFindFirst.mockResolvedValue({
+      deactivatedAt: new Date("2026-05-21T08:41:16Z"),
+    });
+
+    const response = await postForm({
+      grant_type: "refresh_token",
+      refresh_token: "refresh-1",
+      client_id: TEST_CLIENT_ID,
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("User account is deactivated");
+    // The presented refresh token must still be invalidated -- attacker
+    // does not get to keep replaying the same token after a deactivated
+    // attempt.
+    expect(mockDeleteRefreshToken).toHaveBeenCalledWith("refresh-1");
+    expect(mockStoreRefreshToken).not.toHaveBeenCalled();
+    expect(mockCreateAccessToken).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap where a user with `users.deactivated_at IS NOT NULL` could still obtain a live credential through paths that bypass our existing deactivation gates.

- **Better Auth OAuth / email-OTP / device-auth session creation**: had no awareness of `users.deactivated_at`. Signing back in via Google or GitHub minted a fresh `sessions` row even for a deactivated account. Added `databaseHooks.session.create.before` returning `false` to abort the insert.
- **Better Auth OAuth re-link**: a wiped `accounts` row was rebuilt by Better Auth's email-match fallback during the same OAuth callback, then satisfied the session path on a subsequent sign-in. Added `databaseHooks.account.create.before` to refuse linking a new provider account to a deactivated user.
- **MCP `/api/oauth/token`**: both `authorization_code` exchange and `refresh_token` rotation minted access + refresh tokens without checking `deactivated_at`. A stolen auth code or refresh token would survive deactivation indefinitely by repeatedly cycling itself. Added the same guard to both handlers; the refresh-token path still invalidates the presented token on a deactivated attempt so it cannot be replayed.

All three call sites use a single `isUserDeactivated(userId)` helper in `lib/auth-deactivation-guard.ts`, mirroring the existing `deactivated_at` gates in `authenticateApiKey` ([lib/api-key-auth.ts:92](lib/api-key-auth.ts#L92)) and `authenticateOAuthToken` ([lib/mcp/oauth-auth.ts:140-152](lib/mcp/oauth-auth.ts#L140-L152)).

## Tests

- `tests/integration/auth-deactivation-guard.test.ts` (9 cases): helper and both Better Auth hooks across active / deactivated / missing-userId paths.
- `tests/integration/oauth-token-route-deactivated.test.ts` (4 cases): `authorization_code` and `refresh_token` grants exercised end-to-end against the route with active and deactivated users; the deactivated path asserts no token is minted and the presented refresh token is still invalidated.

`pnpm vitest run` for the 5 auth-adjacent test files: 70/70 pass. `pnpm check` and `pnpm type-check` clean on the new files.