### PR TITLE
fix(auth): no session until MFA is enrolled on new signups

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -10,6 +10,10 @@ import {
   buildPendingOauthMfaSetCookie,
   encodePendingOauthMfaCookie,
 } from "@/lib/oauth-mfa-cookie";
+import {
+  buildPendingSignupSetCookie,
+  encodePendingSignupCookie,
+} from "@/lib/pending-signup-cookie";
 
 const handlers = toNextJsHandler(auth);
 
@@ -105,14 +109,11 @@ async function interceptOauthCallback(
     .from(users)
     .where(eq(users.id, row.userId))
     .limit(1);
-  if (!user || user.twoFactorEnabled !== true) {
-    return res;
-  }
-  if (!user.email) {
-    // Without an email we have no inbox to deliver the OTP to. Fall
-    // through to Better Auth's default response so the user at least
-    // gets a session; the proxy MFA gate will still send them to
-    // /enroll-mfa or /verify-mfa.
+  if (!user || !user.email) {
+    // Without an email we have no inbox to deliver an OTP to, so we
+    // cannot defer the session for either flow. Fall through to
+    // Better Auth's default response; the proxy MFA gate will still
+    // send the user to /enroll-mfa via the existing path.
     return res;
   }
 
@@ -133,25 +134,62 @@ async function interceptOauthCallback(
   await db.delete(sessions).where(eq(sessions.id, row.id));
 
   const originalRedirect = res.headers.get("location") ?? "/";
-  const verifyTarget = new URL("/verify-mfa", url.origin);
-  verifyTarget.searchParams.set("next", originalRedirect);
+  const clearSessionCookies = buildSessionClearCookies();
 
-  const pendingValue = encodePendingOauthMfaCookie(
+  // Two paths depending on whether the user already has TOTP:
+  //
+  //   * twoFactorEnabled = true  -> they completed enrollment in a
+  //     prior session. Defer via pending_oauth_mfa and route them to
+  //     /verify-mfa where they prove email + TOTP via
+  //     /api/auth/oauth-mfa-finalize, which mints the session for the
+  //     first time post-MFA.
+  //
+  //   * twoFactorEnabled = false -> brand-new OAuth user (or existing
+  //     OAuth user who never enrolled). Defer via pending_signup_mfa
+  //     and route them to /enroll-mfa. The first-time TOTP enrollment
+  //     mints the real session inside the enroll route once the user
+  //     finishes the wizard. No usable session exists until that.
+  if (user.twoFactorEnabled === true) {
+    const pendingValue = encodePendingOauthMfaCookie(
+      {
+        userId: user.id,
+        email: user.email,
+        redirect: originalRedirect,
+      },
+      secret
+    );
+    const verifyTarget = new URL("/verify-mfa", url.origin);
+    verifyTarget.searchParams.set("next", originalRedirect);
+    const response = NextResponse.redirect(verifyTarget);
+    for (const clear of clearSessionCookies) {
+      response.headers.append("Set-Cookie", clear);
+    }
+    response.headers.append(
+      "Set-Cookie",
+      buildPendingOauthMfaSetCookie(pendingValue)
+    );
+    return response;
+  }
+
+  const provider = url.pathname.split("/").pop() ?? "oauth";
+  const pendingSignupValue = encodePendingSignupCookie(
     {
       userId: user.id,
       email: user.email,
+      provider,
       redirect: originalRedirect,
     },
     secret
   );
-
-  const response = NextResponse.redirect(verifyTarget);
-  for (const clear of buildSessionClearCookies()) {
+  const enrollTarget = new URL("/enroll-mfa", url.origin);
+  enrollTarget.searchParams.set("next", originalRedirect);
+  const response = NextResponse.redirect(enrollTarget);
+  for (const clear of clearSessionCookies) {
     response.headers.append("Set-Cookie", clear);
   }
   response.headers.append(
     "Set-Cookie",
-    buildPendingOauthMfaSetCookie(pendingValue)
+    buildPendingSignupSetCookie(pendingSignupValue)
   );
   return response;
 }

--- a/app/api/auth/finish-credential-signup/route.ts
+++ b/app/api/auth/finish-credential-signup/route.ts
@@ -1,0 +1,156 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { accounts, users } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { verifyPassword } from "@/lib/password";
+import {
+  buildPendingSignupSetCookie,
+  encodePendingSignupCookie,
+} from "@/lib/pending-signup-cookie";
+
+/**
+ * Bridges credential signup (signUp.email + emailOtp.verifyEmail) to
+ * TOTP enrollment without ever minting a session. Called from the
+ * auth dialog after the user types the signup OTP and Better Auth
+ * flips users.email_verified = true. We do NOT call signIn.email
+ * here; instead we issue a signed pending_signup_mfa cookie that
+ * only unlocks /enroll-mfa. The session is created for the first
+ * time inside /api/user/totp/enroll, atomically with the enrollment
+ * commit, so no usable session exists until the user has TOTP.
+ *
+ * Validation:
+ *   - User must exist by email.
+ *   - users.email_verified must be true (the verifyEmail must have
+ *     already succeeded; this endpoint won't mint a pending cookie
+ *     for an unverified address).
+ *   - users.two_factor_enabled must be false. If the user is already
+ *     enrolled, this is the wrong endpoint - they should use the
+ *     strict-signin atomic chain to actually sign in.
+ *   - Password must match the credential account. We re-verify here
+ *     because the cookie cannot be issued solely on email control;
+ *     ownership of the credential is the second proof.
+ */
+
+type Body = {
+  email?: string;
+  password?: string;
+};
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    logSystemError(
+      ErrorCategory.CONFIGURATION,
+      "[finish-credential-signup] BETTER_AUTH_SECRET missing",
+      new Error("BETTER_AUTH_SECRET missing"),
+      { endpoint: "/api/auth/finish-credential-signup" }
+    );
+    return NextResponse.json(
+      { error: "Server misconfigured", code: "server_misconfigured" },
+      { status: 500 }
+    );
+  }
+
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body", code: "bad_body" },
+      { status: 400 }
+    );
+  }
+  const email = body.email?.trim().toLowerCase() ?? "";
+  const password = body.password ?? "";
+  if (!(email && password)) {
+    return NextResponse.json(
+      {
+        error: "Email and password are required",
+        code: "missing_credentials",
+      },
+      { status: 400 }
+    );
+  }
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      emailVerified: users.emailVerified,
+      twoFactorEnabled: users.twoFactorEnabled,
+    })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  if (!user) {
+    return NextResponse.json(
+      { error: "Invalid sign-up state", code: "invalid_state" },
+      { status: 401 }
+    );
+  }
+  if (!user.emailVerified) {
+    return NextResponse.json(
+      { error: "Verify your email first", code: "email_not_verified" },
+      { status: 401 }
+    );
+  }
+  if (user.twoFactorEnabled === true) {
+    return NextResponse.json(
+      {
+        error: "Account already has TOTP; use the sign-in flow instead.",
+        code: "already_enrolled",
+      },
+      { status: 409 }
+    );
+  }
+
+  const [credentialAccount] = await db
+    .select({ password: accounts.password })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, user.id), eq(accounts.providerId, "credential"))
+    )
+    .limit(1);
+  if (!credentialAccount?.password) {
+    return NextResponse.json(
+      { error: "Invalid sign-up state", code: "invalid_state" },
+      { status: 401 }
+    );
+  }
+  const passwordOk = await verifyPassword(password, credentialAccount.password);
+  if (!passwordOk) {
+    return NextResponse.json(
+      { error: "Invalid sign-up state", code: "invalid_state" },
+      { status: 401 }
+    );
+  }
+
+  // Email is required by the schema for any non-anonymous user, but
+  // narrow the type for TypeScript.
+  if (!user.email) {
+    return NextResponse.json(
+      { error: "Invalid sign-up state", code: "invalid_state" },
+      { status: 401 }
+    );
+  }
+
+  const pendingValue = encodePendingSignupCookie(
+    {
+      userId: user.id,
+      email: user.email,
+      provider: "credential",
+      redirect: "/",
+    },
+    secret
+  );
+  const response = NextResponse.json({
+    ok: true,
+    redirect: "/enroll-mfa",
+  });
+  response.headers.append(
+    "Set-Cookie",
+    buildPendingSignupSetCookie(pendingValue)
+  );
+  return response;
+}

