### PR TITLE
fix: KEEP-613 gate workflow credential use on executor authorization

### DIFF
--- a/drizzle/0087_integration_visibility_grants.sql
+++ b/drizzle/0087_integration_visibility_grants.sql
@@ -1,0 +1,49 @@
+-- Per-integration authorization: gate credential use on the executing
+-- principal's grant, not just shared org membership.
+--
+-- Until now any member of an integration's organization could run a workflow
+-- referencing that integration and have its decrypted credentials used on
+-- their behalf (validateWorkflowIntegrations only checked organization_id ==
+-- workflow.organization_id). This migration introduces an explicit visibility
+-- model so credential use can be scoped to the owner, named members, or the
+-- whole org.
+--
+-- Backfill is deliberately non-breaking: existing org-scoped integrations are
+-- set to 'organization' so currently-working workflows keep running. New
+-- integrations default to 'private' (opt-in). Tightening an existing
+-- integration to private/specific_members is a follow-up owner action.
+
+CREATE TYPE "public"."integration_visibility" AS ENUM ('private', 'specific_members', 'organization');
+
+ALTER TABLE "integrations"
+  ADD COLUMN "visibility" "integration_visibility" NOT NULL DEFAULT 'private';
+
+-- Preserve current behaviour for already-shared org credentials. Personal
+-- (organization_id IS NULL) integrations stay 'private' (owner-only), which
+-- matches the pre-migration owner-scoped check for anonymous workflows.
+UPDATE "integrations"
+   SET "visibility" = 'organization'
+ WHERE "organization_id" IS NOT NULL;
+
+CREATE TABLE "integration_grants" (
+  "id" text PRIMARY KEY NOT NULL,
+  "integration_id" text NOT NULL,
+  "user_id" text NOT NULL,
+  "granted_by" text,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "integration_grants"
+  ADD CONSTRAINT "integration_grants_integration_id_integrations_id_fk"
+  FOREIGN KEY ("integration_id") REFERENCES "public"."integrations"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "integration_grants"
+  ADD CONSTRAINT "integration_grants_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "integration_grants"
+  ADD CONSTRAINT "integration_grants_granted_by_users_id_fk"
+  FOREIGN KEY ("granted_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+
+CREATE UNIQUE INDEX "idx_integration_grants_integration_user" ON "integration_grants" ("integration_id","user_id");
+CREATE INDEX "idx_integration_grants_user" ON "integration_grants" ("user_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1779430610634,
       "tag": "0086_drop_employee_only_signup_block",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1779670685294,
+      "tag": "0087_integration_visibility_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/credential-fetcher.ts
+++ b/lib/credential-fetcher.ts
@@ -18,6 +18,10 @@ import "server-only";
 import { PLUGIN_CREDENTIAL_MAP } from "./credential-map";
 import { buildDatabaseUrlFromConfig } from "./db/connection-utils";
 import { getIntegrationById } from "./db/integrations";
+import {
+  filterUnauthorizedIntegrationIds,
+  type IntegrationPrincipal,
+} from "./integrations/authorization";
 import type { IntegrationConfig, IntegrationType } from "./types/integration";
 
 // WorkflowCredentials is now a generic record since plugins define their own keys
@@ -78,14 +82,35 @@ function mapIntegrationConfig(
 }
 
 /**
- * Fetch credentials for an integration by ID
+ * Fetch credentials for an integration by ID.
+ *
+ * When `principal` is provided, the fetch is authorized against it (owner /
+ * organization visibility / specific_members grant) before any credential is
+ * decrypted, and returns no credentials if the principal is not authorized.
+ * This is runtime defense-in-depth: execution entry points already authorize
+ * the effective principal before dispatch, but only the owner-context
+ * (ownerId/organizationId) is available once a run is in flight, so steps pass
+ * that here to fail closed if a referenced id ever escapes the pre-execution
+ * check. Omitting `principal` preserves the prior unauthenticated behaviour.
  *
  * @param integrationId - The ID of the integration to fetch credentials for
+ * @param principal - Optional owner-context principal to authorize against
  * @returns WorkflowCredentials object with the integration's credentials
  */
 export async function fetchCredentials(
-  integrationId: string
+  integrationId: string,
+  principal?: IntegrationPrincipal
 ): Promise<WorkflowCredentials> {
+  if (principal) {
+    const unauthorized = await filterUnauthorizedIntegrationIds(
+      [integrationId],
+      principal
+    );
+    if (unauthorized.length > 0) {
+      return {};
+    }
+  }
+
   const integration = await getIntegrationById(integrationId);
   if (!integration) {
     return {};
@@ -98,7 +123,8 @@ export async function fetchCredentials(
  * Now fetches by integration ID instead of workflow ID
  */
 export function fetchIntegrationCredentials(
-  integrationId: string
+  integrationId: string,
+  principal?: IntegrationPrincipal
 ): Promise<WorkflowCredentials> {
-  return fetchCredentials(integrationId);
+  return fetchCredentials(integrationId, principal);
 }

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { toChecksumAddress } from "@/lib/address-utils";
+import { filterUnauthorizedIntegrationIds } from "@/lib/integrations/authorization";
 import {
   getOrganizationWallet,
   organizationHasWallet,
@@ -636,15 +637,19 @@ export function extractIntegrationIds(
 }
 
 /**
- * Validate that all integration IDs in workflow nodes either:
- * 1. Belong to the specified user (or organization), or
- * 2. Don't exist (deleted integrations - stale references are allowed)
+ * Validate that the executing/saving principal is authorized to use every
+ * integration referenced by a workflow's nodes.
  *
- * This prevents users from accessing other users' credentials by embedding
- * foreign integration IDs in their workflows, while allowing workflows
- * with references to deleted integrations to still be saved.
+ * Authorization is per-integration against the principal's grant (owner,
+ * organization visibility + membership, or an explicit specific_members
+ * grant) - not merely "same organization". This is what closes the
+ * lateral-movement path where any org member could run a workflow that
+ * referenced another member's credential. Non-existent ids (deleted
+ * integrations) stay valid so stale references remain savable.
  *
- * Updated to support organization context
+ * `userId` + `organizationId` together are the effective principal: the
+ * authenticated caller for interactive executions and saves, or the workflow
+ * owner for owner-context executions (webhook, scheduler, internal, MCP).
  *
  * @returns Object with `valid` boolean and optional `invalidIds` array
  */
@@ -659,29 +664,10 @@ export async function validateWorkflowIntegrations(
     return { valid: true };
   }
 
-  // Query for ALL integrations with these IDs (regardless of user/org)
-  // to check if any belong to other users/orgs
-  const existingIntegrations = await db
-    .select({
-      id: integrations.id,
-      userId: integrations.userId,
-      organizationId: integrations.organizationId,
-    })
-    .from(integrations)
-    .where(inArray(integrations.id, integrationIds));
-
-  // Find integrations that exist but belong to a different user/org
-  // (deleted integrations won't appear here, which is fine)
-  const invalidIds = existingIntegrations
-    .filter((i) => {
-      if (organizationId) {
-        // For org workflows, check org membership
-        return i.organizationId !== organizationId;
-      }
-      // For anonymous workflows, check user ownership
-      return i.userId !== userId;
-    })
-    .map((i) => i.id);
+  const invalidIds = await filterUnauthorizedIntegrationIds(integrationIds, {
+    userId,
+    organizationId: organizationId ?? null,
+  });
 
   if (invalidIds.length > 0) {
     return { valid: false, invalidIds };

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -384,6 +384,11 @@ export async function createIntegration(
       type,
       config: encryptedConfig,
       organizationId,
+      // Org-scoped integrations are team-shared by default so collaborative
+      // workflows keep working without a grant step; personal (no-org)
+      // integrations stay owner-only. Matches the migration backfill. Owners
+      // can later tighten an org integration to private/specific_members.
+      visibility: organizationId ? "organization" : "private",
     })
     .returning();
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -289,6 +289,17 @@ export const workflows = pgTable(
   ]
 );
 
+// Integration visibility controls which principals may use a credential at
+// workflow execution time (not just view it).
+// - private: only the owner (creator) may use it (default / opt-in)
+// - specific_members: the owner plus users with an integration_grants row
+// - organization: any current member of the owning organization may use it
+export const integrationVisibility = pgEnum("integration_visibility", [
+  "private",
+  "specific_members",
+  "organization",
+]);
+
 // Integrations table for storing user credentials
 export const integrations = pgTable(
   "integrations",
@@ -308,6 +319,9 @@ export const integrations = pgTable(
     config: jsonb("config").notNull().$type<any>(),
     // Whether this integration was created via OAuth (managed by app) vs manual entry
     isManaged: boolean("is_managed").default(false),
+    visibility: integrationVisibility("visibility")
+      .notNull()
+      .default("private"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
@@ -323,6 +337,36 @@ export const integrations = pgTable(
         sql`${table.type} = 'web3' AND ${table.organizationId} IS NOT NULL`
       ),
     index("idx_integrations_user_id").on(table.userId),
+  ]
+);
+
+// Per-user grants for integrations with visibility = 'specific_members'.
+// A row authorizes `userId` to use `integrationId` at execution time.
+// Rows are deleted (cascade) when the integration or grantee user is removed,
+// which is the lazy-revocation mechanism: dropping the row fails execution closed.
+export const integrationGrants = pgTable(
+  "integration_grants",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    integrationId: text("integration_id")
+      .notNull()
+      .references(() => integrations.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    grantedBy: text("granted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_integration_grants_integration_user").on(
+      table.integrationId,
+      table.userId
+    ),
+    index("idx_integration_grants_user").on(table.userId),
   ]
 );
 
@@ -885,6 +929,10 @@ export type ListedWorkflowView = Pick<
 >;
 export type Integration = typeof integrations.$inferSelect;
 export type NewIntegration = typeof integrations.$inferInsert;
+export type IntegrationVisibility =
+  (typeof integrationVisibility.enumValues)[number];
+export type IntegrationGrant = typeof integrationGrants.$inferSelect;
+export type NewIntegrationGrant = typeof integrationGrants.$inferInsert;
 export type WorkflowExecution = typeof workflowExecutions.$inferSelect;
 export type NewWorkflowExecution = typeof workflowExecutions.$inferInsert;
 export type WorkflowExecutionLog = typeof workflowExecutionLogs.$inferSelect;

--- a/lib/integrations/authorization.ts
+++ b/lib/integrations/authorization.ts
@@ -1,0 +1,158 @@
+import "server-only";
+
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  type IntegrationVisibility,
+  integrationGrants,
+  integrations,
+  users,
+} from "@/lib/db/schema";
+import { isUserMemberOfOrganization } from "@/lib/workflow/access";
+
+/**
+ * The identity whose grants gate credential use for a given execution.
+ *
+ * - Interactive executions: the authenticated caller.
+ * - Owner-context executions (webhook, scheduler, internal, MCP/agent): the
+ *   workflow owner. The caller's identity is not available once a run is
+ *   dispatched, so owner-context authorization is the only check possible at
+ *   runtime and is resolved up front at the execution entry point.
+ */
+export type IntegrationPrincipal = {
+  userId: string | null;
+  organizationId: string | null;
+};
+
+/** Minimal integration shape needed to make an authorization decision. */
+export type IntegrationAuthRow = {
+  id: string;
+  userId: string;
+  organizationId: string | null;
+  visibility: IntegrationVisibility;
+};
+
+type AuthContext = {
+  /** Owner of the integration is deactivated - credentials are frozen. */
+  isOwnerDeactivated: boolean;
+  /** Principal is a current member of its own organization. */
+  isPrincipalMember: boolean;
+  /** A specific_members grant exists for (integration, principal). */
+  hasGrant: boolean;
+};
+
+/**
+ * Pure authorization decision for a single (integration, principal) pair.
+ * No I/O - the caller resolves the AuthContext via batched queries. Kept pure
+ * so the rule table is unit-testable without a database.
+ */
+export function isIntegrationUsable(
+  integration: IntegrationAuthRow,
+  principal: IntegrationPrincipal,
+  ctx: AuthContext
+): boolean {
+  // A deactivated owner's credentials are frozen for everyone, including
+  // owner-context (scheduled/webhook) executions that would otherwise run as
+  // the now-deactivated owner. This is the lazy deactivation cascade.
+  if (ctx.isOwnerDeactivated) {
+    return false;
+  }
+
+  // Owner may always use their own integration.
+  if (principal.userId !== null && principal.userId === integration.userId) {
+    return true;
+  }
+
+  switch (integration.visibility) {
+    case "organization":
+      return (
+        integration.organizationId !== null &&
+        integration.organizationId === principal.organizationId &&
+        ctx.isPrincipalMember
+      );
+    case "specific_members":
+      return ctx.hasGrant;
+    default:
+      // "private" - only the owner, handled above.
+      return false;
+  }
+}
+
+/**
+ * Given a set of integration ids and the executing principal, return the
+ * subset the principal is NOT authorized to use.
+ *
+ * Non-existent ids (e.g. deleted integrations) are treated as authorized -
+ * stale references must stay savable and must not leak existence. All
+ * context lookups (membership, grants, owner deactivation) are batched into a
+ * single query each to avoid N+1.
+ */
+export async function filterUnauthorizedIntegrationIds(
+  integrationIds: string[],
+  principal: IntegrationPrincipal
+): Promise<string[]> {
+  if (integrationIds.length === 0) {
+    return [];
+  }
+
+  const rows = await db
+    .select({
+      id: integrations.id,
+      userId: integrations.userId,
+      organizationId: integrations.organizationId,
+      visibility: integrations.visibility,
+    })
+    .from(integrations)
+    .where(inArray(integrations.id, integrationIds));
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const isPrincipalMember =
+    principal.userId !== null && principal.organizationId !== null
+      ? await isUserMemberOfOrganization(
+          principal.userId,
+          principal.organizationId
+        )
+      : false;
+
+  const grantedIds = new Set<string>();
+  if (principal.userId !== null) {
+    const grantRows = await db
+      .select({ integrationId: integrationGrants.integrationId })
+      .from(integrationGrants)
+      .where(
+        and(
+          inArray(integrationGrants.integrationId, integrationIds),
+          eq(integrationGrants.userId, principal.userId)
+        )
+      );
+    for (const grant of grantRows) {
+      grantedIds.add(grant.integrationId);
+    }
+  }
+
+  const ownerIds = [...new Set(rows.map((row) => row.userId))];
+  const deactivatedOwners = new Set<string>();
+  const deactivatedRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(and(inArray(users.id, ownerIds), isNotNull(users.deactivatedAt)));
+  for (const user of deactivatedRows) {
+    deactivatedOwners.add(user.id);
+  }
+
+  const unauthorized: string[] = [];
+  for (const row of rows) {
+    const usable = isIntegrationUsable(row, principal, {
+      isOwnerDeactivated: deactivatedOwners.has(row.userId),
+      isPrincipalMember,
+      hasGrant: grantedIds.has(row.id),
+    });
+    if (!usable) {
+      unauthorized.push(row.id);
+    }
+  }
+  return unauthorized;
+}

--- a/lib/workflow/access.ts
+++ b/lib/workflow/access.ts
@@ -28,7 +28,7 @@ export type WorkflowAccess = {
   isDeleted: boolean;
 };
 
-async function isUserMemberOfOrganization(
+export async function isUserMemberOfOrganization(
   userId: string,
   organizationId: string
 ): Promise<boolean> {

--- a/lib/workflow/nodes/database-query/step.ts
+++ b/lib/workflow/nodes/database-query/step.ts
@@ -122,7 +122,10 @@ async function databaseQuery(
   }
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, {
+        userId: input._context?.ownerId ?? null,
+        organizationId: input._context?.organizationId ?? null,
+      })
     : {};
 
   const databaseUrl = credentials.DATABASE_URL;

--- a/tests/integration/execute-route-integration-authz.test.ts
+++ b/tests/integration/execute-route-integration-authz.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Route-level wiring for per-integration authorization (KEEP-613).
+ *
+ * The rule table is unit-tested in tests/unit/integration-authorization.test.ts.
+ * This proves the execute route honors an unauthorized result: it must return
+ * 403 and must call validateWorkflowIntegrations with the CALLER's principal
+ * (not the workflow owner) on the interactive path - the line that closes the
+ * lateral-movement hole.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("workflow/api", () => ({ start: vi.fn() }));
+
+const mockAuthenticateInternalService = vi.fn();
+const mockGetDualAuthContext = vi.fn();
+const mockGetWorkflowAccess = vi.fn();
+const mockValidateWorkflowIntegrations = vi.fn();
+const mockFindWorkflow = vi.fn();
+
+vi.mock("@/lib/internal-service-auth", () => ({
+  authenticateInternalService: mockAuthenticateInternalService,
+}));
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+}));
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: mockGetWorkflowAccess,
+}));
+vi.mock("@/lib/db/integrations", () => ({
+  validateWorkflowIntegrations: mockValidateWorkflowIntegrations,
+}));
+vi.mock("@/lib/db", () => ({
+  db: { query: { workflows: { findFirst: mockFindWorkflow } } },
+}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
+  logSystemError: vi.fn(),
+}));
+
+// Workflow owned by user A in org_1, referencing a private integration A owns.
+const workflow = {
+  id: "wf_1",
+  userId: "owner_a",
+  organizationId: "org_1",
+  nodes: [
+    {
+      id: "node-1",
+      type: "action",
+      data: { config: { integrationId: "int_priv" } },
+    },
+  ],
+  edges: [],
+  deletedAt: null,
+  isAnonymous: false,
+};
+
+async function callExecute(): Promise<Response> {
+  const { POST } = await import(
+    "@/app/api/workflow/[workflowId]/execute/route"
+  );
+  const request = new Request("http://localhost/api/workflow/wf_1/execute", {
+    method: "POST",
+    body: JSON.stringify({}),
+  });
+  return POST(request, { params: Promise.resolve({ workflowId: "wf_1" }) });
+}
+
+describe("execute route - per-integration authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthenticateInternalService.mockReturnValue({ authenticated: false });
+    mockFindWorkflow.mockResolvedValue(workflow);
+    mockGetWorkflowAccess.mockResolvedValue({
+      isCreatorWithCurrentAccess: false,
+      isSameOrg: true,
+      hasFullAccess: true,
+      isDeleted: false,
+    });
+  });
+
+  it("returns 403 when the caller is not authorized for a referenced integration", async () => {
+    // member_b has workflow access (same org) but is not authorized for the
+    // owner's private integration.
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "member_b",
+      organizationId: "org_1",
+      authMethod: "session",
+      apiKeyId: null,
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({
+      valid: false,
+      invalidIds: ["int_priv"],
+    });
+
+    const response = await callExecute();
+
+    expect(response.status).toBe(403);
+  });
+
+  it("authorizes against the caller's principal, not the workflow owner", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "member_b",
+      organizationId: "org_1",
+      authMethod: "session",
+      apiKeyId: null,
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({
+      valid: false,
+      invalidIds: ["int_priv"],
+    });
+
+    await callExecute();
+
+    // The crux of the fix: the caller (member_b) is the principal, not the
+    // workflow owner (owner_a). The org dimension is the workflow's org.
+    expect(mockValidateWorkflowIntegrations).toHaveBeenCalledWith(
+      workflow.nodes,
+      "member_b",
+      "org_1"
+    );
+  });
+});

