### PR TITLE
chore: harden PR-env deploys (turnstile test keys + external-secrets deploy timeout)

### DIFF
--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -198,7 +198,7 @@ jobs:
           target: ${{ matrix.image.target }}
           push: true
           provenance: false
-          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, vars.NEXT_PUBLIC_GITHUB_CLIENT_ID, vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY) || '' }}
+          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, vars.NEXT_PUBLIC_GITHUB_CLIENT_ID, vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, '1x00000000000000000000AA') || '' }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.tag_prefix }}-${{ steps.vars.outputs.sha_short }}
           cache-from: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -198,7 +198,19 @@ jobs:
           target: ${{ matrix.image.target }}
           push: true
           provenance: false
-          build-args: ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}\nNEXT_PUBLIC_GITHUB_CLIENT_ID={1}\nNEXT_PUBLIC_GOOGLE_CLIENT_ID={2}\nNEXT_PUBLIC_BILLING_ENABLED={3}\nNEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={4}\nNEXT_PUBLIC_TURNSTILE_SITE_KEY={5}', vars.NEXT_PUBLIC_AUTH_PROVIDERS, vars.NEXT_PUBLIC_GITHUB_CLIENT_ID, vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID, vars.NEXT_PUBLIC_BILLING_ENABLED, vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED, '1x00000000000000000000AA') || '' }}
+          # One arg per line via a YAML block scalar. A previous version used
+          # format('...\n...') in a single expression, but GitHub Actions does
+          # not interpret \n as a newline, so every NEXT_PUBLIC_* collapsed into
+          # the value of the first build-arg and the rest (incl. the Turnstile
+          # site key) were never set - the signup captcha never rendered. Blank
+          # lines (migrator image, build_args=false) are ignored by buildx.
+          build-args: |
+            ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_AUTH_PROVIDERS={0}', vars.NEXT_PUBLIC_AUTH_PROVIDERS) || '' }}
+            ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_GITHUB_CLIENT_ID={0}', vars.NEXT_PUBLIC_GITHUB_CLIENT_ID) || '' }}
+            ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_GOOGLE_CLIENT_ID={0}', vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID) || '' }}
+            ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_BILLING_ENABLED={0}', vars.NEXT_PUBLIC_BILLING_ENABLED) || '' }}
+            ${{ matrix.image.build_args == true && format('NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED={0}', vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED) || '' }}
+            ${{ matrix.image.build_args == true && 'NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA' || '' }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.tag_prefix }}-${{ steps.vars.outputs.sha_short }}
           cache-from: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -542,7 +542,13 @@ jobs:
       - name: Deploy satellite services (parallel)
         run: |
           set -euo pipefail
