### PR TITLE
ci: serialize keeperhub helm deploys per target branch

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -10,6 +10,17 @@ on:
         default: ''
 
 name: deploy-keeperhub
+
+# Serialize app deploys per target so two near-simultaneous pushes to the same
+# branch never run `helm upgrade` against the same release at once. Without this
+# the second run fails with "another operation (install/upgrade/rollback) is in
+# progress". cancel-in-progress is false: the second deploy queues behind the
+# first rather than cancelling an in-flight helm operation (cancelling mid-upgrade
+# is what leaves a release stuck in pending-*). Mirrors deploy-executor.yaml.
+concurrency:
+  group: deploy-keeperhub-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}


### PR DESCRIPTION
## Problem

The `deploy / deploy` job in the CI Pipeline intermittently fails with:

```
Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
```

This has been recurring and dismissed as transient. It is not. It is a deterministic concurrency collision.

## Root cause

`deploy-keeperhub.yaml` had no `concurrency` group. When two merges land on `staging` (or `prod`) close together, both push events fire the CI Pipeline, and both run `helm upgrade --install --atomic` against the **same** `keeperhub` release simultaneously. Helm permits only one in-flight operation per release, so the loser fails.

Evidence from the most recent occurrence (two merges 20s apart):

| Run | Job window | Result |
|-----|-----------|--------|
| 26265270391 (PR #1327) | deploy 02:52:08 -> 02:54:42 | held the helm lock, succeeded |
| 26265280448 (PR #1341) | deploy started 02:52:41 (mid-window) | failed 02:53:15: "another operation in progress" |

Re-running only ever "worked" because by retry time the other run had released the lock.

## Fix

Add a `concurrency` group keyed on `github.ref_name` so app deploys queue instead of racing. `cancel-in-progress: false` is deliberate: the second deploy waits for the first to finish rather than cancelling an in-flight helm operation -- cancelling mid-upgrade is precisely what leaves a release stuck in `pending-*`. Staging and prod still deploy in parallel (separate keys).

This mirrors the guard already present in `deploy-executor.yaml`, which is why the executor deploy never exhibits this failure.