### PR TITLE
fix: wire SSRF guard into database query code export

### DIFF
--- a/lib/workflow/codegen/templates/database-query.ts
+++ b/lib/workflow/codegen/templates/database-query.ts
@@ -4,20 +4,124 @@
  *
  * Requires: pnpm add postgres
  * Environment: DATABASE_URL
+ *
+ * SSRF data: the embedded blocklist is interpolated from
+ * `lib/ssrf-blocklist.json` (the same canonical source consumed by
+ * `lib/safe-fetch.ts` and `lib/db/connection-host-guard.ts`) at module
+ * load time, so any future update to the JSON propagates to exported
+ * workflows on the next export. Re-exporting the workflow is required to
+ * pick up upstream changes; previously exported code carries a snapshot.
+ *
+ * The body of databaseQueryStep is extracted by the SDK code generator's
+ * function-body regex; all guard logic and helpers therefore live INSIDE
+ * the main function (as local `const` arrows) so they survive extraction.
+ *
+ * NAT64 well-known prefix and IPv4-mapped-IPv6 special-cases from the
+ * canonical guard are intentionally omitted here: they require non-trivial
+ * extraction logic and only matter on dual-stack networks. The standard
+ * CIDR / hostname checks below cover the documented threat (cloud
+ * metadata, RFC1918, link-local, cluster-internal DNS).
  */