-          COMMON_ARGS=(--namespace "${NAMESPACE}" --timeout 5m0s --atomic --version 0.2.1)
+          # 10m (not 5m): satellite env secrets are provisioned asynchronously by
+          # external-secrets (parameterStore -> ExternalSecret -> Secret). The
+          # executor needs 8 such secrets (Optional: false); when ESO is slow to
+          # reconcile, the pod sits in CreateContainerConfigError and the 5m
+          # --atomic window rolled back before the secrets landed - the deploy's
+          # intermittent "context deadline exceeded". Match the app's 10m budget.
+          COMMON_ARGS=(--namespace "${NAMESPACE}" --timeout 10m0s --atomic --version 0.2.1)
           LOGDIR=$(mktemp -d)
 
           (

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -190,20 +190,23 @@ env:
     type: parameterStore
     name: next-public-google-client-id
     parameter_name: /eks/techops-staging/keeperhub/google-client-id
-  # Cloudflare Turnstile (signup captcha). PR envs reuse the staging keys.
-  # Site key is also baked into the client bundle at build time
-  # (build-images.yml); this runtime entry covers server-side reads.
+  # Cloudflare Turnstile (signup captcha). PR envs use Cloudflare's public
+  # always-pass test keys rather than the real staging keys: real site keys
+  # are bound to a hostname allowlist, and PR deploys get ephemeral hostnames
+  # that are not on it, so the real widget would fail with a domain mismatch.
+  # The test keys are domain-agnostic and always pass. The site key is also
+  # baked into the client bundle at build time (deploy-pr-environment.yaml);
+  # this runtime entry covers server-side reads.
   NEXT_PUBLIC_TURNSTILE_SITE_KEY:
-    type: parameterStore
-    name: next-public-turnstile-site-key
-    parameter_name: /eks/techops-staging/keeperhub/turnstile-site-key
+    type: kv
+    value: "1x00000000000000000000AA"
   TURNSTILE_SECRET_KEY:
-    type: parameterStore
-    name: turnstile-secret-key
-    parameter_name: /eks/techops-staging/keeperhub/turnstile-secret-key
+    type: kv
+    value: "1x0000000000000000000000000000000AA"
   # Opt PR deploys into enforcing the captcha plugin (otherwise skipped where
-  # admin test endpoints are enabled). Lets us exercise the real Turnstile
-  # flow before prod. Disables the X-Test-API-Key signup bypass.
+  # admin test endpoints are enabled). Lets us exercise the Turnstile
+  # flow (with the always-pass test keys above) before prod. Disables the
+  # X-Test-API-Key signup bypass.
   TURNSTILE_ENFORCE:
     type: kv
     value: "true"

--- a/keeperhub-executor/startup-checks.test.ts
+++ b/keeperhub-executor/startup-checks.test.ts
@@ -24,6 +24,17 @@ function makeDb(rows: Array<{ id: string }>): AssertDb {
   } as unknown as AssertDb;
 }
 
