### PR TITLE
feat: add sessions INSERT trigger rejecting deactivated owners

### DIFF
--- a/drizzle/0090_block_sessions_for_deactivated_users.sql
+++ b/drizzle/0090_block_sessions_for_deactivated_users.sql
@@ -34,7 +34,7 @@ DECLARE
 BEGIN
   SELECT u.deactivated_at
     INTO v_owner_deactivated_at
-  FROM users u
+  FROM public.users u
   WHERE u.id = NEW.user_id;
 
   IF v_owner_deactivated_at IS NOT NULL THEN

--- a/drizzle/0090_block_sessions_for_deactivated_users.sql
+++ b/drizzle/0090_block_sessions_for_deactivated_users.sql
@@ -1,0 +1,49 @@
+-- Defense-in-depth backstop for the deactivated-user auth bypass.
+--
+-- The app-layer gate (lib/auth-deactivation-guard.ts -> better-auth
+-- session.create.before / account.create.before) already aborts session
+-- creation when the owning user has deactivated_at set. This trigger is the
+-- last line of defense at the DB layer: it rejects ANY insert into sessions
+-- whose owning user is deactivated, including paths that bypass the app gate
+-- (future OAuth providers, direct db.insert(sessions) call sites, or a
+-- regression in the hooks).
+--
+-- Complements the cascade trigger from 0085_cascade_user_deactivation.sql:
+-- that deletes existing sessions when a user is deactivated; this prevents
+-- new ones from being minted afterwards.
+--
+-- Detection signal contract (consumed by the future detection layer):
+--   SQLSTATE 'KH001'
+--   MESSAGE  'Session owner is deactivated; new sessions are not allowed.'
+-- A dedicated custom SQLSTATE (not the 42501 the incident triggers reuse) so a
+-- deactivated-session rejection is unambiguously identifiable by error code
+-- alone, without parsing the message text.
+
+CREATE OR REPLACE FUNCTION public.block_sessions_for_deactivated_users()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_owner_deactivated_at timestamp;
+BEGIN
+  SELECT u.deactivated_at
+    INTO v_owner_deactivated_at
+  FROM users u
+  WHERE u.id = NEW.user_id;
+
+  IF v_owner_deactivated_at IS NOT NULL THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'Session owner is deactivated; new sessions are not allowed.',
+      ERRCODE = 'KH001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS block_sessions_for_deactivated_users ON sessions;
+
+CREATE TRIGGER block_sessions_for_deactivated_users
+  BEFORE INSERT ON sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.block_sessions_for_deactivated_users();

--- a/drizzle/0090_block_sessions_for_deactivated_users.sql
+++ b/drizzle/0090_block_sessions_for_deactivated_users.sql
@@ -12,6 +12,12 @@
 -- that deletes existing sessions when a user is deactivated; this prevents
 -- new ones from being minted afterwards.
 --
+-- Limitation: this is a backstop, not an airtight guarantee. The check reads
+-- the committed deactivated_at under READ COMMITTED, so a session insert that
+-- races a not-yet-committed deactivation (landing after 0085's cascade DELETE
+-- but before the deactivating transaction commits) can still succeed. The
+-- app-layer gate is the primary control; this closes the common case.
+--
 -- Detection signal contract (consumed by the future detection layer):
 --   SQLSTATE 'KH001'
 --   MESSAGE  'Session owner is deactivated; new sessions are not allowed.'

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -631,6 +631,13 @@
       "when": 1779670685296,
       "tag": "0089_two_factor_and_session_mfa",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1779843819653,
