### PR TITLE
fix(auth): clean up dual-factor verify form UX

### DIFF
--- a/components/auth/dual-factor-steps.tsx
+++ b/components/auth/dual-factor-steps.tsx
@@ -76,7 +76,7 @@ const STEP_DEFS: ReadonlyArray<{ key: Phase; label: string }> = [
 type StepStatus = "current" | "done" | "pending";
 
 function bubbleClassFor(status: StepStatus): string {
-  if (status === "current" || status === "done") {
+  if (status === "current") {
     return "border-keeperhub-green-dark bg-keeperhub-green text-foreground dark:text-background";
   }
   return "border-border text-foreground";
@@ -119,10 +119,7 @@ function StepIndicator({
             </span>
             <span className={labelClassFor(status)}>{s.label}</span>
             {!isLast && (
-              <span
-                aria-hidden="true"
-                className={`h-px w-6 ${status === "done" ? "bg-keeperhub-green" : "bg-border"}`}
-              />
+              <span aria-hidden="true" className="h-px w-6 bg-border" />
             )}
           </li>
         );
@@ -190,9 +187,13 @@ export function DualFactorSteps({
               Email code
             </Label>
             <Input
-              autoComplete="one-time-code"
+              autoComplete="off"
               autoFocus
               className={INPUT_CLASSES}
+              data-1p-ignore
+              data-bwignore
+              data-form-type="other"
+              data-lpignore="true"
               disabled={busy}
               id="dfs-email"
               inputMode="numeric"


### PR DESCRIPTION
## Summary

Two small UX fixes for the locked-open dual-factor prompt used at /verify-ip and /verify-mfa.

## 1. Step indicator: only the current step is green

Previously, once the user advanced from the email phase to the authenticator phase, **both** step bubbles rendered green because the \"done\" status reused the same green style as \"current\". The connector line also went green between them. Visually it looked like both steps were active at once.

Behaviour now:

| Phase | Step 1 (Email) | Step 2 (Authenticator) |
|---|---|---|
| Email | Green | Neutral |
| Authenticator | Neutral | Green |

Connector line stays neutral in both phases. Only the active step is emphasised.

## 2. Email code field opts out of password-manager autofill

The email-code input carried `autoComplete=\"one-time-code\"`. 1Password, Bitwarden, LastPass, and Dashlane all read that attribute as \"this field expects an OTP — fill it with the stored TOTP for this site\". Because the email phase mounts first with only the email field in the DOM, the password manager stuffed the user's TOTP code into the email-code box, and the user had to clear it manually before entering the real email OTP.

Switch the email field to `autoComplete=\"off\"` plus the vendor-specific opt-out attributes that each manager respects:

- `data-1p-ignore` (1Password)
- `data-lpignore=\"true\"` (LastPass)
- `data-bwignore` (Bitwarden)
- `data-form-type=\"other\"` (Dashlane)

The authenticator field keeps `autoComplete=\"one-time-code\"` because there we *want* the password manager to fill in the stored TOTP.

Side effect: iOS Safari's \"code from SMS\" suggestion bar no longer fires on the email field. We don't deliver SMS, so no functional loss.