### PR TITLE
chore: wire Understand-Anything codebase graph into team workflow

### DIFF
--- a/.claude/commands/add-protocol.md
+++ b/.claude/commands/add-protocol.md
@@ -71,6 +71,8 @@ Phases run in order. After VERIFY, if any check failed, loop back to BUILD with 
 
 PHASE 1 - RESEARCH (web search + explorer lookups, BEFORE any code is written)
 
+**Orient locally first**: run `/understand-chat protocols/` to see how the existing protocols are structured (definition strategy, ABI layout, TEST_DATA shape) and to confirm no entry for $ARGUMENTS already exists. The closest existing protocol is your structural template; the graph names it faster than `ls protocols/` + grep does.
+
 Use WebSearch and WebFetch to gather concrete facts. Cite URLs and addresses for every claim. Do not guess; if a fact cannot be confirmed, mark it open and surface to the user.
 
 1.1 Identity and version (do this FIRST; everything downstream depends on getting the version right)

--- a/.claude/commands/develop-plugin.md
+++ b/.claude/commands/develop-plugin.md
@@ -482,6 +482,10 @@ UTILITY PLUGINS:
    - For web3 plugins, use chain-select, abi-with-auto-fetch, etc.
    - For security steps, plan for maxRetries = 0
 
+3.5. ORIENT WITH THE KNOWLEDGE GRAPH (cheap, do it before creating files)
+   - Run `/understand-chat plugins/` to find the closest existing plugin to use as a template (file layout, step pattern, credential handling). Copying from a near-fit plugin beats writing from spec.
+   - For an action being added to an existing plugin, run `/understand-chat plugins/<plugin>/steps/` to see the sibling step pattern.
+
 4. CREATE PLUGIN FILES
    If NEW PLUGIN:
    - Create directory: `plugins/[name]/`

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -54,6 +54,8 @@ Git status: !`git status --short`
 
 ## Stage 3: Research
 
+**Orient with the knowledge graph first.** For any issue whose blast radius is unclear, or that touches `lib/` or multiple plugins, run `/understand-chat <subsystem>` (or `/understand-diff` if a WIP diff already exists) before dispatching researchers. The graph answers "what calls X?" and "where does this flow next?" cheaper than a research subagent does, and the researchers can then focus on the actual unknowns.
+
 Spawn parallel KeeperHub **researcher** agents -- one per issue. Each agent
 receives:
 - The issue title and feedback text

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,5 +22,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "understand-anything@understand-anything": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ packages/*/dist/
 reports/
 
 .mcp.json
+
+# Understand-Anything (commit knowledge-graph.json; ignore scratch + dashboard local state)
+.understand-anything/intermediate/
+.understand-anything/diff-overlay.json

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ reports/
 
 .mcp.json
 
-# Understand-Anything (commit knowledge-graph.json; ignore scratch + dashboard local state)
+# Understand-Anything: commit knowledge-graph.json + config.json + .understandignore.
+# Ignore meta (timestamp churn) and fingerprints (per-machine incremental cache).
 .understand-anything/intermediate/
 .understand-anything/diff-overlay.json
+.understand-anything/meta.json
+.understand-anything/fingerprints.json

--- a/.understand-anything/.understandignore
+++ b/.understand-anything/.understandignore
@@ -1,0 +1,35 @@
+# .understandignore — generated for KeeperHub first-pass scoped to plugins/
+# Syntax: same as .gitignore (globs, # comments, ! negation, trailing / for dirs)
+# Strategy: deny-all, then re-include only plugins/. This keeps the initial
+# knowledge graph small (~140 files) while keeping config + graph at the
+# repo root so the auto-update hook fires on commits.
+#
+# To widen coverage later: un-ignore additional roots (e.g. negate app/, lib/),
+# then re-run `/understand --auto-update` to incrementally extend the graph.
+#
+# Built-in defaults still apply on top (node_modules/, .git/, dist/, etc.)
+
+# --- Scope filter: exclude everything ---
+*
+
+# --- Re-include the plugins/ subtree (and its parents so the walker reaches it) ---
+!plugins/
+!plugins/**
+
+# --- Belt-and-braces: keep typical large/noisy dirs out even inside plugins ---
+plugins/**/node_modules/
+plugins/**/dist/
+plugins/**/build/
+plugins/**/.next/
+plugins/**/coverage/
+plugins/**/*.lock
+plugins/**/*.min.js
+plugins/**/*.min.css
+plugins/**/*.map
+plugins/**/*.snap
+plugins/**/*.test.*
+plugins/**/*.spec.*
+plugins/**/__tests__/
+plugins/**/test/
+plugins/**/tests/
+plugins/**/fixtures/