+      "tag": "0090_block_sessions_for_deactivated_users",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/vitest/sessions-deactivated-trigger.test.ts
+++ b/tests/e2e/vitest/sessions-deactivated-trigger.test.ts
@@ -1,0 +1,131 @@
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.unmock("@/lib/db");
+vi.mock("server-only", () => ({}));
+
+import { sessions, users } from "@/lib/db/schema";
+import { generateId } from "@/lib/utils/id";
+
+/**
+ * Runtime contract for the 0090 sessions block trigger
+ * (drizzle/0090_block_sessions_for_deactivated_users.sql). The trigger is the
+ * DB-layer backstop for the deactivated-user auth bypass: it rejects any
+ * sessions INSERT whose owning user has deactivated_at set, regardless of which
+ * code path attempts the write. This exercises the real migrated database so a
+ * dropped/renamed/weakened trigger fails CI rather than silently re-opening the
+ * bypass.
+ *
+ * The rejection raises SQLSTATE 'KH001' (postgres-js surfaces it on err.code),
+ * which is the signal a future detection layer keys off. Asserting the code
+ * here locks that contract at runtime.
+ *
+ * Skipped when no DATABASE_URL is configured.
+ */
+
+const shouldSkip =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+describe.skipIf(shouldSkip)("sessions deactivated-owner block trigger", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let activeUserId: string;
+  let deactivatedUserId: string;
+
+  beforeAll(async () => {
+    const connectionString =
+      process.env.DATABASE_URL ??
+      "postgresql://postgres:postgres@localhost:5433/keeperhub";
+    client = postgres(connectionString, { max: 2 });
+    db = drizzle(client);
+
+    const now = new Date();
+    activeUserId = `test-active-${generateId()}`;
+    deactivatedUserId = `test-deactivated-${generateId()}`;
+
+    await db.insert(users).values([
+      {
+        id: activeUserId,
+        email: `${activeUserId}@techops.services`,
+        emailVerified: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: deactivatedUserId,
+        email: `${deactivatedUserId}@techops.services`,
+        emailVerified: false,
+        createdAt: now,
+        updatedAt: now,
+        deactivatedAt: now,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    if (!client) {
+      return;
+    }
+    // sessions.userId has no ON DELETE CASCADE, so sweep sessions before users
+    // to avoid an FK violation on cleanup.
+    for (const userId of [activeUserId, deactivatedUserId]) {
+      if (userId) {
+        await db.delete(sessions).where(eq(sessions.userId, userId));
+        await db.delete(users).where(eq(users.id, userId));
+      }
+    }
+    await client.end({ timeout: 2 });
+  });
+
+  it("allows a session insert for an active user", async () => {
+    const sessionId = `sess-${generateId()}`;
+    await db.insert(sessions).values({
+      id: sessionId,
+      token: `token-${generateId()}`,
+      expiresAt: new Date(Date.now() + ONE_DAY_MS),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      userId: activeUserId,
+    });
+
+    const [row] = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId));
+    expect(row?.id).toBe(sessionId);
+  });
+
+  it("rejects a session insert for a deactivated user with SQLSTATE KH001", async () => {
+    // drizzle wraps the driver error in DrizzleQueryError and puts the
+    // postgres-js PostgresError (carrying the SQLSTATE) on `.cause`. Read from
+    // either spot so the assertion survives a change in drizzle's wrapping.
+    type SqlError = { code?: string; cause?: { code?: string } };
+    let caught: SqlError | undefined;
+    try {
+      await db.insert(sessions).values({
+        id: `sess-${generateId()}`,
+        token: `token-${generateId()}`,
+        expiresAt: new Date(Date.now() + ONE_DAY_MS),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        userId: deactivatedUserId,
+      });
+    } catch (err) {
+      caught = err as SqlError;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught?.code ?? caught?.cause?.code).toBe("KH001");
+
+    // The row must not exist - the trigger fires BEFORE INSERT.
+    const rows = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.userId, deactivatedUserId));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/e2e/vitest/sessions-deactivated-trigger.test.ts
+++ b/tests/e2e/vitest/sessions-deactivated-trigger.test.ts
@@ -132,4 +132,43 @@ describe.skipIf(shouldSkip)("sessions deactivated-owner block trigger", () => {
       .where(eq(sessions.userId, deactivatedUserId));
     expect(rows).toHaveLength(0);
   });
+
+  it("allows a session insert again after the owner is reactivated", async () => {
+    // Self-contained: proves the trigger reads the live deactivated_at, not a
+    // one-time state. Uses its own user with explicit cleanup so it does not
+    // depend on the order of the cases above.
+    const userId = `test-reactivated-${generateId()}`;
+    const now = new Date();
+    await db.insert(users).values({
+      id: userId,
+      email: `${userId}@techops.services`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+      deactivatedAt: now,
+    });
+    await db
+      .update(users)
+      .set({ deactivatedAt: null })
+      .where(eq(users.id, userId));
+
+    const sessionId = `sess-${generateId()}`;
+    await db.insert(sessions).values({
+      id: sessionId,
+      token: `token-${generateId()}`,
+      expiresAt: new Date(Date.now() + ONE_DAY_MS),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      userId,
+    });
+
+    const [row] = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId));
+    expect(row?.id).toBe(sessionId);
+
+    await db.delete(sessions).where(eq(sessions.userId, userId));
+    await db.delete(users).where(eq(users.id, userId));
+  });
 });