--- a/tests/unit/integration-authorization.test.ts
+++ b/tests/unit/integration-authorization.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Per-integration authorization (KEEP-613).
+ *
+ * The pure rule table (isIntegrationUsable) is the security boundary that
+ * gates credential use on the executing principal's grant rather than mere
+ * shared-org membership. filterUnauthorizedIntegrationIds wires that rule to
+ * batched DB lookups; it is tested with the db client and membership helper
+ * mocked so the suite stays hermetic.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { fixtures, mockIsMember } = vi.hoisted(() => ({
+  fixtures: {
+    integrations: [] as unknown[],
+    grants: [] as unknown[],
+    users: [] as unknown[],
+  },
+  mockIsMember: vi.fn<(userId: string, orgId: string) => Promise<boolean>>(),
+}));
+
+// Dispatch the db.select().from(table).where() chain by drizzle's table-name
+// symbol so the three batched queries resolve to their own fixtures.
+const DRIZZLE_NAME = Symbol.for("drizzle:Name");
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: (table: Record<symbol, string>) => ({
+        where: () => {
+          const name = table[DRIZZLE_NAME];
+          if (name === "integrations") {
+            return Promise.resolve(fixtures.integrations);
+          }
+          if (name === "integration_grants") {
+            return Promise.resolve(fixtures.grants);
+          }
+          if (name === "users") {
+            return Promise.resolve(fixtures.users);
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: mockIsMember,
+}));
+
+import {
+  filterUnauthorizedIntegrationIds,
+  type IntegrationAuthRow,
+  isIntegrationUsable,
+} from "@/lib/integrations/authorization";
+
+const NO_CTX = {
+  isOwnerDeactivated: false,
+  isPrincipalMember: false,
+  hasGrant: false,
+};
+
+function row(overrides: Partial<IntegrationAuthRow>): IntegrationAuthRow {
+  return {
+    id: "int_1",
+    userId: "owner_1",
+    organizationId: "org_1",
+    visibility: "private",
+    ...overrides,
+  };
+}
+
+describe("isIntegrationUsable", () => {
+  it("allows the owner to use their own private integration", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "private" }),
+        { userId: "owner_1", organizationId: "org_1" },
+        NO_CTX
+      )
+    ).toBe(true);
+  });
+
+  it("denies a non-owner on a private integration (the closed lateral-movement path)", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "private" }),
+        { userId: "member_b", organizationId: "org_1" },
+        { ...NO_CTX, isPrincipalMember: true }
+      )
+    ).toBe(false);
+  });
+
+  it("allows an org member on an organization-visible integration in the same org", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "organization" }),
+        { userId: "member_b", organizationId: "org_1" },
+        { ...NO_CTX, isPrincipalMember: true }
+      )
+    ).toBe(true);
+  });
+
+  it("denies a non-member on an organization-visible integration", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "organization" }),
+        { userId: "member_b", organizationId: "org_1" },
+        { ...NO_CTX, isPrincipalMember: false }
+      )
+    ).toBe(false);
+  });
+
+  it("denies when the principal's org differs from the integration's org", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "organization", organizationId: "org_1" }),
+        { userId: "member_b", organizationId: "org_2" },
+        { ...NO_CTX, isPrincipalMember: true }
+      )
+    ).toBe(false);
+  });
+
+  it("denies organization visibility when the integration has no org", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "organization", organizationId: null }),
+        { userId: "member_b", organizationId: null },
+        { ...NO_CTX, isPrincipalMember: true }
+      )
+    ).toBe(false);
+  });
+
+  it("allows a specific member only when a grant exists", () => {
+    const integration = row({ visibility: "specific_members" });
+    const principal = { userId: "member_b", organizationId: "org_1" };
+    expect(
+      isIntegrationUsable(integration, principal, { ...NO_CTX, hasGrant: true })
+    ).toBe(true);
+    expect(
+      isIntegrationUsable(integration, principal, {
+        ...NO_CTX,
+        hasGrant: false,
+      })
+    ).toBe(false);
+  });
+
+  it("freezes credentials when the owner is deactivated, even for the owner-context principal", () => {
+    expect(
+      isIntegrationUsable(
+        row({ visibility: "organization" }),
+        { userId: "owner_1", organizationId: "org_1" },
+        { ...NO_CTX, isOwnerDeactivated: true, isPrincipalMember: true }
+      )
+    ).toBe(false);
+  });
+});
+
+describe("filterUnauthorizedIntegrationIds", () => {
+  beforeEach(() => {
+    fixtures.integrations = [];
+    fixtures.grants = [];
+    fixtures.users = [];
+    mockIsMember.mockReset();
+    mockIsMember.mockResolvedValue(false);
+  });
+
+  it("returns nothing for an empty id list without querying", async () => {
+    expect(
+      await filterUnauthorizedIntegrationIds([], {
+        userId: "u",
+        organizationId: "o",
+      })
+    ).toEqual([]);
+  });
+
+  it("treats non-existent ids as authorized (stale references stay savable)", async () => {
+    fixtures.integrations = [];
+    expect(
+      await filterUnauthorizedIntegrationIds(["missing"], {
+        userId: "member_b",
+        organizationId: "org_1",
+      })
+    ).toEqual([]);
+  });
+
+  it("flags a private integration referenced by a same-org non-owner (regression guard)", async () => {
+    fixtures.integrations = [
+      {
+        id: "int_1",
+        userId: "owner_1",
+        organizationId: "org_1",
+        visibility: "private",
+      },
+    ];
+    mockIsMember.mockResolvedValue(true);
+
+    expect(
+      await filterUnauthorizedIntegrationIds(["int_1"], {
+        userId: "member_b",
+        organizationId: "org_1",
+      })
+    ).toEqual(["int_1"]);
+  });
+
+  it("authorizes an org-visible integration for a member but flags one without a grant", async () => {
+    fixtures.integrations = [
+      {
+        id: "org_int",
+        userId: "owner_1",
+        organizationId: "org_1",
+        visibility: "organization",
+      },
+      {
+        id: "specific_int",
+        userId: "owner_1",
+        organizationId: "org_1",
+        visibility: "specific_members",
+      },
+    ];
+    fixtures.grants = []; // member_b has no grant on specific_int
+    mockIsMember.mockResolvedValue(true);
+
+    expect(
+      await filterUnauthorizedIntegrationIds(["org_int", "specific_int"], {
+        userId: "member_b",
+        organizationId: "org_1",
+      })
+    ).toEqual(["specific_int"]);
+  });
+
+  it("flags every integration whose owner is deactivated", async () => {
+    fixtures.integrations = [
+      {
+        id: "org_int",
+        userId: "owner_1",
+        organizationId: "org_1",
+        visibility: "organization",
+      },
+    ];
+    fixtures.users = [{ id: "owner_1" }]; // owner_1 is deactivated
+    mockIsMember.mockResolvedValue(true);
+
+    expect(
+      await filterUnauthorizedIntegrationIds(["org_int"], {
+        userId: "member_b",
+        organizationId: "org_1",
+      })
+    ).toEqual(["org_int"]);
+  });
+});