+import blocklist from "@/lib/ssrf-blocklist.json" with { type: "json" };
+
+const BLOCKLIST_LITERAL = JSON.stringify(blocklist);
+
 export default `export async function databaseQueryStep(input: {
   query: string;
 }) {
   "use step";
-  
+
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     return { success: false, error: "DATABASE_URL environment variable is not set" };
   }
-  
+
+  // SSRF blocklist mirrored from KeeperHub's lib/ssrf-blocklist.json at
+  // export time. Single source of truth lives in the KeeperHub repo;
+  // re-export the workflow to refresh.
+  const SSRF_BLOCKLIST = ${BLOCKLIST_LITERAL} as {
+    ipv4Cidrs: [string, number][];
+    ipv4BroadcastAddresses: string[];
+    ipv6Cidrs: [string, number][];
+    ipv6LiteralAddresses: string[];
+    blockedHostExact: string[];
+    blockedHostSuffixes: string[];
+  };
+
+  const { BlockList, isIP } = await import("node:net");
+  const blockList = new BlockList();
+  for (const [addr, prefix] of SSRF_BLOCKLIST.ipv4Cidrs) {
+    blockList.addSubnet(addr, prefix, "ipv4");
+  }
+  for (const addr of SSRF_BLOCKLIST.ipv4BroadcastAddresses) {
+    blockList.addAddress(addr, "ipv4");
+  }
+  for (const [addr, prefix] of SSRF_BLOCKLIST.ipv6Cidrs) {
+    blockList.addSubnet(addr, prefix, "ipv6");
+  }
+  for (const addr of SSRF_BLOCKLIST.ipv6LiteralAddresses) {
+    blockList.addAddress(addr, "ipv6");
+  }
+
+  const isBlockedHostname = (h: string): boolean => {
+    let normalised = h.trim().toLowerCase();
+    if (normalised.endsWith(".")) {
+      normalised = normalised.slice(0, -1);
+    }
+    if (normalised === "") return false;
+    if (SSRF_BLOCKLIST.blockedHostExact.includes(normalised)) return true;
+    for (const suffix of SSRF_BLOCKLIST.blockedHostSuffixes) {
+      if (normalised.endsWith(suffix)) return true;
+    }
+    return false;
+  };
+
+  const isBlockedIp = (ip: string): boolean => {
+    const fam = isIP(ip);
+    if (fam === 4) return blockList.check(ip, "ipv4");
+    if (fam === 6) return blockList.check(ip, "ipv6");
+    return false;
+  };
+
+  let parsedHost: string;
+  try {
+    parsedHost = new URL(databaseUrl).hostname;
+  } catch {
+    return { success: false, error: "Connection string is missing a host" };
+  }
+  if (!parsedHost) {
+    return { success: false, error: "Connection string is missing a host" };
+  }
+  const host =
+    parsedHost.startsWith("[") && parsedHost.endsWith("]")
+      ? parsedHost.slice(1, -1)
+      : parsedHost;
+
+  if (isBlockedHostname(host)) {
+    return { success: false, error: "Host is not allowed: must resolve to a public address" };
+  }
+  if (isIP(host) !== 0) {
+    if (isBlockedIp(host)) {
+      return { success: false, error: "Host is not allowed: must resolve to a public address" };
+    }
+  } else {
+    const dnsModule = await import("node:dns");
+    let addresses: Array<{ address: string }>;
+    try {
+      addresses = await dnsModule.promises.lookup(host, { all: true });
+    } catch {
+      return { success: false, error: "Host could not be resolved" };
+    }
+    for (const addr of addresses) {
+      if (isBlockedIp(addr.address)) {
+        return { success: false, error: "Host is not allowed: must resolve to a public address" };
+      }
+    }
+  }
+
   const postgres = await import("postgres");
   const sql = postgres.default(databaseUrl, { max: 1 });
-  
+
   try {
     const result = await sql.unsafe(input.query);
     await sql.end();

--- a/tests/unit/database-query-codegen-template.test.ts
+++ b/tests/unit/database-query-codegen-template.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import blocklist from "@/lib/ssrf-blocklist.json" with { type: "json" };
+import databaseQueryTemplate from "@/lib/workflow/codegen/templates/database-query";
+
+// sdk.ts imports "server-only" at module load; stub for vitest.
+vi.mock("server-only", () => ({}));
+
+const { generateWorkflowSDKCode } = await import("@/lib/workflow/codegen/sdk");
+
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+
+// Mirrors lib/workflow/codegen/sdk.ts. If the SDK extractor changes, update
+// this regex in lockstep so the template's guard logic is still emitted into
+// exported workflows.
+const FUNCTION_BODY_REGEX =
+  /export\s+(?:async\s+)?function\s+\w+\s*\([^)]*\)\s*(?::\s*[^{]+)?\s*\{([\s\S]*)\}/;
+
+describe("database-query codegen template", () => {
+  it("interpolates the canonical SSRF blocklist JSON, not a hand-rolled copy", () => {
+    // Single source of truth: lib/ssrf-blocklist.json. Every entry in the
+    // canonical JSON must appear verbatim in the emitted template; if a new
+    // range is added to the JSON, this assertion catches divergence.
+    const literal = JSON.stringify(blocklist);
+    expect(databaseQueryTemplate).toContain(literal);
+  });
+
+  it("uses Node BlockList for CIDR checks (matches safe-fetch.ts pattern)", () => {
+    expect(databaseQueryTemplate).toContain('await import("node:net")');
+    expect(databaseQueryTemplate).toContain("new BlockList()");
+    expect(databaseQueryTemplate).toContain(
+      'blockList.addSubnet(addr, prefix, "ipv4")'
+    );
+    expect(databaseQueryTemplate).toContain(
+      'blockList.addSubnet(addr, prefix, "ipv6")'
+    );
+  });
+
+  it("includes hostname pre-DNS denylist using JSON-sourced exact/suffix sets", () => {
+    expect(databaseQueryTemplate).toContain("SSRF_BLOCKLIST.blockedHostExact");
+    expect(databaseQueryTemplate).toContain(
+      "SSRF_BLOCKLIST.blockedHostSuffixes"
+    );
+  });
+
+  it("returns the canonical error string used by lib/db/connection-host-guard", () => {
+    expect(databaseQueryTemplate).toContain(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(databaseQueryTemplate).toContain(
+      "Connection string is missing a host"
+    );
+    expect(databaseQueryTemplate).toContain("Host could not be resolved");
+  });
+
+  it("runs the guard before any postgres connection is opened", () => {
+    const postgresIdx = databaseQueryTemplate.indexOf(
+      "postgres.default(databaseUrl"
+    );
+    const guardIdx = databaseQueryTemplate.indexOf("isBlockedHostname(host)");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(postgresIdx).toBeGreaterThan(guardIdx);
+  });
+
+  it("is still extractable by the SDK function-body regex", () => {
+    const match = databaseQueryTemplate.match(FUNCTION_BODY_REGEX);
+    expect(match).not.toBeNull();
+    const body = match?.[1] ?? "";
+    expect(body).toContain("SSRF_BLOCKLIST");
+    expect(body).toContain("postgres.default(databaseUrl");
+  });
+
+  it("emits the guard into generated SDK code for a Database Query node", () => {
+    const trigger: WorkflowNode = {
+      id: "trigger-1",
+      type: "trigger",
+      position: { x: 0, y: 0 },
+      data: {
+        type: "trigger",
+        label: "Manual Trigger",
+        config: { triggerType: "Manual" },
+      },
+    };
+    const dbNode: WorkflowNode = {
+      id: "db-1",
+      type: "action",
+      position: { x: 0, y: 0 },
+      data: {
+        type: "action",
+        label: "Database Query",
+        config: {
+          actionType: "Database Query",
+          dbQuery: "SELECT 1",
+        },
+      },
+    };
+    const edge: WorkflowEdge = {
+      id: "trigger-1-db-1",
+      source: "trigger-1",
+      target: "db-1",
+    };
+
+    const code = generateWorkflowSDKCode(
+      "db_query_workflow",
+      [trigger, dbNode],
+      [edge]
+    );
+
+    // The canonical JSON literal is embedded in the emitted workflow.
+    expect(code).toContain(JSON.stringify(blocklist));
+    // Guard precedes the postgres call.
+    const guardIdx = code.indexOf("isBlockedHostname(host)");
+    const postgresIdx = code.indexOf("postgres.default(databaseUrl");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(postgresIdx).toBeGreaterThan(guardIdx);
+  });
+});

--- a/tests/unit/database-query-step.test.ts
+++ b/tests/unit/database-query-step.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Server-only guard module loads "server-only"; stub it for vitest.
+vi.mock("server-only", () => ({}));
+
+// Hoisted mocks shared by the vi.mock factories below.
+const { mockFetchCredentials, mockPostgres, mockLookup, mockWithStepLogging } =
+  vi.hoisted(() => ({
+    mockFetchCredentials: vi.fn(),
+    mockPostgres: vi.fn(),
+    mockLookup: vi.fn(),
+    mockWithStepLogging: vi.fn(
+      (_input: unknown, fn: () => unknown) => fn() as unknown
+    ),
+  }));
+
+vi.mock("@/lib/credential-fetcher", () => ({
+  fetchCredentials: (...args: unknown[]) =>
+    mockFetchCredentials(...(args as [string])),
+}));
+
+vi.mock("postgres", () => ({
+  default: (...args: unknown[]) => mockPostgres(...args),
+}));
+
+vi.mock("node:dns", () => ({
+  promises: { lookup: mockLookup },
+}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (...args: unknown[]) =>
+    mockWithStepLogging(...(args as [unknown, () => unknown])),
+}));
+
+import {
+  type DatabaseQueryInput,
+  databaseQueryStep,
+} from "@/lib/workflow/nodes/database-query/step";
+
+const STEP_INPUT_BASE: DatabaseQueryInput = {
+  integrationId: "integration-1",
+  dbQuery: "SELECT 1",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("databaseQueryStep guard wiring", () => {
+  it.each([
+    ["IPv4 IMDS link-local", "postgres://u:p@169.254.169.254:5432/db"],
+    ["IPv4 private 10/8", "postgres://u:p@10.0.0.5:5432/db"],
+    ["IPv4 loopback", "postgres://u:p@127.0.0.1:5432/db"],
+    ["IPv6 loopback bracketed", "postgres://u:p@[::1]:5432/db"],
+    ["IPv6 ULA bracketed", "postgres://u:p@[fc00::1]:5432/db"],
+  ])("rejects %s before opening a socket", async (_label, url) => {
+    mockFetchCredentials.mockResolvedValue({ DATABASE_URL: url });
+
+    const result = (await databaseQueryStep(STEP_INPUT_BASE)) as {
+      success: boolean;
+      error?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockPostgres).not.toHaveBeenCalled();
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["localhost", "postgres://u:p@localhost:5432/db"],
+    [
+      "k8s service DNS",
+      "postgres://u:p@db.keeperhub.svc.cluster.local:5432/db",
+    ],
+    [
+      "EC2 internal hostname",
+      "postgres://u:p@ip-10-0-0-5.us-east-2.compute.internal:5432/db",
+    ],
+    ["mDNS suffix", "postgres://u:p@db.local:5432/db"],
+  ])("rejects hostname pattern %s before any DNS lookup or socket", async (_label, url) => {
+    mockFetchCredentials.mockResolvedValue({ DATABASE_URL: url });
+
+    const result = (await databaseQueryStep(STEP_INPUT_BASE)) as {
+      success: boolean;
+      error?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockPostgres).not.toHaveBeenCalled();
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostname that resolves to a private address", async () => {
+    mockFetchCredentials.mockResolvedValue({
+      DATABASE_URL: "postgres://u:p@db.example:5432/db",
+    });
+    mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+
+    const result = (await databaseQueryStep(STEP_INPUT_BASE)) as {
+      success: boolean;
+      error?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Host is not allowed: must resolve to a public address"
+    );
+    expect(mockLookup).toHaveBeenCalled();
+    expect(mockPostgres).not.toHaveBeenCalled();
+  });
+
+  it("does not leak the connection string in the error", async () => {
+    const url =
+      "postgres://supersecretuser:supersecretpassword@10.0.0.1:5432/internal";
+    mockFetchCredentials.mockResolvedValue({ DATABASE_URL: url });
+
+    const result = (await databaseQueryStep(STEP_INPUT_BASE)) as {
+      success: boolean;
+      error?: string;
+    };
+
+    expect(result.success).toBe(false);
+    const error = result.error ?? "";
+    expect(error).not.toContain("supersecret");
+    expect(error).not.toContain("10.0.0.1");
+    expect(error).not.toContain("internal");
+  });
+});


### PR DESCRIPTION
## Summary

The runtime DB Query path was wired with the SSRF guard
(`assertConnectionUrlIsPublic` in `lib/db/connection-host-guard.ts`) in
the recent security hotfix, but the workflow code-export template at
`lib/workflow/codegen/templates/database-query.ts` had no guard. An
exported workflow could still dial RFC1918 / link-local / cluster-
internal hosts from the user's runtime.

## Changes

- Interpolate `lib/ssrf-blocklist.json` (the canonical source already
  consumed by `safe-fetch.ts` and `connection-host-guard.ts`) into the
  codegen template. The emitted user code uses Node `BlockList` for
  CIDR checks plus the JSON-sourced exact / suffix hostname denylist.
  NAT64 prefix and IPv4-mapped IPv6 special-cases are documented as
  intentionally omitted; the threat-relevant CIDRs (cloud metadata,
  RFC1918, link-local, cluster DNS) are covered.

- Add `tests/unit/database-query-step.test.ts` (11 cases) proving the
  runtime step rejects IMDS link-local, RFC1918, loopback, IPv6 ULA,
  localhost, k8s service DNS, EC2 internal hostnames, and DNS that
  resolves to a private address - before any `postgres()` socket is
  opened. Also asserts the connection string never leaks into the
  error.

- Add `tests/unit/database-query-codegen-template.test.ts` (7 cases)
  asserting the canonical JSON literal is embedded verbatim (catches
  future drift from `ssrf-blocklist.json`), the template uses Node
  `BlockList`, and the guard precedes `postgres.default` both in the
  template and in the SDK code emitted by `generateWorkflowSDKCode`
  for a Database Query node.

## Test Plan

- [x] `pnpm vitest run tests/unit/database-query-step.test.ts tests/unit/database-query-codegen-template.test.ts` - 18/18 pass
- [x] `pnpm vitest run tests/unit/connection-guards.test.ts tests/unit/safe-fetch.test.ts tests/unit/protocol-synthesiser-sdk.test.ts tests/integration/workflow-code-route.test.ts` - 202/202 pass (no regressions)
- [x] `pnpm type-check` - clean
- [x] Biome lint on the three touched files - clean
- [ ] Verify the exported workflow code for a Database Query node compiles and runs on a downstream consumer