--- a/tests/e2e/vitest/sessions-deactivated-trigger.test.ts
+++ b/tests/e2e/vitest/sessions-deactivated-trigger.test.ts
@@ -18,11 +18,15 @@ import { generateId } from "@/lib/utils/id";
  * dropped/renamed/weakened trigger fails CI rather than silently re-opening the
  * bypass.
  *
- * The rejection raises SQLSTATE 'KH001' (postgres-js surfaces it on err.code),
- * which is the signal a future detection layer keys off. Asserting the code
- * here locks that contract at runtime.
+ * The rejection raises SQLSTATE 'KH001', which is the signal a future detection
+ * layer keys off. drizzle wraps the driver error in DrizzleQueryError and puts
+ * the postgres-js PostgresError (carrying the SQLSTATE) on `.cause`, so the
+ * assertion reads err.cause.code. Asserting it here locks that contract at
+ * runtime.
  *
- * Skipped when no DATABASE_URL is configured.
+ * tests/setup.ts sets a default DATABASE_URL, so the no-URL branch below rarely
+ * fires in practice; set SKIP_INFRA_TESTS=true to opt out when no Postgres is
+ * reachable.
  */
 
 const shouldSkip =

--- a/tests/unit/migration-0090-block-deactivated-sessions.test.ts
+++ b/tests/unit/migration-0090-block-deactivated-sessions.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Drift catch for the sessions deactivated-owner block trigger. This is a
+// defense-in-depth backstop for the deactivated-user auth bypass: it rejects
+// any sessions INSERT whose owning user has deactivated_at set, covering paths
+// that bypass the app-layer gate in lib/auth-deactivation-guard.ts.
+//
+// The trigger raises a dedicated SQLSTATE 'KH001' that the detection layer
+// keys off, so the error code and message are part of a contract -- the
+// assertions below are deliberately strict to catch a silent weakening.
+
+const MIGRATION_PATH = join(
+  __dirname,
+  "../../drizzle/0090_block_sessions_for_deactivated_users.sql"
+);
+
+const READ_SQL = (): string => readFileSync(MIGRATION_PATH, "utf8");
+
+// Strip pg line-comments (`-- ...`) so identifier-name assertions can ignore
+// the migration's prose. Sibling trigger names appear in comments intentionally
+// (to document the relationship); checking the full file text would
+// false-positive on those.
+const READ_SQL_DDL_ONLY = (): string =>
+  READ_SQL()
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n");
+
+describe("migration 0090: block sessions for deactivated owners", () => {
+  it("creates the block function by exact name (idempotent)", () => {
+    const sql = READ_SQL();
+    expect(sql).toMatch(
+      /CREATE OR REPLACE FUNCTION public\.block_sessions_for_deactivated_users\(\)/
+    );
+  });
+
+  it("checks the owning user's deactivated_at via user_id", () => {
+    const ddl = READ_SQL_DDL_ONLY();
+    expect(ddl).toMatch(/FROM users u/);
+    expect(ddl).toMatch(/WHERE u\.id = NEW\.user_id/);
+    expect(ddl).toMatch(/v_owner_deactivated_at IS NOT NULL/);
+  });
+
+  it("raises the KH001 detection signal with the exact message", () => {
+    const sql = READ_SQL();
+    expect(sql).toMatch(/ERRCODE = 'KH001'/);
+    expect(sql).toMatch(
+      /MESSAGE = 'Session owner is deactivated; new sessions are not allowed\.'/
+    );
+  });
+
+  it("installs a BEFORE INSERT row trigger on sessions by exact name", () => {
+    const ddl = READ_SQL_DDL_ONLY();
+    expect(ddl).toMatch(/DROP TRIGGER IF EXISTS block_sessions_for_deactivated_users ON sessions;/);
+    expect(ddl).toMatch(
+      /CREATE TRIGGER block_sessions_for_deactivated_users\s+BEFORE INSERT ON sessions\s+FOR EACH ROW\s+EXECUTE FUNCTION public\.block_sessions_for_deactivated_users\(\);/
+    );
+  });
+
+  it("gates only INSERT, leaving UPDATE/DELETE of existing sessions alone", () => {
+    const ddl = READ_SQL_DDL_ONLY();
+    expect(ddl).not.toMatch(/BEFORE\s+(?:INSERT\s+OR\s+)?(?:UPDATE|DELETE)/);
+  });
+
+  it("does not touch sibling security triggers (0082/0084/0085)", () => {
+    const ddl = READ_SQL_DDL_ONLY();
+    expect(ddl).not.toMatch(/block_executions_security_2026_05_21/);
+    expect(ddl).not.toMatch(/block_executions_for_inactive_workflows/);
+    expect(ddl).not.toMatch(/block_database_integration/);
+    expect(ddl).not.toMatch(/block_user_signup_security_2026_05_21/);
+    expect(ddl).not.toMatch(/cascade_user_deactivation/);
+  });
+
+  it("does not use wildcard / LIKE matchers in any DROP statement", () => {
+    const sql = READ_SQL();
+    const dropStatements = sql
+      .split("\n")
+      .filter((line) => /^\s*DROP\s+/i.test(line));
+    for (const stmt of dropStatements) {
+      expect(stmt).not.toMatch(/LIKE|REGEXP|~/);
+      expect(stmt).not.toMatch(/\*/);
+    }
+  });
+});

