### PR TITLE
fix(api): structured 404 envelope for unknown routes + docs drift guard

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -199,6 +199,58 @@ jobs:
           CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
 
+      - name: Probe documented API endpoints
+        # Walks specs/api-coverage.json (committed by the PR-time
+        # check:api-docs guard) and sends a HEAD to every documented GET
+        # endpoint on the deployed env. Treats 200/401/403 as reachable
+        # (auth gates the response); 404/5xx as drift. Warn-only on the
+        # first deploy after merge so we can see what fires before it
+        # gates a release - flip continue-on-error to false once a clean
+        # run is recorded.
+        continue-on-error: true
+        run: |
+          if [ ! -f specs/api-coverage.json ]; then
+            echo "specs/api-coverage.json not found; skipping endpoint probe"
+            exit 0
+          fi
+          HEADERS=(-H "X-API-Key: ${TEST_API_KEY}")
+          if [[ -n "$CF_ACCESS_CLIENT_ID" && -n "$CF_ACCESS_CLIENT_SECRET" ]]; then
+            HEADERS+=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+          fi
+          # Concrete fixtures for the {param} placeholders in documented
+          # paths. We do not invent ids per env; we ask the API to look
+          # up a known-invalid value and accept the 401/403/404 that
+          # comes back as "the route is reachable". A 5xx or HTML 404
+          # from the catch-all is the actual signal.
+          FIXTURE="probe-fixture"
+          FAILED=0
+          REACHED=0
+          # jq filter: only GET endpoints, output one line each.
+          while IFS=$'\t' read -r METHOD PATH_TEMPLATE; do
+            [ "$METHOD" = "GET" ] || continue
+            URL_PATH=$(printf '%s' "$PATH_TEMPLATE" | sed -E "s/\{[^}]+\}/${FIXTURE}/g")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L \
+              -X HEAD "${HEADERS[@]}" \
+              "${{ env.BASE_URL }}${URL_PATH}" || echo "000")
+            case "$STATUS" in
+              200|401|403)
+                REACHED=$((REACHED+1))
+                ;;
+              *)
+                FAILED=$((FAILED+1))
+                echo "::warning::endpoint drift: GET ${PATH_TEMPLATE} returned ${STATUS} on ${{ env.BASE_URL }}"
+                ;;
+            esac
+          done < <(jq -r '.endpoints[] | [.method, .path] | @tsv' specs/api-coverage.json)
+          echo "Reached ${REACHED} documented GET endpoints; ${FAILED} drift."
+          if [ "$FAILED" -gt 0 ]; then
+            exit 1
+          fi
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
+          TEST_API_KEY: ${{ env.TEST_API_KEY }}
+
       - name: Run Playwright tests against deployed environment
         run: pnpm exec playwright test --grep-invert "happy-paths"
         env:

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -201,39 +201,43 @@ jobs:
 
       - name: Probe documented API endpoints
         # Walks specs/api-coverage.json (committed by the PR-time
-        # check:api-docs guard) and sends a HEAD to every documented GET
-        # endpoint on the deployed env. Treats 200/401/403 as reachable
-        # (auth gates the response); 404/5xx as drift. Warn-only on the
-        # first deploy after merge so we can see what fires before it
-        # gates a release - flip continue-on-error to false once a clean
-        # run is recorded.
+        # check:api-docs guard) and sends a GET to every documented GET
+        # endpoint on the deployed env. We deliberately use GET (not
+        # HEAD): many Next.js App Router handlers and any middleware
+        # that branches on request.method do not implement HEAD, so a
+        # 405 from a healthy GET handler would look like drift. Also
+        # avoids the curl -L + -X HEAD redirect-to-GET footgun.
+        #
+        # Reachable statuses include 400 because path-param routes
+        # validate the fixture string ("probe-fixture") and return 400;
+        # that proves the route exists and parsed the input. The actual
+        # drift signals are 404 (no route file shipped or wrong path)
+        # and 5xx (route exists but blew up).
+        #
+        # Warn-only on the first deploy after merge so we can see what
+        # fires before it gates a release - flip continue-on-error to
+        # false once a clean run is recorded.
         continue-on-error: true
         run: |
           if [ ! -f specs/api-coverage.json ]; then
-            echo "specs/api-coverage.json not found; skipping endpoint probe"
-            exit 0
+            echo "::error::specs/api-coverage.json not found; PR-time check:api-docs should have produced this"
+            exit 1
           fi
           HEADERS=(-H "X-API-Key: ${TEST_API_KEY}")
           if [[ -n "$CF_ACCESS_CLIENT_ID" && -n "$CF_ACCESS_CLIENT_SECRET" ]]; then
             HEADERS+=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
           fi
-          # Concrete fixtures for the {param} placeholders in documented
-          # paths. We do not invent ids per env; we ask the API to look
-          # up a known-invalid value and accept the 401/403/404 that
-          # comes back as "the route is reachable". A 5xx or HTML 404
-          # from the catch-all is the actual signal.
           FIXTURE="probe-fixture"
           FAILED=0
           REACHED=0
-          # jq filter: only GET endpoints, output one line each.
           while IFS=$'\t' read -r METHOD PATH_TEMPLATE; do
             [ "$METHOD" = "GET" ] || continue
             URL_PATH=$(printf '%s' "$PATH_TEMPLATE" | sed -E "s/\{[^}]+\}/${FIXTURE}/g")
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L \
-              -X HEAD "${HEADERS[@]}" \
+              "${HEADERS[@]}" \
               "${{ env.BASE_URL }}${URL_PATH}" || echo "000")
             case "$STATUS" in
-              200|401|403)
+              200|400|401|403)
                 REACHED=$((REACHED+1))
                 ;;
               *)
@@ -242,7 +246,16 @@ jobs:
                 ;;
             esac
           done < <(jq -r '.endpoints[] | [.method, .path] | @tsv' specs/api-coverage.json)
-          echo "Reached ${REACHED} documented GET endpoints; ${FAILED} drift."
+          TOTAL=$((REACHED + FAILED))
+          echo "Reached ${REACHED} documented GET endpoints; ${FAILED} drift; ${TOTAL} probed."
+          # Schema sanity guard: if 0 endpoints were probed at all, the
+          # artifact shape changed (renamed field, empty array, jq filter
+          # silently producing nothing) and the probe is meaningless.
+          # We fail rather than greenlight a deploy with no signal.
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "::error::api-coverage probe walked zero endpoints; specs/api-coverage.json may have changed shape"
+            exit 1
+          fi
           if [ "$FAILED" -gt 0 ]; then
             exit 1
           fi

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -237,10 +237,16 @@ jobs:
           FIXTURE="probe-fixture"
           FAILED=0
           REACHED=0
+          SKIPPED=$(jq '[.endpoints[] | select(.streaming == true) | .path] | length' specs/api-coverage.json)
+          if [ "$SKIPPED" -gt 0 ]; then
+            echo "Skipping ${SKIPPED} streaming endpoint(s) (text/event-stream; curl would block indefinitely):"
+            jq -r '.endpoints[] | select(.streaming == true) | "  GET \(.path)"' specs/api-coverage.json
+          fi
           while IFS=$'\t' read -r METHOD PATH_TEMPLATE; do
             [ "$METHOD" = "GET" ] || continue
             URL_PATH=$(printf '%s' "$PATH_TEMPLATE" | sed -E "s/\{[^}]+\}/${FIXTURE}/g")
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 10 \
               "${HEADERS[@]}" \
               "${{ env.BASE_URL }}${URL_PATH}" || echo "000")
             HAS_PARAM=0
@@ -265,7 +271,7 @@ jobs:
                 echo "::warning::endpoint drift: GET ${PATH_TEMPLATE} returned ${STATUS} on ${{ env.BASE_URL }}"
                 ;;
             esac
-          done < <(jq -r '.endpoints[] | [.method, .path] | @tsv' specs/api-coverage.json)
+          done < <(jq -r '.endpoints[] | select(.streaming != true) | [.method, .path] | @tsv' specs/api-coverage.json)
           TOTAL=$((REACHED + FAILED))
           echo "Reached ${REACHED} documented GET endpoints; ${FAILED} drift; ${TOTAL} probed."
           # Schema sanity guard: if 0 endpoints were probed at all, the

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -205,14 +205,21 @@ jobs:
         # endpoint on the deployed env. We deliberately use GET (not
         # HEAD): many Next.js App Router handlers and any middleware
         # that branches on request.method do not implement HEAD, so a
