### PR TITLE
fix(security): cache IP gate result to absorb request stampedes

### DIFF
--- a/app/api/user/verify-ip/route.ts
+++ b/app/api/user/verify-ip/route.ts
@@ -27,6 +27,7 @@ import {
 import {
   assessIpTrust,
   buildRiskFlagsJsonForIp,
+  clearTrustCacheEntry,
 } from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
 import { generateId } from "@/lib/utils/id";
@@ -350,6 +351,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       { status: 500 }
     );
   }
+
+  // Same-pod cache invalidation so the next request on this pod sees the
+  // freshly-trusted IP without waiting for the UNTRUSTED_TTL_MS window in
+  // the proxy gate. Cross-pod stale entries age out on their own.
+  clearTrustCacheEntry(decoded.payload.userId, decoded.payload.ip);
 
   const response = NextResponse.json({
     ok: true,

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -303,6 +303,56 @@ export type RequestIpGate =
   | { kind: "no_ip" };
 
 /**
+ * Per-pod TTL cache for gate results. A single page navigation in the
+ * KeeperHub app fans out into ~20 parallel API requests, each of which
+ * passes through the proxy. Without caching the gate would do one DB
+ * round-trip per request, plus a redundant evaluation of every header
+ * lookup. The cache collapses those to one DB hit per (user, ip) per
+ * TTL window.
+ *
+ * Trusted results get a long TTL because the trust list rarely changes
+ * for an active user. Untrusted gets a short TTL so that once the user
+ * completes /verify-ip the next request picks up the new trust quickly
+ * without requiring cross-pod invalidation; same-pod invalidation is
+ * driven explicitly from /api/user/verify-ip via clearTrustCacheEntry.
+ * `no_ip` is rare and stable (only fires when CF-Connecting-IP is
+ * missing) so it gets the long TTL too.
+ */
+type CachedTrust = { result: RequestIpGate; expiresAt: number };
+const TRUST_CACHE = new Map<string, CachedTrust>();
+const TRUST_CACHE_LIMIT = 10_000;
+const TRUSTED_TTL_MS = 60_000;
+const UNTRUSTED_TTL_MS = 5000;
+
+function trustCacheKey(userId: string, ip: string): string {
+  return `${userId}:${ip}`;
+}
+
+function rememberTrust(key: string, entry: CachedTrust): void {
+  if (TRUST_CACHE.size >= TRUST_CACHE_LIMIT) {
+    const retained = Array.from(TRUST_CACHE.entries()).slice(
+      -Math.floor(TRUST_CACHE_LIMIT / 2)
+    );
+    TRUST_CACHE.clear();
+    for (const [k, v] of retained) {
+      TRUST_CACHE.set(k, v);
+    }
+  }
+  TRUST_CACHE.set(key, entry);
+}
+
+/**
+ * Drop the cached gate result for this (user, ip). Called by
+ * /api/user/verify-ip after a successful upsert so the next request on
+ * the same pod sees the freshly-trusted IP without waiting for the
+ * untrusted TTL to expire. Cross-pod stale entries age out on their own
+ * within UNTRUSTED_TTL_MS.
+ */
+export function clearTrustCacheEntry(userId: string, ip: string): void {
+  TRUST_CACHE.delete(trustCacheKey(userId, ip));
+}
+
+/**
  * Per-request IP gate consulted by the root proxy on every authenticated
  * request. Unlike assessIpTrust (used at sign-in time), this never
  * grants a first-attestation: if the user has zero trusted IPs we still
@@ -317,16 +367,25 @@ export type RequestIpGate =
 export async function gateRequestIp(userId: string): Promise<RequestIpGate> {
   const rawIp = await resolveLoginIp();
   if (!rawIp) {
-    return { kind: "no_ip" };
+    const result: RequestIpGate = { kind: "no_ip" };
+    return result;
   }
   const ip = normalizeIpForTrust(rawIp);
+  const key = trustCacheKey(userId, ip);
+  const now = Date.now();
+  const cached = TRUST_CACHE.get(key);
+  if (cached && cached.expiresAt > now) {
+    return cached.result;
+  }
   const [hit] = await db
     .select({ id: userTrustedIps.id })
     .from(userTrustedIps)
     .where(and(eq(userTrustedIps.userId, userId), eq(userTrustedIps.ip, ip)))
     .limit(1);
   if (hit) {
-    return { kind: "trusted" };
+    const result: RequestIpGate = { kind: "trusted" };
+    rememberTrust(key, { result, expiresAt: now + TRUSTED_TTL_MS });
+    return result;
   }
   // CF-attested country only on the hot path; the external IP-to-location
   // lookup has a 2-second timeout and isn't wanted here.
@@ -337,7 +396,9 @@ export async function gateRequestIp(userId: string): Promise<RequestIpGate> {
   } catch {
     country = null;
   }
-  return { kind: "untrusted", ip, country };
+  const result: RequestIpGate = { kind: "untrusted", ip, country };
+  rememberTrust(key, { result, expiresAt: now + UNTRUSTED_TTL_MS });
+  return result;
 }
 
 export async function assessIpTrust(userId: string): Promise<IpTrust> {

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -322,7 +322,7 @@ type CachedTrust = { result: RequestIpGate; expiresAt: number };
 const TRUST_CACHE = new Map<string, CachedTrust>();
 const TRUST_CACHE_LIMIT = 10_000;
 const TRUSTED_TTL_MS = 60_000;
-const UNTRUSTED_TTL_MS = 5000;
+const UNTRUSTED_TTL_MS = 30_000;
 
 function trustCacheKey(userId: string, ip: string): string {
   return `${userId}:${ip}`;

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -321,7 +321,7 @@ export type RequestIpGate =
 type CachedTrust = { result: RequestIpGate; expiresAt: number };
 const TRUST_CACHE = new Map<string, CachedTrust>();
 const TRUST_CACHE_LIMIT = 10_000;
-const TRUSTED_TTL_MS = 60_000;
+const TRUSTED_TTL_MS = 300_000;
 const UNTRUSTED_TTL_MS = 30_000;
 
 function trustCacheKey(userId: string, ip: string): string {


### PR DESCRIPTION
## Summary

The new IP gate added in the verify-ip series ran one DB query per request. A single page navigation in this app fans out into ~20 parallel API calls, so a normal page load cost ~20 round-trips just to the trust check, and on an untrusted-IP burst every concurrent fetch independently returned 403 and independently considered firing the notification email.

## What changes

- `gateRequestIp` now caches its result in a per-pod `Map<string, CachedTrust>`.
  - **Trusted: 5min TTL.** Trust list rarely changes for an active user, so a steady-state authenticated session sees one DB hit per (user, ip) every 5 minutes regardless of request volume. Page nav fans-out collapse to one query.
  - **Untrusted: 30s TTL.** Long enough to absorb brute-force pressure from a single attacker IP (capped at ~2 trust-list queries per minute per (user, ip, pod) even under sustained attack), short enough that cross-pod stale-cache friction after a verify lasts at most 30s.
- Cache is size-bounded at 10k entries with simple half-eviction so a high-cardinality attack cannot grow it unbounded; pods restart often enough that perfect eviction is not needed.
- `/api/user/verify-ip` now calls `clearTrustCacheEntry(userId, ip)` after the successful trust upsert so the verifying user's next request on the same pod skips the stale untrusted entry immediately. Cross-pod stale entries age out on their own within 30s.
- Notification email dedup was already per (user, ip) per pod lifetime in proxy.ts, so the inbox-flood failure mode was already covered. This PR addresses the DB-load and 403-UI-stampede failure modes.

## Behavioural cost we're accepting

- A future revoke-trust feature (removing a row from user_trusted_ips while the user is active) would take up to 5 minutes to propagate across pods. No such revoke path exists in the UI today, so this is a theoretical cost we can pay back later by adding a cache-bust call from wherever revocation happens.

## Not fixed in this PR (worth a follow-up)

- Client-side fetch wrapper: when an API call comes back with `403 ip_verification_required`, the page should navigate to /verify-ip instead of letting each card render its own error toast. Frontend concern, doesn't block the gate behaviour.