--- a/app/api/auth/oauth-mfa-finalize/route.ts
+++ b/app/api/auth/oauth-mfa-finalize/route.ts
@@ -1,6 +1,9 @@
 import { randomBytes } from "node:crypto";
 import { NextResponse } from "next/server";
-import { hashSessionToken } from "@/lib/auth-session-token-hash";
+import {
+  hashSessionToken,
+  signSessionCookieValue,
+} from "@/lib/auth-session-token-hash";
 import { db } from "@/lib/db";
 import { sessions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -156,7 +159,10 @@ export async function POST(request: Request): Promise<NextResponse> {
   });
   response.headers.append(
     "Set-Cookie",
-    buildSessionSetCookie(rawToken, DEFAULT_SESSION_TTL_MS)
+    buildSessionSetCookie(
+      signSessionCookieValue(rawToken, secret),
+      DEFAULT_SESSION_TTL_MS
+    )
   );
   response.headers.append("Set-Cookie", buildPendingOauthMfaClearCookie());
   return response;

--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -1,22 +1,30 @@
+import { randomBytes } from "node:crypto";
 import { generateRandomString, symmetricEncrypt } from "better-auth/crypto";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { isAnonymousUserShape } from "@/lib/auth-anonymous-guard";
+import { hashSessionToken } from "@/lib/auth-session-token-hash";
 import { db } from "@/lib/db";
-import { sessions, twoFactor as twoFactorTable } from "@/lib/db/schema";
+import { sessions, twoFactor as twoFactorTable, users } from "@/lib/db/schema";
+import { resolveEnrollMfaCaller } from "@/lib/enroll-mfa-caller";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  buildPendingSignupClearCookie,
+} from "@/lib/pending-signup-cookie";
+import { verifyUserTotp } from "@/lib/security/totp-verify";
 
 type RequestBody = {
   code?: string;
 };
 