-        # 405 from a healthy GET handler would look like drift. Also
-        # avoids the curl -L + -X HEAD redirect-to-GET footgun.
+        # 405 from a healthy GET handler would look like drift.
         #
-        # Reachable statuses include 400 because path-param routes
-        # validate the fixture string ("probe-fixture") and return 400;
-        # that proves the route exists and parsed the input. The actual
-        # drift signals are 404 (no route file shipped or wrong path)
-        # and 5xx (route exists but blew up).
+        # Redirects are NOT followed (no curl -L, on purpose): curl
+        # resends custom -H headers - including X-API-Key and the CF
+        # Access secret - across redirects, even cross-host, which would
+        # leak those credentials if BASE_URL ever 30x'd off-origin.
+        #
+        # 404 is treated as drift ONLY for static (parameter-free) paths.
+        # A path-param route (e.g. /api/workflows/{workflowId}) probed
+        # with a fixture id legitimately returns 404 "resource not found"
+        # while the route itself exists and works - indistinguishable from
+        # a missing route file, so we cannot gate a release on it. For
+        # param routes only 5xx and connection failures (000) count as
+        # drift; any 2xx/4xx proves the route is reachable. Static routes
+        # must resolve, so a static 404 is real drift.
         #
         # Warn-only on the first deploy after merge so we can see what
         # fires before it gates a release - flip continue-on-error to
@@ -233,12 +240,25 @@ jobs:
           while IFS=$'\t' read -r METHOD PATH_TEMPLATE; do
             [ "$METHOD" = "GET" ] || continue
             URL_PATH=$(printf '%s' "$PATH_TEMPLATE" | sed -E "s/\{[^}]+\}/${FIXTURE}/g")
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L \
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
               "${HEADERS[@]}" \
               "${{ env.BASE_URL }}${URL_PATH}" || echo "000")
+            HAS_PARAM=0
+            case "$PATH_TEMPLATE" in
+              *"{"*) HAS_PARAM=1 ;;
+            esac
             case "$STATUS" in
               200|400|401|403)
                 REACHED=$((REACHED+1))
+                ;;
+              404)
+                if [ "$HAS_PARAM" -eq 1 ]; then
+                  REACHED=$((REACHED+1))
+                  echo "GET ${PATH_TEMPLATE} -> 404 (param route; resource-not-found for a fixture id is expected, route assumed present)"
+                else
+                  FAILED=$((FAILED+1))
+                  echo "::warning::endpoint drift: GET ${PATH_TEMPLATE} returned 404 on ${{ env.BASE_URL }} (static route should resolve)"
+                fi
                 ;;
               *)
                 FAILED=$((FAILED+1))

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -137,6 +137,26 @@ jobs:
             exit 1
           fi
 
