### PR TITLE
feat: workflow editor UX polish (name field, run-panel tooltips, faucet, workflowType auto-flip)

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -518,13 +518,39 @@ export async function PATCH(
       !isTransitioningToUnlisted &&
       (isTransitioningToListed || existingWorkflow.isListed === true);
 
+    // `finalNodes` is `unknown` (updateData.nodes is unknown after the generic
+    // Record cast). Both code paths actually hold an array — the body branch
+    // went through `sanitizeWorkflowData`, the existing branch is `nodes`
+    // declared `$type<any[]>` in lib/db/schema.ts. The cast is honest and
+    // matches how lib/mcp/listing.ts calls the same function.
+    const finalNodes =
+      updateData.nodes !== undefined ? updateData.nodes : existingWorkflow.nodes;
+    const hasWriteNode =
+      findFirstWriteActionNode(finalNodes as unknown[]) !== undefined;
+
+    // Auto-derive workflowType from content. A callable write node
+    // (write-contract / protocol-write) forces "write", overriding a
+    // previously-persisted "read". Detection matches the calldata generator
+    // (findFirstWriteActionNode) so a "write"-typed workflow can always be
+    // served by call_workflow. Value transfers and token approvals mutate
+    // chain state but are not calldata-generatable, so they do not qualify
+    // as "write" here — labelling them write would make the call route fail
+    // at runtime with "No write action node found in workflow".
+    //
+    // This intentionally replaces the historical "workflowType is curator-
+    // only" model. A body's `workflowType` is still dropped at the
+    // persistence layer (it is not in `buildUpdateData`'s allowlist); the
+    // value is now solely a function of node content. The curator listing
+    // path (lib/mcp/listing.ts) applies the same derivation for symmetry.
+    const workflowTypeChanged =
+      hasWriteNode && existingWorkflow.workflowType !== "write";
+    if (workflowTypeChanged) {
+      updateData.workflowType = "write";
+    }
+
     if (willBeListed) {
       const checkNodes =
         updateData.nodes !== undefined || isTransitioningToListed;
-      const finalNodes =
-        updateData.nodes !== undefined
-          ? updateData.nodes
-          : existingWorkflow.nodes;
       const checkSchema =
         updateData.inputSchema !== undefined || isTransitioningToListed;
       const finalSchema =
@@ -535,24 +561,14 @@ export async function PATCH(
       // Gate ordering matches the publish path (lib/mcp/listing.ts::listWorkflow):
       // write-action -> bare-@ -> input-schema. Same DB state therefore yields
       // the same error code regardless of which gate-bearing route the caller
-      // hits, which keeps client-side error handling consistent.
-      //
-      // workflowType is curator-only — it's not in `buildUpdateData`'s field
-      // allowlist (lines 156-170 above), so a body's `workflowType` is silently
-      // dropped at the persistence layer. We read it directly from
-      // `existingWorkflow.workflowType` (no fallback chain) so the gate truly
-      // reflects what will be persisted. Type changes flow through
-      // updateWorkflowListing (lib/mcp/listing.ts), which is unconditionally
-      // strict.
-      // `finalNodes` is `unknown` (updateData.nodes is unknown after the
-      // generic Record cast). Both code paths actually hold an array — the
-      // body branch went through `sanitizeWorkflowData`, the existing branch
-      // is `nodes` declared `$type<any[]>` in lib/db/schema.ts. The cast is
-      // honest and matches how lib/mcp/listing.ts:151 calls the same function.
+      // hits, which keeps client-side error handling consistent. The gate uses
+      // `existingWorkflow.workflowType` because the auto-flip above only flips
+      // to "write" (never back to "read"), so a workflow that WAS write and
+      // now has no write node still trips this guard correctly.
       if (
         checkNodes &&
         existingWorkflow.workflowType === "write" &&
-        findFirstWriteActionNode(finalNodes as unknown[]) === undefined
+        !hasWriteNode
       ) {
         return NextResponse.json(
           {
@@ -591,14 +607,16 @@ export async function PATCH(
     }
 
     // Bump listingVersion when a listed (or about-to-be-listed) workflow has
-    // its schema-defining fields changed via this route. Keeps per-workflow
-    // MCP consumers in sync without a dedicated version endpoint.
+    // its schema-defining fields changed via this route — including an
+    // auto-flip of workflowType. Keeps per-workflow MCP consumers in sync
+    // without a dedicated version endpoint.
     if (
       willBeListed &&
       (body.nodes !== undefined ||
         body.edges !== undefined ||
         body.inputSchema !== undefined ||
-        body.outputMapping !== undefined)
+        body.outputMapping !== undefined ||
+        workflowTypeChanged)
     ) {
       updateData.listingVersion = sql`${workflows.listingVersion} + 1`;
     }

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -8,7 +8,10 @@ import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { extractActionTypeNodes } from "@/lib/features";
 import { enforceWorkflowFeatures } from "@/lib/features/route-guard";
 import { projects, publicTags, tags, workflowExecutions, workflowPublicTags, workflowSchedules, workflows } from "@/lib/db/schema";
-import { findFirstWriteActionNode } from "@/lib/mcp/calldata";
+import {
+  deriveWorkflowType,
+  findFirstWriteActionNode,
+} from "@/lib/mcp/calldata";
 import {
   findBareAtLiterals,
   isInputSchemaPresent,
@@ -525,27 +528,22 @@ export async function PATCH(
     // matches how lib/mcp/listing.ts calls the same function.
     const finalNodes =
       updateData.nodes !== undefined ? updateData.nodes : existingWorkflow.nodes;
-    const hasWriteNode =
-      findFirstWriteActionNode(finalNodes as unknown[]) !== undefined;
 
-    // Auto-derive workflowType from content. A callable write node
-    // (write-contract / protocol-write) forces "write", overriding a
-    // previously-persisted "read". Detection matches the calldata generator
-    // (findFirstWriteActionNode) so a "write"-typed workflow can always be
-    // served by call_workflow. Value transfers and token approvals mutate
-    // chain state but are not calldata-generatable, so they do not qualify
-    // as "write" here — labelling them write would make the call route fail
-    // at runtime with "No write action node found in workflow".
-    //
-    // This intentionally replaces the historical "workflowType is curator-
-    // only" model. A body's `workflowType` is still dropped at the
-    // persistence layer (it is not in `buildUpdateData`'s allowlist); the
-    // value is now solely a function of node content. The curator listing
-    // path (lib/mcp/listing.ts) applies the same derivation for symmetry.
+    // Auto-derive workflowType from content via the shared helper
+    // (lib/mcp/calldata.ts::deriveWorkflowType). This intentionally replaces
+    // the historical "workflowType is curator-only" model: a body's
+    // `workflowType` is still dropped at the persistence layer (not in
+    // `buildUpdateData`'s allowlist), so the requested type passed to the
+    // helper is the row's current value. The curator listing path
+    // (lib/mcp/listing.ts) calls the same helper for symmetry.
+    const resolvedWorkflowType = deriveWorkflowType(
+      finalNodes as unknown[],
+      existingWorkflow.workflowType
+    );
     const workflowTypeChanged =
-      hasWriteNode && existingWorkflow.workflowType !== "write";
+      resolvedWorkflowType !== existingWorkflow.workflowType;
     if (workflowTypeChanged) {
-      updateData.workflowType = "write";
+      updateData.workflowType = resolvedWorkflowType;
     }
 
     if (willBeListed) {
@@ -568,7 +566,7 @@ export async function PATCH(
       if (
         checkNodes &&
         existingWorkflow.workflowType === "write" &&
-        !hasWriteNode
+        findFirstWriteActionNode(finalNodes as unknown[]) === undefined
       ) {
         return NextResponse.json(
           {

--- a/components/settings/web3-wallet-section.tsx
+++ b/components/settings/web3-wallet-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSetAtom } from "jotai";
+import { Copy, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { useSession } from "@/lib/auth-client";
 import { integrationsVersionAtom } from "@/lib/integrations-store";
+import { TESTNET_FAUCETS } from "@/lib/web3/faucets";
 
 type Web3WalletSectionProps = {
   onSuccess?: (integrationId: string) => void;
@@ -175,15 +177,61 @@ export function Web3WalletSection({
         }
 
         if (hasWallet) {
+          const checksummedAddress = walletAddress
+            ? toChecksumAddress(walletAddress)
+            : null;
           return (
             <div className="space-y-3">
               <div className="rounded-lg border bg-muted/50 p-3">
-                <div className="mb-1 text-muted-foreground text-xs">
-                  Wallet Address
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <span className="text-muted-foreground text-xs">
+                    Wallet Address
+                  </span>
+                  {checksummedAddress && (
+                    <button
+                      aria-label="Copy wallet address"
+                      className="inline-flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
+                      onClick={async () => {
+                        try {
+                          await navigator.clipboard.writeText(
+                            checksummedAddress
+                          );
+                          toast.success("Address copied");
+                        } catch {
+                          toast.error("Failed to copy address");
+                        }
+                      }}
+                      type="button"
+                    >
+                      <Copy className="size-3" />
+                      Copy
+                    </button>
+                  )}
                 </div>
                 <code className="break-all font-mono text-xs">
-                  {walletAddress ? toChecksumAddress(walletAddress) : null}
+                  {checksummedAddress}
                 </code>
+              </div>
+              <div className="rounded-lg border bg-muted/50 p-3">
+                <div className="font-medium text-sm">Fund this wallet</div>
+                <p className="mt-1 text-muted-foreground text-xs">
+                  New wallets start empty. Use a testnet faucet to add gas before
+                  running Web3 workflows.
+                </p>
+                <div className="mt-2 flex flex-col gap-1">
+                  {TESTNET_FAUCETS.map((faucet) => (
+                    <a
+                      className="inline-flex items-center gap-1.5 text-primary text-xs hover:underline"
+                      href={faucet.url}
+                      key={faucet.chainId}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ExternalLink className="size-3" />
+                      {faucet.name} faucet
+                    </a>
+                  ))}
+                </div>
               </div>
               {showDelete && (
                 <Button

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -723,6 +723,23 @@ function ForEachLogGroup({
     </div>
   );
 }
+// Human-readable explanation for each run/step status, surfaced as a tooltip
+// so a grey or non-success dot isn't ambiguous about why a step is in that state.
+function getStatusLabel(status: string): string {
+  switch (status) {
+    case "success":
+      return "Completed successfully";
+    case "error":
+      return "Failed - expand for the error";
+    case "running":
+      return "Running";
+    case "cancelled":
+      return "Cancelled before it finished";
+    default:
+      return "Pending - has not run yet";
+  }
+}
+
 // Component for rendering individual execution log entries
 function ExecutionLogEntry({
   log,
@@ -753,6 +770,7 @@ function ExecutionLogEntry({
             "z-10 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-0",
             getStatusDotClass(log.status)
           )}
+          title={getStatusLabel(log.status)}
         >
           {getStatusIcon(log.status)}
         </div>
@@ -1189,6 +1207,7 @@ export function WorkflowRuns({
                     "flex size-5 items-center justify-center rounded-full border-0",
                     getStatusDotClass(execution.status)
                   )}
+                  title={getStatusLabel(execution.status)}
                 >
                   {getStatusIcon(execution.status)}
                 </div>

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -1728,6 +1728,76 @@ function RunButtonGroup({
 }
 
 // Read-only badge - pill with a strong accent outline on the toolbar
+// Editable workflow name shown at the top of the editor. Saves on blur.
+function WorkflowNameField({
+  workflowId,
+  name,
+  canEdit,
+  onRename,
+}: {
+  workflowId: string;
+  name: string;
+  canEdit: boolean;
+  onRename: (next: string) => void;
+}) {
+  const [draft, setDraft] = useState(name);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Re-sync when the loaded workflow changes or a rename lands from elsewhere.
+  useEffect(() => {
+    setDraft(name);
+  }, [name]);
+
+  const commit = async () => {
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === name) {
+      setDraft(name);
+      return;
+    }
+    onRename(trimmed);
+    setIsSaving(true);
+    try {
+      await api.workflow.update(workflowId, { name: trimmed });
+    } catch (error) {
+      console.error("Failed to rename workflow:", error);
+      toast.error("Failed to rename workflow. Please try again.");
+      onRename(name);
+      setDraft(name);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!canEdit) {
+    return (
+      <span className="hidden max-w-48 truncate font-medium text-foreground text-sm lg:inline-block">
+        {name}
+      </span>
+    );
+  }
+
+  return (
+    <input
+      aria-label="Workflow name"
+      className="hidden h-8 max-w-48 rounded-md border border-transparent bg-transparent px-2 font-medium text-foreground text-sm transition-colors hover:border-border focus-visible:border-border focus-visible:bg-background focus-visible:outline-none disabled:opacity-50 lg:inline-block"
+      disabled={isSaving}
+      onBlur={commit}
+      onChange={(event) => setDraft(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          inputRef.current?.blur();
+        } else if (event.key === "Escape") {
+          setDraft(name);
+          inputRef.current?.blur();
+        }
+      }}
+      ref={inputRef}
+      value={draft}
+    />
+  );
+}
+
 function ReadOnlyBadge({ className }: { className?: string }) {
   return (
     <Badge
@@ -1854,6 +1924,14 @@ export const WorkflowToolbar = ({
             state={state}
             workflowId={effectiveWorkflowId}
           />
+          {isWorkflowRoute && state.currentWorkflowId && (
+            <WorkflowNameField
+              canEdit={state.isOwner}
+              name={state.workflowName}
+              onRename={state.setCurrentWorkflowName}
+              workflowId={state.currentWorkflowId}
+            />
+          )}
           {isWorkflowRoute &&
             effectiveWorkflowId &&
             !state.isOwner &&

--- a/lib/mcp/calldata.ts
+++ b/lib/mcp/calldata.ts
@@ -73,6 +73,32 @@ export function findFirstWriteActionNode(
   return undefined;
 }
 
+/**
+ * Returns the workflowType that should be persisted given current node content.
+ *
+ * A workflow containing a callable write node (write-contract / protocol-write)
+ * is unconditionally "write" - this auto-flips a "read" and overrides a
+ * conflicting requested "read". When no callable write node is present, the
+ * requested type (or the current type when no explicit request is made) is
+ * preserved unchanged.
+ *
+ * Detection is intentionally narrow and matches the calldata generator so a
+ * "write"-typed workflow can always be served by call_workflow. Value
+ * transfers and token approvals mutate chain state but are not calldata-
+ * generatable, so they do not qualify here - labelling them "write" would
+ * make the call route fail at runtime with "No write action node found in
+ * workflow".
+ */
+export function deriveWorkflowType(
+  nodes: unknown[],
+  requestedType: "read" | "write"
+): "read" | "write" {
+  if (findFirstWriteActionNode(nodes) !== undefined) {
+    return "write";
+  }
+  return requestedType;
+}
+
 export function resolveTriggerTemplates(
   value: string,
   triggerInputs: Record<string, unknown>

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -144,32 +144,39 @@ export async function listWorkflow(
   if (metadata.outputMapping !== undefined) {
     updateSet.outputMapping = metadata.outputMapping;
   }
-  if (metadata.workflowType !== undefined) {
-    updateSet.workflowType = metadata.workflowType as "read" | "write";
-  }
+  // Auto-derive workflowType from content. A workflow that contains a callable
+  // write node (write-contract / protocol-write) is unconditionally "write":
+  // this fills in an unset type and overrides a curator-supplied "read" that
+  // conflicts with the content. Detection deliberately matches the calldata
+  // generator (findFirstWriteActionNode) so a listed "write" can always be
+  // served by call_workflow. Value transfers and token approvals mutate chain
+  // state but are not calldata-generatable, so they do not qualify as "write"
+  // here -- labelling them write would make the call route fail at runtime.
+  const hasWriteNode = findFirstWriteActionNode(current.nodes) !== undefined;
+  const requestedWorkflowType: "read" | "write" =
+    (metadata.workflowType as "read" | "write" | undefined) ??
+    current.workflowType;
+  const resolvedWorkflowType: "read" | "write" = hasWriteNode
+    ? "write"
+    : requestedWorkflowType;
+  updateSet.workflowType = resolvedWorkflowType;
 
   // Bump listingVersion whenever we are transitioning to listed OR whenever
   // any of the schema-defining fields changes on an already-listed workflow.
   const isSchemaTouched =
     metadata.inputSchema !== undefined ||
     metadata.outputMapping !== undefined ||
-    metadata.workflowType !== undefined;
+    resolvedWorkflowType !== current.workflowType;
   if (!current.isListed || isSchemaTouched) {
     // biome-ignore lint/suspicious/noExplicitAny: Drizzle sql template tag produces a typed SQL expression that satisfies the column type at runtime
     (updateSet as any).listingVersion = sql`${workflows.listingVersion} + 1`;
   }
 
-  // A write workflow must contain at least one node whose actionType matches
-  // the calldata matcher; otherwise call_workflow would later fail at runtime
-  // with "No write action node found in workflow". Reject at publish time so
-  // the listing can never reach search results in a broken state.
-  const resolvedWorkflowType: "read" | "write" =
-    (updateSet.workflowType as "read" | "write" | undefined) ??
-    current.workflowType;
-  if (
-    resolvedWorkflowType === "write" &&
-    findFirstWriteActionNode(current.nodes) === undefined
-  ) {
+  // A "write" workflow must contain a calldata-generatable write node;
+  // otherwise call_workflow would later fail at runtime with "No write action
+  // node found in workflow". With auto-derive above, this can only trigger when
+  // a curator forces "write" on content that has no callable write node.
+  if (resolvedWorkflowType === "write" && !hasWriteNode) {
     return { ok: false, error: "MISSING_WRITE_ACTION" };
   }
 
@@ -297,8 +304,20 @@ export async function updateWorkflowListing(
   if (patch.outputMapping !== undefined) {
     updateSet.outputMapping = patch.outputMapping;
   }
-  if (patch.workflowType !== undefined) {
-    updateSet.workflowType = patch.workflowType;
+  // Auto-derive workflowType from content (see listWorkflow for the rationale):
+  // a callable write node forces "write" and overrides a conflicting "read".
+  // Transfers/approvals mutate chain state but are not calldata-generatable, so
+  // they do not qualify here.
+  const hasWriteNode = findFirstWriteActionNode(current.nodes) !== undefined;
+  const requestedWorkflowType: "read" | "write" =
+    (patch.workflowType as "read" | "write" | undefined) ??
+    current.workflowType;
+  const resolvedWorkflowType: "read" | "write" = hasWriteNode
+    ? "write"
+    : requestedWorkflowType;
+  const workflowTypeChanged = resolvedWorkflowType !== current.workflowType;
+  if (patch.workflowType !== undefined || workflowTypeChanged) {
+    updateSet.workflowType = resolvedWorkflowType;
   }
   if (patch.priceUsdcPerCall !== undefined) {
     // Only reachable when isListed === false (price-change-while-listed guard above)
@@ -310,22 +329,18 @@ export async function updateWorkflowListing(
   const isUpdateSchemaTouched =
     patch.inputSchema !== undefined ||
     patch.outputMapping !== undefined ||
-    patch.workflowType !== undefined;
+    workflowTypeChanged;
   if (current.isListed && isUpdateSchemaTouched) {
     updateSet.listingVersion = sql`${workflows.listingVersion} + 1`;
   }
 
-  // Same write-workflow guard as listWorkflow: only validate when the row is
-  // (or is becoming) listed AND resolves to write. An unlisted draft is allowed
-  // to be in a read state with a "write" type still set, but a listed write
-  // must have a matching action node.
-  const resolvedWorkflowType: "read" | "write" =
-    (patch.workflowType as "read" | "write" | undefined) ??
-    current.workflowType;
+  // Same write-workflow guard as listWorkflow: a listed "write" must contain a
+  // calldata-generatable write node. An unlisted draft may still carry a "write"
+  // type without one. resolvedWorkflowType already reflects the auto-derive.
   if (
     current.isListed === true &&
     resolvedWorkflowType === "write" &&
-    findFirstWriteActionNode(current.nodes) === undefined
+    !hasWriteNode
   ) {
     return { ok: false, error: "MISSING_WRITE_ACTION" };
   }

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -1,7 +1,10 @@
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
-import { findFirstWriteActionNode } from "@/lib/mcp/calldata";
+import {
+  deriveWorkflowType,
+  findFirstWriteActionNode,
+} from "@/lib/mcp/calldata";
 import {
   findBareAtLiterals,
   isInputSchemaPresent,
@@ -144,21 +147,17 @@ export async function listWorkflow(
   if (metadata.outputMapping !== undefined) {
     updateSet.outputMapping = metadata.outputMapping;
   }
-  // Auto-derive workflowType from content. A workflow that contains a callable
-  // write node (write-contract / protocol-write) is unconditionally "write":
-  // this fills in an unset type and overrides a curator-supplied "read" that
-  // conflicts with the content. Detection deliberately matches the calldata
-  // generator (findFirstWriteActionNode) so a listed "write" can always be
-  // served by call_workflow. Value transfers and token approvals mutate chain
-  // state but are not calldata-generatable, so they do not qualify as "write"
-  // here -- labelling them write would make the call route fail at runtime.
-  const hasWriteNode = findFirstWriteActionNode(current.nodes) !== undefined;
+  // Auto-derive workflowType from content via the shared helper
+  // (lib/mcp/calldata.ts::deriveWorkflowType). A callable write node forces
+  // "write" and overrides a curator-supplied "read" that conflicts with
+  // the content.
   const requestedWorkflowType: "read" | "write" =
     (metadata.workflowType as "read" | "write" | undefined) ??
     current.workflowType;
-  const resolvedWorkflowType: "read" | "write" = hasWriteNode
-    ? "write"
-    : requestedWorkflowType;
+  const resolvedWorkflowType = deriveWorkflowType(
+    current.nodes,
+    requestedWorkflowType
+  );
   updateSet.workflowType = resolvedWorkflowType;
 
   // Bump listingVersion whenever we are transitioning to listed OR whenever
@@ -176,7 +175,10 @@ export async function listWorkflow(
   // otherwise call_workflow would later fail at runtime with "No write action
   // node found in workflow". With auto-derive above, this can only trigger when
   // a curator forces "write" on content that has no callable write node.
-  if (resolvedWorkflowType === "write" && !hasWriteNode) {
+  if (
+    resolvedWorkflowType === "write" &&
+    findFirstWriteActionNode(current.nodes) === undefined
+  ) {
     return { ok: false, error: "MISSING_WRITE_ACTION" };
   }
 
@@ -304,17 +306,15 @@ export async function updateWorkflowListing(
   if (patch.outputMapping !== undefined) {
     updateSet.outputMapping = patch.outputMapping;
   }
-  // Auto-derive workflowType from content (see listWorkflow for the rationale):
-  // a callable write node forces "write" and overrides a conflicting "read".
-  // Transfers/approvals mutate chain state but are not calldata-generatable, so
-  // they do not qualify here.
-  const hasWriteNode = findFirstWriteActionNode(current.nodes) !== undefined;
+  // Auto-derive workflowType from content via the shared helper
+  // (lib/mcp/calldata.ts::deriveWorkflowType). See listWorkflow for rationale.
   const requestedWorkflowType: "read" | "write" =
     (patch.workflowType as "read" | "write" | undefined) ??
     current.workflowType;
-  const resolvedWorkflowType: "read" | "write" = hasWriteNode
-    ? "write"
-    : requestedWorkflowType;
+  const resolvedWorkflowType = deriveWorkflowType(
+    current.nodes,
+    requestedWorkflowType
+  );
   const workflowTypeChanged = resolvedWorkflowType !== current.workflowType;
   if (patch.workflowType !== undefined || workflowTypeChanged) {
     updateSet.workflowType = resolvedWorkflowType;
@@ -340,7 +340,7 @@ export async function updateWorkflowListing(
   if (
     current.isListed === true &&
     resolvedWorkflowType === "write" &&
-    !hasWriteNode
+    findFirstWriteActionNode(current.nodes) === undefined
   ) {
     return { ok: false, error: "MISSING_WRITE_ACTION" };
   }

--- a/lib/web3/faucets.ts
+++ b/lib/web3/faucets.ts
@@ -1,0 +1,23 @@
+import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
+
+export type TestnetFaucet = {
+  chainId: number;
+  name: string;
+  url: string;
+};
+
+// Public faucets for the EVM testnets supported by the platform. Organization
+// wallets are EVM addresses, so only EVM testnets are listed here. Used by the
+// wallet creation flow to point users at testnet funds (KEEP-493).
+export const TESTNET_FAUCETS: TestnetFaucet[] = [
+  {
+    chainId: SUPPORTED_CHAIN_IDS.SEPOLIA,
+    name: "Ethereum Sepolia",
+    url: "https://www.alchemy.com/faucets/ethereum-sepolia",
+  },
+  {
+    chainId: SUPPORTED_CHAIN_IDS.BASE_SEPOLIA,
+    name: "Base Sepolia",
+    url: "https://www.alchemy.com/faucets/base-sepolia",
+  },
+];

--- a/tests/integration/workflow-listing-lifecycle.test.ts
+++ b/tests/integration/workflow-listing-lifecycle.test.ts
@@ -422,4 +422,85 @@ describe("workflow listing lifecycle", () => {
       firstListedAt.getTime()
     );
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // workflowType is auto-derived from content: a callable write node forces
+  // "write" and overrides a conflicting "read". Detection matches the calldata
+  // generator, so value transfers/approvals do not qualify.
+  // ──────────────────────────────────────────────────────────────────────
+
+  const WRITE_CONTRACT_NODE = {
+    id: "write-1",
+    data: {
+      actionType: "web3/write-contract",
+      config: {
+        contractAddress: "0xabc",
+        network: "11155111",
+        abi: "[]",
+        abiFunction: "transfer",
+      },
+    },
+  };
+
+  it("list: auto-flips workflowType to 'write' when a write node exists and no type was supplied", async () => {
+    workflowState.workflowType = "read";
+    workflowState.nodes = [WRITE_CONTRACT_NODE];
+
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "auto-write",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.listing.workflowType).toBe("write");
+  });
+
+  it("list: overrides a conflicting 'read' to 'write' when content has a write node", async () => {
+    workflowState.workflowType = "read";
+    workflowState.nodes = [WRITE_CONTRACT_NODE];
+
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "conflicting-read",
+      workflowType: "read",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.listing.workflowType).toBe("write");
+  });
+
+  it("update: auto-flips an unlisted draft to 'write' when a write node exists", async () => {
+    workflowState.isListed = false;
+    workflowState.workflowType = "read";
+    workflowState.nodes = [WRITE_CONTRACT_NODE];
+
+    const result = await updateWorkflowListing(WORKFLOW_ID, ORG_ID, {
+      category: "defi",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.listing.workflowType).toBe("write");
+  });
+
+  it("list: does NOT classify a transfer-token node as 'write' (not calldata-generatable)", async () => {
+    workflowState.workflowType = "read";
+    workflowState.nodes = [
+      {
+        id: "transfer-1",
+        data: {
+          actionType: "web3/transfer-token",
+          config: { network: "11155111" },
+        },
+      },
+    ];
+
+    const result = await listWorkflow(WORKFLOW_ID, ORG_ID, {
+      slug: "transfer-only",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.listing.workflowType).toBe("read");
+  });
 });

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -7,6 +7,7 @@ const {
   mockMemberLimit,
   mockSelectFrom,
   mockValidateWorkflowIntegrations,
+  capturedSet,
 } = vi.hoisted(() => ({
   mockGetDualAuthContext: vi.fn(),
   mockWorkflowsFindFirst: vi.fn(),
@@ -14,6 +15,11 @@ const {
   mockMemberLimit: vi.fn(),
   mockSelectFrom: vi.fn(),
   mockValidateWorkflowIntegrations: vi.fn(),
+  // Side-effect capture of the most recent db.update().set() argument so
+  // workflowType-auto-flip tests can verify what the route actually persisted
+  // (the response is the value returned by mockUpdateReturning, so it can't
+  // distinguish "auto-flipped" from "echoed by the mock").
+  capturedSet: { data: null as Record<string, unknown> | null },
 }));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
@@ -28,11 +34,14 @@ vi.mock("@/lib/db", () => ({
       },
     },
     update: vi.fn(() => ({
-      set: vi.fn(() => ({
-        where: vi.fn(() => ({
-          returning: mockUpdateReturning,
-        })),
-      })),
+      set: vi.fn((data: Record<string, unknown>) => {
+        capturedSet.data = data;
+        return {
+          where: vi.fn(() => ({
+            returning: mockUpdateReturning,
+          })),
+        };
+      }),
     })),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
@@ -1403,5 +1412,104 @@ describe("GET /api/workflows/[workflowId] — description sanitization", () => {
     const data = await response.json();
     expect(data.description).toBe("## Hello **world**");
     expect(data.description).not.toMatch(SANITIZED_PREFIX_RE);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// workflowType is auto-derived from content on every PATCH: a callable
+// write node forces "write", overriding a persisted "read". Detection
+// matches the calldata generator, so value transfers/approvals do not
+// qualify (labelling them write would make call_workflow fail at runtime).
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/workflows/[workflowId] — workflowType auto-flip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedSet.data = null;
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-123",
+      organizationId: "org-123",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+    mockSelectFrom.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
+  });
+
+  const WRITE_CONTRACT_NODE = {
+    id: "write-1",
+    type: "action",
+    data: {
+      type: "action",
+      config: {
+        actionType: "web3/write-contract",
+        contractAddress: "0xabc",
+        network: "11155111",
+        abi: "[]",
+        abiFunction: "transfer",
+      },
+    },
+  };
+
+  it("auto-flips workflowType to 'write' when PATCH adds a write-contract node", async () => {
+    const existing = makeWorkflow({ workflowType: "read", nodes: [] });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({ workflowType: "write", nodes: [WRITE_CONTRACT_NODE] }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        nodes: [WRITE_CONTRACT_NODE],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBe("write");
+  });
+
+  it("does NOT flip workflowType when PATCH has no callable write node", async () => {
+    // The narrow-detector decision (transfers/approvals don't qualify) is
+    // unit-tested in workflow-listing-lifecycle.test.ts. Here we just confirm
+    // the route doesn't spuriously touch workflowType when nothing in the
+    // node set matches the calldata detector.
+    const existing = makeWorkflow({ workflowType: "read", nodes: [] });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({ workflowType: "read", nodes: [] }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBeUndefined();
+  });
+
+  it("does NOT write workflowType when content matches existing 'write' type (no-op)", async () => {
+    const existing = makeWorkflow({
+      workflowType: "write",
+      nodes: [WRITE_CONTRACT_NODE],
+    });
+    mockWorkflowsFindFirst.mockResolvedValue(existing);
+    mockUpdateReturning.mockResolvedValue([
+      makeWorkflow({
+        workflowType: "write",
+        nodes: [WRITE_CONTRACT_NODE],
+        description: "updated",
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { description: "updated" }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Workflow-editor UX polish addressing a cluster of gaps surfaced during hackathon usage. Six commits, one logical change per commit.

## Changes

- **Editable workflow name in the toolbar.** The persistent toolbar already held the workflow name but never rendered it. Adds an inline name field (save on blur, Enter to commit, Escape to revert) that is read-only for non-owners.
- **Run-panel status tooltips.** Each run-level and per-node status dot now has a tooltip explaining the state (pending / running / success / failed / cancelled), so a grey or non-success dot is no longer ambiguous.
- **Fund-this-wallet faucet panel.** After a wallet exists, the wallet settings section shows a copy-address affordance and links to testnet faucets (Ethereum Sepolia, Base Sepolia). New static faucet map keyed by chain id.
- **workflowType is auto-derived from content on every save.** A workflow containing a callable write node (write-contract / protocol-write) is unconditionally typed `write`; a conflicting `read` is overridden. The derivation runs on both the regular `/api/workflows/[id]` PATCH route (the path the UI hits) and the curator listing path (`lib/mcp/listing.ts`), via a shared helper `deriveWorkflowType` in `lib/mcp/calldata.ts`. This intentionally replaces the historical "workflowType is curator-only" model: a body's `workflowType` is still dropped at the persistence layer, but the value is now solely a function of node content.

## Key design decision: workflowType stays calldata-bound

`workflowType: "write"` is a hard contract with the `call_workflow` route, which serves write workflows by generating a single transaction's calldata via `generateCalldataForWorkflow`. That generator only understands `write-contract` / `protocol-write` (ABI calls). Value transfers and token approvals mutate chain state but are not calldata-generatable, so they are intentionally NOT classified as `write` here - labelling them write would make the call route fail at runtime with "No write action node found in workflow". A test locks in the `transfer-token` exclusion.

If transfer / approval workflows need to be listed and served as writes, that requires extending the calldata generator to emit ERC20 / native-transfer calldata - a separate change to the on-chain call path, recommended as a follow-up.

## Out of scope / follow-ups

- Run panel: `skipped (branch)` and `config-invalid` states need executor persistence (new statuses + schema migration); not delivered here.
- Signer-dropdown label: the original "shows integration id" report appears already addressed by the Web3ConnectionSelect refactor and the integration address column; no change made.
- Listing UX: when a marketplace listing fails an early gate (e.g. `INPUT_SCHEMA_REQUIRED`), `listedSlug` and `priceUsdcPerCall` still persist via the workflow PATCH allowlist - the workflow looks half-listed even though nothing actually committed. Worth a follow-up.

## Verification

- `pnpm type-check`: clean
- `pnpm check` (ultracite): no diagnostics in the changed files
- `node scripts/token-audit.js`: no errors in the changed files
- Tests: 75 pass across the three suites covering this work (`workflow-listing-route`, `workflow-listing-lifecycle`, `mcp-calldata`) - includes auto-flip via the workflow PATCH route, transfer-token exclusion, override of a conflicting `read`, no-op when content already matches existing type, and the listing.ts curator-path coverage.
