### PR TITLE
fix(layout): opt out of in-page translation to stop React DOM crashes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,6 +47,14 @@ export const metadata: Metadata = {
       "Build powerful blockchain workflow automations with a visual, node-based editor.",
     images: ["/api/og/default"],
   },
+  // Discourage automatic translation of the app shell. External
+  // translators (Chrome's built-in translator, browser extensions) swap
+  // text nodes in-place, which leaves React's fiber tree referencing
+  // the original parents and throws `NotFoundError` on the next
+  // insertBefore/removeChild. See facebook/react#11538.
+  other: {
+    google: "notranslate",
+  },
 };
 
 export const viewport: Viewport = {
@@ -102,6 +110,7 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
       lang="en"
       style={{ "--nav-sidebar-width": navSidebarWidth } as React.CSSProperties}
       suppressHydrationWarning
+      translate="no"
     >
       <body className={cn(sans.variable, mono.variable, "antialiased")}>
         <KeeperHubExtensionLoader />


### PR DESCRIPTION
## Summary

- Adds \`<meta name=\"google\" content=\"notranslate\" />\` via the App Router \`Metadata.other\` field and \`translate=\"no\"\` on the root \`<html>\` element.
- Three production Sentry groups (\`NotFoundError: insertBefore\` on \`/\`, \`NotFoundError: removeChild\` on \`/\` and \`/workflows/:workflowId\`) share a single fingerprint: zh-CN locale, Asia/Shanghai timezone, Chrome 147 on Linux, identical client IP, no first-party frames in the stack. This is the canonical \`facebook/react#11538\` pattern: an external translator (Chrome's built-in translator or a translation extension) swaps text nodes in place; React's fiber tree still references the original parents; the next reconciler commit hits a DOM op against a node whose parent has changed and throws.
- The notranslate signals tell well-behaved translators to leave the page alone, eliminating the swap that triggers the reconciler crash. Not a code regression; this only silences external interference.

## Follow-up (not in this PR)

- The ticket also calls for a Sentry inbound filter on these error groups so any remaining stragglers (extensions that ignore the meta hint) do not page or pollute issue counts. That is a Sentry-platform UI change, not a code change.