### PR TITLE
perf(metrics): add a statement_timeout backstop on the metrics DB pool

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -106,9 +106,29 @@ export const db = globalForDb.db ?? drizzle(queryClient, { schema });
 // raise max without re-measuring the refresh against the scrapeTimeout (see
 // KEEP-682). Composes with the updateDbMetrics cache; idle_timeout releases
 // idle connections between scrape bursts.
+//
+// statement_timeout is set once on every metrics-pool connection (not per
+// query) as a backstop: a single runaway aggregation -- e.g. a query-plan
+// regression as workflow_executions grows -- is cancelled with 57014 and
+// caught per section (-> default gauges) instead of hanging the scrape past
+// its timeout. Kept below the db-metrics scrapeTimeout and overridable via
+// METRICS_STATEMENT_TIMEOUT_MS.
+const parsedMetricsTimeoutMs = Number.parseInt(
+  process.env.METRICS_STATEMENT_TIMEOUT_MS ?? "",
+  10
+);
+const METRICS_STATEMENT_TIMEOUT_MS =
+  Number.isFinite(parsedMetricsTimeoutMs) && parsedMetricsTimeoutMs > 0
+    ? parsedMetricsTimeoutMs
+    : 8000;
+
 const metricsClient =
   globalForDb.metricsClient ??
-  postgres(connectionString, { max: 2, idle_timeout: 20 });
+  postgres(connectionString, {
+    max: 2,
+    idle_timeout: 20,
+    connection: { statement_timeout: METRICS_STATEMENT_TIMEOUT_MS },
+  });
 export const metricsDb =
   globalForDb.metricsDb ?? drizzle(metricsClient, { schema });
 


### PR DESCRIPTION
## What

Set `statement_timeout` once on every connection in the dedicated metrics pool (`metricsDb`, KEEP-679), via the pool's `connection` options in `lib/db/index.ts`. Every `/api/metrics/db` aggregation is then bounded with no per-query wrapping. A runaway statement -- e.g. a query-plan regression as `workflow_executions` grows -- is cancelled with `57014` and caught per section, degrading that section's gauges to defaults rather than hanging the scrape past its timeout. Configurable via `METRICS_STATEMENT_TIMEOUT_MS` (default 8000), kept below the db-metrics scrapeTimeout.

The whole change is now a single block on the existing `metricsClient`:

```ts
const metricsClient = postgres(connectionString, {
  max: 2,
  idle_timeout: 20,
  connection: { statement_timeout: METRICS_STATEMENT_TIMEOUT_MS },
});
```

## Scope / history

This branch started larger (a TTL cache, a dedicated pool, per-query transaction wrapping). While it was in review, staging shipped equivalents independently:

- **Cache** -> KEEP-669
- **Dedicated metrics pool** (`max: 2`) -> KEEP-679
- **Index-only scans** -> migration 0095

Those address the 2026-05-29 incident directly. The one piece they do not include is a per-statement timeout, so the branch is reduced to exactly that -- as an always-on backstop layered on the KEEP-679 pool, not a separate mechanism. Net diff is now `lib/db/index.ts` only.

## Testing

- `pnpm type-check` clean, `pnpm check` (biome) clean.
- The `set_config('statement_timeout', ...)` + `pg_sleep` cancellation (57014) was verified live on the pr-1393 Postgres in an earlier iteration; this change sets the same GUC at connection time instead of per transaction.

## Review note

The earlier inline threads were against the previous transaction-wrapping approach, which has been removed -- they no longer apply to the current diff. Needs a fresh review + the `metrics-db-reviewed` label (non-author) on `lib/db/index.ts`.
