### PR TITLE
feat: surface per-chain support status, MCP endpoint URL, and hackathon quickstart

### DIFF
--- a/app/api/mcp/schemas/route.ts
+++ b/app/api/mcp/schemas/route.ts
@@ -163,6 +163,9 @@ type ChainInfo = {
   symbol: string;
   chainType: string;
   isTestnet: boolean;
+  // Support maturity: "stable" | "experimental" | "deprecated". Agents should
+  // avoid experimental/deprecated chains for production writes.
+  status: string;
   explorerUrl: string | null;
 };
 
@@ -226,6 +229,7 @@ export async function GET(request: Request) {
         symbol: chain.symbol,
         chainType: chain.chainType,
         isTestnet: chain.isTestnet ?? false,
+        status: chain.status,
         explorerUrl: explorer?.explorerUrl ?? null,
       }));
     } catch (error) {

--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -143,6 +143,7 @@ export async function GET(request: Request) {
         defaultPrivateRpcUrl: chains.defaultPrivateRpcUrl,
         isTestnet: chains.isTestnet,
         isEnabled: chains.isEnabled,
+        status: chains.status,
         createdAt: chains.createdAt,
         updatedAt: chains.updatedAt,
         gasConfig: chains.gasConfig,

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy, Key, Trash2 } from "lucide-react";
+import { Copy, Key, Server, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -489,6 +489,57 @@ function useApiKeys(
 }
 
 /**
+ * Read-only card surfacing the MCP server endpoint URL with a copy button.
+ * The endpoint is derived from NEXT_PUBLIC_APP_URL, falling back to the current
+ * origin (resolved after mount to avoid a hydration mismatch when the env var
+ * is unset).
+ */
+function McpEndpointCard() {
+  const [mcpUrl, setMcpUrl] = useState(
+    process.env.NEXT_PUBLIC_APP_URL
+      ? `${process.env.NEXT_PUBLIC_APP_URL}/mcp`
+      : ""
+  );
+
+  useEffect(() => {
+    if (!mcpUrl) {
+      setMcpUrl(`${window.location.origin}/mcp`);
+    }
+  }, [mcpUrl]);
+
+  const copyEndpoint = () => {
+    navigator.clipboard.writeText(mcpUrl);
+    toast.success("Copied to clipboard");
+  };
+
+  return (
+    <div className="mb-4 rounded-md border border-border bg-muted/40 p-3">
+      <div className="mb-2 flex items-center gap-2">
+        <Server className="size-4 text-muted-foreground" />
+        <p className="font-medium text-sm">MCP endpoint</p>
+      </div>
+      <p className="mb-2 text-muted-foreground text-xs">
+        Connect an agent or MCP client to this URL, authenticating with an
+        organisation API key.
+      </p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 break-all rounded bg-muted px-2 py-1 font-mono text-xs">
+          {mcpUrl}
+        </code>
+        <Button
+          disabled={!mcpUrl}
+          onClick={copyEndpoint}
+          size="sm"
+          variant="outline"
+        >
+          <Copy className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
  * Main API Keys management overlay with tabs for Webhook and Organisation keys.
  */
 export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
@@ -537,6 +588,7 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
       overlayId={overlayId}
       title="API Keys"
     >
+      <McpEndpointCard />
       <Tabs className="-mt-2" onValueChange={setActiveTab} value={activeTab}>
         <TabsList className="w-full">
           <TabsTrigger className="flex-1" value="organisation">

--- a/docs/_meta.ts
+++ b/docs/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   index: "Overview",
   intro: "Introduction",
+  quickstart: "Hackathon Quickstart",
   "getting-started": "Getting Started",
   keepers: "Nodes",
   workflows: "Workflows",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,101 @@
+---
+title: "Hackathon Quickstart"
+description: "Everything you need to integrate KeeperHub in one place - MCP endpoint, supported chains, USDC addresses, faucets, API key types, and rate limits."
+---
+
+# Hackathon Quickstart
+
+A single copy-paste reference for the facts you need in the first thirty minutes:
+where the MCP endpoint is, which chains are supported, which USDC address and
+faucet to use, what the two API key types are for, and the rate limits. Each
+section links to its full reference page.
+
+## 1. Connect the MCP endpoint
+
+The hosted MCP server is the fastest way to drive KeeperHub from an AI agent.
+
+```bash
+claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+```
+
+Run `/mcp` in Claude Code to complete OAuth in the browser. For headless or CI
+environments, pass an organization API key instead:
+
+```bash
+claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp \
+  --header "Authorization: Bearer kh_your_key_here"
+```
+
+Every listed marketplace workflow is also reachable as its own typed MCP server
+at `https://app.keeperhub.com/mcp/w/<slug>`. See the [MCP Server](/ai-tools/mcp-server)
+reference for the full tool list and per-workflow details.
+
+The endpoint URL is also shown, with a copy button, in the dashboard under
+**Settings -> API Keys**.
+
+## 2. Pick a key type
+
+KeeperHub has two key systems. They are not interchangeable.
+
+| Prefix | Scope | Managed at | Use for |
+|--------|-------|------------|---------|
+| `kh_` | Organization | `/api/keys` | REST API, MCP server, Claude Code plugin |
+| `wfb_` | User | `/api/api-keys` | Webhook trigger authentication |
+
+For programmatic API and MCP access, use an organization (`kh_`) key. Full
+details: [API Keys](/api/api-keys).
+
+## 3. Supported chains
+
+Status reflects support maturity: **stable** chains are production-ready;
+**experimental** chains are accepted but may behave unreliably (for example,
+broadcasts can hang) and should not be used for production writes without
+opting in explicitly.
+
+Start on a testnet. Fund the wallet with native gas first, then test USDC.
+
+### Testnets (recommended for hacking)
+
+| Network | chainId | USDC | Faucets | Status |
+|---|---|---|---|---|
+| Ethereum Sepolia | `11155111` | `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` | [ETH](https://cloud.google.com/application/web3/faucet/ethereum/sepolia), [USDC](https://faucet.circle.com) | stable |
+| Base Sepolia | `84532` | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | [ETH](https://portal.cdp.coinbase.com/products/faucet), [USDC](https://faucet.circle.com) | stable |
+
+### Mainnets
+
+| Network | chainId | USDC | Status |
+|---|---|---|---|
+| Ethereum | `1` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | stable |
+| Base | `8453` | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | stable |
+| Arbitrum One | `42161` | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` | stable |
+| Optimism | `10` | `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85` | stable |
+| Polygon | `137` | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` | stable |
+
+### Experimental
+
+| Network | chainId | Status |
+|---|---|---|
+| 0G | `16661` | experimental |
+| 0G Galileo (testnet) | `16602` | experimental |
+
+The live source of truth for chains is `GET /api/chains`; agents can read the
+same list (including per-chain `status`) from the `list_action_schemas` MCP
+tool. Faucet links are third-party and may change. See the full
+[Chains](/api/chains) reference for chain-name aliases and ABI fetching.
+
+## 4. Rate limits
+
+| Context | Limit |
+|---|---|
+| Authenticated requests | 100 / minute |
+| Unauthenticated requests | 10 / minute |
+| Direct execution (per API key) | 60 / minute |
+
+Rate-limited requests return `429` with a `Retry-After` header. See
+[Direct Execution](/api/direct-execution) for spending caps.
+
+## 5. Sandbox
+
+The Code action runs untrusted JavaScript in an isolated `node:vm` sandbox with
+outbound SSRF protection. See [Code Plugin](/plugins/code) for what is allowed
+and blocked.

--- a/drizzle/0094_chain_status.sql
+++ b/drizzle/0094_chain_status.sql
@@ -1,0 +1,15 @@
+-- Per-chain support maturity signal.
+--
+-- chains.status: "stable" | "experimental" | "deprecated". Surfaced to agents
+-- through list_action_schemas (/api/mcp/schemas) so they can tell at request
+-- time whether a chain is production-ready. Orthogonal to is_enabled: a chain
+-- can be enabled (selectable) yet experimental (broadcast may be unreliable).
+-- 0G mainnet (16661) and 0G Galileo testnet (16602) ship as experimental
+-- because broadcasts can hang despite the request being accepted.
+
+ALTER TABLE chains
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'stable';
+
+UPDATE chains
+  SET status = 'experimental'
+  WHERE chain_id IN (16661, 16602);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1779843900000,
       "tag": "0093_workflow_execution_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1779843900001,
+      "tag": "0094_chain_status",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -783,6 +783,9 @@ export const chains = pgTable(
     defaultPrivateRpcUrl: text("default_private_rpc_url"),
     isTestnet: boolean("is_testnet").default(false),
     isEnabled: boolean("is_enabled").default(true), // Can disable chains
+    // Support maturity signal surfaced to agents via list_action_schemas:
+    // "stable" | "experimental" | "deprecated". Orthogonal to isEnabled.
+    status: text("status").notNull().default("stable"),
     // KEEP-1240: Chain-specific gas configuration
     gasConfig: jsonb("gas_config").default({}),
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -592,7 +592,7 @@ export function registerTools(
 
   server.tool(
     "list_action_schemas",
-    "List all available action schemas, triggers, and supported chains. Use this to discover what actions and integrations are available for workflow creation.",
+    "List all available action schemas, triggers, and supported chains. Use this to discover what actions and integrations are available for workflow creation. Each chain includes a 'status' field (stable, experimental, or deprecated) - prefer stable chains for production writes and avoid experimental/deprecated ones unless the user explicitly opts in.",
     {
       category: z
         .string()

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -491,6 +491,7 @@ const DEFAULT_CHAINS: NewChain[] = [
     }),
     isTestnet: getChainConfigValue("0g-mainnet", "isTestnet", false),
     isEnabled: getChainConfigValue("0g-mainnet", "isEnabled", true),
+    status: "experimental",
     usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "0g-mainnet" }),
     defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "0g-mainnet" }),
   },
@@ -513,6 +514,7 @@ const DEFAULT_CHAINS: NewChain[] = [
     }),
     isTestnet: getChainConfigValue("0g-galileo", "isTestnet", true),
     isEnabled: getChainConfigValue("0g-galileo", "isEnabled", true),
+    status: "experimental",
     usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "0g-galileo" }),
     defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "0g-galileo" }),
   },
