### PR TITLE
fix: prevent horizontal page scroll in docs-site

### DIFF
--- a/docs-site/app/globals.css
+++ b/docs-site/app/globals.css
@@ -39,6 +39,13 @@ body {
   line-height: 1.6;
 }
 
+/* Guard against accidental page-level horizontal scroll. clip (not hidden)
+   avoids creating a scroll container, so position: sticky keeps working. */
+html,
+body {
+  overflow-x: clip;
+}
+
 /* ----------------------------------------------------------------
    Dark mode: Background foundation
    ---------------------------------------------------------------- */
@@ -188,7 +195,6 @@ html.dark .nextra-navbar::after {
   bottom: 0;
   left: 0;
   right: 0;
-  width: 100vw;
   height: 1px;
   background-color: rgb(var(--kh-border));
 }


### PR DESCRIPTION
## Problem

The docs site had a few pixels of page-level horizontal scroll on every page.

## Cause

The navbar bottom-border pseudo-element (`.nextra-navbar::after`) used `width: 100vw`. `100vw` includes the vertical scrollbar gutter, so the element was wider than the document by roughly the scrollbar width, producing the horizontal overflow. The existing `left: 0; right: 0` already span the navbar's width, making the `width` declaration redundant.

## Fix

- Remove `width: 100vw` from the navbar border pseudo-element (the actual fix).
- Add `overflow-x: clip` on `html, body` as a guard against future horizontal overflow. `clip` (not `hidden`) avoids creating a scroll container, so `position: sticky` on the navbar and sidebar keeps working.

## Verification

Built the production Docker image and ran it, then measured `documentElement.scrollWidth` vs `clientWidth` with a headless browser across `/`, `/intro`, `/intro/concepts` at 1440 / 1024 / 768 / 390 px. With the `overflow-x: clip` guard disabled at runtime (to isolate the `100vw` removal), every page/width reported zero horizontal overflow, confirming the `100vw` removal alone resolves the issue.