### PR TITLE
fix: sanitize ethers v6 error logs to prevent RPC key leak in scripts

### DIFF
--- a/lib/rpc/sanitize-rpc-error.ts
+++ b/lib/rpc/sanitize-rpc-error.ts
@@ -1,0 +1,84 @@
+/**
+ * Sanitize unknown thrown values from ethers/RPC call sites for safe logging.
+ *
+ * Ethers v6 inlines `info.requestUrl` (the full URL, including any embedded
+ * API key) into `Error.message`. Catch blocks that log only `error.message`
+ * therefore leak the key. This module returns a normalized shape that:
+ *
+ *   - prefers `error.shortMessage` (which does not contain `requestUrl`
+ *     in ethers 6.x)
+ *   - falls back to `error.message` after running it through `scrubRpcUrls`
+ *   - preserves `error.code` so callers retain retry-decision semantics
+ *
+ * Mirrors the defensive `Partial<EthersError>` + key-check idiom used in
+ * `lib/rpc/providers/error-classification.ts`. See `lib/utils/redact.ts`
+ * for the orthogonal field-name redaction utility (different threat model
+ * - structured object input, not error-string output).
+ */
+
+import type { EthersError } from "ethers";
+import { scrubRpcUrls } from "./scrub-rpc-urls";
+
+export type SanitizedRpcError = {
+  message: string;
+  code?: string;
+  shortMessage?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(
+  candidate: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = candidate[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function sanitizeRpcError(error: unknown): SanitizedRpcError {
+  if (error === null || error === undefined) {
+    return { message: "Unknown error (no error value)" };
+  }
+
+  if (typeof error === "string") {
+    return { message: scrubRpcUrls(error) };
+  }
+
+  if (!isObject(error)) {
+    return { message: scrubRpcUrls(String(error)) };
+  }
+
+  // Read fields by name rather than narrowing to a specific EthersError
+  // variant - the v6 union discriminates on `code` and not every catch
+  // receives a true EthersError instance (intercepted, re-thrown, etc).
+  const candidate = error as Partial<EthersError> & Record<string, unknown>;
+
+  const code = readString(candidate, "code");
+
+  const rawShort = readString(candidate, "shortMessage");
+  const shortMessage =
+    rawShort === undefined ? undefined : scrubRpcUrls(rawShort);
+
+  const rawMessage = readString(candidate, "message");
+  const scrubbedMessage =
+    rawMessage === undefined ? undefined : scrubRpcUrls(rawMessage);
+
+  // Preference order: shortMessage (cleanest in ethers v6) > scrubbed
+  // message > code > constant. Always non-empty.
+  const message =
+    shortMessage ?? scrubbedMessage ?? code ?? "Unknown RPC error";
+
+  return { message, code, shortMessage };
+}
+
+/**
+ * Single-string variant for direct use in `console.error(...)` / template
+ * literals. Includes the ethers error code in parentheses when present so
+ * the log line stays useful for debugging retry behavior.
+ */
+export function formatSanitizedRpcError(error: unknown): string {
+  const { message, code } = sanitizeRpcError(error);
+  return code ? `${message} (${code})` : message;
+}

--- a/lib/rpc/scrub-rpc-urls.ts
+++ b/lib/rpc/scrub-rpc-urls.ts
@@ -1,0 +1,65 @@
+/**
+ * Strip secrets out of any URL substrings inside an arbitrary string.
+ *
+ * Defense-in-depth pipeline:
+ *   1. Drop query strings on any http(s)/ws(s) URL.
+ *   2. Mask path segments that look like API keys for known providers
+ *      (Alchemy /v2/<key>, Infura /v3/<key>, QuickNode .quiknode.pro/<key>,
+ *      Ankr rpc.ankr.com/<chain>/<key>).
+ *   3. As a generic fallback, mask any path segment that looks opaque
+ *      (32+ chars of base58/base64).
+ *
+ * The host and the path prefix up to the secret are preserved on purpose so
+ * debug output still tells an operator which provider failed. We mask the
+ * trailing secret, not the whole URL.
+ *
+ * Failure mode: if a vendor inlines its key in a shape none of these
+ * patterns match (e.g. an opaque 8-char host prefix, or a custom header
+ * echoed into a multi-line error body), this helper passes the string
+ * through unchanged. The mitigation for that residual risk is a Sentry
+ * `beforeSend` hook (tracked as a follow-up) plus the higher-level
+ * guidance to log `code` + `shortMessage` instead of full messages
+ * (ethers v6 today does not inline `requestUrl` into `shortMessage`).
+ */
+
+const URL_RE = /\bhttps?:\/\/[^\s)'"<>]+|wss?:\/\/[^\s)'"<>]+/gi;
+
+// Patterns whose match ends at the secret segment. Each is applied to the
+// query-stripped URL; the trailing secret is masked while the provider-
+// identifying prefix is kept.
+const PROVIDER_KEY_PATTERNS: readonly RegExp[] = [
+  // Alchemy:  https://eth-mainnet.g.alchemy.com/v2/<KEY>
+  // Infura:   https://mainnet.infura.io/v3/<KEY>
+  /\/v[23]\/[A-Za-z0-9_-]{16,}/g,
+  // QuickNode: https://<name>.quiknode.pro/<KEY>/
+  /\.quiknode\.pro\/[A-Za-z0-9_-]{16,}/g,
+  // Ankr premium: https://rpc.ankr.com/<chain>/<KEY>
+  /rpc\.ankr\.com\/[a-z-]+\/[A-Za-z0-9_-]{16,}/g,
+  // Generic 32+ char opaque path segment as a last-resort mask. Anchored
+  // on the leading "/" so it does not eat into hostnames.
+  /\/[A-Za-z0-9_-]{32,}(?=\/|$)/g,
+];
+
+function maskUrl(url: string): string {
+  const queryIdx = url.indexOf("?");
+  const base = queryIdx === -1 ? url : url.slice(0, queryIdx);
+
+  let masked = base;
+  for (const pattern of PROVIDER_KEY_PATTERNS) {
+    masked = masked.replace(pattern, (match) => {
+      const slash = match.lastIndexOf("/");
+      return slash >= 0
+        ? `${match.slice(0, slash + 1)}[REDACTED]`
+        : "[REDACTED]";
+    });
+  }
+
+  return queryIdx === -1 ? masked : `${masked}?[REDACTED-QUERY]`;
+}
+
+export function scrubRpcUrls(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(URL_RE, maskUrl);
+}

--- a/lib/rpc/scrub-rpc-urls.ts
+++ b/lib/rpc/scrub-rpc-urls.ts
@@ -28,13 +28,19 @@ const URL_RE = /\bhttps?:\/\/[^\s)'"<>]+|wss?:\/\/[^\s)'"<>]+/gi;
 // query-stripped URL; the trailing secret is masked while the provider-
 // identifying prefix is kept.
 const PROVIDER_KEY_PATTERNS: readonly RegExp[] = [
-  // Alchemy:  https://eth-mainnet.g.alchemy.com/v2/<KEY>
+  // Alchemy:  https://<network>.g.alchemy.com/v2/<KEY>
   // Infura:   https://mainnet.infura.io/v3/<KEY>
   /\/v[23]\/[A-Za-z0-9_-]{16,}/g,
-  // QuickNode: https://<name>.quiknode.pro/<KEY>/
+  // QuickNode: https://<name>.<chain>.quiknode.pro/<KEY>/
   /\.quiknode\.pro\/[A-Za-z0-9_-]{16,}/g,
   // Ankr premium: https://rpc.ankr.com/<chain>/<KEY>
   /rpc\.ankr\.com\/[a-z-]+\/[A-Za-z0-9_-]{16,}/g,
+  // dRPC load balancer: https://lb.drpc.live/<chain>/<KEY>
+  //                     wss://lb.drpc.live/<chain>/<KEY>
+  // Explicit pattern (rather than relying on the generic 32+ fallback below)
+  // so a future shorter dRPC key still gets caught and the chain segment
+  // stays visible in masked output.
+  /lb\.drpc\.live\/[a-z0-9-]+\/[A-Za-z0-9_-]{16,}/g,
   // Generic 32+ char opaque path segment as a last-resort mask. Anchored
   // on the leading "/" so it does not eat into hostnames.
   /\/[A-Za-z0-9_-]{32,}(?=\/|$)/g,

--- a/scripts/frax-ether-v2-fork-test.ts
+++ b/scripts/frax-ether-v2-fork-test.ts
@@ -38,6 +38,7 @@
 
 import { ethers } from "ethers";
 import fraxEtherV2Abi from "@/protocols/abis/frax-ether-v2.json";
+import { formatSanitizedRpcError } from "../lib/rpc/sanitize-rpc-error";
 
 const ANVIL_URL = process.env.ANVIL_URL ?? "http://localhost:8545";
 
@@ -137,7 +138,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  console.error(`\nFAIL: ${msg}`);
+  console.error(`\nFAIL: ${formatSanitizedRpcError(err)}`);
   process.exit(1);
 });

--- a/scripts/pin-agent-card.ts
+++ b/scripts/pin-agent-card.ts
@@ -22,6 +22,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ethers } from "ethers";
+import { formatSanitizedRpcError } from "../lib/rpc/sanitize-rpc-error";
 
 const DEFAULT_AGENT_ID = "31875";
 const DEFAULT_REGISTRY = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
@@ -106,7 +107,7 @@ async function readOnchainAgentURI(
       console.log(`[pin] Drift check via ${rpcUrl}`);
       return result;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatSanitizedRpcError(err);
       console.warn(`[pin] RPC ${rpcUrl} unavailable: ${message.split("\n")[0]}`);
     }
   }