+function makeFailingDb(error: Error): AssertDb {
+  const chain: Chain = {
+    from: () => chain,
+    where: () => chain,
+    limit: () => Promise.reject(error),
+  };
+  return {
+    select: (): Chain => chain,
+  } as unknown as AssertDb;
+}
+
 describe("assertTurnkeyEnvForActiveWallets", () => {
   const originalEnv = process.env;
 
@@ -31,6 +42,7 @@ describe("assertTurnkeyEnvForActiveWallets", () => {
     const {
       TURNKEY_API_PUBLIC_KEY: _pub,
       TURNKEY_API_PRIVATE_KEY: _priv,
+      K8S_NAMESPACE: _ns,
       ...rest
     } = originalEnv;
     process.env = rest;
@@ -88,5 +100,27 @@ describe("assertTurnkeyEnvForActiveWallets", () => {
     await expect(assertTurnkeyEnvForActiveWallets(db)).rejects.toThrow(
       BOTH_KEYS_PATTERN
     );
+  });
+
+  it("does not throw on missing env in an ephemeral PR environment", async () => {
+    process.env.K8S_NAMESPACE = "pr-1373";
+    const db = makeDb([{ id: "wallet-1" }]);
+
+    await expect(assertTurnkeyEnvForActiveWallets(db)).resolves.toBeUndefined();
+  });
+
+  it("rethrows a query failure outside ephemeral environments", async () => {
+    const db = makeFailingDb(new Error("connection refused"));
+
+    await expect(assertTurnkeyEnvForActiveWallets(db)).rejects.toThrow(
+      /connection refused/
+    );
+  });
+
+  it("does not throw on a query failure in an ephemeral PR environment", async () => {
+    process.env.K8S_NAMESPACE = "pr-1373";
+    const db = makeFailingDb(new Error("connection refused"));
+
+    await expect(assertTurnkeyEnvForActiveWallets(db)).resolves.toBeUndefined();
   });
 });

--- a/keeperhub-executor/startup-checks.ts
+++ b/keeperhub-executor/startup-checks.ts
@@ -4,24 +4,86 @@ import { organizationWallets } from "../lib/db/schema";
 
 type Db = ReturnType<typeof drizzle>;
 
+const STARTUP_QUERY_TIMEOUT_MS = 10_000;
+
+/**
+ * Ephemeral PR environments set K8S_NAMESPACE to "pr-<number>" (see
+ * deploy/pr-environment/executor.template.yaml). Staging and production use
+ * their own namespaces and are treated as non-ephemeral.
+ */
+function isEphemeralEnv(): boolean {
+  return process.env.K8S_NAMESPACE?.startsWith("pr-") ?? false;
+}
+
+function withTimeout<T>(
+  operation: PromiseLike<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    Promise.resolve(operation).then(
+      (value) => {
+        clearTimeout(timer);
+        return value;
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        throw error;
+      }
+    ),
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new Error(`Turnkey startup check timed out after ${timeoutMs}ms`)
+          ),
+        timeoutMs
+      );
+    }),
+  ]);
+}
+
 /**
  * If any org has an active Turnkey wallet, the executor pod (and by extension
  * the runner Jobs it spawns via RUNNER_SYSTEM_ENV_VARS forwarding) must have
  * TURNKEY_API_PUBLIC_KEY and TURNKEY_API_PRIVATE_KEY set. Fail at startup
  * instead of per-job so the regression surfaces on deploy, not on the first
  * Turnkey-backed workflow run.
+ *
+ * In ephemeral PR environments the check is downgraded to a warning. A PR env
+ * may legitimately lack Turnkey credentials or hit a transient secret-sync gap,
+ * and because this runs before the health server starts listening, a hard
+ * failure here stops the pod from ever becoming ready and fails the whole PR
+ * deploy. Staging and production keep the hard failure.
  */
 export async function assertTurnkeyEnvForActiveWallets(db: Db): Promise<void> {
-  const rows = await db
-    .select({ id: organizationWallets.id })
-    .from(organizationWallets)
-    .where(
-      and(
-        eq(organizationWallets.provider, "turnkey"),
-        eq(organizationWallets.isActive, true)
-      )
-    )
-    .limit(1);
+  const ephemeral = isEphemeralEnv();
+
+  let rows: { id: string }[];
+  try {
+    rows = await withTimeout(
+      db
+        .select({ id: organizationWallets.id })
+        .from(organizationWallets)
+        .where(
+          and(
+            eq(organizationWallets.provider, "turnkey"),
+            eq(organizationWallets.isActive, true)
+          )
+        )
+        .limit(1),
+      STARTUP_QUERY_TIMEOUT_MS
+    );
+  } catch (error) {
+    if (ephemeral) {
+      console.error(
+        "[Executor] Turnkey startup check could not query the database; continuing because this is an ephemeral PR environment:",
+        error
+      );
+      return;
+    }
+    throw error;
+  }
 
   if (rows.length === 0) {
     return;
@@ -35,10 +97,20 @@ export async function assertTurnkeyEnvForActiveWallets(db: Db): Promise<void> {
     missing.push("TURNKEY_API_PRIVATE_KEY");
   }
 
-  if (missing.length > 0) {
-    throw new Error(
-      `Active Turnkey wallets exist but required env vars are unset: ${missing.join(", ")}. ` +
-        "Set these on the executor deployment so they forward to workflow runner Jobs."
-    );
+  if (missing.length === 0) {
+    return;
   }
+
+  const message =
+    `Active Turnkey wallets exist but required env vars are unset: ${missing.join(", ")}. ` +
+    "Set these on the executor deployment so they forward to workflow runner Jobs.";
+
+  if (ephemeral) {
+    console.error(
+      `[Executor] ${message} Continuing because this is an ephemeral PR environment.`
+    );
+    return;
+  }
+
+  throw new Error(message);
 }


### PR DESCRIPTION
This PR makes PR-environment deploys reliable. It contains three changes; the third is the one that actually fixes the intermittent deploy failure.

## Summary of what fixes what

- The intermittent `deploy` failure (`context deadline exceeded` on the executor satellite) is caused by an **external-secrets reconciliation race**, fixed by raising the satellite helm timeout (change 3).
- The earlier executor startup-check change (change 2) was added believing the Turnkey check was the cause. Investigation disproved that - the container never starts, so that code never runs in the failing case. It is retained as independent hardening, not as the deploy fix. See "Correction" below.
- The Turnstile test-keys change (change 1) is unrelated and stands on its own.

---

## 1. Cloudflare Turnstile test keys for PR deploys

### What
PR deploys use Cloudflare's public always-pass Turnstile test keys instead of the real staging keys.

- Build time (`deploy-pr-environment.yaml`): bake the test site key `1x00000000000000000000AA` into the client bundle instead of `vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY`.
- Runtime (`deploy/pr-environment/values.template.yaml`): serve the test site key and the always-pass test secret `1x0000000000000000000000000000000AA` via `kv` literals instead of the staging SSM params.
- `TURNSTILE_ENFORCE=true` is unchanged, so the captcha plugin still runs end to end.

### Why
Real Turnstile site keys are bound to a hostname allowlist. PR environments get ephemeral hostnames that are not on staging's allowlist, so the real widget fails with a domain mismatch and signup breaks. The test keys are domain-agnostic and always pass.

### Tradeoffs
- The PR signup captcha is effectively a no-op (always passes). The genuine flow is still validated on staging, which keeps the real keys.

---

## 2. Executor Turnkey startup-check hardening (independent - NOT the deploy fix)

### What
`keeperhub-executor/startup-checks.ts`: wrap the active-Turnkey-wallet query in a 10s timeout, and in ephemeral PR environments (`K8S_NAMESPACE` starting with `pr-`) downgrade both a query failure and a missing-Turnkey-env condition from a thrown error to a logged warning. Staging and production keep the hard failure.

### Why it is kept
A PR env may legitimately lack Turnkey credentials or hit a transient secret-sync gap. The assertion runs before the health server listens, so a hard failure there would stop the pod from becoming ready. This is reasonable defensive hardening on its own.

### Correction
This change was originally presented as the fix for the failing `deploy`. That diagnosis was wrong. The deploy fails before the executor process starts at all (see change 3), so this code does not execute in the failing case and cannot be what fixes the deploy. It is retained as independent hardening only. Reviewers may reasonably ask to split it into its own PR.

---

## 3. Raise PR-env satellite deploy timeout (the actual fix)

### Root cause (diagnosed and validated against the live PR env)
The executor pod hard-references (`Optional: false`) eight `parameterStore`-backed secrets (`executor-pr-<n>-common-{chain-rpc-config, etherscan-api-key, integration-encryption-key, scheduler-service-api-key, para-api-key, turnkey-api-public-key, turnkey-api-private-key, wallet-encryption-key}`). The `common` chart renders these into ExternalSecret resources that external-secrets operator (ESO) populates asynchronously, out-of-band, in the same release as the Deployment. The pod schedules before the backing Secrets exist:

```
waiting=CreateContainerConfigError
Error: secret "executor-pr-<n>-common-chain-rpc-config" not found
```

Until ESO reconciles all eight, the container cannot be created, the pod never becomes Ready, and `helm --atomic --timeout 5m0s` rolls the release back -> `context deadline exceeded`. It is timing-dependent, which is why it was intermittent: when ESO synced within 5m the deploy passed, otherwise it lost the race. Observed ESO reconcile was ~3.5 min against a 5 min budget.

### What
`deploy-pr-environment.yaml`, "Deploy satellite services (parallel)": raise the shared satellite `COMMON_ARGS` helm timeout from `5m0s` to `10m0s`, matching the main app's existing 10m budget, so ESO has time to reconcile before `--atomic` would roll back.

### Ruled out with evidence
- Image pull: executor image is ~484MB and pulls in ~0.5s.
- Memory/OOM: the executor process peaks ~248MiB under a 512Mi cap and serves `/health` in seconds.
- Executor app code: the container never starts in the failing case, so it is not implicated.

### Validation
Pushed to this branch and observed live in the PR env: the executor pod entered `CreateContainerConfigError` for ~2.5 min (ESO race, as expected), then the secrets synced, the container started, and it reached `ready=true` well within the 10m window. The `deploy` job went green - the first successful PR-env deploy on this branch.

### Note on durability
This widens the window; it does not remove the race. The durable follow-ups (out of scope here): dedup the executor's ExternalSecrets against the already-synced `keeperhub-pr-<n>-common-*` ones (or gate the Deployment rollout on ExternalSecret readiness), and investigate why ESO takes minutes to reconcile freshly created ExternalSecrets.
