### PR TITLE
ci: build NEXT_PUBLIC_* from SSM Parameter Store

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -34,13 +34,16 @@ jobs:
       ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       # INCLUDE_TEST_ENDPOINTS is derived from ENVIRONMENT_TAG in the
       # "Derive build flags" step below (KEEP-237).
+      # Static NEXT_PUBLIC_* flags with no Parameter Store backing stay as
+      # GHA environment vars.
       NEXT_PUBLIC_AUTH_PROVIDERS: ${{ vars.NEXT_PUBLIC_AUTH_PROVIDERS }}
-      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
       NEXT_PUBLIC_BILLING_ENABLED: ${{ vars.NEXT_PUBLIC_BILLING_ENABLED }}
       NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: ${{ vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED }}
-      NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-      NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+      # NEXT_PUBLIC_GITHUB_CLIENT_ID, NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+      # NEXT_PUBLIC_TURNSTILE_SITE_KEY and NEXT_PUBLIC_SENTRY_DSN are read from
+      # SSM Parameter Store in the "Fetch NEXT_PUBLIC_* from SSM" step so the
+      # values baked into the client bundle match what the running pods read at
+      # runtime via External Secrets (single source of truth, no drift).
       SENTRY_ORG: ${{ vars.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -111,6 +114,36 @@ jobs:
         run: |
           echo "::error::Cannot skip build: one or more images for ${{ steps.vars.outputs.sha_short }} do not exist in ECR. Remove [skip build] from the commit message or push a build first."
           exit 1
+
+      # Source the SSM-backed NEXT_PUBLIC_* values at build time so the values
+      # inlined into the client bundle are identical to what the running pods
+      # read from the same Parameter Store paths via External Secrets. Runs in
+      # the per-environment GitHub Environment (prod|staging) so vars/secrets -
+      # including the AWS creds configured above - resolve to the right account.
+      #
+      # Path is per-environment via ${ENVIRONMENT_TAG} (prod|staging).
+      # Region is NOT the cluster/ECR region (TO_REGION): SSM is centralized in
+      # us-east-2 (staging clusters run in us-east-1, prod in us-east-2), so the
+      # read uses a dedicated SSM_REGION that defaults to us-east-2 and can be
+      # overridden per environment via the SSM_REGION variable if that changes.
+      - name: Fetch NEXT_PUBLIC_* from SSM
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        env:
+          SSM_PREFIX: /eks/techops-${{ env.ENVIRONMENT_TAG }}/keeperhub
+          SSM_REGION: ${{ vars.SSM_REGION || 'us-east-2' }}
+        run: |
+          set -euo pipefail
+          fetch() {
+            local var="$1" path="$2" val
+            val=$(aws ssm get-parameter --name "$path" --with-decryption \
+              --query 'Parameter.Value' --output text --region "$SSM_REGION")
+            echo "::add-mask::$val"
+            echo "$var=$val" >> "$GITHUB_ENV"
+          }
+          fetch NEXT_PUBLIC_TURNSTILE_SITE_KEY "$SSM_PREFIX/turnstile-site-key"
+          fetch NEXT_PUBLIC_GITHUB_CLIENT_ID   "$SSM_PREFIX/github-client-id"
+          fetch NEXT_PUBLIC_GOOGLE_CLIENT_ID   "$SSM_PREFIX/google-client-id"
+          fetch NEXT_PUBLIC_SENTRY_DSN         "$SSM_PREFIX/next-public-sentry-dsn"
 
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -133,11 +133,13 @@ jobs:
           SSM_REGION: ${{ vars.SSM_REGION || 'us-east-2' }}
         run: |
           set -euo pipefail
+          # These are NEXT_PUBLIC_* values - inlined into the client bundle and
+          # therefore public - so they are deliberately not masked. Keeping them
+          # visible in build logs is what makes baked-vs-runtime drift debuggable.
           fetch() {
             local var="$1" path="$2" val
             val=$(aws ssm get-parameter --name "$path" --with-decryption \
               --query 'Parameter.Value' --output text --region "$SSM_REGION")
-            echo "::add-mask::$val"
             echo "$var=$val" >> "$GITHUB_ENV"
           }
           fetch NEXT_PUBLIC_TURNSTILE_SITE_KEY "$SSM_PREFIX/turnstile-site-key"

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -189,6 +189,29 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      # Mirror build-images.yml: source the SSM-backed NEXT_PUBLIC_* values for
+      # the app image from Parameter Store so PR-environment bundles match what
+      # build-images.yml bakes and what the pods read at runtime. PR envs run in
+      # the staging GitHub Environment and use the staging parameter tree.
+      # Region is us-east-2 (where SSM lives), not the cluster region (TO_REGION
+      # is us-east-1 for staging).
+      - name: Fetch NEXT_PUBLIC_* from SSM
+        if: matrix.image.build_args == true && steps.check-image.outputs.exists != 'true'
+        env:
+          SSM_PREFIX: /eks/techops-staging/keeperhub
+          SSM_REGION: ${{ vars.SSM_REGION || 'us-east-2' }}
+        run: |
+          set -euo pipefail
+          fetch() {
+            local var="$1" path="$2" val
+            val=$(aws ssm get-parameter --name "$path" --with-decryption \
+              --query 'Parameter.Value' --output text --region "$SSM_REGION")
+            echo "$var=$val" >> "$GITHUB_ENV"
+          }
+          fetch NEXT_PUBLIC_TURNSTILE_SITE_KEY "$SSM_PREFIX/turnstile-site-key"
+          fetch NEXT_PUBLIC_GITHUB_CLIENT_ID   "$SSM_PREFIX/github-client-id"
+          fetch NEXT_PUBLIC_GOOGLE_CLIENT_ID   "$SSM_PREFIX/google-client-id"
+
       - name: Build and push image
         if: steps.check-image.outputs.exists != 'true'
         uses: docker/build-push-action@v7
@@ -198,7 +221,7 @@ jobs:
           target: ${{ matrix.image.target }}
           push: true
           provenance: false
-          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, vars.NEXT_PUBLIC_GITHUB_CLIENT_ID, vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY) || '' }}
+          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, env.NEXT_PUBLIC_GITHUB_CLIENT_ID, env.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, env.NEXT_PUBLIC_TURNSTILE_SITE_KEY) || '' }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.tag_prefix }}-${{ steps.vars.outputs.sha_short }}
           cache-from: |