### PR DESCRIPTION
## Summary

Workflow execution authorized integration references on org membership alone: `validateWorkflowIntegrations` only checked that an integration belonged to the same organization as the workflow, never that the executing principal was authorized to use that specific credential. Any org member (or agent invocation) could run a workflow referencing another member's integration and have its decrypted credentials used on their behalf - a lateral-movement path. A second gap: the runtime credential fetch (`fetchCredentials` -> `getIntegrationById`) decrypted any integration by id with no authorization at all.

This introduces an explicit per-integration grant model and authorizes credential use against the executing principal at every execution and save entry point.

## Changes

- **Schema**: new `integration_visibility` enum (`private` | `specific_members` | `organization`) and a `visibility` column on `integrations` (column default `private`); new `integration_grants` table for per-user grants. Migration `0087` backfills existing org-scoped integrations to `organization` so current workflows keep running; personal integrations stay `private`.
- **Authorization predicate** (`lib/integrations/authorization.ts`): `isIntegrationUsable` (pure rule table) + `filterUnauthorizedIntegrationIds` (batched membership/grant/deactivation lookups, no N+1).
- **Primary gate (the fix)**: `validateWorkflowIntegrations` now delegates to the predicate and runs at every execution and save entry point, authorizing each referenced integration against the effective principal *before* the run is dispatched. The existing `(userId, organizationId)` arguments already carry that principal at all 8 call sites (authenticated caller for interactive executions/saves; workflow owner for webhook/scheduler/internal/MCP), so no call-site changes were needed. This is the sole gate that closes the caller-based lateral-movement path.
- **Runtime guard (owner-context only, not a caller backstop)**: once a run is dispatched, only the owner-context (`ownerId`/`organizationId`) is available - the interactive caller's identity is gone. `fetchCredentials` therefore takes an optional owner-context principal and authorizes against it before decrypt, failing closed. This only catches "the workflow owner itself cannot use this integration" cases (e.g. a referenced id that escaped the pre-execution check); it does **not** re-authorize the interactive caller, so it is not a backstop for the primary threat - the pre-execution gate above is. Wired into the database-query system step.
- **Creation default**: new org-scoped integrations are created with `organization` visibility (team-shared); personal/no-org integrations stay `private`. Keeps collaborative workflows working without a grant UI while still blocking cross-org and personal-credential access.
- **Lazy revocation/deactivation**: grant rows cascade-delete with the integration or grantee; a deactivated owner's credentials freeze. No proactive workflow disabling - enforcement is at execution time.