@@ -828,6 +830,7 @@ async function seedChains() {
           defaultPrivateRpcUrl: chain.defaultPrivateRpcUrl ?? null,
           isTestnet: chain.isTestnet,
           isEnabled: chain.isEnabled,
+          status: chain.status ?? "stable",
           updatedAt: new Date(),
         })
         .where(eq(chains.chainId, chain.chainId));

--- a/tests/integration/mcp-schemas-chain-status.test.ts
+++ b/tests/integration/mcp-schemas-chain-status.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression guard: /api/mcp/schemas must surface per-chain `status`
+ * (stable / experimental / deprecated) so the `list_action_schemas` MCP
+ * tool can tell agents which chains are production-ready. Without this
+ * guard, a future refactor of the select map silently drops the field
+ * and only manifests as a soft signal-loss in agent behaviour.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Route transitively pulls in "server-only" via dependencies; stub it
+// so vitest can import the handler.
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+// Empty plugin registry keeps the test focused on the chains shape
+// rather than re-asserting every plugin's action schema.
+vi.mock("@/plugins/registry", () => ({
+  computeActionId: vi.fn(() => "noop"),
+  flattenConfigFields: vi.fn(() => []),
+  getAllIntegrations: vi.fn(() => []),
+}));
+
+// db.select({...}).from(chains).leftJoin(...).where(...) -> Promise<rows>
+// The route only awaits `.where(...)`, so mocking that terminal step
+// covers the whole chain.
+const { mockChainsWhere } = vi.hoisted(() => ({
+  mockChainsWhere: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        leftJoin: vi.fn(() => ({
+          where: mockChainsWhere,
+        })),
+      })),
+    })),
+  },
+}));
+
+import { GET } from "@/app/api/mcp/schemas/route";
+
+const STABLE_ETH = {
+  chain: {
+    chainId: 1,
+    name: "Ethereum Mainnet",
+    symbol: "ETH",
+    chainType: "evm",
+    isTestnet: false,
+    status: "stable",
+  },
+  explorer: { explorerUrl: "https://etherscan.io" },
+};
+
+const EXPERIMENTAL_OG_GALILEO = {
+  chain: {
+    chainId: 16_602,
+    name: "0G Galileo",
+    symbol: "0G",
+    chainType: "evm",
+    isTestnet: true,
+    status: "experimental",
+  },
+  explorer: null,
+};
+
+const EXPERIMENTAL_OG = {
+  chain: {
+    chainId: 16_661,
+    name: "0G",
+    symbol: "0G",
+    chainType: "evm",
+    isTestnet: false,
+    status: "experimental",
+  },
+  explorer: null,
+};
+
+function buildRequest(): Request {
+  return new Request("http://localhost/api/mcp/schemas");
+}
+
+describe("GET /api/mcp/schemas - chain status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes a status field on every chain entry", async () => {
+    mockChainsWhere.mockResolvedValue([
+      STABLE_ETH,
+      EXPERIMENTAL_OG,
+      EXPERIMENTAL_OG_GALILEO,
+    ]);
+
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chains: Array<{ status: string }> };
+
+    expect(body.chains).toHaveLength(3);
+    for (const chain of body.chains) {
+      expect(typeof chain.status).toBe("string");
+      expect(chain.status.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("propagates the row's status value (stable / experimental) verbatim", async () => {
+    mockChainsWhere.mockResolvedValue([
+      STABLE_ETH,
+      EXPERIMENTAL_OG,
+      EXPERIMENTAL_OG_GALILEO,
+    ]);
+
+    const res = await GET(buildRequest());
+    const body = (await res.json()) as {
+      chains: Array<{ chainId: number; status: string }>;
+    };
+    const byId = new Map(body.chains.map((c) => [c.chainId, c.status]));
+
+    expect(byId.get(1)).toBe("stable");
+    expect(byId.get(16_661)).toBe("experimental");
+    expect(byId.get(16_602)).toBe("experimental");
+  });
+
+  it("omits chains entirely when includeChains=false (status field is moot)", async () => {
+    mockChainsWhere.mockResolvedValue([STABLE_ETH]);
+
+    const res = await GET(
+      new Request("http://localhost/api/mcp/schemas?includeChains=false")
+    );
+    const body = (await res.json()) as { chains: unknown[] };
+    expect(body.chains).toEqual([]);
+  });
+});

--- a/tests/unit/rpc-preferences-routes.test.ts
+++ b/tests/unit/rpc-preferences-routes.test.ts
@@ -117,6 +117,7 @@ describe("RPC Preferences API Routes", () => {
     usePrivateMempoolRpc: false,
     defaultPrivateRpcUrl: null,
     isEnabled: true,
+    status: "stable",
     createdAt: new Date("2026-01-01"),
     updatedAt: new Date("2026-01-01"),
     isTestnet: false,


### PR DESCRIPTION
## Summary

Hackathon teams piece together basic integration facts (supported chains, USDC addresses, the MCP endpoint URL, whether a chain like 0G is production-ready) from MCP error messages and DM threads. This adds a single discoverable surface for that information, for both humans and agents.

## Changes

- **Per-chain support status**: new `status` column on the `chains` table (`stable` | `experimental` | `deprecated`, default `stable`), orthogonal to `is_enabled`. 0G mainnet and 0G Galileo are seeded as `experimental` (broadcasts can hang despite being accepted). Migration `0090_chain_status.sql` adds the column and flips the 0G rows.
- **`list_action_schemas`**: the MCP schemas endpoint (`/api/mcp/schemas`) now returns `status` per chain, and the tool description tells agents to prefer stable chains for production writes.
- **Dashboard**: the API keys overlay now shows the MCP endpoint URL with a copy button.
- **Docs**: new Hackathon Quickstart page consolidating supported chains (chainId, USDC address, faucets, status), the MCP endpoint, `kh_`/`wfb_` key types, rate limits, and sandbox guidance, with links to the canonical pages.

## Test Plan

- [x] `type-check` and `ultracite check` pass; design-system token audit clean for changed UI
- [x] Migrations apply cleanly from scratch on a fresh DB through `0090`; `status` column created
- [x] Seed marks both 0G chains `experimental`, all others `stable`
- [x] `GET /api/mcp/schemas` returns 200 with `status` on every chain; only 0G chains `experimental`
- [ ] CI E2E
- [ ] Verify on staging