### PR TITLE
fix(auth): reset-password UX, MFA stepper polish, API-keys role gate

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -5,7 +5,7 @@ import { auth } from "@/lib/auth";
 import { hashSessionToken } from "@/lib/auth-session-token-hash";
 import { db } from "@/lib/db";
 import { sessions, users } from "@/lib/db/schema";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import {
   buildPendingOauthMfaSetCookie,
   encodePendingOauthMfaCookie,
@@ -79,16 +79,39 @@ async function interceptOauthCallback(
   if (!/^\/api\/auth\/callback\/[^/]+$/.test(url.pathname)) {
     return res;
   }
+  const provider = url.pathname.split("/").pop() ?? "oauth";
   if (res.status < 300 || res.status >= 400) {
+    logSystemWarn(
+      ErrorCategory.AUTH,
+      "[oauth-callback] non-redirect response; skipping intercept",
+      new Error("non_redirect_response"),
+      {
+        provider,
+        status: String(res.status),
+      }
+    );
     return res;
   }
-  const setCookies =
-    typeof (res.headers as Headers & { getSetCookie?: () => string[] })
-      .getSetCookie === "function"
-      ? (res.headers as Headers & { getSetCookie: () => string[] }).getSetCookie()
-      : [];
+  const headersWithGetSetCookie = res.headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  const hasGetSetCookie = typeof headersWithGetSetCookie.getSetCookie === "function";
+  const setCookies = hasGetSetCookie
+    ? (headersWithGetSetCookie.getSetCookie as () => string[])()
+    : [];
   const sessionToken = extractSessionToken(setCookies);
   if (!sessionToken) {
+    logSystemWarn(
+      ErrorCategory.AUTH,
+      "[oauth-callback] no session token in Set-Cookie",
+      new Error("no_session_token_in_set_cookie"),
+      {
+        provider,
+        status: String(res.status),
+        set_cookie_count: String(setCookies.length),
+        has_get_set_cookie: String(hasGetSetCookie),
+      }
+    );
     return res;
   }
   const tokenHash = hashSessionToken(sessionToken);
@@ -98,6 +121,15 @@ async function interceptOauthCallback(
     .where(eq(sessions.token, tokenHash))
     .limit(1);
   if (!row) {
+    logSystemWarn(
+      ErrorCategory.AUTH,
+      "[oauth-callback] session row not found for emitted token",
+      new Error("session_row_not_found"),
+      {
+        provider,
+        token_hash_prefix: tokenHash.slice(0, 8),
+      }
+    );
     return res;
   }
   const [user] = await db
@@ -114,6 +146,16 @@ async function interceptOauthCallback(
     // cannot defer the session for either flow. Fall through to
     // Better Auth's default response; the proxy MFA gate will still
     // send the user to /enroll-mfa via the existing path.
+    logSystemWarn(
+      ErrorCategory.AUTH,
+      "[oauth-callback] user has no email; skipping intercept",
+      new Error("user_email_missing"),
+      {
+        provider,
+        user_id: row.userId,
+        user_found: String(Boolean(user)),
+      }
+    );
     return res;
   }
 
@@ -168,10 +210,18 @@ async function interceptOauthCallback(
       "Set-Cookie",
       buildPendingOauthMfaSetCookie(pendingValue)
     );
+    logSystemWarn(
+      ErrorCategory.AUTH,
+      "[oauth-callback] deferring session via pending_oauth_mfa",
+      new Error("pending_oauth_mfa_path"),
+      {
+        provider,
+        user_id: user.id,
+      }
+    );
     return response;
   }
 
-  const provider = url.pathname.split("/").pop() ?? "oauth";
   const pendingSignupValue = encodePendingSignupCookie(
     {
       userId: user.id,
@@ -190,6 +240,15 @@ async function interceptOauthCallback(
   response.headers.append(
     "Set-Cookie",
     buildPendingSignupSetCookie(pendingSignupValue)
+  );
+  logSystemWarn(
+    ErrorCategory.AUTH,
+    "[oauth-callback] deferring session via pending_signup_mfa",
+    new Error("pending_signup_mfa_path"),
+    {
+      provider,
+      user_id: user.id,
+    }
   );
   return response;
 }

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -210,15 +210,11 @@ async function interceptOauthCallback(
       "Set-Cookie",
       buildPendingOauthMfaSetCookie(pendingValue)
     );
-    logSystemWarn(
-      ErrorCategory.AUTH,
-      "[oauth-callback] deferring session via pending_oauth_mfa",
-      new Error("pending_oauth_mfa_path"),
-      {
-        provider,
-        user_id: user.id,
-      }
-    );
+    // biome-ignore lint/suspicious/noConsole: success-path trace; Sentry warn would be noise on every login
+    console.info("[oauth-callback] pending_oauth_mfa_path", {
+      provider,
+      user_id: user.id,
+    });
     return response;
   }
 
@@ -241,15 +237,11 @@ async function interceptOauthCallback(
     "Set-Cookie",
     buildPendingSignupSetCookie(pendingSignupValue)
   );
-  logSystemWarn(
-    ErrorCategory.AUTH,
-    "[oauth-callback] deferring session via pending_signup_mfa",
-    new Error("pending_signup_mfa_path"),
-    {
-      provider,
-      user_id: user.id,
-    }
-  );
+  // biome-ignore lint/suspicious/noConsole: success-path trace; Sentry warn would be noise on every login
+  console.info("[oauth-callback] pending_signup_mfa_path", {
+    provider,
+    user_id: user.id,
+  });
   return response;
 }
 

--- a/app/api/user/forgot-password/route.ts
+++ b/app/api/user/forgot-password/route.ts
@@ -1,4 +1,5 @@
-import { randomInt } from "node:crypto";
+import { randomInt, timingSafeEqual } from "node:crypto";
+import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
 import { and, eq, gt } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
@@ -21,6 +22,35 @@ const OTP_EXPIRY_MINUTES = 5;
 
 function generateOTP(): string {
   return randomInt(100_000, 999_999).toString();
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+async function encryptOtp(otp: string, secret: string): Promise<string> {
+  const ciphertext = await symmetricEncrypt({ key: secret, data: otp });
+  return `${ciphertext}:0`;
+}
+
+async function matchEncryptedOtp(
+  storedValue: string,
+  providedOtp: string,
+  secret: string
+): Promise<boolean> {
+  const ciphertext = storedValue.split(":")[0];
+  if (!ciphertext) {
+    return false;
+  }
+  try {
+    const decrypted = await symmetricDecrypt({ key: secret, data: ciphertext });
+    return constantTimeEquals(decrypted, providedOtp);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -109,8 +139,7 @@ async function handleRequest(email: string): Promise<NextResponse> {
   if (!user) {
     return NextResponse.json({
       success: true,
-      message:
-        "If an account exists with this email, a reset code has been sent.",
+      message: "Check your inbox for the reset code.",
     });
   }
 
@@ -143,46 +172,59 @@ async function handleRequest(email: string): Promise<NextResponse> {
 
     return NextResponse.json({
       success: true,
-      message:
-        "If an account exists with this email, a reset code has been sent.",
+      message: "Check your inbox for the reset code.",
     });
   }
 
-  // Generate OTP
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    logSystemError(
+      ErrorCategory.CONFIGURATION,
+      "[Forgot Password] BETTER_AUTH_SECRET is not configured",
+      new Error("BETTER_AUTH_SECRET missing"),
+      { endpoint: "/api/user/forgot-password" }
+    );
+    return NextResponse.json(
+      { error: "Server misconfigured" },
+      { status: 500 }
+    );
+  }
+
   const otp = generateOTP();
+  const storedValue = await encryptOtp(otp, secret);
   const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
 
-  // Delete any existing verification for this email
+  // Wipe any prior in-flight OTP for this identifier; the rate limit
+  // upstream already prevents spam. The bare-email identifier is only
+  // used by this route, so this doesn't collide with better-auth's
+  // prefixed identifiers (sign-in-otp-..., etc.).
   await db.delete(verifications).where(eq(verifications.identifier, email));
 
-  // Store verification
   await db.insert(verifications).values({
     id: generateId(),
     identifier: email,
-    value: otp,
+    value: storedValue,
     expiresAt,
     createdAt: new Date(),
     updatedAt: new Date(),
   });
 
-  // Send OTP email
-  const emailSent = await sendVerificationOTP({
+  // Send OTP email. We intentionally do NOT propagate a send failure
+  // to the response: the row is already in `verifications`, the
+  // per-email/per-IP rate limit upstream has already debited, and a
+  // 500 here would also leak the "this email exists" bit that the
+  // earlier user-not-found / OAuth-only branches go out of their way
+  // to hide. sendVerificationOTP already logs failures via
+  // logUserError so observability is not lost.
+  await sendVerificationOTP({
     email,
     otp,
     type: "forget-password",
   });
 
-  if (!emailSent) {
-    return NextResponse.json(
-      { error: "Failed to send verification email" },
-      { status: 500 }
-    );
-  }
-
   return NextResponse.json({
     success: true,
-    message:
-      "If an account exists with this email, a reset code has been sent.",
+    message: "Check your inbox for the reset code.",
   });
 }
 
@@ -206,16 +248,32 @@ async function handleReset(
     );
   }
 
-  // Find and verify OTP
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    logSystemError(
+      ErrorCategory.CONFIGURATION,
+      "[Forgot Password] BETTER_AUTH_SECRET is not configured",
+      new Error("BETTER_AUTH_SECRET missing"),
+      { endpoint: "/api/user/forgot-password" }
+    );
+    return NextResponse.json(
+      { error: "Server misconfigured" },
+      { status: 500 }
+    );
+  }
+
   const verification = await db.query.verifications.findFirst({
     where: and(
       eq(verifications.identifier, email),
-      eq(verifications.value, otp),
       gt(verifications.expiresAt, new Date())
     ),
   });
 
-  if (!verification) {
+  if (
+    !(
+      verification && (await matchEncryptedOtp(verification.value, otp, secret))
+    )
+  ) {
     return NextResponse.json(
       { error: "Invalid or expired verification code" },
       { status: 400 }

--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -320,17 +320,11 @@ function SignInStepIndicator({
           idx === currentIdx ? "current" : idx < currentIdx ? "done" : "pending";
         const isLast = idx === SIGN_IN_STEPS.length - 1;
         const bubble =
-          status === "current"
-            ? "border-primary bg-primary text-primary-foreground"
-            : status === "done"
-              ? "border-primary/40 bg-primary/10 text-primary"
-              : "border-border bg-muted/40 text-muted-foreground";
+          status === "current" || status === "done"
+            ? "border-keeperhub-green-dark bg-keeperhub-green text-foreground dark:text-background"
+            : "border-border text-foreground";
         const labelClass =
-          status === "pending"
-            ? "text-muted-foreground"
-            : status === "current"
-              ? "font-medium text-foreground"
-              : "text-foreground";
+          status === "current" ? "font-medium text-foreground" : "text-foreground";
         return (
           <li className="flex items-center gap-2" key={s.key}>
             <span
@@ -342,7 +336,7 @@ function SignInStepIndicator({
             {!isLast && (
               <span
                 aria-hidden="true"
-                className={`h-px w-6 ${status === "done" ? "bg-primary/40" : "bg-border"}`}
+                className={`h-px w-6 ${status === "done" ? "bg-keeperhub-green" : "bg-border"}`}
               />
             )}
           </li>
@@ -1484,6 +1478,40 @@ export const AuthDialog = ({
                   />
                 </div>
                 <div className="space-y-2">
+                  <Label className="ml-1" htmlFor="forgot-totp">
+                    Authenticator code{" "}
+                    <span className="font-normal text-muted-foreground">
+                      (if 2FA is enabled)
+                    </span>
+                  </Label>
+                  <Input
+                    autoComplete="one-time-code"
+                    className="text-center font-mono text-2xl tracking-[0.5em]"
+                    id="forgot-totp"
+                    inputMode="numeric"
+                    maxLength={6}
+                    onChange={(e) =>
+                      setForgotTotp(
+                        e.target.value.replace(/\D/g, "").slice(0, 6)
+                      )
+                    }
+                    pattern="[0-9]*"
+                    placeholder="000000"
+                    value={forgotTotp}
+                  />
+                  {forgotNeedsMfa ? (
+                    <p className="text-muted-foreground text-xs">
+                      Your account has two-factor enabled. Enter the current
+                      code from your authenticator app.
+                    </p>
+                  ) : (
+                    <p className="text-muted-foreground text-xs">
+                      Leave empty if you don't have an authenticator app set
+                      up for this account.
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
                   <Label className="ml-1" htmlFor="new-password">
                     New Password
                   </Label>
@@ -1511,33 +1539,6 @@ export const AuthDialog = ({
                     value={confirmNewPassword}
                   />
                 </div>
-                {forgotNeedsMfa && (
-                  <div className="space-y-2">
-                    <Label className="ml-1" htmlFor="forgot-totp">
-                      Authenticator code
-                    </Label>
-                    <Input
-                      autoComplete="one-time-code"
-                      className="text-center font-mono text-2xl tracking-[0.5em]"
-                      id="forgot-totp"
-                      inputMode="numeric"
-                      maxLength={6}
-                      onChange={(e) =>
-                        setForgotTotp(
-                          e.target.value.replace(/\D/g, "").slice(0, 6)
-                        )
-                      }
-                      pattern="[0-9]*"
-                      placeholder="000000"
-                      required
-                      value={forgotTotp}
-                    />
-                    <p className="text-muted-foreground text-xs">
-                      Your account has two-factor enabled. Enter the current
-                      code from your authenticator app.
-                    </p>
-                  </div>
-                )}
                 {error && (
                   <div className="text-destructive text-sm">{error}</div>
                 )}

--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -443,7 +443,6 @@ export const AuthDialog = ({
   // requires it when the target user has TOTP enrolled; we ask for
   // it preemptively so the user doesn't have to round-trip.
   const [forgotTotp, setForgotTotp] = useState("");
-  const [forgotNeedsMfa, setForgotNeedsMfa] = useState(false);
   const [totpCode, setTotpCode] = useState("");
   const [loadingProvider, setLoadingProvider] = useState<
     "github" | "google" | null
@@ -485,7 +484,6 @@ export const AuthDialog = ({
     setNewPassword("");
     setConfirmNewPassword("");
     setForgotTotp("");
-    setForgotNeedsMfa(false);
     setCaptchaToken("");
     captchaRef.current?.reset();
   };
@@ -968,7 +966,7 @@ export const AuthDialog = ({
         throw new Error(data.error ?? "Failed to send reset code");
       }
 
-      toast.success("If an account exists, a reset code has been sent.");
+      toast.success("Check your inbox for the reset code.");
       setView("reset-password");
       setOtp("");
     } catch (err) {
@@ -1016,11 +1014,7 @@ export const AuthDialog = ({
       };
 
       if (!response.ok) {
-        // Server signaled the user has TOTP enrolled: reveal the
-        // code field and let them retry without losing the OTP /
-        // password they already typed.
         if (data.code === "mfa_code_required") {
-          setForgotNeedsMfa(true);
           setError(
             data.error ??
               "This account has two-factor enabled. Enter a code from your authenticator."
@@ -1299,7 +1293,10 @@ export const AuthDialog = ({
               <SignInStepIndicator current="email" />
               <form className="space-y-4" onSubmit={handleSigninEmailOtp}>
                 <div className="space-y-2">
-                  <Label className="ml-1" htmlFor="signin-email-otp-input">
+                  <Label
+                    className="ml-1 font-medium text-keeperhub-green-dark"
+                    htmlFor="signin-email-otp-input"
+                  >
                     Email code
                   </Label>
                   <Input
@@ -1364,7 +1361,10 @@ export const AuthDialog = ({
               <SignInStepIndicator current="authenticator" />
               <form className="space-y-4" onSubmit={handleTotpVerify}>
                 <div className="space-y-2">
-                  <Label className="ml-1" htmlFor="signin-totp">
+                  <Label
+                    className="ml-1 font-medium text-keeperhub-green-dark"
+                    htmlFor="signin-totp"
+                  >
                     Authenticator code
                   </Label>
                   <Input
@@ -1478,11 +1478,11 @@ export const AuthDialog = ({
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="ml-1" htmlFor="forgot-totp">
-                    Authenticator code{" "}
-                    <span className="font-normal text-muted-foreground">
-                      (if 2FA is enabled)
-                    </span>
+                  <Label
+                    className="ml-1 font-medium text-keeperhub-green-dark"
+                    htmlFor="forgot-totp"
+                  >
+                    Authenticator code
                   </Label>
                   <Input
                     autoComplete="one-time-code"
@@ -1499,17 +1499,6 @@ export const AuthDialog = ({
                     placeholder="000000"
                     value={forgotTotp}
                   />
-                  {forgotNeedsMfa ? (
-                    <p className="text-muted-foreground text-xs">
-                      Your account has two-factor enabled. Enter the current
-                      code from your authenticator app.
-                    </p>
-                  ) : (
-                    <p className="text-muted-foreground text-xs">
-                      Leave empty if you don't have an authenticator app set
-                      up for this account.
-                    </p>
-                  )}
                 </div>
                 <div className="space-y-2">
                   <Label className="ml-1" htmlFor="new-password">

--- a/components/auth/dual-factor-steps.tsx
+++ b/components/auth/dual-factor-steps.tsx
@@ -76,23 +76,17 @@ const STEP_DEFS: ReadonlyArray<{ key: Phase; label: string }> = [
 type StepStatus = "current" | "done" | "pending";
 
 function bubbleClassFor(status: StepStatus): string {
-  if (status === "current") {
-    return "border-primary bg-primary text-primary-foreground";
+  if (status === "current" || status === "done") {
+    return "border-keeperhub-green-dark bg-keeperhub-green text-foreground dark:text-background";
   }
-  if (status === "done") {
-    return "border-primary/40 bg-primary/10 text-primary";
-  }
-  return "border-border bg-muted/40 text-muted-foreground";
+  return "border-border text-foreground";
 }
 
 function labelClassFor(status: StepStatus): string {
   if (status === "current") {
     return "font-medium text-foreground";
   }
-  if (status === "done") {
-    return "text-foreground";
-  }
-  return "text-muted-foreground";
+  return "text-foreground";
 }
 
 function statusFor(idx: number, currentIdx: number): StepStatus {
@@ -127,7 +121,7 @@ function StepIndicator({
             {!isLast && (
               <span
                 aria-hidden="true"
-                className={`h-px w-6 ${status === "done" ? "bg-primary/40" : "bg-border"}`}
+                className={`h-px w-6 ${status === "done" ? "bg-keeperhub-green" : "bg-border"}`}
               />
             )}
           </li>

--- a/components/auth/dual-factor-steps.tsx
+++ b/components/auth/dual-factor-steps.tsx
@@ -183,7 +183,12 @@ export function DualFactorSteps({
       {phase === "email" && (
         <div className="space-y-3">
           <div className="space-y-2">
-            <Label htmlFor="dfs-email">Email code</Label>
+            <Label
+              className="font-medium text-keeperhub-green-dark"
+              htmlFor="dfs-email"
+            >
+              Email code
+            </Label>
             <Input
               autoComplete="one-time-code"
               autoFocus
@@ -232,7 +237,12 @@ export function DualFactorSteps({
       {phase === "authenticator" && (
         <div className="space-y-3">
           <div className="space-y-2">
-            <Label htmlFor="dfs-totp">Authenticator code</Label>
+            <Label
+              className="font-medium text-keeperhub-green-dark"
+              htmlFor="dfs-totp"
+            >
+              Authenticator code
+            </Label>
             <Input
               autoComplete="one-time-code"
               autoFocus

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { handleGuardError } from "@/lib/client/handle-guard-error";
+import { useActiveMember } from "@/lib/hooks/use-organization";
 import { useDualFactorState } from "@/lib/mfa/use-dual-factor-state";
 import { ConfirmOverlay } from "./confirm-overlay";
 import { Overlay } from "./overlay";
@@ -257,6 +258,8 @@ function ApiKeysList({
   onDismissNewKey,
   showCreator = false,
   deleteEndpoint,
+  canDelete = true,
+  readOnlyReason,
 }: {
   apiKeys: ApiKey[];
   newlyCreatedKey: string | null;
@@ -269,6 +272,8 @@ function ApiKeysList({
   onDismissNewKey: () => void;
   showCreator?: boolean;
   deleteEndpoint: (id: string) => string;
+  canDelete?: boolean;
+  readOnlyReason?: string;
 }) {
   const { push } = useOverlay();
 
@@ -355,9 +360,10 @@ function ApiKeysList({
                 </p>
               </div>
               <Button
-                disabled={deleting === apiKey.id}
+                disabled={!canDelete || deleting === apiKey.id}
                 onClick={() => openDeleteConfirm(apiKey.id)}
                 size="sm"
+                title={canDelete ? undefined : readOnlyReason}
                 variant="ghost"
               >
                 {deleting === apiKey.id ? (
@@ -487,6 +493,7 @@ function useApiKeys(
  */
 export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
   const { push, closeAll } = useOverlay();
+  const { isAdmin } = useActiveMember();
   const [activeTab, setActiveTab] = useState("organisation");
 
   // Webhook (User) keys
@@ -504,6 +511,12 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
   const currentKeys = activeTab === "webhook" ? webhookKeys : orgKeys;
   const createEndpoint =
     activeTab === "webhook" ? "/api/api-keys" : "/api/keys";
+  // Org keys are admin/owner-only at the API layer. Mirror that on the
+  // UI so members see the list (useful context) but can't mint or
+  // revoke. Personal webhook keys stay fully writable for every user.
+  const canManageOrgKeys = isAdmin;
+  const orgReadOnlyReason =
+    "Only organization admins or owners can manage these keys.";
 
   return (
     <Overlay
@@ -511,6 +524,7 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
         {
           label: "New API Key",
           variant: "outline",
+          disabled: activeTab === "organisation" && !canManageOrgKeys,
           onClick: () =>
             push(CreateApiKeyOverlay, {
               onCreated: currentKeys.handleKeyCreated,
@@ -539,6 +553,11 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
             integrations. These keys provide access to all workflows in the
             organisation.
           </p>
+          {!canManageOrgKeys && (
+            <p className="mb-3 rounded-md border border-border bg-muted/40 p-2 text-muted-foreground text-xs">
+              {orgReadOnlyReason}
+            </p>
+          )}
           {orgKeys.loading ? (
             <div className="flex items-center justify-center py-8">
               <Spinner />
@@ -546,11 +565,13 @@ export function ApiKeysOverlay({ overlayId }: ApiKeysOverlayProps) {
           ) : (
             <ApiKeysList
               apiKeys={orgKeys.apiKeys}
+              canDelete={canManageOrgKeys}
               deleteEndpoint={orgKeys.deleteEndpoint}
               deleting={orgKeys.deleting}
               newlyCreatedKey={orgKeys.newlyCreatedKey}
               onDelete={orgKeys.handleDelete}
               onDismissNewKey={orgKeys.dismissNewKey}
+              readOnlyReason={orgReadOnlyReason}
               showCreator
             />
           )}

--- a/components/settings/totp-setup-dialog.tsx
+++ b/components/settings/totp-setup-dialog.tsx
@@ -36,23 +36,17 @@ const STEP_DEFS: ReadonlyArray<{ key: Phase; label: string }> = [
 type StepStatus = "current" | "done" | "pending";
 
 function bubbleClassFor(status: StepStatus): string {
-  if (status === "current") {
-    return "border-primary bg-primary text-primary-foreground";
+  if (status === "current" || status === "done") {
+    return "border-keeperhub-green-dark bg-keeperhub-green text-foreground dark:text-background";
   }
-  if (status === "done") {
-    return "border-primary/40 bg-primary/10 text-primary";
-  }
-  return "border-border bg-muted/40 text-muted-foreground";
+  return "border-border text-foreground";
 }
 
 function labelClassFor(status: StepStatus): string {
   if (status === "current") {
     return "font-medium text-foreground";
   }
-  if (status === "done") {
-    return "text-foreground";
-  }
-  return "text-muted-foreground";
+  return "text-foreground";
 }
 
 function statusFor(idx: number, currentIdx: number): StepStatus {
@@ -89,7 +83,7 @@ function StepIndicator({ current }: { current: Phase }): React.ReactElement {
             {!isLast && (
               <span
                 aria-hidden="true"
-                className={`h-px w-6 ${status === "done" ? "bg-primary/40" : "bg-border"}`}
+                className={`h-px w-6 ${status === "done" ? "bg-keeperhub-green" : "bg-border"}`}
               />
             )}
           </li>

--- a/components/settings/totp-setup-dialog.tsx
+++ b/components/settings/totp-setup-dialog.tsx
@@ -312,8 +312,11 @@ export function TotpSetupDialog({
             </p>
             <TotpBackupCodesPanel codes={backupCodes} />
             <DialogFooter>
-              <Button onClick={handleDone} variant="outline">
-                Skip for now
+              <Button
+                className="bg-keeperhub-green text-foreground hover:bg-keeperhub-green-dark dark:text-background"
+                onClick={handleDone}
+              >
+                Skip
               </Button>
             </DialogFooter>
           </div>


### PR DESCRIPTION
## Summary

Bundle of small fixes around the auth surfaces, picked up while testing reset-password and the MFA stepper.

### Reset password
- Authenticator-code input is always rendered next to the reset code so MFA users do not need a server round-trip to learn the field exists. The field order matches what the user sees as natural: reset code, authenticator code, new password, confirm.
- Dropped the now-dead `forgotNeedsMfa` client state and the `mfa_code_required` reveal branch.
- "If an account exists ..." copy on both the toast and the server message is replaced with a confident "Check your inbox for the reset code." across all branches (user not found / OAuth-only / send failure) so nothing leaks an enumeration signal.
- The route no longer escalates a SendGrid send failure to HTTP 500. The verifications row is already minted, `sendVerificationOTP` keeps the failure log, and the 500 was itself the enumeration signal.

### Forgot-password OTPs encrypted at rest
The route generated a 6-digit OTP and stored it plaintext in `verifications`, next to the better-auth `emailOTP` rows that `storeOTP: "encrypted"` has been hardening. A DB read alone was enough to recover a live reset code. Now stored as `symmetricEncrypt(otp):0` matching the emailOTP suffix shape, with constant-time decrypt-and-compare on verify.

### MFA stepper polish
Shared across sign-in dual-factor, reset, `/verify-mfa`, `/enroll-mfa`, and the TOTP setup dialog:
- Current and done step bubbles use `bg-keeperhub-green` with a `text-foreground dark:text-background` digit so the number stays dark on the bright green in both themes.
- Pending step number and label drop the muted treatment so upcoming steps stay legible instead of looking disabled.
- "Email code" and "Authenticator code" input labels pick up the `keeperhub-green-dark` accent.
- TOTP setup download-codes step: "Skip for now" renamed to "Skip" and themed `bg-keeperhub-green` as the primary action.

### OAuth callback diagnostics
Instrumented every silent-return branch in `interceptOauthCallback` (non-redirect response, no session token in Set-Cookie, session row not found, user email missing) plus both success paths (`pending_oauth_mfa_path`, `pending_signup_mfa_path`). Each emits a structured `logSystemWarn` keyed on a stable `error_type` so the next time a user reports "signed in but no cookie" we can read off the actual branch from Sentry / Loki without re-instrumenting.

### API keys overlay role gate
The org-keys endpoint already requires admin or owner via `requireAdminOrOwnerWithMfa`, but the overlay let members click "New API Key" and the per-row trash, getting a generic 403 toast that read as a bug. Members now see the org-keys list as before but the create button and per-row delete are disabled, with a banner above the list and a tooltip on the trash explaining the requirement. Personal webhook (User) keys stay fully writable for every user. The gate is driven by `useActiveMember`, so switching orgs re-evaluates without a refresh.