### PR TITLE
feat(sandbox): pin pod to dedicated sandbox NodePool via toleration and nodeSelector

### DIFF
--- a/deploy/keeperhub-sandbox/prod/values.yaml
+++ b/deploy/keeperhub-sandbox/prod/values.yaml
@@ -72,6 +72,18 @@ securityContext:
     drop:
       - ALL
 
+# Pin to the dedicated sandbox NodePool (see commentary in
+# deploy/keeperhub-sandbox/staging/values.yaml and the infrastructure
+# repo karpenter-sandbox.tf).
+nodeSelector:
+  node-role.keeperhub.io/sandbox-only: "true"
+
+tolerations:
+  - key: node-role.keeperhub.io/sandbox-only
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+
 livenessProbe:
   httpGet:
     path: /healthz

--- a/deploy/keeperhub-sandbox/staging/values.yaml
+++ b/deploy/keeperhub-sandbox/staging/values.yaml
@@ -111,6 +111,27 @@ securityContext:
     drop:
       - ALL
 
+# Pin the sandbox Pod to the dedicated Karpenter NodePool whose nodes
+# carry a stripped IAM role (no SSM, no S3, no SecretsManager, no KMS).
+# The NodePool and EC2NodeClass are defined in the infrastructure repo
+# (staging/eks-cluster/karpenter-sandbox.tf, prod/eks-cluster/karpenter-sandbox.tf).
+#
+# Even if a future kernel exploit lets an attacker escape this container
+# to the host node, the instance-profile credentials reachable via IMDS
+# carry no permissions reusable against any other workload.
+#
+# nodeSelector restricts scheduling to nodes labeled by the sandbox
+# NodePool template. tolerations let the Pod be scheduled despite the
+# NoSchedule taint that keeps non-sandbox workloads off these nodes.
+nodeSelector:
+  node-role.keeperhub.io/sandbox-only: "true"
+
+tolerations:
+  - key: node-role.keeperhub.io/sandbox-only
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+
 livenessProbe:
   httpGet:
     path: /healthz


### PR DESCRIPTION
## Summary

Binds the `keeperhub-sandbox` Deployment to the dedicated Karpenter NodePool that was just created in the infrastructure repo (PR techops-services/infrastructure#219, applied to both `eks-cluster-staging` and `eks-cluster-prod` workspaces). After this lands and the next `deploy-sandbox.yaml` workflow runs per env, sandbox Pods schedule onto sandbox-only nodes whose IAM role carries no reusable AWS permissions.

## What changes

`deploy/keeperhub-sandbox/{staging,prod}/values.yaml` add:

```yaml
nodeSelector:
  node-role.keeperhub.io/sandbox-only: "true"

tolerations:
  - key: node-role.keeperhub.io/sandbox-only
    operator: Equal
    value: "true"
    effect: NoSchedule
```

## Why

The dedicated NodePool's nodes use a stripped IAM role (`Karpenter-sandbox-node-{staging,prod}-us`) attached to only three policies:

- `AmazonEKSWorkerNodePolicy`
- `AmazonEKS_CNI_Policy`
- `AmazonEC2ContainerRegistryReadOnly`

It does NOT carry `SSMCoreScoped` (which the default Karpenter node role carries), or any S3 / SecretsManager / KMS / RDS policy. The taint keeps non-sandbox workloads off these nodes. If a future kernel exploit lets an attacker escape the sandbox container to the host, the instance-profile credentials reachable via IMDS (hop-limit=1 cluster-wide) yield nothing reusable against the rest of the platform.

This is the binding piece that completes the Tier 1 work started in PR #1364 (image + pod-level lockdown) and the infrastructure side (techops-services/infrastructure#219, dedicated NodePool).

## Effect after merge

- `deploy-sandbox.yaml` fires on push to staging -> sandbox Pods on the staging cluster migrate off shared default-private nodes onto the dedicated sandbox NodePool. Karpenter provisions one fresh EC2 instance at that moment (the NodePool has been idle since techops-services/infrastructure#219 applied).
- Prod side waits until the next staging->prod release. Once that runs, the prod sandbox Pods migrate the same way.

## Test plan

- [ ] `helm template` with the new values renders `nodeSelector` and `tolerations` correctly (verified locally before push).
- [ ] After merge: watch `deploy-sandbox.yaml` -> sandbox Deployment rolling restart -> new Pods scheduled on a node labeled `techops.services/nodepool=sandbox`.
- [ ] `kubectl -n keeperhub get pods -l app.kubernetes.io/instance=keeperhub-sandbox -o wide` shows pods on new nodes.
- [ ] `kubectl get nodes -l techops.services/nodepool=sandbox` returns 1 node (matches `replicaCount` and Karpenter consolidation policy).
- [ ] `kubectl get ec2nodeclass sandbox` shows `Ready=True`, `InstanceProfileReady=True` (will flip from Unknown to True once Karpenter has to actually provision an instance).
- [ ] `aws iam get-instance-profile --instance-profile-name Karpenter-sandbox-node-staging-us` now returns the profile (Karpenter creates it lazily on first provision).
- [ ] `aws ec2 describe-instances` for the new node shows it uses the `Karpenter-sandbox-node-staging-us` IAM role and `httpPutResponseHopLimit=1` on its IMDS metadata options.
- [ ] `sandbox-escape-matrix` workflow TEST-01..10 all green against the new pods.

## Out of scope

- The escape-matrix workflow's pre-existing `ssm:PutParameter` IAM gap on the `techops-staging-cicd` user blocks the TEST-01..10 run at the canary-plant step. Tracked separately under [KEEP-630](https://linear.app/keeperhubapp/issue/KEEP-630).
- The TF kubectl_manifest stale-auth race seen during the infrastructure apply is tracked separately under [TECH-21](https://linear.app/keeperhubapp/issue/TECH-21).