@@ -174,7 +175,7 @@ const isMain =
 
 if (isMain) {
   pinAgentCard().catch((err) => {
-    console.error("[pin] Failed:", err instanceof Error ? err.message : err);
+    console.error("[pin] Failed:", formatSanitizedRpcError(err));
     process.exit(1);
   });
 }

--- a/scripts/register-agent.ts
+++ b/scripts/register-agent.ts
@@ -21,6 +21,7 @@ import postgres from "postgres";
 import { getDatabaseUrl } from "../lib/db/connection-utils";
 import { agentRegistrations } from "../lib/db/schema";
 import { getRpcUrlByChainId } from "../lib/rpc/rpc-config";
+import { formatSanitizedRpcError } from "../lib/rpc/sanitize-rpc-error";
 
 export const IDENTITY_REGISTRY_ADDRESS =
   "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
@@ -210,10 +211,7 @@ async function main(): Promise<void> {
   try {
     await registerAgent();
   } catch (err) {
-    console.error(
-      "Registration failed:",
-      err instanceof Error ? err.message : err
-    );
+    console.error("Registration failed:", formatSanitizedRpcError(err));
     process.exit(1);
   }
 }

--- a/scripts/seed/seed-tokens.ts
+++ b/scripts/seed/seed-tokens.ts
@@ -22,6 +22,7 @@ import { supportedTokens } from "@/lib/db/schema-extensions";
 import ERC20_ABI from "../../lib/contracts/abis/erc20.json";
 import { getDatabaseUrl } from "../../lib/db/connection-utils";
 import { getRpcUrlByChainId } from "../../lib/rpc/rpc-config";