--- a/tests/unit/migration-0090-block-deactivated-sessions.test.ts
+++ b/tests/unit/migration-0090-block-deactivated-sessions.test.ts
@@ -38,7 +38,7 @@ describe("migration 0090: block sessions for deactivated owners", () => {
 
   it("checks the owning user's deactivated_at via user_id", () => {
     const ddl = READ_SQL_DDL_ONLY();
-    expect(ddl).toMatch(/FROM users u/);
+    expect(ddl).toMatch(/FROM public\.users u/);
     expect(ddl).toMatch(/WHERE u\.id = NEW\.user_id/);
     expect(ddl).toMatch(/v_owner_deactivated_at IS NOT NULL/);
   });


### PR DESCRIPTION
## What

Adds a Postgres `BEFORE INSERT` trigger on `sessions` that rejects any insert whose owning user has `deactivated_at` set.

## Why

Defense-in-depth backstop for the deactivated-user auth bypass. The app-layer gate (`lib/auth-deactivation-guard.ts` wired into better-auth's `session.create.before` / `account.create.before`) already aborts session creation for deactivated users. This trigger is the last line of defense at the DB layer, covering any path that bypasses the app gate: future OAuth providers, direct `db.insert(sessions)` call sites, or a regression in the hooks.

It complements the existing cascade trigger (`0085_cascade_user_deactivation.sql`): that deletes a user's sessions on deactivation, this prevents new ones from being minted afterwards.

## Detection signal

The rejection raises a dedicated `SQLSTATE 'KH001'` plus a fixed message (`Session owner is deactivated; new sessions are not allowed.`), so a future detection layer can classify a deactivated-session block by error code alone rather than parsing message text.

## Migration mechanics

Shipped as a hand-authored versioned migration (`0090`) because `drizzle-kit generate` is broken on this repo (snapshot id collision across 0081-0089). No snapshot file, matching the existing hand-authored 0086-0088. The trigger is idempotent (`CREATE OR REPLACE` + `DROP TRIGGER IF EXISTS`), so it is a no-op on an already-protected database and reinstates protection on a fresh one.

## Testing

- `tests/unit/migration-0090-block-deactivated-sessions.test.ts` - static drift assertions on the migration SQL (exact trigger name, BEFORE INSERT on sessions only, the KH001 + message contract, no touching of sibling security triggers).
- `tests/e2e/vitest/sessions-deactivated-trigger.test.ts` - runtime contract against a real Postgres: active-user insert succeeds; deactivated-user insert is rejected with SQLSTATE KH001 and no row is written.
- Verified locally: `db:migrate` applies cleanly; both test files pass; `type-check` clean.