### PR TITLE
fix: thread workflow owner into scheduled and MCP executor dispatch

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -29,9 +29,9 @@ import {
   CALL_ROUTE_COLUMNS,
   type CallRouteWorkflow,
 } from "@/lib/payments/x402/types";
+import { buildExecutorInput } from "@/lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
-import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -156,16 +156,12 @@ async function startExecutionInBackground(
     getOrgPlanLabel(workflow.organizationId),
   ]);
   start(executeWorkflow, [
-    {
-      nodes: workflow.nodes as WorkflowNode[],
-      edges: workflow.edges as WorkflowEdge[],
+    buildExecutorInput(workflow, {
       triggerInput: body,
       executionId,
-      workflowId: workflow.id,
-      organizationId: workflow.organizationId ?? undefined,
       organizationSlug,
       organizationPlan,
-    },
+    }),
   ]).catch((err: unknown) => {
     logSystemError(
       ErrorCategory.WORKFLOW_ENGINE,

--- a/keeperhub-executor/in-process.ts
+++ b/keeperhub-executor/in-process.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { validateWorkflowIntegrations } from "../lib/db/integrations";
 import { organization, workflows } from "../lib/db/schema";
+import { buildExecutorInput } from "../lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
 import { calculateTotalSteps } from "../lib/workflow/executor/progress";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
@@ -17,7 +18,6 @@ import {
  * Refactored from keeperhub-executor/workflow-runner.ts main() to be callable
  * from the executor without managing its own process lifecycle.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrates multiple phases of workflow execution
 export async function executeInProcess(params: {
   workflowId: string;
   executionId: string;
@@ -89,15 +89,13 @@ export async function executeInProcess(params: {
     await initializeExecutionProgress(db, executionId, totalSteps);
 
     console.log("[Executor:InProcess] Executing workflow...");
-    const result = await executeWorkflow({
-      nodes,
-      edges,
-      triggerInput: input,
-      executionId,
-      workflowId,
-      organizationId: workflow.organizationId ?? undefined,
-      organizationName,
-    });
+    const result = await executeWorkflow(
+      buildExecutorInput(workflow, {
+        triggerInput: input,
+        executionId,
+        organizationName,
+      })
+    );
 
     const duration = Date.now() - startTime;
     console.log(`[Executor:InProcess] Completed in ${duration}ms`);

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -33,6 +33,7 @@ import {
   workflowSchedules,
   workflows,
 } from "../lib/db/schema";
+import { buildExecutorInput } from "../lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
 import { calculateTotalSteps } from "../lib/workflow/executor/progress";
 import { SHUTDOWN_TIMEOUT_MS } from "../lib/workflow/executor/runner-constants";
@@ -154,7 +155,6 @@ async function handleGracefulShutdown(signal: string): Promise<void> {
 process.on("SIGTERM", () => handleGracefulShutdown("SIGTERM"));
 process.on("SIGINT", () => handleGracefulShutdown("SIGINT"));
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Main runner orchestrates multiple phases of workflow execution
 async function main(): Promise<void> {
   const startTime = Date.now();
   const { workflowId, executionId, input, scheduleId } = validateEnv();
@@ -237,15 +237,13 @@ async function main(): Promise<void> {
     }
 
     console.log("[Runner] Executing workflow...");
-    const result = await executeWorkflow({
-      nodes,
-      edges: workflow.edges as WorkflowEdge[],
-      triggerInput: input,
-      executionId,
-      workflowId,
-      organizationId: workflow.organizationId ?? undefined,
-      organizationName,
-    });
+    const result = await executeWorkflow(
+      buildExecutorInput(workflow, {
+        triggerInput: input,
+        executionId,
+        organizationName,
+      })
+    );
 
     const duration = Date.now() - startTime;
     console.log(`[Runner] Workflow completed in ${duration}ms`);

--- a/lib/workflow/executor/build-executor-input.ts
+++ b/lib/workflow/executor/build-executor-input.ts
@@ -1,0 +1,45 @@
+import type { WorkflowExecutionInput } from "@/lib/workflow/executor/executor.workflow";
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+
+/** Minimal workflow shape needed to build executor input. */
+export type ExecutorInputWorkflow = {
+  id: string;
+  userId: string;
+  organizationId: string | null;
+  nodes: unknown;
+  edges: unknown;
+};
+
+/**
+ * Build the executor input from a workflow row, always deriving the
+ * owner-context principal (`ownerId` / `organizationId`) from the workflow.
+ *
+ * Centralised so every dispatch entry point (scheduled K8s job, in-process,
+ * MCP) threads the same owner context. The database-query step authorizes
+ * credential use against this principal; a dropped `ownerId` leaves the
+ * principal with a null userId, so org-visibility integrations fail closed
+ * and surface the misleading "DATABASE_URL is not configured" error.
+ */
+export function buildExecutorInput(
+  workflow: ExecutorInputWorkflow,
+  params: {
+    triggerInput?: Record<string, unknown>;
+    executionId?: string;
+    organizationName?: string;
+    organizationSlug?: string;
+    organizationPlan?: string;
+  }
+): WorkflowExecutionInput {
+  return {
+    nodes: workflow.nodes as WorkflowNode[],
+    edges: workflow.edges as WorkflowEdge[],
+    triggerInput: params.triggerInput,
+    executionId: params.executionId,
+    workflowId: workflow.id,
+    organizationId: workflow.organizationId ?? undefined,
+    ownerId: workflow.userId,
+    organizationName: params.organizationName,
+    organizationSlug: params.organizationSlug,
+    organizationPlan: params.organizationPlan,
+  };
+}

--- a/tests/unit/build-executor-input.test.ts
+++ b/tests/unit/build-executor-input.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildExecutorInput } from "@/lib/workflow/executor/build-executor-input";
+
+// Regression guard for the KEEP-613 follow-up. The database-query step
+// authorizes credential use against the owner-context principal
+// (`ownerId` / `organizationId`). Every dispatch entry point (scheduled K8s
+// job, in-process, MCP) builds its executor input through buildExecutorInput,
+// so pinning the owner derivation here guards all of them: a regression that
+// drops ownerId would leave the principal with a null userId and make
+// org-visibility integrations fail closed as "DATABASE_URL is not configured".
+
+const WORKFLOW = {
+  id: "wf-1",
+  userId: "owner-1",
+  organizationId: "org-1",
+  nodes: [{ id: "n1" }],
+  edges: [{ id: "e1" }],
+};
+
+describe("buildExecutorInput", () => {
+  it("derives ownerId and organizationId from the workflow", () => {
+    const input = buildExecutorInput(WORKFLOW, {
+      triggerInput: { foo: "bar" },
+      executionId: "exec-1",
+    });
+
+    expect(input.ownerId).toBe("owner-1");
+    expect(input.organizationId).toBe("org-1");
+    expect(input.workflowId).toBe("wf-1");
+  });
+
+  it("maps a null organizationId to undefined and still sets ownerId", () => {
+    const input = buildExecutorInput(
+      { ...WORKFLOW, organizationId: null },
+      { executionId: "exec-2" }
+    );
+
+    expect(input.organizationId).toBeUndefined();
+    expect(input.ownerId).toBe("owner-1");
+  });
+
+  it("passes through the optional org metadata it is given", () => {
+    const input = buildExecutorInput(WORKFLOW, {
+      executionId: "exec-3",
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      organizationPlan: "pro",
+    });
+
+    expect(input.organizationName).toBe("Acme");
+    expect(input.organizationSlug).toBe("acme");
+    expect(input.organizationPlan).toBe("pro");
+  });
+});


### PR DESCRIPTION
## Summary

The per-integration authorization check added in #1358 gates database-query credential use on the owner-context principal (`ownerId` / `organizationId`). Three dispatch entry points never passed `ownerId` into `executeWorkflow`, so the check ran with a null-userId principal: the owner short-circuit could not fire, and the organization-visibility branch was forced to fail because membership is only computed when `userId` is non-null. Org-visibility integrations were therefore rejected and the database-query step reported the misleading `DATABASE_URL is not configured. Please add it in Project Integrations.` even though the integration was configured correctly.

This affected every scheduled / executor-dispatched / agent-callable (MCP) workflow whose database-query node references an `organization`-visibility integration. Interactive executions via the singular API execute route were unaffected (that path already passed `ownerId`).

## Root cause

`ownerId` was dropped in three entry points, each of which already had the workflow row in scope:

- `keeperhub-executor/workflow-runner.ts` (K8s job target)
- `keeperhub-executor/in-process.ts` (in-process target)
- `app/api/mcp/workflows/[slug]/call/route.ts` (MCP / agent-callable)

## Changes

- Add `lib/workflow/executor/build-executor-input.ts` - a single helper that builds the executor input from a workflow row and always derives `ownerId` / `organizationId` from it.
- Route all three entry points through the helper, so the owner context can no longer be dropped at one site without the others.
- Add a unit test pinning the owner derivation. Because every path funnels through the helper, this one test guards the whole regression class.

Incidental cleanups enabled by the refactor: two now-redundant `noExcessiveCognitiveComplexity` suppressions and one now-unused type import were removed.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm check` clean for changed files
- [x] Unit: `tests/unit/build-executor-input.test.ts` passes; verified it fails when `ownerId` is dropped

## Note

The underlying production incident remains live until this merges and the executor image is redeployed.