--- a/.understand-anything/config.json
+++ b/.understand-anything/config.json
@@ -1,0 +1,1 @@
+{"autoUpdate": false, "outputLanguage": "en"}

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -1,0 +1,10960 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "keeperhub",
+    "languages": [
+      "json",
+      "markdown",
+      "txt",
+      "typescript"
+    ],
+    "frameworks": [
+      "Drizzle ORM",
+      "Next.js",
+      "Playwright",
+      "React",
+      "Tailwind CSS",
+      "Vite",
+      "Vitest"
+    ],
+    "description": "Web3 workflow automation platform enabling users and AI agents to build, manage, and execute blockchain automation workflows via a visual builder, REST API, or MCP server. This scan is scoped to the plugins/ subtree, which contains the integration adapters (web3, discord, sendgrid, slack, hyperliquid, etc.) that power workflow steps. Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results.",
+    "analyzedAt": "2026-05-27T01:16:14Z",
+    "gitCommitHash": "ccc8dc292ad0506bf925f78c02d998332d67c9a0"
+  },
+  "nodes": [
+    {
+      "id": "file:plugins/code/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/code/icon.tsx",
+      "summary": "React SVG icon component for the Code plugin, used in the workflow builder integration list.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/code/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/code/index.ts",
+      "summary": "Code plugin definition that registers a sandboxed JavaScript Run Code action allowing workflows to execute custom server-side code with workflow template variables.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "registration",
+        "code-execution"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/discord/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/discord/icon.tsx",
+      "summary": "React SVG icon component for the Discord plugin, rendering the Discord brand mark in the integration UI.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/discord/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/discord/index.ts",
+      "summary": "Discord plugin definition that registers a webhook-based integration for posting messages to Discord channels from workflows.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "messaging",
+        "webhook"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/hyperliquid/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/hyperliquid/icon.tsx",
+      "summary": "React SVG icon component for the Hyperliquid plugin, displayed in the workflow builder integration list.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/hyperliquid/index.ts",
+      "summary": "Hyperliquid plugin definition exposing read-only wrappers over the Hyperliquid Info REST API for vault operator reporting, validator monitoring, and account state queries.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "defi",
+        "hyperliquid"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Large action catalogue defined as a single IntegrationPlugin object literal; each action declares slug, configFields, and outputFields for the workflow builder."
+    },
+    {
+      "id": "file:plugins/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/index.ts",
+      "summary": "Auto-generated barrel that side-effect imports every base plugin (blockscout, code, discord, hyperliquid, math, protocol, safe, sendgrid, slack, telegram, web3, webhook) so each plugin registers itself at server startup.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "plugin-registry",
+        "generated"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Side-effect-only imports trigger registerIntegration() calls in each plugin module without binding named exports."
+    },
+    {
+      "id": "file:plugins/keeperhub-plugins.ts",
+      "type": "file",
+      "name": "keeperhub-plugins.ts",
+      "filePath": "plugins/keeperhub-plugins.ts",
+      "summary": "Auto-generated barrel of KeeperHub-specific plugins loaded in addition to the base set, side-effect importing nine integration modules to trigger their registration.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "plugin-registry",
+        "generated"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/math/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/math/icon.tsx",
+      "summary": "React SVG icon component for the Math plugin shown in the action catalogue.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/math/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/math/index.ts",
+      "summary": "Math plugin definition registering aggregation and arithmetic actions that operate across array data or multiple upstream node outputs.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "math",
+        "aggregation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/protocol/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/protocol/index.ts",
+      "summary": "Protocol plugin shell that side-effect imports the auto-generated protocols barrel so each protocol definition registers itself as both a protocol and an IntegrationPlugin at startup.",
+      "tags": [
+        "plugin-definition",
+        "barrel",
+        "registration",
+        "protocol"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/safe/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/safe/index.ts",
+      "summary": "Safe plugin action descriptor for fetching pending multisig transactions from a Safe, including config and output field metadata consumed by the workflow builder.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "safe",
+        "multisig"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/sendgrid/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/sendgrid/icon.tsx",
+      "summary": "Minimal React SVG icon component for the SendGrid (Email) plugin tile.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/sendgrid/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/sendgrid/index.ts",
+      "summary": "SendGrid plugin definition exposing a transactional Email integration that defaults to the shared KeeperHub API key with an opt-in to bring-your-own credentials.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "email",
+        "sendgrid"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/telegram/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/telegram/icon.tsx",
+      "summary": "React SVG icon component for the Telegram plugin displayed in the workflow builder UI.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/telegram/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/telegram/index.ts",
+      "summary": "Telegram plugin definition registering a bot-API integration for sending chat messages, with the bot token captured as an integration-level password field.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "messaging",
+        "telegram"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/web3/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/web3/icon.tsx",
+      "summary": "React SVG icon component for the Web3 plugin shown across the workflow builder and integration list.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/web3/index.ts",
+      "summary": "Core Web3 plugin definition declaring the full catalogue of on-chain workflow actions (read contract, transfer funds, decode calldata, etc.) backed by the user's Para wallet, plus signer routing and RPC failover wiring.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "web3",
+        "blockchain",
+        "wallet"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Single oversized IntegrationPlugin literal (>1200 lines) enumerating every Web3 action with its configFields, outputFields, and step import paths."
+    },
+    {
+      "id": "file:plugins/webhook/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/webhook/icon.tsx",
+      "summary": "React SVG icon component for the Webhook plugin tile.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "plugin-asset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webhook/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/webhook/index.ts",
+      "summary": "Webhook plugin definition exposing a generic HTTP request action where URL, method, headers, and payload are configured per workflow node rather than at integration setup.",
+      "tags": [
+        "plugin-definition",
+        "integration",
+        "http",
+        "webhook"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/code/icon.tsx:CodeIcon",
+      "type": "function",
+      "name": "CodeIcon",
+      "filePath": "plugins/code/icon.tsx",
+      "lineRange": [
+        3,
+        11
+      ],
+      "summary": "React functional component returning the SVG markup for the Code plugin icon.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/discord/icon.tsx:DiscordIcon",
+      "type": "function",
+      "name": "DiscordIcon",
+      "filePath": "plugins/discord/icon.tsx",
+      "lineRange": [
+        1,
+        26
+      ],
+      "summary": "React functional component rendering the Discord brand SVG icon for the integration tile.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/icon.tsx:HyperliquidIcon",
+      "type": "function",
+      "name": "HyperliquidIcon",
+      "filePath": "plugins/hyperliquid/icon.tsx",
+      "lineRange": [
+        1,
+        24
+      ],
+      "summary": "React functional component rendering the Hyperliquid logo SVG used in the workflow builder integration list.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/icon.tsx:MathIcon",
+      "type": "function",
+      "name": "MathIcon",
+      "filePath": "plugins/math/icon.tsx",
+      "lineRange": [
+        1,
+        19
+      ],
+      "summary": "React functional component rendering the Math plugin SVG icon.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/sendgrid/icon.tsx:SendGridIcon",
+      "type": "function",
+      "name": "SendGridIcon",
+      "filePath": "plugins/sendgrid/icon.tsx",
+      "lineRange": [
+        1,
+        5
+      ],
+      "summary": "Minimal React functional component returning the SendGrid (Email) plugin SVG icon.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/telegram/icon.tsx:TelegramIcon",
+      "type": "function",
+      "name": "TelegramIcon",
+      "filePath": "plugins/telegram/icon.tsx",
+      "lineRange": [
+        1,
+        39
+      ],
+      "summary": "React functional component rendering the Telegram brand SVG icon for the integration tile.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/icon.tsx:Web3Icon",
+      "type": "function",
+      "name": "Web3Icon",
+      "filePath": "plugins/web3/icon.tsx",
+      "lineRange": [
+        1,
+        28
+      ],
+      "summary": "React functional component rendering the Web3 plugin SVG icon.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/webhook/icon.tsx:WebhookIcon",
+      "type": "function",
+      "name": "WebhookIcon",
+      "filePath": "plugins/webhook/icon.tsx",
+      "lineRange": [
+        3,
+        11
+      ],
+      "summary": "React functional component returning the SVG markup for the Webhook plugin icon.",
+      "tags": [
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/ai-gateway/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/ai-gateway/icon.tsx",
+      "summary": "Re-exports the AI Gateway plugin icon component used in the integration card and node palette.",
+      "tags": [
+        "icon",
+        "barrel",
+        "component"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/ai-gateway/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/ai-gateway/index.ts",
+      "summary": "Declares the AI Gateway IntegrationPlugin (Generate Text + Generate Image actions across Anthropic/OpenAI/Google/Meta models) and auto-registers it on import.",
+      "tags": [
+        "plugin-definition",
+        "ai-gateway",
+        "entry-point",
+        "integration"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Pure declarative plugin manifest; runtime side-effect of registerIntegration() call at module load."
+    },
+    {
+      "id": "file:plugins/clerk/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/clerk/icon.tsx",
+      "summary": "SVG icon component for the Clerk integration used by the plugin card and node UI.",
+      "tags": [
+        "icon",
+        "component",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/clerk/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/clerk/index.ts",
+      "summary": "Declares the Clerk IntegrationPlugin manifest (user management actions like get-user, list-users, etc.) and registers it via registerIntegration on import.",
+      "tags": [
+        "plugin-definition",
+        "clerk",
+        "entry-point",
+        "integration",
+        "auth"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/legacy-mappings.ts",
+      "type": "file",
+      "name": "legacy-mappings.ts",
+      "filePath": "plugins/legacy-mappings.ts",
+      "summary": "Maps legacy human-readable action labels (e.g. 'Send Email', 'safe-wallet/*') to the new namespaced plugin/action IDs for backward compatibility with stored workflows.",
+      "tags": [
+        "legacy",
+        "compatibility",
+        "mapping",
+        "data"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/registry-core.ts",
+      "type": "file",
+      "name": "registry-core.ts",
+      "filePath": "plugins/registry-core.ts",
+      "summary": "Holds the core IntegrationPlugin Map and registerIntegration setter; isolated from registry.ts to avoid TDZ during the circular plugin-registration load.",
+      "tags": [
+        "registry",
+        "core",
+        "singleton",
+        "service"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Intentionally a tiny module to keep the circular import graph (registry \u2192 @/plugins \u2192 plugins/* \u2192 registry-core) linear."
+    },
+    {
+      "id": "file:plugins/registry.ts",
+      "type": "file",
+      "name": "registry.ts",
+      "filePath": "plugins/registry.ts",
+      "summary": "Defines the IntegrationPlugin type system (action/field schemas) and the public registry API for looking up plugins, actions, credentials, and AI prompt metadata across all integrations.",
+      "tags": [
+        "registry",
+        "type-definition",
+        "service",
+        "plugin-system",
+        "api"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Side-effect import `@/plugins` forces every plugin/index.ts to evaluate and self-register before any reader queries the registry."
+    },
+    {
+      "id": "file:plugins/resend/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/resend/icon.tsx",
+      "summary": "SVG icon component for the Resend email integration.",
+      "tags": [
+        "icon",
+        "component",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/resend/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/resend/index.ts",
+      "summary": "Declares the Resend IntegrationPlugin manifest (send-email action with API key + default sender form fields) and auto-registers it on import.",
+      "tags": [
+        "plugin-definition",
+        "resend",
+        "email",
+        "entry-point",
+        "integration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/slack/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/slack/icon.tsx",
+      "summary": "Multi-colour Slack SVG mark rendered as a React component for the integration card and node UI.",
+      "tags": [
+        "icon",
+        "component",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/slack/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/slack/index.ts",
+      "summary": "Declares the Slack IntegrationPlugin manifest (send-message action with channel + templated message fields) and auto-registers it on import.",
+      "tags": [
+        "plugin-definition",
+        "slack",
+        "messaging",
+        "entry-point",
+        "integration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/v0/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/v0/icon.tsx",
+      "summary": "SVG mark icon for the v0 (Vercel AI UI generation) integration.",
+      "tags": [
+        "icon",
+        "component",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/v0/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/v0/index.ts",
+      "summary": "Declares the v0 IntegrationPlugin manifest (create-chat and send-message actions for AI-generated UI components) and auto-registers it on import.",
+      "tags": [
+        "plugin-definition",
+        "v0",
+        "ai",
+        "entry-point",
+        "integration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/webflow/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/webflow/icon.tsx",
+      "summary": "SVG mark icon for the Webflow CMS integration.",
+      "tags": [
+        "icon",
+        "component",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webflow/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/webflow/index.ts",
+      "summary": "Declares the Webflow IntegrationPlugin manifest (list-sites, get-site, and related actions backed by a Webflow API token) and auto-registers it on import.",
+      "tags": [
+        "plugin-definition",
+        "webflow",
+        "cms",
+        "entry-point",
+        "integration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/clerk/icon.tsx:ClerkIcon",
+      "type": "function",
+      "name": "ClerkIcon",
+      "filePath": "plugins/clerk/icon.tsx",
+      "lineRange": [
+        1,
+        21
+      ],
+      "summary": "React component returning the Clerk brand SVG mark with a className passthrough.",
+      "tags": [
+        "component",
+        "icon",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/resend/icon.tsx:ResendIcon",
+      "type": "function",
+      "name": "ResendIcon",
+      "filePath": "plugins/resend/icon.tsx",
+      "lineRange": [
+        1,
+        12
+      ],
+      "summary": "React component returning the Resend SVG mark with a className passthrough.",
+      "tags": [
+        "component",
+        "icon",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/slack/icon.tsx:SlackIcon",
+      "type": "function",
+      "name": "SlackIcon",
+      "filePath": "plugins/slack/icon.tsx",
+      "lineRange": [
+        1,
+        30
+      ],
+      "summary": "React component rendering the multi-colour Slack SVG mark with a className passthrough.",
+      "tags": [
+        "component",
+        "icon",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/v0/icon.tsx:V0Icon",
+      "type": "function",
+      "name": "V0Icon",
+      "filePath": "plugins/v0/icon.tsx",
+      "lineRange": [
+        1,
+        13
+      ],
+      "summary": "React component returning the v0 SVG mark with a className passthrough.",
+      "tags": [
+        "component",
+        "icon",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/webflow/icon.tsx:WebflowIcon",
+      "type": "function",
+      "name": "WebflowIcon",
+      "filePath": "plugins/webflow/icon.tsx",
+      "lineRange": [
+        1,
+        14
+      ],
+      "summary": "React component returning the Webflow SVG mark with a className passthrough.",
+      "tags": [
+        "component",
+        "icon",
+        "svg"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry-core.ts:registerIntegration",
+      "type": "function",
+      "name": "registerIntegration",
+      "filePath": "plugins/registry-core.ts",
+      "lineRange": [
+        13,
+        15
+      ],
+      "summary": "Inserts an IntegrationPlugin into the central integrationRegistry Map keyed by plugin type, called by every plugin index.ts on import.",
+      "tags": [
+        "registry",
+        "setter",
+        "side-effect"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:computeActionId",
+      "type": "function",
+      "name": "computeActionId",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        315,
+        320
+      ],
+      "summary": "Builds a canonical namespaced action ID by joining the integration type and action slug with a slash.",
+      "tags": [
+        "utility",
+        "id",
+        "registry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:parseActionId",
+      "type": "function",
+      "name": "parseActionId",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        325,
+        337
+      ],
+      "summary": "Splits a namespaced action ID into its integration type and action slug components, returning undefined when malformed.",
+      "tags": [
+        "utility",
+        "id",
+        "parser"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getIntegration",
+      "type": "function",
+      "name": "getIntegration",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        342,
+        346
+      ],
+      "summary": "Looks up a registered IntegrationPlugin by its integration type from the central registry.",
+      "tags": [
+        "registry",
+        "lookup",
+        "getter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getAllIntegrations",
+      "type": "function",
+      "name": "getAllIntegrations",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        351,
+        353
+      ],
+      "summary": "Returns every registered IntegrationPlugin as an array for downstream iteration (UI lists, MCP schema generation, etc.).",
+      "tags": [
+        "registry",
+        "lookup",
+        "getter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getIntegrationTypes",
+      "type": "function",
+      "name": "getIntegrationTypes",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        358,
+        360
+      ],
+      "summary": "Returns the list of all registered IntegrationType keys from the registry Map.",
+      "tags": [
+        "registry",
+        "lookup",
+        "getter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getAllActions",
+      "type": "function",
+      "name": "getAllActions",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        365,
+        379
+      ],
+      "summary": "Flattens every plugin's actions into a single array, attaching the computed namespaced action ID to each entry.",
+      "tags": [
+        "registry",
+        "aggregation",
+        "actions"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getActionsByCategory",
+      "type": "function",
+      "name": "getActionsByCategory",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        384,
+        401
+      ],
+      "summary": "Groups every registered action by its category field, returning a record keyed by category name for grouped UI rendering.",
+      "tags": [
+        "registry",
+        "aggregation",
+        "grouping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/registry.ts:findActionById",
+      "type": "function",
+      "name": "findActionById",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        407,
+        450
+      ],
+      "summary": "Resolves a namespaced action ID (or a legacy label) to its plugin and action definition, falling back to scanning all plugins when the prefix lookup fails.",
+      "tags": [
+        "registry",
+        "lookup",
+        "fallback",
+        "compatibility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/registry.ts:getIntegrationLabels",
+      "type": "function",
+      "name": "getIntegrationLabels",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        455,
+        461
+      ],
+      "summary": "Produces a type-to-label map for every registered plugin, used by UI dropdowns and AI-prompt metadata.",
+      "tags": [
+        "registry",
+        "aggregation",
+        "getter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getIntegrationDescriptions",
+      "type": "function",
+      "name": "getIntegrationDescriptions",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        466,
+        472
+      ],
+      "summary": "Produces a type-to-description map for every registered plugin, used in plugin-picker UI and AI prompts.",
+      "tags": [
+        "registry",
+        "aggregation",
+        "getter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getSortedIntegrationTypes",
+      "type": "function",
+      "name": "getSortedIntegrationTypes",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        477,
+        479
+      ],
+      "summary": "Returns the registered integration type keys sorted alphabetically for stable UI ordering and snapshot tests.",
+      "tags": [
+        "registry",
+        "lookup",
+        "sort"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getAllDependencies",
+      "type": "function",
+      "name": "getAllDependencies",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        484,
+        494
+      ],
+      "summary": "Aggregates the `dependencies` map declared by each plugin into a single object that the workflow bundler uses to scope npm dependencies per integration.",
+      "tags": [
+        "registry",
+        "aggregation",
+        "dependencies",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:getCredentialMapping",
+      "type": "function",
+      "name": "getCredentialMapping",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        499,
+        512
+      ],
+      "summary": "Maps a plugin's declarative formFields onto the runtime credential config object, projecting form values to the keys consumed by step functions.",
+      "tags": [
+        "registry",
+        "credentials",
+        "mapping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:isFieldGroup",
+      "type": "function",
+      "name": "isFieldGroup",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        517,
+        521
+      ],
+      "summary": "Type-guard distinguishing a grouped config field (with child fields) from a leaf ActionConfigField entry.",
+      "tags": [
+        "registry",
+        "type-guard",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:flattenConfigFields",
+      "type": "function",
+      "name": "flattenConfigFields",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        527,
+        541
+      ],
+      "summary": "Recursively flattens nested field groups into a single array of leaf config fields for prompt generation and validation passes.",
+      "tags": [
+        "registry",
+        "utility",
+        "recursion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/registry.ts:generateAIActionPrompts",
+      "type": "function",
+      "name": "generateAIActionPrompts",
+      "filePath": "plugins/registry.ts",
+      "lineRange": [
+        547,
+        586
+      ],
+      "summary": "Walks every plugin's actions and config fields to emit human-readable prompt snippets describing each action for the AI workflow-generation system.",
+      "tags": [
+        "registry",
+        "ai",
+        "prompt-generation",
+        "documentation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/blockscout/chains.ts",
+      "type": "file",
+      "name": "chains.ts",
+      "filePath": "plugins/blockscout/chains.ts",
+      "summary": "Single source of truth mapping EVM chain IDs to their canonical hosted Blockscout instance URLs, plus a derived allowlist used by the plugin's chain selector and step runtime.",
+      "tags": [
+        "data-model",
+        "configuration",
+        "blockchain",
+        "constants"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/blockscout/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/blockscout/credentials.ts",
+      "summary": "Declares the optional BLOCKSCOUT_API_URL and BLOCKSCOUT_API_KEY credential shape consumed by every Blockscout step.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "blockscout"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/blockscout/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/blockscout/icon.tsx",
+      "summary": "React SVG icon component that renders the Blockscout brand mark for use in the plugin picker UI.",
+      "tags": [
+        "component",
+        "icon",
+        "ui"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/blockscout/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/blockscout/index.ts",
+      "summary": "Plugin definition that registers the Blockscout integration with KeeperHub, declaring the chain selector, optional connection form fields, and the five read-only block explorer actions.",
+      "tags": [
+        "entry-point",
+        "plugin-definition",
+        "blockscout",
+        "integration"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Declarative IntegrationPlugin registration; actions reference per-step files via stepImportPath strings rather than direct imports to keep the client bundle small."
+    },
+    {
+      "id": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "type": "file",
+      "name": "blockscout-core.ts",
+      "filePath": "plugins/blockscout/steps/blockscout-core.ts",
+      "summary": "Server-only shared core that resolves the target Blockscout instance from credentials or selected chain and issues normalized GET requests against the Blockscout REST v2 API.",
+      "tags": [
+        "utility",
+        "service",
+        "http-client",
+        "blockscout"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses a discriminated-union result shape so step handlers can pattern-match on success/error without throwing across the workflow boundary."
+    },
+    {
+      "id": "file:plugins/blockscout/steps/get-address-balance.ts",
+      "type": "file",
+      "name": "get-address-balance.ts",
+      "filePath": "plugins/blockscout/steps/get-address-balance.ts",
+      "summary": "Workflow step that fetches an address's native-coin balance from Blockscout for the selected chain.",
+      "tags": [
+        "step",
+        "blockscout",
+        "api-handler",
+        "blockchain"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/blockscout/steps/get-address-counters.ts",
+      "type": "file",
+      "name": "get-address-counters.ts",
+      "filePath": "plugins/blockscout/steps/get-address-counters.ts",
+      "summary": "Workflow step that fetches aggregate counters (transactions, token transfers, gas usage) for an address from the Blockscout API.",
+      "tags": [
+        "step",
+        "blockscout",
+        "api-handler",
+        "analytics"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/blockscout/steps/get-address-info.ts",
+      "type": "file",
+      "name": "get-address-info.ts",
+      "filePath": "plugins/blockscout/steps/get-address-info.ts",
+      "summary": "Workflow step that retrieves rich address metadata (contract status, name tags, implementation pointers) from Blockscout for the selected chain.",
+      "tags": [
+        "step",
+        "blockscout",
+        "api-handler",
+        "blockchain"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/blockscout/steps/get-token-info.ts",
+      "type": "file",
+      "name": "get-token-info.ts",
+      "filePath": "plugins/blockscout/steps/get-token-info.ts",
+      "summary": "Workflow step that returns ERC-20/721 token metadata (name, symbol, decimals, total supply) from Blockscout for a given token address.",
+      "tags": [
+        "step",
+        "blockscout",
+        "api-handler",
+        "tokens"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/blockscout/steps/get-transaction.ts",
+      "type": "file",
+      "name": "get-transaction.ts",
+      "filePath": "plugins/blockscout/steps/get-transaction.ts",
+      "summary": "Workflow step that fetches a transaction's full decoded details from Blockscout by hash for the selected chain.",
+      "tags": [
+        "step",
+        "blockscout",
+        "api-handler",
+        "transactions"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/icon.tsx:BlockscoutIcon",
+      "type": "function",
+      "name": "BlockscoutIcon",
+      "filePath": "plugins/blockscout/icon.tsx",
+      "lineRange": [
+        1,
+        27
+      ],
+      "summary": "Renders the Blockscout brand SVG icon, accepting className and style overrides for sizing in the plugin picker.",
+      "tags": [
+        "component",
+        "icon",
+        "ui"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/blockscout-core.ts:resolveInstance",
+      "type": "function",
+      "name": "resolveInstance",
+      "filePath": "plugins/blockscout/steps/blockscout-core.ts",
+      "lineRange": [
+        35,
+        63
+      ],
+      "summary": "Resolves which Blockscout instance URL to call by precedence: explicit credential override, chain-mapped hosted instance, then default Ethereum mainnet.",
+      "tags": [
+        "utility",
+        "resolver",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "function",
+      "name": "blockscoutGet",
+      "filePath": "plugins/blockscout/steps/blockscout-core.ts",
+      "lineRange": [
+        71,
+        108
+      ],
+      "summary": "Generic GET against the Blockscout REST v2 API that attaches an optional API key and returns a typed success/error discriminated-union result.",
+      "tags": [
+        "http-client",
+        "utility",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-address-balance.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/blockscout/steps/get-address-balance.ts",
+      "lineRange": [
+        39,
+        65
+      ],
+      "summary": "Validates the address input and calls Blockscout to retrieve and shape the native-coin balance response.",
+      "tags": [
+        "handler",
+        "blockscout",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-address-balance.ts:getAddressBalanceStep",
+      "type": "function",
+      "name": "getAddressBalanceStep",
+      "filePath": "plugins/blockscout/steps/get-address-balance.ts",
+      "lineRange": [
+        67,
+        84
+      ],
+      "summary": "Exported workflow step entry that fetches credentials and runs the address-balance handler wrapped with plugin metrics and step logging.",
+      "tags": [
+        "entry-point",
+        "step",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-address-counters.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/blockscout/steps/get-address-counters.ts",
+      "lineRange": [
+        39,
+        66
+      ],
+      "summary": "Validates the address input and queries Blockscout for aggregate counters (transactions, token transfers, gas) for that address.",
+      "tags": [
+        "handler",
+        "blockscout",
+        "analytics"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-address-counters.ts:getAddressCountersStep",
+      "type": "function",
+      "name": "getAddressCountersStep",
+      "filePath": "plugins/blockscout/steps/get-address-counters.ts",
+      "lineRange": [
+        68,
+        85
+      ],
+      "summary": "Exported workflow step entry that fetches credentials and runs the address-counters handler wrapped with plugin metrics and step logging.",
+      "tags": [
+        "entry-point",
+        "step",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-address-info.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/blockscout/steps/get-address-info.ts",
+      "lineRange": [
+        59,
+        96
+      ],
+      "summary": "Validates the address input and pulls rich Blockscout address metadata such as contract flags, names and implementation pointers.",
+      "tags": [
+        "handler",
+        "blockscout",
+        "blockchain"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-address-info.ts:getAddressInfoStep",
+      "type": "function",
+      "name": "getAddressInfoStep",
+      "filePath": "plugins/blockscout/steps/get-address-info.ts",
+      "lineRange": [
+        98,
+        115
+      ],
+      "summary": "Exported workflow step entry that fetches credentials and runs the address-info handler wrapped with plugin metrics and step logging.",
+      "tags": [
+        "entry-point",
+        "step",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-token-info.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/blockscout/steps/get-token-info.ts",
+      "lineRange": [
+        46,
+        76
+      ],
+      "summary": "Validates the token-address input and fetches ERC-20/721 token metadata from Blockscout for the selected chain.",
+      "tags": [
+        "handler",
+        "blockscout",
+        "tokens"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-token-info.ts:getTokenInfoStep",
+      "type": "function",
+      "name": "getTokenInfoStep",
+      "filePath": "plugins/blockscout/steps/get-token-info.ts",
+      "lineRange": [
+        78,
+        95
+      ],
+      "summary": "Exported workflow step entry that fetches credentials and runs the token-info handler wrapped with plugin metrics and step logging.",
+      "tags": [
+        "entry-point",
+        "step",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-transaction.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/blockscout/steps/get-transaction.ts",
+      "lineRange": [
+        49,
+        80
+      ],
+      "summary": "Validates the transaction-hash input and fetches the decoded transaction record from Blockscout for the selected chain.",
+      "tags": [
+        "handler",
+        "blockscout",
+        "transactions"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/blockscout/steps/get-transaction.ts:getTransactionStep",
+      "type": "function",
+      "name": "getTransactionStep",
+      "filePath": "plugins/blockscout/steps/get-transaction.ts",
+      "lineRange": [
+        82,
+        99
+      ],
+      "summary": "Exported workflow step entry that fetches credentials and runs the transaction handler wrapped with plugin metrics and step logging.",
+      "tags": [
+        "entry-point",
+        "step",
+        "blockscout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/active-asset-data.ts",
+      "type": "file",
+      "name": "active-asset-data.ts",
+      "filePath": "plugins/hyperliquid/steps/active-asset-data.ts",
+      "summary": "Hyperliquid plugin step that fetches per-user active asset data (margin, leverage) from the Info API for a given EVM address and coin.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "web3"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses the canonical KeeperHub step pattern: private stepHandler dispatched through withPluginMetrics + withStepLogging by an exported step function carrying the 'use step' directive."
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/active-asset-data.ts:activeAssetDataStep",
+      "type": "function",
+      "name": "activeAssetDataStep",
+      "filePath": "plugins/hyperliquid/steps/active-asset-data.ts",
+      "lineRange": [
+        38,
+        51
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with plugin metrics and step logging for the Hyperliquid activeAssetData action.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/active-asset-data.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/hyperliquid/steps/active-asset-data.ts",
+      "lineRange": [
+        21,
+        35
+      ],
+      "summary": "Validates the user EVM address and coin, then POSTs an activeAssetData query to the Hyperliquid Info API via postInfo.",
+      "tags": [
+        "validation",
+        "api-handler",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "type": "file",
+      "name": "clearinghouse-state.ts",
+      "filePath": "plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "summary": "Hyperliquid plugin step that retrieves a user's perpetuals clearinghouse state (positions, margin, withdrawable balance) from the Info API.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "web3"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:clearinghouseStateStep",
+      "type": "function",
+      "name": "clearinghouseStateStep",
+      "filePath": "plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "lineRange": [
+        36,
+        49
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid clearinghouseState query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "lineRange": [
+        17,
+        33
+      ],
+      "summary": "Validates the user EVM address, optionally toggles dex mode, and posts a clearinghouseState request to the Hyperliquid Info API.",
+      "tags": [
+        "validation",
+        "api-handler",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/funding-history.ts",
+      "type": "file",
+      "name": "funding-history.ts",
+      "filePath": "plugins/hyperliquid/steps/funding-history.ts",
+      "summary": "Hyperliquid plugin step that queries funding rate history for a coin with optional millisecond start/end window timestamps.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/funding-history.ts:fundingHistoryStep",
+      "type": "function",
+      "name": "fundingHistoryStep",
+      "filePath": "plugins/hyperliquid/steps/funding-history.ts",
+      "lineRange": [
+        68,
+        81
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid fundingHistory query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/funding-history.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/hyperliquid/steps/funding-history.ts",
+      "lineRange": [
+        26,
+        65
+      ],
+      "summary": "Validates the coin and parses optional startTime/endTime millisecond timestamps before posting a fundingHistory request to the Hyperliquid Info API.",
+      "tags": [
+        "validation",
+        "api-handler",
+        "hyperliquid",
+        "timestamp-parsing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "file",
+      "name": "info-request-core.ts",
+      "filePath": "plugins/hyperliquid/steps/info-request-core.ts",
+      "summary": "Shared Hyperliquid Info API client used by every read-only step: posts a JSON body to api.hyperliquid.xyz/info via safeFetch with strict content-type checking and categorised error logging.",
+      "tags": [
+        "utility",
+        "api-client",
+        "hyperliquid",
+        "shared-core",
+        "fetch"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Core helper module deliberately omits the 'use step' directive so it can export helpers (isEvmAddress, postInfo, HYPERLIQUID_INFO_URL) without dragging dependencies into the workflow bundle."
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "function",
+      "name": "postInfo",
+      "filePath": "plugins/hyperliquid/steps/info-request-core.ts",
+      "lineRange": [
+        19,
+        102
+      ],
+      "summary": "Generic POST helper for the Hyperliquid Info endpoint that handles HTTP errors, non-JSON responses, JSON parse failures, and network exceptions, returning a typed InfoResult discriminated union.",
+      "tags": [
+        "utility",
+        "api-client",
+        "error-handling",
+        "hyperliquid"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "function",
+      "name": "isEvmAddress",
+      "filePath": "plugins/hyperliquid/steps/info-request-core.ts",
+      "lineRange": [
+        11,
+        13
+      ],
+      "summary": "Type-guard predicate that returns true when the input is a string matching the 0x-prefixed 40-hex-character EVM address pattern.",
+      "tags": [
+        "validation",
+        "type-guard",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/referral.ts",
+      "type": "file",
+      "name": "referral.ts",
+      "filePath": "plugins/hyperliquid/steps/referral.ts",
+      "summary": "Hyperliquid plugin step that queries referral program state (referrer, referred volume, rewards) for a user EVM address.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "web3"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/referral.ts:referralStep",
+      "type": "function",
+      "name": "referralStep",
+      "filePath": "plugins/hyperliquid/steps/referral.ts",
+      "lineRange": [
+        25,
+        38
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid referral query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/spot-deploy-state.ts",
+      "type": "file",
+      "name": "spot-deploy-state.ts",
+      "filePath": "plugins/hyperliquid/steps/spot-deploy-state.ts",
+      "summary": "Hyperliquid plugin step that fetches spotDeployState (auction status and deployable tokens) for a deploying user EVM address.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "web3"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/spot-deploy-state.ts:spotDeployStateStep",
+      "type": "function",
+      "name": "spotDeployStateStep",
+      "filePath": "plugins/hyperliquid/steps/spot-deploy-state.ts",
+      "lineRange": [
+        30,
+        43
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid spotDeployState query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/sub-accounts.ts",
+      "type": "file",
+      "name": "sub-accounts.ts",
+      "filePath": "plugins/hyperliquid/steps/sub-accounts.ts",
+      "summary": "Hyperliquid plugin step that fetches a master account's sub-accounts via the subAccounts Info API request.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "web3"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/sub-accounts.ts:subAccountsStep",
+      "type": "function",
+      "name": "subAccountsStep",
+      "filePath": "plugins/hyperliquid/steps/sub-accounts.ts",
+      "lineRange": [
+        28,
+        41
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid subAccounts query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/validator-summaries.ts",
+      "type": "file",
+      "name": "validator-summaries.ts",
+      "filePath": "plugins/hyperliquid/steps/validator-summaries.ts",
+      "summary": "Hyperliquid plugin step that returns the global validator set summary via the validatorSummaries Info API call (no user input required).",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "validator"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/validator-summaries.ts:validatorSummariesStep",
+      "type": "function",
+      "name": "validatorSummariesStep",
+      "filePath": "plugins/hyperliquid/steps/validator-summaries.ts",
+      "lineRange": [
+        19,
+        32
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid validatorSummaries query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/steps/vault-details.ts",
+      "type": "file",
+      "name": "vault-details.ts",
+      "filePath": "plugins/hyperliquid/steps/vault-details.ts",
+      "summary": "Hyperliquid plugin step that fetches vault details (allocations, performance, follower data) for a given vault EVM address with optional user context.",
+      "tags": [
+        "plugin",
+        "hyperliquid",
+        "step",
+        "api-handler",
+        "vault"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/vault-details.ts:vaultDetailsStep",
+      "type": "function",
+      "name": "vaultDetailsStep",
+      "filePath": "plugins/hyperliquid/steps/vault-details.ts",
+      "lineRange": [
+        45,
+        58
+      ],
+      "summary": "Exported workflow step entry that wraps stepHandler with metrics + logging for the Hyperliquid vaultDetails query.",
+      "tags": [
+        "step",
+        "entry-point",
+        "plugin",
+        "hyperliquid"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/steps/vault-details.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/hyperliquid/steps/vault-details.ts",
+      "lineRange": [
+        17,
+        42
+      ],
+      "summary": "Validates the vault EVM address and optional user address, then POSTs a vaultDetails query to the Hyperliquid Info API.",
+      "tags": [
+        "validation",
+        "api-handler",
+        "hyperliquid"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/clerk/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/clerk/credentials.ts",
+      "summary": "Declares the ClerkCredentials type used by all Clerk plugin steps, exposing the optional CLERK_SECRET_KEY field stored per project integration.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin",
+        "clerk"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/clerk/types.ts",
+      "type": "file",
+      "name": "types.ts",
+      "filePath": "plugins/clerk/types.ts",
+      "summary": "Defines Clerk API user shapes, the flattened ClerkUserData payload returned to workflows, and the toClerkUserData mapper that picks the primary email and renames snake_case fields to camelCase.",
+      "tags": [
+        "type-definition",
+        "serialization",
+        "plugin",
+        "clerk",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/clerk/steps/create-user.ts",
+      "type": "file",
+      "name": "create-user.ts",
+      "filePath": "plugins/clerk/steps/create-user.ts",
+      "summary": "Workflow step that creates a Clerk user via POST /v1/users, validating credentials, parsing optional public/private metadata JSON, and returning the normalized ClerkUserData on success.",
+      "tags": [
+        "plugin",
+        "clerk",
+        "api-handler",
+        "workflow-step",
+        "user-management"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the 'use step' directive so the workflow bundler treats clerkCreateUserStep as a deployable step boundary; maxRetries is forced to 0 to avoid duplicate-user creation on retry."
+    },
+    {
+      "id": "file:plugins/clerk/steps/delete-user.ts",
+      "type": "file",
+      "name": "delete-user.ts",
+      "filePath": "plugins/clerk/steps/delete-user.ts",
+      "summary": "Workflow step that deletes a Clerk user by ID via DELETE /v1/users/{id}, returning a typed success/error result and surfacing the first Clerk API error message on non-2xx responses.",
+      "tags": [
+        "plugin",
+        "clerk",
+        "api-handler",
+        "workflow-step",
+        "user-management"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "'use step' directive plus maxRetries = 0 prevents repeated destructive calls if the executor retries the node."
+    },
+    {
+      "id": "file:plugins/clerk/steps/get-user.ts",
+      "type": "file",
+      "name": "get-user.ts",
+      "filePath": "plugins/clerk/steps/get-user.ts",
+      "summary": "Workflow step that fetches a Clerk user via GET /v1/users/{id}, normalizing the response through toClerkUserData and returning a discriminated union ClerkUserResult.",
+      "tags": [
+        "plugin",
+        "clerk",
+        "api-handler",
+        "workflow-step",
+        "user-lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/clerk/steps/update-user.ts",
+      "type": "file",
+      "name": "update-user.ts",
+      "filePath": "plugins/clerk/steps/update-user.ts",
+      "summary": "Workflow step that updates a Clerk user via PATCH /v1/users/{id}, conditionally including first/last name and JSON-parsed public/private metadata in the request body.",
+      "tags": [
+        "plugin",
+        "clerk",
+        "api-handler",
+        "workflow-step",
+        "user-management"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Treats firstName/lastName as 'set when defined' (including empty string) but only includes metadata when truthy and JSON-parseable."
+    },
+    {
+      "id": "function:plugins/clerk/types.ts:toClerkUserData",
+      "type": "function",
+      "name": "toClerkUserData",
+      "filePath": "plugins/clerk/types.ts",
+      "lineRange": [
+        35,
+        47
+      ],
+      "summary": "Maps a raw Clerk API user object into the flat ClerkUserData shape used by workflow steps, resolving the primary email address from the email_addresses list.",
+      "tags": [
+        "serialization",
+        "mapper",
+        "clerk",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/clerk/steps/create-user.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/clerk/steps/create-user.ts",
+      "lineRange": [
+        26,
+        115
+      ],
+      "summary": "Portable core handler that validates inputs and credentials, builds the Clerk create-user payload (optionally parsing metadata JSON), and calls Clerk's POST /v1/users endpoint with bearer auth.",
+      "tags": [
+        "api-handler",
+        "validation",
+        "clerk",
+        "plugin-core"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/clerk/steps/create-user.ts:clerkCreateUserStep",
+      "type": "function",
+      "name": "clerkCreateUserStep",
+      "filePath": "plugins/clerk/steps/create-user.ts",
+      "lineRange": [
+        120,
+        130
+      ],
+      "summary": "Workflow-bundler step entry point that resolves project-level Clerk credentials and delegates to stepHandler, wrapped in withStepLogging for execution telemetry.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "clerk",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/clerk/steps/delete-user.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/clerk/steps/delete-user.ts",
+      "lineRange": [
+        24,
+        79
+      ],
+      "summary": "Core handler that validates the secret key and user ID, then issues a DELETE request to Clerk's /v1/users/{id} endpoint and shapes success/error into the standard step result.",
+      "tags": [
+        "api-handler",
+        "validation",
+        "clerk",
+        "plugin-core"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/clerk/steps/delete-user.ts:clerkDeleteUserStep",
+      "type": "function",
+      "name": "clerkDeleteUserStep",
+      "filePath": "plugins/clerk/steps/delete-user.ts",
+      "lineRange": [
+        84,
+        94
+      ],
+      "summary": "Workflow step entry that fetches Clerk credentials by integrationId and invokes the delete-user handler under withStepLogging.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "clerk",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/clerk/steps/get-user.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/clerk/steps/get-user.ts",
+      "lineRange": [
+        21,
+        76
+      ],
+      "summary": "Core handler that validates credentials and user ID, calls Clerk's GET /v1/users/{id}, and returns the normalized ClerkUserData (via toClerkUserData) or a structured error.",
+      "tags": [
+        "api-handler",
+        "validation",
+        "clerk",
+        "plugin-core",
+        "user-lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/clerk/steps/get-user.ts:clerkGetUserStep",
+      "type": "function",
+      "name": "clerkGetUserStep",
+      "filePath": "plugins/clerk/steps/get-user.ts",
+      "lineRange": [
+        81,
+        91
+      ],
+      "summary": "Workflow step entry that resolves Clerk credentials from the integration store and delegates to the get-user handler with logging instrumentation.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "clerk",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/clerk/steps/update-user.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/clerk/steps/update-user.ts",
+      "lineRange": [
+        25,
+        112
+      ],
+      "summary": "Core handler that conditionally assembles an update payload (name fields plus optional JSON-parsed metadata) and PATCHes it to Clerk's /v1/users/{id} endpoint, returning normalized user data on success.",
+      "tags": [
+        "api-handler",
+        "validation",
+        "clerk",
+        "plugin-core"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/clerk/steps/update-user.ts:clerkUpdateUserStep",
+      "type": "function",
+      "name": "clerkUpdateUserStep",
+      "filePath": "plugins/clerk/steps/update-user.ts",
+      "lineRange": [
+        117,
+        127
+      ],
+      "summary": "Workflow step entry that resolves Clerk credentials by integrationId and runs the update-user handler under withStepLogging telemetry.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "clerk",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/approve-token-core.ts",
+      "type": "file",
+      "name": "approve-token-core.ts",
+      "filePath": "plugins/web3/steps/approve-token-core.ts",
+      "summary": "Core ERC20 approve(spender, amount) logic shared by the web3 approve-token workflow step and the direct execution API; handles signer routing across EOA, Safe, and Safe-role modes plus optional ERC-4337 gas sponsorship and Flashbots private-mempool routing.",
+      "tags": [
+        "web3",
+        "service",
+        "transaction",
+        "erc20",
+        "signer-routing"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Plugin core-file pattern: contains no \"use step\" directive so it can export helpers without breaking the workflow bundler."
+    },
+    {
+      "id": "function:plugins/web3/steps/approve-token-core.ts:approveTokenCore",
+      "type": "function",
+      "name": "approveTokenCore",
+      "filePath": "plugins/web3/steps/approve-token-core.ts",
+      "lineRange": [
+        100,
+        487
+      ],
+      "summary": "Executes an ERC20 approve call with validation, decimals-aware amount parsing (including \"max\"), explorer link enrichment, revert classification, and dispatch across EOA / Safe / Safe-role signer modes with optional gas sponsorship.",
+      "tags": [
+        "transaction",
+        "erc20",
+        "approval",
+        "signer-dispatch",
+        "exported"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/approve-token.ts",
+      "type": "file",
+      "name": "approve-token.ts",
+      "filePath": "plugins/web3/steps/approve-token.ts",
+      "summary": "Workflow step wrapper that enriches the input with a spender explorer link, then delegates to approveTokenCore under the \"use step\" directive with retries disabled.",
+      "tags": [
+        "web3",
+        "step",
+        "wrapper",
+        "workflow",
+        "erc20"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Step file contract: declares `\"use step\"` and exports only the step function, types, and `_integrationType`."
+    },
+    {
+      "id": "function:plugins/web3/steps/approve-token.ts:approveTokenStep",
+      "type": "function",
+      "name": "approveTokenStep",
+      "filePath": "plugins/web3/steps/approve-token.ts",
+      "lineRange": [
+        26,
+        52
+      ],
+      "summary": "Workflow-bundler step entry that resolves chain explorer config, enriches the input with a spender address link for logging, and invokes approveTokenCore through withStepLogging.",
+      "tags": [
+        "step",
+        "workflow-entry",
+        "logging-enrichment",
+        "exported"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/check-allowance.ts",
+      "type": "file",
+      "name": "check-allowance.ts",
+      "filePath": "plugins/web3/steps/check-allowance.ts",
+      "summary": "Web3 step that reads ERC20 allowance(owner, spender) along with token decimals and symbol, using the chain adapter's RPC failover and structured user error logging.",
+      "tags": [
+        "web3",
+        "step",
+        "read-contract",
+        "erc20",
+        "allowance"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-allowance.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/check-allowance.ts",
+      "lineRange": [
+        51,
+        159
+      ],
+      "summary": "Validates network, token, owner, and spender inputs; resolves an RPC provider with user-scoped failover; and reads allowance, decimals, and symbol from the ERC20 contract in a single failover-protected batch.",
+      "tags": [
+        "validation",
+        "rpc-failover",
+        "erc20",
+        "read-only"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-allowance.ts:checkAllowanceStep",
+      "type": "function",
+      "name": "checkAllowanceStep",
+      "filePath": "plugins/web3/steps/check-allowance.ts",
+      "lineRange": [
+        166,
+        172
+      ],
+      "summary": "Workflow-bundler step entry that wraps the internal stepHandler in withStepLogging under the \"use step\" directive.",
+      "tags": [
+        "step",
+        "workflow-entry",
+        "wrapper",
+        "exported"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/transfer-token-core.ts",
+      "type": "file",
+      "name": "transfer-token-core.ts",
+      "filePath": "plugins/web3/steps/transfer-token-core.ts",
+      "summary": "Core ERC20 transfer logic shared between the web3 transfer-token step and the direct execution API, including a token-config parser that normalizes new and legacy formats and a transfer dispatcher across EOA, Safe, Safe-role, sponsored, and private-mempool paths.",
+      "tags": [
+        "web3",
+        "service",
+        "transaction",
+        "erc20",
+        "signer-routing"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Source of the shared parseTokenAddress helper reused by approve-token-core and check-allowance to keep token-config parsing consistent across steps."
+    },
+    {
+      "id": "function:plugins/web3/steps/transfer-token-core.ts:parseTokenAddress",
+      "type": "function",
+      "name": "parseTokenAddress",
+      "filePath": "plugins/web3/steps/transfer-token-core.ts",
+      "lineRange": [
+        91,
+        190
+      ],
+      "summary": "Normalizes the tokenConfig input across legacy and current shapes (supportedTokenId, custom token, raw address, JSON or object) and resolves it to a concrete on-chain token address for the given chainId.",
+      "tags": [
+        "parsing",
+        "token-config",
+        "backwards-compat",
+        "exported",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/transfer-token-core.ts:transferTokenCore",
+      "type": "function",
+      "name": "transferTokenCore",
+      "filePath": "plugins/web3/steps/transfer-token-core.ts",
+      "lineRange": [
+        199,
+        585
+      ],
+      "summary": "Performs an ERC20 transfer with full input validation, decimals-aware amount parsing, revert classification, and signer routing across EOA, Safe, and Safe-role modes with optional ERC-4337 sponsorship or Flashbots private-mempool delivery.",
+      "tags": [
+        "transaction",
+        "erc20",
+        "transfer",
+        "signer-dispatch",
+        "exported"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/transfer-token.ts",
+      "type": "file",
+      "name": "transfer-token.ts",
+      "filePath": "plugins/web3/steps/transfer-token.ts",
+      "summary": "Workflow step wrapper that enriches the input with a recipient explorer link, then delegates to transferTokenCore under the \"use step\" directive with retries disabled.",
+      "tags": [
+        "web3",
+        "step",
+        "wrapper",
+        "workflow",
+        "erc20"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/transfer-token.ts:transferTokenStep",
+      "type": "function",
+      "name": "transferTokenStep",
+      "filePath": "plugins/web3/steps/transfer-token.ts",
+      "lineRange": [
+        26,
+        52
+      ],
+      "summary": "Workflow-bundler step entry that resolves the chain explorer config, enriches the input with a recipient address link for logging, and invokes transferTokenCore through withStepLogging.",
+      "tags": [
+        "step",
+        "workflow-entry",
+        "logging-enrichment",
+        "exported"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webflow/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/webflow/credentials.ts",
+      "summary": "Declares the WebflowCredentials type carrying the WEBFLOW_API_KEY used by Webflow plugin step handlers.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin",
+        "webflow"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webflow/steps/get-site.ts",
+      "type": "file",
+      "name": "get-site.ts",
+      "filePath": "plugins/webflow/steps/get-site.ts",
+      "summary": "Workflow step that fetches metadata for a single Webflow site (display name, preview URL, custom domains) via the Webflow v2 REST API using the stored API key.",
+      "tags": [
+        "plugin",
+        "webflow",
+        "workflow-step",
+        "api-handler",
+        "integration"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the 'use step' directive and exports _integrationType as required by the KeeperHub workflow bundler; sets maxRetries = 0 on the step function."
+    },
+    {
+      "id": "function:plugins/webflow/steps/get-site.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/webflow/steps/get-site.ts",
+      "lineRange": [
+        55,
+        119
+      ],
+      "summary": "Internal handler that validates the API key plus siteId, calls Webflow's GET /sites/{id} endpoint, and shapes the response into a success or error result.",
+      "tags": [
+        "api-handler",
+        "webflow",
+        "fetch",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/webflow/steps/get-site.ts:getSiteStep",
+      "type": "function",
+      "name": "getSiteStep",
+      "filePath": "plugins/webflow/steps/get-site.ts",
+      "lineRange": [
+        121,
+        131
+      ],
+      "summary": "Exported workflow step entry point: resolves the integration credentials and invokes the get-site handler under withStepLogging instrumentation.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "webflow",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webflow/steps/list-sites.ts",
+      "type": "file",
+      "name": "list-sites.ts",
+      "filePath": "plugins/webflow/steps/list-sites.ts",
+      "summary": "Workflow step that lists all Webflow sites accessible to the configured API key and returns a normalized summary including custom domain URLs.",
+      "tags": [
+        "plugin",
+        "webflow",
+        "workflow-step",
+        "api-handler",
+        "integration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/webflow/steps/list-sites.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/webflow/steps/list-sites.ts",
+      "lineRange": [
+        48,
+        103
+      ],
+      "summary": "Internal handler that calls Webflow's GET /sites endpoint and maps each site (with custom domains) into a stable summary shape, surfacing HTTP errors as structured failures.",
+      "tags": [
+        "api-handler",
+        "webflow",
+        "fetch",
+        "data-mapping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/webflow/steps/list-sites.ts:listSitesStep",
+      "type": "function",
+      "name": "listSitesStep",
+      "filePath": "plugins/webflow/steps/list-sites.ts",
+      "lineRange": [
+        105,
+        115
+      ],
+      "summary": "Exported workflow step entry point: resolves credentials by integrationId then invokes the list-sites handler under withStepLogging.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "webflow",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webflow/steps/publish-site.ts",
+      "type": "file",
+      "name": "publish-site.ts",
+      "filePath": "plugins/webflow/steps/publish-site.ts",
+      "summary": "Workflow step that publishes a Webflow site by POSTing to /sites/{id}/publish, optionally restricting publication to a comma-separated list of custom domain IDs.",
+      "tags": [
+        "plugin",
+        "webflow",
+        "workflow-step",
+        "api-handler",
+        "integration"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Parses the comma-separated customDomainIds input client-side and serializes it into the Webflow publish payload via JSON.stringify."
+    },
+    {
+      "id": "function:plugins/webflow/steps/publish-site.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/webflow/steps/publish-site.ts",
+      "lineRange": [
+        37,
+        125
+      ],
+      "summary": "Internal handler that validates credentials and siteId, splits the optional customDomainIds string, calls Webflow's publish endpoint, and returns the published-domain summary or a structured error.",
+      "tags": [
+        "api-handler",
+        "webflow",
+        "fetch",
+        "publishing",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/webflow/steps/publish-site.ts:publishSiteStep",
+      "type": "function",
+      "name": "publishSiteStep",
+      "filePath": "plugins/webflow/steps/publish-site.ts",
+      "lineRange": [
+        127,
+        137
+      ],
+      "summary": "Exported workflow step entry point: resolves credentials by integrationId then invokes the publish-site handler under withStepLogging.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "webflow",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/protocol/steps/protocol-read.ts",
+      "type": "file",
+      "name": "protocol-read.ts",
+      "filePath": "plugins/protocol/steps/protocol-read.ts",
+      "summary": "Workflow step that performs a read-only contract call for any registered protocol action by resolving its metadata, ABI, contract address, and arguments before delegating to readContractCore.",
+      "tags": [
+        "plugin",
+        "workflow-step",
+        "web3",
+        "read",
+        "protocol"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the workflow bundler 'use step' directive; only the step function and _integrationType may be exported."
+    },
+    {
+      "id": "function:plugins/protocol/steps/protocol-read.ts:buildFunctionArgs",
+      "type": "function",
+      "name": "buildFunctionArgs",
+      "filePath": "plugins/protocol/steps/protocol-read.ts",
+      "lineRange": [
+        26,
+        61
+      ],
+      "summary": "Maps the step's named inputs onto the protocol action's declared input order, applying encode transforms and returning a JSON-stringified positional argument array.",
+      "tags": [
+        "utility",
+        "argument-builder",
+        "protocol",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/protocol/steps/protocol-read.ts:protocolReadStep",
+      "type": "function",
+      "name": "protocolReadStep",
+      "filePath": "plugins/protocol/steps/protocol-read.ts",
+      "lineRange": [
+        63,
+        142
+      ],
+      "summary": "Exported workflow step that resolves protocol metadata, contract address, ABI, and arguments, then delegates to readContractCore to execute an on-chain view call.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "read",
+        "web3"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/protocol/steps/protocol-write.ts",
+      "type": "file",
+      "name": "protocol-write.ts",
+      "filePath": "plugins/protocol/steps/protocol-write.ts",
+      "summary": "Workflow step that executes a state-changing contract call for a registered protocol action, including Uniswap native-ETH preflight checks, ethValue sanitization against non-payable ABIs, and Flashbots private-mempool support.",
+      "tags": [
+        "plugin",
+        "workflow-step",
+        "web3",
+        "write",
+        "protocol"
+      ],
+      "complexity": "complex",
+      "languageNotes": "maxRetries pinned to 0 because writes are non-idempotent; preflights run before any RPC or Etherscan I/O to fail fast on misconfiguration."
+    },
+    {
+      "id": "function:plugins/protocol/steps/protocol-write.ts:resolveEthValue",
+      "type": "function",
+      "name": "resolveEthValue",
+      "filePath": "plugins/protocol/steps/protocol-write.ts",
+      "lineRange": [
+        42,
+        89
+      ],
+      "summary": "Sanitizes a user-supplied ethValue by dropping it when the resolved ABI function is positively non-payable, preventing stale form state from triggering opaque on-chain reverts.",
+      "tags": [
+        "validation",
+        "abi",
+        "payable",
+        "sanitization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/protocol/steps/protocol-write.ts:checkUniswapNativeEthPreflight",
+      "type": "function",
+      "name": "checkUniswapNativeEthPreflight",
+      "filePath": "plugins/protocol/steps/protocol-write.ts",
+      "lineRange": [
+        100,
+        160
+      ],
+      "summary": "KEEP-408 preflight that rejects Uniswap swap configurations setting ETH Value with a tokenIn that is not the chain's WETH address, preventing native ETH from being stranded in SwapRouter02.",
+      "tags": [
+        "validation",
+        "preflight",
+        "uniswap",
+        "safety"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/protocol/steps/protocol-write.ts:buildFunctionArgs",
+      "type": "function",
+      "name": "buildFunctionArgs",
+      "filePath": "plugins/protocol/steps/protocol-write.ts",
+      "lineRange": [
+        162,
+        197
+      ],
+      "summary": "Maps the step's named inputs onto the protocol action's declared input order for write calls, applying encode transforms and returning a JSON-stringified positional argument array.",
+      "tags": [
+        "utility",
+        "argument-builder",
+        "protocol",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "type": "function",
+      "name": "protocolWriteStep",
+      "filePath": "plugins/protocol/steps/protocol-write.ts",
+      "lineRange": [
+        199,
+        298
+      ],
+      "summary": "Exported workflow step that resolves protocol metadata, runs Uniswap preflight, resolves ABI, sanitizes ethValue, builds args, and dispatches to writeContractCore with private-mempool and strict-mode forwarding.",
+      "tags": [
+        "entry-point",
+        "workflow-step",
+        "write",
+        "web3"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+      "type": "file",
+      "name": "resolve-protocol-meta.ts",
+      "filePath": "plugins/protocol/steps/resolve-protocol-meta.ts",
+      "summary": "Shared helper that resolves a ProtocolMeta record from a workflow node's _actionType (authoritative) or falls back to the cached _protocolMeta JSON for legacy nodes.",
+      "tags": [
+        "utility",
+        "protocol",
+        "metadata",
+        "resolver"
+      ],
+      "complexity": "simple",
+      "languageNotes": "No 'use step' directive; safely importable from multiple step files because it's a regular module."
+    },
+    {
+      "id": "function:plugins/protocol/steps/resolve-protocol-meta.ts:deriveFromActionType",
+      "type": "function",
+      "name": "deriveFromActionType",
+      "filePath": "plugins/protocol/steps/resolve-protocol-meta.ts",
+      "lineRange": [
+        13,
+        37
+      ],
+      "summary": "Parses a 'protocolSlug/actionSlug' action type and consults the protocol registry to return the contract key, function name, and action type.",
+      "tags": [
+        "utility",
+        "parser",
+        "protocol-registry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/protocol/steps/resolve-protocol-meta.ts:resolveProtocolMeta",
+      "type": "function",
+      "name": "resolveProtocolMeta",
+      "filePath": "plugins/protocol/steps/resolve-protocol-meta.ts",
+      "lineRange": [
+        50,
+        72
+      ],
+      "summary": "Public resolver that prefers _actionType to reflect the current workflow selection, falling back to parsing the cached _protocolMeta JSON snapshot when needed.",
+      "tags": [
+        "entry-point",
+        "resolver",
+        "protocol",
+        "metadata"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/safe/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/safe/credentials.ts",
+      "summary": "Single-line type alias declaring SafeCredentials as a string-keyed credentials map for the Safe (Gnosis) plugin.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin",
+        "safe"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/safe/steps/get-pending-transactions.ts",
+      "type": "file",
+      "name": "get-pending-transactions.ts",
+      "filePath": "plugins/safe/steps/get-pending-transactions.ts",
+      "summary": "Workflow step that fetches pending multisig transactions from the Safe Transaction Service for a given Safe address and chain, optionally filtering by signer, and normalizes the response into a pending-transactions list.",
+      "tags": [
+        "plugin",
+        "step",
+        "safe",
+        "api-handler",
+        "multisig"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses the `use step` directive inside the exported step function; helper utilities (getSafeChainSlug, stepHandler) are kept module-private per plugin step-file rules."
+    },
+    {
+      "id": "function:plugins/safe/steps/get-pending-transactions.ts:getSafeChainSlug",
+      "type": "function",
+      "name": "getSafeChainSlug",
+      "filePath": "plugins/safe/steps/get-pending-transactions.ts",
+      "lineRange": [
+        91,
+        106
+      ],
+      "summary": "Maps EVM chain IDs to Safe Transaction Service EIP-3770 chain slugs (eth, base, arb1, etc.) used to build the unified Safe API URL.",
+      "tags": [
+        "utility",
+        "chain-mapping",
+        "safe"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/safe/steps/get-pending-transactions.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/safe/steps/get-pending-transactions.ts",
+      "lineRange": [
+        108,
+        275
+      ],
+      "summary": "Validates the Safe address/network/credentials, calls the Safe Transaction Service for queued transactions and Safe info concurrently with a 15s timeout, then filters by signer and shapes the pending-transactions result.",
+      "tags": [
+        "handler",
+        "validation",
+        "safe",
+        "http",
+        "filter"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/safe/steps/get-pending-transactions.ts:getPendingTransactionsStep",
+      "type": "function",
+      "name": "getPendingTransactionsStep",
+      "filePath": "plugins/safe/steps/get-pending-transactions.ts",
+      "lineRange": [
+        277,
+        292
+      ],
+      "summary": "Exported workflow step entrypoint that loads credentials, wraps the handler in plugin metrics and step logging, and invokes stepHandler with the user input.",
+      "tags": [
+        "entry-point",
+        "step",
+        "safe",
+        "metrics",
+        "logging"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/safe/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/safe/test.ts",
+      "summary": "Integration connection test for the Safe plugin that hits the Safe Transaction Service /about/ endpoint with the configured API key to verify the credential works.",
+      "tags": [
+        "plugin",
+        "connection-test",
+        "safe",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/safe/test.ts:testSafe",
+      "type": "function",
+      "name": "testSafe",
+      "filePath": "plugins/safe/test.ts",
+      "lineRange": [
+        3,
+        36
+      ],
+      "summary": "Performs an authenticated GET against the Safe Transaction Service /about/ endpoint and returns a success/error result used by the credentials UI to validate the API key.",
+      "tags": [
+        "connection-test",
+        "api-handler",
+        "safe"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/v0/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/v0/credentials.ts",
+      "summary": "Declares the V0Credentials TypeScript type that models the optional V0_API_KEY used by the v0 plugin steps to authenticate against the v0-sdk.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin",
+        "v0"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/v0/steps/create-chat.ts",
+      "type": "file",
+      "name": "create-chat.ts",
+      "filePath": "plugins/v0/steps/create-chat.ts",
+      "summary": "Workflow step that creates a new v0 chat session via the v0-sdk, returning the new chat id, web URL, and optional demo URL or a structured error.",
+      "tags": [
+        "plugin",
+        "step",
+        "v0",
+        "api-handler",
+        "ai"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the 'use step' directive so the workflow bundler treats createChatStep as a step entry point; helper stepHandler is intentionally not exported per plugin rules."
+    },
+    {
+      "id": "function:plugins/v0/steps/create-chat.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/v0/steps/create-chat.ts",
+      "lineRange": [
+        26,
+        60
+      ],
+      "summary": "Core (non-exported) handler that validates the API key, calls v0-sdk chats.create, and maps the response to a CreateChatResult success/error union.",
+      "tags": [
+        "handler",
+        "v0",
+        "sdk-call",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/v0/steps/create-chat.ts:createChatStep",
+      "type": "function",
+      "name": "createChatStep",
+      "filePath": "plugins/v0/steps/create-chat.ts",
+      "lineRange": [
+        65,
+        75
+      ],
+      "summary": "Exported workflow step entry point that fetches plugin credentials when an integrationId is present and runs stepHandler under withStepLogging instrumentation.",
+      "tags": [
+        "step",
+        "entry-point",
+        "v0",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/v0/steps/send-message.ts",
+      "type": "file",
+      "name": "send-message.ts",
+      "filePath": "plugins/v0/steps/send-message.ts",
+      "summary": "Workflow step that sends a follow-up message to an existing v0 chat via the v0-sdk and returns the updated chat id plus optional demo URL.",
+      "tags": [
+        "plugin",
+        "step",
+        "v0",
+        "api-handler",
+        "ai"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Mirrors the create-chat step structure: 'use step' directive marks sendMessageStep, while the stepHandler helper stays module-private per plugin rules."
+    },
+    {
+      "id": "function:plugins/v0/steps/send-message.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/v0/steps/send-message.ts",
+      "lineRange": [
+        26,
+        59
+      ],
+      "summary": "Core (non-exported) handler that checks for the API key, calls v0-sdk chats.sendMessage with chatId and message, and returns a structured success/error result.",
+      "tags": [
+        "handler",
+        "v0",
+        "sdk-call",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/v0/steps/send-message.ts:sendMessageStep",
+      "type": "function",
+      "name": "sendMessageStep",
+      "filePath": "plugins/v0/steps/send-message.ts",
+      "lineRange": [
+        64,
+        74
+      ],
+      "summary": "Exported workflow step entry point that resolves credentials when integrationId is provided and runs stepHandler under withStepLogging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "v0",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/assess-risk.ts",
+      "type": "file",
+      "name": "assess-risk.ts",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "summary": "Web3 workflow step that assesses on-chain transaction risk by combining deterministic rule-based heuristics (approvals, privileged ops, value, interaction) with an optional LLM scoring pass, returning a normalised risk level, score, and reasoning.",
+      "tags": [
+        "web3-plugin",
+        "workflow-step",
+        "risk-assessment",
+        "security",
+        "llm"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Step file follows the KeeperHub workflow plugin convention: keeps helpers module-private, exports only the step function and `_integrationType`, and wraps the handler with `withPluginMetrics` + `withStepLogging`."
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:isUnlimitedValue",
+      "type": "function",
+      "name": "isUnlimitedValue",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        98,
+        107
+      ],
+      "summary": "Detects whether a numeric string represents an unlimited token amount by matching MAX_UINT256 in decimal or hex form.",
+      "tags": [
+        "utility",
+        "validation",
+        "approval"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:checkApprovalRisks",
+      "type": "function",
+      "name": "checkApprovalRisks",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        109,
+        150
+      ],
+      "summary": "Inspects ERC-20 approval-style calls (approve, increaseAllowance, permit) and emits risk factors for unlimited amounts and approvals to the zero address.",
+      "tags": [
+        "risk-rule",
+        "approval",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:checkPrivilegedOps",
+      "type": "function",
+      "name": "checkPrivilegedOps",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        152,
+        178
+      ],
+      "summary": "Flags privileged contract operations such as ownership transfer, upgrade, and emergency-withdraw functions with critical or high risk levels.",
+      "tags": [
+        "risk-rule",
+        "privileged-ops",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:checkValueRisks",
+      "type": "function",
+      "name": "checkValueRisks",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        180,
+        201
+      ],
+      "summary": "Adds risk factors when the native value of a transaction exceeds the large-value threshold, parsing the value safely.",
+      "tags": [
+        "risk-rule",
+        "value",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:checkInteractionRisks",
+      "type": "function",
+      "name": "checkInteractionRisks",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        203,
+        239
+      ],
+      "summary": "Evaluates interaction-shape risks such as sending funds to the zero address, calling unknown contracts, or invoking unknown selectors.",
+      "tags": [
+        "risk-rule",
+        "interaction",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:computeRiskFromFactors",
+      "type": "function",
+      "name": "computeRiskFromFactors",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        247,
+        261
+      ],
+      "summary": "Aggregates a list of risk factors into a single weighted score and the highest observed risk level.",
+      "tags": [
+        "risk-scoring",
+        "utility",
+        "aggregation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:scoreToLevel",
+      "type": "function",
+      "name": "scoreToLevel",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        263,
+        274
+      ],
+      "summary": "Maps a numeric risk score onto the discrete low/medium/high/critical risk levels using fixed thresholds.",
+      "tags": [
+        "risk-scoring",
+        "utility",
+        "mapping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:buildLlmPrompt",
+      "type": "function",
+      "name": "buildLlmPrompt",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        284,
+        321
+      ],
+      "summary": "Assembles the LLM prompt used for security-grade transaction analysis, embedding the decoded function, parameters, rule findings, and contextual fields.",
+      "tags": [
+        "llm",
+        "prompt-engineering",
+        "risk-assessment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:parseLlmResponse",
+      "type": "function",
+      "name": "parseLlmResponse",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        323,
+        341
+      ],
+      "summary": "Parses the LLM JSON response into a validated risk assessment structure, clamping the score and defaulting reasoning when missing.",
+      "tags": [
+        "llm",
+        "parsing",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:callLlmAssessment",
+      "type": "function",
+      "name": "callLlmAssessment",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        343,
+        398
+      ],
+      "summary": "Calls the configured LLM endpoint with a bounded timeout to score transaction risk, returning the parsed assessment or a fail-closed marker on error.",
+      "tags": [
+        "llm",
+        "external-call",
+        "timeout",
+        "risk-assessment"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:buildRulesOnlyResult",
+      "type": "function",
+      "name": "buildRulesOnlyResult",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        402,
+        419
+      ],
+      "summary": "Builds the final risk result when LLM scoring is disabled or unavailable, relying solely on deterministic rule factors.",
+      "tags": [
+        "risk-result",
+        "fallback",
+        "rules"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:buildFailClosedResult",
+      "type": "function",
+      "name": "buildFailClosedResult",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        421,
+        438
+      ],
+      "summary": "Produces a fail-closed risk result that escalates the level when the LLM call fails, preferring caution over silent downgrades.",
+      "tags": [
+        "risk-result",
+        "fail-closed",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        442,
+        545
+      ],
+      "summary": "Internal handler orchestrating calldata decoding, deterministic rule evaluation, and optional LLM assessment to produce the structured risk report consumed by workflows.",
+      "tags": [
+        "handler",
+        "orchestration",
+        "risk-assessment"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/assess-risk.ts:assessRiskStep",
+      "type": "function",
+      "name": "assessRiskStep",
+      "filePath": "plugins/web3/steps/assess-risk.ts",
+      "lineRange": [
+        552,
+        565
+      ],
+      "summary": "Exported workflow step that wraps `stepHandler` with plugin metrics and step logging; registered as the web3 plugin's assess-risk action.",
+      "tags": [
+        "workflow-step",
+        "entry-point",
+        "web3-plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "type": "file",
+      "name": "decode-calldata-core.ts",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "summary": "Shared core library for decoding raw EVM transaction calldata into a function name and named parameters using a manually supplied ABI, the chain's block explorer, or the 4byte signature directory in turn.",
+      "tags": [
+        "web3-plugin",
+        "calldata",
+        "abi-decoding",
+        "shared-core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Intentionally NOT a step file (no `\"use step\"` directive) so its helpers can be re-exported and shared between multiple step files without confusing the workflow bundler."
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:serializeValue",
+      "type": "function",
+      "name": "serializeValue",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        48,
+        64
+      ],
+      "summary": "Converts a decoded ABI value (including BigInt, arrays, and plain objects) into a stable string representation suitable for downstream display.",
+      "tags": [
+        "utility",
+        "serialization",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:extractParameters",
+      "type": "function",
+      "name": "extractParameters",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        69,
+        82
+      ],
+      "summary": "Walks an ethers `FunctionFragment` together with parsed arguments to produce the named, typed parameter list returned by the decode step.",
+      "tags": [
+        "utility",
+        "abi",
+        "parsing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWithAbi",
+      "type": "function",
+      "name": "tryDecodeWithAbi",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        87,
+        109
+      ],
+      "summary": "Attempts to parse calldata against a given ABI using `ethers.Interface`, returning the decoded fragment plus extracted parameters or null on failure.",
+      "tags": [
+        "decoding",
+        "abi",
+        "ethers"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:fetch4byteSignatures",
+      "type": "function",
+      "name": "fetch4byteSignatures",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        119,
+        132
+      ],
+      "summary": "Queries the public 4byte.directory API for human-readable function signatures matching a given selector.",
+      "tags": [
+        "external-api",
+        "signature-lookup",
+        "decoding"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWith4byte",
+      "type": "function",
+      "name": "tryDecodeWith4byte",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        137,
+        161
+      ],
+      "summary": "Iterates candidate signatures from 4byte.directory and returns the first one that successfully parses the given calldata.",
+      "tags": [
+        "decoding",
+        "signature-lookup",
+        "fallback"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:fetchAbiFromExplorer",
+      "type": "function",
+      "name": "fetchAbiFromExplorer",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        166,
+        195
+      ],
+      "summary": "Resolves the configured block explorer for a chain and fetches the verified contract ABI for the given address, returning null when unsupported.",
+      "tags": [
+        "external-api",
+        "explorer",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:validateCalldata",
+      "type": "function",
+      "name": "validateCalldata",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        200,
+        214
+      ],
+      "summary": "Validates that the input calldata is a non-empty 0x-prefixed hex string of plausible length, returning a normalized lowercase form or an error.",
+      "tags": [
+        "validation",
+        "calldata",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:tryManualAbi",
+      "type": "function",
+      "name": "tryManualAbi",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        219,
+        239
+      ],
+      "summary": "Decoding strategy that uses an ABI supplied directly by the user, parsing the JSON and delegating to the ABI decoder.",
+      "tags": [
+        "decoding",
+        "strategy",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:tryExplorerStrategy",
+      "type": "function",
+      "name": "tryExplorerStrategy",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        244,
+        267
+      ],
+      "summary": "Decoding strategy that resolves the contract ABI from the chain's block explorer (when address + network are provided) and decodes against it.",
+      "tags": [
+        "decoding",
+        "strategy",
+        "explorer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:try4byteStrategy",
+      "type": "function",
+      "name": "try4byteStrategy",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        272,
+        296
+      ],
+      "summary": "Final-fallback decoding strategy that resolves the function name from 4byte.directory, returning at minimum a selector-and-name pair when full decoding is impossible.",
+      "tags": [
+        "decoding",
+        "strategy",
+        "fallback"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "type": "function",
+      "name": "decodeCalldata",
+      "filePath": "plugins/web3/steps/decode-calldata-core.ts",
+      "lineRange": [
+        307,
+        371
+      ],
+      "summary": "Public entry point that validates the calldata, extracts its selector, and chains the manual-ABI, explorer, and 4byte decoding strategies until one succeeds.",
+      "tags": [
+        "entry-point",
+        "decoding",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/decode-calldata.ts",
+      "type": "file",
+      "name": "decode-calldata.ts",
+      "filePath": "plugins/web3/steps/decode-calldata.ts",
+      "summary": "Thin workflow-step wrapper around `decodeCalldata` that exposes calldata decoding as a web3 plugin action with fail-safe retry behaviour (maxRetries = 0).",
+      "tags": [
+        "web3-plugin",
+        "workflow-step",
+        "calldata",
+        "entry-point"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Re-exports core types so workflow consumers can import the decode result types from the step file directly."
+    },
+    {
+      "id": "function:plugins/web3/steps/decode-calldata.ts:decodeCalldataStep",
+      "type": "function",
+      "name": "decodeCalldataStep",
+      "filePath": "plugins/web3/steps/decode-calldata.ts",
+      "lineRange": [
+        24,
+        37
+      ],
+      "summary": "Workflow step that decodes raw transaction calldata into a human-readable function call, wrapped with plugin metrics and step logging.",
+      "tags": [
+        "workflow-step",
+        "entry-point",
+        "calldata"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:plugins/AGENTS.md",
+      "type": "document",
+      "name": "AGENTS.md",
+      "filePath": "plugins/AGENTS.md",
+      "summary": "Comprehensive plugin development guide for AI agents, covering plugin architecture, the index.ts/credentials.ts/steps/test.ts/icon.tsx file layout, config field types, naming conventions, error handling patterns, and submission workflow with reference plugins (web3, sendgrid, discord, webhook).",
+      "tags": [
+        "documentation",
+        "plugin-development",
+        "agent-guide",
+        "architecture",
+        "reference"
+      ],
+      "complexity": "complex",
+      "languageNotes": "25 H2/H3 sections spanning ~390 non-empty lines; serves as the canonical contributor handbook for adding new workflow plugins."
+    },
+    {
+      "id": "document:plugins/CLAUDE.md",
+      "type": "document",
+      "name": "CLAUDE.md",
+      "filePath": "plugins/CLAUDE.md",
+      "summary": "Plugin-specific Claude Code rules supplementing the root CLAUDE.md, codifying the 'use step' directive constraints, the *-core.ts shared-logic pattern, signer routing with RPC failover, plugin registration, testing expectations, and lint rules.",
+      "tags": [
+        "documentation",
+        "plugin-standards",
+        "ai-instructions",
+        "conventions",
+        "step-files"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Critical rules section warns that exporting helpers from a 'use step' file pulls all transitive deps into the workflow runtime and breaks the production bundle."
+    },
+    {
+      "id": "config:plugins/plugin-allowlist.json",
+      "type": "config",
+      "name": "plugin-allowlist.json",
+      "filePath": "plugins/plugin-allowlist.json",
+      "summary": "Runtime allowlist controlling which workflow plugins are enabled at startup: blockscout, code, discord, hyperliquid, math, protocol, safe, sendgrid, slack, telegram, web3, and webhook.",
+      "tags": [
+        "configuration",
+        "plugin-registry",
+        "feature-gating",
+        "allowlist"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:plugins/plugin-allowlist.schema.json",
+      "type": "config",
+      "name": "plugin-allowlist.schema.json",
+      "filePath": "plugins/plugin-allowlist.schema.json",
+      "summary": "JSON Schema (draft-07) that validates plugin-allowlist.json, requiring a plugins array of unique string entries plus an optional description field.",
+      "tags": [
+        "configuration",
+        "json-schema",
+        "validation",
+        "schema-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/_template/credentials.ts.txt",
+      "type": "file",
+      "name": "credentials.ts.txt",
+      "filePath": "plugins/_template/credentials.ts.txt",
+      "summary": "Starter template for a new plugin's credentials type definition; copied and renamed to credentials.ts when scaffolding a new integration. Inert until copied (stored as .txt to avoid TypeScript compilation).",
+      "tags": [
+        "scaffolding",
+        "template",
+        "credentials",
+        "plugin-starter"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses placeholder tokens like [IntegrationName] and [INTEGRATION_NAME] that get substituted during plugin scaffolding."
+    },
+    {
+      "id": "file:plugins/_template/icon.tsx.txt",
+      "type": "file",
+      "name": "icon.tsx.txt",
+      "filePath": "plugins/_template/icon.tsx.txt",
+      "summary": "Starter template for a new plugin's React icon component (SVG); copied and renamed to icon.tsx when scaffolding a new integration. Includes guidance comments pointing authors at simpleicons.org.",
+      "tags": [
+        "scaffolding",
+        "template",
+        "icon",
+        "plugin-starter",
+        "ui-component"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/_template/index.ts.txt",
+      "type": "file",
+      "name": "index.ts.txt",
+      "filePath": "plugins/_template/index.ts.txt",
+      "summary": "Starter template for a new plugin's main definition file (IntegrationPlugin object + registerIntegration call); copied and renamed to index.ts when scaffolding a new integration. Documents the full action/configFields/testConfig surface.",
+      "tags": [
+        "scaffolding",
+        "template",
+        "plugin-definition",
+        "plugin-starter",
+        "entry-point"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Heavy use of bracketed placeholders ([integration-type], [actionName]Step, etc.) intended for find-and-replace during plugin generation."
+    },
+    {
+      "id": "file:plugins/_template/test.ts.txt",
+      "type": "file",
+      "name": "test.ts.txt",
+      "filePath": "plugins/_template/test.ts.txt",
+      "summary": "Starter template for a new plugin's connection-test function (lazy-loaded by index.ts's testConfig.getTestFunction); copied and renamed to test.ts when scaffolding a new integration.",
+      "tags": [
+        "scaffolding",
+        "template",
+        "connection-test",
+        "plugin-starter",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:plugins/_template/steps/action.ts.txt",
+      "type": "document",
+      "name": "action.ts.txt",
+      "filePath": "plugins/_template/steps/action.ts.txt",
+      "summary": "Annotated step-file template documenting the canonical KeeperHub plugin step structure: stepHandler core logic, exported wrapper with logging/metrics, and credential typing.",
+      "tags": [
+        "documentation",
+        "template",
+        "plugin-development",
+        "scaffolding"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/ai-gateway/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/ai-gateway/test.ts",
+      "summary": "Placeholder integration connection test for the AI Gateway plugin that always reports success without making any external calls.",
+      "tags": [
+        "test",
+        "plugin",
+        "ai-gateway",
+        "stub"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/ai-gateway/test.ts:testConnection",
+      "type": "function",
+      "name": "testConnection",
+      "filePath": "plugins/ai-gateway/test.ts",
+      "lineRange": [
+        1,
+        9
+      ],
+      "summary": "Default stub connection test for the AI Gateway plugin returning a fixed success response.",
+      "tags": [
+        "test",
+        "stub",
+        "connection-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/blockscout/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/blockscout/test.ts",
+      "summary": "Validates Blockscout API connectivity by issuing a stats query against the configured explorer URL with an optional API key.",
+      "tags": [
+        "test",
+        "plugin",
+        "blockscout",
+        "connection-test",
+        "explorer"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/blockscout/test.ts:testBlockscout",
+      "type": "function",
+      "name": "testBlockscout",
+      "filePath": "plugins/blockscout/test.ts",
+      "lineRange": [
+        4,
+        38
+      ],
+      "summary": "Pings the Blockscout v1 stats endpoint with the user's API URL and key to confirm the explorer integration is reachable.",
+      "tags": [
+        "test",
+        "blockscout",
+        "http-request",
+        "credential-validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/clerk/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/clerk/test.ts",
+      "summary": "Verifies Clerk API connectivity by validating the secret-key prefix and probing the Clerk users endpoint with bearer authentication.",
+      "tags": [
+        "test",
+        "plugin",
+        "clerk",
+        "connection-test",
+        "authentication"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/clerk/test.ts:testClerk",
+      "type": "function",
+      "name": "testClerk",
+      "filePath": "plugins/clerk/test.ts",
+      "lineRange": [
+        1,
+        48
+      ],
+      "summary": "Validates Clerk credentials by checking the sk_ prefix on the secret key and issuing a paginated request against the users endpoint.",
+      "tags": [
+        "test",
+        "clerk",
+        "credential-validation",
+        "http-request"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/code/steps/run-code.ts",
+      "type": "file",
+      "name": "run-code.ts",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "summary": "Sandboxed Code-plugin step that executes user-authored JavaScript in a hardened child Node process (or remote isolate) with import bans, timeout enforcement, and structured error normalization.",
+      "tags": [
+        "plugin",
+        "code-execution",
+        "sandbox",
+        "step-handler",
+        "security"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses child_process.spawn with environment scrubbing and a sentinel-delimited stdin/stdout protocol to safely serialize user code results back to the workflow runtime."
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:extractLineNumber",
+      "type": "function",
+      "name": "extractLineNumber",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        53,
+        63
+      ],
+      "summary": "Parses a JavaScript error stack trace to recover the 1-indexed source line where the user's code threw.",
+      "tags": [
+        "utility",
+        "error-handling",
+        "parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:buildChildEnv",
+      "type": "function",
+      "name": "buildChildEnv",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        74,
+        83
+      ],
+      "summary": "Constructs a minimal scrubbed environment for the sandbox child process, exposing only PATH and NODE_OPTIONS.",
+      "tags": [
+        "utility",
+        "sandbox",
+        "security",
+        "environment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:parseChildOutput",
+      "type": "function",
+      "name": "parseChildOutput",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        94,
+        115
+      ],
+      "summary": "Locates the result sentinel in child stdout, decodes the base64-serialized payload, and splits captured console logs from the result blob.",
+      "tags": [
+        "serialization",
+        "parsing",
+        "sandbox",
+        "child-process"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:runInChild",
+      "type": "function",
+      "name": "runInChild",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        118,
+        197
+      ],
+      "summary": "Spawns the sandbox Node child, wires stdout/stderr capture and a timeout watchdog, and resolves with either the parsed result or a structured failure.",
+      "tags": [
+        "sandbox",
+        "child-process",
+        "timeout",
+        "execution"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements its own once-only finish() guard to avoid double-resolving the result promise when stdout, error, exit, and timeout races overlap."
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:validateInput",
+      "type": "function",
+      "name": "validateInput",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        204,
+        221
+      ],
+      "summary": "Rejects empty code and statically scans for import/require/dynamic-import patterns outside string literals to enforce the no-imports sandbox policy.",
+      "tags": [
+        "validation",
+        "security",
+        "sandbox",
+        "static-analysis"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:runLocal",
+      "type": "function",
+      "name": "runLocal",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        229,
+        266
+      ],
+      "summary": "Local execution path that delegates to runInChild, classifies failures (timeout vs. runtime), and emits structured logUserError diagnostics with line numbers.",
+      "tags": [
+        "sandbox",
+        "execution",
+        "error-handling",
+        "step-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:normalizeRemoteError",
+      "type": "function",
+      "name": "normalizeRemoteError",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        276,
+        297
+      ],
+      "summary": "Translates outcomes from the remote isolate executor into the standard CodeStepResult shape, mapping timeout markers to user-facing messages.",
+      "tags": [
+        "error-handling",
+        "normalization",
+        "remote-execution"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        299,
+        317
+      ],
+      "summary": "Step entry point: validates input, clamps the timeout, then dispatches to either remote isolate or local child execution depending on configuration.",
+      "tags": [
+        "step-handler",
+        "dispatch",
+        "sandbox",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/code/steps/run-code.ts:runCodeStep",
+      "type": "function",
+      "name": "runCodeStep",
+      "filePath": "plugins/code/steps/run-code.ts",
+      "lineRange": [
+        320,
+        331
+      ],
+      "summary": "Exported Run Code step wrapping stepHandler with plugin metrics and step-logging instrumentation per KeeperHub plugin conventions.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/code/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/code/test.ts",
+      "summary": "Sanity test for the Code plugin runtime: instantiates a vm context and runs a trivial expression to confirm Node's vm module is available.",
+      "tags": [
+        "test",
+        "plugin",
+        "code",
+        "connection-test",
+        "sandbox"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/code/test.ts:testCode",
+      "type": "function",
+      "name": "testCode",
+      "filePath": "plugins/code/test.ts",
+      "lineRange": [
+        3,
+        22
+      ],
+      "summary": "Validates that the Code plugin's vm sandbox can compile and execute a basic 2+2 expression and reports success or a parse-time failure.",
+      "tags": [
+        "test",
+        "sandbox",
+        "vm",
+        "connection-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/cowswap/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "plugins/cowswap/index.ts",
+      "summary": "CoW Swap plugin definition wiring the six orderbook actions (quote, create-order, cancel-order, order-status, trades, account-orders) with their config and output field schemas.",
+      "tags": [
+        "plugin",
+        "entry-point",
+        "cowswap",
+        "defi",
+        "integration-definition"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Pure declarative action manifest -- no runtime functions defined here; tree-sitter therefore reports zero functions despite the 271 lines."
+    },
+    {
+      "id": "file:plugins/cowswap/steps/cancel-order.ts",
+      "type": "file",
+      "name": "cancel-order.ts",
+      "filePath": "plugins/cowswap/steps/cancel-order.ts",
+      "summary": "Cancels a CoW Swap order off-chain by issuing a DELETE against the orderbook API for the resolved chain.",
+      "tags": [
+        "plugin",
+        "cowswap",
+        "step-handler",
+        "defi",
+        "order-management"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/cancel-order.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/cowswap/steps/cancel-order.ts",
+      "lineRange": [
+        29,
+        111
+      ],
+      "summary": "Validates inputs, resolves the CoW orderbook URL for the chain, and issues the DELETE /orders/:uid request with abortable timeout and structured error reporting.",
+      "tags": [
+        "step-handler",
+        "cowswap",
+        "http-request",
+        "order-management"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/cancel-order.ts:cancelOrderStep",
+      "type": "function",
+      "name": "cancelOrderStep",
+      "filePath": "plugins/cowswap/steps/cancel-order.ts",
+      "lineRange": [
+        113,
+        126
+      ],
+      "summary": "Exported Cancel Order step that wraps stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/cowswap/steps/create-order.ts",
+      "type": "file",
+      "name": "create-order.ts",
+      "filePath": "plugins/cowswap/steps/create-order.ts",
+      "summary": "Submits a signed CoW Swap order to the orderbook API after parsing the user-supplied signed-order JSON payload.",
+      "tags": [
+        "plugin",
+        "cowswap",
+        "step-handler",
+        "defi",
+        "order-submission"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/create-order.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/cowswap/steps/create-order.ts",
+      "lineRange": [
+        29,
+        126
+      ],
+      "summary": "Parses the signed order JSON, resolves the orderbook URL for the chain, POSTs the order, and surfaces the returned order UID or a structured error.",
+      "tags": [
+        "step-handler",
+        "cowswap",
+        "http-request",
+        "order-submission"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/create-order.ts:createOrderStep",
+      "type": "function",
+      "name": "createOrderStep",
+      "filePath": "plugins/cowswap/steps/create-order.ts",
+      "lineRange": [
+        128,
+        141
+      ],
+      "summary": "Exported Create Order step wrapping stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/cowswap/steps/get-account-orders.ts",
+      "type": "file",
+      "name": "get-account-orders.ts",
+      "filePath": "plugins/cowswap/steps/get-account-orders.ts",
+      "summary": "Lists CoW Swap orders for a given account by paging GET /account/:address/orders on the orderbook API.",
+      "tags": [
+        "plugin",
+        "cowswap",
+        "step-handler",
+        "defi",
+        "data-query"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-account-orders.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/cowswap/steps/get-account-orders.ts",
+      "lineRange": [
+        30,
+        115
+      ],
+      "summary": "Resolves chain orderbook URL, builds a paginated query string, fetches account orders with timeout, and shapes the response into the step output.",
+      "tags": [
+        "step-handler",
+        "cowswap",
+        "http-request",
+        "pagination"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-account-orders.ts:getAccountOrdersStep",
+      "type": "function",
+      "name": "getAccountOrdersStep",
+      "filePath": "plugins/cowswap/steps/get-account-orders.ts",
+      "lineRange": [
+        117,
+        130
+      ],
+      "summary": "Exported Get Account Orders step wrapping stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/cowswap/steps/get-order-status.ts",
+      "type": "file",
+      "name": "get-order-status.ts",
+      "filePath": "plugins/cowswap/steps/get-order-status.ts",
+      "summary": "Fetches the status of a single CoW Swap order by UID and surfaces convenience flags (executed/filled/expired) on top of the raw orderbook response.",
+      "tags": [
+        "plugin",
+        "cowswap",
+        "step-handler",
+        "defi",
+        "order-status"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-order-status.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/cowswap/steps/get-order-status.ts",
+      "lineRange": [
+        43,
+        134
+      ],
+      "summary": "Resolves the chain orderbook URL, fetches GET /orders/:uid, then derives executed/filled/expired booleans from the response amounts and status string.",
+      "tags": [
+        "step-handler",
+        "cowswap",
+        "http-request",
+        "status-derivation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-order-status.ts:getOrderStatusStep",
+      "type": "function",
+      "name": "getOrderStatusStep",
+      "filePath": "plugins/cowswap/steps/get-order-status.ts",
+      "lineRange": [
+        136,
+        149
+      ],
+      "summary": "Exported Get Order Status step wrapping stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/cowswap/steps/get-quote.ts",
+      "type": "file",
+      "name": "get-quote.ts",
+      "filePath": "plugins/cowswap/steps/get-quote.ts",
+      "summary": "Requests a CoW Swap price quote for a token-pair swap, posting the trade parameters to the orderbook /quote endpoint for the resolved chain.",
+      "tags": [
+        "plugin",
+        "cowswap",
+        "step-handler",
+        "defi",
+        "quoting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-quote.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/cowswap/steps/get-quote.ts",
+      "lineRange": [
+        47,
+        151
+      ],
+      "summary": "Builds and POSTs the quote request body (sell/buy token, amount, kind, receiver) to the chain's CoW orderbook and returns the priced quote.",
+      "tags": [
+        "step-handler",
+        "cowswap",
+        "http-request",
+        "quoting"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-quote.ts:getQuoteStep",
+      "type": "function",
+      "name": "getQuoteStep",
+      "filePath": "plugins/cowswap/steps/get-quote.ts",
+      "lineRange": [
+        153,
+        164
+      ],
+      "summary": "Exported Get Quote step wrapping stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/cowswap/steps/get-trades.ts",
+      "type": "file",
+      "name": "get-trades.ts",
+      "filePath": "plugins/cowswap/steps/get-trades.ts",
+      "summary": "Fetches trade executions for a CoW Swap order or owner by querying the orderbook /trades endpoint for the resolved chain.",
+      "tags": [
+        "plugin",
+        "cowswap",
+        "step-handler",
+        "defi",
+        "trades-query"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-trades.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/cowswap/steps/get-trades.ts",
+      "lineRange": [
+        29,
+        111
+      ],
+      "summary": "Resolves the CoW orderbook URL for the chain, builds the /trades query for either owner or orderUid, fetches with timeout, and returns the trade list.",
+      "tags": [
+        "step-handler",
+        "cowswap",
+        "http-request",
+        "trades-query"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/cowswap/steps/get-trades.ts:getTradesStep",
+      "type": "function",
+      "name": "getTradesStep",
+      "filePath": "plugins/cowswap/steps/get-trades.ts",
+      "lineRange": [
+        113,
+        126
+      ],
+      "summary": "Exported Get Trades step wrapping stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/discord/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/discord/credentials.ts",
+      "summary": "Type definition for Discord plugin credentials, modeled as an open string-keyed record because webhook URLs are stored under user-defined slugs.",
+      "tags": [
+        "plugin",
+        "discord",
+        "type-definition",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/discord/steps/send-message.ts",
+      "type": "file",
+      "name": "send-message.ts",
+      "filePath": "plugins/discord/steps/send-message.ts",
+      "summary": "Posts a chat message to a Discord channel via a configured incoming webhook URL with optional username/avatar overrides and basic webhook-URL validation.",
+      "tags": [
+        "plugin",
+        "discord",
+        "step-handler",
+        "webhook",
+        "messaging"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/discord/steps/send-message.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/discord/steps/send-message.ts",
+      "lineRange": [
+        34,
+        139
+      ],
+      "summary": "Validates the webhook URL pattern, POSTs the message payload to Discord's webhook endpoint, and normalizes success/error responses into the step result shape.",
+      "tags": [
+        "step-handler",
+        "discord",
+        "webhook",
+        "http-request",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/discord/steps/send-message.ts:sendDiscordMessageStep",
+      "type": "function",
+      "name": "sendDiscordMessageStep",
+      "filePath": "plugins/discord/steps/send-message.ts",
+      "lineRange": [
+        144,
+        159
+      ],
+      "summary": "Exported Send Discord Message step that fetches user credentials and wraps stepHandler in plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/discord/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/discord/test.ts",
+      "summary": "Stub connection test for the Discord plugin -- webhooks have no test endpoint, so this always reports success.",
+      "tags": [
+        "test",
+        "plugin",
+        "discord",
+        "stub"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/discord/test.ts:testDiscord",
+      "type": "function",
+      "name": "testDiscord",
+      "filePath": "plugins/discord/test.ts",
+      "lineRange": [
+        1,
+        5
+      ],
+      "summary": "No-op Discord credential test that returns a fixed success result.",
+      "tags": [
+        "test",
+        "stub",
+        "connection-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/hyperliquid/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/hyperliquid/test.ts",
+      "summary": "Validates Hyperliquid API connectivity by issuing a metadata query against the public info endpoint -- no credentials are required.",
+      "tags": [
+        "test",
+        "plugin",
+        "hyperliquid",
+        "connection-test",
+        "defi"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/hyperliquid/test.ts:testHyperliquid",
+      "type": "function",
+      "name": "testHyperliquid",
+      "filePath": "plugins/hyperliquid/test.ts",
+      "lineRange": [
+        4,
+        28
+      ],
+      "summary": "POSTs a meta info request to the Hyperliquid public API and reports the connection as successful if the JSON response shape is valid.",
+      "tags": [
+        "test",
+        "hyperliquid",
+        "http-request",
+        "connection-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/linear/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/linear/credentials.ts",
+      "summary": "Type definition for the Linear plugin's credentials, currently just the LINEAR_API_KEY bearer token.",
+      "tags": [
+        "plugin",
+        "linear",
+        "type-definition",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/linear/steps/find-issues.ts",
+      "type": "file",
+      "name": "find-issues.ts",
+      "filePath": "plugins/linear/steps/find-issues.ts",
+      "summary": "Queries the Linear GraphQL API to search issues by team, status, assignee, label, or free-text filters and returns a normalized issue list.",
+      "tags": [
+        "plugin",
+        "linear",
+        "step-handler",
+        "graphql",
+        "issue-search"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/linear/steps/find-issues.ts:linearQuery",
+      "type": "function",
+      "name": "linearQuery",
+      "filePath": "plugins/linear/steps/find-issues.ts",
+      "lineRange": [
+        57,
+        76
+      ],
+      "summary": "POSTs a GraphQL query and variables to the Linear API with bearer auth and returns the parsed JSON payload.",
+      "tags": [
+        "utility",
+        "graphql",
+        "http-request",
+        "linear"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/linear/steps/find-issues.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/linear/steps/find-issues.ts",
+      "lineRange": [
+        81,
+        169
+      ],
+      "summary": "Composes the Linear GraphQL issue filter from input fields (team, state, assignee, labels, search, dates), executes the query, and shapes the result for downstream steps.",
+      "tags": [
+        "step-handler",
+        "linear",
+        "graphql",
+        "filtering",
+        "issue-search"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/linear/steps/find-issues.ts:findIssuesStep",
+      "type": "function",
+      "name": "findIssuesStep",
+      "filePath": "plugins/linear/steps/find-issues.ts",
+      "lineRange": [
+        174,
+        184
+      ],
+      "summary": "Exported Find Linear Issues step that fetches credentials and wraps stepHandler with step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/math/steps/aggregate.ts",
+      "type": "file",
+      "name": "aggregate.ts",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "summary": "Aggregate math step that parses arrays or explicit numeric inputs, performs sum/mean/median/min/max/count operations (with BigInt-aware arithmetic), and applies optional unary or binary post-operations.",
+      "tags": [
+        "plugin",
+        "math",
+        "step-handler",
+        "aggregation",
+        "bigint"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses a discriminated NumericValue union and a pluggable arithmetic adapter so the same aggregation pipeline runs over either Number or BigInt without losing precision."
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:sanitizeRawValueToString",
+      "type": "function",
+      "name": "sanitizeRawValueToString",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        174,
+        186
+      ],
+      "summary": "Coerces an unknown raw input into a trimmed comma-stripped string suitable for numeric parsing, preserving finite numbers and BigInts.",
+      "tags": [
+        "utility",
+        "normalization",
+        "parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:parseStringToNumericValue",
+      "type": "function",
+      "name": "parseStringToNumericValue",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        188,
+        201
+      ],
+      "summary": "Parses a cleaned numeric string into either a BigInt (for safe integers) or a finite Number, returning null when the value is non-numeric.",
+      "tags": [
+        "utility",
+        "parsing",
+        "bigint",
+        "numeric"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:resolveFieldPath",
+      "type": "function",
+      "name": "resolveFieldPath",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        222,
+        235
+      ],
+      "summary": "Walks a dot-delimited path through a nested object/array structure and returns the resolved leaf value or undefined.",
+      "tags": [
+        "utility",
+        "object-traversal",
+        "field-path"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:parseJsonToArray",
+      "type": "function",
+      "name": "parseJsonToArray",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        239,
+        256
+      ],
+      "summary": "Accepts a JSON-encoded string or an already-parsed array and normalizes the input to a plain JavaScript array, throwing a descriptive error on malformed input.",
+      "tags": [
+        "utility",
+        "parsing",
+        "json",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:collectNumericValues",
+      "type": "function",
+      "name": "collectNumericValues",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        258,
+        271
+      ],
+      "summary": "Walks an items array, applies the optional field-path resolver, parses each entry to a NumericValue, and collects the parseable results.",
+      "tags": [
+        "utility",
+        "extraction",
+        "numeric"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:extractExplicitValues",
+      "type": "function",
+      "name": "extractExplicitValues",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        281,
+        291
+      ],
+      "summary": "Splits a comma-or-newline-separated string of user-typed values and parses each into a NumericValue, dropping unparseable entries.",
+      "tags": [
+        "utility",
+        "extraction",
+        "parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:reduceValues",
+      "type": "function",
+      "name": "reduceValues",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        307,
+        317
+      ],
+      "summary": "Generic numeric reducer over a homogeneous Number or BigInt array with a starting accumulator, used by sum/product/min/max paths.",
+      "tags": [
+        "utility",
+        "reducer",
+        "aggregation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:findExtremeValue",
+      "type": "function",
+      "name": "findExtremeValue",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        319,
+        330
+      ],
+      "summary": "Iterates values and returns either the minimum or maximum based on a supplied less-than comparator, enabling BigInt-safe min/max.",
+      "tags": [
+        "utility",
+        "min-max",
+        "aggregation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:computeMedian",
+      "type": "function",
+      "name": "computeMedian",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        332,
+        342
+      ],
+      "summary": "Sorts the numeric values ascending and returns the middle element (or average of the two middles) using the supplied arithmetic adapter.",
+      "tags": [
+        "utility",
+        "median",
+        "aggregation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:computeAggregation",
+      "type": "function",
+      "name": "computeAggregation",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        344,
+        388
+      ],
+      "summary": "Dispatches to the right aggregation routine (sum, mean, median, min, max, count, product) for the selected operation using the arithmetic adapter.",
+      "tags": [
+        "aggregation",
+        "dispatch",
+        "math",
+        "core-logic"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:applyBinaryPostOperation",
+      "type": "function",
+      "name": "applyBinaryPostOperation",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        392,
+        423
+      ],
+      "summary": "Applies a binary post-operation (add, subtract, multiply, divide, modulo, percent, round) to the aggregated value using the supplied operand.",
+      "tags": [
+        "post-processing",
+        "math",
+        "binary-operation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:applyUnaryPostOperation",
+      "type": "function",
+      "name": "applyUnaryPostOperation",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        425,
+        441
+      ],
+      "summary": "Applies a unary post-operation (abs, round, floor, ceil, negate) to the aggregated value.",
+      "tags": [
+        "post-processing",
+        "math",
+        "unary-operation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:applyPostOperation",
+      "type": "function",
+      "name": "applyPostOperation",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        443,
+        457
+      ],
+      "summary": "Routes a post-operation request to either the binary or unary applier based on the operation kind.",
+      "tags": [
+        "post-processing",
+        "dispatch",
+        "math"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:parseInputValues",
+      "type": "function",
+      "name": "parseInputValues",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        461,
+        485
+      ],
+      "summary": "Top-level input parser that picks between the explicit values string and the array+fieldPath path, returning either parsed numeric values or a failure result.",
+      "tags": [
+        "parsing",
+        "input-validation",
+        "dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:validatePostOperation",
+      "type": "function",
+      "name": "validatePostOperation",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        487,
+        516
+      ],
+      "summary": "Validates the optional post-operation choice, requires an operand for binary operations, and parses the operand to a number.",
+      "tags": [
+        "validation",
+        "input-validation",
+        "post-processing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        527,
+        610
+      ],
+      "summary": "Orchestrates the aggregate step: validates operation, parses inputs, picks BigInt vs Number arithmetic, runs aggregation, applies post-operation, and returns the labelled string result.",
+      "tags": [
+        "step-handler",
+        "aggregation",
+        "math",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/math/steps/aggregate.ts:aggregateStep",
+      "type": "function",
+      "name": "aggregateStep",
+      "filePath": "plugins/math/steps/aggregate.ts",
+      "lineRange": [
+        614,
+        627
+      ],
+      "summary": "Exported Aggregate step wrapping stepHandler with plugin metrics and step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/math/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/math/test.ts",
+      "summary": "Stub connection test for the Math plugin -- there is no external service so this always returns success.",
+      "tags": [
+        "test",
+        "plugin",
+        "math",
+        "stub"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/math/test.ts:testMath",
+      "type": "function",
+      "name": "testMath",
+      "filePath": "plugins/math/test.ts",
+      "lineRange": [
+        1,
+        6
+      ],
+      "summary": "No-op Math credential test that returns a fixed success result.",
+      "tags": [
+        "test",
+        "stub",
+        "connection-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/protocol/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/protocol/icon.tsx",
+      "summary": "Protocol-plugin icon helpers: a default Box-based fallback icon and a factory that builds a memoized Next.js Image-backed icon component from a static asset path.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "protocol",
+        "factory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/protocol/icon.tsx:ProtocolIcon",
+      "type": "function",
+      "name": "ProtocolIcon",
+      "filePath": "plugins/protocol/icon.tsx",
+      "lineRange": [
+        4,
+        10
+      ],
+      "summary": "Default lucide Box icon used when a protocol does not supply a bespoke icon.",
+      "tags": [
+        "component",
+        "icon",
+        "react",
+        "default"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/protocol/icon.tsx:createProtocolIconComponent",
+      "type": "function",
+      "name": "createProtocolIconComponent",
+      "filePath": "plugins/protocol/icon.tsx",
+      "lineRange": [
+        12,
+        29
+      ],
+      "summary": "Factory that builds a named React icon component rendering a 48x48 Next.js Image from the supplied iconPath asset.",
+      "tags": [
+        "factory",
+        "component",
+        "icon",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/resend/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/resend/credentials.ts",
+      "summary": "Type definition for Resend plugin credentials -- the API key and a default From address.",
+      "tags": [
+        "plugin",
+        "resend",
+        "type-definition",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/resend/steps/send-email.ts",
+      "type": "file",
+      "name": "send-email.ts",
+      "filePath": "plugins/resend/steps/send-email.ts",
+      "summary": "Sends transactional email through the Resend API using the configured API key and default From address with the user-supplied recipient, subject, and HTML body.",
+      "tags": [
+        "plugin",
+        "resend",
+        "step-handler",
+        "email",
+        "messaging"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/resend/steps/send-email.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/resend/steps/send-email.ts",
+      "lineRange": [
+        44,
+        111
+      ],
+      "summary": "Builds the Resend email payload, POSTs it to the API with bearer auth, and surfaces the returned message id or a structured error.",
+      "tags": [
+        "step-handler",
+        "resend",
+        "email",
+        "http-request"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/resend/steps/send-email.ts:sendEmailStep",
+      "type": "function",
+      "name": "sendEmailStep",
+      "filePath": "plugins/resend/steps/send-email.ts",
+      "lineRange": [
+        116,
+        131
+      ],
+      "summary": "Exported Send Email step that fetches Resend credentials and wraps stepHandler with step-logging instrumentation.",
+      "tags": [
+        "step-handler",
+        "exported",
+        "entry-point",
+        "instrumentation",
+        "credentials"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/resend/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/resend/test.ts",
+      "summary": "Validates Resend credentials by checking the re_ prefix on the API key and probing the /domains endpoint with bearer auth.",
+      "tags": [
+        "test",
+        "plugin",
+        "resend",
+        "connection-test",
+        "email"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/resend/test.ts:testResend",
+      "type": "function",
+      "name": "testResend",
+      "filePath": "plugins/resend/test.ts",
+      "lineRange": [
+        3,
+        42
+      ],
+      "summary": "Validates the Resend API key format and hits GET /domains to confirm the key is accepted by the Resend API.",
+      "tags": [
+        "test",
+        "resend",
+        "credential-validation",
+        "http-request"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/check-token-balance.ts",
+      "type": "file",
+      "name": "check-token-balance.ts",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "summary": "Workflow step that reads an ERC-20 balance for a wallet, supporting both the supportedTokens registry (by token ID) and ad-hoc custom token addresses, with bytes32-symbol fallback.",
+      "tags": [
+        "step",
+        "web3",
+        "erc20",
+        "balance",
+        "read"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/get-transaction.ts",
+      "type": "file",
+      "name": "get-transaction.ts",
+      "filePath": "plugins/web3/steps/get-transaction.ts",
+      "summary": "Workflow step that fetches a transaction by hash from the chain's RPC, validates the hash format, and returns normalized fields (from/to/value/gas/nonce) plus explorer links.",
+      "tags": [
+        "step",
+        "web3",
+        "rpc",
+        "transaction",
+        "read"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/query-events.ts",
+      "type": "file",
+      "name": "query-events.ts",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "summary": "Workflow step that scans EVM event logs for a contract over a resolved block range, batching getLogs calls and returning decoded args via ethers.Interface.parseLog.",
+      "tags": [
+        "step",
+        "web3",
+        "events",
+        "logs",
+        "rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/query-transactions-core.ts",
+      "type": "file",
+      "name": "query-transactions-core.ts",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "summary": "Core (non-step) logic for the query-transactions action: parses the ABI, resolves a block window, fetches contract transactions via the explorer, decodes function calls, and filters by argument values.",
+      "tags": [
+        "service",
+        "web3",
+        "transactions",
+        "decoder",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Lives outside any \"use step\" file so it can be re-used from both the workflow step and direct execution callers without triggering the workflow bundler's transitive-import rules."
+    },
+    {
+      "id": "file:plugins/web3/steps/query-transactions.ts",
+      "type": "file",
+      "name": "query-transactions.ts",
+      "filePath": "plugins/web3/steps/query-transactions.ts",
+      "summary": "Thin \"use step\" wrapper that exposes queryTransactionsCore as a workflow step with plugin metrics, step logging, and zero retries.",
+      "tags": [
+        "step",
+        "web3",
+        "wrapper",
+        "transactions"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/read-contract-core.ts",
+      "type": "file",
+      "name": "read-contract-core.ts",
+      "filePath": "plugins/web3/steps/read-contract-core.ts",
+      "summary": "Core (non-step) logic for read-contract: parses/validates the ABI and arguments, looks up the chain adapter, calls a view/pure function via an RPC provider, and formats results plus revert errors.",
+      "tags": [
+        "service",
+        "web3",
+        "rpc",
+        "abi",
+        "core"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/web3/steps/read-contract.ts",
+      "type": "file",
+      "name": "read-contract.ts",
+      "filePath": "plugins/web3/steps/read-contract.ts",
+      "summary": "Workflow step wrapper around readContractCore that enriches the execution log with an explorer link for the target contract address and disables retries.",
+      "tags": [
+        "step",
+        "web3",
+        "wrapper",
+        "read"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/sign-typed-data-core.ts",
+      "type": "file",
+      "name": "sign-typed-data-core.ts",
+      "filePath": "plugins/web3/steps/sign-typed-data-core.ts",
+      "summary": "Core (non-step) logic for EIP-712 typed-data signing: validates the payload shape, enforces a 32 KiB size cap, resolves the org's Turnkey wallet, and returns a typed signature plus signer address.",
+      "tags": [
+        "service",
+        "web3",
+        "eip-712",
+        "signing",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Routes through the org's Turnkey-backed wallet so signatures are produced inside KeeperHub's trust boundary instead of buyer-side KMS."
+    },
+    {
+      "id": "file:plugins/web3/steps/sign-typed-data.ts",
+      "type": "file",
+      "name": "sign-typed-data.ts",
+      "filePath": "plugins/web3/steps/sign-typed-data.ts",
+      "summary": "Workflow step wrapper around signTypedDataCore that adds plugin metrics and step logging. Hard-codes maxRetries=0 to prevent double-spend from retried signatures.",
+      "tags": [
+        "step",
+        "web3",
+        "wrapper",
+        "signing",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/transfer-funds-core.ts",
+      "type": "file",
+      "name": "transfer-funds-core.ts",
+      "filePath": "plugins/web3/steps/transfer-funds-core.ts",
+      "summary": "Core (non-step) logic for native-token transfers: resolves the signer mode (EOA / Safe / Safe role), routes through ERC-4337 sponsorship or a private mempool when applicable, manages nonces, and returns transaction metadata.",
+      "tags": [
+        "service",
+        "web3",
+        "transfer",
+        "signer",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements the canonical signer-routing pattern: resolveSignerForNode() dispatches between Safe role / Safe / EOA branches; ERC-4337 sponsorship is gated to EOA mode because bundlers swap msg.sender."
+    },
+    {
+      "id": "file:plugins/web3/steps/transfer-funds.ts",
+      "type": "file",
+      "name": "transfer-funds.ts",
+      "filePath": "plugins/web3/steps/transfer-funds.ts",
+      "summary": "Workflow step wrapper around transferFundsCore that enriches the execution log with a recipient explorer link and disables retries (security-critical).",
+      "tags": [
+        "step",
+        "web3",
+        "wrapper",
+        "transfer",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/write-contract-core.ts",
+      "type": "file",
+      "name": "write-contract-core.ts",
+      "filePath": "plugins/web3/steps/write-contract-core.ts",
+      "summary": "Core (non-step) logic for contract writes: validates the ABI and arguments, resolves Safe/Safe-role/EOA signing, attempts ERC-4337 sponsorship or private mempool when configured, sends and waits for the transaction, and decodes revert errors.",
+      "tags": [
+        "service",
+        "web3",
+        "write",
+        "signer",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses withNonceSession to serialize tx submission within a logical nonce window; classifyRevert distinguishes user rejections from on-chain reverts so the workflow surfaces actionable errors."
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        19,
+        33
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:extractSupportedTokenId",
+      "type": "function",
+      "name": "extractSupportedTokenId",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        81,
+        103
+      ],
+      "summary": "Parses the tokenConfig field to extract the supportedTokenId when mode=supported.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:extractCustomToken",
+      "type": "function",
+      "name": "extractCustomToken",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        110,
+        164
+      ],
+      "summary": "Parses the tokenConfig field to extract a CustomToken descriptor (address + optional decimals/symbol) when mode=custom.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:parseTokenConfig",
+      "type": "function",
+      "name": "parseTokenConfig",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        170,
+        214
+      ],
+      "summary": "Normalizes the tokenConfig input (string JSON or object), then dispatches to the supported or custom extractor based on mode.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:getTokenAddress",
+      "type": "function",
+      "name": "getTokenAddress",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        220,
+        247
+      ],
+      "summary": "Looks up the ERC-20 contract address for a supportedTokens row on the given chain.",
+      "tags": [
+        "utility",
+        "database",
+        "erc20"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:fetchStringOrBytes32",
+      "type": "function",
+      "name": "fetchStringOrBytes32",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        253,
+        275
+      ],
+      "summary": "Reads an ERC-20 string field (name/symbol) and falls back to decoding bytes32 for legacy tokens that don't return strings.",
+      "tags": [
+        "utility",
+        "erc20",
+        "rpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:fetchTokenBalance",
+      "type": "function",
+      "name": "fetchTokenBalance",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        280,
+        305
+      ],
+      "summary": "Reads an ERC-20 balanceOf result and pairs it with the token's decimals, symbol, and name for the response payload.",
+      "tags": [
+        "utility",
+        "erc20",
+        "rpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-token-balance.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/check-token-balance.ts",
+      "lineRange": [
+        310,
+        456
+      ],
+      "summary": "Internal handler that parses the token config, resolves the chain + address (supported or custom), reads the ERC-20 balance/decimals/symbol/name, and formats the response.",
+      "tags": [
+        "api-handler",
+        "erc20",
+        "balance"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/get-transaction.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/get-transaction.ts",
+      "lineRange": [
+        17,
+        31
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/get-transaction.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/get-transaction.ts",
+      "lineRange": [
+        57,
+        144
+      ],
+      "summary": "Internal handler that validates the tx hash format, fetches the transaction via the RPC provider, and returns normalized fields plus explorer links.",
+      "tags": [
+        "api-handler",
+        "web3",
+        "rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/get-transaction.ts:getTransactionStep",
+      "type": "function",
+      "name": "getTransactionStep",
+      "filePath": "plugins/web3/steps/get-transaction.ts",
+      "lineRange": [
+        151,
+        183
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics + step logging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "web3"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        18,
+        32
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:decodeEventArgs",
+      "type": "function",
+      "name": "decodeEventArgs",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        71,
+        81
+      ],
+      "summary": "Converts an ethers Result of event arguments into a plain Record<string, unknown> with BigInts serialized to strings.",
+      "tags": [
+        "utility",
+        "serialization",
+        "events"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:parseAbi",
+      "type": "function",
+      "name": "parseAbi",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        85,
+        103
+      ],
+      "summary": "Parses and validates a JSON-encoded ABI string for use with ethers.Interface.",
+      "tags": [
+        "utility",
+        "abi",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:parseBlockCount",
+      "type": "function",
+      "name": "parseBlockCount",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        105,
+        131
+      ],
+      "summary": "Validates and normalizes the blockCount input, returning the lookback window in blocks (default 6500).",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:resolveFromBlock",
+      "type": "function",
+      "name": "resolveFromBlock",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        133,
+        160
+      ],
+      "summary": "Resolves a starting block number from explicit fromBlock, blockCount, or the chain's tip minus the default lookback.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:resolveBlockRange",
+      "type": "function",
+      "name": "resolveBlockRange",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        162,
+        199
+      ],
+      "summary": "Combines resolveFromBlock with toBlock resolution to produce the final [fromBlock, toBlock] window for log queries.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:queryEventBatches",
+      "type": "function",
+      "name": "queryEventBatches",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        201,
+        238
+      ],
+      "summary": "Splits the block range into DEFAULT_BATCH_SIZE-sized windows and issues sequential getLogs calls, concatenating results.",
+      "tags": [
+        "service",
+        "rpc",
+        "events"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        240,
+        363
+      ],
+      "summary": "Internal handler that parses the ABI, resolves the block range, batches getLogs across that range, and decodes each event via ethers.Interface.parseLog.",
+      "tags": [
+        "api-handler",
+        "events",
+        "rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-events.ts:queryEventsStep",
+      "type": "function",
+      "name": "queryEventsStep",
+      "filePath": "plugins/web3/steps/query-events.ts",
+      "lineRange": [
+        365,
+        398
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics + step logging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "web3"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        60,
+        74
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:parseAbi",
+      "type": "function",
+      "name": "parseAbi",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        76,
+        107
+      ],
+      "summary": "Parses and validates a JSON-encoded ABI string for downstream function-call decoding.",
+      "tags": [
+        "utility",
+        "abi",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:parseBlockCount",
+      "type": "function",
+      "name": "parseBlockCount",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        109,
+        135
+      ],
+      "summary": "Validates and normalizes the blockCount input, returning the lookback window in blocks.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:resolveFromBlock",
+      "type": "function",
+      "name": "resolveFromBlock",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        137,
+        164
+      ],
+      "summary": "Resolves a starting block number from explicit fromBlock, blockCount, or the chain tip minus the default lookback.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:resolveBlockRange",
+      "type": "function",
+      "name": "resolveBlockRange",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        168,
+        204
+      ],
+      "summary": "Combines resolveFromBlock with toBlock resolution to produce the final block window for the explorer query.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:serializeValue",
+      "type": "function",
+      "name": "serializeValue",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        206,
+        225
+      ],
+      "summary": "Recursively converts BigInts and other non-JSON values within decoded function args into JSON-safe strings.",
+      "tags": [
+        "utility",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:decodeTransaction",
+      "type": "function",
+      "name": "decodeTransaction",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        229,
+        261
+      ],
+      "summary": "Decodes the calldata of a NormalizedTransaction against the supplied ABI, returning the function name + named args, or skipping non-matching txs.",
+      "tags": [
+        "utility",
+        "abi",
+        "transactions"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:matchesArgFilter",
+      "type": "function",
+      "name": "matchesArgFilter",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        263,
+        283
+      ],
+      "summary": "Tests whether a decoded transaction's args match a user-supplied filter map (supports single value, array of values, and string comparison).",
+      "tags": [
+        "utility",
+        "filtering"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:parseFunctionArgsFilter",
+      "type": "function",
+      "name": "parseFunctionArgsFilter",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        293,
+        322
+      ],
+      "summary": "Parses the functionArgs filter input (JSON string or object) into a normalized map ready for matchesArgFilter.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:filterAndDecodeTransactions",
+      "type": "function",
+      "name": "filterAndDecodeTransactions",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        324,
+        363
+      ],
+      "summary": "Walks the explorer's NormalizedTransaction array, calling decodeTransaction and matchesArgFilter to produce the final DecodedTransaction list.",
+      "tags": [
+        "service",
+        "transactions",
+        "filtering"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:validateInputs",
+      "type": "function",
+      "name": "validateInputs",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        371,
+        408
+      ],
+      "summary": "Validates network, contractAddress, abi, abiFunction and the optional block-window inputs before any RPC/explorer call.",
+      "tags": [
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions-core.ts:queryTransactionsCore",
+      "type": "function",
+      "name": "queryTransactionsCore",
+      "filePath": "plugins/web3/steps/query-transactions-core.ts",
+      "lineRange": [
+        410,
+        507
+      ],
+      "summary": "Top-level core driver that resolves the chain, fetches contract transactions via the explorer service, decodes calldata, filters by function args, and returns the result envelope.",
+      "tags": [
+        "service",
+        "entry-point",
+        "transactions"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/query-transactions.ts:queryTransactionsStep",
+      "type": "function",
+      "name": "queryTransactionsStep",
+      "filePath": "plugins/web3/steps/query-transactions.ts",
+      "lineRange": [
+        13,
+        26
+      ],
+      "summary": "Workflow step that wraps queryTransactionsCore in plugin metrics + step logging; maxRetries=0.",
+      "tags": [
+        "step",
+        "entry-point",
+        "wrapper"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/read-contract-core.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/read-contract-core.ts",
+      "lineRange": [
+        38,
+        52
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/read-contract-core.ts:readContractCore",
+      "type": "function",
+      "name": "readContractCore",
+      "filePath": "plugins/web3/steps/read-contract-core.ts",
+      "lineRange": [
+        60,
+        303
+      ],
+      "summary": "Exported core that parses/validates the ABI + arguments, looks up the chain adapter, calls the view/pure function via the RPC provider, and formats the result or decoded revert reason.",
+      "tags": [
+        "service",
+        "entry-point",
+        "web3",
+        "rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/read-contract.ts:readContractStep",
+      "type": "function",
+      "name": "readContractStep",
+      "filePath": "plugins/web3/steps/read-contract.ts",
+      "lineRange": [
+        22,
+        56
+      ],
+      "summary": "Workflow step that enriches the execution log with a contract-address explorer link and delegates to readContractCore. maxRetries=0.",
+      "tags": [
+        "step",
+        "entry-point",
+        "wrapper"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/sign-typed-data-core.ts:validateTypedData",
+      "type": "function",
+      "name": "validateTypedData",
+      "filePath": "plugins/web3/steps/sign-typed-data-core.ts",
+      "lineRange": [
+        67,
+        85
+      ],
+      "summary": "Type guard that verifies an unknown payload is a valid EIP-712 TypedData object (domain, types, primaryType, message).",
+      "tags": [
+        "utility",
+        "validation",
+        "eip-712"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/sign-typed-data-core.ts:signTypedDataCore",
+      "type": "function",
+      "name": "signTypedDataCore",
+      "filePath": "plugins/web3/steps/sign-typed-data-core.ts",
+      "lineRange": [
+        87,
+        198
+      ],
+      "summary": "Exported core that accepts an EIP-712 payload (object or JSON string), enforces a 32 KiB size cap, resolves the org's Turnkey wallet, and returns a signature + checksummed signer address with typed error codes.",
+      "tags": [
+        "service",
+        "entry-point",
+        "eip-712",
+        "signing"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/sign-typed-data.ts:signTypedDataStep",
+      "type": "function",
+      "name": "signTypedDataStep",
+      "filePath": "plugins/web3/steps/sign-typed-data.ts",
+      "lineRange": [
+        26,
+        39
+      ],
+      "summary": "Workflow step that wraps signTypedDataCore in plugin metrics + step logging. maxRetries=0 because retried signatures can enable downstream double-spend.",
+      "tags": [
+        "step",
+        "entry-point",
+        "wrapper",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/transfer-funds-core.ts:transferFundsCore",
+      "type": "function",
+      "name": "transferFundsCore",
+      "filePath": "plugins/web3/steps/transfer-funds-core.ts",
+      "lineRange": [
+        82,
+        411
+      ],
+      "summary": "Exported core that orchestrates native-token transfers: resolves signer mode (EOA / Safe / Safe role), optionally routes through ERC-4337 sponsorship or a private mempool, manages nonces via withNonceSession, and returns tx metadata or a classified rejection.",
+      "tags": [
+        "service",
+        "entry-point",
+        "web3",
+        "transfer"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/transfer-funds.ts:transferFundsStep",
+      "type": "function",
+      "name": "transferFundsStep",
+      "filePath": "plugins/web3/steps/transfer-funds.ts",
+      "lineRange": [
+        27,
+        61
+      ],
+      "summary": "Workflow step that enriches the execution log with a recipient explorer link and delegates to transferFundsCore. maxRetries=0 for security.",
+      "tags": [
+        "step",
+        "entry-point",
+        "wrapper",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/write-contract-core.ts:writeContractCore",
+      "type": "function",
+      "name": "writeContractCore",
+      "filePath": "plugins/web3/steps/write-contract-core.ts",
+      "lineRange": [
+        97,
+        519
+      ],
+      "summary": "Exported core that orchestrates contract writes: validates ABI + args, resolves Safe/Safe-role/EOA signer routing, attempts ERC-4337 sponsorship or private mempool when configured, sends and waits for the tx with nonce-session protection, and decodes revert errors.",
+      "tags": [
+        "service",
+        "entry-point",
+        "web3",
+        "write"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/safe/icon.tsx",
+      "type": "file",
+      "name": "icon.tsx",
+      "filePath": "plugins/safe/icon.tsx",
+      "summary": "Renders the Safe (Gnosis Safe) plugin icon as a lucide ShieldCheck SVG used in the plugin picker UI.",
+      "tags": [
+        "component",
+        "icon",
+        "ui",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/sendgrid/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/sendgrid/credentials.ts",
+      "summary": "Type definition for SendGrid plugin credentials, exposing the SENDGRID_API_KEY env-style field consumed by the send-email step.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/sendgrid/steps/send-email.ts",
+      "type": "file",
+      "name": "send-email.ts",
+      "filePath": "plugins/sendgrid/steps/send-email.ts",
+      "summary": "Workflow step that sends a transactional email through the SendGrid v3 API, selecting between the user's BYO API key and the platform-provided key based on anonymous-execution status.",
+      "tags": [
+        "step",
+        "api-handler",
+        "plugin",
+        "email",
+        "integration"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses the \"use step\" directive for Workflow DevKit bundling; helpers are kept module-private so the bundler does not pull transitive deps into the workflow runtime."
+    },
+    {
+      "id": "file:plugins/sendgrid/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/sendgrid/test.ts",
+      "summary": "Integration connection test that validates a SendGrid API key by hitting GET /v3/scopes and returning a structured success/failure verdict for the integrations UI.",
+      "tags": [
+        "test",
+        "integration",
+        "connection-check",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/slack/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/slack/credentials.ts",
+      "summary": "Type definition for Slack plugin credentials, exposing the SLACK_API_KEY bot token consumed by the send-slack-message step.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/slack/steps/send-slack-message.ts",
+      "type": "file",
+      "name": "send-slack-message.ts",
+      "filePath": "plugins/slack/steps/send-slack-message.ts",
+      "summary": "Workflow step that posts a message to a Slack channel via chat.postMessage, fetching the org's Slack bot token through the central credential fetcher.",
+      "tags": [
+        "step",
+        "api-handler",
+        "plugin",
+        "slack",
+        "integration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/slack/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/slack/test.ts",
+      "summary": "Integration connection test that validates a Slack bot token by calling auth.test and surfacing the bot identity/team for the integrations UI.",
+      "tags": [
+        "test",
+        "integration",
+        "connection-check",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/telegram/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/telegram/credentials.ts",
+      "summary": "Type definition for Telegram plugin credentials as an open record of per-bot env-style fields used by the send-message step.",
+      "tags": [
+        "type-definition",
+        "credentials",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/telegram/steps/send-message.ts",
+      "type": "file",
+      "name": "send-message.ts",
+      "filePath": "plugins/telegram/steps/send-message.ts",
+      "summary": "Workflow step that sends a Telegram chat message via Bot API sendMessage, with parse-mode handling and friendlier MarkdownV2 escape-error messages.",
+      "tags": [
+        "step",
+        "api-handler",
+        "plugin",
+        "telegram",
+        "integration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:plugins/telegram/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/telegram/test.ts",
+      "summary": "Integration connection test that validates a Telegram bot token via the getMe Bot API endpoint and reports back the bot's username.",
+      "tags": [
+        "test",
+        "integration",
+        "connection-check",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/v0/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/v0/test.ts",
+      "summary": "Integration connection test for the Vercel v0 plugin that validates an API key by issuing a small completion request and confirming a 200 response.",
+      "tags": [
+        "test",
+        "integration",
+        "connection-check",
+        "plugin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/web3/steps/batch-read-contract.ts",
+      "type": "file",
+      "name": "batch-read-contract.ts",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "summary": "Workflow step that fans out many EVM view/pure calls through Multicall3, supporting both uniform (one ABI/contract, many args) and mixed (per-call ABI/contract/network) modes with chunked execution and rich result decoding.",
+      "tags": [
+        "step",
+        "web3",
+        "multicall",
+        "rpc",
+        "batch"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses ethers.Interface for ABI encoding/decoding and groups mixed-mode calls per chain to dispatch one Multicall3 per network."
+    },
+    {
+      "id": "file:plugins/web3/steps/check-balance.ts",
+      "type": "file",
+      "name": "check-balance.ts",
+      "filePath": "plugins/web3/steps/check-balance.ts",
+      "summary": "Workflow step that reads a wallet's native-token balance on the requested network via an RPC provider and returns both wei and human-formatted values plus an explorer link.",
+      "tags": [
+        "step",
+        "web3",
+        "rpc",
+        "balance",
+        "read"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/safe/icon.tsx:SafeIcon",
+      "type": "function",
+      "name": "SafeIcon",
+      "filePath": "plugins/safe/icon.tsx",
+      "lineRange": [
+        3,
+        13
+      ],
+      "summary": "React component that renders the lucide ShieldCheck icon styled as the Safe plugin icon.",
+      "tags": [
+        "component",
+        "icon",
+        "ui"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/sendgrid/steps/send-email.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/sendgrid/steps/send-email.ts",
+      "lineRange": [
+        44,
+        133
+      ],
+      "summary": "Internal handler that validates the From/To/CC/BCC fields, picks between the user's API key and the KeeperHub-managed key, and POSTs to SendGrid /v3/mail/send.",
+      "tags": [
+        "api-handler",
+        "email",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/sendgrid/steps/send-email.ts:isAnonymousExecution",
+      "type": "function",
+      "name": "isAnonymousExecution",
+      "filePath": "plugins/sendgrid/steps/send-email.ts",
+      "lineRange": [
+        138,
+        151
+      ],
+      "summary": "Looks up the workflow row for the current execution to decide whether the run is anonymous (uses platform key) or owned by an organization (uses BYO key).",
+      "tags": [
+        "utility",
+        "database",
+        "auth-check"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/sendgrid/steps/send-email.ts:sendEmailStep",
+      "type": "function",
+      "name": "sendEmailStep",
+      "filePath": "plugins/sendgrid/steps/send-email.ts",
+      "lineRange": [
+        156,
+        191
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics + step logging, fetching credentials via the central credential fetcher.",
+      "tags": [
+        "step",
+        "entry-point",
+        "email"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/sendgrid/test.ts:testSendGrid",
+      "type": "function",
+      "name": "testSendGrid",
+      "filePath": "plugins/sendgrid/test.ts",
+      "lineRange": [
+        3,
+        42
+      ],
+      "summary": "Integration connection test that calls SendGrid /v3/scopes with the supplied API key and returns a structured success/failure verdict.",
+      "tags": [
+        "test",
+        "connection-check",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/slack/steps/send-slack-message.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/slack/steps/send-slack-message.ts",
+      "lineRange": [
+        34,
+        88
+      ],
+      "summary": "Internal handler that fetches the org's Slack token and POSTs to chat.postMessage, surfacing Slack API errors back to the workflow.",
+      "tags": [
+        "api-handler",
+        "slack",
+        "messaging"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/slack/steps/send-slack-message.ts:sendSlackMessageStep",
+      "type": "function",
+      "name": "sendSlackMessageStep",
+      "filePath": "plugins/slack/steps/send-slack-message.ts",
+      "lineRange": [
+        93,
+        103
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics and step logging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "slack"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/slack/test.ts:testSlack",
+      "type": "function",
+      "name": "testSlack",
+      "filePath": "plugins/slack/test.ts",
+      "lineRange": [
+        8,
+        49
+      ],
+      "summary": "Validates a Slack bot token by calling auth.test and reporting back the bot username and workspace.",
+      "tags": [
+        "test",
+        "connection-check",
+        "api-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/telegram/steps/send-message.ts:enhanceErrorMessage",
+      "type": "function",
+      "name": "enhanceErrorMessage",
+      "filePath": "plugins/telegram/steps/send-message.ts",
+      "lineRange": [
+        42,
+        54
+      ],
+      "summary": "Decorates Telegram MarkdownV2 parse errors with the explicit list of reserved characters that must be escaped.",
+      "tags": [
+        "utility",
+        "error-handling",
+        "telegram"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/telegram/steps/send-message.ts:sendMessage",
+      "type": "function",
+      "name": "sendMessage",
+      "filePath": "plugins/telegram/steps/send-message.ts",
+      "lineRange": [
+        59,
+        138
+      ],
+      "summary": "Low-level fetch wrapper around the Telegram Bot API sendMessage endpoint, handling network errors and structured API failures.",
+      "tags": [
+        "api-handler",
+        "telegram",
+        "http"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/telegram/steps/send-message.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/telegram/steps/send-message.ts",
+      "lineRange": [
+        143,
+        235
+      ],
+      "summary": "Internal handler that fetches the org's Telegram bot token, validates parse-mode + chat ID, and delegates to sendMessage with enriched error messages.",
+      "tags": [
+        "api-handler",
+        "telegram",
+        "messaging"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/telegram/steps/send-message.ts:sendTelegramMessageStep",
+      "type": "function",
+      "name": "sendTelegramMessageStep",
+      "filePath": "plugins/telegram/steps/send-message.ts",
+      "lineRange": [
+        240,
+        255
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics and step logging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "telegram"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/telegram/test.ts:testTelegram",
+      "type": "function",
+      "name": "testTelegram",
+      "filePath": "plugins/telegram/test.ts",
+      "lineRange": [
+        1,
+        46
+      ],
+      "summary": "Connection test that calls Telegram Bot API getMe to verify a token and report the bot username.",
+      "tags": [
+        "test",
+        "connection-check",
+        "api-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/v0/test.ts:testV0",
+      "type": "function",
+      "name": "testV0",
+      "filePath": "plugins/v0/test.ts",
+      "lineRange": [
+        1,
+        26
+      ],
+      "summary": "Connection test that issues a small Vercel v0 completion request to verify the API key is valid.",
+      "tags": [
+        "test",
+        "connection-check",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        24,
+        38
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table; used for per-user error logging.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:parseAbi",
+      "type": "function",
+      "name": "parseAbi",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        86,
+        102
+      ],
+      "summary": "Parses and validates a JSON-encoded contract ABI, returning either the typed fragments or a structured error.",
+      "tags": [
+        "utility",
+        "abi",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:buildUniformCalls",
+      "type": "function",
+      "name": "buildUniformCalls",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        107,
+        159
+      ],
+      "summary": "Builds the per-call argument arrays for uniform mode (one ABI + one function + many argument sets) and enforces the MAX_TOTAL_CALLS cap.",
+      "tags": [
+        "utility",
+        "multicall",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:validateMixedCall",
+      "type": "function",
+      "name": "validateMixedCall",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        164,
+        210
+      ],
+      "summary": "Validates a single mixed-mode call object (contractAddress, abi, abiFunction, args) and returns a normalized shape or a structured error.",
+      "tags": [
+        "utility",
+        "validation",
+        "multicall"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:buildMixedCalls",
+      "type": "function",
+      "name": "buildMixedCalls",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        215,
+        247
+      ],
+      "summary": "Walks the mixed-mode calls array, validating each entry and flattening into NormalizedCall objects ready for encoding.",
+      "tags": [
+        "utility",
+        "multicall",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:serializeBigInts",
+      "type": "function",
+      "name": "serializeBigInts",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        250,
+        265
+      ],
+      "summary": "Recursively converts BigInt values inside a decoded result into strings so the payload is JSON-serializable.",
+      "tags": [
+        "utility",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:structureDecodedResult",
+      "type": "function",
+      "name": "structureDecodedResult",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        270,
+        304
+      ],
+      "summary": "Reshapes an ethers decoded Result into a name-keyed object using the ABI function outputs, so consumers can address values by parameter name.",
+      "tags": [
+        "utility",
+        "abi",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:encodeUniformCalls",
+      "type": "function",
+      "name": "encodeUniformCalls",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        309,
+        366
+      ],
+      "summary": "Encodes uniform-mode calls into Multicall3 EncodedCallWithMeta tuples using a single shared ethers.Interface.",
+      "tags": [
+        "utility",
+        "multicall",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:encodeMixedCalls",
+      "type": "function",
+      "name": "encodeMixedCalls",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        371,
+        436
+      ],
+      "summary": "Encodes mixed-mode calls into Multicall3 EncodedCallWithMeta tuples, building a per-call ethers.Interface from the call's own ABI.",
+      "tags": [
+        "utility",
+        "multicall",
+        "abi"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:decodeCallResult",
+      "type": "function",
+      "name": "decodeCallResult",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        441,
+        485
+      ],
+      "summary": "Decodes a single Multicall3 call result back into structured data, returning a CallResult with either decoded values or a per-call error string.",
+      "tags": [
+        "utility",
+        "multicall",
+        "abi"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:executeMulticallBatches",
+      "type": "function",
+      "name": "executeMulticallBatches",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        490,
+        546
+      ],
+      "summary": "Chunks the encoded calls into batchSize-sized aggregate3 calls and dispatches them through the chain's Multicall3 contract.",
+      "tags": [
+        "service",
+        "multicall",
+        "rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:resolveChainRpc",
+      "type": "function",
+      "name": "resolveChainRpc",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        551,
+        587
+      ],
+      "summary": "Resolves a network name into a chainId + Multicall3-ready ethers Contract instance via the project's RPC provider factory.",
+      "tags": [
+        "utility",
+        "rpc",
+        "multicall"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:executeUniformMode",
+      "type": "function",
+      "name": "executeUniformMode",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        615,
+        680
+      ],
+      "summary": "Top-level driver for uniform mode: parses ABI, builds + encodes calls, executes Multicall3 batches, and decodes the results.",
+      "tags": [
+        "service",
+        "multicall",
+        "entry-point"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:groupCallsByNetwork",
+      "type": "function",
+      "name": "groupCallsByNetwork",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        685,
+        701
+      ],
+      "summary": "Groups mixed-mode calls by their target network so each group can be dispatched against the correct chain's Multicall3 contract.",
+      "tags": [
+        "utility",
+        "multicall"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:executeMixedMode",
+      "type": "function",
+      "name": "executeMixedMode",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        706,
+        785
+      ],
+      "summary": "Top-level driver for mixed mode: validates each call, groups by network, executes per-chain Multicall3 batches, and recombines results in input order.",
+      "tags": [
+        "service",
+        "multicall",
+        "entry-point"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        790,
+        801
+      ],
+      "summary": "Dispatches between uniform and mixed execution drivers based on the inputMode field.",
+      "tags": [
+        "api-handler",
+        "router"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/batch-read-contract.ts:batchReadContractStep",
+      "type": "function",
+      "name": "batchReadContractStep",
+      "filePath": "plugins/web3/steps/batch-read-contract.ts",
+      "lineRange": [
+        807,
+        820
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics + step logging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "web3"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-balance.ts:getUserIdFromExecution",
+      "type": "function",
+      "name": "getUserIdFromExecution",
+      "filePath": "plugins/web3/steps/check-balance.ts",
+      "lineRange": [
+        19,
+        33
+      ],
+      "summary": "Looks up the userId for a given executionId via the workflowExecutions table.",
+      "tags": [
+        "utility",
+        "database",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-balance.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/web3/steps/check-balance.ts",
+      "lineRange": [
+        55,
+        166
+      ],
+      "summary": "Internal handler that resolves an RPC provider for the network, calls getBalance for the address, and formats the result with an explorer link.",
+      "tags": [
+        "api-handler",
+        "web3",
+        "rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/web3/steps/check-balance.ts:checkBalanceStep",
+      "type": "function",
+      "name": "checkBalanceStep",
+      "filePath": "plugins/web3/steps/check-balance.ts",
+      "lineRange": [
+        172,
+        202
+      ],
+      "summary": "Exported workflow step that wraps stepHandler in plugin metrics + step logging.",
+      "tags": [
+        "step",
+        "entry-point",
+        "web3"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/web3/steps/write-contract.ts",
+      "type": "file",
+      "name": "write-contract.ts",
+      "filePath": "plugins/web3/steps/write-contract.ts",
+      "summary": "Web3 plugin step that writes data to a smart contract via state-changing functions, enriching the execution log with an explorer link before delegating to writeContractCore.",
+      "tags": [
+        "plugin-step",
+        "web3",
+        "smart-contract",
+        "transaction",
+        "service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the workflow bundler 'use step' directive and disables retries (maxRetries = 0) because writes must not be replayed."
+    },
+    {
+      "id": "function:plugins/web3/steps/write-contract.ts:writeContractStep",
+      "type": "function",
+      "name": "writeContractStep",
+      "filePath": "plugins/web3/steps/write-contract.ts",
+      "lineRange": [
+        22,
+        56
+      ],
+      "summary": "Step entry point that resolves the chain explorer config, attaches a contract address link, and runs writeContractCore inside the plugin metrics and step logging wrappers.",
+      "tags": [
+        "plugin-step",
+        "web3",
+        "transaction",
+        "instrumentation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:plugins/web3/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/web3/test.ts",
+      "summary": "Trivial integration connection-test stub for the web3 plugin; always resolves successfully because there is no external service to ping.",
+      "tags": [
+        "plugin-test",
+        "web3",
+        "stub",
+        "integration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webflow/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/webflow/test.ts",
+      "summary": "Integration connection test for the Webflow plugin that calls the Webflow sites API with the user's credentials and reports success or a human-readable error.",
+      "tags": [
+        "plugin-test",
+        "webflow",
+        "integration",
+        "credential-check"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/webflow/test.ts:testWebflow",
+      "type": "function",
+      "name": "testWebflow",
+      "filePath": "plugins/webflow/test.ts",
+      "lineRange": [
+        3,
+        43
+      ],
+      "summary": "Verifies a Webflow API token by issuing an authenticated GET against the sites endpoint and returning a structured success or error result.",
+      "tags": [
+        "plugin-test",
+        "webflow",
+        "credential-check",
+        "api-call"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webhook/credentials.ts",
+      "type": "file",
+      "name": "credentials.ts",
+      "filePath": "plugins/webhook/credentials.ts",
+      "summary": "Placeholder credentials module for the webhook plugin; the plugin requires no auth so the file is effectively empty.",
+      "tags": [
+        "plugin-credentials",
+        "webhook",
+        "stub",
+        "placeholder"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webhook/steps/send-webhook.ts",
+      "type": "file",
+      "name": "send-webhook.ts",
+      "filePath": "plugins/webhook/steps/send-webhook.ts",
+      "summary": "Webhook plugin step that POSTs (or otherwise dispatches) a configurable HTTP request with optional JSON headers and body via safeFetch, returning status code and parsed response.",
+      "tags": [
+        "plugin-step",
+        "webhook",
+        "http-client",
+        "service",
+        "validation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Wrapped in withStepLogging and withPluginMetrics; uses safeFetch to block SSRF against internal networks."
+    },
+    {
+      "id": "function:plugins/webhook/steps/send-webhook.ts:parseJsonSafely",
+      "type": "function",
+      "name": "parseJsonSafely",
+      "filePath": "plugins/webhook/steps/send-webhook.ts",
+      "lineRange": [
+        25,
+        44
+      ],
+      "summary": "Safely parses a JSON string for webhook headers or body, logging a validation error and returning null when parsing fails.",
+      "tags": [
+        "utility",
+        "validation",
+        "json",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:plugins/webhook/steps/send-webhook.ts:stepHandler",
+      "type": "function",
+      "name": "stepHandler",
+      "filePath": "plugins/webhook/steps/send-webhook.ts",
+      "lineRange": [
+        50,
+        193
+      ],
+      "summary": "Core webhook dispatcher: validates URL and method, parses headers and body JSON, performs the HTTP request through safeFetch, and returns structured success or error responses.",
+      "tags": [
+        "http-client",
+        "webhook",
+        "validation",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:plugins/webhook/steps/send-webhook.ts:sendWebhookStep",
+      "type": "function",
+      "name": "sendWebhookStep",
+      "filePath": "plugins/webhook/steps/send-webhook.ts",
+      "lineRange": [
+        199,
+        212
+      ],
+      "summary": "Public step entry point that runs the webhook stepHandler inside the standard plugin metrics and step logging wrappers.",
+      "tags": [
+        "plugin-step",
+        "webhook",
+        "instrumentation",
+        "entry-point"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:plugins/webhook/test.ts",
+      "type": "file",
+      "name": "test.ts",
+      "filePath": "plugins/webhook/test.ts",
+      "summary": "Trivial integration connection-test stub for the webhook plugin; always resolves successfully because there are no credentials to validate.",
+      "tags": [
+        "plugin-test",
+        "webhook",
+        "stub",
+        "integration"
+      ],
+      "complexity": "simple"
+    }
+  ],
+  "edges": [
+    {
+      "source": "file:plugins/code/icon.tsx",
+      "target": "function:plugins/code/icon.tsx:CodeIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/icon.tsx",
+      "target": "function:plugins/code/icon.tsx:CodeIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/discord/icon.tsx",
+      "target": "function:plugins/discord/icon.tsx:DiscordIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/discord/icon.tsx",
+      "target": "function:plugins/discord/icon.tsx:DiscordIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/icon.tsx",
+      "target": "function:plugins/hyperliquid/icon.tsx:HyperliquidIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/icon.tsx",
+      "target": "function:plugins/hyperliquid/icon.tsx:HyperliquidIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/math/icon.tsx",
+      "target": "function:plugins/math/icon.tsx:MathIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/icon.tsx",
+      "target": "function:plugins/math/icon.tsx:MathIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/sendgrid/icon.tsx",
+      "target": "function:plugins/sendgrid/icon.tsx:SendGridIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/sendgrid/icon.tsx",
+      "target": "function:plugins/sendgrid/icon.tsx:SendGridIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/telegram/icon.tsx",
+      "target": "function:plugins/telegram/icon.tsx:TelegramIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/telegram/icon.tsx",
+      "target": "function:plugins/telegram/icon.tsx:TelegramIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/icon.tsx",
+      "target": "function:plugins/web3/icon.tsx:Web3Icon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/icon.tsx",
+      "target": "function:plugins/web3/icon.tsx:Web3Icon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webhook/icon.tsx",
+      "target": "function:plugins/webhook/icon.tsx:WebhookIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webhook/icon.tsx",
+      "target": "function:plugins/webhook/icon.tsx:WebhookIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/code/index.ts",
+      "target": "file:plugins/code/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/discord/index.ts",
+      "target": "file:plugins/discord/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/index.ts",
+      "target": "file:plugins/hyperliquid/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/blockscout/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/code/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/discord/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/hyperliquid/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/math/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/protocol/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/safe/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/sendgrid/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/slack/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/telegram/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/web3/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/index.ts",
+      "target": "file:plugins/webhook/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/code/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/discord/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/math/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/protocol/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/safe/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/sendgrid/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/telegram/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/web3/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/keeperhub-plugins.ts",
+      "target": "file:plugins/webhook/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/math/index.ts",
+      "target": "file:plugins/math/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/sendgrid/index.ts",
+      "target": "file:plugins/sendgrid/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/telegram/index.ts",
+      "target": "file:plugins/telegram/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/index.ts",
+      "target": "file:plugins/web3/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webhook/index.ts",
+      "target": "file:plugins/webhook/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/ai-gateway/index.ts",
+      "target": "file:plugins/ai-gateway/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/ai-gateway/index.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/index.ts",
+      "target": "file:plugins/clerk/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/index.ts",
+      "target": "file:plugins/registry-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/index.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/registry-core.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "file:plugins/legacy-mappings.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "file:plugins/registry-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/resend/index.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/resend/index.ts",
+      "target": "file:plugins/resend/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/slack/index.ts",
+      "target": "file:plugins/registry-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/slack/index.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/slack/index.ts",
+      "target": "file:plugins/slack/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/v0/index.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/v0/index.ts",
+      "target": "file:plugins/v0/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webflow/index.ts",
+      "target": "file:plugins/registry-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webflow/index.ts",
+      "target": "file:plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webflow/index.ts",
+      "target": "file:plugins/webflow/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/icon.tsx",
+      "target": "function:plugins/clerk/icon.tsx:ClerkIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/icon.tsx",
+      "target": "function:plugins/clerk/icon.tsx:ClerkIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/resend/icon.tsx",
+      "target": "function:plugins/resend/icon.tsx:ResendIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/resend/icon.tsx",
+      "target": "function:plugins/resend/icon.tsx:ResendIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/slack/icon.tsx",
+      "target": "function:plugins/slack/icon.tsx:SlackIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/slack/icon.tsx",
+      "target": "function:plugins/slack/icon.tsx:SlackIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/v0/icon.tsx",
+      "target": "function:plugins/v0/icon.tsx:V0Icon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/v0/icon.tsx",
+      "target": "function:plugins/v0/icon.tsx:V0Icon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webflow/icon.tsx",
+      "target": "function:plugins/webflow/icon.tsx:WebflowIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/icon.tsx",
+      "target": "function:plugins/webflow/icon.tsx:WebflowIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry-core.ts",
+      "target": "function:plugins/registry-core.ts:registerIntegration",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry-core.ts",
+      "target": "function:plugins/registry-core.ts:registerIntegration",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:computeActionId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:computeActionId",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:parseActionId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:parseActionId",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegration",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegration",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getAllIntegrations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getAllIntegrations",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegrationTypes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegrationTypes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getAllActions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getAllActions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getActionsByCategory",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getActionsByCategory",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:findActionById",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:findActionById",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegrationLabels",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegrationLabels",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegrationDescriptions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getIntegrationDescriptions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getSortedIntegrationTypes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getSortedIntegrationTypes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getAllDependencies",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getAllDependencies",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getCredentialMapping",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:getCredentialMapping",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:isFieldGroup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:isFieldGroup",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:flattenConfigFields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:flattenConfigFields",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:generateAIActionPrompts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/registry.ts",
+      "target": "function:plugins/registry.ts:generateAIActionPrompts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:getAllActions",
+      "target": "function:plugins/registry.ts:computeActionId",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:getActionsByCategory",
+      "target": "function:plugins/registry.ts:computeActionId",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:findActionById",
+      "target": "function:plugins/registry.ts:parseActionId",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:findActionById",
+      "target": "function:plugins/registry.ts:computeActionId",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:flattenConfigFields",
+      "target": "function:plugins/registry.ts:isFieldGroup",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:generateAIActionPrompts",
+      "target": "function:plugins/registry.ts:computeActionId",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/registry.ts:generateAIActionPrompts",
+      "target": "function:plugins/registry.ts:flattenConfigFields",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/icon.tsx",
+      "target": "function:plugins/blockscout/icon.tsx:BlockscoutIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/icon.tsx",
+      "target": "function:plugins/blockscout/icon.tsx:BlockscoutIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/index.ts",
+      "target": "file:plugins/blockscout/chains.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/index.ts",
+      "target": "file:plugins/blockscout/icon.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "target": "file:plugins/blockscout/chains.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "target": "file:plugins/blockscout/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:resolveInstance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:resolveInstance",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:resolveInstance",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-balance.ts",
+      "target": "file:plugins/blockscout/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-balance.ts",
+      "target": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-balance.ts",
+      "target": "function:plugins/blockscout/steps/get-address-balance.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-balance.ts",
+      "target": "function:plugins/blockscout/steps/get-address-balance.ts:getAddressBalanceStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-balance.ts",
+      "target": "function:plugins/blockscout/steps/get-address-balance.ts:getAddressBalanceStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-address-balance.ts:stepHandler",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-address-balance.ts:getAddressBalanceStep",
+      "target": "function:plugins/blockscout/steps/get-address-balance.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-counters.ts",
+      "target": "file:plugins/blockscout/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-counters.ts",
+      "target": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-counters.ts",
+      "target": "function:plugins/blockscout/steps/get-address-counters.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-counters.ts",
+      "target": "function:plugins/blockscout/steps/get-address-counters.ts:getAddressCountersStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-counters.ts",
+      "target": "function:plugins/blockscout/steps/get-address-counters.ts:getAddressCountersStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-address-counters.ts:stepHandler",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-address-counters.ts:getAddressCountersStep",
+      "target": "function:plugins/blockscout/steps/get-address-counters.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-info.ts",
+      "target": "file:plugins/blockscout/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-info.ts",
+      "target": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-info.ts",
+      "target": "function:plugins/blockscout/steps/get-address-info.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-info.ts",
+      "target": "function:plugins/blockscout/steps/get-address-info.ts:getAddressInfoStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-address-info.ts",
+      "target": "function:plugins/blockscout/steps/get-address-info.ts:getAddressInfoStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-address-info.ts:stepHandler",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-address-info.ts:getAddressInfoStep",
+      "target": "function:plugins/blockscout/steps/get-address-info.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-token-info.ts",
+      "target": "file:plugins/blockscout/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-token-info.ts",
+      "target": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-token-info.ts",
+      "target": "function:plugins/blockscout/steps/get-token-info.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-token-info.ts",
+      "target": "function:plugins/blockscout/steps/get-token-info.ts:getTokenInfoStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-token-info.ts",
+      "target": "function:plugins/blockscout/steps/get-token-info.ts:getTokenInfoStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-token-info.ts:stepHandler",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-token-info.ts:getTokenInfoStep",
+      "target": "function:plugins/blockscout/steps/get-token-info.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-transaction.ts",
+      "target": "file:plugins/blockscout/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-transaction.ts",
+      "target": "file:plugins/blockscout/steps/blockscout-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-transaction.ts",
+      "target": "function:plugins/blockscout/steps/get-transaction.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-transaction.ts",
+      "target": "function:plugins/blockscout/steps/get-transaction.ts:getTransactionStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/steps/get-transaction.ts",
+      "target": "function:plugins/blockscout/steps/get-transaction.ts:getTransactionStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-transaction.ts:stepHandler",
+      "target": "function:plugins/blockscout/steps/blockscout-core.ts:blockscoutGet",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/blockscout/steps/get-transaction.ts:getTransactionStep",
+      "target": "function:plugins/blockscout/steps/get-transaction.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/active-asset-data.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/active-asset-data.ts",
+      "target": "function:plugins/hyperliquid/steps/active-asset-data.ts:activeAssetDataStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/active-asset-data.ts",
+      "target": "function:plugins/hyperliquid/steps/active-asset-data.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/active-asset-data.ts",
+      "target": "function:plugins/hyperliquid/steps/active-asset-data.ts:activeAssetDataStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/active-asset-data.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/active-asset-data.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/active-asset-data.ts:activeAssetDataStep",
+      "target": "function:plugins/hyperliquid/steps/active-asset-data.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "target": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:clearinghouseStateStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "target": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/clearinghouse-state.ts",
+      "target": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:clearinghouseStateStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:clearinghouseStateStep",
+      "target": "function:plugins/hyperliquid/steps/clearinghouse-state.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/funding-history.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/funding-history.ts",
+      "target": "function:plugins/hyperliquid/steps/funding-history.ts:fundingHistoryStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/funding-history.ts",
+      "target": "function:plugins/hyperliquid/steps/funding-history.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/funding-history.ts",
+      "target": "function:plugins/hyperliquid/steps/funding-history.ts:fundingHistoryStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/funding-history.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/funding-history.ts:fundingHistoryStep",
+      "target": "function:plugins/hyperliquid/steps/funding-history.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/referral.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/referral.ts",
+      "target": "function:plugins/hyperliquid/steps/referral.ts:referralStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/referral.ts",
+      "target": "function:plugins/hyperliquid/steps/referral.ts:referralStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/referral.ts:referralStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/referral.ts:referralStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/spot-deploy-state.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/spot-deploy-state.ts",
+      "target": "function:plugins/hyperliquid/steps/spot-deploy-state.ts:spotDeployStateStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/spot-deploy-state.ts",
+      "target": "function:plugins/hyperliquid/steps/spot-deploy-state.ts:spotDeployStateStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/spot-deploy-state.ts:spotDeployStateStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/spot-deploy-state.ts:spotDeployStateStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/sub-accounts.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/sub-accounts.ts",
+      "target": "function:plugins/hyperliquid/steps/sub-accounts.ts:subAccountsStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/sub-accounts.ts",
+      "target": "function:plugins/hyperliquid/steps/sub-accounts.ts:subAccountsStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/sub-accounts.ts:subAccountsStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/sub-accounts.ts:subAccountsStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/validator-summaries.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/validator-summaries.ts",
+      "target": "function:plugins/hyperliquid/steps/validator-summaries.ts:validatorSummariesStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/validator-summaries.ts",
+      "target": "function:plugins/hyperliquid/steps/validator-summaries.ts:validatorSummariesStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/validator-summaries.ts:validatorSummariesStep",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/vault-details.ts",
+      "target": "file:plugins/hyperliquid/steps/info-request-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/vault-details.ts",
+      "target": "function:plugins/hyperliquid/steps/vault-details.ts:vaultDetailsStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/vault-details.ts",
+      "target": "function:plugins/hyperliquid/steps/vault-details.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/steps/vault-details.ts",
+      "target": "function:plugins/hyperliquid/steps/vault-details.ts:vaultDetailsStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/vault-details.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:isEvmAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/vault-details.ts:stepHandler",
+      "target": "function:plugins/hyperliquid/steps/info-request-core.ts:postInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/hyperliquid/steps/vault-details.ts:vaultDetailsStep",
+      "target": "function:plugins/hyperliquid/steps/vault-details.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/types.ts",
+      "target": "function:plugins/clerk/types.ts:toClerkUserData",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/types.ts",
+      "target": "function:plugins/clerk/types.ts:toClerkUserData",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/create-user.ts",
+      "target": "function:plugins/clerk/steps/create-user.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/create-user.ts",
+      "target": "function:plugins/clerk/steps/create-user.ts:clerkCreateUserStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/create-user.ts",
+      "target": "function:plugins/clerk/steps/create-user.ts:clerkCreateUserStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/create-user.ts",
+      "target": "file:plugins/clerk/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/steps/create-user.ts",
+      "target": "file:plugins/clerk/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/clerk/steps/create-user.ts:stepHandler",
+      "target": "function:plugins/clerk/types.ts:toClerkUserData",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/clerk/steps/create-user.ts:clerkCreateUserStep",
+      "target": "function:plugins/clerk/steps/create-user.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/delete-user.ts",
+      "target": "function:plugins/clerk/steps/delete-user.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/delete-user.ts",
+      "target": "function:plugins/clerk/steps/delete-user.ts:clerkDeleteUserStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/delete-user.ts",
+      "target": "function:plugins/clerk/steps/delete-user.ts:clerkDeleteUserStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/delete-user.ts",
+      "target": "file:plugins/clerk/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/clerk/steps/delete-user.ts:clerkDeleteUserStep",
+      "target": "function:plugins/clerk/steps/delete-user.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/get-user.ts",
+      "target": "function:plugins/clerk/steps/get-user.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/get-user.ts",
+      "target": "function:plugins/clerk/steps/get-user.ts:clerkGetUserStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/get-user.ts",
+      "target": "function:plugins/clerk/steps/get-user.ts:clerkGetUserStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/get-user.ts",
+      "target": "file:plugins/clerk/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/steps/get-user.ts",
+      "target": "file:plugins/clerk/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/clerk/steps/get-user.ts:stepHandler",
+      "target": "function:plugins/clerk/types.ts:toClerkUserData",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/clerk/steps/get-user.ts:clerkGetUserStep",
+      "target": "function:plugins/clerk/steps/get-user.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/update-user.ts",
+      "target": "function:plugins/clerk/steps/update-user.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/update-user.ts",
+      "target": "function:plugins/clerk/steps/update-user.ts:clerkUpdateUserStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/steps/update-user.ts",
+      "target": "function:plugins/clerk/steps/update-user.ts:clerkUpdateUserStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/steps/update-user.ts",
+      "target": "file:plugins/clerk/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/clerk/steps/update-user.ts",
+      "target": "file:plugins/clerk/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/clerk/steps/update-user.ts:stepHandler",
+      "target": "function:plugins/clerk/types.ts:toClerkUserData",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/clerk/steps/update-user.ts:clerkUpdateUserStep",
+      "target": "function:plugins/clerk/steps/update-user.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/approve-token-core.ts",
+      "target": "function:plugins/web3/steps/approve-token-core.ts:approveTokenCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/approve-token-core.ts",
+      "target": "function:plugins/web3/steps/approve-token-core.ts:approveTokenCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/approve-token-core.ts",
+      "target": "file:plugins/web3/steps/transfer-token-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/web3/steps/approve-token-core.ts:approveTokenCore",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:parseTokenAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/approve-token.ts",
+      "target": "function:plugins/web3/steps/approve-token.ts:approveTokenStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/approve-token.ts",
+      "target": "function:plugins/web3/steps/approve-token.ts:approveTokenStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/approve-token.ts",
+      "target": "file:plugins/web3/steps/approve-token-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/web3/steps/approve-token.ts:approveTokenStep",
+      "target": "function:plugins/web3/steps/approve-token-core.ts:approveTokenCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/check-allowance.ts",
+      "target": "function:plugins/web3/steps/check-allowance.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/check-allowance.ts",
+      "target": "function:plugins/web3/steps/check-allowance.ts:checkAllowanceStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/check-allowance.ts",
+      "target": "function:plugins/web3/steps/check-allowance.ts:checkAllowanceStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/check-allowance.ts",
+      "target": "file:plugins/web3/steps/transfer-token-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/web3/steps/check-allowance.ts:stepHandler",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:parseTokenAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/check-allowance.ts:checkAllowanceStep",
+      "target": "function:plugins/web3/steps/check-allowance.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token-core.ts",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:parseTokenAddress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token-core.ts",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:transferTokenCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token-core.ts",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:parseTokenAddress",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token-core.ts",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:transferTokenCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/transfer-token-core.ts:transferTokenCore",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:parseTokenAddress",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token.ts",
+      "target": "function:plugins/web3/steps/transfer-token.ts:transferTokenStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token.ts",
+      "target": "function:plugins/web3/steps/transfer-token.ts:transferTokenStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-token.ts",
+      "target": "file:plugins/web3/steps/transfer-token-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/web3/steps/transfer-token.ts:transferTokenStep",
+      "target": "function:plugins/web3/steps/transfer-token-core.ts:transferTokenCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webflow/steps/get-site.ts",
+      "target": "file:plugins/webflow/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webflow/steps/list-sites.ts",
+      "target": "file:plugins/webflow/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webflow/steps/publish-site.ts",
+      "target": "file:plugins/webflow/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/webflow/steps/get-site.ts",
+      "target": "function:plugins/webflow/steps/get-site.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/steps/get-site.ts",
+      "target": "function:plugins/webflow/steps/get-site.ts:getSiteStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/steps/get-site.ts",
+      "target": "function:plugins/webflow/steps/get-site.ts:getSiteStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/webflow/steps/get-site.ts:getSiteStep",
+      "target": "function:plugins/webflow/steps/get-site.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webflow/steps/list-sites.ts",
+      "target": "function:plugins/webflow/steps/list-sites.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/steps/list-sites.ts",
+      "target": "function:plugins/webflow/steps/list-sites.ts:listSitesStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/steps/list-sites.ts",
+      "target": "function:plugins/webflow/steps/list-sites.ts:listSitesStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/webflow/steps/list-sites.ts:listSitesStep",
+      "target": "function:plugins/webflow/steps/list-sites.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webflow/steps/publish-site.ts",
+      "target": "function:plugins/webflow/steps/publish-site.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/steps/publish-site.ts",
+      "target": "function:plugins/webflow/steps/publish-site.ts:publishSiteStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/steps/publish-site.ts",
+      "target": "function:plugins/webflow/steps/publish-site.ts:publishSiteStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/webflow/steps/publish-site.ts:publishSiteStep",
+      "target": "function:plugins/webflow/steps/publish-site.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-read.ts",
+      "target": "function:plugins/protocol/steps/protocol-read.ts:buildFunctionArgs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-read.ts",
+      "target": "function:plugins/protocol/steps/protocol-read.ts:protocolReadStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-read.ts",
+      "target": "function:plugins/protocol/steps/protocol-read.ts:protocolReadStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-read.ts",
+      "target": "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/protocol/steps/protocol-read.ts:protocolReadStep",
+      "target": "function:plugins/protocol/steps/resolve-protocol-meta.ts:resolveProtocolMeta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/protocol/steps/protocol-read.ts:protocolReadStep",
+      "target": "function:plugins/protocol/steps/protocol-read.ts:buildFunctionArgs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-write.ts",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:resolveEthValue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-write.ts",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:checkUniswapNativeEthPreflight",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-write.ts",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:buildFunctionArgs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-write.ts",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-write.ts",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/steps/protocol-write.ts",
+      "target": "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "target": "function:plugins/protocol/steps/resolve-protocol-meta.ts:resolveProtocolMeta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:buildFunctionArgs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:checkUniswapNativeEthPreflight",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/protocol/steps/protocol-write.ts:protocolWriteStep",
+      "target": "function:plugins/protocol/steps/protocol-write.ts:resolveEthValue",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+      "target": "function:plugins/protocol/steps/resolve-protocol-meta.ts:deriveFromActionType",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+      "target": "function:plugins/protocol/steps/resolve-protocol-meta.ts:resolveProtocolMeta",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+      "target": "function:plugins/protocol/steps/resolve-protocol-meta.ts:resolveProtocolMeta",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/protocol/steps/resolve-protocol-meta.ts:resolveProtocolMeta",
+      "target": "function:plugins/protocol/steps/resolve-protocol-meta.ts:deriveFromActionType",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/safe/steps/get-pending-transactions.ts",
+      "target": "file:plugins/safe/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/safe/test.ts",
+      "target": "file:plugins/safe/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/safe/steps/get-pending-transactions.ts",
+      "target": "function:plugins/safe/steps/get-pending-transactions.ts:getSafeChainSlug",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/safe/steps/get-pending-transactions.ts",
+      "target": "function:plugins/safe/steps/get-pending-transactions.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/safe/steps/get-pending-transactions.ts",
+      "target": "function:plugins/safe/steps/get-pending-transactions.ts:getPendingTransactionsStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/safe/steps/get-pending-transactions.ts",
+      "target": "function:plugins/safe/steps/get-pending-transactions.ts:getPendingTransactionsStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/safe/test.ts",
+      "target": "function:plugins/safe/test.ts:testSafe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/safe/test.ts",
+      "target": "function:plugins/safe/test.ts:testSafe",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/safe/steps/get-pending-transactions.ts:getPendingTransactionsStep",
+      "target": "function:plugins/safe/steps/get-pending-transactions.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/safe/steps/get-pending-transactions.ts:stepHandler",
+      "target": "function:plugins/safe/steps/get-pending-transactions.ts:getSafeChainSlug",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/v0/steps/create-chat.ts",
+      "target": "file:plugins/v0/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/v0/steps/send-message.ts",
+      "target": "file:plugins/v0/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/v0/steps/create-chat.ts",
+      "target": "function:plugins/v0/steps/create-chat.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/v0/steps/create-chat.ts",
+      "target": "function:plugins/v0/steps/create-chat.ts:createChatStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/v0/steps/create-chat.ts",
+      "target": "function:plugins/v0/steps/create-chat.ts:createChatStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/v0/steps/send-message.ts",
+      "target": "function:plugins/v0/steps/send-message.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/v0/steps/send-message.ts",
+      "target": "function:plugins/v0/steps/send-message.ts:sendMessageStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/v0/steps/send-message.ts",
+      "target": "function:plugins/v0/steps/send-message.ts:sendMessageStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata.ts",
+      "target": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:isUnlimitedValue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkApprovalRisks",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkPrivilegedOps",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkValueRisks",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkInteractionRisks",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:computeRiskFromFactors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:scoreToLevel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:buildLlmPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:parseLlmResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:callLlmAssessment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:buildRulesOnlyResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:buildFailClosedResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:assessRiskStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/assess-risk.ts",
+      "target": "function:plugins/web3/steps/assess-risk.ts:assessRiskStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:serializeValue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:extractParameters",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWithAbi",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:fetch4byteSignatures",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWith4byte",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:fetchAbiFromExplorer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:validateCalldata",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryManualAbi",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryExplorerStrategy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:try4byteStrategy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata-core.ts",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata.ts",
+      "target": "function:plugins/web3/steps/decode-calldata.ts:decodeCalldataStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/decode-calldata.ts",
+      "target": "function:plugins/web3/steps/decode-calldata.ts:decodeCalldataStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata.ts:decodeCalldataStep",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:assessRiskStep",
+      "target": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:validateCalldata",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryManualAbi",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryExplorerStrategy",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:decodeCalldata",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:try4byteStrategy",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:tryManualAbi",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWithAbi",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:tryExplorerStrategy",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:fetchAbiFromExplorer",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:tryExplorerStrategy",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWithAbi",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:try4byteStrategy",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:fetch4byteSignatures",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:try4byteStrategy",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWith4byte",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWithAbi",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:extractParameters",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:tryDecodeWith4byte",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:extractParameters",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/decode-calldata-core.ts:extractParameters",
+      "target": "function:plugins/web3/steps/decode-calldata-core.ts:serializeValue",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkApprovalRisks",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkPrivilegedOps",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkValueRisks",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:checkInteractionRisks",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:computeRiskFromFactors",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:callLlmAssessment",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:scoreToLevel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:buildRulesOnlyResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:stepHandler",
+      "target": "function:plugins/web3/steps/assess-risk.ts:buildFailClosedResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:callLlmAssessment",
+      "target": "function:plugins/web3/steps/assess-risk.ts:buildLlmPrompt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:callLlmAssessment",
+      "target": "function:plugins/web3/steps/assess-risk.ts:parseLlmResponse",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/assess-risk.ts:checkApprovalRisks",
+      "target": "function:plugins/web3/steps/assess-risk.ts:isUnlimitedValue",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "config:plugins/plugin-allowlist.schema.json",
+      "target": "config:plugins/plugin-allowlist.json",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:plugins/AGENTS.md",
+      "target": "document:plugins/CLAUDE.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:plugins/CLAUDE.md",
+      "target": "document:plugins/AGENTS.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:plugins/ai-gateway/test.ts",
+      "target": "function:plugins/ai-gateway/test.ts:testConnection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/ai-gateway/test.ts",
+      "target": "function:plugins/ai-gateway/test.ts:testConnection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/blockscout/test.ts",
+      "target": "function:plugins/blockscout/test.ts:testBlockscout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/blockscout/test.ts",
+      "target": "function:plugins/blockscout/test.ts:testBlockscout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/clerk/test.ts",
+      "target": "function:plugins/clerk/test.ts:testClerk",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/clerk/test.ts",
+      "target": "function:plugins/clerk/test.ts:testClerk",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:extractLineNumber",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:buildChildEnv",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:parseChildOutput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:runInChild",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:validateInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:runLocal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:normalizeRemoteError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:runCodeStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/steps/run-code.ts",
+      "target": "function:plugins/code/steps/run-code.ts:runCodeStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/code/test.ts",
+      "target": "function:plugins/code/test.ts:testCode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/code/test.ts",
+      "target": "function:plugins/code/test.ts:testCode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/cowswap/steps/cancel-order.ts",
+      "target": "function:plugins/cowswap/steps/cancel-order.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/cancel-order.ts",
+      "target": "function:plugins/cowswap/steps/cancel-order.ts:cancelOrderStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/cancel-order.ts",
+      "target": "function:plugins/cowswap/steps/cancel-order.ts:cancelOrderStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/cowswap/steps/create-order.ts",
+      "target": "function:plugins/cowswap/steps/create-order.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/create-order.ts",
+      "target": "function:plugins/cowswap/steps/create-order.ts:createOrderStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/create-order.ts",
+      "target": "function:plugins/cowswap/steps/create-order.ts:createOrderStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-account-orders.ts",
+      "target": "function:plugins/cowswap/steps/get-account-orders.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-account-orders.ts",
+      "target": "function:plugins/cowswap/steps/get-account-orders.ts:getAccountOrdersStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-account-orders.ts",
+      "target": "function:plugins/cowswap/steps/get-account-orders.ts:getAccountOrdersStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-order-status.ts",
+      "target": "function:plugins/cowswap/steps/get-order-status.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-order-status.ts",
+      "target": "function:plugins/cowswap/steps/get-order-status.ts:getOrderStatusStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-order-status.ts",
+      "target": "function:plugins/cowswap/steps/get-order-status.ts:getOrderStatusStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-quote.ts",
+      "target": "function:plugins/cowswap/steps/get-quote.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-quote.ts",
+      "target": "function:plugins/cowswap/steps/get-quote.ts:getQuoteStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-quote.ts",
+      "target": "function:plugins/cowswap/steps/get-quote.ts:getQuoteStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-trades.ts",
+      "target": "function:plugins/cowswap/steps/get-trades.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-trades.ts",
+      "target": "function:plugins/cowswap/steps/get-trades.ts:getTradesStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/cowswap/steps/get-trades.ts",
+      "target": "function:plugins/cowswap/steps/get-trades.ts:getTradesStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "document:plugins/_template/steps/action.ts.txt",
+      "target": "file:plugins/cowswap/steps/get-quote.ts",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:plugins/discord/steps/send-message.ts",
+      "target": "file:plugins/discord/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/discord/steps/send-message.ts",
+      "target": "function:plugins/discord/steps/send-message.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/discord/steps/send-message.ts",
+      "target": "function:plugins/discord/steps/send-message.ts:sendDiscordMessageStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/discord/steps/send-message.ts",
+      "target": "function:plugins/discord/steps/send-message.ts:sendDiscordMessageStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/discord/test.ts",
+      "target": "function:plugins/discord/test.ts:testDiscord",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/discord/test.ts",
+      "target": "function:plugins/discord/test.ts:testDiscord",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/hyperliquid/test.ts",
+      "target": "function:plugins/hyperliquid/test.ts:testHyperliquid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/hyperliquid/test.ts",
+      "target": "function:plugins/hyperliquid/test.ts:testHyperliquid",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/linear/steps/find-issues.ts",
+      "target": "file:plugins/linear/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/linear/steps/find-issues.ts",
+      "target": "function:plugins/linear/steps/find-issues.ts:linearQuery",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/linear/steps/find-issues.ts",
+      "target": "function:plugins/linear/steps/find-issues.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/linear/steps/find-issues.ts",
+      "target": "function:plugins/linear/steps/find-issues.ts:findIssuesStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/linear/steps/find-issues.ts",
+      "target": "function:plugins/linear/steps/find-issues.ts:findIssuesStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:sanitizeRawValueToString",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:parseStringToNumericValue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:resolveFieldPath",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:parseJsonToArray",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:collectNumericValues",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:extractExplicitValues",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:reduceValues",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:findExtremeValue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:computeMedian",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:computeAggregation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:applyBinaryPostOperation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:applyUnaryPostOperation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:applyPostOperation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:parseInputValues",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:validatePostOperation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:aggregateStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/steps/aggregate.ts",
+      "target": "function:plugins/math/steps/aggregate.ts:aggregateStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/math/test.ts",
+      "target": "function:plugins/math/test.ts:testMath",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/math/test.ts",
+      "target": "function:plugins/math/test.ts:testMath",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/icon.tsx",
+      "target": "function:plugins/protocol/icon.tsx:ProtocolIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/icon.tsx",
+      "target": "function:plugins/protocol/icon.tsx:createProtocolIconComponent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/protocol/icon.tsx",
+      "target": "function:plugins/protocol/icon.tsx:ProtocolIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/protocol/icon.tsx",
+      "target": "function:plugins/protocol/icon.tsx:createProtocolIconComponent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/resend/steps/send-email.ts",
+      "target": "file:plugins/resend/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/resend/steps/send-email.ts",
+      "target": "function:plugins/resend/steps/send-email.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/resend/steps/send-email.ts",
+      "target": "function:plugins/resend/steps/send-email.ts:sendEmailStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/resend/steps/send-email.ts",
+      "target": "function:plugins/resend/steps/send-email.ts:sendEmailStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/resend/test.ts",
+      "target": "function:plugins/resend/test.ts:testResend",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/resend/test.ts",
+      "target": "function:plugins/resend/test.ts:testResend",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:extractSupportedTokenId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:extractCustomToken",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:parseTokenConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:getTokenAddress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:fetchStringOrBytes32",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:fetchTokenBalance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-token-balance.ts",
+      "target": "function:plugins/web3/steps/check-token-balance.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/get-transaction.ts",
+      "target": "function:plugins/web3/steps/get-transaction.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/get-transaction.ts",
+      "target": "function:plugins/web3/steps/get-transaction.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/get-transaction.ts",
+      "target": "function:plugins/web3/steps/get-transaction.ts:getTransactionStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/get-transaction.ts",
+      "target": "function:plugins/web3/steps/get-transaction.ts:getTransactionStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:decodeEventArgs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:parseAbi",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:parseBlockCount",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:resolveFromBlock",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:resolveBlockRange",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:queryEventBatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:queryEventsStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-events.ts",
+      "target": "function:plugins/web3/steps/query-events.ts:queryEventsStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:parseAbi",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:parseBlockCount",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:resolveFromBlock",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:resolveBlockRange",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:serializeValue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:decodeTransaction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:matchesArgFilter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:parseFunctionArgsFilter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:filterAndDecodeTransactions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:validateInputs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:queryTransactionsCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions-core.ts",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:queryTransactionsCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions.ts",
+      "target": "file:plugins/web3/steps/query-transactions-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions.ts",
+      "target": "function:plugins/web3/steps/query-transactions.ts:queryTransactionsStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/query-transactions.ts",
+      "target": "function:plugins/web3/steps/query-transactions.ts:queryTransactionsStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/query-transactions.ts:queryTransactionsStep",
+      "target": "function:plugins/web3/steps/query-transactions-core.ts:queryTransactionsCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/read-contract-core.ts",
+      "target": "function:plugins/web3/steps/read-contract-core.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/read-contract-core.ts",
+      "target": "function:plugins/web3/steps/read-contract-core.ts:readContractCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/read-contract-core.ts",
+      "target": "function:plugins/web3/steps/read-contract-core.ts:readContractCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/read-contract.ts",
+      "target": "file:plugins/web3/steps/read-contract-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/read-contract.ts",
+      "target": "function:plugins/web3/steps/read-contract.ts:readContractStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/read-contract.ts",
+      "target": "function:plugins/web3/steps/read-contract.ts:readContractStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/read-contract.ts:readContractStep",
+      "target": "function:plugins/web3/steps/read-contract-core.ts:readContractCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/sign-typed-data-core.ts",
+      "target": "function:plugins/web3/steps/sign-typed-data-core.ts:validateTypedData",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/sign-typed-data-core.ts",
+      "target": "function:plugins/web3/steps/sign-typed-data-core.ts:signTypedDataCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/sign-typed-data-core.ts",
+      "target": "function:plugins/web3/steps/sign-typed-data-core.ts:signTypedDataCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/sign-typed-data.ts",
+      "target": "file:plugins/web3/steps/sign-typed-data-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/sign-typed-data.ts",
+      "target": "function:plugins/web3/steps/sign-typed-data.ts:signTypedDataStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/sign-typed-data.ts",
+      "target": "function:plugins/web3/steps/sign-typed-data.ts:signTypedDataStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/sign-typed-data.ts:signTypedDataStep",
+      "target": "function:plugins/web3/steps/sign-typed-data-core.ts:signTypedDataCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-funds-core.ts",
+      "target": "function:plugins/web3/steps/transfer-funds-core.ts:transferFundsCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-funds-core.ts",
+      "target": "function:plugins/web3/steps/transfer-funds-core.ts:transferFundsCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-funds.ts",
+      "target": "file:plugins/web3/steps/transfer-funds-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-funds.ts",
+      "target": "function:plugins/web3/steps/transfer-funds.ts:transferFundsStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/transfer-funds.ts",
+      "target": "function:plugins/web3/steps/transfer-funds.ts:transferFundsStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/transfer-funds.ts:transferFundsStep",
+      "target": "function:plugins/web3/steps/transfer-funds-core.ts:transferFundsCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/write-contract-core.ts",
+      "target": "function:plugins/web3/steps/write-contract-core.ts:writeContractCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/write-contract-core.ts",
+      "target": "function:plugins/web3/steps/write-contract-core.ts:writeContractCore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/safe/icon.tsx",
+      "target": "function:plugins/safe/icon.tsx:SafeIcon",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/safe/icon.tsx",
+      "target": "function:plugins/safe/icon.tsx:SafeIcon",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/sendgrid/steps/send-email.ts",
+      "target": "file:plugins/sendgrid/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/sendgrid/steps/send-email.ts",
+      "target": "function:plugins/sendgrid/steps/send-email.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/sendgrid/steps/send-email.ts",
+      "target": "function:plugins/sendgrid/steps/send-email.ts:isAnonymousExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/sendgrid/steps/send-email.ts",
+      "target": "function:plugins/sendgrid/steps/send-email.ts:sendEmailStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/sendgrid/steps/send-email.ts",
+      "target": "function:plugins/sendgrid/steps/send-email.ts:sendEmailStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/sendgrid/test.ts",
+      "target": "function:plugins/sendgrid/test.ts:testSendGrid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/sendgrid/test.ts",
+      "target": "function:plugins/sendgrid/test.ts:testSendGrid",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/slack/steps/send-slack-message.ts",
+      "target": "file:plugins/slack/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/slack/steps/send-slack-message.ts",
+      "target": "function:plugins/slack/steps/send-slack-message.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/slack/steps/send-slack-message.ts",
+      "target": "function:plugins/slack/steps/send-slack-message.ts:sendSlackMessageStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/slack/steps/send-slack-message.ts",
+      "target": "function:plugins/slack/steps/send-slack-message.ts:sendSlackMessageStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/slack/test.ts",
+      "target": "function:plugins/slack/test.ts:testSlack",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/slack/test.ts",
+      "target": "function:plugins/slack/test.ts:testSlack",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/telegram/steps/send-message.ts",
+      "target": "file:plugins/telegram/credentials.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/telegram/steps/send-message.ts",
+      "target": "function:plugins/telegram/steps/send-message.ts:enhanceErrorMessage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/telegram/steps/send-message.ts",
+      "target": "function:plugins/telegram/steps/send-message.ts:sendMessage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/telegram/steps/send-message.ts",
+      "target": "function:plugins/telegram/steps/send-message.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/telegram/steps/send-message.ts",
+      "target": "function:plugins/telegram/steps/send-message.ts:sendTelegramMessageStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/telegram/steps/send-message.ts",
+      "target": "function:plugins/telegram/steps/send-message.ts:sendTelegramMessageStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/telegram/test.ts",
+      "target": "function:plugins/telegram/test.ts:testTelegram",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/telegram/test.ts",
+      "target": "function:plugins/telegram/test.ts:testTelegram",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/v0/test.ts",
+      "target": "function:plugins/v0/test.ts:testV0",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/v0/test.ts",
+      "target": "function:plugins/v0/test.ts:testV0",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:parseAbi",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:buildUniformCalls",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:validateMixedCall",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:buildMixedCalls",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:serializeBigInts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:structureDecodedResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:encodeUniformCalls",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:encodeMixedCalls",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:decodeCallResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:executeMulticallBatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:resolveChainRpc",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:executeUniformMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:groupCallsByNetwork",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:executeMixedMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:batchReadContractStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/batch-read-contract.ts",
+      "target": "function:plugins/web3/steps/batch-read-contract.ts:batchReadContractStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/check-balance.ts",
+      "target": "function:plugins/web3/steps/check-balance.ts:getUserIdFromExecution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-balance.ts",
+      "target": "function:plugins/web3/steps/check-balance.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-balance.ts",
+      "target": "function:plugins/web3/steps/check-balance.ts:checkBalanceStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:plugins/web3/steps/check-balance.ts",
+      "target": "function:plugins/web3/steps/check-balance.ts:checkBalanceStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/web3/steps/write-contract.ts",
+      "target": "file:plugins/web3/steps/write-contract-core.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:plugins/web3/steps/write-contract.ts",
+      "target": "function:plugins/web3/steps/write-contract.ts:writeContractStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/web3/steps/write-contract.ts",
+      "target": "function:plugins/web3/steps/write-contract.ts:writeContractStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/web3/steps/write-contract.ts:writeContractStep",
+      "target": "function:plugins/web3/steps/write-contract-core.ts:writeContractCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webflow/test.ts",
+      "target": "function:plugins/webflow/test.ts:testWebflow",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webflow/test.ts",
+      "target": "function:plugins/webflow/test.ts:testWebflow",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:plugins/webhook/steps/send-webhook.ts",
+      "target": "function:plugins/webhook/steps/send-webhook.ts:parseJsonSafely",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webhook/steps/send-webhook.ts",
+      "target": "function:plugins/webhook/steps/send-webhook.ts:stepHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webhook/steps/send-webhook.ts",
+      "target": "function:plugins/webhook/steps/send-webhook.ts:sendWebhookStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:plugins/webhook/steps/send-webhook.ts",
+      "target": "function:plugins/webhook/steps/send-webhook.ts:sendWebhookStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/webhook/steps/send-webhook.ts:stepHandler",
+      "target": "function:plugins/webhook/steps/send-webhook.ts:parseJsonSafely",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:plugins/webhook/steps/send-webhook.ts:sendWebhookStep",
+      "target": "function:plugins/webhook/steps/send-webhook.ts:stepHandler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    }
+  ],
+  "layers": [
+    {
+      "id": "layer:plugin-registry",
+      "name": "Plugin Registry",
+      "description": "Top-level plugin discovery and registration: the registry that enumerates installed plugins and the allowlist controlling which plugins are exposed to workflow steps.",
+      "nodeIds": [
+        "config:plugins/plugin-allowlist.json",
+        "file:plugins/index.ts",
+        "file:plugins/keeperhub-plugins.ts"
+      ]
+    },
+    {
+      "id": "layer:plugin-definitions",
+      "name": "Plugin Definitions",
+      "description": "Per-plugin entry points (`index.ts`), icons (`icon.tsx`), and supporting metadata that declare each plugin to the registry and provide its visual identity in the workflow builder.",
+      "nodeIds": [
+        "config:plugins/plugin-allowlist.schema.json",
+        "file:plugins/ai-gateway/icon.tsx",
+        "file:plugins/ai-gateway/index.ts",
+        "file:plugins/blockscout/chains.ts",
+        "file:plugins/blockscout/icon.tsx",
+        "file:plugins/blockscout/index.ts",
+        "file:plugins/clerk/icon.tsx",
+        "file:plugins/clerk/index.ts",
+        "file:plugins/clerk/types.ts",
+        "file:plugins/code/icon.tsx",
+        "file:plugins/code/index.ts",
+        "file:plugins/cowswap/index.ts",
+        "file:plugins/discord/icon.tsx",
+        "file:plugins/discord/index.ts",
+        "file:plugins/hyperliquid/icon.tsx",
+        "file:plugins/hyperliquid/index.ts",
+        "file:plugins/legacy-mappings.ts",
+        "file:plugins/math/icon.tsx",
+        "file:plugins/math/index.ts",
+        "file:plugins/protocol/icon.tsx",
+        "file:plugins/protocol/index.ts",
+        "file:plugins/registry-core.ts",
+        "file:plugins/registry.ts",
+        "file:plugins/resend/icon.tsx",
+        "file:plugins/resend/index.ts",
+        "file:plugins/safe/icon.tsx",
+        "file:plugins/safe/index.ts",
+        "file:plugins/sendgrid/icon.tsx",
+        "file:plugins/sendgrid/index.ts",
+        "file:plugins/slack/icon.tsx",
+        "file:plugins/slack/index.ts",
+        "file:plugins/telegram/icon.tsx",
+        "file:plugins/telegram/index.ts",
+        "file:plugins/v0/icon.tsx",
+        "file:plugins/v0/index.ts",
+        "file:plugins/web3/icon.tsx",
+        "file:plugins/web3/index.ts",
+        "file:plugins/webflow/icon.tsx",
+        "file:plugins/webflow/index.ts",
+        "file:plugins/webhook/icon.tsx",
+        "file:plugins/webhook/index.ts"
+      ]
+    },
+    {
+      "id": "layer:plugin-steps",
+      "name": "Plugin Steps",
+      "description": "Concrete workflow step implementations (`plugins/*/steps/*.ts`). Each step is an action that workflows can call \u2014 read/write contracts, send messages, fetch data, etc.",
+      "nodeIds": [
+        "file:plugins/blockscout/steps/blockscout-core.ts",
+        "file:plugins/blockscout/steps/get-address-balance.ts",
+        "file:plugins/blockscout/steps/get-address-counters.ts",
+        "file:plugins/blockscout/steps/get-address-info.ts",
+        "file:plugins/blockscout/steps/get-token-info.ts",
+        "file:plugins/blockscout/steps/get-transaction.ts",
+        "file:plugins/clerk/steps/create-user.ts",
+        "file:plugins/clerk/steps/delete-user.ts",
+        "file:plugins/clerk/steps/get-user.ts",
+        "file:plugins/clerk/steps/update-user.ts",
+        "file:plugins/code/steps/run-code.ts",
+        "file:plugins/cowswap/steps/cancel-order.ts",
+        "file:plugins/cowswap/steps/create-order.ts",
+        "file:plugins/cowswap/steps/get-account-orders.ts",
+        "file:plugins/cowswap/steps/get-order-status.ts",
+        "file:plugins/cowswap/steps/get-quote.ts",
+        "file:plugins/cowswap/steps/get-trades.ts",
+        "file:plugins/discord/steps/send-message.ts",
+        "file:plugins/hyperliquid/steps/active-asset-data.ts",
+        "file:plugins/hyperliquid/steps/clearinghouse-state.ts",
+        "file:plugins/hyperliquid/steps/funding-history.ts",
+        "file:plugins/hyperliquid/steps/info-request-core.ts",
+        "file:plugins/hyperliquid/steps/referral.ts",
+        "file:plugins/hyperliquid/steps/spot-deploy-state.ts",
+        "file:plugins/hyperliquid/steps/sub-accounts.ts",
+        "file:plugins/hyperliquid/steps/validator-summaries.ts",
+        "file:plugins/hyperliquid/steps/vault-details.ts",
+        "file:plugins/linear/steps/find-issues.ts",
+        "file:plugins/math/steps/aggregate.ts",
+        "file:plugins/protocol/steps/protocol-read.ts",
+        "file:plugins/protocol/steps/protocol-write.ts",
+        "file:plugins/protocol/steps/resolve-protocol-meta.ts",
+        "file:plugins/resend/steps/send-email.ts",
+        "file:plugins/safe/steps/get-pending-transactions.ts",
+        "file:plugins/sendgrid/steps/send-email.ts",
+        "file:plugins/slack/steps/send-slack-message.ts",
+        "file:plugins/telegram/steps/send-message.ts",
+        "file:plugins/v0/steps/create-chat.ts",
+        "file:plugins/v0/steps/send-message.ts",
+        "file:plugins/web3/steps/approve-token-core.ts",
+        "file:plugins/web3/steps/approve-token.ts",
+        "file:plugins/web3/steps/assess-risk.ts",
+        "file:plugins/web3/steps/batch-read-contract.ts",
+        "file:plugins/web3/steps/check-allowance.ts",
+        "file:plugins/web3/steps/check-balance.ts",
+        "file:plugins/web3/steps/check-token-balance.ts",
+        "file:plugins/web3/steps/decode-calldata-core.ts",
+        "file:plugins/web3/steps/decode-calldata.ts",
+        "file:plugins/web3/steps/get-transaction.ts",
+        "file:plugins/web3/steps/query-events.ts",
+        "file:plugins/web3/steps/query-transactions-core.ts",
+        "file:plugins/web3/steps/query-transactions.ts",
+        "file:plugins/web3/steps/read-contract-core.ts",
+        "file:plugins/web3/steps/read-contract.ts",
+        "file:plugins/web3/steps/sign-typed-data-core.ts",
+        "file:plugins/web3/steps/sign-typed-data.ts",
+        "file:plugins/web3/steps/transfer-funds-core.ts",
+        "file:plugins/web3/steps/transfer-funds.ts",
+        "file:plugins/web3/steps/transfer-token-core.ts",
+        "file:plugins/web3/steps/transfer-token.ts",
+        "file:plugins/web3/steps/write-contract-core.ts",
+        "file:plugins/web3/steps/write-contract.ts",
+        "file:plugins/webflow/steps/get-site.ts",
+        "file:plugins/webflow/steps/list-sites.ts",
+        "file:plugins/webflow/steps/publish-site.ts",
+        "file:plugins/webhook/steps/send-webhook.ts"
+      ]
+    },
+    {
+      "id": "layer:plugin-credentials",
+      "name": "Plugin Credentials",
+      "description": "Per-plugin credential schemas (`credentials.ts`) defining the auth fields each plugin requires (API keys, OAuth, etc.) for the credential vault.",
+      "nodeIds": [
+        "file:plugins/blockscout/credentials.ts",
+        "file:plugins/clerk/credentials.ts",
+        "file:plugins/discord/credentials.ts",
+        "file:plugins/linear/credentials.ts",
+        "file:plugins/resend/credentials.ts",
+        "file:plugins/safe/credentials.ts",
+        "file:plugins/sendgrid/credentials.ts",
+        "file:plugins/slack/credentials.ts",
+        "file:plugins/telegram/credentials.ts",
+        "file:plugins/v0/credentials.ts",
+        "file:plugins/webflow/credentials.ts",
+        "file:plugins/webhook/credentials.ts"
+      ]
+    },
+    {
+      "id": "layer:plugin-tests",
+      "name": "Plugin Tests",
+      "description": "Self-test entry points (`plugins/*/test.ts`) that exercise plugin step happy paths against real APIs or sandbox endpoints.",
+      "nodeIds": [
+        "file:plugins/ai-gateway/test.ts",
+        "file:plugins/blockscout/test.ts",
+        "file:plugins/clerk/test.ts",
+        "file:plugins/code/test.ts",
+        "file:plugins/discord/test.ts",
+        "file:plugins/hyperliquid/test.ts",
+        "file:plugins/math/test.ts",
+        "file:plugins/resend/test.ts",
+        "file:plugins/safe/test.ts",
+        "file:plugins/sendgrid/test.ts",
+        "file:plugins/slack/test.ts",
+        "file:plugins/telegram/test.ts",
+        "file:plugins/v0/test.ts",
+        "file:plugins/web3/test.ts",
+        "file:plugins/webflow/test.ts",
+        "file:plugins/webhook/test.ts"
+      ]
+    },
+    {
+      "id": "layer:scaffolding-templates",
+      "name": "Scaffolding Templates",
+      "description": "Starter templates under `plugins/_template/` copied by the plugin-scaffolding tooling when bootstrapping a new plugin. Inert files until copied.",
+      "nodeIds": [
+        "document:plugins/_template/steps/action.ts.txt",
+        "file:plugins/_template/credentials.ts.txt",
+        "file:plugins/_template/icon.tsx.txt",
+        "file:plugins/_template/index.ts.txt",
+        "file:plugins/_template/test.ts.txt"
+      ]
+    },
+    {
+      "id": "layer:documentation",
+      "name": "Documentation",
+      "description": "Plugin-layer docs (`AGENTS.md`, `CLAUDE.md`) describing plugin conventions for human and AI contributors.",
+      "nodeIds": [
+        "document:plugins/AGENTS.md",
+        "document:plugins/CLAUDE.md"
+      ]
+    }
+  ],
+  "tour": [
+    {
+      "order": 1,
+      "title": "Plugin Registry: How Plugins Are Discovered",
+      "description": "Start here. The plugin registry enumerates all installed plugins and gates them through an allowlist before the workflow engine can call any steps. Read `plugins/index.ts` and `plugins/keeperhub-plugins.ts` to see the registration mechanism; `plugin-allowlist.json` controls which plugins are exposed in production.",
+      "nodeIds": [
+        "file:plugins/index.ts",
+        "file:plugins/keeperhub-plugins.ts",
+        "config:plugins/plugin-allowlist.json"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "Plugin Conventions: Read the Contributor Guides",
+      "description": "Before reading any individual plugin, skim the plugin-layer contributor docs. They cover the canonical file layout (index.ts / icon.tsx / credentials.ts / steps/ / test.ts), naming rules, and the rationale for the patterns you'll see everywhere.",
+      "nodeIds": [
+        "document:plugins/AGENTS.md",
+        "document:plugins/CLAUDE.md"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "A Complete Plugin Walkthrough: Discord",
+      "description": "Discord is a representative plugin with the full stack: definition, icon, credential schema, multiple steps, and a self-test. Following it end-to-end teaches the pattern every other integration follows.",
+      "nodeIds": [
+        "file:plugins/discord/index.ts",
+        "file:plugins/discord/icon.tsx",
+        "file:plugins/discord/credentials.ts",
+        "file:plugins/discord/steps/send-message.ts",
+        "file:plugins/discord/test.ts"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "Plugin Definitions: Index + Icon Pattern",
+      "description": "Every plugin's `index.ts` registers the plugin's metadata and step list; `icon.tsx` provides the SVG that appears in the workflow builder. These two files together define a plugin's public surface. Compare a few to see the consistent shape.",
+      "nodeIds": [
+        "file:plugins/slack/index.ts",
+        "file:plugins/webflow/index.ts",
+        "file:plugins/sendgrid/index.ts",
+        "file:plugins/clerk/index.ts",
+        "file:plugins/hyperliquid/index.ts"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "Credentials: How Plugins Declare Auth Requirements",
+      "description": "Each plugin's `credentials.ts` declares the auth fields (API keys, tokens, OAuth handles) it needs. The credential vault collects these from users and injects them at step-execution time. The schemas are uniform across plugins.",
+      "nodeIds": [
+        "file:plugins/discord/credentials.ts",
+        "file:plugins/sendgrid/credentials.ts",
+        "file:plugins/clerk/credentials.ts",
+        "file:plugins/webflow/credentials.ts",
+        "file:plugins/safe/credentials.ts"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "Steps: The Action Layer",
+      "description": "Steps under `plugins/*/steps/*.ts` are the units workflows actually call. Each is a typed entry point that takes inputs + credentials, talks to an external API or chain, and returns a result. These three steps span communication, social, and DeFi \u2014 representative of the breadth.",
+      "nodeIds": [
+        "file:plugins/sendgrid/steps/send-email.ts",
+        "file:plugins/clerk/steps/create-user.ts",
+        "file:plugins/hyperliquid/steps/active-asset-data.ts"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "Web3 Steps: Read, Write, and Allowance",
+      "description": "The `web3` plugin is the largest single integration and the on-chain workhorse. Its steps cover the core ERC-20 / contract-call lifecycle: check token allowance, approve spend, read state from any contract, write transactions. These are the primitives most chain workflows compose.",
+      "nodeIds": [
+        "file:plugins/web3/steps/check-allowance.ts",
+        "file:plugins/web3/steps/approve-token.ts",
+        "file:plugins/web3/steps/write-contract.ts",
+        "file:plugins/web3/steps/decode-calldata.ts",
+        "file:plugins/web3/steps/assess-risk.ts"
+      ]
+    },
+    {
+      "order": 8,
+      "title": "Protocol Steps: Read/Write with Auto-Resolution",
+      "description": "The `protocol` plugin is one abstraction up from raw web3: instead of taking a contract address + ABI, it resolves a named protocol (Aave, Uniswap, etc.) to its current addresses before reading or writing. It depends on the web3 layer underneath.",
+      "nodeIds": [
+        "file:plugins/protocol/steps/protocol-read.ts",
+        "file:plugins/protocol/steps/protocol-write.ts",
+        "file:plugins/protocol/steps/resolve-protocol-meta.ts"
+      ]
+    },
+    {
+      "order": 9,
+      "title": "Testing: Plugin Self-Tests",
+      "description": "Each plugin's `test.ts` exercises its happy paths against real APIs or sandbox endpoints. These run independently of the broader test suite and serve as living documentation of a plugin's intended use.",
+      "nodeIds": [
+        "file:plugins/discord/test.ts",
+        "file:plugins/sendgrid/test.ts",
+        "file:plugins/hyperliquid/test.ts",
+        "file:plugins/blockscout/test.ts"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "Scaffolding: The Plugin Template",
+      "description": "When you add a new plugin, you copy from `plugins/_template/`. The templates mirror the canonical layout \u2014 read these to see the minimum a new plugin needs to ship. They're stored with `.txt` extensions to keep them inert until copied.",
+      "nodeIds": [
+        "file:plugins/_template/index.ts.txt",
+        "file:plugins/_template/icon.tsx.txt",
+        "file:plugins/_template/credentials.ts.txt",
+        "file:plugins/_template/test.ts.txt"
+      ]
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ pnpm test                   # All tests
 pnpm test:e2e               # E2E tests
 ```
 
+For codebase exploration, see the "Codebase Understanding" section below — `/understand` and `/understand-dashboard` are Claude Code slash commands, not pnpm scripts.
+
 ## Database Migrations
 
 The build script (`scripts/migrate-prod.ts`) runs `pnpm db:migrate` (file-based migrations), **not** `db:push`. Migration state is tracked in the `drizzle.__drizzle_migrations` table (schema `drizzle`, not `public`). When adding or modifying database tables:
@@ -369,3 +371,68 @@ Combine with the discovery utilities: use MCP to navigate, then call `getInterac
 | `getInteractiveElements(page)` | `./utils/discover` | Get structured element list         |
 | `getPageStructure(page)`       | `./utils/discover` | Get page headings, landmarks, forms |
 | `createTestWorkflow(email)`    | `./utils/db`       | Inject workflow directly into DB    |
+
+---
+
+## Codebase Understanding (Understand-Anything)
+
+The repo uses [Understand-Anything](https://github.com/Lum1104/Understand-Anything) — a Claude Code plugin that produces a queryable knowledge graph of the codebase plus an interactive force-directed dashboard.
+
+### When to reach for it
+
+- **Onboarding** into `plugins/`, `lib/`, or `app/api/`: start with `/understand-onboard` instead of `ls` + grep.
+- **Cross-system debugging** (executor + SDK + DB bugs that span subsystems): `/understand-diff` shows structural impact of in-flight changes.
+- **Pre-PR review** for diffs that touch shared `lib/` or multiple plugins.
+
+Skip it for plugin-local PRs, design-system work, or Drizzle migration ordering bugs — reading the live code is faster.
+
+### Install (one-time, per developer)
+
+In a fresh Claude Code session at the repo root:
+
+```
+/plugin marketplace add Lum1104/Understand-Anything
+/plugin install understand-anything
+```
+
+Restart Claude Code, then enable the post-commit hook so the graph stays in lockstep with `HEAD`:
+
+```
+/understand --auto-update
+```
+
+### Daily usage
+
+```
+/understand plugins/      # scope a first-time analysis to a subtree
+/understand-dashboard     # open the interactive graph at http://127.0.0.1:5173
+/understand-chat ...      # Q&A over the graph
+/understand-diff          # impact analysis of uncommitted changes
+/understand-onboard       # guided tour for a new contributor
+/understand-explain ...   # explain a file/function in context
+/understand-domain        # business-domain grouping view
+```
+
+Run a fresh full index after large refactors or after pulling new `staging`:
+
+```
+/understand --full
+```
+
+### Update process
+
+- **Plugin itself**: `/plugin marketplace update understand-anything` (run periodically; harmless if no update is available).
+- **Knowledge graph**: the `--auto-update` post-commit hook keeps it current. Force a full re-index with `/understand --full` after wide-blast-radius refactors.
+
+### Output and gitignore
+
+- `.understand-anything/knowledge-graph.json` — **committed**; the dashboard reads this so the next person doesn't have to re-run a full index.
+- `.understand-anything/intermediate/` and `.understand-anything/diff-overlay.json` — gitignored (scratch + local diff state).
+
+For graphs over ~10MB, use git-lfs.
+
+### Gotchas specific to this repo
+
+- **tsconfig path aliases**: KeeperHub's `@/*` aliases can be dropped by the indexer (upstream issue #214). After the first run, verify the graph has edges into `@/components`, `@/lib`, and `@/plugins`. If missing, re-run `/understand --full` after the upstream fix lands.
+- **Dashboard port `5173`**: Vite's default. If another Vite project is already running, the dashboard URL will silently serve the wrong app — kill the other one first.
+- **VS Code Copilot Chat 0.48.1**: known incompatibility (upstream issue #218); use Claude Code as the host instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,11 +395,7 @@ In a fresh Claude Code session at the repo root:
 /plugin install understand-anything
 ```
 
-Restart Claude Code, then enable the post-commit hook so the graph stays in lockstep with `HEAD`:
-
-```
-/understand --auto-update
-```
+Restart Claude Code. The post-commit auto-update hook is **off** in this repo's `config.json` on purpose — auto-update couples the graph to every commit and pollutes PR diffs with regenerated JSON. Refresh on cadence instead (see "Update process" below). If you want personal incremental updates that you'll squash before pushing, enable it locally with `/understand --auto-update`.
 
 ### Daily usage
 
@@ -422,7 +418,7 @@ Run a fresh full index after large refactors or after pulling new `staging`:
 ### Update process
 
 - **Plugin itself**: `/plugin marketplace update understand-anything` (run periodically; harmless if no update is available).
-- **Knowledge graph**: the `--auto-update` post-commit hook keeps it current. Force a full re-index with `/understand --full` after wide-blast-radius refactors.
+- **Knowledge graph**: refresh weekly with `/understand` (incremental — only re-analyzes changed files) and after wide-blast-radius refactors with `/understand --full`. Auto-update is off (see above) to keep PR diffs clean. Refresh PRs land as their own commit, never bundled into feature PRs.
 
 ### Output and gitignore
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ pnpm test             # Run all tests
 pnpm test:e2e         # E2E tests
 ```
 
+## Codebase Understanding
+
+This repo ships an [Understand-Anything](https://github.com/Lum1104/Understand-Anything) knowledge graph at `.understand-anything/knowledge-graph.json` plus a Claude Code plugin for exploring it. The graph is a structural map of files, functions, imports, and architectural layers; the dashboard is a force-directed visualization.
+
+**Install (one-time, per developer):** in Claude Code at the repo root:
+
+```
+/plugin marketplace add Lum1104/Understand-Anything
+/plugin install understand-anything
+```
+
+Restart Claude Code, then:
+
+```
+/understand-dashboard           # interactive graph at http://127.0.0.1:5173
+/understand-chat <question>     # Q&A over the graph
+/understand-diff                # impact analysis of uncommitted changes
+/understand-onboard             # guided tour for new contributors
+/understand --full              # full re-index after a large refactor
+```
+
+Auto-refresh on commit is intentionally **off** in this repo (it would couple the graph to every PR diff). Refresh on cadence: weekly `/understand` for incremental, `/understand --full` after wide-blast-radius refactors. See `CLAUDE.md` for when each command is most useful and the known caveats.
+
 ## Architecture
 
 ### Services


### PR DESCRIPTION
## Summary
- Ship initial Understand-Anything knowledge graph (145 files indexed) so teammates can open the dashboard without re-running a full index on first use.
- Disable the auto-update post-commit hook in `config.json` to keep PR diffs clean. Refresh is on a manual cadence: weekly incremental `/understand`, full `/understand --full` after wide-blast-radius refactors.
- Add orientation pointers to `/add-protocol`, `/fix-issue`, and `/develop-plugin` so research subagents are dispatched only for what the graph can't answer cheaply.
- Enable the plugin in `.claude/settings.json` so teammates who install it locally see it auto-enabled.
- Document install + usage in `README.md` (brief) and `CLAUDE.md` (deeper guidance + known caveats).

## How to use after this lands

In Claude Code at the repo root:

```
/plugin marketplace add Lum1104/Understand-Anything
/plugin install understand-anything
```

Restart Claude Code, then:

- `/understand-dashboard` — interactive force-directed graph at http://127.0.0.1:5173
- `/understand-chat <question>` — Q&A over the graph
- `/understand-diff` — impact analysis of uncommitted changes
- `/understand-onboard` — guided tour for new contributors
- `/understand --full` — full re-index after a large refactor

## Gitignore strategy

- Committed: `knowledge-graph.json`, `config.json`, `.understandignore` (shared team settings).
- Ignored: `meta.json` (timestamp churn), `fingerprints.json` (per-machine incremental cache), `intermediate/`, `diff-overlay.json`.

## Test plan
- [ ] Pull this branch, run `/plugin marketplace add Lum1104/Understand-Anything` + `/plugin install understand-anything`, restart, confirm plugin loads.
- [ ] `/understand-dashboard` opens and renders the committed graph (no re-index needed).
- [ ] `/understand-chat "where does X live?"` returns sensible answers against `plugins/`, `lib/`, and `app/api/`.
- [ ] `/understand --full` from a clean checkout produces only the expected diff to `knowledge-graph.json`; no `meta.json` / `fingerprints.json` show up in `git status`.
- [ ] tsconfig `@/*` aliases are picked up as edges in the graph (known upstream bug — verify after first run; see CLAUDE.md gotchas).

## Known caveats (called out in CLAUDE.md)
- Upstream tsconfig path-alias issue (#214) may drop `@/*` edges; re-run after upstream fix lands.
- Dashboard hardcodes Vite port `5173`; kill other Vite projects first.
- VS Code Copilot Chat 0.48.1 incompatibility (#218) — use Claude Code as the host.