### PR TITLE
fix: drop runtime Turnstile site key env that blocked pod startup

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -219,13 +219,11 @@ env:
     type: parameterStore
     name: next-public-google-client-id
     parameter_name: /eks/techops-prod/keeperhub/google-client-id
-  # Cloudflare Turnstile (signup captcha). Site key is also baked into the
-  # client bundle at build time (build-images.yml); this runtime entry covers
-  # server-side reads. Secret key is server-only (lib/auth.ts).
-  NEXT_PUBLIC_TURNSTILE_SITE_KEY:
-    type: parameterStore
-    name: next-public-turnstile-site-key
-    parameter_name: /eks/techops-prod/keeperhub/turnstile-site-key
+  # Cloudflare Turnstile (signup captcha). The public site key is baked into
+  # the client bundle at build time (NEXT_PUBLIC_TURNSTILE_SITE_KEY build arg,
+  # sourced from a GitHub Actions variable) and is never read server-side, so
+  # it is intentionally NOT a runtime env here. Only the secret key is needed
+  # at runtime (lib/auth.ts).
   TURNSTILE_SECRET_KEY:
     type: parameterStore
     name: turnstile-secret-key

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -209,13 +209,11 @@ env:
     type: parameterStore
     name: next-public-google-client-id
     parameter_name: /eks/techops-staging/keeperhub/google-client-id
-  # Cloudflare Turnstile (signup captcha). Site key is also baked into the
-  # client bundle at build time (build-images.yml); this runtime entry covers
-  # server-side reads. Secret key is server-only (lib/auth.ts).
-  NEXT_PUBLIC_TURNSTILE_SITE_KEY:
-    type: parameterStore
-    name: next-public-turnstile-site-key
-    parameter_name: /eks/techops-staging/keeperhub/turnstile-site-key
+  # Cloudflare Turnstile (signup captcha). The public site key is baked into
+  # the client bundle at build time (NEXT_PUBLIC_TURNSTILE_SITE_KEY build arg,
+  # sourced from a GitHub Actions variable) and is never read server-side, so
+  # it is intentionally NOT a runtime env here. Only the secret key is needed
+  # at runtime (lib/auth.ts).
   TURNSTILE_SECRET_KEY:
     type: parameterStore
     name: turnstile-secret-key

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -190,13 +190,11 @@ env:
     type: parameterStore
     name: next-public-google-client-id
     parameter_name: /eks/techops-staging/keeperhub/google-client-id
-  # Cloudflare Turnstile (signup captcha). PR envs reuse the staging keys.
-  # Site key is also baked into the client bundle at build time
-  # (build-images.yml); this runtime entry covers server-side reads.
-  NEXT_PUBLIC_TURNSTILE_SITE_KEY:
-    type: parameterStore
-    name: next-public-turnstile-site-key
-    parameter_name: /eks/techops-staging/keeperhub/turnstile-site-key
+  # Cloudflare Turnstile (signup captcha). PR envs reuse the staging secret.
+  # The public site key is baked into the client bundle at build time
+  # (NEXT_PUBLIC_TURNSTILE_SITE_KEY build arg, sourced from a GitHub Actions
+  # variable) and is never read server-side, so it is intentionally NOT a
+  # runtime env here. Only the secret key is needed at runtime (lib/auth.ts).
   TURNSTILE_SECRET_KEY:
     type: parameterStore
     name: turnstile-secret-key


### PR DESCRIPTION
## Problem

After the Turnstile PR merged to staging, the `keeperhub-common` deployment never advanced to the new image. The new pod stuck in `CreateContainerConfigError`:

```
Error: secret "keeperhub-common-next-public-turnstile-site-key" not found
```

The app container references `NEXT_PUBLIC_TURNSTILE_SITE_KEY` from a runtime secret, but that secret's ExternalSecret never synced (the SSM param `/eks/techops-*/keeperhub/turnstile-site-key` isn't present). Container can't be created -> pod never passes its tcp readiness probe -> `helm --atomic` rolls the release back to the previous image. Result: staging (and the PR environments) silently stayed on the pre-Turnstile build with no widget.

## Fix

Remove the `NEXT_PUBLIC_TURNSTILE_SITE_KEY` `parameterStore` entry from the staging, prod, and pr-environment values. The public site key is **inlined into the client bundle at build time** via the build arg (sourced from a GitHub Actions variable) and is never read server-side, so it never needed to be a runtime env. Only `TURNSTILE_SECRET_KEY` (server-side) and `TURNSTILE_ENFORCE` remain.

## Why it's safe

- Client widget reads the build-time-baked value - unaffected.
- Server (`lib/auth.ts`) only reads `TURNSTILE_SECRET_KEY` - unaffected.
- Removes a hard dependency on a non-existent SSM param that was blocking pod startup in every environment.

## Prerequisite

The pod's only remaining Turnstile runtime dependency is `TURNSTILE_SECRET_KEY` <- `/eks/<env>/keeperhub/turnstile-secret-key`. That param must exist and be readable by external-secrets, or the pod will hit the same `CreateContainerConfigError` on the secret key instead.