### PR DESCRIPTION
## What

Make SSM Parameter Store the single source of truth for the SSM-backed `NEXT_PUBLIC_*` build args, so the values inlined into the client bundle match what the pods read at runtime via External Secrets - no build/runtime drift.

### `build-images.yml` (staging + prod builds)
Source these from SSM instead of GitHub Actions `vars`:
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`
- `NEXT_PUBLIC_GITHUB_CLIENT_ID`
- `NEXT_PUBLIC_GOOGLE_CLIENT_ID`
- `NEXT_PUBLIC_SENTRY_DSN`

Static flags with no Parameter Store backing (`NEXT_PUBLIC_AUTH_PROVIDERS`, `NEXT_PUBLIC_BILLING_ENABLED`, `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED`) stay as `vars`.

### `deploy-pr-environment.yaml` (PR ephemeral envs)
Mirror the same change for the app image so PR-environment bundles are consistent with staging/prod builds. PR envs run in the staging GitHub Environment and read the staging parameter tree (turnstile site key, github + google client IDs; sentry DSN is not a build arg here). Static flags stay as `vars`.

### Public values are not masked
`NEXT_PUBLIC_*` are inlined into the client bundle and shipped to browsers, so they are deliberately not `::add-mask::`ed - masking gives no security benefit and would hide the baked values that make drift debuggable.

## Why

These values are inlined by `next build`. Previously the build-time copies came from GitHub Actions `vars` and the runtime copies came from SSM - two independent sources that could drift (e.g. a Turnstile site key baked into the bundle not matching the secret key the server verifies). Sourcing both from the same Parameter Store paths removes the drift.

## Environment handling

- **Path** is per-environment: `/eks/techops-${ENVIRONMENT_TAG}/keeperhub/...` in `build-images.yml` (`prod` on the `prod` branch, else `staging`); `deploy-pr-environment.yaml` hardcodes the staging tree.
- **Account**: jobs run in the per-environment GitHub Environment, so `secrets.TO_AWS_*` resolve to the correct account.
- **Region** uses a dedicated `SSM_REGION` (default `us-east-2`, overridable via the `SSM_REGION` variable). Deliberately NOT `TO_REGION`: SSM is centralized in us-east-2, while the staging cluster runs in us-east-1.
- Fail-fast: `set -euo pipefail` + per-param `get-parameter` means a missing param / denied permission fails the build loudly rather than baking an empty value. (A batch `get-parameters` was considered and rejected - it silently drops missing names into `InvalidParameters`, defeating fail-fast.)
- Follows the existing `aws ssm get-parameter` precedent in `deploy-keeperhub.yaml`.

## Verified

- Staging: all 4 SSM params exist (synced secrets confirmed), build creds proven to read staging SSM (existing deploy-job read), region us-east-2, paths match `values.yaml`. Staging is fully satisfied.
- Prod: 3/4 params confirmed present via synced secrets; paths match `prod/values.yaml`; region us-east-2 confirmed.

## Verify before this reaches prod

- [ ] `/eks/techops-prod/keeperhub/turnstile-site-key` exists in prod SSM (us-east-2). It has no consumer in prod yet (turnstile signup not promoted), so it could not be confirmed from the cluster. If missing, the first prod build fails at the fetch step.
- [ ] Prod environment `TO_AWS_*` has `ssm:GetParameter` on `/eks/techops-prod/keeperhub/*` (staging is proven; prod is assumed).

This merges to `staging` where everything is satisfied; the prod items are a staging-to-prod promotion gate, not a staging-merge blocker.