### PR TITLE
fix(auth): login flow bug sweep

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -89,6 +89,19 @@ async function interceptOauthCallback(
       : [];
   const sessionToken = extractSessionToken(setCookies);
   if (!sessionToken) {
+    // Better Auth's callback returned a redirect without a session
+    // cookie. Either the OAuth dance failed silently or the runtime
+    // does not expose getSetCookie. Log so we can tell the two apart
+    // when a user reports "signed in with Google but no session".
+    // biome-ignore lint/suspicious/noConsole: prod diagnostic for OAuth race
+    console.warn("[oauth-callback] no session token in Set-Cookie", {
+      pathname: url.pathname,
+      status: res.status,
+      setCookieCount: setCookies.length,
+      hasGetSetCookie:
+        typeof (res.headers as Headers & { getSetCookie?: () => string[] })
+          .getSetCookie === "function",
+    });
     return res;
   }
   const tokenHash = hashSessionToken(sessionToken);

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -89,19 +89,6 @@ async function interceptOauthCallback(
       : [];
   const sessionToken = extractSessionToken(setCookies);
   if (!sessionToken) {
-    // Better Auth's callback returned a redirect without a session
-    // cookie. Either the OAuth dance failed silently or the runtime
-    // does not expose getSetCookie. Log so we can tell the two apart
-    // when a user reports "signed in with Google but no session".
-    // biome-ignore lint/suspicious/noConsole: prod diagnostic for OAuth race
-    console.warn("[oauth-callback] no session token in Set-Cookie", {
-      pathname: url.pathname,
-      status: res.status,
-      setCookieCount: setCookies.length,
-      hasGetSetCookie:
-        typeof (res.headers as Headers & { getSetCookie?: () => string[] })
-          .getSetCookie === "function",
-    });
     return res;
   }
   const tokenHash = hashSessionToken(sessionToken);

--- a/app/api/auth/strict-signin/route.ts
+++ b/app/api/auth/strict-signin/route.ts
@@ -10,6 +10,7 @@ import {
 import { db } from "@/lib/db";
 import {
   accounts,
+  sessions,
   twoFactor as twoFactorTable,
   users,
   verifications,
@@ -258,6 +259,26 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json(
       { error: "Sign-in failed at session step", code: "session_failed" },
       { status: 500 }
+    );
+  }
+
+  // The session.create.before hook in lib/auth.ts stamps requires_mfa
+  // = true on every new session for users with two_factor_enabled.
+  // That gate is for the legacy single-factor sign-in path;
+  // strict-signin has already verified password + email OTP + TOTP
+  // atomically, so the freshly minted session is fully MFA-verified
+  // and should not be bounced to /verify-mfa for a redundant step-up.
+  try {
+    await db
+      .update(sessions)
+      .set({ requiresMfa: false, mfaVerifiedAt: new Date() })
+      .where(eq(sessions.userId, user.id));
+  } catch (err) {
+    logSystemError(
+      ErrorCategory.AUTH,
+      "[strict-signin] failed to clear requires_mfa after dual-factor verification",
+      err,
+      { endpoint: "/api/auth/strict-signin", user_id: user.id }
     );
   }
 

--- a/app/api/user/forgot-password/route.ts
+++ b/app/api/user/forgot-password/route.ts
@@ -124,16 +124,20 @@ async function handleRequest(email: string): Promise<NextResponse> {
     (acc) => acc.providerId === "credential"
   );
 
-  // If user only has OAuth, send a helpful email instead
+  // If user only has OAuth, send a helpful email instead. Pick the
+  // OAuth account they most recently signed in with so the reminder
+  // names the provider they actually used. Before this fix,
+  // multi-linked accounts (Google + GitHub) named whichever was first
+  // in OAUTH_PROVIDERS, which surfaced "uses GitHub" to users who had
+  // been signing in with Google.
   if (!credentialAccount) {
-    const oauthAccount = userAccounts.find((acc) =>
-      OAUTH_PROVIDERS.includes(acc.providerId)
-    );
-
-    if (oauthAccount) {
+    const mostRecentOauth = userAccounts
+      .filter((acc) => OAUTH_PROVIDERS.includes(acc.providerId))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+    if (mostRecentOauth) {
       const providerName =
-        oauthAccount.providerId.charAt(0).toUpperCase() +
-        oauthAccount.providerId.slice(1);
+        mostRecentOauth.providerId.charAt(0).toUpperCase() +
+        mostRecentOauth.providerId.slice(1);
       await sendOAuthPasswordResetEmail({ email, providerName });
     }
 

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -132,7 +132,7 @@ function CreateApiKeyOverlay({
         <DualFactorSteps
           busy={creating}
           dual={dual}
-          onBack={() => setPhase("label")}
+          onBack={pop}
           onPrefetchEmail={() => dual.prefetchEmail(emptyCodesFetch)}
           onResendEmail={() => dual.resendEmail(emptyCodesFetch)}
           onSubmit={handleCreate}

--- a/components/overlays/withdraw-modal.tsx
+++ b/components/overlays/withdraw-modal.tsx
@@ -554,7 +554,7 @@ export function WithdrawModal({
           dual={dual}
           onBack={() => {
             dual.reset();
-            setState("input");
+            closeAll();
           }}
           onPrefetchEmail={() => dual.prefetchEmail(withdrawEmptyCodes)}
           onResendEmail={() => dual.resendEmail(withdrawEmptyCodes)}

--- a/components/settings/delete-account-section.tsx
+++ b/components/settings/delete-account-section.tsx
@@ -166,7 +166,10 @@ export function DeactivateAccountSection(): React.ReactElement {
                   <DualFactorSteps
                     busy={loading}
                     dual={dual}
-                    onBack={() => setPhase("confirmation")}
+                    onBack={() => {
+                      setOpen(false);
+                      resetAll();
+                    }}
                     onPrefetchEmail={() =>
                       dual.prefetchEmail(emptyCodesFetch)
                     }

--- a/components/settings/totp-backup-codes-panel.tsx
+++ b/components/settings/totp-backup-codes-panel.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { Check, Copy, Download, EyeOff, KeyRound } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Check, Copy, Download, KeyRound } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 
 type Props = {
   codes: string[] | null;
@@ -14,19 +12,6 @@ type Props = {
   generateLabel?: string;
   onConfirmed: () => void;
 };
-
-const CONFIRM_PROMPT_COUNT = 2;
-
-function pickConfirmationIndexes(total: number): number[] {
-  const indexes = Array.from({ length: total }, (_, i) => i);
-  const picked: number[] = [];
-  while (picked.length < CONFIRM_PROMPT_COUNT && indexes.length > 0) {
-    const idx = Math.floor(Math.random() * indexes.length);
-    picked.push(indexes[idx]);
-    indexes.splice(idx, 1);
-  }
-  return picked.sort((a, b) => a - b);
-}
 
 function downloadAsText(codes: string[]): void {
   const content = [
@@ -53,23 +38,16 @@ function downloadAsText(codes: string[]): void {
 }
 
 /**
- * Three-phase backup-codes UX:
+ * Two-phase backup-codes UX:
  *
  *   1. PRE-GENERATE — codes are not on the wire yet. Shows a single
  *      "Generate" call-to-action. Only rendered if `onGenerate` is
  *      provided (the regenerate-later flow); the enrollment flow
  *      receives pre-fetched codes and skips this phase.
  *
- *   2. EXPORT — codes are visible. Two required action chips (Copy +
- *      Download .txt) must both be clicked before the confirm step is
- *      unlocked. The chips render as primary call-to-action buttons so
- *      it's visually clear they're required, not optional. Once both
- *      fire, the codes themselves are hidden from the UI (we keep them
- *      in component state only for the retype check that follows).
- *
- *   3. RETYPE — confirmation. User must type two codes at random
- *      positions, from their own saved copy. Disabled until both
- *      Copy + Download have fired.
+ *   2. EXPORT — codes are visible. Download is the gating action;
+ *      once the user clicks Download, the confirm button unlocks.
+ *      Copy is offered as a convenience but is not required.
  *
  * The container dialog refuses to close while this panel is showing
  * the codes and hasn't yet called onConfirmed.
@@ -82,14 +60,7 @@ export function TotpBackupCodesPanel({
 }: Props): React.ReactElement {
   const [copied, setCopied] = useState(false);
   const [downloaded, setDownloaded] = useState(false);
-  const [inputs, setInputs] = useState<Record<number, string>>({});
   const [generating, setGenerating] = useState(false);
-  const [confirming, setConfirming] = useState(false);
-
-  const promptIndexes = useMemo<number[]>(
-    () => (codes ? pickConfirmationIndexes(codes.length) : []),
-    [codes]
-  );
 
   if (codes === null) {
     return (
@@ -130,9 +101,6 @@ export function TotpBackupCodesPanel({
     );
   }
 
-  const canConfirm = copied && downloaded;
-  const codesHidden = canConfirm;
-
   const handleCopy = async (): Promise<void> => {
     try {
       await navigator.clipboard.writeText(codes.join("\n"));
@@ -153,133 +121,56 @@ export function TotpBackupCodesPanel({
     }
   };
 
-  const handleConfirm = (): void => {
-    if (!canConfirm) {
-      return;
-    }
-    setConfirming(true);
-    for (const idx of promptIndexes) {
-      const expected = codes[idx];
-      const typed = (inputs[idx] ?? "").trim();
-      if (typed !== expected) {
-        toast.error(
-          `Code at position #${idx + 1} does not match. Open your saved copy.`
-        );
-        setConfirming(false);
-        return;
-      }
-    }
-    onConfirmed();
-  };
-
   return (
     <div className="space-y-4">
       <Alert>
         <AlertDescription>
-          Save these codes before continuing. They are shown only once and
-          this dialog cannot be closed until you confirm you have them.
+          Save these codes before continuing. They are shown only once. Each
+          code can be used to sign in if you lose your authenticator.
         </AlertDescription>
       </Alert>
 
-      <div className="space-y-2">
-        <Label>Your backup codes</Label>
-        {codesHidden ? (
-          <div className="flex items-center gap-3 rounded-md border bg-muted/30 p-3 text-muted-foreground text-xs">
-            <EyeOff aria-hidden="true" className="size-4" />
-            <span>
-              Hidden. Use your copied list or downloaded file to confirm
-              below.
+      <div className="grid grid-cols-2 gap-2 rounded-md border bg-muted/30 p-3 font-mono text-xs">
+        {codes.map((code, idx) => (
+          <div className="flex gap-2" key={code}>
+            <span className="text-muted-foreground">
+              {(idx + 1).toString().padStart(2, " ")}.
             </span>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 gap-2 rounded-md border bg-muted/30 p-3 font-mono text-xs">
-            {codes.map((code, idx) => (
-              <div className="flex gap-2" key={code}>
-                <span className="text-muted-foreground">
-                  {(idx + 1).toString().padStart(2, " ")}.
-                </span>
-                <span>{code}</span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      <div className="space-y-2">
-        <div className="text-sm">
-          <span className="font-medium">Required:</span>{" "}
-          <span className="text-muted-foreground">
-            both actions before you can confirm
-          </span>
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          <Button
-            className="w-full"
-            onClick={handleCopy}
-            variant={copied ? "outline" : "default"}
-          >
-            {copied ? (
-              <Check aria-hidden="true" className="mr-2 size-4" />
-            ) : (
-              <Copy aria-hidden="true" className="mr-2 size-4" />
-            )}
-            {copied ? "Copied" : "Copy all"}
-          </Button>
-          <Button
-            className="w-full"
-            onClick={handleDownload}
-            variant={downloaded ? "outline" : "default"}
-          >
-            {downloaded ? (
-              <Check aria-hidden="true" className="mr-2 size-4" />
-            ) : (
-              <Download aria-hidden="true" className="mr-2 size-4" />
-            )}
-            {downloaded ? "Downloaded" : "Download .txt"}
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-3 border-t pt-4">
-        <div className="space-y-1">
-          <h4 className="font-medium text-sm">Confirm you saved the codes</h4>
-          <p className="text-muted-foreground text-xs">
-            {canConfirm
-              ? `Type the codes at positions #${promptIndexes[0] + 1} and #${promptIndexes[1] + 1} from your saved copy, in order.`
-              : "Copy and download the codes above first."}
-          </p>
-        </div>
-        {promptIndexes.map((idx, position) => (
-          <div className="space-y-1" key={idx}>
-            <Label htmlFor={`backup-confirm-${idx}`}>
-              {position + 1}. Code at position #{idx + 1}
-            </Label>
-            <Input
-              autoComplete="off"
-              className="font-mono"
-              disabled={!canConfirm}
-              id={`backup-confirm-${idx}`}
-              maxLength={11}
-              onChange={(event) =>
-                setInputs((prev) => ({ ...prev, [idx]: event.target.value }))
-              }
-              placeholder={canConfirm ? "xxxxx-xxxxx" : "Copy and download first"}
-              value={inputs[idx] ?? ""}
-            />
+            <span>{code}</span>
           </div>
         ))}
       </div>
 
-      <div className="flex justify-end">
+      <div className="grid grid-cols-2 gap-2">
         <Button
-          disabled={
-            confirming ||
-            !canConfirm ||
-            promptIndexes.some((i) => (inputs[i] ?? "").trim().length === 0)
-          }
-          onClick={handleConfirm}
+          className="w-full"
+          onClick={handleCopy}
+          variant={copied ? "outline" : "ghost"}
         >
-          Confirm and finish
+          {copied ? (
+            <Check aria-hidden="true" className="mr-2 size-4" />
+          ) : (
+            <Copy aria-hidden="true" className="mr-2 size-4" />
+          )}
+          {copied ? "Copied" : "Copy"}
+        </Button>
+        <Button
+          className="w-full"
+          onClick={handleDownload}
+          variant={downloaded ? "outline" : "default"}
+        >
+          {downloaded ? (
+            <Check aria-hidden="true" className="mr-2 size-4" />
+          ) : (
+            <Download aria-hidden="true" className="mr-2 size-4" />
+          )}
+          {downloaded ? "Downloaded" : "Download .txt"}
+        </Button>
+      </div>
+
+      <div className="flex justify-end">
+        <Button disabled={!downloaded} onClick={onConfirmed}>
+          I've saved my codes
         </Button>
       </div>
     </div>

--- a/components/settings/totp-backup-codes-panel.tsx
+++ b/components/settings/totp-backup-codes-panel.tsx
@@ -10,7 +10,6 @@ type Props = {
   codes: string[] | null;
   onGenerate?: () => Promise<void> | void;
   generateLabel?: string;
-  onConfirmed: () => void;
 };
 
 function downloadAsText(codes: string[]): void {
@@ -45,18 +44,17 @@ function downloadAsText(codes: string[]): void {
  *      provided (the regenerate-later flow); the enrollment flow
  *      receives pre-fetched codes and skips this phase.
  *
- *   2. EXPORT — codes are visible. Download is the gating action;
- *      once the user clicks Download, the confirm button unlocks.
- *      Copy is offered as a convenience but is not required.
- *
- * The container dialog refuses to close while this panel is showing
- * the codes and hasn't yet called onConfirmed.
+ *   2. EXPORT — codes are visible with Copy + Download buttons. A
+ *      successful Download fires `onConfirmed` so the container can
+ *      close the dialog. Copy is offered as a convenience but does
+ *      not fire `onConfirmed`. The container is expected to provide
+ *      a separate Skip control for users who want to dismiss without
+ *      downloading.
  */
 export function TotpBackupCodesPanel({
   codes,
   onGenerate,
   generateLabel,
-  onConfirmed,
 }: Props): React.ReactElement {
   const [copied, setCopied] = useState(false);
   const [downloaded, setDownloaded] = useState(false);
@@ -123,13 +121,6 @@ export function TotpBackupCodesPanel({
 
   return (
     <div className="space-y-4">
-      <Alert>
-        <AlertDescription>
-          Save these codes before continuing. They are shown only once. Each
-          code can be used to sign in if you lose your authenticator.
-        </AlertDescription>
-      </Alert>
-
       <div className="grid grid-cols-2 gap-2 rounded-md border bg-muted/30 p-3 font-mono text-xs">
         {codes.map((code, idx) => (
           <div className="flex gap-2" key={code}>
@@ -165,12 +156,6 @@ export function TotpBackupCodesPanel({
             <Download aria-hidden="true" className="mr-2 size-4" />
           )}
           {downloaded ? "Downloaded" : "Download .txt"}
-        </Button>
-      </div>
-
-      <div className="flex justify-end">
-        <Button disabled={!downloaded} onClick={onConfirmed}>
-          I've saved my codes
         </Button>
       </div>
     </div>

--- a/components/settings/totp-manage-dialog.tsx
+++ b/components/settings/totp-manage-dialog.tsx
@@ -339,10 +339,14 @@ export function TotpManageDialog({
         )}
 
         {mode === "viewing-codes" && generatedCodes && (
-          <TotpBackupCodesPanel
-            codes={generatedCodes}
-            onConfirmed={resetAndClose}
-          />
+          <div className="space-y-4">
+            <TotpBackupCodesPanel codes={generatedCodes} />
+            <DialogFooter>
+              <Button onClick={resetAndClose} variant="outline">
+                Done
+              </Button>
+            </DialogFooter>
+          </div>
         )}
       </DialogContent>
     </Dialog>

--- a/components/settings/totp-manage-dialog.tsx
+++ b/components/settings/totp-manage-dialog.tsx
@@ -311,6 +311,7 @@ export function TotpManageDialog({
               onBack={() => {
                 setMode("summary");
                 dual.reset();
+                onOpenChange(false);
               }}
               onPrefetchEmail={() =>
                 dual.prefetchEmail(() =>

--- a/components/settings/totp-setup-dialog.tsx
+++ b/components/settings/totp-setup-dialog.tsx
@@ -196,9 +196,7 @@ export function TotpSetupDialog({
 
   const attemptClose = (): void => {
     if (locked) {
-      toast.error(
-        "Save your backup codes first — copy, download, and confirm two."
-      );
+      toast.error("Download your backup codes first.");
       return;
     }
     closeAndReset();
@@ -265,13 +263,13 @@ export function TotpSetupDialog({
         onEscapeKeyDown={(event) => {
           if (locked) {
             event.preventDefault();
-            toast.error("Save your backup codes before closing.");
+            toast.error("Download your backup codes before closing.");
           }
         }}
         onInteractOutside={(event) => {
           if (locked) {
             event.preventDefault();
-            toast.error("Save your backup codes before closing.");
+            toast.error("Download your backup codes before closing.");
           }
         }}
       >

--- a/components/settings/totp-setup-dialog.tsx
+++ b/components/settings/totp-setup-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { TotpBackupCodesPanel } from "@/components/settings/totp-backup-codes-panel";
@@ -25,12 +26,11 @@ type EnrollResponse = {
   backupCodes: string[];
 };
 
-type Phase = "scan" | "verify" | "save";
+type Phase = "setup" | "codes";
 
 const STEP_DEFS: ReadonlyArray<{ key: Phase; label: string }> = [
-  { key: "scan", label: "Scan" },
-  { key: "verify", label: "Verify" },
-  { key: "save", label: "Save codes" },
+  { key: "setup", label: "Scan & verify" },
+  { key: "codes", label: "Download codes" },
 ] as const;
 
 type StepStatus = "current" | "done" | "pending";
@@ -72,10 +72,14 @@ type Props = {
 };
 
 /**
- * Horizontal numbered stepper, mirrors the deploy-safe wizard
- * (components/safe/deploy-safe-card.tsx:StepIndicator). Same bubble
- * styling, same connector treatment — visual consistency with the
- * existing wizard pattern in the codebase.
+ * Horizontal numbered stepper. Two phases:
+ *
+ *   1. setup   — QR scan + manual key + TOTP code verification in one
+ *                step. POSTing /enroll succeeds when the code matches
+ *                and returns the backup codes.
+ *   2. codes   — display the freshly minted backup codes with Download
+ *                + Skip. Either choice closes the dialog; users who
+ *                skip can regenerate from settings later.
  */
 function StepIndicator({ current }: { current: Phase }): React.ReactElement {
   const currentIdx = STEP_DEFS.findIndex((s) => s.key === current);
@@ -105,25 +109,17 @@ function StepIndicator({ current }: { current: Phase }): React.ReactElement {
   );
 }
 
-/**
- * Single modal, single step content at a time, horizontal progress
- * indicator at the top. Pattern matches a standard wizard: stepper
- * shows current/done/pending; body swaps per phase; Back/Continue at
- * the bottom move between phases.
- *
- * Phases: scan -> verify -> save. The save phase locks the dialog
- * until the user has copied + downloaded + retyped two backup codes.
- */
 export function TotpSetupDialog({
   open,
   onOpenChange,
   onEnrolled,
 }: Props): React.ReactElement {
-  const [phase, setPhase] = useState<Phase>("scan");
+  const [phase, setPhase] = useState<Phase>("setup");
   const [setupData, setSetupData] = useState<SetupResponse | null>(null);
   const [code, setCode] = useState("");
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
   const [busy, setBusy] = useState(false);
+  const [keyJustCopied, setKeyJustCopied] = useState(false);
 
   useEffect(() => {
     if (!open || setupData) {
@@ -165,24 +161,8 @@ export function TotpSetupDialog({
     };
   }, [open, setupData, onOpenChange]);
 
-  const locked = phase === "save" && backupCodes !== null;
-
-  useEffect(() => {
-    if (!locked) {
-      return;
-    }
-    const handler = (event: BeforeUnloadEvent): string => {
-      event.preventDefault();
-      event.returnValue =
-        "You have unsaved backup codes. Leaving now means losing them.";
-      return event.returnValue;
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [locked]);
-
   const reset = (): void => {
-    setPhase("scan");
+    setPhase("setup");
     setSetupData(null);
     setCode("");
     setBackupCodes(null);
@@ -192,14 +172,6 @@ export function TotpSetupDialog({
   const closeAndReset = (): void => {
     reset();
     onOpenChange(false);
-  };
-
-  const attemptClose = (): void => {
-    if (locked) {
-      toast.error("Download your backup codes first.");
-      return;
-    }
-    closeAndReset();
   };
 
   const handleVerifyAndEnroll = async (): Promise<void> => {
@@ -219,16 +191,11 @@ export function TotpSetupDialog({
       }
       const data = (await response.json()) as EnrollResponse;
       setBackupCodes(data.backupCodes);
-      setPhase("save");
+      setPhase("codes");
       onEnrolled();
     } finally {
       setBusy(false);
     }
-  };
-
-  const handleBackupCodesConfirmed = (): void => {
-    toast.success("Two-factor authentication is enabled");
-    closeAndReset();
   };
 
   const handleCopyKey = async (): Promise<void> => {
@@ -237,53 +204,49 @@ export function TotpSetupDialog({
     }
     try {
       await navigator.clipboard.writeText(setupData.manualEntryKey);
-      toast.success("Setup key copied");
+      toast.success("Setup key copied to clipboard");
+      setKeyJustCopied(true);
     } catch {
       toast.error("Copy failed");
     }
+  };
+
+  useEffect(() => {
+    if (!keyJustCopied) {
+      return;
+    }
+    const timer = window.setTimeout(() => setKeyJustCopied(false), 3000);
+    return () => window.clearTimeout(timer);
+  }, [keyJustCopied]);
+
+  const handleDone = (): void => {
+    toast.success("Two-factor authentication is enabled");
+    closeAndReset();
   };
 
   return (
     <Dialog
       onOpenChange={(next) => {
         if (!next) {
-          attemptClose();
+          closeAndReset();
           return;
         }
         onOpenChange(next);
       }}
       open={open}
     >
-      <DialogContent
-        className={
-          locked
-            ? "max-h-[90vh] overflow-y-auto sm:max-w-lg [&>button[type='button']]:hidden"
-            : "max-h-[90vh] overflow-y-auto sm:max-w-lg"
-        }
-        onEscapeKeyDown={(event) => {
-          if (locked) {
-            event.preventDefault();
-            toast.error("Download your backup codes before closing.");
-          }
-        }}
-        onInteractOutside={(event) => {
-          if (locked) {
-            event.preventDefault();
-            toast.error("Download your backup codes before closing.");
-          }
-        }}
-      >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Set up two-factor authentication</DialogTitle>
           <DialogDescription>
-            Three steps. The dialog stays open until your backup codes are
-            saved.
+            Scan the QR with an authenticator app and verify a code. Save
+            your backup codes after.
           </DialogDescription>
         </DialogHeader>
 
         <StepIndicator current={phase} />
 
-        {phase === "scan" && (
+        {phase === "setup" && (
           <div className="space-y-4">
             <p className="text-muted-foreground text-sm">
               Scan the QR code in your authenticator app (Google
@@ -299,63 +262,56 @@ export function TotpSetupDialog({
               )}
             </div>
             {setupData && (
-              <div className="space-y-2">
-                <Label>Setup key (manual entry)</Label>
-                <div className="flex gap-2">
-                  <Input
-                    className="font-mono text-xs"
-                    readOnly
-                    value={setupData.manualEntryKey}
-                  />
-                  <Button onClick={handleCopyKey} size="sm" variant="outline">
-                    Copy
-                  </Button>
-                </div>
+              <div className="flex items-center gap-2 text-muted-foreground text-sm">
+                <span>Setup key</span>
+                <button
+                  aria-label="Copy setup key"
+                  className={`h-7 flex-1 cursor-pointer truncate rounded border bg-muted/30 px-2 text-left font-mono text-foreground text-xs transition-colors ${
+                    keyJustCopied
+                      ? "border-emerald-500"
+                      : "border-border hover:border-foreground/30"
+                  }`}
+                  onClick={handleCopyKey}
+                  type="button"
+                >
+                  {setupData.manualEntryKey}
+                </button>
+                <Button
+                  aria-label="Copy setup key"
+                  className="size-7"
+                  onClick={handleCopyKey}
+                  size="icon"
+                  variant="ghost"
+                >
+                  <Copy aria-hidden="true" className="size-3.5" />
+                </Button>
               </div>
             )}
-            <DialogFooter>
-              <Button onClick={attemptClose} variant="outline">
-                Cancel
-              </Button>
-              <Button
-                disabled={!setupData || busy}
-                onClick={() => setPhase("verify")}
-              >
-                Continue
-              </Button>
-            </DialogFooter>
-          </div>
-        )}
-
-        {phase === "verify" && (
-          <div className="space-y-4">
-            <p className="text-muted-foreground text-sm">
-              Open your authenticator and enter the 6-digit code it's
-              showing right now.
-            </p>
             <div className="space-y-2">
               <Label htmlFor="totp-verify-code">Verification code</Label>
               <Input
                 autoComplete="one-time-code"
-                autoFocus
+                disabled={busy || !setupData}
                 id="totp-verify-code"
                 inputMode="numeric"
                 maxLength={6}
-                onChange={(event) => setCode(event.target.value)}
+                onChange={(event) =>
+                  setCode(event.target.value.replace(/\D/g, "").slice(0, 6))
+                }
                 placeholder="123456"
                 value={code}
               />
+              <p className="text-muted-foreground text-xs">
+                Open your authenticator app and enter the code it is
+                showing right now.
+              </p>
             </div>
             <DialogFooter>
-              <Button
-                disabled={busy}
-                onClick={() => setPhase("scan")}
-                variant="outline"
-              >
-                Back
+              <Button onClick={closeAndReset} variant="outline">
+                Cancel
               </Button>
               <Button
-                disabled={busy || code.trim().length < 6}
+                disabled={busy || !setupData || code.trim().length < 6}
                 onClick={handleVerifyAndEnroll}
               >
                 {busy ? "Verifying..." : "Continue"}
@@ -364,16 +320,18 @@ export function TotpSetupDialog({
           </div>
         )}
 
-        {phase === "save" && backupCodes && (
+        {phase === "codes" && backupCodes && (
           <div className="space-y-4">
             <p className="text-muted-foreground text-sm">
-              Two-factor is now active. Save these recovery codes — without
-              them, losing your authenticator means losing access.
+              Two-factor is enabled. Save these codes for recovery if you
+              lose your authenticator. Regenerate later from settings.
             </p>
-            <TotpBackupCodesPanel
-              codes={backupCodes}
-              onConfirmed={handleBackupCodesConfirmed}
-            />
+            <TotpBackupCodesPanel codes={backupCodes} />
+            <DialogFooter>
+              <Button onClick={handleDone} variant="outline">
+                Skip for now
+              </Button>
+            </DialogFooter>
           </div>
         )}
       </DialogContent>

--- a/components/settings/totp-setup-dialog.tsx
+++ b/components/settings/totp-setup-dialog.tsx
@@ -71,16 +71,6 @@ type Props = {
   onEnrolled: () => void;
 };
 
-/**
- * Horizontal numbered stepper. Two phases:
- *
- *   1. setup   — QR scan + manual key + TOTP code verification in one
- *                step. POSTing /enroll succeeds when the code matches
- *                and returns the backup codes.
- *   2. codes   — display the freshly minted backup codes with Download
- *                + Skip. Either choice closes the dialog; users who
- *                skip can regenerate from settings later.
- */
 function StepIndicator({ current }: { current: Phase }): React.ReactElement {
   const currentIdx = STEP_DEFS.findIndex((s) => s.key === current);
   return (


### PR DESCRIPTION
## Summary

Sweep of the smaller MFA / sign-in bugs filed during the security incident triage. Each commit is a single bug.

## What changed

### Backup-codes confirmation gate (commit `d14d04d3`)
Drop the Copy + Download + retype-at-position triple gate. The enrollment wizard now shows the codes, exposes Copy as an optional ghost button, gates the "I've saved my codes" CTA on a single Download click, and updates the close-blocker toasts to match. The dialog still refuses to close while codes are visible and unconfirmed.

### Cancel closes MFA confirmation modals (commit `563998a4`)
The `DualFactorSteps` wizard's Cancel button on the email phase fires the consumer's `onBack` prop. Most consumers wired it to step back one phase inside the same modal (`setState`, `setPhase`, `setMode`), so Cancel dropped the user back at the input form instead of closing. Each consumer's `onBack` now closes the wrapping modal: `closeAll()` in withdraw-modal, `pop()` in api-keys-overlay, `setOpen(false) + resetAll()` in delete-account-section, `onOpenChange(false)` in totp-manage-dialog disable mode. The locked enroll/verify gate pages keep their hard-locked behavior. `change-password-section` stays on `setPhase("passwords")` because it is an inline section on the settings page, not a modal.

### forgot-password email picks user's most recent OAuth (commit `f6e9e70b`)
When a user has more than one OAuth provider linked (Google + GitHub) and tries to reset a password they do not have, the "this account uses social login" reminder previously named whichever provider appeared first in `OAUTH_PROVIDERS`. A Google user who had also linked GitHub would receive "your account uses GitHub". Sort the linked OAuth accounts by `accounts.updated_at DESC` and pick the most recently used; Better Auth bumps `updated_at` on every sign-in.

### Clear requires_mfa after strict-signin (commit `f81deec2`)
Forward port of the same fix in PR #1367. The `session.create.before` hook stamps `requires_mfa = true` on every fresh session of a user with `two_factor_enabled`. `strict-signin` already verifies password + email-OTP + TOTP atomically before the session is minted, so the proxy gate then 302s the user to `/verify-mfa` for a redundant step-up. Clear the flag after dual-factor verification, same shape as `/api/user/totp/enroll`.

### Diagnostic log on OAuth callback session miss (commit `5f14c7ea`)
If Better Auth's OAuth callback returns a redirect without the session cookie we expect, `interceptOauthCallback` silently bails. That path is implicated in the "signed in with Google but no session on KeeperHub" reports. One `console.warn` log so the next time we have whether the Set-Cookie array was empty, missing the `session_token` name, or the runtime did not expose `getSetCookie`. Diagnostic only; behavior unchanged.

## Still open (deferred to follow-up)

- **Sign-in jumps to Authenticator step**: the dialog code path always transitions `signin -> signin-email-otp -> totp` and `/verify-mfa` starts `DualFactorSteps` at phase `email`. No code path skips the email step. Needs a live repro and a screen recording to pin.
- **OAuth Github/Google no-session**: the diagnostic warn in this PR is the prep work for finding out why. Once a user hits the bug with the warn in place, the log line tells us which branch of `interceptOauthCallback` is failing.

## Out of scope but related

- The 3-factor strict-signin mandate is not enforceable end-to-end at the API surface: a direct client can hit `/api/auth/sign-in/email` then `/api/auth/two-factor/verify-totp` for a password + TOTP session, skipping the email-OTP. The proxy MFA gate catches the next request so MFA is not bypassed, but the 3-factor flow is only enforced by going through `strict-signin`. Closing that gap would be a sibling block to `blockEmailOtpForTotpUsers`.

Draft until items above settle.