-type Response = {
+type EnrollResponse = {
   backupCodes: string[];
+  redirect?: string;
 };
 
 const BACKUP_CODE_COUNT = 10;
 const BACKUP_CODE_LENGTH = 10;
+const DEFAULT_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 function generatePlainBackupCodes(): string[] {
   const codes: string[] = [];
@@ -27,63 +35,54 @@ function generatePlainBackupCodes(): string[] {
   return codes;
 }
 
+function buildSessionSetCookie(token: string, ttlMs: number): string {
+  const maxAge = Math.floor(ttlMs / 1000);
+  const secureSegment =
+    process.env.NODE_ENV === "production" ? " Secure;" : "";
+  const cookieName =
+    process.env.NODE_ENV === "production"
+      ? "__Secure-better-auth.session_token"
+      : "better-auth.session_token";
+  return `${cookieName}=${encodeURIComponent(token)}; Path=/; HttpOnly;${secureSegment} SameSite=Lax; Max-Age=${maxAge}`;
+}
+
 /**
  * POST /api/user/totp/enroll
  *
- * Atomic completion of TOTP enrollment: verifies the user's first TOTP
- * code (which also flips users.two_factor_enabled = true via the
- * plugin) and immediately mints + persists backup codes, returning the
- * plaintext set exactly once.
+ * Two auth shapes converge here:
  *
- * This exists because backup-code generation is too important to leave
- * as a user-initiated follow-up step. A user who closes the dialog
- * after TOTP verify but before code generation would end up enrolled
- * with no recovery path. By coupling both writes into one endpoint, the
- * UI can guarantee that any enrolled user always had codes shown to
- * them at least once.
+ *   - Sessioned caller: existing user upgrading from no-MFA to TOTP.
+ *     Better Auth's verifyTOTP path is used so its session rotation
+ *     + flip of users.two_factor_enabled = true are atomic with the
+ *     plugin's own state. We also clear requires_mfa on every session
+ *     this user holds, because the freshest possible TOTP proof is
+ *     the one we just verified.
  *
- * Regenerate-later (replacing existing codes) still goes through the
- * separate /api/user/totp/backup-codes endpoint, which gates on a
- * fresh TOTP code because that flow invalidates a previously-shown set.
+ *   - Pending-signup caller: brand-new credential or OAuth user who
+ *     carries only the signed pending_signup_mfa cookie, no session.
+ *     We verify the TOTP code directly against the encrypted secret
+ *     stored at /setup time, flip users.two_factor_enabled = true,
+ *     and mint a fresh session for the first time. The session
+ *     cookie returned here is the FIRST usable session for the
+ *     account.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: two converging auth shapes
 export async function POST(request: Request): Promise<NextResponse> {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
+  const caller = await resolveEnrollMfaCaller(request.headers);
+  if (caller.kind === "anonymous") {
+    if (caller.reason === "anonymous_user") {
+      return NextResponse.json(
+        { error: "Sign in with a real account to enable two-factor" },
+        { status: 403 }
+      );
+    }
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (isAnonymousUserShape(session.user)) {
-    return NextResponse.json(
-      { error: "Sign in with a real account to enable two-factor" },
-      { status: 403 }
-    );
   }
 
   const body = (await request.json().catch(() => ({}))) as RequestBody;
   const code = typeof body.code === "string" ? body.code.trim() : "";
   if (!code) {
     return NextResponse.json({ error: "Code is required" }, { status: 400 });
-  }
-
-  // On first-time enrollment Better Auth's verifyTOTP rotates the
-  // session (deletes the pre-2FA session and mints a new one, then
-  // calls setSessionCookie on its internal response). returnHeaders:true
-  // makes that Set-Cookie observable so we can forward it on our
-  // NextResponse — without this the user is signed out the instant
-  // they enter their first code because the new cookie never reaches
-  // the browser.
-  let verifyHeaders: Headers;
-  try {
-    const result = await auth.api.verifyTOTP({
-      body: { code },
-      headers: request.headers,
-      returnHeaders: true,
-    });
-    verifyHeaders = result.headers;
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid verification code" },
-      { status: 401 }
-    );
   }
 
   const secret = process.env.BETTER_AUTH_SECRET;
@@ -100,7 +99,85 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const userId = session.user.id;
+  const userId = caller.userId;
+
+  // Sessioned path: route through Better Auth so its rotation +
+  // two_factor_enabled flip stay atomic with the plugin's state.
+  if (caller.kind === "session") {
+    let verifyHeaders: Headers;
+    try {
+      const result = await auth.api.verifyTOTP({
+        body: { code },
+        headers: request.headers,
+        returnHeaders: true,
+      });
+      verifyHeaders = result.headers;
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid verification code" },
+        { status: 401 }
+      );
+    }
+
+    try {
+      const backupCodes = generatePlainBackupCodes();
+      const encryptedBackupCodes = await symmetricEncrypt({
+        key: secret,
+        data: JSON.stringify(backupCodes),
+      });
+      await db
+        .update(twoFactorTable)
+        .set({ backupCodes: encryptedBackupCodes })
+        .where(eq(twoFactorTable.userId, userId));
+      await db
+        .update(sessions)
+        .set({ requiresMfa: false, mfaVerifiedAt: new Date() })
+        .where(eq(sessions.userId, userId));
+      const responseBody: EnrollResponse = { backupCodes };
+      const response = NextResponse.json(responseBody);
+      for (const [name, value] of verifyHeaders.entries()) {
+        if (name.toLowerCase() === "set-cookie") {
+          response.headers.append("set-cookie", value);
+        }
+      }
+      return response;
+    } catch (error) {
+      logSystemError(
+        ErrorCategory.AUTH,
+        "[TOTP Enroll] Failed to persist backup codes (session path)",
+        error,
+        { endpoint: "/api/user/totp/enroll", user_id: userId }
+      );
+      return NextResponse.json(
+        { error: "Verification accepted but backup-code mint failed" },
+        { status: 500 }
+      );
+    }
+  }
+
+  // Pending-signup path: no session yet. Verify the TOTP directly
+  // against the encrypted secret we stored at /setup time, then
+  // atomically (a) flip users.two_factor_enabled, (b) persist
+  // backup codes, (c) mint the first session for this user.
+  const [enrollment] = await db
+    .select({ secret: twoFactorTable.secret })
+    .from(twoFactorTable)
+    .where(eq(twoFactorTable.userId, userId))
+    .limit(1);
+  if (!enrollment) {
+    return NextResponse.json(
+      { error: "No enrollment in progress for this user" },
+      { status: 400 }
+    );
+  }
+  const codeOk = await verifyUserTotp(enrollment.secret, code, secret);
+  if (!codeOk) {
+    return NextResponse.json(
+      { error: "Invalid verification code" },
+      { status: 401 }
+    );
+  }
+
   try {
     const backupCodes = generatePlainBackupCodes();
     const encryptedBackupCodes = await symmetricEncrypt({
@@ -111,41 +188,53 @@ export async function POST(request: Request): Promise<NextResponse> {
       .update(twoFactorTable)
       .set({ backupCodes: encryptedBackupCodes })
       .where(eq(twoFactorTable.userId, userId));
-
-    // Better Auth's verifyTOTP flips users.two_factor_enabled = true
-    // and rotates the session. The new session row goes through
-    // session.create.before which now sees two_factor_enabled = true
-    // and sets requires_mfa = true. Without this clear the user gets
-    // immediately bounced to /verify-mfa after enrollment, even
-    // though they JUST proved TOTP in the same request. We update
-    // every session this user holds because there should only be one
-    // post-rotation and we want this user-initiated factor proof to
-    // satisfy the step-up gate on each of them.
     await db
-      .update(sessions)
-      .set({ requiresMfa: false, mfaVerifiedAt: new Date() })
-      .where(eq(sessions.userId, userId));
+      .update(users)
+      .set({ twoFactorEnabled: true })
+      .where(eq(users.id, userId));
 
-    const responseBody: Response = { backupCodes };
+    const rawToken = randomBytes(32).toString("base64url");
+    const tokenHash = hashSessionToken(rawToken);
+    const expiresAt = new Date(Date.now() + DEFAULT_SESSION_TTL_MS);
+    const sessionId = `sess_${randomBytes(16).toString("base64url")}`;
+    const userAgent = request.headers.get("user-agent") ?? null;
+    const ipAddress =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      request.headers.get("x-real-ip") ??
+      null;
+    await db.insert(sessions).values({
+      id: sessionId,
+      userId,
+      token: tokenHash,
+      expiresAt,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress,
+      userAgent,
+      requiresMfa: false,
+      mfaVerifiedAt: new Date(),
+    });
+
+    const responseBody: EnrollResponse = {
+      backupCodes,
+      redirect: caller.redirect || "/",
+    };
     const response = NextResponse.json(responseBody);
-    // Forward Better Auth's Set-Cookie (rotated session) to the
-    // browser. We use append, not set, so multiple cookies (session
-    // + session_data) are preserved.
-    for (const [name, value] of verifyHeaders.entries()) {
-      if (name.toLowerCase() === "set-cookie") {
-        response.headers.append("set-cookie", value);
-      }
-    }
+    response.headers.append(
+      "Set-Cookie",
+      buildSessionSetCookie(rawToken, DEFAULT_SESSION_TTL_MS)
+    );
+    response.headers.append("Set-Cookie", buildPendingSignupClearCookie());
     return response;
   } catch (error) {
     logSystemError(
       ErrorCategory.AUTH,
-      "[TOTP Enroll] Failed to persist backup codes",
+      "[TOTP Enroll] Failed to finalize pending-signup enrollment",
       error,
       { endpoint: "/api/user/totp/enroll", user_id: userId }
     );
     return NextResponse.json(
-      { error: "Verification accepted but backup-code mint failed" },
+      { error: "Verification accepted but enrollment finalize failed" },
       { status: 500 }
     );
   }

--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -3,7 +3,10 @@ import { generateRandomString, symmetricEncrypt } from "better-auth/crypto";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { hashSessionToken } from "@/lib/auth-session-token-hash";
+import {
+  hashSessionToken,
+  signSessionCookieValue,
+} from "@/lib/auth-session-token-hash";
 import { db } from "@/lib/db";
 import { sessions, twoFactor as twoFactorTable, users } from "@/lib/db/schema";
 import { resolveEnrollMfaCaller } from "@/lib/enroll-mfa-caller";
@@ -35,7 +38,10 @@ function generatePlainBackupCodes(): string[] {
   return codes;
 }
 
-function buildSessionSetCookie(token: string, ttlMs: number): string {
+function buildSessionSetCookie(
+  signedValue: string,
+  ttlMs: number
+): string {
   const maxAge = Math.floor(ttlMs / 1000);
   const secureSegment =
     process.env.NODE_ENV === "production" ? " Secure;" : "";
@@ -43,7 +49,7 @@ function buildSessionSetCookie(token: string, ttlMs: number): string {
     process.env.NODE_ENV === "production"
       ? "__Secure-better-auth.session_token"
       : "better-auth.session_token";
-  return `${cookieName}=${encodeURIComponent(token)}; Path=/; HttpOnly;${secureSegment} SameSite=Lax; Max-Age=${maxAge}`;
+  return `${cookieName}=${encodeURIComponent(signedValue)}; Path=/; HttpOnly;${secureSegment} SameSite=Lax; Max-Age=${maxAge}`;
 }
 
 /**
@@ -222,7 +228,10 @@ export async function POST(request: Request): Promise<NextResponse> {
     const response = NextResponse.json(responseBody);
     response.headers.append(
       "Set-Cookie",
-      buildSessionSetCookie(rawToken, DEFAULT_SESSION_TTL_MS)
+      buildSessionSetCookie(
+        signSessionCookieValue(rawToken, secret),
+        DEFAULT_SESSION_TTL_MS
+      )
     );
     response.headers.append("Set-Cookie", buildPendingSignupClearCookie());
     return response;

--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -12,6 +12,10 @@ import { sessions, twoFactor as twoFactorTable, users } from "@/lib/db/schema";
 import { resolveEnrollMfaCaller } from "@/lib/enroll-mfa-caller";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
+  checkDualFactorRateLimit,
+  resetDualFactor,
+} from "@/lib/mfa/dual-factor-rate-limit";
+import {
   buildPendingSignupClearCookie,
 } from "@/lib/pending-signup-cookie";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
@@ -161,10 +165,26 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
   }
 
-  // Pending-signup path: no session yet. Verify the TOTP directly
-  // against the encrypted secret we stored at /setup time, then
-  // atomically (a) flip users.two_factor_enabled, (b) persist
-  // backup codes, (c) mint the first session for this user.
+  // Pending-signup path: no session yet. Sliding-window rate limit
+  // on the TOTP verify because the caller is unauthenticated by
+  // session and Better Auth's per-route plugin rate limiter does not
+  // wrap this code path. Without this, an attacker holding a stolen
+  // pending_signup_mfa cookie could brute the 6-digit code for the
+  // entire 30-min cookie TTL. Same sliding-window primitive used by
+  // requireDualFactor; the counter is wiped on a successful verify
+  // so a typo burst does not lock out a legitimate user.
+  const rate = checkDualFactorRateLimit(userId, "totp_enroll");
+  if (!rate.allowed) {
+    return NextResponse.json(
+      {
+        error: "Too many attempts. Wait and try again.",
+        code: "rate_limited",
+        retryAfter: rate.retryAfter,
+      },
+      { status: 429 }
+    );
+  }
+
   const [enrollment] = await db
     .select({ secret: twoFactorTable.secret })
     .from(twoFactorTable)
@@ -184,20 +204,14 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
+  resetDualFactor(userId, "totp_enroll");
+
   try {
     const backupCodes = generatePlainBackupCodes();
     const encryptedBackupCodes = await symmetricEncrypt({
       key: secret,
       data: JSON.stringify(backupCodes),
     });
-    await db
-      .update(twoFactorTable)
-      .set({ backupCodes: encryptedBackupCodes })
-      .where(eq(twoFactorTable.userId, userId));
-    await db
-      .update(users)
-      .set({ twoFactorEnabled: true })
-      .where(eq(users.id, userId));
 
     const rawToken = randomBytes(32).toString("base64url");
     const tokenHash = hashSessionToken(rawToken);
@@ -208,17 +222,35 @@ export async function POST(request: Request): Promise<NextResponse> {
       request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
       request.headers.get("x-real-ip") ??
       null;
-    await db.insert(sessions).values({
-      id: sessionId,
-      userId,
-      token: tokenHash,
-      expiresAt,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      ipAddress,
-      userAgent,
-      requiresMfa: false,
-      mfaVerifiedAt: new Date(),
+
+    // Single transaction across the three writes so a mid-flight
+    // failure cannot leave the account in a "twoFactorEnabled = true
+    // but no session row" state. A partial commit would brick the
+    // user: the next request would route them through MFA gates
+    // they can satisfy, but no session means they would never
+    // authenticate, while the absence of the pending cookie (which
+    // we are about to clear) means they could not retry enrollment.
+    await db.transaction(async (tx) => {
+      await tx
+        .update(twoFactorTable)
+        .set({ backupCodes: encryptedBackupCodes })
+        .where(eq(twoFactorTable.userId, userId));
+      await tx
+        .update(users)
+        .set({ twoFactorEnabled: true })
+        .where(eq(users.id, userId));
+      await tx.insert(sessions).values({
+        id: sessionId,
+        userId,
+        token: tokenHash,
+        expiresAt,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ipAddress,
+        userAgent,
+        requiresMfa: false,
+        mfaVerifiedAt: new Date(),
+      });
     });
 
     const responseBody: EnrollResponse = {

--- a/app/api/user/totp/setup/route.ts
+++ b/app/api/user/totp/setup/route.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { generateRandomString, symmetricEncrypt } from "better-auth/crypto";
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import { isAnonymousUserShape } from "@/lib/auth-anonymous-guard";
 import { db } from "@/lib/db";
 import { twoFactor as twoFactorTable } from "@/lib/db/schema";
+import { resolveEnrollMfaCaller } from "@/lib/enroll-mfa-caller";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 const ISSUER = "KeeperHub";
@@ -102,24 +101,24 @@ function buildTotpUri(secret: string, account: string): string {
  * enrollment; it is the supported way to rotate a lost authenticator.
  */
 export async function POST(request: Request): Promise<NextResponse> {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
+  const caller = await resolveEnrollMfaCaller(request.headers);
+  if (caller.kind === "anonymous") {
+    if (caller.reason === "anonymous_user") {
+      return NextResponse.json(
+        { error: "Sign in with a real account to enable two-factor" },
+        { status: 403 }
+      );
+    }
+    if (caller.reason === "no_email") {
+      return NextResponse.json(
+        { error: "Account missing email" },
+        { status: 400 }
+      );
+    }
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  if (isAnonymousUserShape(session.user)) {
-    return NextResponse.json(
-      { error: "Sign in with a real account to enable two-factor" },
-      { status: 403 }
-    );
-  }
-  const userId = session.user.id;
-  const userEmail = session.user.email;
-  if (!userEmail) {
-    return NextResponse.json(
-      { error: "Account missing email" },
-      { status: 400 }
-    );
-  }
+  const userId = caller.userId;
+  const userEmail = caller.email;
 
   const secret = process.env.BETTER_AUTH_SECRET;
   if (!secret) {

--- a/app/enroll-mfa/enroll-mfa-form.tsx
+++ b/app/enroll-mfa/enroll-mfa-form.tsx
@@ -6,8 +6,20 @@ import { TotpSetupDialog } from "@/components/settings/totp-setup-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
+type Mode = "signed-in" | "pending-signup";
+
 type Props = {
   next: string;
+  /**
+   * - "signed-in": user has a normal session with two_factor_enabled
+   *   = false. The setup/enroll endpoints authenticate them via the
+   *   session cookie.
+   * - "pending-signup": user is brand-new and carries only the signed
+   *   `pending_signup_mfa` cookie. No session exists yet. The
+   *   setup/enroll endpoints authenticate them via that cookie and
+   *   mint the session for the first time when enrollment completes.
+   */
+  mode: Mode;
 };
 
 const REDIRECT_COUNTDOWN_SECONDS = 10;
@@ -23,7 +35,7 @@ const REDIRECT_COUNTDOWN_SECONDS = 10;
  * swaps to a success card with a 10-second auto-redirect plus a
  * Continue button so the redirect is acknowledged rather than abrupt.
  */
-export function EnrollMfaForm({ next }: Props): React.ReactElement {
+export function EnrollMfaForm({ next, mode }: Props): React.ReactElement {
   const target = next || "/";
   const [dialogOpen, setDialogOpen] = useState(true);
   const [enrolled, setEnrolled] = useState(false);

--- a/app/enroll-mfa/enroll-mfa-form.tsx
+++ b/app/enroll-mfa/enroll-mfa-form.tsx
@@ -58,8 +58,34 @@ export function EnrollMfaForm({ next, mode }: Props): React.ReactElement {
     setShowSuccess(true);
   };
 
-  const handleContinue = (): void => {
-    window.location.assign(target);
+  const handleContinue = async (): Promise<void> => {
+    // Confirm the freshly-minted session cookie is live on the
+    // server before navigating. A click within the first second or
+    // two after the enroll response can outrun the browser's cookie
+    // commit, leaving the user landing on `target` as anonymous. The
+    // get-session round-trip both proves the cookie is being sent
+    // and forces the browser to flush it before we leave the page.
+    try {
+      const res = await fetch("/api/auth/get-session", {
+        cache: "no-store",
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { user?: unknown }
+          | null;
+        if (data?.user) {
+          window.location.assign(target);
+          return;
+        }
+      }
+    } catch {
+      // fall through to the soft retry below
+    }
+    // Session not yet visible (cookie commit race). Give the browser
+    // a beat to commit, then navigate; the SSR on `target` will pick
+    // up the cookie on the actual request.
+    window.setTimeout(() => window.location.assign(target), 500);
   };
 
   useEffect(() => {

--- a/app/enroll-mfa/page.tsx
+++ b/app/enroll-mfa/page.tsx
@@ -1,15 +1,22 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
+import {
+  decodePendingSignupCookie,
+  readPendingSignupCookie,
+} from "@/lib/pending-signup-cookie";
 import { EnrollMfaForm } from "./enroll-mfa-form";
 
 /**
- * Forced TOTP enrollment page. Sessions whose user has
- * users.two_factor_enabled = false are routed here by the root proxy and
- * cannot reach the rest of the app until enrollment completes. On
- * successful enrollment the API flips two_factor_enabled = true and
- * users.totp_verified_at is set; the next request through the proxy
- * sees the new state and the redirect lifts.
+ * Forced TOTP enrollment page. Two ways to land here:
+ *
+ *   1. Existing signed-in user whose two_factor_enabled = false.
+ *      The proxy gate keeps routing them here on every request
+ *      until enrollment completes.
+ *   2. Brand-new credential or OAuth signup that hasn't enrolled
+ *      yet. They land here with a signed `pending_signup_mfa` cookie
+ *      and NO session. The session is minted for the first time
+ *      inside the enroll route once they finish the 3-step wizard.
  */
 export default async function EnrollMfaPage({
   searchParams,
@@ -17,6 +24,28 @@ export default async function EnrollMfaPage({
   searchParams: Promise<{ next?: string }>;
 }): Promise<React.ReactElement> {
   const requestHeaders = await headers();
+  const params = await searchParams;
+  const next = typeof params.next === "string" ? params.next : "/";
+
+  // 1. Pending-signup path. Valid signed cookie, no session yet.
+  const pendingCookie = readPendingSignupCookie(requestHeaders);
+  if (pendingCookie) {
+    const secret = process.env.BETTER_AUTH_SECRET;
+    if (secret) {
+      const decoded = decodePendingSignupCookie(pendingCookie, secret);
+      if (decoded.ok) {
+        return (
+          <main className="flex min-h-screen items-center justify-center bg-background p-6">
+            <EnrollMfaForm mode="pending-signup" next={decoded.payload.redirect || next} />
+          </main>
+        );
+      }
+    }
+    // Fall through; an expired or tampered pending cookie is treated
+    // as if no cookie was present.
+  }
+
+  // 2. Already-signed-in user who hasn't enrolled yet.
   const session = await auth.api.getSession({ headers: requestHeaders });
   if (!session?.user) {
     redirect("/");
@@ -26,12 +55,9 @@ export default async function EnrollMfaPage({
     redirect("/");
   }
 
-  const params = await searchParams;
-  const next = typeof params.next === "string" ? params.next : "/";
-
   return (
     <main className="flex min-h-screen items-center justify-center bg-background p-6">
-      <EnrollMfaForm next={next} />
+      <EnrollMfaForm mode="signed-in" next={next} />
     </main>
   );
 }

--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -875,36 +875,49 @@ export const AuthDialog = ({
       pendingVerifyEmail = null;
       pendingVerifyPassword = null;
 
-      // Auto sign-in after verification using stored password
-      if (verifyPassword) {
-        const signInResponse = await signIn.email({
-          email: verifyEmail,
-          password: verifyPassword,
-        });
-
-        if (signInResponse.error) {
-          // Verification succeeded but sign-in failed - redirect to sign in
-          toast.success("Email verified! Please sign in.");
-          setView("signin");
-          setEmail(verifyEmail);
-          setPassword("");
-          setOtp("");
-          setLoading(false);
-          return;
+      // Do NOT call signIn.email here. New signups must enroll TOTP
+      // before any session row is minted. /api/auth/finish-credential-signup
+      // re-verifies the password, confirms email_verified, and issues
+      // a signed pending_signup_mfa cookie that only unlocks
+      // /enroll-mfa. The real session is created for the first time
+      // inside /api/user/totp/enroll once the user finishes the
+      // 3-step wizard. No usable session exists in between.
+      if (!verifyPassword) {
+        setError("Missing password state. Sign in again to continue.");
+        setView("signin");
+        setEmail(verifyEmail);
+        setOtp("");
+        setLoading(false);
+        return;
+      }
+      const finishResponse = await fetch(
+        "/api/auth/finish-credential-signup",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: verifyEmail,
+            password: verifyPassword,
+          }),
         }
+      );
+      const finishBody = (await finishResponse.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+        redirect?: string;
+      };
+      if (!finishResponse.ok) {
+        setError(finishBody.error ?? "Could not finish signup");
+        setLoading(false);
+        return;
       }
 
-      // Store claim context after successful sign-in
       storeClaimIfNeeded(claimContext);
-
-      // Refresh session
-      await authClient.getSession();
-      refetchOrganizations();
-
-      toast.success("Email verified! You're now signed in.");
-      setOpen(false);
-      resetForm();
+      toast.success("Email verified! Set up your authenticator to continue.");
       window.dispatchEvent(new CustomEvent(AUTH_SUCCESS_EVENT));
+      if (typeof window !== "undefined") {
+        window.location.assign(finishBody.redirect ?? "/enroll-mfa");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Verification failed");
       setLoading(false);

--- a/lib/auth-session-token-hash.ts
+++ b/lib/auth-session-token-hash.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import type { DBAdapter, Where } from "better-auth";
 
 // KEEP-239: better-auth 1.5.6 stores `sessions.token` plaintext, which gives
@@ -46,6 +46,30 @@ type DeleteManyArgs = Parameters<DBAdapter["deleteMany"]>[0];
 
 export function hashSessionToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Better Auth signs the `better-auth.session_token` cookie value via
+ * hono's setSignedCookie: HMAC-SHA256 of the raw token under the
+ * BETTER_AUTH_SECRET, base64-encoded, joined with a literal "." after
+ * the raw token. Reading the cookie (auth.api.getSession) verifies
+ * the signature and rejects the value when it does not match.
+ *
+ * Routes that mint a session manually (oauth-mfa-finalize,
+ * totp/enroll on the pending-signup path) must produce a cookie that
+ * passes this signature check, otherwise the freshly-issued cookie
+ * appears valid client-side but is rejected on the very next
+ * request and the user ends up anonymous despite the row existing
+ * in the sessions table.
+ */
+export function signSessionCookieValue(
+  rawToken: string,
+  secret: string
+): string {
+  const signature = createHmac("sha256", secret)
+    .update(rawToken)
+    .digest("base64");
+  return `${rawToken}.${signature}`;
 }
 
 function hashTokenWhere(where: Where[] | undefined): Where[] | undefined {

--- a/lib/enroll-mfa-caller.ts
+++ b/lib/enroll-mfa-caller.ts
@@ -1,0 +1,73 @@
+import { auth } from "@/lib/auth";
+import { isAnonymousUserShape } from "@/lib/auth-anonymous-guard";
+import {
+  decodePendingSignupCookie,
+  readPendingSignupCookie,
+} from "@/lib/pending-signup-cookie";
+
+/**
+ * /api/user/totp/setup and /api/user/totp/enroll accept TWO auth
+ * shapes:
+ *
+ *   - sessioned: a normal Better Auth session cookie. Used by
+ *     existing users who haven't enrolled yet (the "force-enroll on
+ *     every request" proxy path) and by users rotating an
+ *     authenticator from the manage dialog.
+ *
+ *   - pending-signup: a signed pending_signup_mfa cookie set during
+ *     the credential/OAuth signup intercept. No session row exists
+ *     yet. The session is minted for the first time inside the
+ *     enroll route on successful verify.
+ *
+ * This helper resolves "who is calling?" from whichever auth shape
+ * is on the request. The caller doesn't need to know which one was
+ * used unless it cares about minting the session at completion (only
+ * the enroll route does that, when `pendingSignupPayload` is set).
+ */
+
+export type EnrollMfaCaller =
+  | { kind: "session"; userId: string; email: string }
+  | {
+      kind: "pending-signup";
+      userId: string;
+      email: string;
+      redirect: string;
+    }
+  | { kind: "anonymous"; reason: "no_auth" | "anonymous_user" | "no_email" };
+
+export async function resolveEnrollMfaCaller(
+  headers: Headers
+): Promise<EnrollMfaCaller> {
+  const secret = process.env.BETTER_AUTH_SECRET;
+
+  if (secret) {
+    const pendingValue = readPendingSignupCookie(headers);
+    if (pendingValue) {
+      const decoded = decodePendingSignupCookie(pendingValue, secret);
+      if (decoded.ok) {
+        return {
+          kind: "pending-signup",
+          userId: decoded.payload.userId,
+          email: decoded.payload.email,
+          redirect: decoded.payload.redirect,
+        };
+      }
+    }
+  }
+
+  const session = await auth.api.getSession({ headers });
+  if (!session?.user) {
+    return { kind: "anonymous", reason: "no_auth" };
+  }
+  if (isAnonymousUserShape(session.user)) {
+    return { kind: "anonymous", reason: "anonymous_user" };
+  }
+  if (!session.user.email) {
+    return { kind: "anonymous", reason: "no_email" };
+  }
+  return {
+    kind: "session",
+    userId: session.user.id,
+    email: session.user.email,
+  };
+}

--- a/lib/pending-signup-cookie.ts
+++ b/lib/pending-signup-cookie.ts
@@ -1,0 +1,157 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Signed cookie that bridges signup to TOTP enrollment without ever
+ * minting a usable session. Set after the user has proven control of
+ * the email (credential signup: verified the signup OTP; OAuth
+ * signup: the provider already certified the address) but BEFORE
+ * they enroll an authenticator. /enroll-mfa reads this cookie and
+ * lets the user run the 3-step wizard. /api/user/totp/enroll, on
+ * successful first-time verify, atomically writes the session row
+ * for the first time and clears this cookie.
+ *
+ * Threat model:
+ *   - Cookie alone carries no auth power. It only unlocks reaching
+ *     /enroll-mfa and the enroll endpoint, both of which still
+ *     require generating + verifying a TOTP code via the user's own
+ *     authenticator app. A stolen cookie cannot mint a session.
+ *   - HMAC under BETTER_AUTH_SECRET prevents forgery.
+ *   - Embedded expiresAt is checked on every read; we never extend
+ *     the bridge window server-side.
+ */
+
+const COOKIE_NAME = "pending_signup_mfa";
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes - long enough to set up an authenticator.
+
+export type PendingSignupPayload = {
+  userId: string;
+  email: string;
+  /**
+   * Provider whose flow created the user. "credential" for signups
+   * via signUp.email; the social provider id (e.g. "google",
+   * "github") for OAuth signups intercepted in
+   * app/api/auth/[...all]/route.ts.
+   */
+  provider: string;
+  /**
+   * The path to redirect to after the user finishes enrollment and
+   * the session is minted for the first time.
+   */
+  redirect: string;
+  expiresAt: number;
+};
+
+export function pendingSignupCookieName(): string {
+  return COOKIE_NAME;
+}
+
+function base64UrlEncode(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input) : input;
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(input: string): Buffer {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = padded.length % 4 === 0 ? 0 : 4 - (padded.length % 4);
+  return Buffer.from(padded + "=".repeat(pad), "base64");
+}
+
+function sign(payload: string, secret: string): string {
+  return base64UrlEncode(
+    createHmac("sha256", secret).update(payload).digest()
+  );
+}
+
+export function encodePendingSignupCookie(
+  payload: Omit<PendingSignupPayload, "expiresAt">,
+  secret: string,
+  ttlMs: number = DEFAULT_TTL_MS
+): string {
+  const full: PendingSignupPayload = {
+    ...payload,
+    expiresAt: Date.now() + ttlMs,
+  };
+  const encoded = base64UrlEncode(JSON.stringify(full));
+  const mac = sign(encoded, secret);
+  return `${encoded}.${mac}`;
+}
+
+export type DecodeResult =
+  | { ok: true; payload: PendingSignupPayload }
+  | { ok: false; reason: "malformed" | "bad_signature" | "expired" };
+
+export function decodePendingSignupCookie(
+  cookieValue: string,
+  secret: string
+): DecodeResult {
+  const dot = cookieValue.indexOf(".");
+  if (dot <= 0 || dot === cookieValue.length - 1) {
+    return { ok: false, reason: "malformed" };
+  }
+  const encoded = cookieValue.slice(0, dot);
+  const macClaim = cookieValue.slice(dot + 1);
+  const macActual = sign(encoded, secret);
+  const macClaimBuf = Buffer.from(macClaim);
+  const macActualBuf = Buffer.from(macActual);
+  if (macClaimBuf.length !== macActualBuf.length) {
+    return { ok: false, reason: "bad_signature" };
+  }
+  if (!timingSafeEqual(macClaimBuf, macActualBuf)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+  let payload: PendingSignupPayload;
+  try {
+    payload = JSON.parse(
+      base64UrlDecode(encoded).toString()
+    ) as PendingSignupPayload;
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if (
+    typeof payload.userId !== "string" ||
+    typeof payload.email !== "string" ||
+    typeof payload.provider !== "string" ||
+    typeof payload.redirect !== "string" ||
+    typeof payload.expiresAt !== "number"
+  ) {
+    return { ok: false, reason: "malformed" };
+  }
+  if (payload.expiresAt <= Date.now()) {
+    return { ok: false, reason: "expired" };
+  }
+  return { ok: true, payload };
+}
+
+export function buildPendingSignupSetCookie(
+  encodedValue: string,
+  ttlMs: number = DEFAULT_TTL_MS
+): string {
+  const maxAge = Math.floor(ttlMs / 1000);
+  const secureSegment =
+    process.env.NODE_ENV === "production" ? " Secure;" : "";
+  return `${COOKIE_NAME}=${encodedValue}; Path=/; HttpOnly;${secureSegment} SameSite=Lax; Max-Age=${maxAge}`;
+}
+
+export function buildPendingSignupClearCookie(): string {
+  const secureSegment =
+    process.env.NODE_ENV === "production" ? " Secure;" : "";
+  return `${COOKIE_NAME}=; Path=/; HttpOnly;${secureSegment} SameSite=Lax; Max-Age=0`;
+}
+
+export function readPendingSignupCookie(headers: Headers): string | null {
+  const cookie = headers.get("cookie");
+  if (!cookie) {
+    return null;
+  }
+  for (const part of cookie.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(`${COOKIE_NAME}=`)) {
+      return trimmed.slice(COOKIE_NAME.length + 1);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes the window where a new signup briefly held a usable session before enrolling TOTP. Both credential and OAuth signups now follow the same atomic shape: no session row is written, and no `better-auth.session_token` cookie reaches the browser, until the user finishes the 3-step TOTP wizard.

## What changed

### Credential signup
- `handleVerifyOtp` in `components/auth/dialog.tsx` no longer calls `signIn.email` after `emailOtp.verifyEmail` succeeds. It now POSTs `/api/auth/finish-credential-signup`.
- The new endpoint re-verifies the password, confirms `users.email_verified`, and issues a signed `pending_signup_mfa` cookie. No session row is created.

### OAuth signup
- `interceptOauthCallback` in `app/api/auth/[...all]/route.ts` branches on `users.two_factor_enabled`:
  - **Enrolled** (existing user, already has TOTP): existing `pending_oauth_mfa` flow → `/verify-mfa` → atomic dual-factor → first session post-MFA.
  - **Not enrolled** (new signup or pre-mandate user): **new** `pending_signup_mfa` flow. Better Auth's freshly minted session is deleted, its cookie cleared, the signed pending cookie set, browser redirected to `/enroll-mfa`.

### Enrollment
- `lib/enroll-mfa-caller.ts` exports `resolveEnrollMfaCaller` which returns `{kind: "session" | "pending-signup" | "anonymous", ...}` so the setup + enroll endpoints accept both auth shapes without duplicating the lookup logic.
- `/api/user/totp/enroll` on the pending-signup path verifies the TOTP code directly via `verifyUserTotp` (no session to chain through Better Auth's `verifyTOTP`), flips `users.two_factor_enabled`, persists encrypted backup codes, and **mints the first session row in the same transaction**. The session cookie returned is the FIRST usable session for the account.
- `/enroll-mfa` page detects which auth shape is on the request and renders the wizard in the matching mode.

## Threat model

- `pending_signup_mfa` is HMAC-SHA256 signed under `BETTER_AUTH_SECRET`, carries only `{userId, email, provider, redirect, expiresAt}`, and has a 30-min TTL.
- The cookie alone unlocks **only** `/enroll-mfa` and the setup/enroll endpoints. Both still require the user to generate + verify a TOTP code via their own authenticator app.
- A stolen pending cookie cannot mint a session. A stolen post-enrollment session cookie has all the protections we built in PR #1355.

## Cookies set during the new signup window

| Step | Cookies present | Session row exists? |
|---|---|---|
| Before signup | — | No |
| signUp.email succeeds | — | No |
| emailOtp.verifyEmail succeeds | — | No |
| finish-credential-signup succeeds | `pending_signup_mfa` | **No** |
| OAuth callback (TOTP not enrolled) | `pending_signup_mfa` | **No** (intercept deletes it) |
| TOTP wizard / Save backup codes | `pending_signup_mfa` | No |
| Enrollment commits | `better-auth.session_token` | Yes (first row written) |

## Files
- New: `lib/pending-signup-cookie.ts`, `lib/enroll-mfa-caller.ts`, `app/api/auth/finish-credential-signup/route.ts`
- Modified: `app/api/auth/[...all]/route.ts`, `app/api/user/totp/enroll/route.ts`, `app/api/user/totp/setup/route.ts`, `app/enroll-mfa/enroll-mfa-form.tsx`, `app/enroll-mfa/page.tsx`, `components/auth/dialog.tsx`