## Behavior notes

- Backfill + creation default are intentionally non-breaking: org integrations (existing and new) are usable by org members until an owner tightens them to `private`/`specific_members`; personal integrations are owner-only.
- The `organization` visibility check is anchored to the workflow's organization (not the caller's active-org header) plus current membership.
- Save now rejects referencing an integration the saver is not authorized for (previously any same-org integration was allowed).

## Follow-ups (out of scope here)

- Grant-management UI and the specific-members granting UX (no in-product way to grant `specific_members` access yet).
- Threading the owner-context principal through the remaining plugin steps to complete the runtime guard (the pre-execution gate already covers them for the primary threat).
- Eager cascade: proactively flagging dependent workflows on revocation.

## Test Plan

Validated by the `test-unit` and `test-integration` CI jobs (vitest), which run `vitest run tests/unit` and `vitest run tests/integration` - both new test files live in those globs and pass. The Playwright E2E suite (`test:e2e`) is a separate runner that does not cover this path and is skipped on this PR, so E2E does not gate this change.

- [x] Unit: authorization rule table + batch helper, incl. a regression guard (same-org non-owner referencing a private integration is rejected) - runs in `test-unit`
- [x] Route-level: execute route returns 403 for an unauthorized reference and authorizes against the caller's principal (not the owner) - runs in `test-integration`
- [x] `pnpm type-check` clean
- [x] Migration applies cleanly to a fresh DB; FKs/indexes and backfill verified locally (note: the repo's `migrate-check` drift step relies on `drizzle-kit generate`, which currently errors on a pre-existing snapshot-id collision in `drizzle/meta` - unrelated to this PR)
- [ ] Manual verification on staging
