### PR TITLE
ci: revert SSM-sourced NEXT_PUBLIC_* build args (#1362)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -34,16 +34,13 @@ jobs:
       ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       # INCLUDE_TEST_ENDPOINTS is derived from ENVIRONMENT_TAG in the
       # "Derive build flags" step below (KEEP-237).
-      # Static NEXT_PUBLIC_* flags with no Parameter Store backing stay as
-      # GHA environment vars.
       NEXT_PUBLIC_AUTH_PROVIDERS: ${{ vars.NEXT_PUBLIC_AUTH_PROVIDERS }}
+      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
       NEXT_PUBLIC_BILLING_ENABLED: ${{ vars.NEXT_PUBLIC_BILLING_ENABLED }}
       NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: ${{ vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED }}
-      # NEXT_PUBLIC_GITHUB_CLIENT_ID, NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-      # NEXT_PUBLIC_TURNSTILE_SITE_KEY and NEXT_PUBLIC_SENTRY_DSN are read from
-      # SSM Parameter Store in the "Fetch NEXT_PUBLIC_* from SSM" step so the
-      # values baked into the client bundle match what the running pods read at
-      # runtime via External Secrets (single source of truth, no drift).
+      NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+      NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
       SENTRY_ORG: ${{ vars.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -114,38 +111,6 @@ jobs:
         run: |
           echo "::error::Cannot skip build: one or more images for ${{ steps.vars.outputs.sha_short }} do not exist in ECR. Remove [skip build] from the commit message or push a build first."
           exit 1
-
-      # Source the SSM-backed NEXT_PUBLIC_* values at build time so the values
-      # inlined into the client bundle are identical to what the running pods
-      # read from the same Parameter Store paths via External Secrets. Runs in
-      # the per-environment GitHub Environment (prod|staging) so vars/secrets -
-      # including the AWS creds configured above - resolve to the right account.
-      #
-      # Path is per-environment via ${ENVIRONMENT_TAG} (prod|staging).
-      # Region is NOT the cluster/ECR region (TO_REGION): SSM is centralized in
-      # us-east-2 (staging clusters run in us-east-1, prod in us-east-2), so the
-      # read uses a dedicated SSM_REGION that defaults to us-east-2 and can be
-      # overridden per environment via the SSM_REGION variable if that changes.
-      - name: Fetch NEXT_PUBLIC_* from SSM
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
-        env:
-          SSM_PREFIX: /eks/techops-${{ env.ENVIRONMENT_TAG }}/keeperhub
-          SSM_REGION: ${{ vars.SSM_REGION || 'us-east-2' }}
-        run: |
-          set -euo pipefail
-          # These are NEXT_PUBLIC_* values - inlined into the client bundle and
-          # therefore public - so they are deliberately not masked. Keeping them
-          # visible in build logs is what makes baked-vs-runtime drift debuggable.
-          fetch() {
-            local var="$1" path="$2" val
-            val=$(aws ssm get-parameter --name "$path" --with-decryption \
-              --query 'Parameter.Value' --output text --region "$SSM_REGION")
-            echo "$var=$val" >> "$GITHUB_ENV"
-          }
-          fetch NEXT_PUBLIC_TURNSTILE_SITE_KEY "$SSM_PREFIX/turnstile-site-key"
-          fetch NEXT_PUBLIC_GITHUB_CLIENT_ID   "$SSM_PREFIX/github-client-id"
-          fetch NEXT_PUBLIC_GOOGLE_CLIENT_ID   "$SSM_PREFIX/google-client-id"
-          fetch NEXT_PUBLIC_SENTRY_DSN         "$SSM_PREFIX/next-public-sentry-dsn"
 
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -189,29 +189,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      # Mirror build-images.yml: source the SSM-backed NEXT_PUBLIC_* values for
-      # the app image from Parameter Store so PR-environment bundles match what
-      # build-images.yml bakes and what the pods read at runtime. PR envs run in
-      # the staging GitHub Environment and use the staging parameter tree.
-      # Region is us-east-2 (where SSM lives), not the cluster region (TO_REGION
-      # is us-east-1 for staging).
-      - name: Fetch NEXT_PUBLIC_* from SSM
-        if: matrix.image.build_args == true && steps.check-image.outputs.exists != 'true'
-        env:
-          SSM_PREFIX: /eks/techops-staging/keeperhub
-          SSM_REGION: ${{ vars.SSM_REGION || 'us-east-2' }}
-        run: |
-          set -euo pipefail
-          fetch() {
-            local var="$1" path="$2" val
-            val=$(aws ssm get-parameter --name "$path" --with-decryption \
-              --query 'Parameter.Value' --output text --region "$SSM_REGION")
-            echo "$var=$val" >> "$GITHUB_ENV"
-          }
-          fetch NEXT_PUBLIC_TURNSTILE_SITE_KEY "$SSM_PREFIX/turnstile-site-key"
-          fetch NEXT_PUBLIC_GITHUB_CLIENT_ID   "$SSM_PREFIX/github-client-id"
-          fetch NEXT_PUBLIC_GOOGLE_CLIENT_ID   "$SSM_PREFIX/google-client-id"
-
       - name: Build and push image
         if: steps.check-image.outputs.exists != 'true'
         uses: docker/build-push-action@v7
@@ -221,7 +198,7 @@ jobs:
           target: ${{ matrix.image.target }}
           push: true
           provenance: false
-          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, env.NEXT_PUBLIC_GITHUB_CLIENT_ID, env.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, env.NEXT_PUBLIC_TURNSTILE_SITE_KEY) || '' }}
+          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, vars.NEXT_PUBLIC_GITHUB_CLIENT_ID, vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY) || '' }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.tag_prefix }}-${{ steps.vars.outputs.sha_short }}
           cache-from: |


### PR DESCRIPTION
Reverts the merge of #1362.

## Why
The new `Fetch NEXT_PUBLIC_* from SSM` step in `build-images.yml` fails on staging:

```
AccessDeniedException: User arn:aws:iam::020732533267:user/techops-staging-cicd
is not authorized to perform ssm:GetParameter on
parameter/eks/techops-staging/keeperhub/turnstile-site-key
```

The CI IAM user has no `ssm:GetParameter` permission, so every staging build hard-fails at this step and no new staging deploys can ship. The running staging release is unaffected.

## Re-land plan
The change itself is correct. Before re-merging #1362's commits:
1. Grant `ssm:GetParameter` to `techops-staging-cicd` on `arn:aws:ssm:us-east-2:020732533267:parameter/eks/techops-staging/keeperhub/*` (plus `kms:Decrypt` if any are SecureString).
2. Grant the analogous policy to the prod CI user on `/eks/techops-prod/keeperhub/*`.
3. Re-open / re-merge the feature branch.

Reverts only the two workflow files; no other changes.