+      - name: Check public API docs match route files
+        # Parses every documented (METHOD /api/...) entry in docs/api/*.md
+        # and asserts the corresponding app/api/<path>/route.ts exists and
+        # exports a handler for that method. Also writes
+        # specs/api-coverage.json which the post-deploy live HEAD check
+        # reads. Hackathon teams reported endpoints that 404 in prod or
+        # return shapes that diverge from docs; this guard blocks new drift
+        # at PR time.
+        run: pnpm check:api-docs
+
+      - name: Detect uncommitted api-coverage drift
+        # specs/api-coverage.json is committed and read by the post-deploy
+        # live HEAD check. If the script regenerated it during this job we
+        # need the contributor to commit the regenerated file.
+        run: |
+          if ! git diff --exit-code specs/api-coverage.json; then
+            echo "::error::specs/api-coverage.json is stale. Run 'pnpm check:api-docs' locally and commit the result."
+            exit 1
+          fi
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/app/api/[...slug]/route.ts
+++ b/app/api/[...slug]/route.ts
@@ -1,0 +1,58 @@
+/**
+ * Catch-all 404 handler for unmatched /api/* paths.
+ *
+ * Next.js's default 404 returns an HTML page, which makes a wrong URL
+ * look identical to a 401 when a builder is probing an API. This handler
+ * returns the canonical {error, detail, request_id} envelope so unknown
+ * routes are unambiguous and machine-parseable.
+ *
+ * Precedence: more specific route segments win over [...slug] in the
+ * Next.js App Router, so existing catch-alls at deeper paths
+ * (app/api/auth/[...all], app/api/execute/[...slug]) keep their own
+ * behavior. This file only fires when no other route matches.
+ *
+ * Cache-Control: no-store so a transient prod misconfig (route file not
+ * shipped, missing env var, etc.) does not get cached at the edge as a
+ * permanent 404.
+ */
+import type { NextRequest } from "next/server";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
+
+function notFoundResponse(request: NextRequest) {
+  const { pathname } = new URL(request.url);
+  return apiError({
+    status: 404,
+    code: ApiErrorCodes.NOT_FOUND,
+    detail: `Route ${request.method} ${pathname} not found`,
+    requestHeaders: request.headers,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+export function GET(request: NextRequest) {
+  return notFoundResponse(request);
+}
+
+export function POST(request: NextRequest) {
+  return notFoundResponse(request);
+}
+
+export function PUT(request: NextRequest) {
+  return notFoundResponse(request);
+}
+
+export function PATCH(request: NextRequest) {
+  return notFoundResponse(request);
+}
+
+export function DELETE(request: NextRequest) {
+  return notFoundResponse(request);
+}
+
+export function HEAD(request: NextRequest) {
+  return notFoundResponse(request);
+}
+
+export function OPTIONS(request: NextRequest) {
+  return notFoundResponse(request);
+}

--- a/app/api/[...slug]/route.ts
+++ b/app/api/[...slug]/route.ts
@@ -17,9 +17,24 @@
  */
 import type { NextRequest } from "next/server";
 import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
 
 function notFoundResponse(request: NextRequest) {
   const { pathname } = new URL(request.url);
+  // Emit a structured warn so Loki and Sentry surface frequently-probed
+  // unknown routes. Without this, the catch-all silently absorbs every
+  // misrouted client - which is exactly the diagnostic gap that
+  // motivated the ticket. Bots probe noisily, so consider sampling here
+  // if log volume becomes a concern.
+  logSystemWarn(
+    ErrorCategory.VALIDATION,
+    "[api-catch-all] unknown route",
+    new Error("api_route_not_found"),
+    {
+      path: pathname,
+      method: request.method,
+    }
+  );
   return apiError({
     status: 404,
     code: ApiErrorCodes.NOT_FOUND,

--- a/app/api/[...slug]/route.ts
+++ b/app/api/[...slug]/route.ts
@@ -15,7 +15,7 @@
  * shipped, missing env var, etc.) does not get cached at the edge as a
  * permanent 404.
  */
-import type { NextRequest } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 
@@ -66,7 +66,14 @@ export function DELETE(request: NextRequest) {
 }
 
 export function HEAD(request: NextRequest) {
-  return notFoundResponse(request);
+  // HEAD must not carry a response body (RFC 9110 9.3.2). Reuse the GET
+  // 404 so the status, correlation id, and cache headers stay identical,
+  // then return a body-less response with the same headers.
+  const response = notFoundResponse(request);
+  return new NextResponse(null, {
+    status: response.status,
+    headers: response.headers,
+  });
 }
 
 export function OPTIONS(request: NextRequest) {

--- a/app/api/[...slug]/route.ts
+++ b/app/api/[...slug]/route.ts
@@ -17,23 +17,24 @@
  */
 import type { NextRequest } from "next/server";
 import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
-import { ErrorCategory, logSystemWarn } from "@/lib/logging";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 
 function notFoundResponse(request: NextRequest) {
   const { pathname } = new URL(request.url);
-  // Emit a structured warn so Loki and Sentry surface frequently-probed
-  // unknown routes. Without this, the catch-all silently absorbs every
-  // misrouted client - which is exactly the diagnostic gap that
-  // motivated the ticket. Bots probe noisily, so consider sampling here
-  // if log volume becomes a concern.
-  logSystemWarn(
+  // Emit a structured Loki line so frequently-probed unknown routes stay
+  // diagnosable. This is a public surface that bots hammer with random
+  // paths; a miss is a client error, not a system fault, so it must not
+  // page on-call or burn a Sentry event per request. logUserError with no
+  // error argument logs to console/Loki and bumps a bounded Prometheus
+  // counter but skips captureException entirely. The unbounded path lives
+  // in the message (extractContext keeps only the "[api-catch-all]"
+  // prefix as the metric context), never in a metric label, so Prometheus
+  // cardinality stays flat.
+  logUserError(
     ErrorCategory.VALIDATION,
-    "[api-catch-all] unknown route",
-    new Error("api_route_not_found"),
-    {
-      path: pathname,
-      method: request.method,
-    }
+    `[api-catch-all] unknown route ${request.method} ${pathname}`,
+    undefined,
+    { method: request.method }
   );
   return apiError({
     status: 404,

--- a/docs/api/chains.md
+++ b/docs/api/chains.md
@@ -23,34 +23,59 @@ Returns all supported blockchain networks.
 
 ### Response
 
+Returns a bare JSON array of chain objects. The response is not wrapped in a `data` envelope.
+
 ```json
-{
-  "data": [
-    {
-      "id": "chain_1",
-      "chainId": 1,
-      "name": "Ethereum Mainnet",
-      "symbol": "ETH",
-      "chainType": "evm",
-      "defaultPrimaryRpc": "https://...",
-      "defaultFallbackRpc": "https://...",
-      "explorerUrl": "https://etherscan.io",
-      "explorerApiUrl": "https://api.etherscan.io",
-      "isTestnet": false,
-      "isEnabled": true
-    },
-    {
-      "id": "chain_2",
-      "chainId": 11155111,
-      "name": "Sepolia",
-      "symbol": "ETH",
-      "chainType": "evm",
-      "isTestnet": true,
-      "isEnabled": true
-    }
-  ]
-}
+[
+  {
+    "id": "chain_1",
+    "chainId": 1,
+    "name": "Ethereum Mainnet",
+    "symbol": "ETH",
+    "chainType": "evm",
+    "explorerUrl": "https://etherscan.io",
+    "explorerAddressPath": "/address/",
+    "explorerApiUrl": "https://api.etherscan.io",
+    "explorerApiType": "etherscan",
+    "isTestnet": false,
+    "isEnabled": true,
+    "usePrivateMempoolRpc": false
+  },
+  {
+    "id": "chain_2",
+    "chainId": 11155111,
+    "name": "Sepolia",
+    "symbol": "ETH",
+    "chainType": "evm",
+    "explorerUrl": "https://sepolia.etherscan.io",
+    "explorerAddressPath": "/address/",
+    "explorerApiUrl": "https://api-sepolia.etherscan.io",
+    "explorerApiType": "etherscan",
+    "isTestnet": true,
+    "isEnabled": true,
+    "usePrivateMempoolRpc": false
+  }
+]
 ```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Internal chain identifier |
+| `chainId` | number | Numeric EVM chain ID (or Solana network ID) |
+| `name` | string | Human-readable chain name |
+| `symbol` | string | Native token symbol |
+| `chainType` | string | `evm` or `solana` (see below) |
+| `explorerUrl` | string \| null | Block explorer base URL |
+| `explorerAddressPath` | string \| null | Path segment appended to `explorerUrl` for address links |
+| `explorerApiUrl` | string \| null | Explorer API base URL for ABI / verification lookups |
+| `explorerApiType` | string \| null | Explorer API family (e.g. `etherscan`, `blockscout`) |
+| `isTestnet` | boolean | Whether this chain is a testnet |
+| `isEnabled` | boolean | Whether the chain is currently available for workflow execution |
+| `usePrivateMempoolRpc` | boolean | Whether KeeperHub routes transactions through a private mempool (Flashbots Protect) by default |
+
+RPC endpoint URLs (`defaultPrimaryRpc`, `defaultFallbackRpc`) are not returned by this endpoint. They may embed provider API keys and are read server-side only; client code should use the user-configurable RPC preferences API instead.
 
 ### Chain Types
 
@@ -114,10 +139,3 @@ Fetches the ABI for a verified contract from the block explorer. The `{chainId}`
 }
 ```
 
-## Alternative ABI Fetch
-
-```http
-GET /api/web3/fetch-abi?address={address}&chainId={chainId}
-```
-
-Alternative endpoint for fetching contract ABIs.

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -77,31 +77,31 @@ GET /api/user/rpc-preferences
 
 ### Response
 
+Returns two arrays. `preferences` lists the user's saved overrides; `resolved` lists the effective RPC config for every chain after merging overrides with platform defaults. `source` is `"user"` when a preference is in effect, `"default"` otherwise.
+
 ```json
 {
-  "data": [
+  "preferences": [
+    {
+      "id": "pref_abc123",
+      "chainId": 1,
+      "primaryRpcUrl": "https://custom-rpc.example.com",
+      "fallbackRpcUrl": "https://fallback.example.com",
+      "createdAt": "2026-05-01T12:00:00.000Z",
+      "updatedAt": "2026-05-01T12:00:00.000Z"
+    }
+  ],
+  "resolved": [
     {
       "chainId": 1,
-      "primaryRpc": "https://custom-rpc.example.com",
-      "fallbackRpc": "https://fallback.example.com"
+      "chainName": "Ethereum Mainnet",
+      "primaryRpcUrl": "https://custom-rpc.example.com",
+      "fallbackRpcUrl": "https://fallback.example.com",
+      "primaryWssUrl": null,
+      "fallbackWssUrl": null,
+      "source": "user"
     }
   ]
-}
-```
-
-### Set RPC Preferences
-
-```http
-POST /api/user/rpc-preferences
-```
-
-### Request Body
-
-```json
-{
-  "chainId": 1,
-  "primaryRpc": "https://custom-rpc.example.com",
-  "fallbackRpc": "https://fallback.example.com"
 }
 ```
 
@@ -111,11 +111,22 @@ POST /api/user/rpc-preferences
 GET /api/user/rpc-preferences/{chainId}
 ```
 
-### Update Chain RPC Preference
+### Set or Update Chain RPC Preference
 
 ```http
 PUT /api/user/rpc-preferences/{chainId}
 ```
+
+#### Request Body
+
+```json
+{
+  "primaryRpcUrl": "https://custom-rpc.example.com",
+  "fallbackRpcUrl": "https://fallback.example.com"
+}
+```
+
+`fallbackRpcUrl` is optional. To clear an existing preference, use the DELETE endpoint below instead of sending an empty body.
 
 ### Delete Chain RPC Preference
 

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -303,23 +303,6 @@ Returns all public workflows with optional filtering.
 ]
 ```
 
-## Workflow Taxonomy
-
-```http
-GET /api/workflows/taxonomy
-```
-
-Returns distinct categories and protocols from all public workflows. Useful for building filter UIs.
-
-### Response
-
-```json
-{
-  "categories": ["defi", "nft"],
-  "protocols": ["uniswap", "aave-v3"]
-}
-```
-
 ## Update Featured Status (Internal)
 
 ```http

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "type-check": "tsc --noEmit",
     "check": "ultracite check",
+    "check:api-docs": "tsx scripts/check-api-docs-routes.ts",
     "fix": "ultracite fix",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/scripts/check-api-docs-routes.ts
+++ b/scripts/check-api-docs-routes.ts
@@ -141,22 +141,6 @@ function parseDocsFile(absPath: string): DocumentedEndpoint[] {
 }
 
 /**
- * Map a canonical docs path like /api/workflows/{workflowId}/execute to
- * the Next.js App Router file location, allowing the docs param name to
- * differ from the filesystem param name (`{executionId}` in docs vs
- * `[id]` on disk is fine; only the URL pattern shape matters).
- *
- * Returns null when no route file matches the shape.
- */
-function docsPathToRouteFile(
-  canonicalPath: string,
-  shapeIndex: Map<string, string>
-): string | null {
-  const shape = pathShape(canonicalPath);
-  return shapeIndex.get(shape) ?? null;
-}
-
-/**
  * Collapse every dynamic segment (`{x}`, `[x]`, `[...x]`) to a stable
  * wildcard so /api/runs/{id} and /api/runs/[executionId] hash to the
  * same shape. Static segments are preserved verbatim.
@@ -321,10 +305,22 @@ function writeCoverageArtifact(
   shapeIndex: Map<string, string>
 ) {
   mkdirSync(dirname(COVERAGE_OUT), { recursive: true });
-  // Stable ordering so the artifact diff is reviewable.
-  const sorted = [...endpoints].sort((a, b) =>
-    `${a.method} ${a.path}`.localeCompare(`${b.method} ${b.path}`)
-  );
+  // Stable ordering so the artifact diff is reviewable. Sort by raw code
+  // point, NOT localeCompare: the committed file is byte-compared by the
+  // CI drift check, and localeCompare's default collation depends on the
+  // runtime locale/ICU, so a contributor whose machine sorts differently
+  // from CI could regenerate a "stale" artifact that fails the build.
+  const sorted = [...endpoints].sort((a, b) => {
+    const ka = `${a.method} ${a.path}`;
+    const kb = `${b.method} ${b.path}`;
+    if (ka < kb) {
+      return -1;
+    }
+    if (ka > kb) {
+      return 1;
+    }
+    return 0;
+  });
   const json = {
     endpoints: sorted.map((ep) => ({
       method: ep.method,

--- a/scripts/check-api-docs-routes.ts
+++ b/scripts/check-api-docs-routes.ts
@@ -200,6 +200,20 @@ function indexRouteFiles(): {
 }
 
 /**
+ * Returns true if the route file sets Content-Type: text/event-stream,
+ * indicating a Server-Sent Events endpoint. The post-deploy curl probe
+ * skips these: curl has no --max-time by default, so a keep-alive stream
+ * blocks the probe indefinitely.
+ */
+function isStreamingRoute(absRouteFile: string): boolean {
+  try {
+    return readFileSync(absRouteFile, "utf8").includes("text/event-stream");
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read a route file and report which HTTP methods it exports. Matches
  * the three styles observed in the codebase:
  *   export async function GET(...) { ... }
@@ -322,13 +336,19 @@ function writeCoverageArtifact(
     return 0;
   });
   const json = {
-    endpoints: sorted.map((ep) => ({
-      method: ep.method,
-      path: ep.path,
-      route_file: shapeIndex.get(pathShape(ep.path)) ?? null,
-      source: ep.source,
-      line: ep.line,
-    })),
+    endpoints: sorted.map((ep) => {
+      const routeFile = shapeIndex.get(pathShape(ep.path)) ?? null;
+      const streaming =
+        routeFile !== null && isStreamingRoute(join(REPO_ROOT, routeFile));
+      return {
+        method: ep.method,
+        path: ep.path,
+        route_file: routeFile,
+        ...(streaming ? { streaming: true } : {}),
+        source: ep.source,
+        line: ep.line,
+      };
+    }),
   };
   writeFileSync(COVERAGE_OUT, `${JSON.stringify(json, null, 2)}\n`);
 }

--- a/scripts/check-api-docs-routes.ts
+++ b/scripts/check-api-docs-routes.ts
@@ -1,0 +1,383 @@
+#!/usr/bin/env tsx
+
+/**
+ * Static guard against docs-vs-code drift in the public API.
+ *
+ * For every (METHOD, /api/path) advertised inside a fenced ```http block
+ * under docs/api/**.md, this script asserts that the corresponding
+ * Next.js App Router route file (app/api/<segments>/route.ts) exists and
+ * exports a handler for that method. Path parameters in docs (`{id}`) are
+ * mapped to the filesystem convention (`[id]`).
+ *
+ * Exits non-zero on any drift. Also emits specs/api-coverage.json so the
+ * post-deploy live HEAD check (deploy-keeperhub.yaml) reads the same
+ * source of truth without re-parsing markdown in YAML.
+ *
+ * Routes that exist in code but appear in no docs file are surfaced as
+ * warnings, not failures - many internal/cron/og/auth routes are
+ * intentionally undocumented.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const DOCS_DIR = join(REPO_ROOT, "docs/api");
+const APP_API_DIR = join(REPO_ROOT, "app/api");
+const COVERAGE_OUT = join(REPO_ROOT, "specs/api-coverage.json");
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+const HTTP_METHODS: readonly HttpMethod[] = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+] as const;
+
+type DocumentedEndpoint = {
+  method: HttpMethod;
+  path: string; // canonical, with {param} placeholders
+  source: string; // docs file (repo-relative)
+  line: number; // 1-based line in source
+};
+
+type Drift =
+  | {
+      kind: "missing-file";
+      endpoint: DocumentedEndpoint;
+      expectedShape: string;
+    }
+  | {
+      kind: "missing-method";
+      endpoint: DocumentedEndpoint;
+      routeFile: string;
+    };
+
+// Routes that intentionally have no public-facing docs page. We do NOT
+// fail or warn on these when walking app/api/** in reverse.
+const UNDOCUMENTED_PREFIX_ALLOWLIST: readonly string[] = [
+  "/api/internal/",
+  "/api/cron/",
+  "/api/admin/",
+  "/api/og/",
+  "/api/metrics",
+  "/api/auth/",
+  "/api/oauth/",
+  "/api/health",
+  "/api/openapi",
+  "/api/feedback", // platform internal feedback collector
+  "/api/features",
+  "/api/notifications/",
+  "/api/billing/webhooks/", // 3rd-party callback surface
+  "/api/agent-registry",
+  "/api/protocols", // exposed via hub, not public REST docs
+  "/api/supported-tokens",
+  "/api/validate-token",
+  "/api/web3/", // legacy alias under chains
+  "/api/gas/",
+  "/api/mcp/", // documented via MCP catalog, not REST docs
+];
+
+function walkFiles(dir: string, suffix: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...walkFiles(full, suffix));
+    } else if (name.endsWith(suffix)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse every fenced ```http block in a markdown file and extract
+ * (method, path) lines. Returns matches with 1-based line numbers.
+ */
+function parseDocsFile(absPath: string): DocumentedEndpoint[] {
+  const text = readFileSync(absPath, "utf8");
+  const lines = text.split(/\r?\n/);
+  const endpoints: DocumentedEndpoint[] = [];
+  let inHttpBlock = false;
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (/^```http\b/.test(raw)) {
+      inHttpBlock = true;
+      continue;
+    }
+    if (inHttpBlock && raw.startsWith("```")) {
+      inHttpBlock = false;
+      continue;
+    }
+    if (!inHttpBlock) {
+      continue;
+    }
+    const match = raw.match(/^\s*(GET|POST|PUT|PATCH|DELETE)\s+(\/api\/\S+)/);
+    if (!match) {
+      continue;
+    }
+    const method = match[1] as HttpMethod;
+    // Strip query string and trailing punctuation; we only validate the
+    // route, not its query parameters.
+    const rawPath = match[2].split("?")[0].replace(/[).,;]+$/u, "");
+    const canonical = rawPath.replace(/\/+$/u, "");
+    endpoints.push({
+      method,
+      path: canonical,
+      source: relative(REPO_ROOT, absPath),
+      line: i + 1,
+    });
+  }
+  return endpoints;
+}
+
+/**
+ * Map a canonical docs path like /api/workflows/{workflowId}/execute to
+ * the Next.js App Router file location, allowing the docs param name to
+ * differ from the filesystem param name (`{executionId}` in docs vs
+ * `[id]` on disk is fine; only the URL pattern shape matters).
+ *
+ * Returns null when no route file matches the shape.
+ */
+function docsPathToRouteFile(
+  canonicalPath: string,
+  shapeIndex: Map<string, string>
+): string | null {
+  const shape = pathShape(canonicalPath);
+  return shapeIndex.get(shape) ?? null;
+}
+
+/**
+ * Collapse every dynamic segment (`{x}`, `[x]`, `[...x]`) to a stable
+ * wildcard so /api/runs/{id} and /api/runs/[executionId] hash to the
+ * same shape. Static segments are preserved verbatim.
+ */
+function pathShape(p: string): string {
+  return p
+    .split("/")
+    .map((seg) => {
+      if (/^\[\.\.\..+\]$/u.test(seg)) {
+        return "**";
+      }
+      if (/^\[.+\]$/u.test(seg) || /^\{.+\}$/u.test(seg)) {
+        return "*";
+      }
+      return seg;
+    })
+    .join("/");
+}
+
+/**
+ * Walk app/api/**.route.ts(x) once and return:
+ *   shapeIndex: path-shape -> route file (repo-relative)
+ *   routeFiles: list of (absPath, route URL with {param} placeholders)
+ */
+function indexRouteFiles(): {
+  shapeIndex: Map<string, string>;
+  routeFiles: { abs: string; routePath: string }[];
+} {
+  const shapeIndex = new Map<string, string>();
+  const routeFiles: { abs: string; routePath: string }[] = [];
+  const files = walkFiles(APP_API_DIR, "route.ts").concat(
+    walkFiles(APP_API_DIR, "route.tsx")
+  );
+  for (const abs of files) {
+    const rel = relative(REPO_ROOT, abs);
+    const routePath =
+      "/" +
+      rel
+        .replace(/\\/g, "/")
+        .replace(/^app\//u, "")
+        .replace(/\/route\.tsx?$/u, "")
+        .split("/")
+        .map((seg) => seg.replace(/^\[(.+)\]$/u, "{$1}"))
+        .join("/");
+    routeFiles.push({ abs, routePath });
+    const shape = pathShape(routePath);
+    // First write wins; if two route files collide on shape (e.g.
+    // `/api/workflow/{id}` and `/api/workflows/{id}` both collapse to
+    // `/api/workflows/*` only if both literal segments match, which is
+    // not the case here), the later one is silently ignored. The
+    // un-documented warning pass surfaces any duplicate that mattered.
+    if (!shapeIndex.has(shape)) {
+      shapeIndex.set(shape, rel);
+    }
+  }
+  return { shapeIndex, routeFiles };
+}
+
+/**
+ * Read a route file and report which HTTP methods it exports. Matches
+ * the three styles observed in the codebase:
+ *   export async function GET(...) { ... }
+ *   export const GET = requireOrganization(async (req, ctx) => { ... });
+ *   export { POST } from "@/app/api/.../route";
+ */
+function exportedMethods(absRouteFile: string): Set<HttpMethod> {
+  const text = readFileSync(absRouteFile, "utf8");
+  const found = new Set<HttpMethod>();
+  for (const method of HTTP_METHODS) {
+    const fn = new RegExp(
+      String.raw`(?:^|\n)\s*export\s+(?:async\s+)?function\s+${method}\s*\(`,
+      "u"
+    );
+    const cnst = new RegExp(
+      String.raw`(?:^|\n)\s*export\s+const\s+${method}\s*=`,
+      "u"
+    );
+    // export { GET } from "..."; or export { GET, POST } from "...";
+    // Match within the braces of a re-export, allowing aliases (GET as Foo).
+    const reExport = new RegExp(
+      String.raw`(?:^|\n)\s*export\s*\{[^}]*\b${method}\b[^}]*\}\s*from\b`,
+      "u"
+    );
+    if (fn.test(text) || cnst.test(text) || reExport.test(text)) {
+      found.add(method);
+    }
+  }
+  return found;
+}
+
+function collectDocumentedEndpoints(): DocumentedEndpoint[] {
+  if (!existsSync(DOCS_DIR)) {
+    throw new Error(`docs/api directory not found at ${DOCS_DIR}`);
+  }
+  const docFiles = walkFiles(DOCS_DIR, ".md");
+  const all = docFiles.flatMap(parseDocsFile);
+  // Deduplicate (a path may be re-mentioned in the same file).
+  const seen = new Set<string>();
+  const out: DocumentedEndpoint[] = [];
+  for (const ep of all) {
+    const key = `${ep.method} ${ep.path}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(ep);
+  }
+  return out;
+}
+
+function validate(
+  endpoints: DocumentedEndpoint[],
+  shapeIndex: Map<string, string>
+): Drift[] {
+  const drifts: Drift[] = [];
+  for (const ep of endpoints) {
+    const routeFile = shapeIndex.get(pathShape(ep.path));
+    if (!routeFile) {
+      drifts.push({
+        kind: "missing-file",
+        endpoint: ep,
+        expectedShape: pathShape(ep.path),
+      });
+      continue;
+    }
+    const methods = exportedMethods(join(REPO_ROOT, routeFile));
+    if (!methods.has(ep.method)) {
+      drifts.push({ kind: "missing-method", endpoint: ep, routeFile });
+    }
+  }
+  return drifts;
+}
+
+/**
+ * Walk app/api/**.route.ts and flag routes that are not mentioned in any
+ * docs/api/**.md file. Allowlisted prefixes (internal, cron, og, auth,
+ * etc.) are skipped silently. Output is warn-only.
+ */
+function reportUndocumentedRoutes(
+  documentedShapes: ReadonlySet<string>,
+  routeFiles: { abs: string; routePath: string }[]
+): string[] {
+  const warnings: string[] = [];
+  for (const { abs, routePath } of routeFiles) {
+    // The catch-all itself - never warn on it.
+    if (routePath === "/api/{...slug}") {
+      continue;
+    }
+    if (UNDOCUMENTED_PREFIX_ALLOWLIST.some((p) => routePath.startsWith(p))) {
+      continue;
+    }
+    if (!documentedShapes.has(pathShape(routePath))) {
+      const rel = relative(REPO_ROOT, abs);
+      warnings.push(`warn: ${routePath} (${rel}) is not mentioned in docs/api`);
+    }
+  }
+  return warnings.sort();
+}
+
+function writeCoverageArtifact(
+  endpoints: DocumentedEndpoint[],
+  shapeIndex: Map<string, string>
+) {
+  mkdirSync(dirname(COVERAGE_OUT), { recursive: true });
+  // Stable ordering so the artifact diff is reviewable.
+  const sorted = [...endpoints].sort((a, b) =>
+    `${a.method} ${a.path}`.localeCompare(`${b.method} ${b.path}`)
+  );
+  const json = {
+    endpoints: sorted.map((ep) => ({
+      method: ep.method,
+      path: ep.path,
+      route_file: shapeIndex.get(pathShape(ep.path)) ?? null,
+      source: ep.source,
+      line: ep.line,
+    })),
+  };
+  writeFileSync(COVERAGE_OUT, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+function main(): number {
+  const endpoints = collectDocumentedEndpoints();
+  const { shapeIndex, routeFiles } = indexRouteFiles();
+  const drifts = validate(endpoints, shapeIndex);
+  writeCoverageArtifact(endpoints, shapeIndex);
+
+  console.log(
+    `Scanned ${endpoints.length} documented endpoints across docs/api/`
+  );
+
+  if (drifts.length > 0) {
+    console.error("\nDRIFT detected:\n");
+    for (const d of drifts) {
+      const { method, path, source, line } = d.endpoint;
+      const reason =
+        d.kind === "missing-file"
+          ? `no route file matches the URL pattern ${d.expectedShape}`
+          : `${d.routeFile} exists but does not export ${method}`;
+      console.error(`  ${method} ${path}`);
+      console.error(`    documented in ${source}:${line}`);
+      console.error(`    ${reason}\n`);
+    }
+  }
+
+  const documentedShapes = new Set(endpoints.map((e) => pathShape(e.path)));
+  const warnings = reportUndocumentedRoutes(documentedShapes, routeFiles);
+  if (warnings.length > 0) {
+    console.log(
+      `\n${warnings.length} routes exist in code but are not in docs/api ` +
+        "(warnings only):"
+    );
+    for (const w of warnings) {
+      console.log(`  ${w}`);
+    }
+  }
+
+  if (drifts.length > 0) {
+    return 1;
+  }
+  console.log("\nNo docs-vs-code drift detected.");
+  return 0;
+}
+
+process.exit(main());

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -1,0 +1,487 @@
+{
+  "endpoints": [
+    {
+      "method": "DELETE",
+      "path": "/api/address-book/{entryId}",
+      "route_file": "app/api/address-book/[entryId]/route.ts",
+      "source": "docs/api/user.md",
+      "line": 241
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/api-keys/{keyId}",
+      "route_file": "app/api/api-keys/[keyId]/route.ts",
+      "source": "docs/api/api-keys.md",
+      "line": 132
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/integrations/{integrationId}",
+      "route_file": "app/api/integrations/[integrationId]/route.ts",
+      "source": "docs/api/integrations.md",
+      "line": 101
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/keys/{keyId}",
+      "route_file": "app/api/keys/[keyId]/route.ts",
+      "source": "docs/api/api-keys.md",
+      "line": 88
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/projects/{projectId}",
+      "route_file": "app/api/projects/[projectId]/route.ts",
+      "source": "docs/api/projects.md",
+      "line": 78
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/tags/{tagId}",
+      "route_file": "app/api/tags/[tagId]/route.ts",
+      "source": "docs/api/tags.md",
+      "line": 76
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/user/rpc-preferences/{chainId}",
+      "route_file": "app/api/user/rpc-preferences/[chainId]/route.ts",
+      "source": "docs/api/user.md",
+      "line": 134
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/workflows/{workflowId}",
+      "route_file": "app/api/workflows/[workflowId]/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 163
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/workflows/{workflowId}/executions",
+      "route_file": "app/api/workflows/[workflowId]/executions/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 259
+    },
+    {
+      "method": "GET",
+      "path": "/api/address-book",
+      "route_file": "app/api/address-book/route.ts",
+      "source": "docs/api/user.md",
+      "line": 208
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/networks",
+      "route_file": "app/api/analytics/networks/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 80
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/runs",
+      "route_file": "app/api/analytics/runs/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 111
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/runs/{executionId}/steps",
+      "route_file": "app/api/analytics/runs/[id]/steps/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 162
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/spend-cap",
+      "route_file": "app/api/analytics/spend-cap/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 188
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/stream",
+      "route_file": "app/api/analytics/stream/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 207
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/summary",
+      "route_file": "app/api/analytics/summary/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 13
+    },
+    {
+      "method": "GET",
+      "path": "/api/analytics/time-series",
+      "route_file": "app/api/analytics/time-series/route.ts",
+      "source": "docs/api/analytics.md",
+      "line": 53
+    },
+    {
+      "method": "GET",
+      "path": "/api/api-keys",
+      "route_file": "app/api/api-keys/route.ts",
+      "source": "docs/api/api-keys.md",
+      "line": 108
+    },
+    {
+      "method": "GET",
+      "path": "/api/chains",
+      "route_file": "app/api/chains/route.ts",
+      "source": "docs/api/chains.md",
+      "line": 13
+    },
+    {
+      "method": "GET",
+      "path": "/api/chains/{chainId}/abi",
+      "route_file": "app/api/chains/[chainId]/abi/route.ts",
+      "source": "docs/api/chains.md",
+      "line": 116
+    },
+    {
+      "method": "GET",
+      "path": "/api/execute/{executionId}/status",
+      "route_file": "app/api/execute/[executionId]/status/route.ts",
+      "source": "docs/api/direct-execution.md",
+      "line": 198
+    },
+    {
+      "method": "GET",
+      "path": "/api/integrations",
+      "route_file": "app/api/integrations/route.ts",
+      "source": "docs/api/integrations.md",
+      "line": 27
+    },
+    {
+      "method": "GET",
+      "path": "/api/integrations/{integrationId}",
+      "route_file": "app/api/integrations/[integrationId]/route.ts",
+      "source": "docs/api/integrations.md",
+      "line": 58
+    },
+    {
+      "method": "GET",
+      "path": "/api/keys",
+      "route_file": "app/api/keys/route.ts",
+      "source": "docs/api/api-keys.md",
+      "line": 28
+    },
+    {
+      "method": "GET",
+      "path": "/api/mcp/schemas",
+      "route_file": "app/api/mcp/schemas/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 317
+    },
+    {
+      "method": "GET",
+      "path": "/api/projects",
+      "route_file": "app/api/projects/route.ts",
+      "source": "docs/api/projects.md",
+      "line": 13
+    },
+    {
+      "method": "GET",
+      "path": "/api/public-tags",
+      "route_file": "app/api/public-tags/route.ts",
+      "source": "docs/api/tags.md",
+      "line": 88
+    },
+    {
+      "method": "GET",
+      "path": "/api/tags",
+      "route_file": "app/api/tags/route.ts",
+      "source": "docs/api/tags.md",
+      "line": 17
+    },
+    {
+      "method": "GET",
+      "path": "/api/user",
+      "route_file": "app/api/user/route.ts",
+      "source": "docs/api/user.md",
+      "line": 15
+    },
+    {
+      "method": "GET",
+      "path": "/api/user/rpc-preferences",
+      "route_file": "app/api/user/rpc-preferences/route.ts",
+      "source": "docs/api/user.md",
+      "line": 75
+    },
+    {
+      "method": "GET",
+      "path": "/api/user/rpc-preferences/{chainId}",
+      "route_file": "app/api/user/rpc-preferences/[chainId]/route.ts",
+      "source": "docs/api/user.md",
+      "line": 111
+    },
+    {
+      "method": "GET",
+      "path": "/api/user/wallet",
+      "route_file": "app/api/user/wallet/route.ts",
+      "source": "docs/api/user.md",
+      "line": 51
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows",
+      "route_file": "app/api/workflows/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 13
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/{workflowId}",
+      "route_file": "app/api/workflows/[workflowId]/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 51
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/{workflowId}/code",
+      "route_file": "app/api/workflows/[workflowId]/code/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 235
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/{workflowId}/download",
+      "route_file": "app/api/workflows/[workflowId]/download/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 227
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/{workflowId}/executions",
+      "route_file": "app/api/workflows/[workflowId]/executions/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 13
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/executions/{executionId}/logs",
+      "route_file": "app/api/workflows/executions/[executionId]/logs/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 116
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/executions/{executionId}/status",
+      "route_file": "app/api/workflows/executions/[executionId]/status/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 46
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/public",
+      "route_file": "app/api/workflows/public/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 270
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/address-book/{entryId}",
+      "route_file": "app/api/address-book/[entryId]/route.ts",
+      "source": "docs/api/user.md",
+      "line": 233
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/projects/{projectId}",
+      "route_file": "app/api/projects/[projectId]/route.ts",
+      "source": "docs/api/projects.md",
+      "line": 60
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/tags/{tagId}",
+      "route_file": "app/api/tags/[tagId]/route.ts",
+      "source": "docs/api/tags.md",
+      "line": 59
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/user",
+      "route_file": "app/api/user/route.ts",
+      "source": "docs/api/user.md",
+      "line": 35
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/workflows/{workflowId}",
+      "route_file": "app/api/workflows/[workflowId]/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 141
+    },
+    {
+      "method": "POST",
+      "path": "/api/address-book",
+      "route_file": "app/api/address-book/route.ts",
+      "source": "docs/api/user.md",
+      "line": 216
+    },
+    {
+      "method": "POST",
+      "path": "/api/api-keys",
+      "route_file": "app/api/api-keys/route.ts",
+      "source": "docs/api/api-keys.md",
+      "line": 116
+    },
+    {
+      "method": "POST",
+      "path": "/api/execute/check-and-execute",
+      "route_file": "app/api/execute/check-and-execute/route.ts",
+      "source": "docs/api/direct-execution.md",
+      "line": 126
+    },
+    {
+      "method": "POST",
+      "path": "/api/execute/contract-call",
+      "route_file": "app/api/execute/contract-call/route.ts",
+      "source": "docs/api/direct-execution.md",
+      "line": 71
+    },
+    {
+      "method": "POST",
+      "path": "/api/execute/transfer",
+      "route_file": "app/api/execute/transfer/route.ts",
+      "source": "docs/api/direct-execution.md",
+      "line": 31
+    },
+    {
+      "method": "POST",
+      "path": "/api/hub/featured",
+      "route_file": "app/api/hub/featured/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 309
+    },
+    {
+      "method": "POST",
+      "path": "/api/integrations",
+      "route_file": "app/api/integrations/route.ts",
+      "source": "docs/api/integrations.md",
+      "line": 66
+    },
+    {
+      "method": "POST",
+      "path": "/api/integrations/{integrationId}/test",
+      "route_file": "app/api/integrations/[integrationId]/test/route.ts",
+      "source": "docs/api/integrations.md",
+      "line": 107
+    },
+    {
+      "method": "POST",
+      "path": "/api/keys",
+      "route_file": "app/api/keys/route.ts",
+      "source": "docs/api/api-keys.md",
+      "line": 54
+    },
+    {
+      "method": "POST",
+      "path": "/api/organizations/{organizationId}/leave",
+      "route_file": "app/api/organizations/[organizationId]/leave/route.ts",
+      "source": "docs/api/organizations.md",
+      "line": 13
+    },
+    {
+      "method": "POST",
+      "path": "/api/projects",
+      "route_file": "app/api/projects/route.ts",
+      "source": "docs/api/projects.md",
+      "line": 38
+    },
+    {
+      "method": "POST",
+      "path": "/api/public-tags",
+      "route_file": "app/api/public-tags/route.ts",
+      "source": "docs/api/tags.md",
+      "line": 110
+    },
+    {
+      "method": "POST",
+      "path": "/api/tags",
+      "route_file": "app/api/tags/route.ts",
+      "source": "docs/api/tags.md",
+      "line": 42
+    },
+    {
+      "method": "POST",
+      "path": "/api/user/delete",
+      "route_file": "app/api/user/delete/route.ts",
+      "source": "docs/api/user.md",
+      "line": 188
+    },
+    {
+      "method": "POST",
+      "path": "/api/user/forgot-password",
+      "route_file": "app/api/user/forgot-password/route.ts",
+      "source": "docs/api/user.md",
+      "line": 159
+    },
+    {
+      "method": "POST",
+      "path": "/api/user/password",
+      "route_file": "app/api/user/password/route.ts",
+      "source": "docs/api/user.md",
+      "line": 142
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflows/{workflowId}/claim",
+      "route_file": "app/api/workflows/[workflowId]/claim/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 243
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflows/{workflowId}/duplicate",
+      "route_file": "app/api/workflows/[workflowId]/duplicate/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 219
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflows/{workflowId}/execute",
+      "route_file": "app/api/workflows/[workflowId]/execute/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 175
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflows/{workflowId}/webhook",
+      "route_file": "app/api/workflows/[workflowId]/webhook/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 211
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflows/create",
+      "route_file": "app/api/workflows/create/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 84
+    },
+    {
+      "method": "PUT",
+      "path": "/api/integrations/{integrationId}",
+      "route_file": "app/api/integrations/[integrationId]/route.ts",
+      "source": "docs/api/integrations.md",
+      "line": 84
+    },
+    {
+      "method": "PUT",
+      "path": "/api/user/rpc-preferences/{chainId}",
+      "route_file": "app/api/user/rpc-preferences/[chainId]/route.ts",
+      "source": "docs/api/user.md",
+      "line": 117
+    },
+    {
+      "method": "PUT",
+      "path": "/api/workflows/{workflowId}/go-live",
+      "route_file": "app/api/workflows/[workflowId]/go-live/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 251
+    }
+  ]
+}

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -102,6 +102,7 @@
       "method": "GET",
       "path": "/api/analytics/stream",
       "route_file": "app/api/analytics/stream/route.ts",
+      "streaming": true,
       "source": "docs/api/analytics.md",
       "line": 207
     },

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -61,7 +61,7 @@
       "path": "/api/workflows/{workflowId}/executions",
       "route_file": "app/api/workflows/[workflowId]/executions/route.ts",
       "source": "docs/api/executions.md",
-      "line": 259
+      "line": 302
     },
     {
       "method": "GET",
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 198
+      "line": 289
     },
     {
       "method": "GET",
@@ -237,7 +237,7 @@
       "path": "/api/workflows/executions/{executionId}/logs",
       "route_file": "app/api/workflows/executions/[executionId]/logs/route.ts",
       "source": "docs/api/executions.md",
-      "line": 116
+      "line": 159
     },
     {
       "method": "GET",
@@ -245,6 +245,13 @@
       "route_file": "app/api/workflows/executions/[executionId]/status/route.ts",
       "source": "docs/api/executions.md",
       "line": 46
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/executions/{executionId}/wait",
+      "route_file": "app/api/workflows/executions/[executionId]/wait/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 116
     },
     {
       "method": "GET",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -233,6 +233,27 @@
     },
     {
       "method": "GET",
+      "path": "/api/workflows/executions/{executionId}/logs",
+      "route_file": "app/api/workflows/executions/[executionId]/logs/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 116
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/executions/{executionId}/status",
+      "route_file": "app/api/workflows/executions/[executionId]/status/route.ts",
+      "source": "docs/api/executions.md",
+      "line": 46
+    },
+    {
+      "method": "GET",
+      "path": "/api/workflows/public",
+      "route_file": "app/api/workflows/public/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 270
+    },
+    {
+      "method": "GET",
       "path": "/api/workflows/{workflowId}",
       "route_file": "app/api/workflows/[workflowId]/route.ts",
       "source": "docs/api/workflows.md",
@@ -258,27 +279,6 @@
       "route_file": "app/api/workflows/[workflowId]/executions/route.ts",
       "source": "docs/api/executions.md",
       "line": 13
-    },
-    {
-      "method": "GET",
-      "path": "/api/workflows/executions/{executionId}/logs",
-      "route_file": "app/api/workflows/executions/[executionId]/logs/route.ts",
-      "source": "docs/api/executions.md",
-      "line": 116
-    },
-    {
-      "method": "GET",
-      "path": "/api/workflows/executions/{executionId}/status",
-      "route_file": "app/api/workflows/executions/[executionId]/status/route.ts",
-      "source": "docs/api/executions.md",
-      "line": 46
-    },
-    {
-      "method": "GET",
-      "path": "/api/workflows/public",
-      "route_file": "app/api/workflows/public/route.ts",
-      "source": "docs/api/workflows.md",
-      "line": 270
     },
     {
       "method": "PATCH",
@@ -429,6 +429,13 @@
     },
     {
       "method": "POST",
+      "path": "/api/workflows/create",
+      "route_file": "app/api/workflows/create/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 84
+    },
+    {
+      "method": "POST",
       "path": "/api/workflows/{workflowId}/claim",
       "route_file": "app/api/workflows/[workflowId]/claim/route.ts",
       "source": "docs/api/workflows.md",
@@ -454,13 +461,6 @@
       "route_file": "app/api/workflows/[workflowId]/webhook/route.ts",
       "source": "docs/api/workflows.md",
       "line": 211
-    },
-    {
-      "method": "POST",
-      "path": "/api/workflows/create",
-      "route_file": "app/api/workflows/create/route.ts",
-      "source": "docs/api/workflows.md",
-      "line": 84
     },
     {
       "method": "PUT",

--- a/tests/unit/api-not-found.test.ts
+++ b/tests/unit/api-not-found.test.ts
@@ -2,14 +2,15 @@
  * Catch-all 404 handler returns the canonical structured envelope.
  *
  * The envelope shape itself is exercised by api-error-envelope.test.ts;
- * this file pins the catch-all's contract: every HTTP method returns a
- * 404 with {error:"not_found", detail:"Route <METHOD> <path> not found",
+ * this file pins the catch-all's contract: every body-bearing verb returns
+ * a 404 with {error:"not_found", detail:"Route <METHOD> <path> not found",
  * request_id:<string>}, Content-Type: application/json, and
- * Cache-Control: no-store.
+ * Cache-Control: no-store. HEAD is special-cased: same status and headers,
+ * but no body (RFC 9110).
  *
  * Routing precedence (more specific routes win over [...slug]) is a
  * property of the Next.js App Router, not of this file; it is exercised
- * end-to-end by the live HEAD check in deploy-keeperhub.yaml. The repo's
+ * end-to-end by the live probe in deploy-keeperhub.yaml. The repo's
  * existing /api/auth/[...all] and /api/execute/[...slug] catch-alls live
  * at deeper segments and therefore take precedence by construction.
  */
@@ -36,13 +37,14 @@ function buildRequest(
   });
 }
 
+// HEAD is excluded here because it intentionally returns no body; it has
+// its own test below.
 const HANDLERS = {
   GET,
   POST,
   PUT,
   PATCH,
   DELETE,
-  HEAD,
   OPTIONS,
 } as const;
 
@@ -73,6 +75,16 @@ describe("/api/[...slug] catch-all 404", () => {
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.request_id).toBe("trace-abc-123");
     expect(response.headers.get("x-request-id")).toBe("trace-abc-123");
+  });
+
+  it("HEAD returns a body-less 404 with the same status and cache headers", async () => {
+    const path = "/api/this-route-does-not-exist";
+    const response = HEAD(buildRequest("HEAD", path));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(typeof response.headers.get("x-request-id")).toBe("string");
+    const text = await response.text();
+    expect(text).toBe("");
   });
 
   it("encodes the request method and path verbatim in detail", async () => {

--- a/tests/unit/api-not-found.test.ts
+++ b/tests/unit/api-not-found.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Catch-all 404 handler returns the canonical structured envelope.
+ *
+ * The envelope shape itself is exercised by api-error-envelope.test.ts;
+ * this file pins the catch-all's contract: every HTTP method returns a
+ * 404 with {error:"not_found", detail:"Route <METHOD> <path> not found",
+ * request_id:<string>}, Content-Type: application/json, and
+ * Cache-Control: no-store.
+ *
+ * Routing precedence (more specific routes win over [...slug]) is a
+ * property of the Next.js App Router, not of this file; it is exercised
+ * end-to-end by the live HEAD check in deploy-keeperhub.yaml. The repo's
+ * existing /api/auth/[...all] and /api/execute/[...slug] catch-alls live
+ * at deeper segments and therefore take precedence by construction.
+ */
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import {
+  DELETE,
+  GET,
+  HEAD,
+  OPTIONS,
+  PATCH,
+  POST,
+  PUT,
+} from "@/app/api/[...slug]/route";
+
+function buildRequest(
+  method: string,
+  path: string,
+  extraHeaders?: HeadersInit
+) {
+  return new NextRequest(`http://localhost${path}`, {
+    method,
+    headers: extraHeaders,
+  });
+}
+
+const HANDLERS = {
+  GET,
+  POST,
+  PUT,
+  PATCH,
+  DELETE,
+  HEAD,
+  OPTIONS,
+} as const;
+
+describe("/api/[...slug] catch-all 404", () => {
+  for (const [method, handler] of Object.entries(HANDLERS)) {
+    it(`${method} unknown route returns structured not_found envelope`, async () => {
+      const path = "/api/this-route-does-not-exist";
+      const response = handler(buildRequest(method, path));
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Content-Type")).toContain(
+        "application/json"
+      );
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("not_found");
+      expect(body.detail).toBe(`Route ${method} ${path} not found`);
+      expect(typeof body.request_id).toBe("string");
+      expect((body.request_id as string).length).toBeGreaterThan(0);
+    });
+  }
+
+  it("echoes inbound x-request-id so clients can correlate", async () => {
+    const response = GET(
+      buildRequest("GET", "/api/missing", {
+        "x-request-id": "trace-abc-123",
+      })
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.request_id).toBe("trace-abc-123");
+    expect(response.headers.get("x-request-id")).toBe("trace-abc-123");
+  });
+
+  it("encodes the request method and path verbatim in detail", async () => {
+    const response = POST(
+      buildRequest("POST", "/api/me", { "content-type": "application/json" })
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.detail).toBe("Route POST /api/me not found");
+  });
+});


### PR DESCRIPTION
## Problem

Hackathon builders reported a pattern where endpoints in `docs/api/` either 404 in production or return a shape that diverges from the docs. Compounding that, Next.js's default 404 returns an HTML page, which makes an unknown URL look identical to a 401 to anyone reading status codes. The result: real time lost probing assumed-by-REST-convention paths that the docs never advertised, plus opaque debugging when docs and code disagreed.

## What this changes

**Structured JSON 404 for unknown `/api/*` paths**

`app/api/[...slug]/route.ts` is a catch-all that exports every verb and returns the canonical `{error, detail, request_id}` envelope from `lib/errors/api-envelope.ts`. `Cache-Control: no-store` so a transient prod misconfig does not get cached as a permanent 404. More specific routes take precedence by App Router rules, so the existing `app/api/auth/[...all]` and `app/api/execute/[...slug]` keep their own behavior.

**Reconcile documented response shapes**

- `docs/api/chains.md`: response is a bare array, not `{data: [...]}`. Field list aligned with what the route returns; documented why `defaultPrimaryRpc`/`defaultFallbackRpc` are intentionally server-only (provider API keys).
- `docs/api/user.md`: `GET /api/user/rpc-preferences` returns `{preferences, resolved}`, not `{data: [...]}`. Removed phantom `POST /api/user/rpc-preferences` entry (no handler exists - writes go through the per-chain PUT, which is now properly documented with the correct body shape `{primaryRpcUrl, fallbackRpcUrl?}`).
- `docs/api/chains.md`: removed phantom `GET /api/web3/fetch-abi` ("Alternative ABI Fetch" - the route is POST with a JSON body; the canonical `/api/chains/{chainId}/abi` is already documented above).
- `docs/api/workflows.md`: removed phantom `GET /api/workflows/taxonomy` (no route file). If we want it, build it - I did not silently expand scope.

**PR-time docs-vs-code guard**

`scripts/check-api-docs-routes.ts` walks every `(METHOD /api/path)` line inside fenced `http` blocks under `docs/api/*.md` and asserts the corresponding `app/api/<path>/route.ts` exports that method. Handles all three export styles observed in the repo: `export async function`, `export const = ...`, and `export { POST } from "..."`. Path-parameter names are allowed to differ between docs (`{executionId}`) and the filesystem (`[id]`) - only the URL pattern shape matters. Routes that exist in code but appear in no docs file are surfaced as warnings, never failures (`/api/internal`, `/api/cron`, `/api/og`, `/api/auth`, `/api/oauth`, etc. are on an explicit allowlist).

Wired into `.github/workflows/pr-checks.yml` as `pnpm check:api-docs`, with a follow-up step that fails CI if `specs/api-coverage.json` (committed) needs regenerating.

**Post-deploy live HEAD probe**

`.github/workflows/deploy-keeperhub.yaml` gets a step after the existing `/api/health` probe that walks `specs/api-coverage.json` and HEADs every documented GET endpoint on the deployed env. Reuses `TEST_API_KEY` (already fetched from SSM) and CF Access secrets. `200/401/403` count as reachable; `404/5xx` are flagged. Initial mode is `continue-on-error: true` so we can observe what fires before it gates a release; flip after one clean run.

## Verification

Local trifecta (worktree):

```
pnpm check                                       # green
NODE_OPTIONS=--max-old-space-size=8192 pnpm type-check  # green (needs pnpm discover-plugins first)
pnpm test tests/unit/api-not-found.test.ts       # 9/9
pnpm check:api-docs                              # 0 drift, 64 undocumented routes (warn-only)
```

Manual smoke:

```
docker compose --profile dev up
curl -s http://localhost:3000/api/does-not-exist | jq
# { "error": "not_found", "detail": "Route GET /api/does-not-exist not found", "request_id": "..." }
```

Post-merge staging probe (in the deploy job logs): every endpoint in `specs/api-coverage.json` should return `200/401/403`. Any `404` is real drift and surfaces as a warn line during the first deploy.

## Tradeoffs

- **No did-you-mean alias map**. The structured 404 is already a step-change; alias maintenance cost is not worth the one-time builder confusion.
- **Not wrapping `/api/chains` in `{data: [...]}`** to "fix" the drift. That would break every external consumer built against the current shape. `/api/workflows` is also bare-array; the house style is bare arrays.
- **No new ts-morph dep**. Regex over the three observed export styles is sufficient; the failure mode (false-negative on unusual formatting) is easy to spot.
- **Live probe is warn-only initially**. Flipping it to required is a one-line change once we see a clean run.

## Follow-ups (separate tickets)

- 64 routes are in code but undocumented. Decide which should become public docs vs. expand the allowlist in `scripts/check-api-docs-routes.ts`.
- `GET /api/workflows/taxonomy` - if the "distinct categories and protocols from public workflows" endpoint is desired, build it (it would be useful for filter UIs).
- OpenAPI spec at `/openapi.json` covering the full REST surface. The current `app/api/openapi/route.ts` only covers listed public workflows; the wider spec is its own piece of work.
