### PR TITLE
feat: improve contract-call and action-schema ergonomics

### DIFF
--- a/app/api/mcp/schemas/route.ts
+++ b/app/api/mcp/schemas/route.ts
@@ -3,15 +3,16 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { chains, explorerConfigs } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import {
-  BUILTIN_NODE_ID,
-  BUILTIN_NODE_LABEL,
-} from "@/lib/workflow/editor/builtin-variables";
+import { synthesizeOutputSchema } from "@/lib/mcp/output-schema";
 import {
   SYSTEM_ACTIONS,
   TEMPLATE_SYNTAX,
   TRIGGERS,
 } from "@/lib/mcp/workflow-schema-constants";
+import {
+  BUILTIN_NODE_ID,
+  BUILTIN_NODE_LABEL,
+} from "@/lib/workflow/editor/builtin-variables";
 import {
   type ActionConfigFieldBase,
   computeActionId,
@@ -64,6 +65,7 @@ function transformPluginAction(
   requiredFields: Record<string, string>;
   optionalFields: Record<string, string>;
   outputFields: Record<string, string>;
+  outputSchema?: Record<string, unknown>;
 } {
   const actionType = computeActionId(plugin.type, action.slug);
   const flatFields = flattenConfigFields(action.configFields);
@@ -88,6 +90,8 @@ function transformPluginAction(
     }
   }
 
+  const outputSchema = synthesizeOutputSchema(action);
+
   return {
     actionType,
     label: action.label,
@@ -99,6 +103,7 @@ function transformPluginAction(
     requiredFields,
     optionalFields,
     outputFields,
+    ...(outputSchema ? { outputSchema } : {}),
   };
 }
 

--- a/lib/mcp/output-schema.ts
+++ b/lib/mcp/output-schema.ts
@@ -1,0 +1,31 @@
+// Derives the optional `outputSchema` surfaced by list_action_schemas.
+// Pure (no DB / network) so it can be unit-tested without the route harness.
+
+import type { PluginAction } from "@/plugins/registry";
+
+/**
+ * Build a JSON Schema for an action's output.
+ *
+ * - When the action declares `outputSchema` explicitly, it is returned as-is
+ *   (for actions whose output is richer than a flat key/description map).
+ * - Otherwise it is synthesized from `outputFields`: each field becomes a
+ *   property carrying its description. Types are left unconstrained because
+ *   outputFields do not record them.
+ * - Returns null when the action declares no outputs, so the caller can omit
+ *   the key entirely rather than emit an empty schema.
+ */
+export function synthesizeOutputSchema(
+  action: PluginAction
+): Record<string, unknown> | null {
+  if (action.outputSchema) {
+    return action.outputSchema;
+  }
+  if (!action.outputFields || action.outputFields.length === 0) {
+    return null;
+  }
+  const properties: Record<string, { description: string }> = {};
+  for (const output of action.outputFields) {
+    properties[output.field] = { description: output.description };
+  }
+  return { type: "object", properties };
+}

--- a/lib/mcp/validate-workflow-codes.ts
+++ b/lib/mcp/validate-workflow-codes.ts
@@ -21,6 +21,9 @@ export const VALIDATION_WARNING_CODES = {
   WRITE_ACTION_ON_READ_WORKFLOW: "write-action-on-read-workflow",
   // ABI deep-check code added in Plan 48-03:
   LOW_CONFIDENCE_ABI_MATCH: "low-confidence-abi-match",
+  // Configure-time hint: write-contract uses an allowance-consuming method
+  // (transferFrom / redeem / withdrawFrom) with no check-allowance node.
+  MISSING_ALLOWANCE_PREFLIGHT: "missing-allowance-preflight",
 } as const;
 
 export type ValidationErrorCode =

--- a/lib/mcp/validate-workflow.ts
+++ b/lib/mcp/validate-workflow.ts
@@ -77,6 +77,10 @@ export function validateWorkflow(
   // VALID-04 write-action consistency
   runWriteActionCheck(workflow, errors, warnings);
 
+  // Allowance preflight hint: a write-contract node calling an
+  // allowance-consuming method with no check-allowance node in the workflow.
+  runAllowancePreflightCheck(workflow, warnings);
+
   // VALID-05: chain ID existence — only when caller pre-fetched chainIds.
   // Per-node check mitigates Pitfall 12 (multi-chain WETH false positives).
   if (opts.chainIds !== undefined) {
@@ -297,5 +301,91 @@ function runWriteActionCheck(
         'workflowType is "read" but workflow contains a write-action node. Confirm this is intentional.',
       parameterPath: "workflowType",
     });
+  }
+}
+
+// ERC-20 transferFrom and ERC-4626 redeem / withdrawFrom move tokens the
+// contract must already be approved to spend. Configuring one on a
+// write-contract node without a prior allowance check is the common cause of
+// runtime "insufficient allowance" reverts. Kept to the methods with explicit
+// hackathon evidence — a conservative set avoids false positives.
+const ALLOWANCE_SPEND_METHODS = new Set([
+  "transferFrom",
+  "redeem",
+  "withdrawFrom",
+]);
+
+// Strips the argument list from an ABI function reference, which may be either
+// a bare name ("redeem") or a full signature ("redeem(uint256,address,address)").
+const FUNCTION_SIGNATURE_ARGS_PATTERN = /\(.*$/;
+
+type NodeActionConfig = { actionType: unknown; abiFunction: unknown };
+
+function readNodeActionConfig(node: unknown): NodeActionConfig | null {
+  if (node === null || typeof node !== "object" || !("data" in node)) {
+    return null;
+  }
+  const { data } = node as { data?: unknown };
+  if (data === null || typeof data !== "object" || !("config" in data)) {
+    return null;
+  }
+  const { config } = data as { config?: unknown };
+  if (config === null || typeof config !== "object") {
+    return null;
+  }
+  const cfg = config as Record<string, unknown>;
+  const actionType =
+    cfg.actionType ?? (data as Record<string, unknown>).actionType;
+  return { actionType, abiFunction: cfg.abiFunction };
+}
+
+function bareMethodName(abiFunction: unknown): string | null {
+  if (typeof abiFunction !== "string") {
+    return null;
+  }
+  const name = abiFunction.replace(FUNCTION_SIGNATURE_ARGS_PATTERN, "").trim();
+  return name === "" ? null : name;
+}
+
+function workflowHasCheckAllowanceNode(nodes: unknown[]): boolean {
+  for (const node of nodes) {
+    const cfg = readNodeActionConfig(node);
+    if (
+      typeof cfg?.actionType === "string" &&
+      cfg.actionType.includes("check-allowance")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function runAllowancePreflightCheck(
+  workflow: ValidatorWorkflow,
+  warnings: ValidationIssue[]
+): void {
+  if (!Array.isArray(workflow.nodes)) {
+    return;
+  }
+  if (workflowHasCheckAllowanceNode(workflow.nodes)) {
+    return;
+  }
+  for (const [idx, node] of workflow.nodes.entries()) {
+    const cfg = readNodeActionConfig(node);
+    if (
+      cfg === null ||
+      typeof cfg.actionType !== "string" ||
+      !cfg.actionType.includes("write-contract")
+    ) {
+      continue;
+    }
+    const method = bareMethodName(cfg.abiFunction);
+    if (method !== null && ALLOWANCE_SPEND_METHODS.has(method)) {
+      warnings.push({
+        code: VALIDATION_WARNING_CODES.MISSING_ALLOWANCE_PREFLIGHT,
+        message: `nodes[${idx}].config calls "${method}", which moves tokens via an existing allowance, but the workflow has no web3/check-allowance node. Add an upstream web3/check-allowance node before this write to avoid an "insufficient allowance" revert at execution time.`,
+        parameterPath: `nodes[${idx}].config.abiFunction`,
+      });
+    }
   }
 }

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -248,6 +248,11 @@ export const TEMPLATE_SYNTAX = {
       description: "Reference 'price' from HTTP request response data",
     },
     {
+      template: "{{@read-1:Read Contract.result[1]}}",
+      description:
+        "Index 1 of a tuple/array output. Bracket indexing belongs inside the field path, not on a bare reference (step2[1] is invalid)",
+    },
+    {
       template: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}}`,
       description:
         "Current Unix timestamp in seconds (built-in, evaluated at execution time)",
@@ -257,6 +262,8 @@ export const TEMPLATE_SYNTAX = {
     "nodeId is the unique identifier of the node (visible in node settings)",
     "Label is the human-readable name shown on the node",
     "Nested fields use dot notation (e.g., data.nested.value)",
+    "Array and tuple outputs are indexed with [n] inside the field path (e.g., result[1]); numeric indices only",
+    "Condition expressions use this same reference and path grammar - reference outputs as {{@nodeId:Label.field[index]}}, never as a bare step2[1]",
     "Templates are resolved at runtime before each step executes",
   ],
 };

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -248,9 +248,14 @@ export const TEMPLATE_SYNTAX = {
       description: "Reference 'price' from HTTP request response data",
     },
     {
-      template: "{{@read-1:Read Contract.result[1]}}",
+      template: "{{@read-1:Read Contract.result.liquidityIndex}}",
       description:
-        "Index 1 of a tuple/array output. Bracket indexing belongs inside the field path, not on a bare reference (step2[1] is invalid)",
+        "Named-field access into a tuple/struct read-contract output. Tuple components surface as named keys (configuration, liquidityIndex, etc.); positional indexing like result[1] does NOT work on tuple outputs and a bare step2[1] is never valid",
+    },
+    {
+      template: "{{@read-1:Read Contract.result.holders[0]}}",
+      description:
+        "Bracket indexing is only valid for ARRAY fields, inside the field path - here `holders` is an address[] output and [0] picks the first element",
     },
     {
       template: `{{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}}`,
@@ -262,8 +267,9 @@ export const TEMPLATE_SYNTAX = {
     "nodeId is the unique identifier of the node (visible in node settings)",
     "Label is the human-readable name shown on the node",
     "Nested fields use dot notation (e.g., data.nested.value)",
-    "Array and tuple outputs are indexed with [n] inside the field path (e.g., result[1]); numeric indices only",
-    "Condition expressions use this same reference and path grammar - reference outputs as {{@nodeId:Label.field[index]}}, never as a bare step2[1]",
+    "Tuple/struct outputs surface their components as NAMED fields - use result.<componentName> (e.g. result.liquidityIndex), NOT positional result[1]",
+    "Bracket indexing [n] is only for ARRAY fields, applied inside the field path (e.g. result.items[0]); numeric indices only",
+    "Condition expressions use this same reference and path grammar - never a bare step2[1] (this fails validation with an actionable error)",
     "Templates are resolved at runtime before each step executes",
   ],
 };

--- a/lib/workflow/editor/action-output-fields.ts
+++ b/lib/workflow/editor/action-output-fields.ts
@@ -6,6 +6,46 @@
 import { findAbiFunction } from "@/lib/abi/utils";
 import type { OutputField } from "@/plugins/registry";
 
+type AbiParam = { name?: string; type?: string; components?: AbiParam[] };
+
+// Cap how deep we expand nested tuple field paths in autocomplete to keep the
+// suggestion list bounded for deeply nested structs.
+const MAX_OUTPUT_FIELD_DEPTH = 4;
+
+function isTupleParam(
+  param: AbiParam
+): param is AbiParam & { components: AbiParam[] } {
+  return (
+    (param.type ?? "").startsWith("tuple") && Array.isArray(param.components)
+  );
+}
+
+// Append a dotted field path for each component of a tuple param, recursing
+// into nested tuples. tuple[] elements are not individually addressable here,
+// so expansion stops at the array field itself. Mirrors structureAbiOutputs.
+function appendTupleComponentPaths(
+  fields: OutputField[],
+  basePath: string,
+  param: AbiParam,
+  depth: number
+): void {
+  if (depth >= MAX_OUTPUT_FIELD_DEPTH || !isTupleParam(param)) {
+    return;
+  }
+  if ((param.type ?? "").endsWith("]")) {
+    return;
+  }
+  for (const [index, component] of param.components.entries()) {
+    const key = component.name?.trim() || `unnamedOutput${index}`;
+    const path = `${basePath}.${key}`;
+    fields.push({
+      field: path,
+      description: `Return value: ${component.type} (${getDeserializedType(component.type ?? "")})`,
+    });
+    appendTupleComponentPaths(fields, path, component, depth + 1);
+  }
+}
+
 /**
  * Get output fields for Read Contract action based on ABI and selected function
  */
@@ -37,10 +77,7 @@ export function getReadContractOutputFields(
       return defaultFields;
     }
 
-    const outputs = functionAbi.outputs as Array<{
-      name?: string;
-      type: string;
-    }>;
+    const outputs = functionAbi.outputs as AbiParam[];
 
     // Build output fields based on function outputs
     const outputFields: OutputField[] = [
@@ -56,18 +93,29 @@ export function getReadContractOutputFields(
         // Named single output: result is an object with this field
         outputFields.push({
           field: `result.${outputName}`,
-          description: `Return value: ${output.type} (${getDeserializedType(output.type)})`,
+          description: `Return value: ${output.type} (${getDeserializedType(output.type ?? "")})`,
         });
+        appendTupleComponentPaths(
+          outputFields,
+          `result.${outputName}`,
+          output,
+          1
+        );
+      } else {
+        // Unnamed single output: a tuple's components surface directly under
+        // result; a scalar is just `result` (already added).
+        appendTupleComponentPaths(outputFields, "result", output, 0);
       }
-      // Unnamed single output: just use result directly (already added)
     } else if (outputs.length > 1) {
       // Multiple outputs: result is an object with named fields
       for (const [index, output] of outputs.entries()) {
         const fieldName = output.name?.trim() || `unnamedOutput${index}`;
+        const path = `result.${fieldName}`;
         outputFields.push({
-          field: `result.${fieldName}`,
-          description: `Return value: ${output.type} (${getDeserializedType(output.type)})`,
+          field: path,
+          description: `Return value: ${output.type} (${getDeserializedType(output.type ?? "")})`,
         });
+        appendTupleComponentPaths(outputFields, path, output, 1);
       }
     }
 

--- a/lib/workflow/nodes/condition/validator.ts
+++ b/lib/workflow/nodes/condition/validator.ts
@@ -156,11 +156,14 @@ function checkBracketExpressions(expression: string): ValidationResult {
     const beforeBracket = match[1];
     const insideBracket = match[2].trim();
 
-    // Check if the part before the bracket is a valid variable (__v0, __v1, etc.)
+    // Check if the part before the bracket is a valid variable (__v0, __v1, etc.).
+    // Bare references like `step2[1]` reach here when an author uses an
+    // unsupported reference grammar instead of the stored template format.
+    // Index access IS supported, but inside the template field path.
     if (!VALID_BRACKET_ACCESS_PATTERN.test(beforeBracket)) {
       return {
         valid: false,
-        error: `Bracket notation is only allowed on workflow variables. Found: "${beforeBracket}[...]"`,
+        error: `Cannot index "${beforeBracket}[...]". Reference step outputs with the {{@nodeId:Label.field}} template format - array and tuple indexing belongs inside the field path, e.g. {{@nodeId:Label.result[1]}}.`,
       };
     }
 

--- a/lib/workflow/nodes/condition/validator.ts
+++ b/lib/workflow/nodes/condition/validator.ts
@@ -159,11 +159,10 @@ function checkBracketExpressions(expression: string): ValidationResult {
     // Check if the part before the bracket is a valid variable (__v0, __v1, etc.).
     // Bare references like `step2[1]` reach here when an author uses an
     // unsupported reference grammar instead of the stored template format.
-    // Index access IS supported, but inside the template field path.
     if (!VALID_BRACKET_ACCESS_PATTERN.test(beforeBracket)) {
       return {
         valid: false,
-        error: `Cannot index "${beforeBracket}[...]". Reference step outputs with the {{@nodeId:Label.field}} template format - array and tuple indexing belongs inside the field path, e.g. {{@nodeId:Label.result[1]}}.`,
+        error: `Cannot index "${beforeBracket}[...]". Reference step outputs with the {{@nodeId:Label.field}} template format - use the component name for tuple/struct outputs (e.g. {{@nodeId:Label.result.liquidityIndex}}) and bracket indexing only inside the field path for arrays (e.g. {{@nodeId:Label.result.items[0]}}).`,
       };
     }
 

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -223,6 +223,11 @@ export type PluginAction = {
   // Output fields for template autocomplete (what this action returns)
   outputFields?: OutputField[];
 
+  // Optional JSON-Schema description of the action output. When omitted,
+  // list_action_schemas synthesizes one from `outputFields`. Declare this on
+  // actions whose output shape is richer than a flat key/description map.
+  outputSchema?: Record<string, unknown>;
+
   // Output display configuration (how to render output in workflow runs panel)
   outputConfig?: OutputDisplayConfig;
 

--- a/plugins/web3/steps/batch-read-contract.ts
+++ b/plugins/web3/steps/batch-read-contract.ts
@@ -12,6 +12,10 @@ import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
+import {
+  type AbiOutputParam,
+  structureAbiOutputs,
+} from "@/plugins/web3/steps/structure-abi-result";
 
 const LOG_PREFIX = "[Batch Read Contract]";
 const DEFAULT_BATCH_SIZE = 100;
@@ -265,42 +269,23 @@ function serializeBigInts(value: unknown): unknown {
 }
 
 /**
- * Structure a decoded result based on ABI function outputs
+ * Structure a decoded result based on ABI function outputs.
+ *
+ * decodeFunctionResult returns an N-element Result (one entry per output, no
+ * auto-unwrap), so the serialized value is already the positional output list
+ * that structureAbiOutputs consumes.
  */
 function structureDecodedResult(
   decodedResult: ethers.Result,
-  functionAbi: { outputs?: { name?: string; type?: string }[] }
+  functionAbi: { outputs?: AbiOutputParam[] }
 ): unknown {
   const serialized = serializeBigInts(decodedResult);
-
-  const outputs = functionAbi.outputs;
-  if (!outputs || outputs.length === 0) {
+  const outputs = functionAbi.outputs ?? [];
+  if (outputs.length === 0) {
     return serialized;
   }
-
-  if (outputs.length === 1) {
-    const singleOutput = outputs[0];
-    const outputName = singleOutput.name?.trim();
-    const outputType = singleOutput.type ?? "";
-    const isArrayType = outputType.endsWith("[]");
-    const singleValue =
-      Array.isArray(serialized) && !isArrayType ? serialized[0] : serialized;
-    if (outputName) {
-      return { [outputName]: singleValue };
-    }
-    return singleValue;
-  }
-
-  if (Array.isArray(serialized)) {
-    const structured: Record<string, unknown> = {};
-    for (const [index, output] of outputs.entries()) {
-      const fieldName = output.name?.trim() || `unnamedOutput${index}`;
-      structured[fieldName] = serialized[index];
-    }
-    return structured;
-  }
-
-  return serialized;
+  const outputValues = Array.isArray(serialized) ? serialized : [serialized];
+  return structureAbiOutputs(outputValues, outputs);
 }
 
 /**

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -253,9 +253,14 @@ export async function readContractCore(
 
     let structuredResult: unknown = serializedResult;
     if (outputs.length > 0) {
-      // ethers v6 Contract methods auto-unwrap a single output, so wrap it back
-      // into a one-element positional array; multi-output calls already arrive
-      // as a positional array.
+      // The EVM adapter calls contract.getFunction(name)(...) / .staticCall(),
+      // and ethers v6 auto-unwraps a single output: a scalar arrives as the
+      // scalar (not a 1-element array) and a tuple arrives as its component
+      // array. We therefore wrap the single output back into a one-element
+      // positional array for structureAbiOutputs; multi-output calls already
+      // arrive as a positional array. If the adapter ever stops auto-unwrapping
+      // (e.g. switching to decodeFunctionResult), this normalization must move
+      // to match batch-read-contract, which passes the N-element Result as-is.
       const outputValues =
         outputs.length === 1
           ? [serializedResult]

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -21,6 +21,10 @@ import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/abi/function-key";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
+import {
+  type AbiOutputParam,
+  structureAbiOutputs,
+} from "@/plugins/web3/steps/structure-abi-result";
 
 export type ReadContractCoreInput = {
   contractAddress: string;
@@ -234,47 +238,29 @@ export async function readContractCore(
       isView,
     });
 
-    // Convert BigInt values to strings for JSON serialization
+    // Convert BigInt values to strings for JSON serialization. This also
+    // flattens the ethers Result into positional arrays (its named getters are
+    // non-enumerable and do not survive JSON), which is exactly the form
+    // structureAbiOutputs consumes to re-attach ABI component names.
     const serializedResult = JSON.parse(
       JSON.stringify(result, (_, value) =>
         typeof value === "bigint" ? value.toString() : value
       )
     );
 
-    // Transform array results into named objects based on ABI outputs
-    let structuredResult = serializedResult;
+    const outputs =
+      (functionAbi as { outputs?: AbiOutputParam[] }).outputs ?? [];
 
-    const outputs = (
-      functionAbi as { outputs?: Array<{ name?: string; type: string }> }
-    ).outputs;
-
-    if (outputs && outputs.length > 0) {
-      if (outputs.length === 1) {
-        const singleOutput = outputs[0];
-        const outputName = singleOutput.name?.trim();
-        const outputType = singleOutput.type ?? "";
-        const isArrayType = outputType.endsWith("[]");
-        // covers "tuple" and "tuple[]"
-        const isTupleType = outputType.startsWith("tuple");
-        // ethers v6 Contract methods auto-unwrap single-output Results; for
-        // tuples that means we already hold the tuple's components, NOT a
-        // wrapper array. Unwrapping again would discard sub-fields.
-        const singleValue =
-          Array.isArray(serializedResult) && !isArrayType && !isTupleType
-            ? serializedResult[0]
-            : serializedResult;
-        if (outputName) {
-          structuredResult = { [outputName]: singleValue };
-        } else {
-          structuredResult = singleValue;
-        }
-      } else if (Array.isArray(serializedResult)) {
-        structuredResult = {};
-        for (const [index, output] of outputs.entries()) {
-          const fieldName = output.name?.trim() || `unnamedOutput${index}`;
-          structuredResult[fieldName] = serializedResult[index];
-        }
-      }
+    let structuredResult: unknown = serializedResult;
+    if (outputs.length > 0) {
+      // ethers v6 Contract methods auto-unwrap a single output, so wrap it back
+      // into a one-element positional array; multi-output calls already arrive
+      // as a positional array.
+      const outputValues =
+        outputs.length === 1
+          ? [serializedResult]
+          : (serializedResult as unknown[]);
+      structuredResult = structureAbiOutputs(outputValues, outputs);
     }
 
     const addressLink = await adapter.getAddressUrl(contractAddress);

--- a/plugins/web3/steps/structure-abi-result.ts
+++ b/plugins/web3/steps/structure-abi-result.ts
@@ -1,0 +1,94 @@
+// Shared, pure ABI-output structuring for read-contract and batch-read-contract.
+// No "use step" directive: safe to export helpers and import from step files.
+//
+// Maps a decoded contract return (already BigInt-serialized to strings, in
+// positional array form) onto the function's ABI outputs, attaching component
+// names as object keys recursively. Named components become keys; unnamed
+// components fall back to `unnamedOutput<index>`; tuple arrays map element-wise.
+// This is what lets downstream steps read `result.liquidityIndex` instead of
+// reverse-engineering positional indices for tuple-returning views.
+
+export type AbiOutputParam = {
+  name?: string;
+  type?: string;
+  components?: AbiOutputParam[];
+};
+
+function isTupleType(type: string): boolean {
+  // Covers "tuple", "tuple[]", and fixed-size "tuple[2]".
+  return type.startsWith("tuple");
+}
+
+function isArrayType(type: string): boolean {
+  return type.endsWith("]");
+}
+
+function structureTuple(value: unknown, components: AbiOutputParam[]): unknown {
+  if (!Array.isArray(value)) {
+    // Defensive: shape did not decode as a positional tuple; pass through.
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [index, component] of components.entries()) {
+    const key = component.name?.trim() || `unnamedOutput${index}`;
+    out[key] = structureAbiValue(value[index], component);
+  }
+  return out;
+}
+
+/**
+ * Structure a single decoded value against its ABI parameter. Primitives and
+ * primitive arrays pass through unchanged; tuples and tuple arrays recurse so
+ * nested component names are attached.
+ */
+export function structureAbiValue(
+  value: unknown,
+  param: AbiOutputParam
+): unknown {
+  const type = param.type ?? "";
+  const { components } = param;
+  if (!(isTupleType(type) && components)) {
+    return value;
+  }
+  if (isArrayType(type)) {
+    if (!Array.isArray(value)) {
+      return value;
+    }
+    return value.map((element) => structureTuple(element, components));
+  }
+  return structureTuple(value, components);
+}
+
+/**
+ * Structure the full output list of a function call.
+ *
+ * `outputValues[i]` must be the serialized value of the i-th ABI output. Each
+ * caller normalizes its decode form to this: read-contract auto-unwraps a
+ * single output (so it wraps it in a one-element array), while batch-read
+ * decodes into an N-element Result already.
+ *
+ * - 0 outputs: returns the raw values untouched.
+ * - 1 output: returns the structured value, wrapped in `{ [name]: value }`
+ *   only when the output is named.
+ * - N outputs: returns an object keyed by output name (or `unnamedOutput<i>`).
+ */
+export function structureAbiOutputs(
+  outputValues: unknown[],
+  outputs: AbiOutputParam[]
+): unknown {
+  if (outputs.length === 0) {
+    return outputValues;
+  }
+  if (outputs.length === 1) {
+    const output = outputs[0];
+    const structured = structureAbiValue(outputValues[0], output);
+    const name = output.name?.trim();
+    return name ? { [name]: structured } : structured;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [index, output] of outputs.entries()) {
+    const key = output.name?.trim() || `unnamedOutput${index}`;
+    out[key] = structureAbiValue(outputValues[index], output);
+  }
+  return out;
+}

--- a/plugins/web3/steps/structure-abi-result.ts
+++ b/plugins/web3/steps/structure-abi-result.ts
@@ -23,6 +23,10 @@ function isArrayType(type: string): boolean {
   return type.endsWith("]");
 }
 
+// Strips the trailing array dimension from a type: "tuple[][]" -> "tuple[]",
+// "tuple[]" -> "tuple", "tuple[2]" -> "tuple".
+const TRAILING_ARRAY_DIM = /\[\d*\]$/;
+
 function structureTuple(value: unknown, components: AbiOutputParam[]): unknown {
   if (!Array.isArray(value)) {
     // Defensive: shape did not decode as a positional tuple; pass through.
@@ -39,7 +43,8 @@ function structureTuple(value: unknown, components: AbiOutputParam[]): unknown {
 /**
  * Structure a single decoded value against its ABI parameter. Primitives and
  * primitive arrays pass through unchanged; tuples and tuple arrays recurse so
- * nested component names are attached.
+ * nested component names are attached. Arbitrary array depth (e.g. tuple[][])
+ * is handled by stripping one dimension per recursion.
  */
 export function structureAbiValue(
   value: unknown,
@@ -54,7 +59,14 @@ export function structureAbiValue(
     if (!Array.isArray(value)) {
       return value;
     }
-    return value.map((element) => structureTuple(element, components));
+    const elementType = type.replace(TRAILING_ARRAY_DIM, "");
+    return value.map((element) =>
+      structureAbiValue(element, {
+        name: param.name,
+        type: elementType,
+        components,
+      })
+    );
   }
   return structureTuple(value, components);
 }

--- a/tests/unit/action-output-fields.test.ts
+++ b/tests/unit/action-output-fields.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { getReadContractOutputFields } from "@/lib/workflow/editor/action-output-fields";
+
+function fieldNames(abi: unknown, fn: string): string[] {
+  return getReadContractOutputFields(JSON.stringify(abi), fn).map(
+    (f) => f.field
+  );
+}
+
+describe("getReadContractOutputFields", () => {
+  it("returns default fields when abi/function are missing", () => {
+    const fields = getReadContractOutputFields(undefined, undefined).map(
+      (f) => f.field
+    );
+    expect(fields).toEqual(["success", "result", "addressLink", "error"]);
+  });
+
+  it("surfaces result.<name> for a single named scalar output", () => {
+    const abi = [
+      {
+        name: "balanceOf",
+        type: "function",
+        inputs: [],
+        outputs: [{ name: "balance", type: "uint256" }],
+      },
+    ];
+    expect(fieldNames(abi, "balanceOf")).toContain("result.balance");
+  });
+
+  it("expands nested tuple components for a single unnamed tuple output", () => {
+    const abi = [
+      {
+        name: "getReserveData",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            name: "",
+            type: "tuple",
+            components: [
+              {
+                name: "configuration",
+                type: "tuple",
+                components: [{ name: "data", type: "uint256" }],
+              },
+              { name: "liquidityIndex", type: "uint128" },
+            ],
+          },
+        ],
+      },
+    ];
+    const names = fieldNames(abi, "getReserveData");
+    expect(names).toContain("result.configuration");
+    expect(names).toContain("result.configuration.data");
+    expect(names).toContain("result.liquidityIndex");
+  });
+
+  it("expands one level into a named tuple within a multi-output function", () => {
+    const abi = [
+      {
+        name: "f",
+        type: "function",
+        inputs: [],
+        outputs: [
+          { name: "ok", type: "bool" },
+          {
+            name: "info",
+            type: "tuple",
+            components: [{ name: "id", type: "uint256" }],
+          },
+        ],
+      },
+    ];
+    const names = fieldNames(abi, "f");
+    expect(names).toContain("result.ok");
+    expect(names).toContain("result.info");
+    expect(names).toContain("result.info.id");
+  });
+
+  it("does not expand elements of a tuple[] output", () => {
+    const abi = [
+      {
+        name: "f",
+        type: "function",
+        inputs: [],
+        outputs: [
+          {
+            name: "items",
+            type: "tuple[]",
+            components: [{ name: "a", type: "uint256" }],
+          },
+        ],
+      },
+    ];
+    const names = fieldNames(abi, "f");
+    expect(names).toContain("result.items");
+    expect(names).not.toContain("result.items.a");
+  });
+});

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -1091,13 +1091,13 @@ describe("batch-read-contract - array-type outputs", () => {
       abiFunction: "getHolders",
     });
 
-    // Single array-type output: isArrayType=true prevents unwrapping the Result tuple,
-    // so holders is [[addr1, addr2]] (the full Result preserved as-is).
-    const resultValue = result.results[0].result as { holders: string[][] };
+    // Single array-type output is named under its ABI name and exposed as the
+    // flat address list (no spurious extra wrapping).
+    const resultValue = result.results[0].result as { holders: string[] };
     expect(resultValue).toHaveProperty("holders");
     expect(Array.isArray(resultValue.holders)).toBe(true);
-    // The inner array should contain the 2 addresses
-    expect(resultValue.holders[0]).toHaveLength(2);
+    expect(resultValue.holders).toHaveLength(2);
+    expect(resultValue.holders[0]).toBe(VALID_ADDRESS);
   });
 });
 

--- a/tests/unit/condition-executor.test.ts
+++ b/tests/unit/condition-executor.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
 import { evaluateConditionExpression } from "@/lib/workflow/executor/executor.workflow";
+import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
+import { validateConditionExpression } from "@/lib/workflow/nodes/condition/validator";
 
 const NO_EXPRESSION_REGEX = /no expression configured/;
+const BARE_INDEX_REGEX = /\{\{@nodeId:Label\.field\}\} template format/;
 
 /**
  * Tests for KEEP-1520: Condition node losing expression at runtime
@@ -799,5 +801,42 @@ describe("condition evaluation edge cases", () => {
       const result = evaluateConditionExpression(expression, outputs);
       expect(result.result).toBe(true);
     });
+  });
+});
+
+describe("condition bracket-notation grammar", () => {
+  it("resolves an array/tuple index inside the stored-format field path", () => {
+    const outputs = {
+      step2: { label: "Read", data: { result: ["a", "x", "z"] } },
+    };
+
+    const result = evaluateConditionExpression(
+      '{{@step2:Read.result[1]}} === "x"',
+      outputs
+    );
+    expect(result.result).toBe(true);
+  });
+
+  it("allows index access on a substituted variable token (__vN[n])", () => {
+    expect(validateConditionExpression('__v0[1] === "x"')).toEqual({
+      valid: true,
+    });
+  });
+
+  it("rejects a bare indexed reference with an actionable grammar hint", () => {
+    const result = validateConditionExpression('step2[1] === "x"');
+    expect(result.valid).toBe(false);
+    if (result.valid) {
+      return;
+    }
+    expect(result.error).toMatch(BARE_INDEX_REGEX);
+  });
+
+  it("surfaces the grammar hint through the executor for a bare reference", () => {
+    expect(() =>
+      evaluateConditionExpression('step2[1] === "x"', {
+        step2: { label: "Read", data: { result: ["a", "x"] } },
+      })
+    ).toThrow(BARE_INDEX_REGEX);
   });
 });

--- a/tests/unit/output-schema.test.ts
+++ b/tests/unit/output-schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { synthesizeOutputSchema } from "@/lib/mcp/output-schema";
+import type { PluginAction } from "@/plugins/registry";
+
+function action(overrides: Partial<PluginAction>): PluginAction {
+  return {
+    slug: "a",
+    label: "A",
+    description: "",
+    category: "web3",
+    stepFunction: "aStep",
+    stepImportPath: "a",
+    configFields: [],
+    ...overrides,
+  };
+}
+
+describe("synthesizeOutputSchema", () => {
+  it("synthesizes an object schema from outputFields", () => {
+    const result = synthesizeOutputSchema(
+      action({
+        outputFields: [
+          { field: "success", description: "Whether it worked" },
+          { field: "balance", description: "Balance in ETH" },
+        ],
+      })
+    );
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        success: { description: "Whether it worked" },
+        balance: { description: "Balance in ETH" },
+      },
+    });
+  });
+
+  it("returns null when the action declares no outputs", () => {
+    expect(synthesizeOutputSchema(action({}))).toBeNull();
+    expect(synthesizeOutputSchema(action({ outputFields: [] }))).toBeNull();
+  });
+
+  it("prefers an explicitly declared outputSchema over synthesis", () => {
+    const declared = { type: "object", properties: { x: { type: "number" } } };
+    const result = synthesizeOutputSchema(
+      action({
+        outputSchema: declared,
+        outputFields: [{ field: "ignored", description: "ignored" }],
+      })
+    );
+    expect(result).toBe(declared);
+  });
+});

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -330,7 +331,7 @@ describe("read-contract-core - tuple output decoding", () => {
     BigInt("0"), // isolationModeTotalDebt
   ];
 
-  it("preserves all 15 tuple components for Aave V3 getReserveData", async () => {
+  it("names all 15 tuple components for Aave V3 getReserveData", async () => {
     setupRpcMocks();
     mockContractFunction.mockResolvedValueOnce(RESERVE_DATA_TUPLE);
 
@@ -347,21 +348,78 @@ describe("read-contract-core - tuple output decoding", () => {
       return;
     }
 
-    // Output has empty name, so structuredResult should be the unwrapped
-    // tuple itself (the 15-element array), NOT just the first sub-field.
-    expect(Array.isArray(result.result)).toBe(true);
-    expect((result.result as unknown[]).length).toBe(15);
+    // The unnamed single tuple is structured into an object keyed by its ABI
+    // component names; downstream steps read result.liquidityIndex instead of
+    // reverse-engineering positional indices. No component is dropped.
+    expect(result.result).toEqual({
+      configuration: { data: "12345" },
+      liquidityIndex: "1000000000000000000000000000",
+      currentLiquidityRate: "10000000000000000000000000",
+      variableBorrowIndex: "1000000000000000000000000000",
+      currentVariableBorrowRate: "20000000000000000000000000",
+      currentStableBorrowRate: "0",
+      lastUpdateTimestamp: "1700000000",
+      id: "3",
+      aTokenAddress: "0x1111111111111111111111111111111111111111",
+      stableDebtTokenAddress: "0x2222222222222222222222222222222222222222",
+      variableDebtTokenAddress: "0x3333333333333333333333333333333333333333",
+      interestRateStrategyAddress: "0x4444444444444444444444444444444444444444",
+      accruedToTreasury: "500",
+      unbacked: "0",
+      isolationModeTotalDebt: "0",
+    });
+  });
 
-    const tuple = result.result as unknown[];
-    // First element is the nested ReserveConfigurationMap tuple -- it must
-    // remain a tuple (array), not collapse to its lone "data" field.
-    expect(Array.isArray(tuple[0])).toBe(true);
-    expect((tuple[0] as unknown[])[0]).toBe("12345");
-    // Remaining fields must be preserved (BigInts serialized to strings).
-    expect(tuple[1]).toBe("1000000000000000000000000000");
-    expect(tuple[7]).toBe("3");
-    expect(tuple[8]).toBe("0x1111111111111111111111111111111111111111");
-    expect(tuple[14]).toBe("0");
+  it("structures a genuine ethers v6 Result (encode -> decode -> serialize)", async () => {
+    setupRpcMocks();
+
+    // Build a real auto-unwrapped ethers Result the way the chain adapter
+    // would, so the JSON.stringify round-trip in production is exercised
+    // rather than a hand-built plain array.
+    const iface = new ethers.Interface(AAVE_GET_RESERVE_DATA_ABI);
+    const encoded = iface.encodeFunctionResult("getReserveData", [
+      [
+        [BigInt(12_345)],
+        BigInt("1000000000000000000000000000"),
+        BigInt(0),
+        BigInt(0),
+        BigInt(0),
+        BigInt(0),
+        BigInt(0),
+        BigInt(3),
+        "0x1111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222",
+        "0x3333333333333333333333333333333333333333",
+        "0x4444444444444444444444444444444444444444",
+        BigInt(0),
+        BigInt(0),
+        BigInt(0),
+      ],
+    ]);
+    const decoded = iface.decodeFunctionResult("getReserveData", encoded);
+    // Contract methods auto-unwrap a single output to its Result.
+    mockContractFunction.mockResolvedValueOnce(decoded[0]);
+
+    const result = await readContractCore({
+      contractAddress: VALID_ADDRESS,
+      network: "ethereum",
+      abi: JSON.stringify(AAVE_GET_RESERVE_DATA_ABI),
+      abiFunction: "getReserveData",
+      functionArgs: JSON.stringify([VALID_ADDRESS]),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    const reserve = result.result as Record<string, unknown>;
+    expect(reserve.configuration).toEqual({ data: "12345" });
+    expect(reserve.liquidityIndex).toBe("1000000000000000000000000000");
+    expect(reserve.id).toBe("3");
+    expect(reserve.aTokenAddress).toBe(
+      "0x1111111111111111111111111111111111111111"
+    );
+    expect(reserve.isolationModeTotalDebt).toBe("0");
   });
 });
 

--- a/tests/unit/structure-abi-result.test.ts
+++ b/tests/unit/structure-abi-result.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type AbiOutputParam,
+  structureAbiOutputs,
+} from "@/plugins/web3/steps/structure-abi-result";
+
+describe("structureAbiOutputs", () => {
+  it("returns raw values when there are no declared outputs", () => {
+    expect(structureAbiOutputs(["x"], [])).toEqual(["x"]);
+  });
+
+  it("wraps a single named scalar output under its name", () => {
+    const outputs: AbiOutputParam[] = [{ name: "balance", type: "uint256" }];
+    expect(structureAbiOutputs(["1000"], outputs)).toEqual({ balance: "1000" });
+  });
+
+  it("returns a single unnamed scalar output directly", () => {
+    const outputs: AbiOutputParam[] = [{ name: "", type: "uint256" }];
+    expect(structureAbiOutputs(["1000"], outputs)).toBe("1000");
+  });
+
+  it("names the components of a single unnamed tuple, recursing into nested tuples", () => {
+    const outputs: AbiOutputParam[] = [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          {
+            name: "configuration",
+            type: "tuple",
+            components: [{ name: "data", type: "uint256" }],
+          },
+          { name: "liquidityIndex", type: "uint128" },
+          { name: "aTokenAddress", type: "address" },
+        ],
+      },
+    ];
+    // Single auto-unwrapped tuple -> outputValues[0] is the component array.
+    const value = [["12345"], "1000000", "0xabc"];
+    expect(structureAbiOutputs([value], outputs)).toEqual({
+      configuration: { data: "12345" },
+      liquidityIndex: "1000000",
+      aTokenAddress: "0xabc",
+    });
+  });
+
+  it("falls back to unnamedOutput<index> for unnamed tuple components", () => {
+    const outputs: AbiOutputParam[] = [
+      {
+        name: "slot0",
+        type: "tuple",
+        components: [
+          { name: "", type: "uint160" },
+          { name: "tick", type: "int24" },
+        ],
+      },
+    ];
+    expect(structureAbiOutputs([["123", "7"]], outputs)).toEqual({
+      slot0: { unnamedOutput0: "123", tick: "7" },
+    });
+  });
+
+  it("keys multiple outputs by name and structures nested tuples", () => {
+    const outputs: AbiOutputParam[] = [
+      { name: "ok", type: "bool" },
+      {
+        name: "info",
+        type: "tuple",
+        components: [{ name: "id", type: "uint256" }],
+      },
+      { name: "", type: "address" },
+    ];
+    expect(structureAbiOutputs([true, ["9"], "0xdead"], outputs)).toEqual({
+      ok: true,
+      info: { id: "9" },
+      unnamedOutput2: "0xdead",
+    });
+  });
+
+  it("maps a tuple[] output element-wise", () => {
+    const outputs: AbiOutputParam[] = [
+      {
+        name: "items",
+        type: "tuple[]",
+        components: [
+          { name: "a", type: "uint256" },
+          { name: "b", type: "address" },
+        ],
+      },
+    ];
+    const value = [
+      ["1", "0x1"],
+      ["2", "0x2"],
+    ];
+    expect(structureAbiOutputs([value], outputs)).toEqual({
+      items: [
+        { a: "1", b: "0x1" },
+        { a: "2", b: "0x2" },
+      ],
+    });
+  });
+
+  it("passes primitive arrays through untouched", () => {
+    const outputs: AbiOutputParam[] = [{ name: "amounts", type: "uint256[]" }];
+    expect(structureAbiOutputs([["1", "2", "3"]], outputs)).toEqual({
+      amounts: ["1", "2", "3"],
+    });
+  });
+});

--- a/tests/unit/structure-abi-result.test.ts
+++ b/tests/unit/structure-abi-result.test.ts
@@ -101,6 +101,20 @@ describe("structureAbiOutputs", () => {
     });
   });
 
+  it("structures a nested tuple[][] without flattening dimensions", () => {
+    const outputs: AbiOutputParam[] = [
+      {
+        name: "grid",
+        type: "tuple[][]",
+        components: [{ name: "a", type: "uint256" }],
+      },
+    ];
+    const value = [[["1"], ["2"]], [["3"]]];
+    expect(structureAbiOutputs([value], outputs)).toEqual({
+      grid: [[{ a: "1" }, { a: "2" }], [{ a: "3" }]],
+    });
+  });
+
   it("passes primitive arrays through untouched", () => {
     const outputs: AbiOutputParam[] = [{ name: "amounts", type: "uint256[]" }];
     expect(structureAbiOutputs([["1", "2", "3"]], outputs)).toEqual({

--- a/tests/unit/validate-workflow-allowance.test.ts
+++ b/tests/unit/validate-workflow-allowance.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { validateWorkflow } from "@/lib/mcp/validate-workflow";
+import {
+  actionNode,
+  edge,
+  makeWorkflow,
+  triggerNode,
+} from "./fixtures/validate-workflow";
+
+const CODE = "missing-allowance-preflight";
+
+function writeWorkflow(
+  overrides: Record<string, unknown>,
+  extraNodes: unknown[] = []
+) {
+  return makeWorkflow({
+    workflowType: "write",
+    nodes: [
+      triggerNode(),
+      actionNode("w1", { actionType: "web3/write-contract", ...overrides }),
+      ...extraNodes,
+    ],
+    edges: [edge("e1", "trigger-1", "w1")],
+  });
+}
+
+describe("validateWorkflow - allowance preflight", () => {
+  it("warns when write-contract calls transferFrom with no check-allowance node", () => {
+    const result = validateWorkflow(
+      writeWorkflow({ abiFunction: "transferFrom" })
+    );
+    const warning = result.warnings.find((w) => w.code === CODE);
+    expect(warning).toBeDefined();
+    expect(warning?.parameterPath).toBe("nodes[1].config.abiFunction");
+    expect(warning?.message).toContain("transferFrom");
+    expect(warning?.message).toContain("web3/check-allowance");
+  });
+
+  it("strips the argument list from a full signature (redeem(...))", () => {
+    const result = validateWorkflow(
+      writeWorkflow({ abiFunction: "redeem(uint256,address,address)" })
+    );
+    expect(result.warnings.some((w) => w.code === CODE)).toBe(true);
+  });
+
+  it("does not warn for a non-allowance method (transfer)", () => {
+    const result = validateWorkflow(writeWorkflow({ abiFunction: "transfer" }));
+    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+  });
+
+  it("is suppressed when a check-allowance node is present", () => {
+    const result = validateWorkflow(
+      writeWorkflow({ abiFunction: "transferFrom" }, [
+        actionNode("ca", { actionType: "web3/check-allowance" }),
+      ])
+    );
+    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+  });
+
+  it("ignores allowance methods on a non-write action (read-contract)", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        nodes: [
+          triggerNode(),
+          actionNode("r1", {
+            actionType: "web3/read-contract",
+            abiFunction: "transferFrom",
+          }),
+        ],
+        edges: [edge("e1", "trigger-1", "r1")],
+      })
+    );
+    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A cluster of contract-call and action-schema ergonomic fixes surfaced by hackathon teams. Four independent changes, one per commit:

1. **Condition bracket-notation (DX).** Bracket indexing already works inside the stored `{{@nodeId:Label.field}}` grammar; only bare references like `step2[1]` fail. The validator now returns an actionable error pointing at the supported grammar, and the agent-facing template-syntax reference documents tuple/array indexing (and that it applies in conditions).

2. **Allowance preflight.** A configure-time warning when a `web3/write-contract` node calls a known ERC-20/4626 spend method (`transferFrom`, `redeem`, `withdrawFrom`) and the workflow has no `web3/check-allowance` node. Implemented as a pure check in the fast validator (no network call) so it always runs, not only under opt-in deep validation.

3. **Output schemas in discovery.** `list_action_schemas` now returns an optional `outputSchema` (JSON Schema) per action, synthesized from `outputFields` or a statically declared schema, so agents stop probing for output keys.

4. **Nested ABI tuple decoding.** `read-contract` and `batch-read-contract` now recursively map ABI component names onto tuple and tuple-array return values via a shared helper, so downstream steps read `result.liquidityIndex` instead of reverse-engineering positional indices. This also fixes a latent double-wrapping bug for single array outputs in batch-read. Builder autocomplete surfaces the nested paths.

## Breaking change

`web3/read-contract` tuple outputs are now **named objects**, not positional arrays. Workflows that read a tuple read positionally (`result[1]`) must switch to the named field (`result.liquidityIndex`). Single array outputs from `batch-read-contract` lose a spurious extra array wrap (`{holders: [[...]]}` becomes `{holders: [...]}`).

## Verification

- New and updated unit tests across condition, allowance, output-schema, ABI structuring, read/batch-contract, and autocomplete suites pass. Includes a reproduction that exercises a genuine ethers v6 `Result` (encode then decode) rather than a hand-built array.
- `biome check` on changed files: zero errors.
- `tsc --noEmit`: clean.