+import { formatSanitizedRpcError } from "../../lib/rpc/sanitize-rpc-error";
 
 // Token logo URLs (using popular token list sources)
 const LOGOS = {
@@ -423,7 +424,7 @@ async function seedTokens() {
     } catch (error) {
       console.error(
         `  ✗ Failed to process ${config.tokenAddress} on chain ${config.chainId}:`,
-        error instanceof Error ? error.message : error
+        formatSanitizedRpcError(error)
       );
       console.log("");
     }
@@ -435,6 +436,6 @@ async function seedTokens() {
 }
 
 seedTokens().catch((err) => {
-  console.error("Error seeding tokens:", err);
+  console.error("Error seeding tokens:", formatSanitizedRpcError(err));
   process.exit(1);
 });

--- a/scripts/update-agent-uri.ts
+++ b/scripts/update-agent-uri.ts
@@ -21,6 +21,7 @@
 
 import "dotenv/config";
 import { ethers } from "ethers";
+import { formatSanitizedRpcError } from "../lib/rpc/sanitize-rpc-error";
 
 const DEFAULT_AGENT_ID = "31875";
 const DEFAULT_REGISTRY = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
@@ -131,7 +132,7 @@ const isMain =
 
 if (isMain) {
   updateAgentURI().catch((err) => {
-    console.error("Update failed:", err instanceof Error ? err.message : err);
+    console.error("Update failed:", formatSanitizedRpcError(err));
     process.exit(1);
   });
 }

--- a/scripts/verify-token.ts
+++ b/scripts/verify-token.ts
@@ -22,6 +22,7 @@ import "dotenv/config";
 import { ethers } from "ethers";
 import ERC20_ABI from "../lib/contracts/abis/erc20.json";
 import { getRpcUrlByChainId } from "../lib/rpc/rpc-config";
+import { formatSanitizedRpcError } from "../lib/rpc/sanitize-rpc-error";
 
 type TokenMetadata = {
   symbol: string;
@@ -77,7 +78,7 @@ async function main(): Promise<void> {
     const fallbackUrl = getRpcUrlByChainId(chainId, "fallback");
     if (fallbackUrl === primaryUrl) {
       console.error(
-        `  primary RPC failed and no distinct fallback is configured: ${(primaryError as Error).message}`
+        `  primary RPC failed and no distinct fallback is configured: ${formatSanitizedRpcError(primaryError)}`
       );
       process.exit(1);
     }
@@ -88,7 +89,7 @@ async function main(): Promise<void> {
       metadata = await fetchMetadata(fallbackUrl, lower);
     } catch (fallbackError) {
       console.error(
-        `  fallback RPC also failed: ${(fallbackError as Error).message}`
+        `  fallback RPC also failed: ${formatSanitizedRpcError(fallbackError)}`
       );
       process.exit(1);
     }

--- a/tests/unit/sanitize-rpc-error.test.ts
+++ b/tests/unit/sanitize-rpc-error.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSanitizedRpcError,
+  sanitizeRpcError,
+} from "@/lib/rpc/sanitize-rpc-error";
+
+// Fake key - matches the generic 32+ char fallback in scrub-rpc-urls.
+const FAKE_KEY = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAA";
+const FAKE_URL = `https://avax-mainnet.g.alchemy.com/v2/${FAKE_KEY}`;
+
+// Top-level regex (biome lint/performance/useTopLevelRegex).
+const SERVER_ERROR_SUFFIX_RE = /\(SERVER_ERROR\)$/;
+
+type EthersServerErrorShape = Error & {
+  code: string;
+  shortMessage: string;
+  info?: { requestUrl: string; responseStatus: string };
+};
+
+/**
+ * Structurally faithful to the ethers 6.16.0 SERVER_ERROR shape: `.message`
+ * inlines the full URL with key, `.shortMessage` does not, `.code` is the
+ * stable ethers code, and `.info.requestUrl` exposes the URL separately.
+ */
+function makeEthersServerError(): EthersServerErrorShape {
+  const err = new Error(
+    "server response 403 Forbidden (request={  }, response={  }, error=null, " +
+      `info={ "requestUrl": "${FAKE_URL}", "responseStatus": "403 Forbidden" }, ` +
+      "code=SERVER_ERROR, version=6.16.0)"
+  ) as EthersServerErrorShape;
+  err.code = "SERVER_ERROR";
+  err.shortMessage = "server response 403 Forbidden";
+  err.info = { requestUrl: FAKE_URL, responseStatus: "403 Forbidden" };
+  return err;
+}
+
+describe("sanitizeRpcError", () => {
+  it("never leaks the key embedded in an ethers SERVER_ERROR.message", () => {
+    const result = sanitizeRpcError(makeEthersServerError());
+    expect(result.message).not.toContain(FAKE_KEY);
+    expect(result.message).not.toContain(FAKE_URL);
+  });
+
+  it("preserves the ethers error code for retry-decision callers", () => {
+    const result = sanitizeRpcError(makeEthersServerError());
+    expect(result.code).toBe("SERVER_ERROR");
+  });
+
+  it("returns the ethers shortMessage when no URL is embedded there", () => {
+    const result = sanitizeRpcError(makeEthersServerError());
+    expect(result.shortMessage).toBe("server response 403 Forbidden");
+    // Prefers shortMessage as the .message field too.
+    expect(result.message).toBe("server response 403 Forbidden");
+  });
+
+  it("sanitizes a plain Error whose .message embeds a URL", () => {
+    const err = new Error(`fetch failed: GET ${FAKE_URL}`);
+    const result = sanitizeRpcError(err);
+    expect(result.message).not.toContain(FAKE_KEY);
+    expect(result.code).toBeUndefined();
+    expect(result.shortMessage).toBeUndefined();
+  });
+
+  it("sanitizes a thrown string containing a URL", () => {
+    const result = sanitizeRpcError(`connect ECONNREFUSED at ${FAKE_URL}`);
+    expect(result.message).not.toContain(FAKE_KEY);
+  });
+
+  it("handles undefined", () => {
+    expect(sanitizeRpcError(undefined).message).toBe(
+      "Unknown error (no error value)"
+    );
+  });
+
+  it("handles null", () => {
+    expect(sanitizeRpcError(null).message).toBe(
+      "Unknown error (no error value)"
+    );
+  });
+
+  it("handles a thrown number", () => {
+    expect(sanitizeRpcError(42).message).toBe("42");
+  });
+
+  it("falls back to code when only a code is available", () => {
+    expect(sanitizeRpcError({ code: "TIMEOUT" }).message).toBe("TIMEOUT");
+  });
+
+  it("falls back to a constant when nothing is available", () => {
+    expect(sanitizeRpcError({}).message).toBe("Unknown RPC error");
+  });
+
+  it("scrubs URLs that ever appear inside shortMessage too (defensive)", () => {
+    const err = {
+      code: "SERVER_ERROR",
+      shortMessage: `bad gateway at ${FAKE_URL}`,
+      message: "bad gateway",
+    };
+    const result = sanitizeRpcError(err);
+    expect(result.shortMessage).not.toContain(FAKE_KEY);
+    expect(result.message).not.toContain(FAKE_KEY);
+  });
+});
+
+describe("formatSanitizedRpcError", () => {
+  it("appends the code in parentheses when present", () => {
+    const out = formatSanitizedRpcError(makeEthersServerError());
+    expect(out).toMatch(SERVER_ERROR_SUFFIX_RE);
+    expect(out).not.toContain(FAKE_KEY);
+  });
+
+  it("omits the parenthesized code when none is available", () => {
+    expect(formatSanitizedRpcError(new Error("boom"))).toBe("boom");
+  });
+
+  it("never returns an empty string", () => {
+    expect(formatSanitizedRpcError(undefined)).not.toBe("");
+    expect(formatSanitizedRpcError(null)).not.toBe("");
+    expect(formatSanitizedRpcError({})).not.toBe("");
+  });
+});

--- a/tests/unit/scrub-rpc-urls.test.ts
+++ b/tests/unit/scrub-rpc-urls.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
+
+// Fake key markers. Long enough to trip the generic 32+ char path mask;
+// recognizable in greps so any regression that lets them through is loud.
+const FAKE_ALCHEMY_KEY = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAA";
+const FAKE_INFURA_KEY = "FAKE_TEST_KEY_DO_NOT_USE_BBBBBBBBBB";
+const FAKE_QUICKNODE_KEY = "FAKE_TEST_KEY_DO_NOT_USE_CCCCCCCCCC";
+const FAKE_ANKR_KEY = "FAKE_TEST_KEY_DO_NOT_USE_DDDDDDDDDD";
+
+describe("scrubRpcUrls", () => {
+  it("masks Alchemy /v2/<key> paths and keeps host visible", () => {
+    const input = `POST https://avax-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_KEY} failed`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_ALCHEMY_KEY);
+    expect(out).toContain("avax-mainnet.g.alchemy.com");
+    expect(out).toContain("/v2/[REDACTED]");
+  });
+
+  it("masks Infura /v3/<key> paths", () => {
+    const input = `https://mainnet.infura.io/v3/${FAKE_INFURA_KEY}`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_INFURA_KEY);
+    expect(out).toContain("/v3/[REDACTED]");
+  });
+
+  it("masks QuickNode subdomain key paths", () => {
+    const input = `https://example.quiknode.pro/${FAKE_QUICKNODE_KEY}/eth/`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_QUICKNODE_KEY);
+  });
+
+  it("masks Ankr premium /<chain>/<key> paths", () => {
+    const input = `https://rpc.ankr.com/eth/${FAKE_ANKR_KEY}`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_ANKR_KEY);
+  });
+
+  it("drops query strings entirely", () => {
+    const input = `https://rpc.example.com/foo?apikey=${FAKE_ALCHEMY_KEY}&debug=1`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_ALCHEMY_KEY);
+    expect(out).toContain("[REDACTED-QUERY]");
+  });
+
+  it("scrubs wss:// URLs the same way", () => {
+    const input = `wss://eth-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_KEY}`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_ALCHEMY_KEY);
+  });
+
+  it("masks multiple URLs in one string", () => {
+    const input =
+      `tried https://eth-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_KEY} ` +
+      `then https://mainnet.infura.io/v3/${FAKE_INFURA_KEY}`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_ALCHEMY_KEY);
+    expect(out).not.toContain(FAKE_INFURA_KEY);
+  });
+
+  it("stops at delimiting characters in error prose", () => {
+    const input = `(POST https://eth-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_KEY}) failed`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(FAKE_ALCHEMY_KEY);
+    // The closing paren should survive intact.
+    expect(out).toContain(") failed");
+  });
+
+  it("leaves plain prose without URLs untouched", () => {
+    expect(scrubRpcUrls("connection refused")).toBe("connection refused");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(scrubRpcUrls("")).toBe("");
+  });
+
+  it("does not over-mask short path segments like /v2/ alone", () => {
+    // Bare provider path without a secret - nothing to redact.
+    const input = "https://example.com/api/v1/health";
+    const out = scrubRpcUrls(input);
+    expect(out).toContain("example.com");
+    expect(out).toContain("/api/v1/health");
+  });
+});

