### PR TITLE
fix(auth): verify TOTP session-lessly in dual-factor gate

### DIFF
--- a/lib/mfa/dual-factor.ts
+++ b/lib/mfa/dual-factor.ts
@@ -29,7 +29,9 @@ function constantTimeEquals(a: string, b: string): boolean {
  * succeed in the same request before the action runs:
  *
  *  1. TOTP (`code` field): proves possession of the user's authenticator
- *     secret. Verified via Better Auth's verifyTOTP endpoint.
+ *     secret. Verified session-lessly against the user's two_factor row
+ *     via verifyUserTotp (see comment at the verify call for why we can
+ *     not call auth.api.verifyTOTP from this gate).
  *  2. Email OTP (`emailOtp` field): proves control of the user's
  *     inbox. Stored encrypted in verifications, identified by
  *     `mfa:<action>:<userId>`, 5-minute TTL.

--- a/lib/mfa/dual-factor.ts
+++ b/lib/mfa/dual-factor.ts
@@ -1,16 +1,16 @@
 import { randomInt, timingSafeEqual } from "node:crypto";
 import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
 import { and, eq, gt } from "drizzle-orm";
-import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { verifications } from "@/lib/db/schema";
+import { twoFactor as twoFactorTable, verifications } from "@/lib/db/schema";
 import { sendVerificationOTP } from "@/lib/email";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { generateId } from "@/lib/utils/id";
 import {
   checkDualFactorRateLimit,
   resetDualFactor,
 } from "@/lib/mfa/dual-factor-rate-limit";
+import { verifyUserTotp } from "@/lib/security/totp-verify";
+import { generateId } from "@/lib/utils/id";
 
 /**
  * Constant-time compare for 6-digit OTP values. Both sides are
@@ -86,7 +86,7 @@ function identifierFor(userId: string, action: string): string {
 export async function requireDualFactor(
   args: DualFactorArgs
 ): Promise<DualFactorResult> {
-  const { userId, email, action, code, emailOtp, headers } = args;
+  const { userId, email, action, code, emailOtp } = args;
   const serverSecret = process.env.BETTER_AUTH_SECRET;
   if (!serverSecret) {
     logSystemError(
@@ -174,13 +174,27 @@ export async function requireDualFactor(
     };
   }
 
-  // TOTP first since it is cheaper than the DB read for the email OTP.
-  try {
-    await auth.api.verifyTOTP({
-      body: { code: totpCode },
-      headers,
-    });
-  } catch {
+  // Session-less TOTP verify against the user's two_factor row. We can't
+  // call auth.api.verifyTOTP from this gate: the OAuth-MFA finalize path
+  // runs after interceptOauthCallback has destroyed the session, leaving
+  // only the pending_oauth_mfa cookie — verifyTOTP requires either an
+  // active session or the TWO_FACTOR_COOKIE_NAME cookie, neither of
+  // which exists here. Same approach as the strict-signin route.
+  const [tfRow] = await db
+    .select({ secret: twoFactorTable.secret })
+    .from(twoFactorTable)
+    .where(eq(twoFactorTable.userId, userId))
+    .limit(1);
+  if (!tfRow) {
+    return {
+      ok: false,
+      status: 401,
+      error: "Invalid authenticator code",
+      code: "mfa_code_invalid",
+    };
+  }
+  const totpOk = await verifyUserTotp(tfRow.secret, totpCode, serverSecret);
+  if (!totpOk) {
     return {
       ok: false,
       status: 401,

--- a/tests/unit/dual-factor.test.ts
+++ b/tests/unit/dual-factor.test.ts
@@ -45,9 +45,13 @@ vi.mock("@/lib/utils/id", () => ({
   generateId: (): string => "test-id",
 }));
 
+const { mockResetDualFactor } = vi.hoisted(() => ({
+  mockResetDualFactor: vi.fn(),
+}));
+
 vi.mock("@/lib/mfa/dual-factor-rate-limit", () => ({
   checkDualFactorRateLimit: (): { allowed: true } => ({ allowed: true }),
-  resetDualFactor: vi.fn(),
+  resetDualFactor: mockResetDualFactor,
 }));
 
 import { requireDualFactor } from "@/lib/mfa/dual-factor";
@@ -135,6 +139,10 @@ describe("requireDualFactor", () => {
     });
 
     expect(result).toEqual({ ok: true });
+    expect(mockResetDualFactor).toHaveBeenCalledWith(
+      "user_1",
+      "oauth_mfa_finalize"
+    );
   });
 
   it("returns mfa_code_invalid when the TOTP code is wrong", async () => {
@@ -172,7 +180,7 @@ describe("requireDualFactor", () => {
       userId: "user_3",
       email: "user@example.com",
       action: "oauth_mfa_finalize",
-      code: totpForNow(TOTP_SECRET),
+      code: "000000",
       emailOtp: "123456",
       headers: new Headers(),
     });

--- a/tests/unit/dual-factor.test.ts
+++ b/tests/unit/dual-factor.test.ts
@@ -1,0 +1,228 @@
+import { createHmac } from "node:crypto";
+import { symmetricEncrypt } from "better-auth/crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockSelect, mockInsert, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockInsert: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+    delete: mockDelete,
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  twoFactor: { userId: "user_id", secret: "secret" },
+  verifications: {
+    id: "id",
+    identifier: "identifier",
+    value: "value",
+    expiresAt: "expires_at",
+  },
+}));
+
+const { mockSendVerificationOTP } = vi.hoisted(() => ({
+  mockSendVerificationOTP: vi.fn(),
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendVerificationOTP: mockSendVerificationOTP,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "auth", CONFIGURATION: "configuration" },
+  logSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/id", () => ({
+  generateId: (): string => "test-id",
+}));
+
+vi.mock("@/lib/mfa/dual-factor-rate-limit", () => ({
+  checkDualFactorRateLimit: (): { allowed: true } => ({ allowed: true }),
+  resetDualFactor: vi.fn(),
+}));
+
+import { requireDualFactor } from "@/lib/mfa/dual-factor";
+
+const SERVER_SECRET = "unit-test-server-secret-32-bytes-long";
+const TOTP_SECRET = "JBSWY3DPEHPK3PXP";
+const TOTP_PERIOD_SECONDS = 30;
+const TOTP_DIGITS = 6;
+
+/**
+ * Generates the TOTP code that lib/security/totp-verify.ts will accept
+ * for the current 30-second window. Same RFC 6238 algorithm; we
+ * regenerate it here rather than importing to keep the test free of
+ * a coupling that could mask a regression in the verify path.
+ */
+function totpForNow(secret: string): string {
+  const step = Math.floor(Date.now() / 1000 / TOTP_PERIOD_SECONDS);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(step));
+  const hmac = createHmac("sha1", Buffer.from(secret, "utf8"))
+    .update(buf)
+    .digest();
+  const offset = (hmac.at(-1) ?? 0) & 0xf;
+  const truncated =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return (truncated % 10 ** TOTP_DIGITS).toString().padStart(TOTP_DIGITS, "0");
+}
+
+function selectChain(rows: unknown[]): {
+  from: () => { where: () => { limit: () => Promise<unknown[]> } };
+} {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve(rows),
+      }),
+    }),
+  };
+}
+
+beforeEach(() => {
+  process.env.BETTER_AUTH_SECRET = SERVER_SECRET;
+  vi.clearAllMocks();
+  mockSendVerificationOTP.mockResolvedValue(true);
+  mockInsert.mockReturnValue({ values: () => Promise.resolve(undefined) });
+  mockDelete.mockReturnValue({ where: () => Promise.resolve(undefined) });
+});
+
+describe("requireDualFactor", () => {
+  // Regression for the KEEP-619 OAuth-MFA bug: before the fix, this
+  // gate called auth.api.verifyTOTP which requires either an active
+  // session or the TWO_FACTOR_COOKIE_NAME cookie. interceptOauthCallback
+  // destroys the session before routing to oauth-mfa-finalize, leaving
+  // only pending_oauth_mfa, so every OAuth-with-TOTP sign-in failed
+  // with "Invalid authenticator code" regardless of the code submitted.
+  // The fix verifies TOTP against two_factor.secret directly. This test
+  // would have failed under the old code (the @/lib/auth import would
+  // pull in the full Better Auth runtime in unit-test context and the
+  // call would throw without a session).
+  it("accepts a valid TOTP + email OTP without an active session", async () => {
+    const encSecret = await symmetricEncrypt({
+      key: SERVER_SECRET,
+      data: TOTP_SECRET,
+    });
+    const encEmailOtp = await symmetricEncrypt({
+      key: SERVER_SECRET,
+      data: "123456",
+    });
+    mockSelect
+      .mockReturnValueOnce(selectChain([{ secret: encSecret }]))
+      .mockReturnValueOnce(
+        selectChain([{ id: "verif_1", value: encEmailOtp }])
+      );
+
+    const result = await requireDualFactor({
+      userId: "user_1",
+      email: "user@example.com",
+      action: "oauth_mfa_finalize",
+      code: totpForNow(TOTP_SECRET),
+      emailOtp: "123456",
+      headers: new Headers(),
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns mfa_code_invalid when the TOTP code is wrong", async () => {
+    const encSecret = await symmetricEncrypt({
+      key: SERVER_SECRET,
+      data: TOTP_SECRET,
+    });
+    mockSelect.mockReturnValueOnce(selectChain([{ secret: encSecret }]));
+
+    const result = await requireDualFactor({
+      userId: "user_2",
+      email: "user@example.com",
+      action: "oauth_mfa_finalize",
+      code: "000000",
+      emailOtp: "123456",
+      headers: new Headers(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      code: "mfa_code_invalid",
+    });
+  });
+
+  it("returns mfa_code_invalid (not a distinct enrollment code) when no two_factor row exists", async () => {
+    // Don't leak enrollment state. Strict-signin uses a distinct
+    // totp_not_configured code because it is the sign-in entry point;
+    // requireDualFactor is invoked only after the user has already
+    // proved they have TOTP set up, so any missing row is a data
+    // anomaly that should look identical to a wrong code.
+    mockSelect.mockReturnValueOnce(selectChain([]));
+
+    const result = await requireDualFactor({
+      userId: "user_3",
+      email: "user@example.com",
+      action: "oauth_mfa_finalize",
+      code: totpForNow(TOTP_SECRET),
+      emailOtp: "123456",
+      headers: new Headers(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      code: "mfa_code_invalid",
+    });
+  });
+
+  it("returns email_code_invalid when the verifications row is missing or expired", async () => {
+    const encSecret = await symmetricEncrypt({
+      key: SERVER_SECRET,
+      data: TOTP_SECRET,
+    });
+    mockSelect
+      .mockReturnValueOnce(selectChain([{ secret: encSecret }]))
+      .mockReturnValueOnce(selectChain([]));
+
+    const result = await requireDualFactor({
+      userId: "user_4",
+      email: "user@example.com",
+      action: "oauth_mfa_finalize",
+      code: totpForNow(TOTP_SECRET),
+      emailOtp: "123456",
+      headers: new Headers(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      code: "email_code_invalid",
+    });
+  });
+
+  it("mints and emails an OTP and returns factors_required when codes are missing", async () => {
+    const result = await requireDualFactor({
+      userId: "user_5",
+      email: "user@example.com",
+      action: "oauth_mfa_finalize",
+      headers: new Headers(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      code: "factors_required",
+    });
+    expect(mockSendVerificationOTP).toHaveBeenCalledOnce();
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- OAuth-with-TOTP sign-in has been broken in production since 2026-05-26 22:17 UTC. `requireDualFactor` called `auth.api.verifyTOTP`, which requires either an active Better Auth session or the `TWO_FACTOR_COOKIE_NAME` cookie. The OAuth-MFA finalize path runs after `interceptOauthCallback` has destroyed the session and leaves only `pending_oauth_mfa`, so verifyTOTP threw on every request and every OAuth user with TOTP enrolled got "Invalid authenticator code" regardless of the code they submitted.
- The fix swaps `auth.api.verifyTOTP` for a direct read of `two_factor.secret` plus `verifyUserTotp()` — the same session-less primitive that `strict-signin` already uses in production at `app/api/auth/strict-signin/route.ts:187`. Same RFC 6238 window, same constant-time compare, no behavior change for the 15 callers that already have a session.
- Adds `tests/unit/dual-factor.test.ts` with the regression case (valid TOTP + email OTP without a session => `ok: true`) plus negative cases. The new test would have failed under the broken code path: importing `@/lib/auth` in a unit-test context pulled in the full Better Auth runtime and threw without a session.

## Root cause
The fix-pack PR that landed on 2026-05-25 shipped two halves that contradict each other: the OAuth callback now destroys the Better Auth session before routing to the MFA finalize endpoint, but the dual-factor gate behind that endpoint still verifies TOTP through a code path that requires a session. The bug is identical in shape to a previous strict-signin issue that was already resolved by moving to `verifyUserTotp`; this PR brings the OAuth-MFA finalize path in line with that pattern.

## Impact
17 users have TOTP enrolled in production. Any of them attempting OAuth sign-in over the last ~33 hours hit the bug. Affected users were unblockable except by switching to the email/password sign-in path.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test:unit` — 5380 pass / 1 skipped, 0 regressions
- [x] New unit suite at `tests/unit/dual-factor.test.ts` — 5 tests, all passing
- [x] `npx @biomejs/biome check` on changed files: no new diagnostics
- [ ] Post-deploy: re-run the synthetic test from the diagnosis session (cookie-forge `pending_oauth_mfa` for a TOTP-enrolled user, POST `/api/auth/oauth-mfa-finalize` with a correct TOTP and a wrong email OTP). Expected: `code: "email_code_invalid"` (TOTP now passes, email OTP fails) instead of the pre-fix `code: "mfa_code_invalid"`.
- [ ] Post-deploy: confirm one affected user can complete OAuth + TOTP sign-in.

## Out of scope (follow-ups)
- Consolidate MFA verify primitives: extract a shared `verifyMfaPair(userId, totpCode, emailOtp, action)` helper used by both strict-signin and oauth-mfa-finalize. The original fix-pack shipped two divergent TOTP-verify code paths and they drifted; one was session-required (broke for 33h), one was session-less. P2/Medium.
- Add an integration test that exercises the full OAuth -> `/verify-mfa` -> `/api/auth/oauth-mfa-finalize` flow against a real session-required path (not mocked). The unit test in this PR catches the import-level explosion, but an integration test would catch this class of bug earlier when the contributor only has unit-test coverage in mind.