--- a/tests/unit/scrub-rpc-urls.test.ts
+++ b/tests/unit/scrub-rpc-urls.test.ts
@@ -81,4 +81,145 @@ describe("scrubRpcUrls", () => {
     expect(out).toContain("example.com");
     expect(out).toContain("/api/v1/health");
   });
+
+  it("masks dRPC /<chain>/<key> paths while keeping the chain visible", () => {
+    // 44-char key shape - matches the dRPC key form used in CHAIN_RPC_CONFIG.
+    const fakeDrpcKey = "FAKE_TEST_KEY_DO_NOT_USE_DDDDDDDDDDDDDDDDDDDD";
+    const input = `https://lb.drpc.live/polygon/${fakeDrpcKey}`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(fakeDrpcKey);
+    expect(out).toContain("lb.drpc.live");
+    expect(out).toContain("/polygon/");
+  });
+
+  it("masks dRPC even on chain names with dashes (e.g. 0g-galileo-testnet)", () => {
+    const fakeDrpcKey = "FAKE_TEST_KEY_DO_NOT_USE_DDDDDDDDDDDDDDDDDDDD";
+    const input = `https://lb.drpc.live/0g-galileo-testnet/${fakeDrpcKey}`;
+    const out = scrubRpcUrls(input);
+    expect(out).not.toContain(fakeDrpcKey);
+    expect(out).toContain("/0g-galileo-testnet/");
+  });
+});
+
+// Regression-style coverage: every distinct URL shape currently present in
+// CHAIN_RPC_CONFIG (host, path layout). Fake keys match the real keys'
+// charset and length so coverage is meaningful. If a new provider lands in
+// the config that this suite does not cover, the corresponding fake key
+// will survive scrubbing and the test will fail loudly.
+describe("scrubRpcUrls - CHAIN_RPC_CONFIG provider coverage", () => {
+  const FAKE_ALCHEMY_21 = "FAKE_TEST_KEY_DO_NOT_AA"; // 23 chars, alchemy form
+  const FAKE_ALCHEMY_32 = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAA"; // 32 chars
+  const FAKE_QUICKNODE_40 = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAA"; // 40 chars
+  const FAKE_DRPC_44 = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA"; // 44 chars
+
+  type Case = { label: string; url: string; fakeKey?: string };
+
+  const cases: readonly Case[] = [
+    // No-secret hosts - the scrubber must not introduce false positives.
+    {
+      label: "TechOps proxy mainnet",
+      url: "https://chain.techops.services/eth-mainnet",
+    },
+    {
+      label: "TechOps proxy testnet",
+      url: "https://chain.techops.services/base-sepolia",
+    },
+    {
+      label: "TechOps proxy wss",
+      url: "wss://chain.techops.services/arb-mainnet",
+    },
+    { label: "Flashbots fast", url: "https://rpc.flashbots.net/fast" },
+    { label: "Flashbots sepolia", url: "https://rpc-sepolia.flashbots.net" },
+    {
+      label: "publicnode polygon",
+      url: "https://polygon-bor-rpc.publicnode.com",
+    },
+    { label: "publicnode bsc", url: "https://bsc-testnet-rpc.publicnode.com" },
+    { label: "arbitrum.io", url: "https://arb1.arbitrum.io/rpc" },
+    {
+      label: "arbitrum sepolia",
+      url: "https://sepolia-rollup.arbitrum.io/rpc",
+    },
+    { label: "binance dataseed", url: "https://bsc-dataseed.binance.org" },
+    {
+      label: "polygon.technology amoy",
+      url: "https://rpc-amoy.polygon.technology",
+    },
+    { label: "solana official mainnet", url: "https://api.mainnet.solana.com" },
+    { label: "solana official devnet wss", url: "wss://api.devnet.solana.com" },
+    { label: "tempo.xyz", url: "https://rpc.tempo.xyz/" },
+    { label: "tempo moderato", url: "https://rpc.moderato.tempo.xyz" },
+    { label: "Ankr public solana", url: "wss://rpc.ankr.com/solana" },
+
+    // Secret-bearing hosts - must redact and must not leak the fake key.
+    {
+      label: "Alchemy eth-mainnet v2",
+      url: `https://eth-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_21}`,
+      fakeKey: FAKE_ALCHEMY_21,
+    },
+    {
+      label: "Alchemy avax-mainnet v2",
+      url: `https://avax-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_32}`,
+      fakeKey: FAKE_ALCHEMY_32,
+    },
+    {
+      label: "Alchemy solana mainnet v2",
+      url: `https://solana-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_21}`,
+      fakeKey: FAKE_ALCHEMY_21,
+    },
+    {
+      label: "Alchemy wss",
+      url: `wss://base-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_21}`,
+      fakeKey: FAKE_ALCHEMY_21,
+    },
+    {
+      label: "dRPC mainnet",
+      url: `https://lb.drpc.live/polygon/${FAKE_DRPC_44}`,
+      fakeKey: FAKE_DRPC_44,
+    },
+    {
+      label: "dRPC testnet with dashed chain",
+      url: `https://lb.drpc.live/0g-galileo-testnet/${FAKE_DRPC_44}`,
+      fakeKey: FAKE_DRPC_44,
+    },
+    {
+      label: "dRPC wss",
+      url: `wss://lb.drpc.live/bsc/${FAKE_DRPC_44}`,
+      fakeKey: FAKE_DRPC_44,
+    },
+    {
+      label: "QuickNode with trailing slash",
+      url: `https://twilight-prettiest-water.0g-mainnet.quiknode.pro/${FAKE_QUICKNODE_40}/`,
+      fakeKey: FAKE_QUICKNODE_40,
+    },
+    {
+      label: "QuickNode without trailing slash",
+      url: `https://twilight-prettiest-water.0g-galileo.quiknode.pro/${FAKE_QUICKNODE_40}`,
+      fakeKey: FAKE_QUICKNODE_40,
+    },
+  ];
+
+  it.each(cases)("$label: never leaks any secret", ({ url, fakeKey }: Case) => {
+    const out = scrubRpcUrls(url);
+    if (fakeKey) {
+      expect(out).not.toContain(fakeKey);
+    } else {
+      // No-secret URLs should round-trip through the scrubber unchanged.
+      expect(out).toBe(url);
+    }
+  });
+
+  it("scrubs all observed shapes when concatenated into one error message", () => {
+    // Worst-case fixture: every secret-bearing URL pasted into a single
+    // string (the kind of payload an ethers v6 error message could become
+    // if multiple failovers happen back-to-back).
+    const secretCases = cases.filter((c) => c.fakeKey !== undefined);
+    const blob = secretCases.map((c) => c.url).join(" | ");
+    const out = scrubRpcUrls(blob);
+    for (const c of secretCases) {
+      if (c.fakeKey) {
+        expect(out).not.toContain(c.fakeKey);
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Ethers v6 inlines `info.requestUrl` (which can include an API key) into `Error.message`. Scripts that logged `error.message` could leak the key on any RPC failure. The primary leak fired in CI for `scripts/seed/seed-tokens.ts` when chain 43114 (AVAX) hit a 403 from a misconfigured Alchemy app.

## What changed

- New `lib/rpc/scrub-rpc-urls.ts` - regex-based URL/key scrubber. Masks known provider key paths (Alchemy `/v2/<key>`, Infura `/v3/<key>`, QuickNode, Ankr premium) and strips query strings entirely. Preserves host and path prefix so debug output still tells an operator which provider failed.
- New `lib/rpc/sanitize-rpc-error.ts` - ethers-aware normalizer. Prefers `error.shortMessage` (which does not contain `requestUrl` in ethers 6.x), falls back to a scrubbed `error.message`, and preserves `error.code` for retry-decision callers. Mirrors the `Partial<EthersError>` + key-check idiom already in `lib/rpc/providers/error-classification.ts`.
- Applied `formatSanitizedRpcError()` in six scripts that previously logged `error.message` verbatim:
  - `scripts/seed/seed-tokens.ts`
  - `scripts/verify-token.ts`
  - `scripts/register-agent.ts`
  - `scripts/update-agent-uri.ts`
  - `scripts/pin-agent-card.ts`
  - `scripts/frax-ether-v2-fork-test.ts`
- 25 unit tests covering an ethers v6 SERVER_ERROR fixture (with leaked URL in `.message` and `.info.requestUrl`), plain Error, thrown string, undefined, null, number, and multiple provider URL shapes. The critical assertion is that no `FAKE_TEST_KEY_DO_NOT_USE` marker survives sanitization.

## Effect on the incident log line

Before:
```
Failed to process 0x97...c7 on chain 43114: server response 403 Forbidden (request={  }, response={  }, error=null, info={ "requestUrl": "https://avax-mainnet.g.alchemy.com/v2/<KEY>", ... }, code=SERVER_ERROR, ...)
```

After:
```
Failed to process 0x97...c7 on chain 43114: server response 403 Forbidden (SERVER_ERROR)
```

## Operator actions required outside this PR

- [ ] Rotate Alchemy app `se9fqm1urwaikfih` in the Alchemy dashboard.
- [ ] Search GitHub Actions retained logs and artifacts for the leaked key string and purge anything still holding it.

## Known residual surface (not addressed here)

- `app/api/**` and `keeperhub-executor/**` still use the old `error.message` pattern via `logSystemError` / `apiError` (about 200 sites). Each call site needs individual review because response-body shape and Sentry contract differ; bulk replace risks frontend regressions. Track as a follow-up.
- Sentry SDK has no `beforeSend` hook for URL scrubbing. If `event.message`, frames, or breadcrumbs include a URL with a key, it reaches Sentry. Track as a follow-up.
- The AVAX RPC config in `CHAIN_RPC_CONFIG` is still pointed at an Alchemy app that does not have `AVAX_MAINNET` enabled, so chain 43114 will keep 403ing in CI. The new sanitizer ensures the post-rotation key is not logged when this happens. This is deliberate scope - the leak vector is closed by the code change; correcting the config is a separate operator action.

## Verification

- `pnpm test tests/unit/scrub-rpc-urls.test.ts tests/unit/sanitize-rpc-error.test.ts` - 25 of 25 pass.
- `npx biome check` on the 10 changed files - 0 errors.
- `pnpm type-check` - 0 errors (after `pnpm discover-plugins` to regenerate codegen registries).
